### PR TITLE
fix: format log message correctly for heartbeat

### DIFF
--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -162,7 +162,7 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 
 	logp.L().Info("heartbeat is running! Hit CTRL-C to stop it.")
 	groups, _ := syscall.Getgroups()
-	logp.L().Info("Effective user/group ids: %d/%d, with groups: %v", syscall.Geteuid(), syscall.Getegid(), groups)
+	logp.L().Infof("Effective user/group ids: %d/%d, with groups: %v", syscall.Geteuid(), syscall.Getegid(), groups)
 
 	waitMonitors := monitors.NewSignalWait()
 
@@ -226,7 +226,7 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 	waitPublished.AddChan(bt.done)
 	waitPublished.Add(monitors.WithLog(pipelineWrapper.Wait, "shutdown: finished publishing events."))
 	if bt.config.PublishTimeout > 0 {
-		logp.Info("shutdown: output timer started. Waiting for max %v.", bt.config.PublishTimeout)
+		logp.L().Infof("shutdown: output timer started. Waiting for max %v.", bt.config.PublishTimeout)
 		waitPublished.Add(monitors.WithLog(monitors.WaitDuration(bt.config.PublishTimeout),
 			"shutdown: timed out waiting for pipeline to publish events."))
 	}
@@ -241,7 +241,7 @@ func (bt *Heartbeat) RunStaticMonitors(b *beat.Beat, pipeline beat.Pipeline) (st
 		created, err := bt.monitorFactory.Create(pipeline, cfg)
 		if err != nil {
 			if errors.Is(err, monitors.ErrMonitorDisabled) {
-				logp.L().Info("skipping disabled monitor: %s", err)
+				logp.L().Infof("skipping disabled monitor: %s", err)
 				continue // don't stop loading monitors just because they're disabled
 			}
 

--- a/x-pack/heartbeat/monitors/browser/source/project.go
+++ b/x-pack/heartbeat/monitors/browser/source/project.go
@@ -168,8 +168,8 @@ func (p *ProjectSource) Close() error {
 
 func runSimpleCommand(cmd *exec.Cmd, dir string) error {
 	cmd.Dir = dir
-	logp.L().Info("Running %s in %s", cmd, dir)
+	logp.L().Infof("Running %s in %s", cmd, dir)
 	output, err := cmd.CombinedOutput()
-	logp.L().Info("Ran %s (%d) got '%s': (%s) as (%d/%d)", cmd, cmd.ProcessState.ExitCode(), string(output), err, syscall.Getuid(), syscall.Geteuid())
+	logp.L().Infof("Ran %s (%d) got '%s': (%s) as (%d/%d)", cmd, cmd.ProcessState.ExitCode(), string(output), err, syscall.Getuid(), syscall.Geteuid())
 	return err
 }


### PR DESCRIPTION
## Summary
+ Fix the formatting of the logs on HB for project monitors. 
```
Running %s in %s/usr/share/heartbeat/.node/node/bin/npm install --no-audit --no-update-notifier --no-fund --package-lock=false --progress=false/tmp/elastic-synthetics-unzip-4066455738
```

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

