### PR TITLE
Add benchmark for filestream input

### DIFF
--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -1,0 +1,175 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// runFilestreamBenchmark runs the entire filestream input with the in-memory registry and the test pipeline.
+// `testID` must be unique for each test run
+// `cfg` must be a valid YAML string containing valid filestream configuration
+// `expEventCount` is an expected amount of produced events
+func runFilestreamBenchmark(b *testing.B, testID string, cfg string, expEventCount int) {
+	logger := logp.L()
+	c, err := conf.NewConfigWithYAML([]byte(cfg), cfg)
+	require.NoError(b, err)
+
+	p := Plugin(logger, createTestStore(b))
+	input, err := p.Manager.Create(c)
+	require.NoError(b, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	context := v2.Context{
+		Logger:      logger,
+		ID:          testID,
+		Cancelation: ctx,
+	}
+
+	connector, eventsDone := newTestPipeline(expEventCount)
+	done := make(chan struct{})
+	go func() {
+		err := input.Run(context, connector)
+		assert.NoError(b, err)
+		done <- struct{}{}
+	}()
+
+	<-eventsDone
+	cancel()
+	<-done // for more stable results we should wait until the full shutdown
+}
+
+func generateFile(b *testing.B, lineCount int) string {
+	b.Helper()
+	dir := b.TempDir()
+	file, err := os.CreateTemp(dir, "lines.log")
+	require.NoError(b, err)
+
+	for i := 0; i < lineCount; i++ {
+		fmt.Fprintf(file, "rather mediocre log line message - %d\n", i)
+	}
+	filename := file.Name()
+	err = file.Close()
+	require.NoError(b, err)
+	return filename
+}
+
+func BenchmarkFilestream(b *testing.B) {
+	logp.TestingSetup(logp.ToDiscardOutput())
+	lineCount := 10000
+	filename := generateFile(b, lineCount)
+
+	b.Run("filestream default throughput", func(b *testing.B) {
+		cfg := `
+type: filestream
+prospector.scanner.check_interval: 1s
+paths:
+    - ` + filename + `
+`
+		for i := 0; i < b.N; i++ {
+			runFilestreamBenchmark(b, fmt.Sprintf("default-benchmark-%d", i), cfg, lineCount)
+		}
+	})
+
+	b.Run("filestream fingerprint throughput", func(b *testing.B) {
+		cfg := `
+type: filestream
+prospector.scanner:
+  fingerprint.enabled: true
+  check_interval: 1s
+file_identity.fingerprint: ~
+paths:
+  - ` + filename + `
+`
+		for i := 0; i < b.N; i++ {
+			runFilestreamBenchmark(b, fmt.Sprintf("fp-benchmark-%d", i), cfg, lineCount)
+		}
+	})
+}
+
+func createTestStore(t *testing.B) loginp.StateStore {
+	return &testStore{registry: statestore.NewRegistry(storetest.NewMemoryStoreBackend())}
+}
+
+type testStore struct {
+	registry *statestore.Registry
+}
+
+func (s *testStore) Close() {
+	s.registry.Close()
+}
+
+func (s *testStore) Access() (*statestore.Store, error) {
+	return s.registry.Get("filestream-benchmark")
+}
+
+func (s *testStore) CleanupInterval() time.Duration {
+	return time.Second
+}
+
+func newTestPipeline(eventLimit int) (pc beat.PipelineConnector, done <-chan struct{}) {
+	ch := make(chan struct{})
+	return &testPipeline{limit: eventLimit, done: ch}, ch
+}
+
+type testPipeline struct {
+	done  chan struct{}
+	limit int
+}
+
+func (p *testPipeline) ConnectWith(beat.ClientConfig) (beat.Client, error) {
+	return p.Connect()
+}
+func (p *testPipeline) Connect() (beat.Client, error) {
+	return &testClient{p}, nil
+}
+
+type testClient struct {
+	testPipeline *testPipeline
+}
+
+func (c *testClient) Publish(event beat.Event) {
+	c.testPipeline.limit--
+	if c.testPipeline.limit == 0 {
+		c.testPipeline.done <- struct{}{}
+	}
+}
+
+func (c *testClient) PublishAll(events []beat.Event) {
+	for _, e := range events {
+		c.Publish(e)
+	}
+}
+func (c *testClient) Close() error {
+	return nil
+}

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -40,14 +40,14 @@ import (
 // `testID` must be unique for each test run
 // `cfg` must be a valid YAML string containing valid filestream configuration
 // `expEventCount` is an expected amount of produced events
-func runFilestreamBenchmark(b *testing.B, testID string, cfg string, expEventCount int) {
+func runFilestreamBenchmark(t require.TestingT, testID string, cfg string, expEventCount int) {
 	logger := logp.L()
 	c, err := conf.NewConfigWithYAML([]byte(cfg), cfg)
-	require.NoError(b, err)
+	require.NoError(t, err)
 
-	p := Plugin(logger, createTestStore(b))
+	p := Plugin(logger, createTestStore(t))
 	input, err := p.Manager.Create(c)
-	require.NoError(b, err)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	context := v2.Context{
@@ -60,7 +60,7 @@ func runFilestreamBenchmark(b *testing.B, testID string, cfg string, expEventCou
 	done := make(chan struct{})
 	go func() {
 		err := input.Run(context, connector)
-		assert.NoError(b, err)
+		assert.NoError(t, err)
 		done <- struct{}{}
 	}()
 
@@ -117,7 +117,7 @@ paths:
 	})
 }
 
-func createTestStore(t *testing.B) loginp.StateStore {
+func createTestStore(t require.TestingT) loginp.StateStore {
 	return &testStore{registry: statestore.NewRegistry(storetest.NewMemoryStoreBackend())}
 }
 

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -40,7 +40,7 @@ import (
 // `testID` must be unique for each test run
 // `cfg` must be a valid YAML string containing valid filestream configuration
 // `expEventCount` is an expected amount of produced events
-func runFilestreamBenchmark(t require.TestingT, testID string, cfg string, expEventCount int) {
+func runFilestreamBenchmark(t testing.TB, testID string, cfg string, expEventCount int) {
 	logger := logp.L()
 	c, err := conf.NewConfigWithYAML([]byte(cfg), cfg)
 	require.NoError(t, err)
@@ -69,18 +69,18 @@ func runFilestreamBenchmark(t require.TestingT, testID string, cfg string, expEv
 	<-done // for more stable results we should wait until the full shutdown
 }
 
-func generateFile(b *testing.B, lineCount int) string {
-	b.Helper()
-	dir := b.TempDir()
+func generateFile(t testing.TB, lineCount int) string {
+	t.Helper()
+	dir := t.TempDir()
 	file, err := os.CreateTemp(dir, "lines.log")
-	require.NoError(b, err)
+	require.NoError(t, err)
 
 	for i := 0; i < lineCount; i++ {
 		fmt.Fprintf(file, "rather mediocre log line message - %d\n", i)
 	}
 	filename := file.Name()
 	err = file.Close()
-	require.NoError(b, err)
+	require.NoError(t, err)
 	return filename
 }
 
@@ -117,7 +117,7 @@ paths:
 	})
 }
 
-func createTestStore(t require.TestingT) loginp.StateStore {
+func createTestStore(t testing.TB) loginp.StateStore {
 	return &testStore{registry: statestore.NewRegistry(storetest.NewMemoryStoreBackend())}
 }
 


### PR DESCRIPTION
Now we can quickly compare performance metrics when we make changes to the filestream implementation without running the whole Filebeat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

### Default Filestream Configuration

```sh
cd ./filebeat/input/filestream
go test -run=none -bench='BenchmarkFilestream/filestream_default_throughput.*' -benchmem -benchtime=100x
```

On my machine I've got the following results:

```
BenchmarkFilestream/filestream_default_throughput-10
100          10703028 ns/op        13576607 B/op     181225 allocs/op
```

![def-cpu-before](https://github.com/elastic/beats/assets/887952/6854a8c6-3e8c-42de-b66a-c2eb6edb107a)
![def-mem-before](https://github.com/elastic/beats/assets/887952/6ac30658-b53a-458c-85b4-3e1d1c2149a7)


### Fingerprint File Identity

```sh
cd ./filebeat/input/filestream
go test -run=none -bench='BenchmarkFilestream/filestream_fingerprint_throughput.*' -benchmem -benchtime=100x
```

```
BenchmarkFilestream/filestream_fingerprint_throughput-10
100          11664752 ns/op        13746616 B/op     191417 allocs/op
```

![fp-cpu-before](https://github.com/elastic/beats/assets/887952/e1f0efcf-4f14-426f-a5ed-971f2bcdb2b1)
![fp-mem-before](https://github.com/elastic/beats/assets/887952/102d840d-21ea-4843-acf6-39765c342bcc)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #36694