### PR TITLE
Fix incorrect indentation in YAML examples

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -1145,14 +1145,14 @@ filebeat.inputs:
   chain:
     # second call
     - step:
-      request.url: https://example.com/services/data/v1.0/$.records[:].id/export_ids
-      request.method: GET
-      replace: $.records[:].id
+        request.url: https://example.com/services/data/v1.0/$.records[:].id/export_ids
+        request.method: GET
+        replace: $.records[:].id
     # third call
     - step:
-      request.url: https://example.com/services/data/v1.0/export_ids/$.file_name/info
-      request.method: GET
-      replace: $.file_name
+        request.url: https://example.com/services/data/v1.0/export_ids/$.file_name/info
+        request.method: GET
+        replace: $.file_name
 ----
 
 Example:
@@ -1257,9 +1257,9 @@ filebeat.inputs:
   chain:
     # second call
     - step:
-      request.url: https://example.com/services/data/v1.0/$.exportId/files
-      request.method: GET
-      replace_with: '$.exportId,.first_response.body.exportId'
+        request.url: https://example.com/services/data/v1.0/$.exportId/files
+        request.method: GET
+        replace_with: '$.exportId,.first_response.body.exportId'
 ----
 
 Example:


### PR DESCRIPTION
Copy-pasting these examples would lead to `step: null`.

<img width="857" alt="Screenshot 2023-11-23 at 10 33 37" src="https://github.com/elastic/beats/assets/887952/88a10070-ca0c-4ffc-860d-4561b1f8f80e">
<img width="787" alt="Screenshot 2023-11-23 at 10 33 19" src="https://github.com/elastic/beats/assets/887952/4b0d841b-d472-4d16-89cb-c75373c5dcbd">
<img width="868" alt="Screenshot 2023-11-23 at 10 32 58" src="https://github.com/elastic/beats/assets/887952/5623d86a-7248-4eb8-874b-9f7e67a2931a">
