### PR TITLE
[DOCS] Note that '--once' is not supported with filestream input

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -744,6 +744,10 @@ and inputs, and runs each input until the harvesters are closed. If you set the
 `--once` flag, you should also set `close_eof` so the harvester is closed when
 the end of the file is reached. By default harvesters are closed after
 `close_inactive` is reached.
++
+The `--once` option is not currently supported with the
+{filebeat-ref}/filebeat-input-filestream.html[`filestream`] input type.
+
 endif::[]
 
 *`--system.hostfs MOUNT_POINT`*::


### PR DESCRIPTION
This updates the Filebeat [command reference](https://www.elastic.co/guide/en/beats/filebeat/current/command-line-options.html) page as shown:

![Screenshot 2023-11-28 at 10 58 27 AM](https://github.com/elastic/beats/assets/41695641/2d71517f-329a-46ae-9bae-9d11d24685da)

Closes: #31416