### PR TITLE
Update Docker install docs with volume mount for registry files

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -167,6 +167,7 @@ docker run -d \
   --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
+  --volume="registry:/usr/share/{beatname_lc}/data:rw \  
   {dockerimage} {beatname_lc} -e --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------


### PR DESCRIPTION
Docker install docs should include volume mount for the registry. See issue for details.

Closes: #22586

---

![Screenshot 2023-11-06 at 9 07 24 AM](https://github.com/elastic/beats/assets/41695641/1bba5caa-1c59-451b-b98b-ebc9333b4010)
