### PR TITLE
Remove Functionbeat from 'Get started with Beats'

### DIFF
--- a/libbeat/docs/getting-started.asciidoc
+++ b/libbeat/docs/getting-started.asciidoc
@@ -5,7 +5,6 @@ Each Beat is a separately installable product. To learn how to get started, see:
 
 * {auditbeat-ref}/auditbeat-installation-configuration.html[Auditbeat]
 * {filebeat-ref}/filebeat-installation-configuration.html[Filebeat]
-* {functionbeat-ref}/functionbeat-installation-configuration.html[Functionbeat]
 * {heartbeat-ref}/heartbeat-installation-configuration.html[Heartbeat]
 * {metricbeat-ref}/metricbeat-installation-configuration.html[Metricbeat]
 * {packetbeat-ref}/packetbeat-installation-configuration.html[Packetbeat]


### PR DESCRIPTION
This removes the Functionbeat entry from the [Get started with Beats](https://www.elastic.co/guide/en/beats/libbeat/current/getting-started.html) page. This is part of deprecating the Functionbeat docs in favour of Elastic Serverless Forwarder.

Rel: https://github.com/elastic/ingest-docs/issues/608

![Screenshot 2023-11-07 at 12 35 59 PM](https://github.com/elastic/beats/assets/41695641/66b9c4de-ddef-4b5d-87c0-b863d6e0db76)
