### PR TITLE
filebeat benchmark input and discard output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -204,6 +204,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add support for Active Directory an entity analytics provider. {pull}37919[37919]
 - Add debugging breadcrumb to logs when writing request trace log. {pull}38636[38636]
 - added benchmark input {pull}37437[37437]
+- added benchmark input and discard output {pull}37437[37437]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -203,6 +203,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Update CEL mito extensions to v1.10.0 to add keys/values helper. {pull}38504[38504]
 - Add support for Active Directory an entity analytics provider. {pull}37919[37919]
 - Add debugging breadcrumb to logs when writing request trace log. {pull}38636[38636]
+- added benchmark input {pull}37437[37437]
 
 *Auditbeat*
 

--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -70,6 +70,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-aws-s3>>
 * <<{beatname_lc}-input-azure-eventhub>>
 * <<{beatname_lc}-input-azure-blob-storage>>
+* <<{beatname_lc}-input-benchmark>>
 * <<{beatname_lc}-input-cel>>
 * <<{beatname_lc}-input-cloudfoundry>>
 * <<{beatname_lc}-input-cometd>>
@@ -103,6 +104,8 @@ include::../../x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc[]
 include::../../x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-azure-blob-storage.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-benchmark.asciidoc[]
 
 include::../../x-pack/filebeat/docs/inputs/input-cel.asciidoc[]
 

--- a/libbeat/docs/outputs-list.asciidoc
+++ b/libbeat/docs/outputs-list.asciidoc
@@ -24,6 +24,9 @@ endif::[]
 ifndef::no_console_output[]
 * <<console-output>>
 endif::[]
+ifndef::no_discard_output[]
+* <<discard-output>>
+endif::[]
 
 //# end::outputs-list[]
 
@@ -75,6 +78,13 @@ ifdef::requires_xpack[]
 [role="xpack"]
 endif::[]
 include::{libbeat-outputs-dir}/console/docs/console.asciidoc[]
+endif::[]
+
+ifndef::no_discard_output[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
+include::{libbeat-outputs-dir}/discard/docs/discard.asciidoc[]
 endif::[]
 
 ifndef::no_codec[]

--- a/libbeat/outputs/discard/config.go
+++ b/libbeat/outputs/discard/config.go
@@ -15,20 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package includes
+package discard
 
 import (
-	// import queue types
-	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/format"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/console"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/discard"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/fileout"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/kafka"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/logstash"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/redis"
-	_ "github.com/elastic/beats/v7/libbeat/outputs/shipper"
-	_ "github.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue"
-	_ "github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
+	"github.com/elastic/elastic-agent-libs/config"
 )
+
+type discardOutConfig struct {
+	Queue config.Namespace `config:"queue"`
+}
+
+func defaultConfig() discardOutConfig {
+	return discardOutConfig{}
+}

--- a/libbeat/outputs/discard/discard.go
+++ b/libbeat/outputs/discard/discard.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package discard
+
+import (
+	"context"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func init() {
+	outputs.RegisterType("discard", makeDiscard)
+}
+
+type discardOutput struct {
+	log      *logp.Logger
+	beat     beat.Info
+	observer outputs.Observer
+}
+
+func makeDiscard(
+	_ outputs.IndexManager,
+	beat beat.Info,
+	observer outputs.Observer,
+	cfg *config.C,
+) (outputs.Group, error) {
+	out := &discardOutput{
+		log:      logp.NewLogger("discard"),
+		beat:     beat,
+		observer: observer,
+	}
+	doConfig := defaultConfig()
+	if err := cfg.Unpack(&doConfig); err != nil {
+		return outputs.Fail(err)
+	}
+
+	// disable bulk support in publisher pipeline
+	_ = cfg.SetInt("bulk_max_size", -1, -1)
+	out.log.Infof("Initialized discard output")
+	return outputs.Success(doConfig.Queue, -1, 0, out)
+}
+
+// Implement Outputer
+func (out *discardOutput) Close() error {
+	return nil
+}
+
+func (out *discardOutput) Publish(_ context.Context, batch publisher.Batch) error {
+	defer batch.ACK()
+
+	st := out.observer
+	events := batch.Events()
+	st.NewBatch(len(events))
+	for range events {
+		st.WriteError(nil)
+	}
+	st.Acked(len(events))
+	return nil
+}
+
+func (out *discardOutput) String() string {
+	return "discard"
+}

--- a/libbeat/outputs/discard/discard.go
+++ b/libbeat/outputs/discard/discard.go
@@ -56,7 +56,7 @@ func makeDiscard(
 	// disable bulk support in publisher pipeline
 	_ = cfg.SetInt("bulk_max_size", -1, -1)
 	out.log.Infof("Initialized discard output")
-	return outputs.Success(doConfig.Queue, -1, 0, out)
+	return outputs.Success(doConfig.Queue, -1, 0, nil, out)
 }
 
 // Implement Outputer

--- a/libbeat/outputs/discard/discard.go
+++ b/libbeat/outputs/discard/discard.go
@@ -70,9 +70,6 @@ func (out *discardOutput) Publish(_ context.Context, batch publisher.Batch) erro
 	st := out.observer
 	events := batch.Events()
 	st.NewBatch(len(events))
-	for range events {
-		st.WriteError(nil)
-	}
 	st.Acked(len(events))
 	return nil
 }

--- a/libbeat/outputs/discard/docs/discard.asciidoc
+++ b/libbeat/outputs/discard/docs/discard.asciidoc
@@ -8,10 +8,10 @@
 The Discard output throws away data.
 
 WARNING: The Discard output should be used only for development or
-debugging issues.  Data is lost.
+debugging issues. Data is lost.
 
 This can be useful if you want to work on your input configuration
-without needing to configure an output.  It can also be useful to test
+without needing to configure an output. It can also be useful to test
 how changes in input and processor configuration affect performance.
 
 Example configuration:

--- a/libbeat/outputs/discard/docs/discard.asciidoc
+++ b/libbeat/outputs/discard/docs/discard.asciidoc
@@ -1,0 +1,34 @@
+[[discard-output]]
+=== Configure the Discard output
+
+++++
+<titleabbrev>Discard</titleabbrev>
+++++
+
+The Discard output throws away data.
+
+WARNING: The Discard output should be used only for development or
+debugging issues.  Data is lost.
+
+This can be useful if you want to work on your input configuration
+without needing to configure an output.  It can also be useful to test
+how changes in input and processor configuration affect performance.
+
+Example configuration:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.discard:
+  enabled: true
+------------------------------------------------------------------------------
+
+==== Configuration options
+
+You can specify the following `output.discard` options in the +{beatname_lc}.yml+ config file:
+
+===== `enabled`
+
+The enabled config is a boolean setting to enable or disable the output. If set
+to false, the output is disabled.
+
+The default value is `true`.

--- a/x-pack/filebeat/docs/inputs/input-benchmark.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-benchmark.asciidoc
@@ -6,12 +6,12 @@
 === Benchmark input
 
 ++++
-<titleabbrev>generic event generator</titleabbrev>
+<titleabbrev>Benchmark</titleabbrev>
 ++++
 
 beta[]
 
-The benchmark input generates generic events and sends them to the output.  This can be useful when you want to benchmark the difference between outputs or output settings.
+The Benchmark input generates generic events and sends them to the output.  This can be useful when you want to benchmark the difference between outputs or output settings.
 
 Example configurations:
 
@@ -49,7 +49,7 @@ Send 5 events per second example:
 
 ==== Configuration options
 
-The `benchmark` input supports the following configuration options plus the
+The Benchmark input supports the following configuration options plus the
 <<{beatname_lc}-input-{type}-common-options>> described later.
 
 [float]

--- a/x-pack/filebeat/docs/inputs/input-benchmark.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-benchmark.asciidoc
@@ -1,0 +1,93 @@
+[role="xpack"]
+
+:type: benchmark
+
+[id="{beatname_lc}-input-{type}"]
+=== Benchmark input
+
+++++
+<titleabbrev>generic event generator</titleabbrev>
+++++
+
+beta[]
+
+The benchmark input generates generic events and sends them to the output.  This can be useful when you want to benchmark the difference between outputs or output settings.
+
+Example configurations:
+
+Basic example, infinite events as quickly as possible:
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: benchmark
+  enabled: true
+  message: "test message"
+  threads: 1
+----
+
+Send 1024 events and stop example:
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: benchmark
+  enabled: true
+  message: "test message"
+  threads: 1
+  count: 1024
+----
+
+Send 5 events per second example:
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: benchmark
+  enabled: true
+  message: "test message"
+  threads: 1
+  eps: 5
+----
+
+==== Configuration options
+
+The `benchmark` input supports the following configuration options plus the
+<<{beatname_lc}-input-{type}-common-options>> described later.
+
+[float]
+==== `message`
+
+This is the value that will be in the `message` field of the json document.
+
+[float]
+==== `threads`
+
+This is the number of go routines that will be started generating messages.  Normally 1 thread can saturate an output but if necessary this can be increased.
+
+[float]
+==== `count`
+
+This is the number of messages to send.  0 represents sending infinite messages.  This is mutually exclusive with the `eps` option.
+
+[float]
+==== `eps`
+
+This is the number of events per second to send. 0 represents sending as quickly as possible.  This is mutually exclusive with the `count` option.
+
+
+[float]
+=== Metrics
+
+This input exposes metrics under the <<http-endpoint, HTTP monitoring endpoint>>.
+These metrics are exposed under the `/inputs` path. They can be used to
+observe the activity of the input.
+
+[options="header"]
+|=======
+| Metric                    | Description
+| `events_published_total`  | Number of events published.
+| `publishing_time`         | Histogram of the elapsed in nanoseconds (time of publisher.Publish).
+|=======
+
+[id="{beatname_lc}-input-{type}-common-options"]
+include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
+
+:type!:

--- a/x-pack/filebeat/docs/inputs/input-benchmark.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-benchmark.asciidoc
@@ -11,7 +11,7 @@
 
 beta[]
 
-The Benchmark input generates generic events and sends them to the output.  This can be useful when you want to benchmark the difference between outputs or output settings.
+The Benchmark input generates generic events and sends them to the output. This can be useful when you want to benchmark the difference between outputs or output settings.
 
 Example configurations:
 
@@ -60,17 +60,17 @@ This is the value that will be in the `message` field of the json document.
 [float]
 ==== `threads`
 
-This is the number of go routines that will be started generating messages.  Normally 1 thread can saturate an output but if necessary this can be increased.
+This is the number of goroutines that will be started generating messages. Normally 1 thread can saturate an output but if necessary this can be increased.
 
 [float]
 ==== `count`
 
-This is the number of messages to send.  0 represents sending infinite messages.  This is mutually exclusive with the `eps` option.
+This is the number of messages to send. 0 represents sending infinite messages. This is mutually exclusive with the `eps` option.
 
 [float]
 ==== `eps`
 
-This is the number of events per second to send. 0 represents sending as quickly as possible.  This is mutually exclusive with the `count` option.
+This is the number of events per second to send. 0 represents sending as quickly as possible. This is mutually exclusive with the `count` option.
 
 
 [float]

--- a/x-pack/filebeat/input/benchmark/config.go
+++ b/x-pack/filebeat/input/benchmark/config.go
@@ -1,0 +1,31 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package benchmark
+
+import "fmt"
+
+type benchmarkConfig struct {
+	Message string `config:"message"`
+	Count   uint64 `config:"count"`
+	Threads uint8  `config:"threads"`
+	Eps     uint64 `config:"eps"`
+}
+
+var (
+	defaultConfig = benchmarkConfig{
+		Message: "generic benchmark message",
+		Threads: 1,
+	}
+)
+
+func (c *benchmarkConfig) Validate() error {
+	if c.Count > 0 && c.Eps > 0 {
+		return fmt.Errorf("only one of count or eps may be specified, not both")
+	}
+	if c.Message == "" {
+		return fmt.Errorf("message must be specified")
+	}
+	return nil
+}

--- a/x-pack/filebeat/input/benchmark/config_test.go
+++ b/x-pack/filebeat/input/benchmark/config_test.go
@@ -1,0 +1,33 @@
+package benchmark
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		cfg         benchmarkConfig
+		expectError bool
+		errorString string
+	}{
+		"default":     {cfg: defaultConfig},
+		"countAndEps": {cfg: benchmarkConfig{Message: "a", Count: 1, Eps: 1}, expectError: true, errorString: "only one of count or eps may be specified"},
+		"empty":       {cfg: benchmarkConfig{}, expectError: true, errorString: "message must be specified"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if err == nil && tc.expectError == true {
+				t.Fatalf("expected validation error, didn't get it")
+			}
+			if err != nil && tc.expectError == false {
+				t.Fatalf("unexpected validation error: %s", err)
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("error: '%s' didn't contain expected string: '%s'", err, tc.errorString)
+			}
+		})
+	}
+}

--- a/x-pack/filebeat/input/benchmark/config_test.go
+++ b/x-pack/filebeat/input/benchmark/config_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package benchmark
 
 import (

--- a/x-pack/filebeat/input/benchmark/input.go
+++ b/x-pack/filebeat/input/benchmark/input.go
@@ -89,7 +89,7 @@ func runThread(ctx v2.Context, publisher stateless.Publisher, thread uint8, cfg 
 			default:
 				publishEvt(publisher, cfg.Message, line, name, thread, metrics)
 				line++
-				if (line % cfg.Count) == 0 {
+				if line == cfg.Count {
 					return
 				}
 			}

--- a/x-pack/filebeat/input/benchmark/input.go
+++ b/x-pack/filebeat/input/benchmark/input.go
@@ -1,0 +1,177 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package benchmark
+
+import (
+	"sync"
+	"time"
+
+	"github.com/rcrowley/go-metrics"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/feature"
+	"github.com/elastic/beats/v7/libbeat/monitoring/inputmon"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-libs/monitoring/adapter"
+)
+
+const (
+	inputName = "benchmark"
+)
+
+// Plugin registers the input
+func Plugin() v2.Plugin {
+	return v2.Plugin{
+		Name:      inputName,
+		Stability: feature.Experimental,
+		Manager:   stateless.NewInputManager(configure),
+	}
+}
+
+func configure(cfg *config.C) (stateless.Input, error) {
+	bConf := defaultConfig
+	if err := cfg.Unpack(&bConf); err != nil {
+		return nil, err
+	}
+	return &benchmarkInput{cfg: bConf}, nil
+}
+
+// benchmarkInput is the main runtime object for the input
+type benchmarkInput struct {
+	cfg benchmarkConfig
+}
+
+// Name returns the name of the input
+func (bi *benchmarkInput) Name() string {
+	return inputName
+}
+
+// Test validates the configuration
+func (bi *benchmarkInput) Test(ctx v2.TestContext) error {
+	return bi.cfg.Validate()
+}
+
+// Run starts the data generation.
+func (bi *benchmarkInput) Run(ctx v2.Context, publisher stateless.Publisher) error {
+	var wg sync.WaitGroup
+	metrics := newInputMetrics(ctx.ID)
+
+	for i := uint8(0); i < bi.cfg.Threads; i++ {
+		wg.Add(1)
+		go func(thread uint8) {
+			defer wg.Done()
+			runThread(ctx, publisher, thread, bi.cfg, metrics)
+		}(i)
+	}
+	wg.Wait()
+	return ctx.Cancelation.Err()
+}
+
+func runThread(ctx v2.Context, publisher stateless.Publisher, thread uint8, cfg benchmarkConfig, metrics *inputMetrics) {
+	ctx.Logger.Infof("starting benchmark input thread: %d", thread)
+	defer ctx.Logger.Infof("stopping benchmark input thread: %d", thread)
+
+	var line uint64
+	var name uint64
+
+	switch {
+	case cfg.Count > 0:
+		for {
+			select {
+			case <-ctx.Cancelation.Done():
+				return
+			default:
+				publishEvt(publisher, cfg.Message, line, name, thread, metrics)
+				line++
+				if (line % cfg.Count) == 0 {
+					return
+				}
+			}
+		}
+	case cfg.Eps > 0:
+		ticker := time.NewTicker(1 * time.Second)
+		pubChan := make(chan bool, int(cfg.Eps))
+		for {
+			select {
+			case <-ctx.Cancelation.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				//don't want to block on filling doPublish channel
+				//so only send as many as it can hold right now
+				numToSend := cap(pubChan) - len(pubChan)
+				for i := 0; i < numToSend; i++ {
+					pubChan <- true
+				}
+			case <-pubChan:
+				publishEvt(publisher, cfg.Message, line, name, thread, metrics)
+				line++
+				if line == 0 {
+					name++
+				}
+			}
+		}
+	default:
+		for {
+			select {
+			case <-ctx.Cancelation.Done():
+				return
+			default:
+				publishEvt(publisher, cfg.Message, line, name, thread, metrics)
+				line++
+				if line == 0 {
+					name++
+				}
+			}
+		}
+	}
+	return
+}
+
+func publishEvt(publisher stateless.Publisher, msg string, line uint64, filename uint64, thread uint8, metrics *inputMetrics) {
+	timestamp := time.Now()
+	evt := beat.Event{
+		Timestamp: timestamp,
+		Fields: mapstr.M{
+			"message":  msg,
+			"line":     line,
+			"filename": filename,
+			"thread":   thread,
+		},
+	}
+	publisher.Publish(evt)
+	metrics.publishingTime.Update(time.Since(timestamp).Nanoseconds())
+	metrics.eventsPublished.Add(1)
+}
+
+type inputMetrics struct {
+	unregister func()
+
+	eventsPublished *monitoring.Uint // number of events published
+	publishingTime  metrics.Sample   // histogram of the elapsed times in nanoseconds (time of publisher.Publish)
+}
+
+// newInputMetrics returns an input metric for the benchmark processor.
+func newInputMetrics(id string) *inputMetrics {
+	reg, unreg := inputmon.NewInputRegistry(inputName, id, nil)
+	out := &inputMetrics{
+		unregister:      unreg,
+		eventsPublished: monitoring.NewUint(reg, "events_published_total"),
+		publishingTime:  metrics.NewUniformSample(1024),
+	}
+
+	_ = adapter.NewGoMetrics(reg, "publishing_time", adapter.Accept).
+		Register("histogram", metrics.NewHistogram(out.publishingTime))
+
+	return out
+}
+
+func (m *inputMetrics) Close() {
+	m.unregister()
+}

--- a/x-pack/filebeat/input/benchmark/input.go
+++ b/x-pack/filebeat/input/benchmark/input.go
@@ -131,7 +131,6 @@ func runThread(ctx v2.Context, publisher stateless.Publisher, thread uint8, cfg 
 			}
 		}
 	}
-	return
 }
 
 func publishEvt(publisher stateless.Publisher, msg string, line uint64, filename uint64, thread uint8, metrics *inputMetrics) {

--- a/x-pack/filebeat/input/default-inputs/inputs_other.go
+++ b/x-pack/filebeat/input/default-inputs/inputs_other.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/awscloudwatch"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/awss3"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/azureblobstorage"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/benchmark"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/cel"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/cloudfoundry"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics"
@@ -45,5 +46,6 @@ func xpackInputs(info beat.Info, log *logp.Logger, store beater.StateStore) []v2
 		shipper.Plugin(log, store),
 		websocket.Plugin(log, store),
 		netflow.Plugin(log),
+		benchmark.Plugin(),
 	}
 }


### PR DESCRIPTION
## Proposed commit message

filebeat benchmark input and discard output

benchmark is simple input that generates synthetic events, useful for benchmarking outputs or for providing load on outputs.

The message of each event is set in the config file.  Event duplication is avoided with the `thread`, `line` and `filename` fields.  Each go routine that generates an event sets a unique `thread` field.  Within each each thread, every event that is generated increments the `line` field.  The `line` field is a uint64, if the max is reached then the `filename` field is incremented and `line` is reset to 0.

The default behavior is to generate events as quickly as possible until filebeat is stopped.  Optionally you can set the `count` option, which will generate that number of events and then stop.  Or you can use the `eps` option which allows you to set an events generated per second.


discard is a simple output that throws the data away, but records in the metrics that an event was successfully sent.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

In `filebeat.yml` add:

```yaml
filebeat.inputs:
- type: benchmark
  message: "uninspired test message"

output.discard:
```

This should result in events with the `message` field set to "uninspried test message", generated as quickly as possible until filebeat is stopped.

## Related issues

- 

## Use cases

- tracking down performance issues
- generating a consistent load for outputs
- performance testing inputs and processors

## Screenshots



## Logs

```
{
  "@timestamp": "2023-12-05T19:09:49.504Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.12.0"
  },
  "ecs": {
    "version": "8.0.0"
  },
  "host": {
    "name": "elastic2"
  },
  "agent": {
    "id": "796fb7fc-e337-4ee0-b1f2-88f133a5e801",
    "name": "elastic2",
    "type": "filebeat",
    "version": "8.12.0",
    "ephemeral_id": "d3318883-aac0-4903-a1fc-1692aade498f"
  },
  "message": "generic message",
  "line": 21049584,
  "filename": 0,
  "thread": 0,
  "input": {
    "type": "benchmark"
  }
}
```

