### PR TITLE
[Heartbeat] Decreases the ES default timeout to 10 for the load monitor state requests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,7 +27,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Switch types of `log.file.device`, `log.file.inode`, `log.file.idxhi`, `log.file.idxlo` and `log.file.vol` fields to strings to better align with ECS and integrations. {pull}36697[36697]
 
 *Heartbeat*
-
+- Decreases the ES default timeout to 10 for the load monitor state requests
 
 *Metricbeat*
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -344,9 +344,12 @@ func makeESClient(cfg *conf.C, attempts int, wait time.Duration) (*eslegclient.C
 
 	// Clone original config since we don't want this change to be global
 	newCfg, err := conf.NewConfigFrom(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error cloning config: %w", err)
+	}
 	timeout := int64((10 * time.Second).Seconds())
 	if err := newCfg.SetInt("timeout", -1, timeout); err != nil {
-		return nil, fmt.Errorf("error setting the ES timeout in config after %d attempts, with %s delay: %w", attempts, wait, err)
+		return nil, fmt.Errorf("error setting the ES timeout in config: %w", err)
 	}
 
 	for i := 0; i < attempts; i++ {

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -341,13 +341,16 @@ func makeESClient(cfg *conf.C, attempts int, wait time.Duration) (*eslegclient.C
 	// Higher values of timeouts cannot be applied on the SAAS Service
 	// where we are running in tight loops and want the next successive check to be run for a given monitor
 	// within the next scheduled interval which could be 1m or 3m
+
+	// Clone original config since we don't want this change to be global
+	newCfg, err := conf.NewConfigFrom(cfg)
 	timeout := int64((10 * time.Second).Seconds())
-	if err := cfg.SetInt("timeout", -1, timeout); err != nil {
+	if err := newCfg.SetInt("timeout", -1, timeout); err != nil {
 		return nil, fmt.Errorf("error setting the ES timeout in config after %d attempts, with %s delay: %w", attempts, wait, err)
 	}
 
 	for i := 0; i < attempts; i++ {
-		esClient, err = eslegclient.NewConnectedClient(cfg, "Heartbeat")
+		esClient, err = eslegclient.NewConnectedClient(newCfg, "Heartbeat")
 		if err == nil {
 			connectDelay.Reset()
 			return esClient, nil

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -339,7 +339,7 @@ func makeESClient(cfg *conf.C, attempts int, wait time.Duration) (*eslegclient.C
 
 	// Overriding the default ES request timeout:
 	// Higher values of timeouts cannot be applied on the SAAS Service
-	// where we are running in tight loops and want the next succesive check to be run for a given monitor
+	// where we are running in tight loops and want the next successive check to be run for a given monitor
 	// within the next scheduled interval which could be 1m or 3m
 	timeout := int64((10 * time.Second).Seconds())
 	if err := cfg.SetInt("timeout", -1, timeout); err != nil {

--- a/heartbeat/beater/heartbeat_test.go
+++ b/heartbeat/beater/heartbeat_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 	"time"
 
-	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
 func TestMakeESClient(t *testing.T) {
@@ -38,7 +39,7 @@ func TestMakeESClient(t *testing.T) {
 		anyAttempt := 1
 		anyDuration := 1 * time.Second
 
-		makeESClient(origCfg, anyAttempt, anyDuration)
+		_, _ = makeESClient(origCfg, anyAttempt, anyDuration)
 
 		timeout, err := origCfg.Int("timeout", -1)
 		require.NoError(t, err)

--- a/heartbeat/beater/heartbeat_test.go
+++ b/heartbeat/beater/heartbeat_test.go
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"testing"
+	"time"
+
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeESClient(t *testing.T) {
+	t.Run("should not modify the timeout setting from original config", func(t *testing.T) {
+		origTimeout := 90
+		origCfg, _ := conf.NewConfigFrom(map[interface{}]interface{}{
+			"hosts":    []string{"http://localhost:9200"},
+			"username": "anyuser",
+			"password": "anypwd",
+			"timeout":  origTimeout,
+		})
+		anyAttempt := 1
+		anyDuration := 1 * time.Second
+
+		makeESClient(origCfg, anyAttempt, anyDuration)
+
+		timeout, err := origCfg.Int("timeout", -1)
+		require.NoError(t, err)
+		assert.EqualValues(t, origTimeout, timeout)
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/elastic/beats/issues/36676

Decreases the ES default timeout (which is 90s) to 10s for the load monitor state requests. Please, see the issue for additional details.



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

**First:**

To reproduce the timeout when loading the monitor state, I created a Node.js server with "slow-response" endpoints:

```
const app3 = express()
const port3 = 3005

app3.use(cors())
app3.use(express.static('./'))

app3.get("*", (req, res) => {
  setTimeout(() => {
    res.end("hello fake ES")
  }, 45000)
})

app3.post("*", (req, res) => {
  setTimeout(() => {
    res.end("hello fake ES")
  }, 45000)
})

app3.listen(port3, () => {
  console.log(`Example app listening at http://localhost:${port3}`)
});
```

**Second:**

I added these two lines at the very beginning of [MakeEsLoader](https://github.com/elastic/beats/blob/48e0660ff060ed1f74f8d29eea093fa0779f1fb4/heartbeat/monitors/wrappers/monitorstate/esloader.go#L35):

```
	esc.URL = "http://localhost:3005/timeout"
	esc.ConnectionSettings.URL = "http://localhost:3005/timeout"
```
<img width="878" alt="Screenshot" src="https://github.com/elastic/beats/assets/15065076/fb4018e8-a346-416d-b181-22782772bc59">


**Final step**

1. Build heartbeat
2. Set up a monitor
3. Run HB


