### PR TITLE
Fix the performance regression when ingesting files on Windows

### DIFF
--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -28,6 +28,7 @@ import (
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-concert/unison"
 )
@@ -330,7 +331,7 @@ func (p *copyTruncateFileProspector) onRotatedFile(
 			return
 		}
 		descCopy := fe.Descriptor
-		descCopy.Info = fi
+		descCopy.Info = file.ExtendFileInfo(fi)
 		originalSrc := p.identifier.GetSource(loginp.FSEvent{NewPath: originalPath, Descriptor: descCopy})
 		p.rotatedFiles.addOriginalFile(originalPath, originalSrc)
 		p.rotatedFiles.addRotatedFile(originalPath, fe.NewPath, src)

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -37,6 +37,7 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common/acker"
+	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/beats/v7/libbeat/common/transform/typeconv"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
@@ -372,7 +373,13 @@ func (e *inputTestingEnvironment) getRegistryState(key string) (registryEntry, e
 
 func getIDFromPath(filepath, inputID string, fi os.FileInfo) string {
 	identifier, _ := newINodeDeviceIdentifier(nil)
-	src := identifier.GetSource(loginp.FSEvent{Descriptor: loginp.FileDescriptor{Info: fi}, Op: loginp.OpCreate, NewPath: filepath})
+	src := identifier.GetSource(loginp.FSEvent{
+		Descriptor: loginp.FileDescriptor{
+			Info: file.ExtendFileInfo(fi),
+		},
+		Op:      loginp.OpCreate,
+		NewPath: filepath,
+	})
 	return "filestream::" + inputID + "::" + src.Name()
 }
 

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/elastic/beats/v7/filebeat/input/file"
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	commonfile "github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -406,7 +407,7 @@ type ingestTarget struct {
 	filename         string
 	originalFilename string
 	symlink          bool
-	info             os.FileInfo
+	info             commonfile.ExtendedFileInfo
 }
 
 func (s *fileScanner) getIngestTarget(filename string) (it ingestTarget, err error) {
@@ -421,10 +422,11 @@ func (s *fileScanner) getIngestTarget(filename string) (it ingestTarget, err err
 	it.filename = filename
 	it.originalFilename = filename
 
-	it.info, err = os.Lstat(it.filename) // to determine if it's a symlink
+	info, err := os.Lstat(it.filename) // to determine if it's a symlink
 	if err != nil {
 		return it, fmt.Errorf("failed to lstat %q: %w", it.filename, err)
 	}
+	it.info = commonfile.ExtendFileInfo(info)
 
 	if it.info.IsDir() {
 		return it, fmt.Errorf("file %q is a directory", it.filename)
@@ -438,10 +440,11 @@ func (s *fileScanner) getIngestTarget(filename string) (it ingestTarget, err err
 		}
 
 		// now we know it's a symlink, we stat with link resolution
-		it.info, err = os.Stat(it.filename)
+		info, err := os.Stat(it.filename)
 		if err != nil {
 			return it, fmt.Errorf("failed to stat the symlink %q: %w", it.filename, err)
 		}
+		it.info = commonfile.ExtendFileInfo(info)
 
 		it.originalFilename, err = filepath.EvalSymlinks(it.filename)
 		if err != nil {

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/common/file"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -68,7 +69,7 @@ scanner:
 			Op:      loginp.OpCreate,
 			Descriptor: loginp.FileDescriptor{
 				Filename: filename,
-				Info:     testFileInfo{name: basename, size: 5}, // 5 bytes written
+				Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 5}), // 5 bytes written
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -91,7 +92,7 @@ scanner:
 			Op:      loginp.OpWrite,
 			Descriptor: loginp.FileDescriptor{
 				Filename: filename,
-				Info:     testFileInfo{name: basename, size: 10}, // +5 bytes appended
+				Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 10}), // +5 bytes appended
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -113,7 +114,7 @@ scanner:
 			Op:      loginp.OpRename,
 			Descriptor: loginp.FileDescriptor{
 				Filename: newFilename,
-				Info:     testFileInfo{name: newBasename, size: 10},
+				Info:     file.ExtendFileInfo(&testFileInfo{name: newBasename, size: 10}),
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -133,7 +134,7 @@ scanner:
 			Op:      loginp.OpTruncate,
 			Descriptor: loginp.FileDescriptor{
 				Filename: filename,
-				Info:     testFileInfo{name: basename, size: 2},
+				Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 2}),
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -153,7 +154,7 @@ scanner:
 			Op:      loginp.OpTruncate,
 			Descriptor: loginp.FileDescriptor{
 				Filename: filename,
-				Info:     testFileInfo{name: basename, size: 2},
+				Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 2}),
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -172,7 +173,7 @@ scanner:
 			Op:      loginp.OpDelete,
 			Descriptor: loginp.FileDescriptor{
 				Filename: filename,
-				Info:     testFileInfo{name: basename, size: 2},
+				Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 2}),
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -210,7 +211,7 @@ scanner:
 			Descriptor: loginp.FileDescriptor{
 				Filename:    filename,
 				Fingerprint: "2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
-				Info:        testFileInfo{name: basename, size: 1024},
+				Info:        file.ExtendFileInfo(&testFileInfo{name: basename, size: 1024}),
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -241,7 +242,7 @@ scanner:
 			Op:      loginp.OpCreate,
 			Descriptor: loginp.FileDescriptor{
 				Filename: filename,
-				Info:     testFileInfo{name: basename, size: 1024},
+				Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 1024}),
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -298,7 +299,7 @@ scanner:
 				Op:      loginp.OpCreate,
 				Descriptor: loginp.FileDescriptor{
 					Filename: filename,
-					Info:     testFileInfo{name: basename, size: 5}, // +5 bytes appended
+					Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 5}), // +5 bytes appended
 				},
 			}
 			requireEqualEvents(t, expEvent, e)
@@ -332,7 +333,7 @@ scanner:
 			Descriptor: loginp.FileDescriptor{
 				Filename:    filename,
 				Fingerprint: "2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
-				Info:        testFileInfo{name: basename, size: 1024},
+				Info:        file.ExtendFileInfo(&testFileInfo{name: basename, size: 1024}),
 			},
 		}
 		requireEqualEvents(t, expEvent, e)
@@ -384,7 +385,7 @@ scanner:
 				Op:      loginp.OpCreate,
 				Descriptor: loginp.FileDescriptor{
 					Filename: firstFilename,
-					Info:     testFileInfo{name: firstBasename, size: 5}, // "line\n"
+					Info:     file.ExtendFileInfo(&testFileInfo{name: firstBasename, size: 5}), // "line\n"
 				},
 			},
 			{
@@ -392,7 +393,7 @@ scanner:
 				Op:      loginp.OpCreate,
 				Descriptor: loginp.FileDescriptor{
 					Filename: secondFilename,
-					Info:     testFileInfo{name: secondBasename, size: 5}, // "line\n"
+					Info:     file.ExtendFileInfo(&testFileInfo{name: secondBasename, size: 5}), // "line\n"
 				},
 			},
 		}
@@ -494,38 +495,38 @@ scanner:
 			expDesc: map[string]loginp.FileDescriptor{
 				normalFilename: {
 					Filename: normalFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[normalFilename],
 						name: normalBasename,
-					},
+					}),
 				},
 				undersizedFilename: {
 					Filename: undersizedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[undersizedFilename],
 						name: undersizedBasename,
-					},
+					}),
 				},
 				excludedFilename: {
 					Filename: excludedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedFilename],
 						name: excludedBasename,
-					},
+					}),
 				},
 				excludedIncludedFilename: {
 					Filename: excludedIncludedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedIncludedFilename],
 						name: excludedIncludedBasename,
-					},
+					}),
 				},
 				travelerSymlinkFilename: {
 					Filename: travelerSymlinkFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[travelerFilename],
 						name: travelerSymlinkBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -543,31 +544,31 @@ scanner:
 			expDesc: map[string]loginp.FileDescriptor{
 				normalFilename: {
 					Filename: normalFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[normalFilename],
 						name: normalBasename,
-					},
+					}),
 				},
 				undersizedFilename: {
 					Filename: undersizedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[undersizedFilename],
 						name: undersizedBasename,
-					},
+					}),
 				},
 				excludedFilename: {
 					Filename: excludedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedFilename],
 						name: excludedBasename,
-					},
+					}),
 				},
 				excludedIncludedFilename: {
 					Filename: excludedIncludedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedIncludedFilename],
 						name: excludedIncludedBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -586,24 +587,24 @@ scanner:
 			expDesc: map[string]loginp.FileDescriptor{
 				normalFilename: {
 					Filename: normalFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[normalFilename],
 						name: normalBasename,
-					},
+					}),
 				},
 				undersizedFilename: {
 					Filename: undersizedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[undersizedFilename],
 						name: undersizedBasename,
-					},
+					}),
 				},
 				travelerSymlinkFilename: {
 					Filename: travelerSymlinkFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[travelerFilename],
 						name: travelerSymlinkBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -617,17 +618,17 @@ scanner:
 			expDesc: map[string]loginp.FileDescriptor{
 				normalFilename: {
 					Filename: normalFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[normalFilename],
 						name: normalBasename,
-					},
+					}),
 				},
 				undersizedFilename: {
 					Filename: undersizedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[undersizedFilename],
 						name: undersizedBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -646,10 +647,10 @@ scanner:
 			expDesc: map[string]loginp.FileDescriptor{
 				excludedIncludedFilename: {
 					Filename: excludedIncludedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedIncludedFilename],
 						name: excludedIncludedBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -663,10 +664,10 @@ scanner:
 			expDesc: map[string]loginp.FileDescriptor{
 				excludedIncludedFilename: {
 					Filename: excludedIncludedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedIncludedFilename],
 						name: excludedIncludedBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -680,17 +681,17 @@ scanner:
 			expDesc: map[string]loginp.FileDescriptor{
 				excludedIncludedFilename: {
 					Filename: excludedIncludedFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedIncludedFilename],
 						name: excludedIncludedBasename,
-					},
+					}),
 				},
 				travelerSymlinkFilename: {
 					Filename: travelerSymlinkFilename,
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[travelerFilename],
 						name: travelerSymlinkBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -709,34 +710,34 @@ scanner:
 				normalFilename: {
 					Filename:    normalFilename,
 					Fingerprint: "2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[normalFilename],
 						name: normalBasename,
-					},
+					}),
 				},
 				excludedFilename: {
 					Filename:    excludedFilename,
 					Fingerprint: "bd151321c3bbdb44185414a1b56b5649a00206dd4792e7230db8904e43987336",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedFilename],
 						name: excludedBasename,
-					},
+					}),
 				},
 				excludedIncludedFilename: {
 					Filename:    excludedIncludedFilename,
 					Fingerprint: "bfdb99a65297062658c26dfcea816d76065df2a2da2594bfd9b96e9e405da1c2",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedIncludedFilename],
 						name: excludedIncludedBasename,
-					},
+					}),
 				},
 				travelerSymlinkFilename: {
 					Filename:    travelerSymlinkFilename,
 					Fingerprint: "c4058942bffcea08810a072d5966dfa5c06eb79b902bf0011890dd8d22e1a5f8",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[travelerFilename],
 						name: travelerSymlinkBasename,
-					},
+					}),
 				},
 			},
 		},
@@ -755,35 +756,35 @@ scanner:
 				normalFilename: {
 					Filename:    normalFilename,
 					Fingerprint: "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[normalFilename],
 						name: normalBasename,
-					},
+					}),
 				},
 				// undersizedFilename got excluded because of the matching fingerprint
 				excludedFilename: {
 					Filename:    excludedFilename,
 					Fingerprint: "9c225a1e6a7df9c869499e923565b93937e88382bb9188145f117195cd41dcd1",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedFilename],
 						name: excludedBasename,
-					},
+					}),
 				},
 				excludedIncludedFilename: {
 					Filename:    excludedIncludedFilename,
 					Fingerprint: "7985b2b9750bdd3c76903db408aff3859204d6334279eaf516ecaeb618a218d5",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[excludedIncludedFilename],
 						name: excludedIncludedBasename,
-					},
+					}),
 				},
 				travelerSymlinkFilename: {
 					Filename:    travelerSymlinkFilename,
 					Fingerprint: "da437600754a8eed6c194b7241b078679551c06c7dc89685a9a71be7829ad7e5",
-					Info: testFileInfo{
+					Info: file.ExtendFileInfo(&testFileInfo{
 						size: sizes[travelerFilename],
 						name: travelerSymlinkBasename,
-					},
+					}),
 				},
 			},
 		},

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
-	"github.com/elastic/beats/v7/libbeat/common/file"
 	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
@@ -114,7 +113,7 @@ func (i *inodeDeviceIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		oldPath:             e.OldPath,
 		truncated:           e.Op == loginp.OpTruncate,
 		archived:            e.Op == loginp.OpArchived,
-		fileID:              i.name + identitySep + file.GetOSState(e.Descriptor.Info).String(),
+		fileID:              i.name + identitySep + e.Descriptor.Info.GetOSState().String(),
 		identifierGenerator: i.name,
 	}
 }

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
-	"github.com/elastic/beats/v7/libbeat/common/file"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -93,7 +92,7 @@ func (i *inodeMarkerIdentifier) markerContents() string {
 }
 
 func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
-	osstate := file.GetOSState(e.Descriptor.Info)
+	osstate := e.Descriptor.Info.GetOSState()
 	return fileSource{
 		desc:                e.Descriptor,
 		newPath:             e.NewPath,

--- a/filebeat/input/filestream/identifier_test.go
+++ b/filebeat/input/filestream/identifier_test.go
@@ -53,7 +53,7 @@ func TestFileIdentifier(t *testing.T) {
 
 		src := identifier.GetSource(loginp.FSEvent{
 			NewPath:    tmpFile.Name(),
-			Descriptor: loginp.FileDescriptor{Info: fi},
+			Descriptor: loginp.FileDescriptor{Info: file.ExtendFileInfo(fi)},
 		})
 
 		assert.Equal(t, identifier.Name()+"::"+file.GetOSState(fi).String(), src.Name())
@@ -77,7 +77,7 @@ func TestFileIdentifier(t *testing.T) {
 
 		src := identifier.GetSource(loginp.FSEvent{
 			NewPath:    tmpFile.Name(),
-			Descriptor: loginp.FileDescriptor{Info: fi},
+			Descriptor: loginp.FileDescriptor{Info: file.ExtendFileInfo(fi)},
 		})
 
 		assert.Equal(t, identifier.Name()+"::"+file.GetOSState(fi).String()+"-my-suffix", src.Name())

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -18,11 +18,9 @@
 package input_logfile
 
 import (
-	"os"
-
 	"github.com/elastic/go-concert/unison"
 
-	file_helper "github.com/elastic/beats/v7/libbeat/common/file"
+	"github.com/elastic/beats/v7/libbeat/common/file"
 )
 
 const (
@@ -63,7 +61,7 @@ type FileDescriptor struct {
 	// the filename from the `Info`.
 	Filename string
 	// Info is the result of file stat
-	Info os.FileInfo
+	Info file.ExtendedFileInfo
 	// Fingerprint is a computed hash of the file header
 	Fingerprint string
 }
@@ -75,7 +73,7 @@ func (fd FileDescriptor) FileID() string {
 	if fd.Fingerprint != "" {
 		return fd.Fingerprint
 	}
-	return file_helper.GetOSState(fd.Info).String()
+	return fd.Info.GetOSState().String()
 }
 
 // SameFile returns true if descriptors point to the same file.

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -19,7 +19,6 @@ package filestream
 
 import (
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
-	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -31,8 +30,11 @@ func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Sourc
 	if event.Descriptor.Fingerprint != "" {
 		log = log.With("fingerprint", event.Descriptor.Fingerprint)
 	}
-	if event.Descriptor.Info != nil && event.Descriptor.Info.Sys() != nil {
-		log = log.With("os_id", file.GetOSState(event.Descriptor.Info))
+	if event.Descriptor.Info != nil {
+		osID := event.Descriptor.Info.GetOSState().String()
+		if osID != "" {
+			log = log.With("os_id", osID)
+		}
 	}
 	if event.NewPath != "" {
 		log = log.With("new_path", event.NewPath)

--- a/libbeat/common/file/file_other.go
+++ b/libbeat/common/file/file_other.go
@@ -32,7 +32,14 @@ type StateOS struct {
 
 // GetOSState returns the FileStateOS for non windows systems
 func GetOSState(info os.FileInfo) StateOS {
-	stat := info.Sys().(*syscall.Stat_t)
+	sys := info.Sys()
+	if sys == nil {
+		return StateOS{}
+	}
+	stat, ok := sys.(*syscall.Stat_t)
+	if !ok {
+		return StateOS{}
+	}
 
 	// Convert inode and dev to uint64 to be cross platform compatible
 	fileState := StateOS{

--- a/libbeat/reader/readfile/fs_metafields_other.go
+++ b/libbeat/reader/readfile/fs_metafields_other.go
@@ -21,7 +21,6 @@ package readfile
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/elastic/beats/v7/libbeat/common/file"
@@ -33,8 +32,8 @@ const (
 	inodeKey    = "log.file.inode"
 )
 
-func setFileSystemMetadata(fi os.FileInfo, fields mapstr.M) error {
-	osstate := file.GetOSState(fi)
+func setFileSystemMetadata(fi file.ExtendedFileInfo, fields mapstr.M) error {
+	osstate := fi.GetOSState()
 	_, err := fields.Put(deviceIDKey, strconv.FormatUint(osstate.Device, 10))
 	if err != nil {
 		return fmt.Errorf("failed to set %q: %w", deviceIDKey, err)

--- a/libbeat/reader/readfile/metafields.go
+++ b/libbeat/reader/readfile/metafields.go
@@ -19,8 +19,8 @@ package readfile
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/beats/v7/libbeat/reader"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -30,14 +30,14 @@ import (
 type FileMetaReader struct {
 	reader      reader.Reader
 	path        string
-	fi          os.FileInfo
+	fi          file.ExtendedFileInfo
 	fingerprint string
 	offset      int64
 }
 
 // New creates a new Encode reader from input reader by applying
 // the given codec.
-func NewFilemeta(r reader.Reader, path string, fi os.FileInfo, fingerprint string, offset int64) reader.Reader {
+func NewFilemeta(r reader.Reader, path string, fi file.ExtendedFileInfo, fingerprint string, offset int64) reader.Reader {
 	return &FileMetaReader{r, path, fi, fingerprint, offset}
 }
 

--- a/libbeat/reader/readfile/metafields_other_test.go
+++ b/libbeat/reader/readfile/metafields_other_test.go
@@ -20,23 +20,23 @@
 package readfile
 
 import (
-	"os"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-func createTestFileInfo() os.FileInfo {
-	return testFileInfo{
+func createTestFileInfo() file.ExtendedFileInfo {
+	return file.ExtendFileInfo(testFileInfo{
 		name: "filename",
 		size: 42,
 		time: time.Now(),
 		sys:  &syscall.Stat_t{Dev: 17, Ino: 999},
-	}
+	})
 }
 
 func checkFields(t *testing.T, expected, actual mapstr.M) {

--- a/libbeat/reader/readfile/metafields_windows_test.go
+++ b/libbeat/reader/readfile/metafields_windows_test.go
@@ -18,12 +18,12 @@
 package readfile
 
 import (
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -34,8 +34,8 @@ type winTestInfo struct {
 	vol   uint32
 }
 
-func createTestFileInfo() os.FileInfo {
-	return &winTestInfo{
+func createTestFileInfo() file.ExtendedFileInfo {
+	return file.ExtendFileInfo(&winTestInfo{
 		testFileInfo: testFileInfo{
 			name: "filename",
 			size: 42,
@@ -44,7 +44,7 @@ func createTestFileInfo() os.FileInfo {
 		idxhi: 100,
 		idxlo: 200,
 		vol:   300,
-	}
+	})
 }
 
 func checkFields(t *testing.T, expected, actual mapstr.M) {


### PR DESCRIPTION
Adding additional file system metadata caused additional system calls that degraded the file reading performance.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run this on `main` and this branch to compare:

```sh
cd ./filebeat/input/filestream
go test -v -run=none -bench='BenchmarkFilestream/default.*' -benchmem -benchtime=100x -cpuprofile=main-cpu-profile.bin -memprofile=main-mem-profile.bin
```

In my case the results are:

```
BenchmarkFilestream/filestream_default_throughput-8
100          16212108 ns/op        13964860 B/op          230522 allocs/op

BenchmarkFilestream/filestream_default_throughput-8
100          13216628 ns/op        13805361 B/op          200519 allocs/op
```

The CPU profile shows that `GetOSState` function is not used per event anymore:

<img width="959" alt="profile-diff" src="https://github.com/elastic/beats/assets/887952/11e0e234-904e-4698-8fdc-e37e8e9525b2">

The profiles themselves for a review:

### Main

[main-cpu-profile.pdf](https://github.com/elastic/beats/files/13601081/main-cpu-profile.pdf)
[main-mem-profile.pdf](https://github.com/elastic/beats/files/13601083/main-mem-profile.pdf)

### This branch

[fix-cpu-profile.pdf](https://github.com/elastic/beats/files/13601091/fix-cpu-profile.pdf)
[fix-mem-profile.pdf](https://github.com/elastic/beats/files/13601092/fix-mem-profile.pdf)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #36694