### PR TITLE
Update CODEOWNERS to rename Hosted Services

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,7 +50,7 @@ CHANGELOG*
 /filebeat/module/santa @elastic/security-external-integrations
 /filebeat/module/system @elastic/elastic-agent-data-plane
 /filebeat/module/traefik @elastic/integrations
-/heartbeat/ @elastic/hosted-services
+/heartbeat/ @elastic/obs-ds-hosted-services
 /journalbeat @elastic/elastic-agent-data-plane
 /libbeat/ @elastic/elastic-agent-data-plane
 /libbeat/docs/processors-list.asciidoc @elastic/ingest-docs
@@ -174,7 +174,7 @@ CHANGELOG*
 /x-pack/filebeat/module/zscaler @elastic/security-external-integrations
 /x-pack/filebeat/modules.d/zoom.yml.disabled @elastic/security-external-integrations
 /x-pack/filebeat/processors/decode_cef/ @elastic/security-external-integrations
-/x-pack/heartbeat/ @elastic/hosted-services
+/x-pack/heartbeat/ @elastic/obs-ds-hosted-services
 /x-pack/metricbeat/ @elastic/elastic-agent-data-plane
 /x-pack/metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /x-pack/metricbeat/module/ @elastic/integrations


### PR DESCRIPTION
Update Hosted Services with the new name to be compliant with Data Sourcing naming policies
Waiting for @elastic/obs-ds-hosted-services to have the right permissions