### PR TITLE
Update documentation to use ingest_pipeline metricset

### DIFF
--- a/metricbeat/module/elasticsearch/ingest_pipeline/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/ingest_pipeline/_meta/docs.asciidoc
@@ -17,6 +17,6 @@ processor-level metrics will be collected during 25% of the time. This can be co
 - module: elasticsearch
   period: 10s
   metricsets:
-    - ingest
+    - ingest_pipeline
   ingest.processor_sample_rate: 0.1 # decrease to 10% of fetches
 ----


### PR DESCRIPTION
As confirmed by Dev in this comment https://github.com/elastic/sdh-beats/issues/4050#issuecomment-1808008624 the metricset name for collecting elasticsearch ingest data should be `ingest_pipeline` and not `ingest`.

## Proposed commit message
Update configuration example for `ingest_pipeline` metricset so it includes the right name, since it was wrongly name `ingest` instead of `ingest_pipeline`.

