### PR TITLE
Update example command to change an index name

### DIFF
--- a/libbeat/docs/howto/change-index-name.asciidoc
+++ b/libbeat/docs/howto/change-index-name.asciidoc
@@ -9,7 +9,7 @@ in the {es} output. You also need to configure the `setup.template.name` and
 ["source","sh",subs="attributes,callouts"]
 -----
 output.elasticsearch.index: "customname-%{[{beat_version_key}]}"
-setup.template.name: "customname"
+setup.template.name: "customname-%{[{beat_version_key}]}"
 setup.template.pattern: "customname-%{[{beat_version_key}]}"
 -----
 


### PR DESCRIPTION
This adds a correction to the "[Change the index name](https://www.elastic.co/guide/en/beats/filebeat/current/change-index-name.html)" docs page.

Closes: #37117 

---

**Original:**

![Screenshot 2023-11-15 at 10 09 17 AM](https://github.com/elastic/beats/assets/41695641/f42788e9-22fe-4231-9520-6bb8ab00130e)

---

**Fixed by this PR:**

![Screenshot 2023-11-15 at 10 05 58 AM](https://github.com/elastic/beats/assets/41695641/f3e92875-fd72-41cc-83c0-82d9651a204d)
