### PR TITLE
add required tags for AWS instances using for testing in CI

### DIFF
--- a/x-pack/metricbeat/module/aws/terraform.tf
+++ b/x-pack/metricbeat/module/aws/terraform.tf
@@ -7,6 +7,10 @@ provider "aws" {
       branch       = var.BRANCH
       build        = var.BUILD_ID
       created_date = var.CREATED_DATE
+      division     = "engineering"
+      org          = "obs"
+      team         = "cloud-monitoring"
+      project      = "metricbeat_aws-ci"
     }
   }
 }


### PR DESCRIPTION
We have some CI failures which we suspect may be related to the cloud resources tagging policy - this PR adds the required tags to the AWS resources created in CI.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.