### PR TITLE
fix: adjust formatting for heartbeat monitor and state loader

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,6 +86,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 *Heartbeat*
 
 - Fix panics when parsing dereferencing invalid parsed url. {pull}34702[34702]
+- Added fix for formatting the logs from stateloader properly. {pull}37369[37369]
 
 *Metricbeat*
 

--- a/heartbeat/monitors/active/icmp/stdloop.go
+++ b/heartbeat/monitors/active/icmp/stdloop.go
@@ -165,7 +165,7 @@ func (l *stdICMPLoop) runICMPRecv(conn *icmp.PacketConn, proto int) {
 		bytes := make([]byte, 512)
 		err := conn.SetReadDeadline(time.Now().Add(time.Second))
 		if err != nil {
-			logp.L().Error("could not set read deadline for ICMP: %w", err)
+			logp.L().Errorf("could not set read deadline for ICMP: %w", err)
 			return
 		}
 		_, addr, err := conn.ReadFrom(bytes)

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -256,7 +256,7 @@ func (m *Monitor) Stop() {
 	if m.close != nil {
 		err := m.close()
 		if err != nil {
-			logp.L().Error("error closing monitor %s: %w", m.String(), err)
+			logp.L().Errorf("error closing monitor %s: %w", m.String(), err)
 		}
 	}
 

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -80,13 +80,13 @@ func (t *configuredJob) Start(pubClient beat.Client) {
 	t.pubClient = pubClient
 
 	if err != nil {
-		logp.L().Info("could not start monitor: %v", err)
+		logp.L().Infof("could not start monitor: %v", err)
 		return
 	}
 
 	t.cancelFn, err = t.monitor.addTask(t.config.Schedule, t.monitor.stdFields.ID, t.makeSchedulerTaskFunc(), t.config.Type)
 	if err != nil {
-		logp.L().Info("could not start monitor: %v", err)
+		logp.L().Infof("could not start monitor: %v", err)
 	}
 }
 
@@ -107,7 +107,7 @@ func runPublishJob(job jobs.Job, pubClient beat.Client) []scheduler.TaskFunc {
 
 	conts, err := job(event)
 	if err != nil {
-		logp.L().Info("Job failed with: %s", err)
+		logp.L().Infof("Job failed with: %s", err)
 	}
 
 	hasContinuations := len(conts) > 0

--- a/heartbeat/monitors/wrappers/monitorstate/esloader.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader.go
@@ -77,7 +77,7 @@ func MakeESLoader(esc *eslegclient.Connection, indexPattern string, beatLocation
 
 		status, body, err := esc.Request("POST", strings.Join([]string{"/", indexPattern, "/", "_search", "?size=1"}, ""), "", nil, reqBody)
 		if err != nil || status > 299 {
-			return nil, fmt.Errorf("error executing state search for %s in loc=%s: %w", sf.ID, runFromID, err)
+			return nil, fmt.Errorf("error executing state search for %s in loc=%s: %s", sf.ID, runFromID, err.Error())
 		}
 
 		type stateHits struct {

--- a/heartbeat/monitors/wrappers/monitorstate/esloader.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader.go
@@ -77,7 +77,7 @@ func MakeESLoader(esc *eslegclient.Connection, indexPattern string, beatLocation
 
 		status, body, err := esc.Request("POST", strings.Join([]string{"/", indexPattern, "/", "_search", "?size=1"}, ""), "", nil, reqBody)
 		if err != nil || status > 299 {
-			return nil, fmt.Errorf("error executing state search for %s in loc=%s: %s", sf.ID, runFromID, err.Error())
+			return nil, fmt.Errorf("error executing state search for %s in loc=%s: %w", sf.ID, runFromID, err)
 		}
 
 		type stateHits struct {

--- a/heartbeat/monitors/wrappers/monitorstate/tracker.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker.go
@@ -104,7 +104,7 @@ func (t *Tracker) GetCurrentState(sf stdfields.StdMonitorFields) (state *State) 
 		time.Sleep(sleepFor)
 	}
 	if err != nil {
-		logp.L().Warn("could not load prior state from elasticsearch after %d attempts, will create new state for monitor: %s", tries, sf.ID)
+		logp.L().Warnf("could not load prior state from elasticsearch after %d attempts, will create new state for monitor: %s", tries, sf.ID)
 	}
 
 	if loadedState != nil {

--- a/x-pack/heartbeat/monitors/browser/sourcejob.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob.go
@@ -125,7 +125,7 @@ func (sj *SourceJob) extraArgs(uiOrigin bool) []string {
 		s, err := json.Marshal(sj.browserCfg.PlaywrightOpts)
 		if err != nil {
 			// This should never happen, if it was parsed as a config it should be serializable
-			logp.L().Warn("could not serialize playwright options '%v': %w", sj.browserCfg.PlaywrightOpts, err)
+			logp.L().Warnf("could not serialize playwright options '%v': %w", sj.browserCfg.PlaywrightOpts, err)
 		} else {
 			extraArgs = append(extraArgs, "--playwright-options", string(s))
 		}

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -219,7 +219,7 @@ func runCmd(
 				break
 			}
 			if err != nil {
-				logp.L().Warn("error decoding json for test json results: %w", err)
+				logp.L().Warnf("error decoding json for test json results: %w", err)
 			}
 
 			mpx.writeSynthEvent(&se)

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -96,7 +96,7 @@ func (se SynthEvent) ToMap() (m mapstr.M) {
 		u, e := url.Parse(se.URL)
 		if e != nil {
 			_, _ = m.Put("url", mapstr.M{"full": se.URL})
-			logp.L().Warn("Could not parse synthetics URL '%s': %s", se.URL, e.Error())
+			logp.L().Warnf("Could not parse synthetics URL '%s': %s", se.URL, e.Error())
 		} else {
 			_, _ = m.Put("url", wraputil.URLFields(u))
 		}


### PR DESCRIPTION
## Summary
+ Fix the formatting of the logs on HB for state loader and monitor wrappers. 
```
could not load prior state from elasticsearch after %d attempts, will create new state for monitor: %s3test-monitor-id
```

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

