### PR TITLE
Support performance presets in the Elasticsearch output

### DIFF
--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -43,9 +43,10 @@ type elasticsearchConfig struct {
 	Backoff            Backoff           `config:"backoff"`
 	NonIndexablePolicy *config.Namespace `config:"non_indexable_policy"`
 	AllowOlderVersion  bool              `config:"allow_older_versions"`
+	Queue              config.Namespace  `config:"queue"`
+	Preset             preset            `config:"preset"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`
-	Queue     config.Namespace                 `config:"queue"`
 }
 
 type Backoff struct {

--- a/libbeat/outputs/elasticsearch/config_presets.go
+++ b/libbeat/outputs/elasticsearch/config_presets.go
@@ -1,0 +1,137 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+type preset string
+
+const (
+	presetNone       preset = ""
+	presetCustom     preset = "custom"
+	presetBalanced   preset = "balanced"
+	presetThroughput preset = "throughput"
+	presetScale      preset = "scale"
+	presetLatency    preset = "latency"
+)
+
+var configMaps = map[preset]*config.C{
+	presetNone:   config.MustNewConfigFrom(map[string]interface{}{}),
+	presetCustom: config.MustNewConfigFrom(map[string]interface{}{}),
+	presetBalanced: config.MustNewConfigFrom(map[string]interface{}{
+		"bulk_max_size":              1600,
+		"workers":                    1,
+		"queue.mem.events":           3200,
+		"queue.mem.flush.min_events": 1600,
+		"queue.mem.flush.timeout":    10 * time.Second,
+		"compression_level":          1,
+		"idle_connection_timeout":    3 * time.Second,
+	}),
+	presetThroughput: config.MustNewConfigFrom(map[string]interface{}{
+		"bulk_max_size":              1600,
+		"workers":                    4,
+		"queue.mem.events":           12800,
+		"queue.mem.flush.min_events": 1600,
+		"queue.mem.flush.timeout":    5 * time.Second,
+		"compression_level":          1,
+		"idle_connection_timeout":    15 * time.Second,
+	}),
+	presetScale: config.MustNewConfigFrom(map[string]interface{}{
+		"bulk_max_size":              1600,
+		"workers":                    1,
+		"queue.mem.events":           3200,
+		"queue.mem.flush.min_events": 1600,
+		"queue.mem.flush.timeout":    20 * time.Second,
+		"compression_level":          1,
+		"idle_connection_timeout":    1 * time.Second,
+	}),
+	presetLatency: config.MustNewConfigFrom(map[string]interface{}{
+		"bulk_max_size":              50,
+		"workers":                    1,
+		"queue.mem.events":           4100,
+		"queue.mem.flush.min_events": 2050,
+		"queue.mem.flush.timeout":    1 * time.Second,
+		"compression_level":          1,
+		"idle_connection_timeout":    60 * time.Second,
+	}),
+}
+
+// Make sure unpacked preset names are valid
+func (p *preset) Unpack(s string) error {
+	value := preset(s)
+	if err := value.Validate(); err != nil {
+		return err
+	}
+	*p = value
+	return nil
+}
+
+// Return an error if the preset name is unknown
+func (p *preset) Validate() error {
+	if configMaps[*p] == nil {
+		return fmt.Errorf("unknown preset name '%v'", p)
+	}
+	return nil
+}
+
+// Apply the configuration for c's "preset" field, returning a list of fields
+// in the provided user config that were overwritten.
+func applyPreset(
+	preset preset, target *elasticsearchConfig, userConfig *config.C,
+) ([]string, error) {
+	// Find the preset and unpack it
+	presetConfig := configMaps[target.Preset]
+	if presetConfig == nil {
+		// This should never happen because the Preset field is validated
+		// when it's first unpacked, but let's be cautious.
+		return nil, fmt.Errorf("unknown preset value %v", target.Preset)
+	}
+	err := presetConfig.Unpack(target)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for any user-provided fields that overlap with the preset.
+	// This will need refinement if we start supporting other queue
+	// types, since e.g. "queue.mem.events" and "queue.disk.events"
+	// don't have explicitly conflicting field names.
+	overridden := []string{}
+	userKeys := userConfig.FlattenedKeys()
+	presetKeys := presetConfig.FlattenedKeys()
+	for _, key := range userKeys {
+		if containsStr(presetKeys, key) {
+			overridden = append(overridden, key)
+		}
+	}
+	return overridden, nil
+}
+
+// TODO: Replace this with slices.Contains ones we hit Go 1.21.
+func containsStr(list []string, str string) bool {
+	for _, s := range list {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -55,6 +55,17 @@ func makeES(
 	if err := cfg.Unpack(&esConfig); err != nil {
 		return outputs.Fail(err)
 	}
+	// If a preset is specified, unpack its contents to overwrite the baseline
+	// config, but log a warning if we override anything explicitly specified
+	// in cfg.
+	overriddenFields, err := applyPreset(esConfig.Preset, &esConfig, cfg)
+	if err != nil {
+		return outputs.Fail(err)
+	}
+	for _, field := range overriddenFields {
+		log.Warnf("setting '%v' is ignored because of config preset '%v'",
+			field, esConfig.Preset)
+	}
 
 	policy, err := newNonIndexablePolicy(esConfig.NonIndexablePolicy)
 	if err != nil {


### PR DESCRIPTION
Still in draft while I add tests and documentation, though so far it seems to be working.

## Proposed commit message

Adds the performance presets described in https://github.com/elastic/elastic-agent/issues/3797 to the Elasticsearch output, configurable with the `preset` field.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Live config flags aren't directly exposed, but there are a few ways to confirm what's happening on a live run:
- Add e.g. `preset: balanced` to the Elasticsearch output config, and confirm that the resulting log files have the message `Applying performance preset 'balanced'`
- Add a preset and also a conflicting flag setting, e.g. `bulk_max_size: 500`, and confirm that the logs have the message `Setting 'bulk_max_size' is ignored because of performance preset`
- Configure the `throughput` preset with a large input load, and confirm that the process uses more than 1 CPU.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/3797