### PR TITLE
[Kubernetes Test] Fix lint error on ktest.go

### DIFF
--- a/metricbeat/helper/kubernetes/ktest/ktest.go
+++ b/metricbeat/helper/kubernetes/ktest/ktest.go
@@ -28,13 +28,13 @@ import (
 )
 
 func getFiles(folder string) ([]string, error) {
-	var files []string
 	entries, err := os.ReadDir(folder)
+	files := make([]string, len(entries))
 	if err != nil {
 		return nil, err
 	}
-	for _, e := range entries {
-		files = append(files, filepath.Join(folder, e.Name()))
+	for i, e := range entries {
+		files[i] = filepath.Join(folder, e.Name())
 	}
 	return files, nil
 }


### PR DESCRIPTION
## Proposed commit message


Please explain:

- WHAT: Fix the lint error on pre allocating the variables `files`.
- WHY:  I forgot to address [this comment](https://github.com/elastic/beats/pull/37240#discussion_r1415073493) on the related PR. This is the fix for that.

