### PR TITLE
Revert 37407 to remove security notice in 8.11.2 RN

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,8 +24,6 @@ The 8.11.3 patch release contains a fix for a potential security vulnerability. 
 === Beats version 8.11.2
 https://github.com/elastic/beats/compare/v8.11.1\...v8.11.2[View commits]
 
-The 8.11.2 patch release contains a fix for a potential security vulnerability. https://discuss.elastic.co/c/announcements/security-announcements/31[Please see our security advisory for more details].
-
 ==== Breaking changes
 
 *Affecting all Beats*


### PR DESCRIPTION
Reverts https://github.com/elastic/beats/pull/37407
The notice should apply to 8.11.3 only.

