### PR TITLE
[auditbeat] replace deprecated io/ioutil package

### DIFF
--- a/auditbeat/helper/hasher/hasher_test.go
+++ b/auditbeat/helper/hasher/hasher_test.go
@@ -27,14 +27,10 @@ import (
 )
 
 func TestHasher(t *testing.T) {
-	dir, err := os.MkdirTemp("", "auditbeat-hasher-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "exe")
-	if err = os.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
+	if err := os.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,14 +57,10 @@ func TestHasher(t *testing.T) {
 }
 
 func TestHasherLimits(t *testing.T) {
-	dir, err := os.MkdirTemp("", "auditbeat-hasher-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "exe")
-	if err = os.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
+	if err := os.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auditbeat/helper/hasher/hasher_test.go
+++ b/auditbeat/helper/hasher/hasher_test.go
@@ -19,7 +19,6 @@ package hasher
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,14 +27,14 @@ import (
 )
 
 func TestHasher(t *testing.T) {
-	dir, err := ioutil.TempDir("", "auditbeat-hasher-test")
+	dir, err := os.MkdirTemp("", "auditbeat-hasher-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
 	file := filepath.Join(dir, "exe")
-	if err = ioutil.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
+	if err = os.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -62,14 +61,14 @@ func TestHasher(t *testing.T) {
 }
 
 func TestHasherLimits(t *testing.T) {
-	dir, err := ioutil.TempDir("", "auditbeat-hasher-test")
+	dir, err := os.MkdirTemp("", "auditbeat-hasher-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
 	file := filepath.Join(dir, "exe")
-	if err = ioutil.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
+	if err = os.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sort"
@@ -366,7 +365,7 @@ func buildSampleEvent(t testing.TB, lines []string, filename string) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filename, output, 0o644); err != nil {
+	if err := os.WriteFile(filename, output, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/auditbeat/module/auditd/config_test.go
+++ b/auditbeat/module/auditd/config_test.go
@@ -166,10 +166,7 @@ audit_rules: |
 			makeRuleFlags(0, 2),
 		}, "\n")
 
-		dir1, err := os.MkdirTemp("", "rules1")
-		if err != nil {
-			t.Fatal(err)
-		}
+		dir1 := t.TempDir()
 
 		for _, file := range []struct {
 			order int
@@ -189,15 +186,12 @@ audit_rules: |
 				makeRuleFlags(1+file.order, 2),
 				makeRuleFlags(1+file.order, 3),
 			}, "\n"))
-			if err = os.WriteFile(path, content, fileMode); err != nil {
+			if err := os.WriteFile(path, content, fileMode); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		dir2, err := os.MkdirTemp("", "rules0")
-		if err != nil {
-			t.Fatal(err)
-		}
+		dir2 := t.TempDir()
 
 		for _, file := range []struct {
 			order int
@@ -215,7 +209,7 @@ audit_rules: |
 				makeRuleFlags(10+file.order, 2),
 				makeRuleFlags(10+file.order, 3),
 			}, "\n"))
-			if err = os.WriteFile(path, content, fileMode); err != nil {
+			if err := os.WriteFile(path, content, fileMode); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -225,7 +219,7 @@ audit_rules: |
 			fmt.Sprintf("%s/*.conf", dir2),
 		}
 
-		if err = config.Validate(); err != nil {
+		if err := config.Validate(); err != nil {
 			t.Fatal(err)
 		}
 

--- a/auditbeat/module/auditd/config_test.go
+++ b/auditbeat/module/auditd/config_test.go
@@ -21,7 +21,7 @@ package auditd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -166,7 +166,7 @@ audit_rules: |
 			makeRuleFlags(0, 2),
 		}, "\n")
 
-		dir1, err := ioutil.TempDir("", "rules1")
+		dir1, err := os.MkdirTemp("", "rules1")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -189,12 +189,12 @@ audit_rules: |
 				makeRuleFlags(1+file.order, 2),
 				makeRuleFlags(1+file.order, 3),
 			}, "\n"))
-			if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+			if err = os.WriteFile(path, content, fileMode); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		dir2, err := ioutil.TempDir("", "rules0")
+		dir2, err := os.MkdirTemp("", "rules0")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -215,7 +215,7 @@ audit_rules: |
 				makeRuleFlags(10+file.order, 2),
 				makeRuleFlags(10+file.order, 3),
 			}, "\n"))
-			if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+			if err = os.WriteFile(path, content, fileMode); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/auditbeat/module/auditd/golden_files_test.go
+++ b/auditbeat/module/auditd/golden_files_test.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -87,7 +86,7 @@ func readLines(path string) (lines []string, err error) {
 }
 
 func readGoldenFile(t testing.TB, path string) (events []mapstr.M) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("can't read golden file '%s': %v", path, err)
 	}
@@ -216,7 +215,7 @@ func TestGoldenFiles(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if err = ioutil.WriteFile(goldenPath, data, 0o644); err != nil {
+				if err = os.WriteFile(goldenPath, data, 0o644); err != nil {
 					t.Fatalf("failed writing golden file '%s': %v", goldenPath, err)
 				}
 			}

--- a/auditbeat/module/file_integrity/event_test.go
+++ b/auditbeat/module/file_integrity/event_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/user"
@@ -177,7 +176,7 @@ func TestDiffEvents(t *testing.T) {
 }
 
 func TestHashFile(t *testing.T) {
-	f, err := ioutil.TempFile("", "input.txt")
+	f, err := os.CreateTemp("", "input.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +287,7 @@ func TestHashFile(t *testing.T) {
 }
 
 func TestNewEventFromFileInfoHash(t *testing.T) {
-	f, err := ioutil.TempFile("", "input.txt")
+	f, err := os.CreateTemp("", "input.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +360,7 @@ func TestNewEventFromFileInfoHash(t *testing.T) {
 }
 
 func BenchmarkHashFile(b *testing.B) {
-	f, err := ioutil.TempFile("", "hash")
+	f, err := os.CreateTemp("", "hash")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/auditbeat/module/file_integrity/event_test.go
+++ b/auditbeat/module/file_integrity/event_test.go
@@ -176,7 +176,7 @@ func TestDiffEvents(t *testing.T) {
 }
 
 func TestHashFile(t *testing.T) {
-	f, err := os.CreateTemp("", "input.txt")
+	f, err := os.CreateTemp(t.TempDir(), "input.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +287,7 @@ func TestHashFile(t *testing.T) {
 }
 
 func TestNewEventFromFileInfoHash(t *testing.T) {
-	f, err := os.CreateTemp("", "input.txt")
+	f, err := os.CreateTemp(t.TempDir(), "input.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +360,7 @@ func TestNewEventFromFileInfoHash(t *testing.T) {
 }
 
 func BenchmarkHashFile(b *testing.B) {
-	f, err := os.CreateTemp("", "hash")
+	f, err := os.CreateTemp(b.TempDir(), "hash")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/auditbeat/module/file_integrity/eventreader_test.go
+++ b/auditbeat/module/file_integrity/eventreader_test.go
@@ -42,18 +42,7 @@ const ErrorSharingViolation syscall.Errno = 32
 func TestEventReader(t *testing.T) {
 	t.Skip("Flaky test: about 1/10 of builds fails https://github.com/elastic/beats/issues/21302")
 	// Make dir to monitor.
-	dir, err := os.MkdirTemp("", "audit")
-	if err != nil {
-		t.Fatal(err)
-	}
-	// under macOS, temp dir has a symlink in the path (/var -> /private/var)
-	// and the path returned in events has the symlink resolved
-	if runtime.GOOS == "darwin" {
-		if dirAlt, err := filepath.EvalSymlinks(dir); err == nil {
-			dir = dirAlt
-		}
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Create a new EventProducer.
 	config := defaultConfig
@@ -251,21 +240,8 @@ func TestRaces(t *testing.T) {
 
 	dirs := make([]string, N)
 	for i := range dirs {
-		dir, err := os.MkdirTemp("", "audit")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if dir, err = filepath.EvalSymlinks(dir); err != nil {
-			t.Fatal(err)
-		}
-		dirs[i] = dir
+		dirs[i] = t.TempDir()
 	}
-
-	defer func() {
-		for _, dir := range dirs {
-			os.RemoveAll(dir)
-		}
-	}()
 
 	// Create a new EventProducer.
 	config := defaultConfig

--- a/auditbeat/module/file_integrity/eventreader_test.go
+++ b/auditbeat/module/file_integrity/eventreader_test.go
@@ -19,7 +19,6 @@ package file_integrity
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,7 +42,7 @@ const ErrorSharingViolation syscall.Errno = 32
 func TestEventReader(t *testing.T) {
 	t.Skip("Flaky test: about 1/10 of builds fails https://github.com/elastic/beats/issues/21302")
 	// Make dir to monitor.
-	dir, err := ioutil.TempDir("", "audit")
+	dir, err := os.MkdirTemp("", "audit")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +74,7 @@ func TestEventReader(t *testing.T) {
 	txt1 := filepath.Join(dir, "test1.txt")
 	var fileMode os.FileMode = 0o640
 	mustRun(t, "created", func(t *testing.T) {
-		if err = ioutil.WriteFile(txt1, []byte("hello"), fileMode); err != nil {
+		if err = os.WriteFile(txt1, []byte("hello"), fileMode); err != nil {
 			t.Fatal(err)
 		}
 
@@ -194,7 +193,7 @@ func TestEventReader(t *testing.T) {
 	var moveInOrig string
 	moveIn := filepath.Join(dir, "test3.txt")
 	mustRun(t, "move in", func(t *testing.T) {
-		f, err := ioutil.TempFile("", "test3.txt")
+		f, err := os.CreateTemp("", "test3.txt")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -232,7 +231,7 @@ func TestEventReader(t *testing.T) {
 	// Test that it does not monitor recursively.
 	subFile := filepath.Join(subDir, "foo.txt")
 	mustRun(t, "non-recursive", func(t *testing.T) {
-		if err = ioutil.WriteFile(subFile, []byte("foo"), fileMode); err != nil {
+		if err = os.WriteFile(subFile, []byte("foo"), fileMode); err != nil {
 			t.Fatal(err)
 		}
 
@@ -252,7 +251,7 @@ func TestRaces(t *testing.T) {
 
 	dirs := make([]string, N)
 	for i := range dirs {
-		dir, err := ioutil.TempDir("", "audit")
+		dir, err := os.MkdirTemp("", "audit")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,7 +285,7 @@ func TestRaces(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			for _, dir := range dirs {
 				fname := filepath.Join(dir, fmt.Sprintf("%d.dat", i))
-				ioutil.WriteFile(fname, []byte("hello"), fileMode)
+				os.WriteFile(fname, []byte("hello"), fileMode)
 			}
 		}
 	}()
@@ -298,7 +297,7 @@ func TestRaces(t *testing.T) {
 	const marker = "test_file"
 	for _, dir := range dirs {
 		fname := filepath.Join(dir, marker)
-		ioutil.WriteFile(fname, []byte("hello"), fileMode)
+		os.WriteFile(fname, []byte("hello"), fileMode)
 	}
 
 	got := 0

--- a/auditbeat/module/file_integrity/fileinfo_test.go
+++ b/auditbeat/module/file_integrity/fileinfo_test.go
@@ -29,11 +29,10 @@ import (
 )
 
 func TestNewMetadata(t *testing.T) {
-	f, err := os.CreateTemp("", "metadata")
+	f, err := os.CreateTemp(t.TempDir(), "metadata")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
 
 	_, err = f.WriteString("metadata test")
 	if err != nil {
@@ -95,11 +94,10 @@ func TestNewMetadata(t *testing.T) {
 }
 
 func TestSetUIDSetGIDBits(t *testing.T) {
-	f, err := os.CreateTemp("", "setuid")
+	f, err := os.CreateTemp(t.TempDir(), "setuid")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
 
 	_, err = f.WriteString("metadata test")
 	if err != nil {

--- a/auditbeat/module/file_integrity/fileinfo_test.go
+++ b/auditbeat/module/file_integrity/fileinfo_test.go
@@ -19,7 +19,6 @@ package file_integrity
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"runtime"
@@ -30,7 +29,7 @@ import (
 )
 
 func TestNewMetadata(t *testing.T) {
-	f, err := ioutil.TempFile("", "metadata")
+	f, err := os.CreateTemp("", "metadata")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +95,7 @@ func TestNewMetadata(t *testing.T) {
 }
 
 func TestSetUIDSetGIDBits(t *testing.T) {
-	f, err := ioutil.TempFile("", "setuid")
+	f, err := os.CreateTemp("", "setuid")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auditbeat/module/file_integrity/fileinfo_windows_test.go
+++ b/auditbeat/module/file_integrity/fileinfo_windows_test.go
@@ -31,15 +31,14 @@ import (
 // a method that doesn't need to open the file for reading.
 // (GetNamedSecurityInfo vs CreateFile+GetSecurityInfo)
 func TestFileInfoPermissions(t *testing.T) {
-	f, err := os.CreateTemp("", "metadata")
+	f, err := os.CreateTemp(t.TempDir(), "metadata")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
+
 	name := f.Name()
-	defer func() {
-		f.Close()
-		os.Remove(f.Name())
-	}()
+
 	makeFileNonReadable(t, f.Name())
 	info, err := os.Stat(name)
 	if err != nil {

--- a/auditbeat/module/file_integrity/fileinfo_windows_test.go
+++ b/auditbeat/module/file_integrity/fileinfo_windows_test.go
@@ -18,7 +18,6 @@
 package file_integrity
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -32,7 +31,7 @@ import (
 // a method that doesn't need to open the file for reading.
 // (GetNamedSecurityInfo vs CreateFile+GetSecurityInfo)
 func TestFileInfoPermissions(t *testing.T) {
-	f, err := ioutil.TempFile("", "metadata")
+	f, err := os.CreateTemp("", "metadata")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -19,7 +19,6 @@ package file_integrity
 
 import (
 	"crypto/sha1"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -40,7 +39,7 @@ import (
 func TestData(t *testing.T) {
 	defer abtest.SetupDataDir(t)()
 
-	dir, err := ioutil.TempDir("", "audit-file")
+	dir, err := os.MkdirTemp("", "audit-file")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +48,7 @@ func TestData(t *testing.T) {
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		file := filepath.Join(dir, "file.data")
-		ioutil.WriteFile(file, []byte("hello world"), 0o600)
+		os.WriteFile(file, []byte("hello world"), 0o600)
 	}()
 
 	ms := mbtest.NewPushMetricSetV2(t, getConfig(dir))
@@ -76,7 +75,7 @@ func TestActions(t *testing.T) {
 	defer bucket.Close()
 
 	// First directory
-	dir, err := ioutil.TempDir("", "audit-file")
+	dir, err := os.MkdirTemp("", "audit-file")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +87,7 @@ func TestActions(t *testing.T) {
 	}
 
 	// Second directory (to be reported with "initial_scan")
-	newDir, err := ioutil.TempDir("", "audit-file-new")
+	newDir, err := os.MkdirTemp("", "audit-file-new")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,8 +135,8 @@ func TestActions(t *testing.T) {
 	}
 
 	// Create some files in first directory
-	ioutil.WriteFile(createdFilepath, []byte("hello world"), 0o600)
-	ioutil.WriteFile(updatedFilepath, []byte("hello world"), 0o600)
+	os.WriteFile(createdFilepath, []byte("hello world"), 0o600)
+	os.WriteFile(updatedFilepath, []byte("hello world"), 0o600)
 
 	ms := mbtest.NewPushMetricSetV2(t, getConfig(dir, newDir))
 	events := mbtest.RunPushMetricSetV2(10*time.Second, 5, ms)
@@ -185,7 +184,7 @@ func TestExcludedFiles(t *testing.T) {
 	}
 	defer bucket.Close()
 
-	dir, err := ioutil.TempDir("", "audit-file")
+	dir, err := os.MkdirTemp("", "audit-file")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +200,7 @@ func TestExcludedFiles(t *testing.T) {
 	go func() {
 		for _, f := range []string{"FILE.TXT", "FILE.TXT.SWP", "file.txt.swo", ".git/HEAD", ".gitignore"} {
 			file := filepath.Join(dir, f)
-			ioutil.WriteFile(file, []byte("hello world"), 0o600)
+			os.WriteFile(file, []byte("hello world"), 0o600)
 		}
 	}()
 
@@ -241,7 +240,7 @@ func TestIncludedExcludedFiles(t *testing.T) {
 	}
 	defer bucket.Close()
 
-	dir, err := ioutil.TempDir("", "audit-file")
+	dir, err := os.MkdirTemp("", "audit-file")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +263,7 @@ func TestIncludedExcludedFiles(t *testing.T) {
 
 	for _, f := range []string{"FILE.TXT", ".ssh/known_hosts", ".ssh/known_hosts.swp"} {
 		file := filepath.Join(dir, f)
-		err := ioutil.WriteFile(file, []byte("hello world"), 0o600)
+		err := os.WriteFile(file, []byte("hello world"), 0o600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -311,7 +310,7 @@ func TestErrorReporting(t *testing.T) {
 	}
 	defer abtest.SetupDataDir(t)()
 
-	dir, err := ioutil.TempDir("", "audit-file")
+	dir, err := os.MkdirTemp("", "audit-file")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +486,7 @@ func (e expectedEvent) validate(t *testing.T, ms *MetricSet) {
 type expectedEvents []expectedEvent
 
 func (e expectedEvents) validate(t *testing.T) {
-	store, err := ioutil.TempFile("", "bucket")
+	store, err := os.CreateTemp("", "bucket")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -759,7 +758,7 @@ func TestEventFailedHash(t *testing.T) {
 }
 
 func TestEventDelete(t *testing.T) {
-	store, err := ioutil.TempFile("", "bucket")
+	store, err := os.CreateTemp("", "bucket")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -39,11 +39,7 @@ import (
 func TestData(t *testing.T) {
 	defer abtest.SetupDataDir(t)()
 
-	dir, err := os.MkdirTemp("", "audit-file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
@@ -75,28 +71,10 @@ func TestActions(t *testing.T) {
 	defer bucket.Close()
 
 	// First directory
-	dir, err := os.MkdirTemp("", "audit-file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	dir, err = filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	// Second directory (to be reported with "initial_scan")
-	newDir, err := os.MkdirTemp("", "audit-file-new")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(newDir)
-
-	newDir, err = filepath.EvalSymlinks(newDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	newDir := t.TempDir()
 
 	createdFilepath := filepath.Join(dir, "created.txt")
 	updatedFilepath := filepath.Join(dir, "updated.txt")
@@ -184,16 +162,7 @@ func TestExcludedFiles(t *testing.T) {
 	}
 	defer bucket.Close()
 
-	dir, err := os.MkdirTemp("", "audit-file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	dir, err = filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	ms := mbtest.NewPushMetricSetV2(t, getConfig(dir))
 
@@ -240,16 +209,7 @@ func TestIncludedExcludedFiles(t *testing.T) {
 	}
 	defer bucket.Close()
 
-	dir, err := os.MkdirTemp("", "audit-file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	dir, err = filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	err = os.Mkdir(filepath.Join(dir, ".ssh"), 0o700)
 	if err != nil {
@@ -310,16 +270,7 @@ func TestErrorReporting(t *testing.T) {
 	}
 	defer abtest.SetupDataDir(t)()
 
-	dir, err := os.MkdirTemp("", "audit-file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	dir, err = filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "unreadable.txt")
 	f, err := os.Create(path)
@@ -441,6 +392,8 @@ func (t *testReporter) Clear() {
 }
 
 func checkExpectedEvent(t *testing.T, ms *MetricSet, title string, input *Event, expected map[string]interface{}) {
+	t.Helper()
+
 	var reporter testReporter
 	if !ms.reportEvent(&reporter, input) {
 		t.Fatal("reportEvent failed", title)
@@ -492,6 +445,7 @@ func (e expectedEvents) validate(t *testing.T) {
 	}
 	defer store.Close()
 	defer os.Remove(store.Name())
+
 	ds := datastore.New(store.Name(), 0o644)
 	bucket, err := ds.OpenBucket(bucketName)
 	if err != nil {
@@ -764,6 +718,7 @@ func TestEventDelete(t *testing.T) {
 	}
 	defer store.Close()
 	defer os.Remove(store.Name())
+
 	ds := datastore.New(store.Name(), 0o644)
 	bucket, err := ds.OpenBucket(bucketName)
 	if err != nil {

--- a/auditbeat/module/file_integrity/mime_test.go
+++ b/auditbeat/module/file_integrity/mime_test.go
@@ -18,7 +18,6 @@
 package file_integrity
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func TestGetMimeType(t *testing.T) {
 		{"png", "image/png"},
 	}
 
-	dir, err := ioutil.TempDir("", "mime-samples")
+	dir, err := os.MkdirTemp("", "mime-samples")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +53,7 @@ func TestGetMimeType(t *testing.T) {
 
 	for extension, sample := range mimeSamples {
 		samplePath := filepath.Join(dir, "sample."+extension)
-		if err := ioutil.WriteFile(samplePath, sample, 0o700); err != nil {
+		if err := os.WriteFile(samplePath, sample, 0o700); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/auditbeat/module/file_integrity/mime_test.go
+++ b/auditbeat/module/file_integrity/mime_test.go
@@ -45,11 +45,7 @@ func TestGetMimeType(t *testing.T) {
 		{"png", "image/png"},
 	}
 
-	dir, err := os.MkdirTemp("", "mime-samples")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for extension, sample := range mimeSamples {
 		samplePath := filepath.Join(dir, "sample."+extension)

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -21,7 +21,6 @@ package monitor
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,7 +36,7 @@ func alwaysInclude(path string) bool {
 }
 
 func TestNonRecursive(t *testing.T) {
-	dir, err := ioutil.TempDir("", "monitor")
+	dir, err := os.MkdirTemp("", "monitor")
 	assertNoError(t, err)
 	// under macOS, temp dir has a symlink in the path (/var -> /private/var)
 	// and the path returned in events has the symlink resolved
@@ -67,7 +66,7 @@ func TestNonRecursive(t *testing.T) {
 
 	// subdirs are not watched
 	subfile := filepath.Join(subdir, "file.dat")
-	assertNoError(t, ioutil.WriteFile(subfile, []byte("foo"), 0o640))
+	assertNoError(t, os.WriteFile(subfile, []byte("foo"), 0o640))
 
 	_, err = readTimeout(t, watcher)
 	assert.Error(t, err)
@@ -85,7 +84,7 @@ func TestRecursive(t *testing.T) {
 		// under Darwin uses fsevents instead of kqueue.
 		t.Skip("Disabled on Darwin")
 	}
-	dir, err := ioutil.TempDir("", "monitor")
+	dir, err := os.MkdirTemp("", "monitor")
 	assertNoError(t, err)
 	// under macOS, temp dir has a symlink in the path (/var -> /private/var)
 	// and the path returned in events has the symlink resolved
@@ -127,7 +126,7 @@ func TestRecursiveNoFollowSymlink(t *testing.T) {
 
 	// Create a watched dir
 
-	dir, err := ioutil.TempDir("", "monitor")
+	dir, err := os.MkdirTemp("", "monitor")
 	assertNoError(t, err)
 	// under macOS, temp dir has a symlink in the path (/var -> /private/var)
 	// and the path returned in events has the symlink resolved
@@ -140,7 +139,7 @@ func TestRecursiveNoFollowSymlink(t *testing.T) {
 
 	// Create a separate dir
 
-	linkedDir, err := ioutil.TempDir("", "linked")
+	linkedDir, err := os.MkdirTemp("", "linked")
 	assertNoError(t, err)
 	defer os.RemoveAll(linkedDir)
 
@@ -160,7 +159,7 @@ func TestRecursiveNoFollowSymlink(t *testing.T) {
 	// Create a file in the other dir
 
 	file := filepath.Join(linkedDir, "not.seen")
-	assertNoError(t, ioutil.WriteFile(file, []byte("hello"), 0o640))
+	assertNoError(t, os.WriteFile(file, []byte("hello"), 0o640))
 
 	// No event is received
 	ev, err := readTimeout(t, watcher)
@@ -178,7 +177,7 @@ func TestRecursiveSubdirPermissions(t *testing.T) {
 
 	// Create dir to be watched
 
-	dir, err := ioutil.TempDir("", "monitor")
+	dir, err := os.MkdirTemp("", "monitor")
 	assertNoError(t, err)
 	if runtime.GOOS == "darwin" {
 		if dirAlt, err := filepath.EvalSymlinks(dir); err == nil {
@@ -189,7 +188,7 @@ func TestRecursiveSubdirPermissions(t *testing.T) {
 
 	// Create not watched dir
 
-	outDir, err := ioutil.TempDir("", "non-watched")
+	outDir, err := os.MkdirTemp("", "non-watched")
 	assertNoError(t, err)
 	if runtime.GOOS == "darwin" {
 		if dirAlt, err := filepath.EvalSymlinks(outDir); err == nil {
@@ -203,7 +202,7 @@ func TestRecursiveSubdirPermissions(t *testing.T) {
 	for _, name := range []string{"a", "b", "c"} {
 		path := filepath.Join(outDir, name)
 		assertNoError(t, os.Mkdir(path, 0o755))
-		assertNoError(t, ioutil.WriteFile(filepath.Join(path, name), []byte("Hello"), 0o644))
+		assertNoError(t, os.WriteFile(filepath.Join(path, name), []byte("Hello"), 0o644))
 	}
 
 	// Make a subdir not accessible
@@ -274,7 +273,7 @@ func TestRecursiveExcludedPaths(t *testing.T) {
 
 	// Create dir to be watched
 
-	dir, err := ioutil.TempDir("", "monitor")
+	dir, err := os.MkdirTemp("", "monitor")
 	assertNoError(t, err)
 	if runtime.GOOS == "darwin" {
 		if dirAlt, err := filepath.EvalSymlinks(dir); err == nil {
@@ -285,7 +284,7 @@ func TestRecursiveExcludedPaths(t *testing.T) {
 
 	// Create not watched dir
 
-	outDir, err := ioutil.TempDir("", "non-watched")
+	outDir, err := os.MkdirTemp("", "non-watched")
 	assertNoError(t, err)
 	if runtime.GOOS == "darwin" {
 		if dirAlt, err := filepath.EvalSymlinks(outDir); err == nil {
@@ -299,7 +298,7 @@ func TestRecursiveExcludedPaths(t *testing.T) {
 	for _, name := range []string{"a", "b", "c"} {
 		path := filepath.Join(outDir, name)
 		assertNoError(t, os.Mkdir(path, 0o755))
-		assertNoError(t, ioutil.WriteFile(filepath.Join(path, name), []byte("Hello"), 0o644))
+		assertNoError(t, os.WriteFile(filepath.Join(path, name), []byte("Hello"), 0o644))
 	}
 
 	// excludes file/dir named "b"
@@ -370,7 +369,7 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	fpath2 := filepath.Join(dir, "file2.txt")
 
 	// Create
-	assertNoError(t, ioutil.WriteFile(fpath, []byte("hello"), 0o640))
+	assertNoError(t, os.WriteFile(fpath, []byte("hello"), 0o640))
 
 	ev, err := readTimeout(t, watcher)
 	assertNoError(t, err)

--- a/auditbeat/module/file_integrity/scanner_test.go
+++ b/auditbeat/module/file_integrity/scanner_test.go
@@ -19,7 +19,6 @@ package file_integrity
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -164,16 +163,16 @@ func TestScanner(t *testing.T) {
 }
 
 func setupTestDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "audit-file-scan")
+	dir, err := os.MkdirTemp("", "audit-file-scan")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(dir, "a"), []byte("file a"), 0o600); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, "a"), []byte("file a"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(dir, "b"), []byte("file b"), 0o600); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, "b"), []byte("file b"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -185,7 +184,7 @@ func setupTestDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(dir, "subdir", "c"), []byte("file c"), 0o600); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, "subdir", "c"), []byte("file c"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auditbeat/module/file_integrity/scanner_test.go
+++ b/auditbeat/module/file_integrity/scanner_test.go
@@ -163,32 +163,29 @@ func TestScanner(t *testing.T) {
 }
 
 func setupTestDir(t *testing.T) string {
-	dir, err := os.MkdirTemp("", "audit-file-scan")
-	if err != nil {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "a"), []byte("file a"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, "a"), []byte("file a"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "b"), []byte("file b"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, "b"), []byte("file b"), 0o600); err != nil {
+	if err := os.Symlink(filepath.Join(dir, "b"), filepath.Join(dir, "link_to_b")); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.Symlink(filepath.Join(dir, "b"), filepath.Join(dir, "link_to_b")); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.Mkdir(filepath.Join(dir, "subdir"), 0o700); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "subdir", "c"), []byte("file c"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, "subdir", "c"), []byte("file c"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err = os.Symlink(filepath.Join(dir, "subdir"), filepath.Join(dir, "link_to_subdir")); err != nil {
+	if err := os.Symlink(filepath.Join(dir, "subdir"), filepath.Join(dir, "link_to_subdir")); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auditbeat/module/file_integrity/security_windows_test.go
+++ b/auditbeat/module/file_integrity/security_windows_test.go
@@ -18,7 +18,6 @@
 package file_integrity
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -29,7 +28,7 @@ import (
 
 func TestGetNamedSecurityInfo(t *testing.T) {
 	// Create a temp file that we will use in checking the owner.
-	file, err := ioutil.TempFile("", "go")
+	file, err := os.CreateTemp("", "go")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auditbeat/testing/setup.go
+++ b/auditbeat/testing/setup.go
@@ -18,7 +18,6 @@
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,7 +28,7 @@ import (
 func SetupDataDir(t testing.TB) func() {
 	// path.data should be set so that the DB is written to a predictable location.
 	var err error
-	paths.Paths.Data, err = ioutil.TempDir("", "beat-data-dir")
+	paths.Paths.Data, err = os.MkdirTemp("", "beat-data-dir")
 	if err != nil {
 		t.Fatal()
 	}


### PR DESCRIPTION
## Proposed commit message

As per https://pkg.go.dev/io/ioutil, packages `io` and `os` should be preferred to `io/ioutil`

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
