### PR TITLE
x-pack/auditbeat/module/system/process Report Linux capabilities

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -166,6 +166,7 @@ Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will d
 
 - Add `ignore_errors` option to audit module. {issue}15768[15768] {pull}36851[36851]
 - Fix copy arguments for strict aligned architectures. {pull}36976[36976]
+- Add process capabilities to the process module. {issue}36404[36404] {pull}37303[37303]
 
 *Filebeat*
 


### PR DESCRIPTION
Implements #36404
ECS: https://www.elastic.co/guide/en/ecs/master/ecs-process.html#field-process-thread-capabilities-effective

Example output:

```
{
  "@timestamp": "2023-12-05T19:34:54.425Z",
  "@metadata": {
    "beat": "auditbeat",
    "type": "_doc",
    "version": "8.12.0"
  },
  "process": {
    "thread": {
      "capabilities": {
        "effective": [
          "CAP_DAC_READ_SEARCH",
          "CAP_SYS_RESOURCE"
        ],
        "permitted": [
          "CAP_DAC_READ_SEARCH",
          "CAP_SYS_RESOURCE"
        ]
      }
    },
    "entity_id": "DADEDQU03GoDNhc1",
    "pid": 2841325,
    "start": "2023-12-05T19:32:53.180Z",
    "args": [
      "systemd-userwork: waiting..."
    ],
...
...
```

Implementation is pretty straightforward, go-sysinfo will parse /proc/$PID/status and fill in CapabilityInfo.

**Don't merge**, this depends on two external PRs:

https://github.com/elastic/go-sysinfo/pull/196
https://github.com/elastic/go-sysinfo/pull/197

Next step is adding the same to add_process_metadata

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
$ cat auditbeat.yml

auditbeat.modules:

- module: system
  datasets:
    - process
#    - socket
  period: 1m # The frequency at which the datasets check for changes


  # How often datasets send state updates with the
  # current state of the system (e.g. all currently
  # running processes, all open sockets).
  state.period: 5m

output.console:
  pretty: true

eru:beats: cat /d/tmp/auditbeat_socket.yml
auditbeat.modules:

- module: system
  datasets:
    - process
#    - socket
  period: 1m # The frequency at which the datasets check for changes


  # How often datasets send state updates with the
  # current state of the system (e.g. all currently
  # running processes, all open sockets).
  state.period: 5m

output.console:
  pretty: true
```

```
$ mage build && sudo auditbeat -c /tmp/auditbeat.yml | grep -C100 CAP_

{
  "@timestamp": "2023-12-05T19:34:54.425Z",
  "@metadata": {
    "beat": "auditbeat",
    "type": "_doc",
    "version": "8.12.0"
  },
  "process": {
    "thread": {
      "capabilities": {
        "effective": [
          "CAP_DAC_READ_SEARCH",
          "CAP_SYS_RESOURCE"
        ],
        "permitted": [
          "CAP_DAC_READ_SEARCH",
          "CAP_SYS_RESOURCE"
        ]
      }
    },
    "entity_id": "DADEDQU03GoDNhc1",
    "pid": 2841325,
    "start": "2023-12-05T19:32:53.180Z",
    "args": [
      "systemd-userwork: waiting..."
    ],
....
```

## Related issues

- Closes #36404