### PR TITLE
[auditbeat] fix golangci lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ issues:
     - text: "imported and not used"
       linters:
         - typecheck
-    # From mage we are priting to the console to ourselves
+    # From mage we are printing to the console to ourselves
     - path: (.*magefile.go|.*dev-tools/mage/.*)
       linters: forbidigo
 
@@ -43,7 +43,7 @@ linters:
   enable:
     - errcheck # checking for unchecked errors in go programs
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - forbidigo # forbids identifiers	matched by reg exps
+    - forbidigo # forbids identifiers matched by reg exps
     - gosimple # linter for Go source code that specializes in simplifying a code
     - misspell # finds commonly misspelled English words in comments
     - nakedret # finds naked returns in functions greater than a specified function length
@@ -79,7 +79,8 @@ linters-settings:
     exclude-functions:
       - (github.com/elastic/elastic-agent-libs/mapstr.M).Delete # Only returns ErrKeyNotFound, can safely be ignored.
       - (github.com/elastic/elastic-agent-libs/mapstr.M).Put # Can only fail on type conversions, usually safe to ignore.
-      - (github.com/elastic/elastic-agent-libs/logp).TestingSetup # Cannot return a non-nil error using the provided API.
+      - github.com/elastic/elastic-agent-libs/logp.TestingSetup # Cannot return a non-nil error using the provided API.
+      - github.com/elastic/elastic-agent-libs/logp.DevelopmentSetup # Cannot return a non-nil error using the provided API.
 
   errorlint:
     # Check whether fmt.Errorf uses the %w verb for formatting errors. See the readme for caveats

--- a/auditbeat/helper/hasher/hasher.go
+++ b/auditbeat/helper/hasher/hasher.go
@@ -199,7 +199,7 @@ func (hasher *FileHasher) HashFile(path string) (map[HashType]Digest, error) {
 		}
 	}
 
-	var hashes []hash.Hash
+	var hashes []hash.Hash //nolint:prealloc // Preallocating doesn't bring improvements.
 	for _, hashType := range hasher.config.HashTypes {
 		h, valid := validHashes[hashType]
 		if !valid {

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -72,7 +72,7 @@ var (
 )
 
 func TestImmutable(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	// Create a mock netlink client that provides the expected responses.
 	mock := NewMock().
@@ -107,7 +107,7 @@ func TestImmutable(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	// Create a mock netlink client that provides the expected responses.
 	mock := NewMock().
@@ -140,7 +140,7 @@ func TestData(t *testing.T) {
 }
 
 func TestLoginType(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	// Create a mock netlink client that provides the expected responses.
 	mock := NewMock().
@@ -259,7 +259,7 @@ func TestUnicastClient(t *testing.T) {
 		t.Skip("-audit was not specified")
 	}
 
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	FailIfAuditdIsRunning(t)
 
 	c := map[string]interface{}{
@@ -289,7 +289,7 @@ func TestMulticastClient(t *testing.T) {
 		t.Skip("no multicast support")
 	}
 
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	FailIfAuditdIsRunning(t)
 
 	c := map[string]interface{}{

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -349,7 +349,7 @@ func TestBuildMetricbeatEvent(t *testing.T) {
 }
 
 func buildSampleEvent(t testing.TB, lines []string, filename string) {
-	var msgs []*auparse.AuditMessage
+	var msgs []*auparse.AuditMessage //nolint:prealloc // Preallocating doesn't bring improvements.
 	for _, txt := range lines {
 		m, err := auparse.ParseLogLine(txt)
 		if err != nil {

--- a/auditbeat/module/auditd/config_test.go
+++ b/auditbeat/module/auditd/config_test.go
@@ -265,7 +265,7 @@ func parseConfig(t testing.TB, yaml string) (Config, error) {
 }
 
 func commands(rules []auditRule) []string {
-	var cmds []string
+	var cmds []string //nolint:prealloc // Preallocating doesn't bring improvements.
 	for _, r := range rules {
 		cmds = append(cmds, r.flags)
 	}

--- a/auditbeat/module/file_integrity/fileinfo_test.go
+++ b/auditbeat/module/file_integrity/fileinfo_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMetadata(t *testing.T) {
@@ -38,7 +39,7 @@ func TestNewMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Sync()
+	require.NoError(t, f.Sync())
 	f.Close()
 
 	info, err := os.Lstat(f.Name())
@@ -103,7 +104,7 @@ func TestSetUIDSetGIDBits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Sync()
+	require.NoError(t, f.Sync())
 	f.Close()
 
 	info, err := os.Lstat(f.Name())

--- a/auditbeat/module/file_integrity/metricset.go
+++ b/auditbeat/module/file_integrity/metricset.go
@@ -41,7 +41,7 @@ const (
 	namespace = "."
 )
 
-var underTest = false
+var underTest bool //nolint:unused // Used in Darwin-only builds.
 
 func init() {
 	mb.Registry.MustAddMetricSet(moduleName, metricsetName, New,

--- a/auditbeat/module/file_integrity/monitor/monitor.go
+++ b/auditbeat/module/file_integrity/monitor/monitor.go
@@ -45,7 +45,7 @@ func New(recursive bool, IsExcludedPath func(path string) bool) (Watcher, error)
 	// Use our simulated recursive watches unless the fsnotify implementation
 	// supports OS-provided recursive watches
 	if recursive && watcher.SetRecursive() != nil {
-		return newRecursiveWatcher(watcher, IsExcludedPath), nil
+		return newRecursiveWatcher(watcher, IsExcludedPath), nil //nolint:nilerr // Ignore SetRecursive() errors.
 	}
 	return (*nonRecursiveWatcher)(watcher), nil
 }

--- a/auditbeat/module/file_integrity/monitor/recursive.go
+++ b/auditbeat/module/file_integrity/monitor/recursive.go
@@ -144,20 +144,19 @@ func (watcher *recursiveWatcher) deliver(ev fsnotify.Event) {
 	}
 }
 
-func (watcher *recursiveWatcher) forwardEvents() error {
+func (watcher *recursiveWatcher) forwardEvents() {
 	defer watcher.close()
 
 	for {
 		select {
 		case <-watcher.done:
-			return nil
-
+			return
 		case path := <-watcher.addC:
 			watcher.addErrC <- watcher.addRecursive(path)
 
 		case event, ok := <-watcher.inner.Events:
 			if !ok {
-				return nil
+				return
 			}
 			if event.Name == "" {
 				continue

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -66,9 +66,7 @@ type registryEntry struct {
 }
 
 func newInputTestingEnvironment(t *testing.T) *inputTestingEnvironment {
-	if err := logp.DevelopmentSetup(logp.ToObserverOutput()); err != nil {
-		t.Fatalf("error setting up dev logging: %s", err)
-	}
+	logp.DevelopmentSetup(logp.ToObserverOutput())
 
 	t.Cleanup(func() {
 		if t.Failed() {

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -265,15 +265,14 @@ scanner:
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 
-		err := logp.DevelopmentSetup(logp.ToObserverOutput())
-		require.NoError(t, err)
+		logp.DevelopmentSetup(logp.ToObserverOutput())
 
 		fw := createWatcherWithConfig(t, paths, cfgStr)
 		go fw.Run(ctx)
 
 		basename := "created.log"
 		filename := filepath.Join(dir, basename)
-		err = os.WriteFile(filename, nil, 0777)
+		err := os.WriteFile(filename, nil, 0777)
 		require.NoError(t, err)
 
 		t.Run("issues a warning in logs", func(t *testing.T) {
@@ -373,8 +372,7 @@ scanner:
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		err = logp.DevelopmentSetup(logp.ToObserverOutput())
-		require.NoError(t, err)
+		logp.DevelopmentSetup(logp.ToObserverOutput())
 
 		fw := createWatcherWithConfig(t, paths, cfgStr)
 

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -733,9 +733,7 @@ func printDebugLogsOnFailure(t *testing.T) {
 	// Use the following line to have the logs being printed
 	// in real time.
 	// logp.DevelopmentSetup(logp.WithLevel(logp.DebugLevel), logp.WithSelectors("*"))
-	if err := logp.DevelopmentSetup(logp.ToObserverOutput()); err != nil {
-		t.Fatalf("error setting up dev logging: %s", err)
-	}
+	logp.DevelopmentSetup(logp.ToObserverOutput())
 
 	t.Cleanup(func() {
 		if t.Failed() {

--- a/libbeat/cmd/instance/locks/lock_test.go
+++ b/libbeat/cmd/instance/locks/lock_test.go
@@ -30,11 +30,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	err := logp.DevelopmentSetup()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error creating logger: %s\n", err)
-		os.Exit(1)
-	}
+	logp.DevelopmentSetup()
+
 	tmp, err := os.MkdirTemp("", "pidfile_test")
 	defer os.RemoveAll(tmp)
 	if err != nil {

--- a/libbeat/esleg/eslegclient/bulkapi_mock_test.go
+++ b/libbeat/esleg/eslegclient/bulkapi_mock_test.go
@@ -36,8 +36,7 @@ import (
 )
 
 func TestOneHostSuccessResp_Bulk(t *testing.T) {
-	setupErr := logp.TestingSetup(logp.WithSelectors("elasticsearch"))
-	require.NoError(t, setupErr)
+	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 	expectedResp := []byte(`{"took":7,"errors":false,"items":[]}`)
 
@@ -73,8 +72,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 }
 
 func TestOneHost500Resp_Bulk(t *testing.T) {
-	setupErr := logp.TestingSetup(logp.WithSelectors("elasticsearch"))
-	require.NoError(t, setupErr)
+	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
 	ops := []map[string]interface{}{
@@ -113,8 +111,7 @@ func TestOneHost500Resp_Bulk(t *testing.T) {
 }
 
 func TestOneHost503Resp_Bulk(t *testing.T) {
-	setupErr := logp.TestingSetup(logp.WithSelectors("elasticsearch"))
-	require.NoError(t, setupErr)
+	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
 	ops := []map[string]interface{}{

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -431,7 +431,7 @@ func TestCollectPublishFailAll(t *testing.T) {
 }
 
 func TestCollectPipelinePublishFail(t *testing.T) {
-	_ = logp.TestingSetup(logp.WithSelectors("elasticsearch"))
+	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 
 	client, err := NewClient(
 		ClientSettings{

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -52,7 +52,7 @@ func (e *MockEC2Client) DescribeTags(ctx context.Context, params *ec2.DescribeTa
 }
 
 func TestMain(m *testing.M) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	code := m.Run()
 	os.Exit(code)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
@@ -88,7 +88,7 @@ func initAzureTestServer() *httptest.Server {
 }
 
 func TestRetrieveAzureMetadata(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	server := initAzureTestServer()
 	defer server.Close()

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -308,7 +308,7 @@ func initGCETestServer(resp string) *httptest.Server {
 }
 
 func TestRetrieveGCEMetadata(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	server := initGCETestServer(gceMetadataV1)
 	defer server.Close()
@@ -357,7 +357,7 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 }
 
 func TestRetrieveGCEMetadataInK8s(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	server := initGCETestServer(gceK8sMetadataV1)
 	defer server.Close()
@@ -412,7 +412,7 @@ func TestRetrieveGCEMetadataInK8s(t *testing.T) {
 }
 
 func TestRetrieveGCEMetadataInK8sNotOverriden(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	server := initGCETestServer(gceK8sMetadataV1)
 	defer server.Close()
@@ -478,7 +478,7 @@ func TestRetrieveGCEMetadataInK8sNotOverriden(t *testing.T) {
 }
 
 func TestRetrieveGCEMetadataInK8sPartial(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	server := initGCETestServer(gceK8sPartialMetadataV1)
 	defer server.Close()

--- a/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud_test.go
@@ -54,7 +54,7 @@ func hetznerMetadataHandler() http.HandlerFunc {
 }
 
 func TestRetrieveHetznerMetadata(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	server := httptest.NewServer(hetznerMetadataHandler())
 	defer server.Close()

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -28,7 +28,6 @@ import (
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -39,7 +38,7 @@ import (
 )
 
 func TestAddProcessMetadata(t *testing.T) {
-	require.NoError(t, logp.TestingSetup(logp.WithSelectors(processorName)))
+	logp.TestingSetup(logp.WithSelectors(processorName))
 
 	startTime := time.Now()
 	testProcs := testProvider{
@@ -817,7 +816,7 @@ func TestAddProcessMetadata(t *testing.T) {
 }
 
 func TestUsingCache(t *testing.T) {
-	require.NoError(t, logp.TestingSetup(logp.WithSelectors(processorName)))
+	logp.TestingSetup(logp.WithSelectors(processorName))
 
 	selfPID := os.Getpid()
 
@@ -926,7 +925,7 @@ func TestUsingCache(t *testing.T) {
 }
 
 func TestSelf(t *testing.T) {
-	require.NoError(t, logp.TestingSetup(logp.WithSelectors(processorName)))
+	logp.TestingSetup(logp.WithSelectors(processorName))
 
 	config, err := conf.NewConfigFrom(mapstr.M{
 		"match_pids": []string{"self_pid"},
@@ -960,7 +959,7 @@ func TestSelf(t *testing.T) {
 }
 
 func TestBadProcess(t *testing.T) {
-	require.NoError(t, logp.TestingSetup(logp.WithSelectors(processorName)))
+	logp.TestingSetup(logp.WithSelectors(processorName))
 
 	config, err := conf.NewConfigFrom(mapstr.M{
 		"match_pids": []string{"self_pid"},

--- a/libbeat/processors/script/javascript/module/processor/processor_test.go
+++ b/libbeat/processors/script/javascript/module/processor/processor_test.go
@@ -67,7 +67,7 @@ function process(evt) {
 }
 `
 
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
 	require.NoError(t, err)
 
@@ -103,7 +103,7 @@ function process(evt) {
 }
 `
 
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
 	require.NoError(t, err)
 
@@ -128,7 +128,7 @@ function process(evt) {
 }
 `
 
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	_, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
 	require.Error(t, err, "processor that implements Closer() shouldn't be allowed")
 }

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -83,8 +83,7 @@ func TestClient(t *testing.T) {
 			},
 		}
 
-		err := logp.TestingSetup()
-		assert.Nil(t, err)
+		logp.TestingSetup()
 
 		for name, test := range cases {
 			t.Run(name, func(t *testing.T) {
@@ -141,8 +140,7 @@ func TestClientWaitClose(t *testing.T) {
 
 		return p
 	}
-	err := logp.TestingSetup()
-	assert.Nil(t, err)
+	logp.TestingSetup()
 
 	q := memqueue.NewQueue(logp.L(), nil, memqueue.Settings{Events: 1}, 0)
 	pipeline := makePipeline(Settings{}, q)

--- a/libbeat/publisher/queue/queuetest/log.go
+++ b/libbeat/publisher/queue/queuetest/log.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"testing"
 
-	"gotest.tools/assert"
-
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -88,8 +86,7 @@ func withOptLogOutput(capture bool, fn func(*testing.T)) func(*testing.T) {
 		if debug {
 			level = logp.DebugLevel
 		}
-		err = logp.DevelopmentSetup(logp.WithLevel(level))
-		assert.NilError(t, err)
+		logp.DevelopmentSetup(logp.WithLevel(level))
 		fn(t)
 	}
 }

--- a/metricbeat/module/system/filesystem/filesystem_test.go
+++ b/metricbeat/module/system/filesystem/filesystem_test.go
@@ -34,8 +34,7 @@ import (
 func TestFetch(t *testing.T) {
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2Error(f)
-	err := logp.DevelopmentSetup()
-	assert.NoError(t, err)
+	logp.DevelopmentSetup()
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
 		t.FailNow()

--- a/metricbeat/module/system/process/process_test.go
+++ b/metricbeat/module/system/process/process_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/system"
@@ -33,8 +32,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	err := logp.DevelopmentSetup()
-	require.NoError(t, err, "could not set the logger to DevelopmentSetup")
+	logp.DevelopmentSetup()
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2Error(f)

--- a/metricbeat/module/system/process_summary/process_summary_test.go
+++ b/metricbeat/module/system/process_summary/process_summary_test.go
@@ -42,8 +42,7 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	err := logp.DevelopmentSetup()
-	require.NoError(t, err)
+	logp.DevelopmentSetup()
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2Error(f)
 
@@ -53,14 +52,13 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
 		event.StringToPrint())
 
-	_, err = event.GetValue("system.process.summary")
+	_, err := event.GetValue("system.process.summary")
 	require.NoError(t, err)
 
 }
 
 func TestStateNames(t *testing.T) {
-	err := logp.DevelopmentSetup()
-	require.NoError(t, err)
+	logp.DevelopmentSetup()
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2Error(f)
 

--- a/packetbeat/decoder/decoder_test.go
+++ b/packetbeat/decoder/decoder_test.go
@@ -91,7 +91,7 @@ var ipv4TcpDNS = []byte{
 
 // Test that DecodePacket decodes and IPv4/TCP packet and invokes the TCP processor.
 func TestDecodePacketData_ipv4Tcp(t *testing.T) {
-	_ = logp.TestingSetup(logp.WithSelectors("decoder"))
+	logp.TestingSetup(logp.WithSelectors("decoder"))
 
 	p := gopacket.NewPacket(ipv4TcpDNS, layers.LinkTypeEthernet, gopacket.Default)
 	if p.ErrorLayer() != nil {

--- a/packetbeat/flows/flows_test.go
+++ b/packetbeat/flows/flows_test.go
@@ -42,7 +42,7 @@ func (f *flowsChan) PublishFlows(events []beat.Event) {
 }
 
 func TestFlowsCounting(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	mac1 := []byte{1, 2, 3, 4, 5, 6}
 	mac2 := []byte{6, 5, 4, 3, 2, 1}

--- a/packetbeat/flows/worker_test.go
+++ b/packetbeat/flows/worker_test.go
@@ -37,7 +37,7 @@ import (
 var dataFlag = flag.Bool("data", false, "Write updated data.json files")
 
 func TestCreateEvent(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	// Build biflow event.
 	start := time.Unix(1542292881, 0)

--- a/packetbeat/procs/procs_linux_test.go
+++ b/packetbeat/procs/procs_linux_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestFindSocketsOfPid(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	proc := []testProcFile{
 		{path: "/proc/766/fd/0", isLink: true, contents: "/dev/null"},

--- a/packetbeat/procs/procs_test.go
+++ b/packetbeat/procs/procs_test.go
@@ -78,7 +78,7 @@ func (w *mockWatcher) GetLocalIPs() ([]net.IP, error) {
 }
 
 func TestFindProcessTuple(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	config := ProcsConfig{
 		Enabled: true,
 		Monitored: []ProcConfig{

--- a/packetbeat/protos/dhcpv4/dhcpv4_test.go
+++ b/packetbeat/protos/dhcpv4/dhcpv4_test.go
@@ -82,7 +82,7 @@ var (
 )
 
 func TestParseDHCPRequest(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 	p, err := newPlugin(true, nil, &procs.ProcessesWatcher{}, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -97,7 +97,7 @@ func newDNS(store *eventStore, verbose bool) *dnsPlugin {
 	if verbose {
 		level = logp.DebugLevel
 	}
-	_ = logp.DevelopmentSetup(
+	logp.DevelopmentSetup(
 		logp.WithLevel(level),
 		logp.WithSelectors("dns"),
 	)

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -103,7 +103,7 @@ type TestStruct struct {
 
 // Helper method for creating mocks and the Udp instance under test.
 func testSetup(t *testing.T) *TestStruct {
-	_ = logp.TestingSetup(logp.WithSelectors("udp"))
+	logp.TestingSetup(logp.WithSelectors("udp"))
 
 	protocols := &TestProtocols{}
 	protocols.udp = make(map[protos.Protocol]protos.UDPPlugin)

--- a/winlogbeat/sys/wineventlog/iterator_test.go
+++ b/winlogbeat/sys/wineventlog/iterator_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestEventIterator(t *testing.T) {
-	logp.TestingSetup() //nolint:errcheck // Not needed.
+	logp.TestingSetup()
 
 	writer, tearDown := createLog(t)
 	defer tearDown()

--- a/winlogbeat/sys/wineventlog/metadata_store_test.go
+++ b/winlogbeat/sys/wineventlog/metadata_store_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestPublisherMetadataStore(t *testing.T) {
-	logp.TestingSetup() //nolint:errcheck // Not needed.
+	logp.TestingSetup()
 
 	s, err := NewPublisherMetadataStore(
 		NilHandle,

--- a/winlogbeat/sys/wineventlog/renderer_test.go
+++ b/winlogbeat/sys/wineventlog/renderer_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 func TestRenderer(t *testing.T) {
-	logp.TestingSetup() //nolint:errcheck // Bad linter! Never returns a non-nil error when called without options.
+	logp.TestingSetup()
 
 	t.Run(filepath.Base(sysmon9File), func(t *testing.T) {
 		log := openLog(t, sysmon9File)

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -45,7 +45,7 @@ func TestData(t *testing.T) {
 }
 
 func TestDpkg(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	defer abtest.SetupDataDir(t)()
 
@@ -104,7 +104,7 @@ func TestDpkgInstalledSize(t *testing.T) {
 		"python2.7-minimal": 0,
 	}
 
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	defer abtest.SetupDataDir(t)()
 

--- a/x-pack/filebeat/input/awscloudwatch/input_integration_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/input_integration_test.go
@@ -132,8 +132,7 @@ func uploadLogMessage(t *testing.T, svc *cloudwatchlogs.Client, message string, 
 }
 
 func TestInputWithLogGroupNamePrefix(t *testing.T) {
-	err := logp.TestingSetup()
-	assert.Nil(t, err)
+	logp.TestingSetup()
 
 	// Terraform is used to set up S3 and SQS and must be executed manually.
 	tfConfig := getTerraformOutputs(t)

--- a/x-pack/filebeat/input/awss3/input_benchmark_test.go
+++ b/x-pack/filebeat/input/awss3/input_benchmark_test.go
@@ -256,7 +256,7 @@ func benchmarkInputSQS(t *testing.T, maxMessagesInflight int) testing.BenchmarkR
 }
 
 func TestBenchmarkInputSQS(t *testing.T) {
-	_ = logp.TestingSetup(logp.WithLevel(logp.InfoLevel))
+	logp.TestingSetup(logp.WithLevel(logp.InfoLevel))
 
 	results := []testing.BenchmarkResult{
 		benchmarkInputSQS(t, 1),
@@ -393,7 +393,7 @@ func benchmarkInputS3(t *testing.T, numberOfWorkers int) testing.BenchmarkResult
 }
 
 func TestBenchmarkInputS3(t *testing.T) {
-	_ = logp.TestingSetup(logp.WithLevel(logp.InfoLevel))
+	logp.TestingSetup(logp.WithLevel(logp.InfoLevel))
 
 	results := []testing.BenchmarkResult{
 		benchmarkInputS3(t, 1),

--- a/x-pack/filebeat/input/awss3/s3_objects_test.go
+++ b/x-pack/filebeat/input/awss3/s3_objects_test.go
@@ -53,8 +53,7 @@ func newS3GetObjectResponse(filename string, data []byte, contentType string) *s
 }
 
 func TestS3ObjectProcessor(t *testing.T) {
-	err := logp.TestingSetup()
-	assert.Nil(t, err)
+	logp.TestingSetup()
 
 	t.Run("download text/plain file", func(t *testing.T) {
 		testProcessS3Object(t, "testdata/log.txt", "text/plain", 2)

--- a/x-pack/filebeat/input/awss3/s3_test.go
+++ b/x-pack/filebeat/input/awss3/s3_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func TestS3Poller(t *testing.T) {
-	err := logp.TestingSetup()
-	assert.Nil(t, err)
+	logp.TestingSetup()
 
 	const bucket = "bucket"
 	const numberOfWorkers = 5

--- a/x-pack/filebeat/input/awss3/sqs_s3_event_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestSQSS3EventProcessor(t *testing.T) {
-	require.NoError(t, logp.TestingSetup())
+	logp.TestingSetup()
 
 	msg := newSQSMessage(newS3Event("log.json"))
 
@@ -237,7 +237,7 @@ func TestSqsProcessor_keepalive(t *testing.T) {
 }
 
 func TestSqsProcessor_getS3Notifications(t *testing.T) {
-	require.NoError(t, logp.TestingSetup())
+	logp.TestingSetup()
 
 	p := newSQSS3EventProcessor(logp.NewLogger(inputName), nil, nil, nil, time.Minute, 5, nil, nil, 5)
 

--- a/x-pack/filebeat/input/awss3/sqs_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_test.go
@@ -29,8 +29,7 @@ var (
 )
 
 func TestSQSReceiver(t *testing.T) {
-	err := logp.TestingSetup()
-	assert.Nil(t, err)
+	logp.TestingSetup()
 
 	const maxMessages = 5
 
@@ -113,8 +112,7 @@ func TestSQSReceiver(t *testing.T) {
 }
 
 func TestGetApproximateMessageCount(t *testing.T) {
-	err := logp.TestingSetup()
-	assert.Nil(t, err)
+	logp.TestingSetup()
 
 	const maxMessages = 5
 	const count = 500

--- a/x-pack/filebeat/input/cometd/cometd_integration_test.go
+++ b/x-pack/filebeat/input/cometd/cometd_integration_test.go
@@ -55,7 +55,7 @@ func (ec *eventCaptor) Done() <-chan struct{} {
 
 func TestInput(t *testing.T) {
 	t.Skip("flaky test: https://github.com/elastic/beats/issues/33423")
-	logp.TestingSetup(logp.WithSelectors("cometd input", "cometd")) //nolint:errcheck // Bad linter! no need to test this.
+	logp.TestingSetup(logp.WithSelectors("cometd input", "cometd"))
 
 	// Setup the input config.
 	config := conf.MustNewConfigFrom(mapstr.M{

--- a/x-pack/filebeat/input/gcppubsub/pubsub_test.go
+++ b/x-pack/filebeat/input/gcppubsub/pubsub_test.go
@@ -57,7 +57,7 @@ func testSetup(t *testing.T) (*pubsub.Client, context.CancelFunc) {
 	}
 
 	once.Do(func() {
-		_ = logp.TestingSetup()
+		logp.TestingSetup()
 
 		// Disable HTTP keep-alives to ensure no extra goroutines hang around.
 		httpClient := http.Client{Transport: &http.Transport{DisableKeepAlives: true}}

--- a/x-pack/filebeat/input/lumberjack/server_test.go
+++ b/x-pack/filebeat/input/lumberjack/server_test.go
@@ -69,7 +69,7 @@ func TestServer(t *testing.T) {
 }
 
 func testSendReceive(t testing.TB, c config, numberOfEvents int, clientTLSConfig *tls.Config) {
-	require.NoError(t, logp.TestingSetup())
+	logp.TestingSetup()
 	log := logp.NewLogger(inputName).With("test_name", t.Name())
 
 	ctx, shutdown := context.WithTimeout(context.Background(), testTimeout)

--- a/x-pack/filebeat/module/cisco/ios/pipeline_test.go
+++ b/x-pack/filebeat/module/cisco/ios/pipeline_test.go
@@ -176,7 +176,7 @@ var testCases = []testCase{
 }
 
 func TestFilebeatSyslogCisco(t *testing.T) {
-	_ = logp.TestingSetup()
+	logp.TestingSetup()
 
 	p, err := javascript.NewFromConfig(
 		javascript.Config{File: "config/pipeline.js"},

--- a/x-pack/metricbeat/module/gcp/metrics/metrics_requester_test.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metrics_requester_test.go
@@ -76,10 +76,7 @@ func TestGetTimeIntervalAligner(t *testing.T) {
 }
 
 func TestGetFilterForMetric(t *testing.T) {
-	if err := logp.DevelopmentSetup(logp.ToObserverOutput()); err != nil {
-		t.Fatalf("cannot initialise logger on development mode: %+v", err)
-	}
-
+	logp.DevelopmentSetup(logp.ToObserverOutput())
 	var logger = logp.NewLogger("TestGetFilterForMetric")
 
 	cases := []struct {


### PR DESCRIPTION
## Proposed commit message

- Fix auditbeat's golangci-lint errors
- Fix exclude rule for `logp.TestingSetup()` and add exclude rule for `logp.DevelopmentSetup()`
- Standardize all instances of `logp.TestingSetup()` and `logp.DevelopmentSetup()` to not check for errors

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

