### PR TITLE
Fix memqueue getting stuck on shutdown

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -61,6 +61,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Upgraded apache arrow library used in x-pack/libbeat/reader/parquet from v11 to v12.0.1 in order to fix cross-compilation issues {pull}35640[35640]
 - Fix panic when MaxRetryInterval is specified, but RetryInterval is not {pull}35820[35820]
 - Support build of projects outside of beats directory {pull}36126[36126]
+- Fix memqueue producer blocking indefinitely even after being cancelled {issue}22813[22813] {pull}37077[37077]
 
 *Auditbeat*
 

--- a/libbeat/publisher/queue/memqueue/queue_test.go
+++ b/libbeat/publisher/queue/memqueue/queue_test.go
@@ -23,10 +23,13 @@ import (
 	"math"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"gotest.tools/assert"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/queuetest"
@@ -72,6 +75,78 @@ func TestProduceConsumer(t *testing.T) {
 
 	t.Run("direct", testWith(makeTestQueue(bufferSize, 0, 0)))
 	t.Run("flush", testWith(makeTestQueue(bufferSize, batchSize/2, 100*time.Millisecond)))
+}
+
+// TestProducerDoesNotBlockWhenCancelled ensures the producer Publish
+// does not block indefinitely.
+//
+// Once we get a producer `p` from the queue we want to ensure
+// that if p.Publish is called and blocks it will unblock once
+// p.Cancel is called.
+//
+// For this test we start a queue with size 2 and try to add more
+// than 2 events to it, p.Publish will block, once we call p.Cancel,
+// we ensure the 3rd event was not successfully published.
+func TestProducerDoesNotBlockWhenCancelled(t *testing.T) {
+	q := NewQueue(nil, nil,
+		Settings{
+			Events:         2, // Queue size
+			FlushMinEvents: 1, // make sure the queue won't buffer events
+			FlushTimeout:   time.Millisecond,
+		}, 0)
+
+	p := q.Producer(queue.ProducerConfig{
+		// We do not read from the queue, so the callbacks are never called
+		ACK:          func(count int) {},
+		OnDrop:       func(e interface{}) {},
+		DropOnCancel: false,
+	})
+
+	success := atomic.Bool{}
+	publishCount := atomic.Int32{}
+	go func() {
+		// Publish 2 events, this will make the queue full, but
+		// both will be accepted
+		for i := 0; i < 2; i++ {
+			id, ok := p.Publish(fmt.Sprintf("Event %d", i))
+			if !ok {
+				t.Errorf("failed to publish to the queue, event ID: %v", id)
+				return
+			}
+			publishCount.Add(1)
+		}
+		_, ok := p.Publish("Event 3")
+		if ok {
+			t.Errorf("publishing the 3rd event must fail")
+			return
+		}
+
+		// Flag the test as successful
+		success.Store(true)
+	}()
+
+	// Allow the producer to run and the queue to do its thing.
+	// Two events should be accepted and the third call to p.Publish
+	// must block
+	// time.Sleep(100 * time.Millisecond)
+
+	// Ensure we published two events
+	require.Eventually(
+		t,
+		func() bool { return publishCount.Load() == 2 },
+		200*time.Millisecond,
+		time.Millisecond,
+		"the first two events were not successfully published")
+
+	// Cancel the producer, this should unblock its Publish method
+	p.Cancel()
+
+	require.Eventually(
+		t,
+		success.Load,
+		200*time.Millisecond,
+		1*time.Millisecond,
+		"test not flagged as successful, p.Publish likely blocked indefinitely")
 }
 
 func TestQueueMetricsDirect(t *testing.T) {


### PR DESCRIPTION
## Proposed commit message

There was a case when openState.publish could get stuck and ignore its shutdown signal, effectively preventing a Beat (confirmed with Filebeat) from gracefully terminating.

This commit fixes this by ensuring every channel read/write also checks for the shutdown signal.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~


## How to test this PR locally
1. Create a server that will reply with logs. I used [my fork from flog](https://github.com/belimawr/flog)
    Build/install and run with `flog -t http -f json`, this will start an HTTP server on `:3000`
2. Build Filebeat from the `x-pack` folder
4. Use the following `filebeat.yml`
      <details><summary>filebeat.yml</summary>
      <p>
      
      ```yaml
      filebeat.inputs:
        - type: httpjson
          interval: 5s
          config_version: 2
          request.url: http://localhost:3000
          response.pagination:
            - set:
                target: url.params.foo
                value: '[[.last_response.body.bytes]]'
          cursor:
            last_requested_at:
              value: '[[now]]'
          processors:
            - decode_json_fields:
                fields: ["message"]
                target: ""
                add_error_key: true
                overwrite_keys: true
      queue:
        mem:
          events: 32
          flush.min_events: 32
      
      output:
        elasticsearch:
          allow_older_versions: true
          hosts:
            - https://localhost:9200
          ssl.verification_mode: none
          protocol: https
          username: elastic
          password: changeme
      
      logging:
        level: debug
        to_stderr: true
      ```
      
      </p>
      </details> 
4. Do NOT deploy an Elasticsearch, you want the output blocked and the queue full!
5. Start filebeat, it will log to `stdout`
6. Wait until no more events are published and the only logs are metrics and reconnection attempts
      ```
      {"log.level":"info","@timestamp":"2023-11-10T18:57:08.999+0100","log.logger":"monitoring","log.origin":{"file.name":"log/log.go","file.line":187},"message":"Non-zero metrics in the last 30s","service.name":"filebeat","monitoring":{"metrics":{"beat":{"cgroup":{"memory":{"mem":{"usage":{"bytes":4805419008}}}},"cpu":{"system":{"ticks":30},"total":{"ticks":150,"value":150},"user":{"ticks":120}},"handles":{"limit":{"hard":524288,"soft":524288},"open":10},"info":{"ephemeral_id":"127caa76-6bef-4760-81ca-5465c5eb0604","uptime":{"ms":90041},"version":"8.12.0"},"memstats":{"gc_next":36516080,"memory_alloc":20845056,"memory_total":75824200,"rss":115867648},"runtime":{"goroutines":23}},"filebeat":{"events":{"active":33},"harvester":{"open_files":0,"running":0}},"libbeat":{"config":{"module":{"running":0}},"output":{"events":{"active":0}},"pipeline":{"clients":1,"events":{"active":33}}},"registrar":{"states":{"current":0}},"system":{"load":{"1":1.27,"15":0.77,"5":0.87,"norm":{"1":0.0794,"15":0.0481,"5":0.0544}}}},"ecs.version":"1.6.0"}}
      {"log.level":"error","@timestamp":"2023-11-10T18:57:09.666+0100","log.logger":"publisher_pipeline_output","log.origin":{"file.name":"pipeline/client_worker.go","file.line":154},"message":"Failed to connect to backoff(elasticsearch(https://localhost:9200)): Get \"https://localhost:9200\": dial tcp 127.0.0.1:9200: connect: connection refused","service.name":"filebeat","ecs.version":"1.6.0"}
      {"log.level":"info","@timestamp":"2023-11-10T18:57:09.666+0100","log.logger":"publisher_pipeline_output","log.origin":{"file.name":"pipeline/client_worker.go","file.line":145},"message":"Attempting to reconnect to backoff(elasticsearch(https://localhost:9200)) with 6 reconnect attempt(s)","service.name":"filebeat","ecs.version":"1.6.0"}
      {"log.level":"debug","@timestamp":"2023-11-10T18:57:09.666+0100","log.logger":"esclientleg","log.origin":{"file.name":"eslegclient/connection.go","file.line":284},"message":"ES Ping(url=https://localhost:9200)","service.name":"filebeat","ecs.version":"1.6.0"}
      {"log.level":"error","@timestamp":"2023-11-10T18:57:09.667+0100","log.logger":"esclientleg","log.origin":{"file.name":"transport/logging.go","file.line":38},"message":"Error dialing dial tcp 127.0.0.1:9200: connect: connection refused","service.name":"filebeat","network":"tcp","address":"localhost:9200","ecs.version":"1.6.0"}
      {"log.level":"debug","@timestamp":"2023-11-10T18:57:09.667+0100","log.logger":"esclientleg","log.origin":{"file.name":"eslegclient/connection.go","file.line":288},"message":"Ping request failed with: Get \"https://localhost:9200\": dial tcp 127.0.0.1:9200: connect: connection refused","service.name":"filebeat","ecs.version":"1.6.0"}
      ```
7. Hit `CTRL+C` or send a `SIGTERM` to Filebeat
8. It should gracefully shutdown within a few seconds.

Even though the issue is within the queue implementation, some inputs will eventually shutdown (like filestream) even if the Publish call got stuck, the httpjson input will stay blocked for ever.

## Related issues
- Closes https://github.com/elastic/beats/issues/22813

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~