### PR TITLE
Update reload-configuration.asciidoc

### DIFF
--- a/filebeat/docs/reload-configuration.asciidoc
+++ b/filebeat/docs/reload-configuration.asciidoc
@@ -41,15 +41,15 @@ Example external configuration file:
 
 [source,yaml]
 ------------------------------------------------------------------------------
-- type: log
+- type: filestream
   paths:
     - /var/log/mysql.log
-  scan_frequency: 10s
+  prospector.scanner.check_interval: 10s
 
-- type: log
+- type: filestream
   paths:
     - /var/log/apache.log
-  scan_frequency: 5s
+  prospector.scanner.check_interval: 5s
 ------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
The official recommendation example provided the log input type, but it's deprecated, it should propose the filestream input instead 

https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-log.html


## Proposed commit message

Change type from log to filestream