### PR TITLE
Fix typo in Docker registry volume mount step

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -167,7 +167,7 @@ docker run -d \
   --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
-  --volume="registry:/usr/share/{beatname_lc}/data:rw \  
+  --volume="registry:/usr/share/{beatname_lc}/data:rw" \  
   {dockerimage} {beatname_lc} -e --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------


### PR DESCRIPTION
Fixes a typo that I introduced in https://github.com/elastic/beats/pull/37043