### PR TITLE
x-pack/auditbeat/module/socket/guess: fix creds trigger for newer kernels

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -67,6 +67,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 *Auditbeat*
 
 - Fix documentation regarding socket type selection. {issue}37174[37174] {pull}37175[37175]
+- Fix guess trigger for system/socket creds on newer kernels. {issue}36905[36905] {pull}37136[37136]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/socket/guess/creds.go
+++ b/x-pack/auditbeat/module/system/socket/guess/creds.go
@@ -20,6 +20,17 @@ import (
 )
 
 /*
+struct mq_attr {
+	long mq_flags;
+	long mq_maxmsg;
+	long mq_msgsize;
+	long mq_curmsgs;
+	long __reserved[4];
+};
+*/
+import "C"
+
+/*
 	creds guess discovers the offsets of (E)UID/(E)GID fields within a
     struct cred (defined in {linux}/include/linux.cred.h):
 		struct cred {
@@ -77,20 +88,20 @@ func (g *guessStructCreds) Provides() []string {
 // Requires declares the variables required to run this guess.
 func (g *guessStructCreds) Requires() []string {
 	return []string{
-		"RET",
+		"P3",
 	}
 }
 
-// Probes returns a kretprobe on prepare_creds that dumps the first bytes
-// pointed to by the return value, which is a struct cred.
+// Probes returns a kprobe on dentry_open that dumps the first bytes
+// pointed to by the third parameter value, which is a struct cred.
 func (g *guessStructCreds) Probes() ([]helper.ProbeDef, error) {
 	return []helper.ProbeDef{
 		{
 			Probe: tracing.Probe{
-				Type:      tracing.TypeKRetProbe,
+				Type:      tracing.TypeKProbe,
 				Name:      "guess_struct_creds",
-				Address:   "prepare_creds",
-				Fetchargs: helper.MakeMemoryDump("{{.RET}}", 0, credDumpBytes),
+				Address:   "dentry_open",
+				Fetchargs: helper.MakeMemoryDump("{{.P3}}", 0, credDumpBytes),
 			},
 			Decoder: tracing.NewDumpDecoder,
 		},
@@ -138,13 +149,26 @@ func (g *guessStructCreds) Extract(ev interface{}) (mapstr.M, bool) {
 	}, true
 }
 
-// Trigger invokes the SYS_ACCESS syscall:
+// Trigger invokes the SYS_MQ_OPEN syscall:
 //
-//	int access(const char *pathname, int mode);
-//
-// The function call will return an error due to path being NULL, but it will
-// have invoked prepare_creds before argument validation.
+//	int mq_open(const char *name, int oflag, mode_t mode, struct mq_attr *attr);
 func (g *guessStructCreds) Trigger() error {
-	syscall.Syscall(unix.SYS_ACCESS, 0, 0, 0)
-	return nil
+	name, err := unix.BytePtrFromString("__guess_creds")
+	if err != nil {
+		return err
+	}
+	attr := C.struct_mq_attr{
+		mq_maxmsg:  1,
+		mq_msgsize: 8,
+	}
+	mqd, _, errno := syscall.Syscall6(unix.SYS_MQ_OPEN,
+		uintptr(unsafe.Pointer(name)),
+		uintptr(os.O_CREATE|os.O_RDWR),
+		0o644,
+		uintptr(unsafe.Pointer(&attr)),
+		0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return unix.Close(int(mqd))
 }

--- a/x-pack/auditbeat/seccomp_linux.go
+++ b/x-pack/auditbeat/seccomp_linux.go
@@ -16,12 +16,22 @@ func init() {
 		// The system/package dataset uses librpm which has additional syscall
 		// requirements beyond the default policy from libbeat so whitelist
 		// these additional syscalls.
-		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "umask", "mremap"); err != nil {
+		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall,
+			"mremap",
+			"umask",
+		); err != nil {
 			panic(err)
 		}
 
 		// The system/socket dataset uses additional syscalls
-		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "perf_event_open", "eventfd2", "ppoll", "mount", "umount2"); err != nil {
+		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall,
+			"eventfd2",
+			"mount",
+			"mq_open", // required for creds kprobe guess trigger.
+			"perf_event_open",
+			"ppoll",
+			"umount2",
+		); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

In kernel commit [981ee95c](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?h=981ee95cc1f5905ae4936b0dd501085909cdc14f) (into v6.3) calls to access_override_creds
were gated behind a test for the requirement for the call. This change
results in non-execution of prepare_creds and so failure of the guess.

An alternative has been identified that does not exhibit this behaviour,
mq_open which calls dentry_open with creds in the third parameter. So
replace the sys_access trigger with sys_mq_open and add the probe to
dentry_open with P3 for the address.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #36905

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
