### PR TITLE
backport: Add 8.12 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -289,3 +289,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.12 branch
+    conditions:
+      - merged
+      - label=backport-v8.12.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.12"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 8.12 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821