### PR TITLE
[Docs] Document memory leak in `8.11.0` and `8.11.1` release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,8 @@ https://github.com/elastic/beats/compare/v8.11.1\...v8.11.2[View commits]
 === Beats version 8.11.1
 https://github.com/elastic/beats/compare/v8.11.0\...v8.11.1[View commits]
 
+IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and waiting for the upcoming 8.11.2 release in which the issue is resolved. If you've already upgraded to version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as it becomes available.
+
 ==== Added
 
 *Affecting all Beats*
@@ -65,9 +67,12 @@ https://github.com/elastic/beats/compare/v8.11.0\...v8.11.1[View commits]
 === Beats version 8.11.0
 https://github.com/elastic/beats/compare/v8.10.4\...v8.11.0[View commits]
 
+IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and waiting for the upcoming 8.11.2 release in which the issue is resolved. If you've already upgraded to version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as it becomes available.
+
 ==== Breaking changes
 
 *Affecting all Beats*
+
 - The Elasticsearch output now enables compression by default. This decreases network data usage by an average of 70-80%, in exchange for 20-25% increased CPU use and ~10% increased ingestion time. The previous default can be restored by setting the flag `compression_level: 0` under `output.elasticsearch`. {pull}36681[36681]
 - The `elastic-agent-autodiscover` library is updated to version 0.6.4, disabling metadata for deployment and cronjob. Pods that will be created from deployments or cronjobs will not have the extra metadata field for `kubernetes.deployment` or `kubernetes.cronjob`, respectively. {pull}36879[36879]
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -67,7 +67,8 @@ IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recomme
 === Beats version 8.11.0
 https://github.com/elastic/beats/compare/v8.10.4\...v8.11.0[View commits]
 
-IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and waiting for the upcoming 8.11.2 release in which the issue is resolved. If you've already upgraded to version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as it becomes available.
+
+IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and instead use the 8.11.2 release in which the issue is resolved. If you've already upgraded to version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as possible.
 
 ==== Breaking changes
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,7 +54,7 @@ https://github.com/elastic/beats/compare/v8.11.1\...v8.11.2[View commits]
 === Beats version 8.11.1
 https://github.com/elastic/beats/compare/v8.11.0\...v8.11.1[View commits]
 
-IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and waiting for the upcoming 8.11.2 release in which the issue is resolved. If you've already upgraded to version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as it becomes available.
+IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and instead use the 8.11.2 release in which the issue is resolved. If you've already upgraded to version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as possible.
 
 ==== Added
 


### PR DESCRIPTION
This PR documents the Windows-only memory leak affecting all Beats when collecting memory-related metrics.  The wording for the note is taken from https://www.elastic.co/guide/en/fleet/8.11/release-notes-8.11.0.html.