### PR TITLE
[kibana] pass unique `service.address` value

### DIFF
--- a/metricbeat/module/kibana/cluster_actions/data.go
+++ b/metricbeat/module/kibana/cluster_actions/data.go
@@ -90,9 +90,9 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 		RootFields: mapstr.M{
 			"service.id":      serviceId,
 			"service.version": version,
-			"service.address": serviceAddress,
 		},
 		MetricSetFields: actionsFields,
+		Host:            fmt.Sprintf("%v", serviceAddress),
 	}
 
 	// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`

--- a/metricbeat/module/kibana/cluster_rules/data.go
+++ b/metricbeat/module/kibana/cluster_rules/data.go
@@ -90,9 +90,9 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 		RootFields: mapstr.M{
 			"service.id":      serviceId,
 			"service.version": version,
-			"service.address": serviceAddress,
 		},
 		MetricSetFields: rulesFields,
+		Host:            fmt.Sprintf("%v", serviceAddress),
 	}
 
 	// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`

--- a/metricbeat/module/kibana/node_actions/data.go
+++ b/metricbeat/module/kibana/node_actions/data.go
@@ -86,9 +86,9 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 		RootFields: mapstr.M{
 			"service.id":      serviceId,
 			"service.version": version,
-			"service.address": serviceAddress,
 		},
 		MetricSetFields: actionsFields,
+		Host:            fmt.Sprintf("%v", serviceAddress),
 	}
 
 	// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`

--- a/metricbeat/module/kibana/node_rules/data.go
+++ b/metricbeat/module/kibana/node_rules/data.go
@@ -86,9 +86,9 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 		RootFields: mapstr.M{
 			"service.id":      serviceId,
 			"service.version": version,
-			"service.address": serviceAddress,
 		},
 		MetricSetFields: rulesFields,
+		Host:            fmt.Sprintf("%v", serviceAddress),
 	}
 
 	// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`

--- a/metricbeat/module/kibana/stats/data.go
+++ b/metricbeat/module/kibana/stats/data.go
@@ -158,6 +158,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 		return event.Error
 	}
 	_, _ = event.RootFields.Put("service.address", serviceAddress)
+	event.Host = fmt.Sprintf("%v", serviceAddress)
 
 	// Set process PID
 	process, ok := data["process"].(map[string]interface{})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Summary

This change ensures all kibana metricsets set a unique `service.address` value. This is necessary for TSDB migration as we want to use this field as a dimension

## How to test this PR locally
- ingest kibana data
```
metricbeat.modules:
  - module: kibana
    xpack.enabled: true
    period: 10s
    hosts: ["http://localhost:5601"]
    username: "elastic"
    password: "changeme"
```
- verify kibana metricsets publish the same unique value for `service.address`

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/37167
