### PR TITLE
[Osquerybeat] Add augeas support

### DIFF
--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -151,13 +151,17 @@ func (bt *osquerybeat) Run(b *beat.Beat) error {
 	defer cleanupFn()
 
 	// Create osqueryd runner
-	osq := osqd.New(
+	osq, err := osqd.New(
 		socketPath,
 		osqd.WithLogger(bt.log),
 		osqd.WithConfigRefresh(configurationRefreshIntervalSecs),
 		osqd.WithConfigPlugin(configPluginName),
 		osqd.WithLoggerPlugin(loggerPluginName),
 	)
+
+	if err != nil {
+		return err
+	}
 
 	// Check that osqueryd exists and runnable
 	err = osq.Check(ctx)

--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -36,6 +36,11 @@ const (
 	osqueryCertsDarwinPath  = "private/var/osquery/certs/" + osqueryCertsPEM
 	osqueryCertsWindowsPath = "osquery/certs/" + osqueryCertsPEM
 
+	osqueryLensesLinuxDir  = "opt/osquery/share/osquery/lenses"
+	osqueryLensesDarwinDir = "private/var/osquery/lenses"
+
+	osqueryLensesDir = "lenses"
+
 	osqueryVersion = "5.10.2"
 	osqueryMSIExt  = ".msi"
 	osqueryPkgExt  = ".pkg"
@@ -90,6 +95,10 @@ func OsquerydCertsPath(dir string) string {
 	return filepath.Join(dir, osqueryCertsPath)
 }
 
+func OsquerydLensesDir(dir string) string {
+	return filepath.Join(dir, osqueryLensesDir)
+}
+
 func OsquerydDarwinDistroPath() string {
 	return osqueryDarwinPath
 }
@@ -108,6 +117,14 @@ func OsquerydCertsDarwinDistroPath() string {
 
 func OsquerydCertsWindowsDistroPath() string {
 	return osqueryCertsWindowsPath
+}
+
+func OsquerydLensesLinuxDistroDir() string {
+	return osqueryLensesLinuxDir
+}
+
+func OsquerydLensesDarwinDistroDir() string {
+	return osqueryLensesDarwinDir
 }
 
 func OsquerydDistroFilename() string {

--- a/x-pack/osquerybeat/internal/fetch/fetch.go
+++ b/x-pack/osquerybeat/internal/fetch/fetch.go
@@ -7,7 +7,7 @@ package fetch
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -26,18 +26,18 @@ func Download(ctx context.Context, url, fp string) (hashout string, err error) {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	res, err := cli.Do(req)
 	if err != nil {
-		return
+		return "", err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		// Read body for extended error message
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		var s string
 		if err != nil {
 			log.Printf("Failed to read the error response body: %v", err)
@@ -49,7 +49,7 @@ func Download(ctx context.Context, url, fp string) (hashout string, err error) {
 
 	out, err := os.OpenFile(fp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
-		return
+		return "", err
 	}
 	defer out.Close()
 

--- a/x-pack/osquerybeat/internal/install/verify_test.go
+++ b/x-pack/osquerybeat/internal/install/verify_test.go
@@ -6,7 +6,6 @@ package install
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,7 +16,7 @@ import (
 // setupFiles helper function that creates subdirectory with a given set of files
 // The verification currently checks for the file presence only
 func setupFiles(testdataBaseDir string, files []string) (string, error) {
-	testdir, err := ioutil.TempDir(testdataBaseDir, "")
+	testdir, err := os.MkdirTemp(testdataBaseDir, "")
 	if err != nil {
 		return "", err
 	}
@@ -31,7 +30,7 @@ func setupFiles(testdataBaseDir string, files []string) (string, error) {
 			return "", err
 		}
 
-		err = ioutil.WriteFile(fp, nil, 0600)
+		err = os.WriteFile(fp, nil, 0600)
 		if err != nil {
 			return "", err
 		}
@@ -117,7 +116,7 @@ func TestVerify(t *testing.T) {
 	}
 
 	// Setup test data
-	testdataBaseDir, err := ioutil.TempDir("", "")
+	testdataBaseDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/osquerybeat/internal/osqd/args.go
+++ b/x-pack/osquerybeat/internal/osqd/args.go
@@ -92,6 +92,9 @@ var protectedFlags = Flags{
 
 	// certificates to use for curl table for example
 	"tls_server_certs": "certs.pem",
+
+	// Augeas lenses are bundled with osquery distributions
+	"augeas_lenses": "lenses",
 }
 
 func init() {

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
@@ -7,7 +7,6 @@ package osqd
 import (
 	"bufio"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,13 +28,16 @@ func TestNew(t *testing.T) {
 	configPluginName := "config_plugin_test"
 	loggerPluginName := "logger_plugin_test"
 
-	osq := New(
+	osq, err := New(
 		socketPath,
 		WithExtensionsTimeout(extensionsTimeout),
 		WithConfigRefresh(configurationRefreshIntervalSecs),
 		WithConfigPlugin(configPluginName),
 		WithLoggerPlugin(loggerPluginName),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	diff := cmp.Diff(extensionsTimeout, osq.extensionsTimeout)
 	if diff != "" {
@@ -76,7 +78,7 @@ func TestPrepareAutoloadFile(t *testing.T) {
 	mandatoryExtensionPath := filepath.Join(dir, extensionName)
 
 	// Write fake extension file for testing
-	err := ioutil.WriteFile(mandatoryExtensionPath, nil, 0600)
+	err := os.WriteFile(mandatoryExtensionPath, nil, 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +123,7 @@ func TestPrepareAutoloadFile(t *testing.T) {
 			// Setup
 			extensionAutoloadPath := filepath.Join(t.TempDir(), osqueryAutoload)
 
-			err = ioutil.WriteFile(extensionAutoloadPath, tc.FileContent, 0600)
+			err = os.WriteFile(extensionAutoloadPath, tc.FileContent, 0600)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
@@ -9,7 +9,6 @@ package osqd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,12 +22,12 @@ const (
 func CreateSocketPath() (string, func(), error) {
 	// Try to create socket in /var/run first
 	// This would result in something the directory something like: /var/run/027202467
-	tpath, err := ioutil.TempDir("/var/run", "")
+	tpath, err := os.MkdirTemp("/var/run", "")
 	if err != nil {
 		var perr *os.PathError
 		if errors.As(err, &perr) {
 			if errors.Is(perr.Err, syscall.EACCES) {
-				tpath, err = ioutil.TempDir("", "")
+				tpath, err = os.MkdirTemp("", "")
 				if err != nil {
 					return "", nil, err
 				}

--- a/x-pack/osquerybeat/internal/tar/tar.go
+++ b/x-pack/osquerybeat/internal/tar/tar.go
@@ -24,9 +24,9 @@ func shouldExtract(name string, files ...string) bool {
 	// In the osquery 4.9.0 version the paths started to be prefixed with "./"
 	// which caused the osqueryd binary not found/extracted from the archive.
 	name = filepath.Clean(name)
-
 	for _, f := range files {
-		if strings.HasPrefix(f, name) {
+		if strings.HasPrefix(name, f) ||
+			strings.HasPrefix(f, name) {
 			return true
 		}
 	}
@@ -58,7 +58,8 @@ func Extract(r io.Reader, destinationDir string, files ...string) error {
 			}
 			return err
 		}
-		if !shouldExtract(header.Name, files...) {
+		shouldExtract := shouldExtract(header.Name, files...)
+		if !shouldExtract {
 			continue
 		}
 

--- a/x-pack/osquerybeat/scripts/mage/package.go
+++ b/x-pack/osquerybeat/scripts/mage/package.go
@@ -47,6 +47,12 @@ func CustomizePackaging() {
 			Mode:   0640,
 			Source: filepath.Join(distro.GetDataInstallDir(distro.OSArch{OS: args.OS, Arch: arch}), "certs", "certs.pem"),
 		}
+
 		args.Spec.Files[filepath.Join("certs", "certs.pem")] = certsFile
+
+		// Augeas lenses are not available for Windows
+		if args.OS != "windows" {
+			args.Spec.Files["lenses"] = devtools.PackageFile{Source: filepath.Join(distro.GetDataInstallDir(distro.OSArch{OS: args.OS, Arch: arch}), "lenses")}
+		}
 	}
 }


### PR DESCRIPTION
## [Osquerybeat] Add augeas support

* Package augeas ```lenses``` files from the official osquery distro with osquerybeat. This adds another 1.2MB uncompressed to the agent install.
* Add another protected flag support https://osquery.readthedocs.io/en/latest/installation/cli-flags/#augeas-flags
* Fix the pathing issue that didn't pick up the certs packages with osquerybeat. It looks like the working directory for the agent managed beats changed to something like ```./data/elastic-agent-3afa07/run/osquery-default``` so the relative path specified for osquery was not correctly referring to the bundled certs, thus failing queries on ```curl``` table.
* Update Go deprecated APIs calls, that are now flagged with linter.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Run the agent with ```osquery_manager``` integration on macOS, linux and windows and make sure it still works. The queries against ```augeas``` table return results on macOS and linux, for example: 
```
SELECT label, value FROM augeas WHERE path = '/etc/ssh/sshd_config' and label='AuthorizedKeysFile';
```
The queries against ```augeas``` table will fail on windows, since that osquery table doesn't exist.


## Related issues

- Closes https://github.com/elastic/beats/issues/37224

## Screenshots

Tested on macOS

<img width="1230" alt="Screenshot 2023-11-28 at 8 18 13 PM" src="https://github.com/elastic/beats/assets/872351/62ab56c0-b07b-4749-b167-1c5bd5270d9b">

Tested on linux

<img width="1239" alt="Screenshot 2023-11-28 at 10 07 49 PM" src="https://github.com/elastic/beats/assets/872351/54139b92-7419-43c1-a3ba-bc5bb12bc073">


Tested on Windows, the table is not found as expected

<img width="1309" alt="Screenshot 2023-11-28 at 9 21 20 PM" src="https://github.com/elastic/beats/assets/872351/933f2eef-4eb7-4841-b185-72d9504c57c5">


