### PR TITLE
Remove event fields from error log.

### DIFF
--- a/libbeat/processors/script/javascript/session.go
+++ b/libbeat/processors/script/javascript/session.go
@@ -210,7 +210,6 @@ func (s *session) runProcessFunc(b *beat.Event) (out *beat.Event, err error) {
 		if r := recover(); r != nil {
 			s.log.Errorw("The javascript processor caused an unexpected panic "+
 				"while processing an event. Recovering, but please report this.",
-				"event", mapstr.M{"original": b.Fields.String()},
 				"panic", r,
 				zap.Stack("stack"))
 			if !s.evt.IsCancelled() {


### PR DESCRIPTION
## Proposed commit message

Remove event fields from error log when the script processor panics. This is an unlikely situation to happen as the Javascript runtime we use should not panic on any error while executing Javascript code, hence the event fields are just removed.

## Checklist


- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

