### PR TITLE
Log raw events and errors containing events to a separate file

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -129,6 +129,7 @@ Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will d
 - The Elasticsearch output can now configure performance presets with the `preset` configuration field. {pull}37259[37259]
 - Upgrade to elastic-agent-libs v0.7.3 and golang.org/x/crypto v0.17.0. {pull}37544[37544]
 - Make more selective the Pod autodiscovery upon node and namespace update events. {issue}37338[37338] {pull}37431[37431]
+- Raw event data logged by outputs on error is now logged to a different log file {pull}37475[37475]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12700,12 +12700,12 @@ SOFTWARE
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/elastic/elastic-agent-libs
-Version: v0.7.5
+Dependency : github.com/belimawr/elastic-agent-libs
+Version: v0.2.9-0.20240116105334-25f61a14ad41
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.7.5/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/belimawr/elastic-agent-libs@v0.2.9-0.20240116105334-25f61a14ad41/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12701,11 +12701,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/belimawr/elastic-agent-libs
-Version: v0.2.9-0.20240116105334-25f61a14ad41
+Version: v0.2.9-0.20240122163001-efb117578ab2
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/belimawr/elastic-agent-libs@v0.2.9-0.20240116105334-25f61a14ad41/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/belimawr/elastic-agent-libs@v0.2.9-0.20240122163001-efb117578ab2/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1560,7 +1560,7 @@ logging.files:
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-sensitive
+    #name: auditbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1545,10 +1545,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1564,10 +1564,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1544,6 +1544,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/auditbeat
+
+    # The name of the files where the logs are written to.
+    #name: auditbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1553,14 +1553,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-events-data
+    #name: auditbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -174,14 +174,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-events-data
+    #name: auditbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -181,7 +181,7 @@ processors:
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-sensitive
+    #name: auditbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -169,6 +169,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/auditbeat
+
+    # The name of the files where the logs are written to.
+    #name: auditbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/auditbeat/tests/system/requirements.txt
+++ b/auditbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5

--- a/dev-tools/requirements.txt
+++ b/dev-tools/requirements.txt
@@ -1,3 +1,3 @@
 elasticsearch
 requests
-protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2656,7 +2656,7 @@ logging.files:
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-sensitive
+    #name: filebeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2640,6 +2640,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/filebeat
+
+    # The name of the files where the logs are written to.
+    #name: filebeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2660,10 +2660,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2641,10 +2641,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2649,14 +2649,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-events-data
+    #name: filebeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -186,6 +186,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/filebeat
+
+    # The name of the files where the logs are written to.
+    #name: filebeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -198,7 +198,7 @@ processors:
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-sensitive
+    #name: filebeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -191,14 +191,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-events-data
+    #name: filebeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring

--- a/filebeat/tests/integration/events_log_file_test.go
+++ b/filebeat/tests/integration/events_log_file_test.go
@@ -1,0 +1,131 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+)
+
+var eventsLogFileCfg = `
+filebeat.inputs:
+  - type: filestream
+    id: filestream-input-id
+    enabled: true
+    parsers:
+      - ndjson:
+          target: ""
+          overwrite_keys: true
+          expand_keys: true
+          add_error_key: true
+          ignore_decoding_error: false
+    paths:
+      - %s
+
+output:
+  elasticsearch:
+    hosts:
+      - localhost:9200
+    protocol: http
+    username: admin
+    password: testing
+
+logging:
+  level: debug
+  files:
+    events:
+      files:
+        name: filebeat-events-data
+`
+
+func TestEventsLoggerESOutput(t *testing.T) {
+	// First things first, ensure ES is running and we can connect to it.
+	// If ES is not running, the test will timeout and the only way to know
+	// what caused it is going through Filebeat's logs.
+	integration.EnsureESIsRunning(t)
+
+	filebeat := integration.NewBeat(
+		t,
+		"filebeat",
+		"../../filebeat.test",
+	)
+
+	logFilePath := filepath.Join(filebeat.TempDir(), "log.log")
+	filebeat.WriteConfigFile(fmt.Sprintf(eventsLogFileCfg, logFilePath))
+
+	logFile, err := os.Create(logFilePath)
+	if err != nil {
+		t.Fatalf("could not create file '%s': %s", logFilePath, err)
+	}
+
+	logFile.WriteString(`
+{"message":"foo bar","int":10,"string":"str"}
+{"message":"another message","int":20,"string":"str2"}
+{"message":"index failure","int":"not a number","string":10}
+{"message":"second index failure","int":"not a number","string":10}
+`)
+	if err := logFile.Sync(); err != nil {
+		t.Fatalf("could not sync log file '%s': %s", logFilePath, err)
+	}
+	if err := logFile.Close(); err != nil {
+		t.Fatalf("could not close log file '%s': %s", logFilePath, err)
+	}
+
+	filebeat.Start()
+
+	// Wait for a log entry that indicates an entry in the events
+	// logger file.
+	msg := "Cannot index event (status=400)"
+	require.Eventually(t, func() bool {
+		return filebeat.LogContains(msg)
+	}, time.Minute, 100*time.Millisecond,
+		fmt.Sprintf("String '%s' not found on Filebeat logs", msg))
+
+	glob := filepath.Join(filebeat.TempDir(), "filebeat-events-data*.ndjson")
+	files, err := filepath.Glob(glob)
+	if err != nil {
+		t.Fatalf("could not read files matching glob '%s': %s", glob, err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("there must be only one file matching the glob '%s', found: %s", glob, files)
+	}
+
+	eventsLogFile := files[0]
+	data, err := os.ReadFile(eventsLogFile)
+	if err != nil {
+		t.Fatalf("could not read '%s': %s", eventsLogFile, err)
+	}
+
+	strData := string(data)
+	eventMsg := "not a number"
+	if !strings.Contains(strData, eventMsg) {
+		t.Errorf("expecting to find '%s' on '%s'", eventMsg, eventsLogFile)
+		t.Errorf("Contents:\n%s", strData)
+		t.FailNow()
+	}
+}

--- a/filebeat/tests/integration/events_log_file_test.go
+++ b/filebeat/tests/integration/events_log_file_test.go
@@ -83,7 +83,7 @@ func TestEventsLoggerESOutput(t *testing.T) {
 		t.Fatalf("could not create file '%s': %s", logFilePath, err)
 	}
 
-	logFile.WriteString(`
+	_, _ = logFile.WriteString(`
 {"message":"foo bar","int":10,"string":"str"}
 {"message":"another message","int":20,"string":"str2"}
 {"message":"index failure","int":"not a number","string":10}

--- a/filebeat/tests/integration/sensitive_log_file_test.go
+++ b/filebeat/tests/integration/sensitive_log_file_test.go
@@ -60,7 +60,7 @@ logging:
   files:
     events:
       files:
-        name: filebeat-events-data
+        name: filebeat-sensitive-data
 `
 
 func TestEventsLoggerESOutput(t *testing.T) {
@@ -106,7 +106,7 @@ func TestEventsLoggerESOutput(t *testing.T) {
 	}, time.Minute, 100*time.Millisecond,
 		fmt.Sprintf("String '%s' not found on Filebeat logs", msg))
 
-	glob := filepath.Join(filebeat.TempDir(), "filebeat-events-data*.ndjson")
+	glob := filepath.Join(filebeat.TempDir(), "filebeat-sensitive-data*.ndjson")
 	files, err := filepath.Glob(glob)
 	if err != nil {
 		t.Fatalf("could not read files matching glob '%s': %s", glob, err)

--- a/go.mod
+++ b/go.mod
@@ -420,4 +420,4 @@ replace (
 // Exclude this version because the version has an invalid checksum.
 exclude github.com/docker/distribution v2.8.0+incompatible
 
-replace github.com/elastic/elastic-agent-libs => github.com/belimawr/elastic-agent-libs v0.2.9-0.20231220154111-efc1fba83b4b
+replace github.com/elastic/elastic-agent-libs => github.com/belimawr/elastic-agent-libs v0.2.9-0.20231221105324-aedb70a4f832

--- a/go.mod
+++ b/go.mod
@@ -420,4 +420,4 @@ replace (
 // Exclude this version because the version has an invalid checksum.
 exclude github.com/docker/distribution v2.8.0+incompatible
 
-replace github.com/elastic/elastic-agent-libs => github.com/belimawr/elastic-agent-libs v0.2.9-0.20240116105334-25f61a14ad41
+replace github.com/elastic/elastic-agent-libs => github.com/belimawr/elastic-agent-libs v0.2.9-0.20240122163001-efb117578ab2

--- a/go.mod
+++ b/go.mod
@@ -420,4 +420,4 @@ replace (
 // Exclude this version because the version has an invalid checksum.
 exclude github.com/docker/distribution v2.8.0+incompatible
 
-replace github.com/elastic/elastic-agent-libs => github.com/belimawr/elastic-agent-libs v0.2.9-0.20231221105324-aedb70a4f832
+replace github.com/elastic/elastic-agent-libs => github.com/belimawr/elastic-agent-libs v0.2.9-0.20240116105334-25f61a14ad41

--- a/go.mod
+++ b/go.mod
@@ -419,3 +419,5 @@ replace (
 
 // Exclude this version because the version has an invalid checksum.
 exclude github.com/docker/distribution v2.8.0+incompatible
+
+replace github.com/elastic/elastic-agent-libs => github.com/belimawr/elastic-agent-libs v0.2.9-0.20231220154111-efc1fba83b4b

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/awslabs/goformation/v4 v4.1.0 h1:JRxIW0IjhYpYDrIZOTJGMu2azXKI+OK5dP56
 github.com/awslabs/goformation/v4 v4.1.0/go.mod h1:MBDN7u1lMNDoehbFuO4uPvgwPeolTMA2TzX1yO6KlxI=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5 h1:lxW5Q6K2IisyF5tlr6Ts0W4POGWQZco05MJjFmoeIHs=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5/go.mod h1:0Qr1uMHFmHsIYMcG4T7BJ9yrJtWadhOmpABCX69dwuc=
-github.com/belimawr/elastic-agent-libs v0.2.9-0.20231221105324-aedb70a4f832 h1:hCPNCDrtpZg8GekH7RptPcJ9C/Dgr2ebku2lETqFFw0=
-github.com/belimawr/elastic-agent-libs v0.2.9-0.20231221105324-aedb70a4f832/go.mod h1:EbRwBMsWoU4IHGKJlTrxbxC03hkihS9W4h+UgraLdDM=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20240116105334-25f61a14ad41 h1:4kwfzIBmNATT0es3HsgZP7W4p6OUo1TCOk5qchsUzTs=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20240116105334-25f61a14ad41/go.mod h1:pGMj5myawdqu+xE+WKvM5FQzKQ/MonikkWOzoFTJxaU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/immutable v0.2.1/go.mod h1:uc6OHo6PN2++n98KHLxW8ef4W42ylHiQSENghE1ezxI=
 github.com/benbjohnson/tmpl v1.0.0/go.mod h1:igT620JFIi44B6awvU9IsDhR77IXWtFigTLil/RPdps=

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/awslabs/goformation/v4 v4.1.0 h1:JRxIW0IjhYpYDrIZOTJGMu2azXKI+OK5dP56
 github.com/awslabs/goformation/v4 v4.1.0/go.mod h1:MBDN7u1lMNDoehbFuO4uPvgwPeolTMA2TzX1yO6KlxI=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5 h1:lxW5Q6K2IisyF5tlr6Ts0W4POGWQZco05MJjFmoeIHs=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5/go.mod h1:0Qr1uMHFmHsIYMcG4T7BJ9yrJtWadhOmpABCX69dwuc=
-github.com/belimawr/elastic-agent-libs v0.2.9-0.20231220154111-efc1fba83b4b h1:GEwwH9rTwJzcHAcdCFkfta0AHbADcTNpxZhL51ASLpo=
-github.com/belimawr/elastic-agent-libs v0.2.9-0.20231220154111-efc1fba83b4b/go.mod h1:EbRwBMsWoU4IHGKJlTrxbxC03hkihS9W4h+UgraLdDM=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20231221105324-aedb70a4f832 h1:hCPNCDrtpZg8GekH7RptPcJ9C/Dgr2ebku2lETqFFw0=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20231221105324-aedb70a4f832/go.mod h1:EbRwBMsWoU4IHGKJlTrxbxC03hkihS9W4h+UgraLdDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/immutable v0.2.1/go.mod h1:uc6OHo6PN2++n98KHLxW8ef4W42ylHiQSENghE1ezxI=
 github.com/benbjohnson/tmpl v1.0.0/go.mod h1:igT620JFIi44B6awvU9IsDhR77IXWtFigTLil/RPdps=

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/awslabs/goformation/v4 v4.1.0 h1:JRxIW0IjhYpYDrIZOTJGMu2azXKI+OK5dP56
 github.com/awslabs/goformation/v4 v4.1.0/go.mod h1:MBDN7u1lMNDoehbFuO4uPvgwPeolTMA2TzX1yO6KlxI=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5 h1:lxW5Q6K2IisyF5tlr6Ts0W4POGWQZco05MJjFmoeIHs=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5/go.mod h1:0Qr1uMHFmHsIYMcG4T7BJ9yrJtWadhOmpABCX69dwuc=
-github.com/belimawr/elastic-agent-libs v0.2.9-0.20240116105334-25f61a14ad41 h1:4kwfzIBmNATT0es3HsgZP7W4p6OUo1TCOk5qchsUzTs=
-github.com/belimawr/elastic-agent-libs v0.2.9-0.20240116105334-25f61a14ad41/go.mod h1:pGMj5myawdqu+xE+WKvM5FQzKQ/MonikkWOzoFTJxaU=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20240122163001-efb117578ab2 h1:QOTo5kTJ8oqdrSOH8/OhSkEMA3mnRltGg52M9YyH7Zo=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20240122163001-efb117578ab2/go.mod h1:pGMj5myawdqu+xE+WKvM5FQzKQ/MonikkWOzoFTJxaU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/immutable v0.2.1/go.mod h1:uc6OHo6PN2++n98KHLxW8ef4W42ylHiQSENghE1ezxI=
 github.com/benbjohnson/tmpl v1.0.0/go.mod h1:igT620JFIi44B6awvU9IsDhR77IXWtFigTLil/RPdps=

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/awslabs/goformation/v4 v4.1.0 h1:JRxIW0IjhYpYDrIZOTJGMu2azXKI+OK5dP56
 github.com/awslabs/goformation/v4 v4.1.0/go.mod h1:MBDN7u1lMNDoehbFuO4uPvgwPeolTMA2TzX1yO6KlxI=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5 h1:lxW5Q6K2IisyF5tlr6Ts0W4POGWQZco05MJjFmoeIHs=
 github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5/go.mod h1:0Qr1uMHFmHsIYMcG4T7BJ9yrJtWadhOmpABCX69dwuc=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20231220154111-efc1fba83b4b h1:GEwwH9rTwJzcHAcdCFkfta0AHbADcTNpxZhL51ASLpo=
+github.com/belimawr/elastic-agent-libs v0.2.9-0.20231220154111-efc1fba83b4b/go.mod h1:EbRwBMsWoU4IHGKJlTrxbxC03hkihS9W4h+UgraLdDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/immutable v0.2.1/go.mod h1:uc6OHo6PN2++n98KHLxW8ef4W42ylHiQSENghE1ezxI=
 github.com/benbjohnson/tmpl v1.0.0/go.mod h1:igT620JFIi44B6awvU9IsDhR77IXWtFigTLil/RPdps=
@@ -662,8 +664,6 @@ github.com/elastic/elastic-agent-autodiscover v0.6.7 h1:+KVjltN0rPsBrU8b156gV4lO
 github.com/elastic/elastic-agent-autodiscover v0.6.7/go.mod h1:hFeFqneS2r4jD0/QzGkrNk0YVdN0JGh7lCWdsH7zcI4=
 github.com/elastic/elastic-agent-client/v7 v7.6.0 h1:FEn6FjzynW4TIQo5G096Tr7xYK/P5LY9cSS6wRbXZTc=
 github.com/elastic/elastic-agent-client/v7 v7.6.0/go.mod h1:GlUKrbVd/O1CRAZonpBeN3J0RlVqP6VGcrBjFWca+aM=
-github.com/elastic/elastic-agent-libs v0.7.5 h1:4UMqB3BREvhwecYTs/L23oQp1hs/XUkcunPlmTZn5yg=
-github.com/elastic/elastic-agent-libs v0.7.5/go.mod h1:pGMj5myawdqu+xE+WKvM5FQzKQ/MonikkWOzoFTJxaU=
 github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3 h1:sb+25XJn/JcC9/VL8HX4r4QXSUq4uTNzGS2kxOE7u1U=
 github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3/go.mod h1:rWarFM7qYxJKsi9WcV6ONcFjH/NA3niDNpTxO+8/GVI=
 github.com/elastic/elastic-agent-system-metrics v0.9.1 h1:r0ofKHgPpl+W09ie7tzGcCDC0d4NZbQUv37rSgHf4FM=

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1645,14 +1645,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-events-data
+    #name: heartbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1636,6 +1636,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/heartbeat
+
+    # The name of the files where the logs are written to.
+    #name: heartbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1656,10 +1656,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1637,10 +1637,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1652,7 +1652,7 @@ logging.files:
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-sensitive
+    #name: heartbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -152,6 +152,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/heartbeat
+
+    # The name of the files where the logs are written to.
+    #name: heartbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -164,7 +164,7 @@ processors:
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-sensitive
+    #name: heartbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -157,14 +157,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-events-data
+    #name: heartbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring

--- a/heartbeat/tests/system/requirements.txt
+++ b/heartbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -67,3 +67,39 @@ logging.files:
   # Rotate existing logs on startup rather than appending them to the existing
   # file. Defaults to true.
   # rotateonstartup: true
+
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/{{.BeatName}}
+
+    # The name of the files where the logs are written to.
+    #name: {{.BeatName}}-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -69,10 +69,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -88,10 +88,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -84,7 +84,7 @@ logging.files:
     #path: /var/log/{{.BeatName}}
 
     # The name of the files where the logs are written to.
-    #name: {{.BeatName}}-sensitive
+    #name: {{.BeatName}}-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -77,14 +77,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/{{.BeatName}}
 
     # The name of the files where the logs are written to.
-    #name: {{.BeatName}}-events-data
+    #name: {{.BeatName}}-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/libbeat/_meta/config/logging.yml.tmpl
+++ b/libbeat/_meta/config/logging.yml.tmpl
@@ -14,11 +14,11 @@
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/{{.BeatName}}
 
     # The name of the files where the logs are written to.
-    #name: {{.BeatName}}-events-data
+    #name: {{.BeatName}}-sensitive

--- a/libbeat/_meta/config/logging.yml.tmpl
+++ b/libbeat/_meta/config/logging.yml.tmpl
@@ -8,3 +8,17 @@
 # To enable all selectors, use ["*"]. Examples of other selectors are "beat",
 # "publisher", "service".
 #logging.selectors: ["*"]
+
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/{{.BeatName}}
+
+    # The name of the files where the logs are written to.
+    #name: {{.BeatName}}-events-data

--- a/libbeat/_meta/config/logging.yml.tmpl
+++ b/libbeat/_meta/config/logging.yml.tmpl
@@ -21,4 +21,4 @@
     #path: /var/log/{{.BeatName}}
 
     # The name of the files where the logs are written to.
-    #name: {{.BeatName}}-sensitive
+    #name: {{.BeatName}}-sensitive-data

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -399,7 +399,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	if sensitiveLoggerCfg.Files.Name == "" {
 		sensitiveLoggerCfg.Files.Name = b.Info.Beat
 		// Append the name so the files do not overwrite themselves.
-		sensitiveLoggerCfg.Files.Name = sensitiveLoggerCfg.Files.Name + "-events-data"
+		sensitiveLoggerCfg.Files.Name = sensitiveLoggerCfg.Files.Name + "-sensitive-data"
 	}
 
 	outputFactory := b.makeOutputFactory(b.Config.Output, sensitiveLoggerCfg)

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -386,7 +386,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	eventsLoggerCfg := logp.DefaultConfig(configure.GetEnvironment())
 
 	// merge eventsLoggerCfg with b.Config.Logging, so logging.events.* only
-	// overwrites logging.*
+	// overwrites the files block.
 	if err := b.Config.EventLogging.Unpack(&eventsLoggerCfg); err != nil {
 		return nil, fmt.Errorf("error initialising events logger: %w", err)
 	}
@@ -807,9 +807,12 @@ func (b *Beat) configure(settings Settings) error {
 	if b.Config.EventLogging == nil {
 		b.Config.EventLogging = config.NewConfig()
 	}
-	b.Config.EventLogging.Merge(b.Config.Logging)
-	if _, err := b.Config.EventLogging.Remove("events", -1); err != nil {
+	if err := b.Config.EventLogging.Merge(b.Config.Logging); err != nil {
 		return fmt.Errorf("cannot merge logging and logging.events configuration: %w", err)
+	}
+
+	if _, err := b.Config.EventLogging.Remove("events", -1); err != nil {
+		return fmt.Errorf("cannot update logging.events configuration: %w", err)
 	}
 
 	if err := promoteOutputQueueSettings(&b.Config); err != nil {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -18,6 +18,7 @@
 package instance
 
 import (
+	"bytes"
 	"context"
 	cryptRand "crypto/rand"
 	"encoding/json"
@@ -31,6 +32,7 @@ import (
 	"net"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"strconv"
@@ -398,6 +400,11 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 		eventsLoggerCfg.Files.Name = eventsLoggerCfg.Files.Name + "-events-data"
 	}
 
+	// Now that the events logger is configured, we can register it's diagnostic
+	// hook
+	b.Manager.RegisterDiagnosticHook("events log",
+		"log files containing raw events", "events_log.ndjson",
+		"application/x-ndjson", b.eventsLogDiagnosticsHook(eventsLoggerCfg))
 	outputFactory := b.makeOutputFactory(b.Config.Output, eventsLoggerCfg)
 	settings := pipeline.Settings{
 		Processors:     b.processors,
@@ -421,6 +428,44 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	}
 
 	return beater, nil
+}
+
+func (b *Beat) eventsLogDiagnosticsHook(logCfg logp.Config) func() []byte {
+	// Setup a no-op function to return in case of an error
+	data := []byte{}
+	fn := func() []byte {
+		return data
+	}
+
+	glob := fmt.Sprintf("%s*.ndjson",
+		paths.Resolve(
+			paths.Logs,
+			filepath.Join(
+				logCfg.Files.Path,
+				logCfg.LogFilename(),
+			)))
+
+	files, err := filepath.Glob(glob)
+	if err != nil {
+		logp.Warn("could not get 'event log' files: %s", err)
+		return fn
+	}
+
+	filesData := [][]byte{}
+	fn = func() []byte {
+		return bytes.Join(filesData, []byte{})
+	}
+
+	for _, f := range files {
+		logData, err := os.ReadFile(f)
+		if err != nil {
+			logp.Warn("could not read event log file '%s': %s", f, err)
+			return fn
+		}
+		filesData = append(filesData, logData)
+	}
+
+	return fn
 }
 
 func (b *Beat) launch(settings Settings, bt beat.Creator) error {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -804,8 +804,14 @@ func (b *Beat) configure(settings Settings) error {
 		return fmt.Errorf("error unpacking config data: %w", err)
 	}
 
+	// If either b.Config.EventLoggingor b.Config.Logging are nil
+	// merging them will fail, so in case any of them is nil,
+	// we set them to an empty config.C
 	if b.Config.EventLogging == nil {
 		b.Config.EventLogging = config.NewConfig()
+	}
+	if b.Config.Logging == nil {
+		b.Config.Logging = config.NewConfig()
 	}
 	if err := b.Config.EventLogging.Merge(b.Config.Logging); err != nil {
 		return fmt.Errorf("cannot merge logging and logging.events configuration: %w", err)

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -384,8 +384,11 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 
 	// Get the default/current logging configuration
 	// we need some defaults to be populates otherwise Unpack will
-	// fail
+	// fail. We also overwrite some defaults that are specific to the
+	// events logger.
 	eventsLoggerCfg := logp.DefaultConfig(configure.GetEnvironment())
+	eventsLoggerCfg.Files.MaxSize = 5242880 // 5MB
+	eventsLoggerCfg.Files.MaxBackups = 5
 
 	// merge eventsLoggerCfg with b.Config.Logging, so logging.events.* only
 	// overwrites the files block.

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-ucfg/yaml"
 
 	"github.com/gofrs/uuid"
@@ -247,7 +248,7 @@ elasticsearch:
 
 		update := &reload.ConfigWithMeta{Config: c}
 		m := &outputReloaderMock{}
-		reloader := b.makeOutputReloader(m)
+		reloader := b.makeOutputReloader(m, logp.Config{})
 
 		require.False(t, b.Config.Output.IsSet(), "the output should not be set yet")
 		require.True(t, b.isConnectionToOlderVersionAllowed(), "allow_older_versions flag should be true from 8.11")
@@ -266,7 +267,8 @@ type outputReloaderMock struct {
 
 func (r *outputReloaderMock) Reload(
 	cfg *reload.ConfigWithMeta,
-	factory func(o outputs.Observer, cfg config.Namespace) (outputs.Group, error),
+	eventsLoggerCfg logp.Config,
+	factory func(o outputs.Observer, cfg config.Namespace, eventsLoggerCfg logp.Config) (outputs.Group, error),
 ) error {
 	r.cfg = cfg
 	return nil

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -267,8 +267,8 @@ type outputReloaderMock struct {
 
 func (r *outputReloaderMock) Reload(
 	cfg *reload.ConfigWithMeta,
-	eventsLoggerCfg logp.Config,
-	factory func(o outputs.Observer, cfg config.Namespace, eventsLoggerCfg logp.Config) (outputs.Group, error),
+	sensitiveLoggerCfg logp.Config,
+	factory func(o outputs.Observer, cfg config.Namespace, sensitiveLoggerCfg logp.Config) (outputs.Group, error),
 ) error {
 	r.cfg = cfg
 	return nil

--- a/libbeat/cmd/test/output.go
+++ b/libbeat/cmd/test/output.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt"
 	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/testing"
 )
 
@@ -41,7 +42,8 @@ func GenTestOutputCmd(settings instance.Settings) *cobra.Command {
 			}
 
 			im, _ := idxmgmt.DefaultSupport(nil, b.Info, nil)
-			output, err := outputs.Load(im, b.Info, nil, b.Config.Output.Name(), b.Config.Output.Config())
+			// we use an empty config for the events logger because this is just a output test
+			output, err := outputs.Load(im, b.Info, nil, b.Config.Output.Name(), b.Config.Output.Config(), logp.Config{})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing output: %s\n", err)
 				os.Exit(1)

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -304,6 +304,9 @@ log messages, a different log file, only for log entries containing raw events,
 is used. It will use the same level, selectors and all other configurations
 from the default logger, but it will have it's own file configuration.
 
+IMPORTANT: No matter the default logger output configuration, raw events
+will **always** be logged to a file configured by `logging.events.files`.
+
 [float]
 ==== `logging.events.files.path`
 

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -296,7 +296,7 @@ Below are some samples:
 
 ifndef::serverless[]
 [float]
-=== Configuration options for events logger
+=== Configuration options for sensitive logger
 
 Some outputs will log raw events on errors like indexing errors in the
 Elasticsearch output, to prevent logging raw events (that may contain
@@ -309,34 +309,34 @@ Having a different log file for raw events also prevents event data
 from drowning out the regular log files.
 
 IMPORTANT: No matter the default logger output configuration, raw events
-will **always** be logged to a file configured by `logging.events.files`.
+will **always** be logged to a file configured by `logging.sensitive.files`.
 
 [float]
-==== `logging.events.files.path`
+==== `logging.sensitive.files.path`
 
 The directory that log files are written to. The default is the logs path. See
 the <<directory-layout>> section for details.
 
 [float]
-==== `logging.events.files.name`
+==== `logging.sensitive.files.name`
 
-The name of the file that logs are written to. The default is '{beatname_lc}'.
+The name of the file that logs are written to. The default is '{beatname_lc}'-sensitive.
 
 [float]
-==== `logging.events.files.rotateeverybytes`
+==== `logging.sensitive.files.rotateeverybytes`
 
 The maximum size of a log file. If the limit is reached, a new log file is
 generated. The default size limit is 5242880 (5 MB).
 
 [float]
-==== `logging.events.files.keepfiles`
+==== `logging.sensitive.files.keepfiles`
 
 The number of most recent rotated log files to keep on disk. Older files are
 deleted during log rotation. The default value is 5. The `keepfiles` options has
 to be in the range of 2 to 1024 files.
 
 [float]
-==== `logging.events.files.permissions`
+==== `logging.sensitive.files.permissions`
 
 The permissions mask to apply when rotating log files. The default value is
 0600. The `permissions` option must be a valid Unix-style file permissions mask
@@ -354,7 +354,7 @@ Examples:
 * 0600: give read and write access to the file owner, and no access to all others.
 
 [float]
-==== `logging.events.files.interval`
+==== `logging.sensitive.files.interval`
 
 Enable log file rotation on time intervals in addition to size-based rotation.
 Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
@@ -363,7 +363,7 @@ reported by the local system clock. All other intervals are calculated from the
 unix epoch. Defaults to disabled.
 
 [float]
-==== `logging.events.files.rotateonstartup`
+==== `logging.sensitive.files.rotateonstartup`
 
 If the log file already exists on startup, immediately rotate it and start
 writing to a new file instead of appending to the existing one. Defaults to

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -326,13 +326,13 @@ The name of the file that logs are written to. The default is '{beatname_lc}'.
 ==== `logging.events.files.rotateeverybytes`
 
 The maximum size of a log file. If the limit is reached, a new log file is
-generated. The default size limit is 10485760 (10 MB).
+generated. The default size limit is 5242880 (5 MB).
 
 [float]
 ==== `logging.events.files.keepfiles`
 
 The number of most recent rotated log files to keep on disk. Older files are
-deleted during log rotation. The default value is 7. The `keepfiles` options has
+deleted during log rotation. The default value is 5. The `keepfiles` options has
 to be in the range of 2 to 1024 files.
 
 [float]

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -299,10 +299,14 @@ ifndef::serverless[]
 === Configuration options for events logger
 
 Some outputs will log raw events on errors like indexing errors in the
-Elasticsearch output, to prevent logging raw events together with other
-log messages, a different log file, only for log entries containing raw events,
-is used. It will use the same level, selectors and all other configurations
-from the default logger, but it will have it's own file configuration.
+Elasticsearch output, to prevent logging raw events (that may contain
+sensitive information) together with other log messages, a different
+log file, only for log entries containing raw events, is used. It will
+use the same level, selectors and all other configurations from the
+default logger, but it will have it's own file configuration.
+
+Having a different log file for raw events also prevents event data
+from drowning out the regular log files.
 
 IMPORTANT: No matter the default logger output configuration, raw events
 will **always** be logged to a file configured by `logging.events.files`.

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -293,3 +293,73 @@ Below are some samples:
 `2017-12-17T18:54:16.242-0500	INFO	[example]	logp/core_test.go:16	some message`
 
 `2017-12-17T18:54:16.242-0500	INFO	[example]	logp/core_test.go:19	some message	{"x": 1}`
+
+ifndef::serverless[]
+[float]
+=== Configuration options for events logger
+
+Some outputs will log raw events on errors like indexing errors in the
+Elasticsearch output, to prevent logging raw events together with other
+log messages, a different log file, only for log entries containing raw events,
+is used. It will use the same level, selectors and all other configurations
+from the default logger, but it will have it's own file configuration.
+
+[float]
+==== `logging.events.files.path`
+
+The directory that log files are written to. The default is the logs path. See
+the <<directory-layout>> section for details.
+
+[float]
+==== `logging.events.files.name`
+
+The name of the file that logs are written to. The default is '{beatname_lc}'.
+
+[float]
+==== `logging.events.files.rotateeverybytes`
+
+The maximum size of a log file. If the limit is reached, a new log file is
+generated. The default size limit is 10485760 (10 MB).
+
+[float]
+==== `logging.events.files.keepfiles`
+
+The number of most recent rotated log files to keep on disk. Older files are
+deleted during log rotation. The default value is 7. The `keepfiles` options has
+to be in the range of 2 to 1024 files.
+
+[float]
+==== `logging.events.files.permissions`
+
+The permissions mask to apply when rotating log files. The default value is
+0600. The `permissions` option must be a valid Unix-style file permissions mask
+expressed in octal notation. In Go, numbers in octal notation must start with
+'0'.
+
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to an umask of 0027.
+
+This option is not supported on Windows.
+
+Examples:
+
+* 0640: give read and write access to the file owner, and read access to members of the group associated with the file.
+* 0600: give read and write access to the file owner, and no access to all others.
+
+[float]
+==== `logging.events.files.interval`
+
+Enable log file rotation on time intervals in addition to size-based rotation.
+Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+are boundary-aligned with minutes, hours, days, weeks, months, and years as
+reported by the local system clock. All other intervals are calculated from the
+unix epoch. Defaults to disabled.
+
+[float]
+==== `logging.events.files.rotateonstartup`
+
+If the log file already exists on startup, immediately rotate it and start
+writing to a new file instead of appending to the existing one. Defaults to
+true.
+endif::serverless[]
+

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -51,7 +51,7 @@ func makeConsole(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *config.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	config := defaultConfig
 	err := cfg.Unpack(&config)

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -51,6 +51,7 @@ func makeConsole(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *config.C,
+	eventsLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	config := defaultConfig
 	err := cfg.Unpack(&config)

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -437,11 +437,11 @@ func (client *Client) bulkCollectPublishFails(result eslegclient.BulkResult, dat
 				result, _ := data[i].Content.Meta.HasKey(dead_letter_marker_field)
 				if result {
 					stats.nonIndexable++
-					client.log.Errorf("Can't deliver to dead letter index event (status=%v). Look for events-data log file to view the event and cause.", status)
+					client.log.Errorf("Can't deliver to dead letter index event (status=%v). Look for sensitive-data log file to view the event and cause.", status)
 					client.sensitiveLogger.Errorf("Can't deliver to dead letter index event %#v (status=%v): %s", data[i], status, msg)
 					// poison pill - this will clog the pipeline if the underlying failure is non transient.
 				} else if client.NonIndexableAction == dead_letter_index {
-					client.log.Warnf("Cannot index event (status=%v), trying dead letter index. Look for events-data log file to view the event and cause.", status)
+					client.log.Warnf("Cannot index event (status=%v), trying dead letter index. Look for sensitive-data log file to view the event and cause.", status)
 					client.sensitiveLogger.Warnf("Cannot index event %#v (status=%v): %s, trying dead letter index", data[i], status, msg)
 					if data[i].Content.Meta == nil {
 						data[i].Content.Meta = mapstr.M{
@@ -457,7 +457,7 @@ func (client *Client) bulkCollectPublishFails(result eslegclient.BulkResult, dat
 					}
 				} else { // drop
 					stats.nonIndexable++
-					client.log.Warnf("Cannot index event (status=%v): dropping event! Look for events-data log file to view the event and cause.", status)
+					client.log.Warnf("Cannot index event (status=%v): dropping event! Look for sensitive-data log file to view the event and cause.", status)
 					client.sensitiveLogger.Warnf("Cannot index event %#v (status=%v): %s, dropping event!", data[i], status, msg)
 					continue
 				}

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -422,7 +422,15 @@ func connectTestEs(t *testing.T, cfg interface{}, stats outputs.Observer) (outpu
 	info := beat.Info{Beat: "libbeat"}
 	// disable ILM if using specified index name
 	im, _ := idxmgmt.DefaultSupport(nil, info, conf.MustNewConfigFrom(map[string]interface{}{"setup.ilm.enabled": "false"}))
-	output, err := makeES(im, info, stats, config, logp.Config{})
+
+	// Creates the events logger configuration for testing
+	// It used the default one but logs to stderr instead of a file
+	eventsLoggerCfg := logp.DefaultConfig(logp.DefaultEnvironment)
+	eventsLoggerCfg.Level = logp.DebugLevel
+	eventsLoggerCfg.ToStderr = true
+	eventsLoggerCfg.ToFiles = false
+
+	output, err := makeES(im, info, stats, config, eventsLoggerCfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -422,7 +422,7 @@ func connectTestEs(t *testing.T, cfg interface{}, stats outputs.Observer) (outpu
 	info := beat.Info{Beat: "libbeat"}
 	// disable ILM if using specified index name
 	im, _ := idxmgmt.DefaultSupport(nil, info, conf.MustNewConfigFrom(map[string]interface{}{"setup.ilm.enabled": "false"}))
-	output, err := makeES(im, info, stats, config)
+	output, err := makeES(im, info, stats, config, logp.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -426,12 +426,12 @@ func connectTestEs(t *testing.T, cfg interface{}, stats outputs.Observer) (outpu
 	// Creates the events logger configuration for testing,
 	// it uses the default one but logs to stderr instead of a file.
 	// This prevents the test to leave log files behind.
-	eventsLoggerCfg := logp.DefaultConfig(logp.DefaultEnvironment)
-	eventsLoggerCfg.Level = logp.DebugLevel
-	eventsLoggerCfg.ToStderr = true
-	eventsLoggerCfg.ToFiles = false
+	sensitiveLoggerCfg := logp.DefaultConfig(logp.DefaultEnvironment)
+	sensitiveLoggerCfg.Level = logp.DebugLevel
+	sensitiveLoggerCfg.ToStderr = true
+	sensitiveLoggerCfg.ToFiles = false
 
-	output, err := makeES(im, info, stats, config, eventsLoggerCfg)
+	output, err := makeES(im, info, stats, config, sensitiveLoggerCfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -423,8 +423,9 @@ func connectTestEs(t *testing.T, cfg interface{}, stats outputs.Observer) (outpu
 	// disable ILM if using specified index name
 	im, _ := idxmgmt.DefaultSupport(nil, info, conf.MustNewConfigFrom(map[string]interface{}{"setup.ilm.enabled": "false"}))
 
-	// Creates the events logger configuration for testing
-	// It used the default one but logs to stderr instead of a file
+	// Creates the events logger configuration for testing,
+	// it uses the default one but logs to stderr instead of a file.
+	// This prevents the test to leave log files behind.
 	eventsLoggerCfg := logp.DefaultConfig(logp.DefaultEnvironment)
 	eventsLoggerCfg.Level = logp.DebugLevel
 	eventsLoggerCfg.ToStderr = true

--- a/libbeat/outputs/elasticsearch/client_proxy_test.go
+++ b/libbeat/outputs/elasticsearch/client_proxy_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/outputs/outil"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
@@ -204,7 +205,7 @@ func doClientPing(t *testing.T) {
 
 		clientSettings.Transport.Proxy.URL = &proxyURL
 	}
-	client, err := NewClient(clientSettings, nil)
+	client, err := NewClient(logp.L(), logp.L(), clientSettings, nil)
 	require.NoError(t, err)
 
 	// This ping won't succeed; we aren't testing end-to-end communication

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -90,6 +90,8 @@ func (bm *batchMock) RetryEvents(events []publisher.Event) {
 func TestPublish(t *testing.T) {
 	makePublishTestClient := func(t *testing.T, url string) *Client {
 		client, err := NewClient(
+			logp.L(),
+			logp.L(),
 			ClientSettings{
 				Observer:           outputs.NewNilObserver(),
 				ConnectionSettings: eslegclient.ConnectionSettings{URL: url},
@@ -248,6 +250,8 @@ func TestPublish(t *testing.T) {
 
 func TestCollectPublishFailsNone(t *testing.T) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -272,6 +276,8 @@ func TestCollectPublishFailsNone(t *testing.T) {
 
 func TestCollectPublishFailMiddle(t *testing.T) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -302,6 +308,8 @@ func TestCollectPublishFailMiddle(t *testing.T) {
 
 func TestCollectPublishFailDeadLetterQueue(t *testing.T) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "dead_letter_index",
@@ -361,6 +369,8 @@ func TestCollectPublishFailDeadLetterQueue(t *testing.T) {
 
 func TestCollectPublishFailDrop(t *testing.T) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -405,6 +415,8 @@ func TestCollectPublishFailDrop(t *testing.T) {
 
 func TestCollectPublishFailAll(t *testing.T) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -434,6 +446,8 @@ func TestCollectPipelinePublishFail(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -481,6 +495,8 @@ func TestCollectPipelinePublishFail(t *testing.T) {
 
 func BenchmarkCollectPublishFailsNone(b *testing.B) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -510,6 +526,8 @@ func BenchmarkCollectPublishFailsNone(b *testing.B) {
 
 func BenchmarkCollectPublishFailMiddle(b *testing.B) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -540,6 +558,8 @@ func BenchmarkCollectPublishFailMiddle(b *testing.B) {
 
 func BenchmarkCollectPublishFailAll(b *testing.B) {
 	client, err := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer:           outputs.NewNilObserver(),
 			NonIndexableAction: "drop",
@@ -589,17 +609,20 @@ func TestClientWithHeaders(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewClient(ClientSettings{
-		Observer: outputs.NewNilObserver(),
-		ConnectionSettings: eslegclient.ConnectionSettings{
-			URL: ts.URL,
-			Headers: map[string]string{
-				"host":   "myhost.local",
-				"X-Test": "testing value",
+	client, err := NewClient(
+		logp.L(),
+		logp.L(),
+		ClientSettings{
+			Observer: outputs.NewNilObserver(),
+			ConnectionSettings: eslegclient.ConnectionSettings{
+				URL: ts.URL,
+				Headers: map[string]string{
+					"host":   "myhost.local",
+					"X-Test": "testing value",
+				},
 			},
-		},
-		Index: outil.MakeSelector(outil.ConstSelectorExpr("test", outil.SelectorLowerCase)),
-	}, nil)
+			Index: outil.MakeSelector(outil.ConstSelectorExpr("test", outil.SelectorLowerCase)),
+		}, nil)
 	assert.NoError(t, err)
 
 	// simple ping
@@ -667,6 +690,8 @@ func TestBulkEncodeEvents(t *testing.T) {
 			}
 
 			client, err := NewClient(
+				logp.L(),
+				logp.L(),
 				ClientSettings{
 					Observer: outputs.NewNilObserver(),
 					Index:    index,
@@ -743,6 +768,8 @@ func TestBulkEncodeEventsWithOpType(t *testing.T) {
 	}
 
 	client, _ := NewClient(
+		logp.L(),
+		logp.L(),
 		ClientSettings{
 			Observer: outputs.NewNilObserver(),
 			Index:    index,
@@ -786,13 +813,16 @@ func TestClientWithAPIKey(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewClient(ClientSettings{
-		Observer: outputs.NewNilObserver(),
-		ConnectionSettings: eslegclient.ConnectionSettings{
-			URL:    ts.URL,
-			APIKey: "hyokHG4BfWk5viKZ172X:o45JUkyuS--yiSAuuxl8Uw",
-		},
-	}, nil)
+	client, err := NewClient(
+		logp.L(),
+		logp.L(),
+		ClientSettings{
+			Observer: outputs.NewNilObserver(),
+			ConnectionSettings: eslegclient.ConnectionSettings{
+				URL:    ts.URL,
+				APIKey: "hyokHG4BfWk5viKZ172X:o45JUkyuS--yiSAuuxl8Uw",
+			},
+		}, nil)
 	assert.NoError(t, err)
 
 	// This connection will fail since the server doesn't return a valid
@@ -806,6 +836,8 @@ func TestClientWithAPIKey(t *testing.T) {
 func TestPublishEventsWithBulkFiltering(t *testing.T) {
 	makePublishTestClient := func(t *testing.T, url string, configParams map[string]string) *Client {
 		client, err := NewClient(
+			logp.L(),
+			logp.L(),
 			ClientSettings{
 				Observer: outputs.NewNilObserver(),
 				ConnectionSettings: eslegclient.ConnectionSettings{

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -18,6 +18,8 @@
 package elasticsearch
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
@@ -25,7 +27,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs/outil"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -46,7 +46,7 @@ func makeES(
 	sensitiveLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
 	sensitiveLogger = sensitiveLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(sensitiveLoggerCfg)))
-	sensitiveLogger = sensitiveLogger.With("logger.type", "sensitive")
+	sensitiveLogger = sensitiveLogger.With("log.type", "sensitive")
 
 	if !cfg.HasField("bulk_max_size") {
 		if err := cfg.SetInt("bulk_max_size", -1, defaultBulkSize); err != nil {

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -44,7 +44,7 @@ func makeES(
 	log := logp.NewLogger(logSelector)
 	eventsLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = log.WithOptions(zap.WrapCore(logp.WithFileOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOutput(eventsLoggerCfg)))
 
 	if !cfg.HasField("bulk_max_size") {
 		if err := cfg.SetInt("bulk_max_size", -1, defaultBulkSize); err != nil {

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -45,7 +45,8 @@ func makeES(
 	log := logp.NewLogger(logSelector)
 	eventsLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.With("logger.type", "sensitive")
 
 	if !cfg.HasField("bulk_max_size") {
 		if err := cfg.SetInt("bulk_max_size", -1, defaultBulkSize); err != nil {

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -40,13 +40,13 @@ func makeES(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *config.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	log := logp.NewLogger(logSelector)
-	eventsLogger := logp.NewLogger(logSelector)
+	sensitiveLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(eventsLoggerCfg)))
-	eventsLogger = eventsLogger.With("logger.type", "sensitive")
+	sensitiveLogger = sensitiveLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(sensitiveLoggerCfg)))
+	sensitiveLogger = sensitiveLogger.With("logger.type", "sensitive")
 
 	if !cfg.HasField("bulk_max_size") {
 		if err := cfg.SetInt("bulk_max_size", -1, defaultBulkSize); err != nil {
@@ -120,7 +120,7 @@ func makeES(
 		var client outputs.NetworkClient
 		client, err = NewClient(
 			log,
-			eventsLogger,
+			sensitiveLogger,
 			ClientSettings{
 				ConnectionSettings: eslegclient.ConnectionSettings{
 					URL:              esURL,

--- a/libbeat/outputs/elasticsearch/elasticsearch_test.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch_test.go
@@ -122,11 +122,12 @@ func TestPipelineSelection(t *testing.T) {
 			selector, err := buildPipelineSelector(config.MustNewConfigFrom(test.cfg))
 
 			client, err := NewClient(
+				logp.L(),
+				logp.L(),
 				ClientSettings{
 					Pipeline: &selector,
 				},
 				nil,
-				logp.Config{},
 			)
 			assert.NoError(t, err)
 

--- a/libbeat/outputs/elasticsearch/elasticsearch_test.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -125,6 +126,7 @@ func TestPipelineSelection(t *testing.T) {
 					Pipeline: &selector,
 				},
 				nil,
+				logp.Config{},
 			)
 			assert.NoError(t, err)
 

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -68,7 +68,7 @@ func makeFileout(
 	sensitiveLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
 	sensitiveLogger = sensitiveLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(sensitiveLoggerCfg)))
-	sensitiveLogger = sensitiveLogger.With("logger.type", "sensitive")
+	sensitiveLogger = sensitiveLogger.With("log.type", "sensitive")
 
 	fo := &fileOutput{
 		log:          logp.NewLogger(logSelector),
@@ -142,7 +142,7 @@ func (out *fileOutput) Publish(_ context.Context, batch publisher.Batch) error {
 			} else {
 				out.log.Warnf("Failed to serialize the event: %+v", err)
 			}
-			out.log.Debug("Event logged to events-data log file")
+			out.log.Debug("Event logged to sensitive-data log file")
 			out.sensitiveLogger.Debugf("Failed event: %v", event)
 
 			dropped++

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/codec"
@@ -30,7 +32,6 @@ import (
 	c "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/file"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -51,6 +51,7 @@ func makeFileout(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *c.C,
+	eventsLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	foConfig := defaultConfig()
 	if err := cfg.Unpack(&foConfig); err != nil {

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -40,7 +40,7 @@ func init() {
 
 type fileOutput struct {
 	log          *logp.Logger
-	eventsLogger *logp.Logger
+	sensitiveLogger *logp.Logger
 	filePath     string
 	beat         beat.Info
 	observer     outputs.Observer
@@ -54,7 +54,7 @@ func makeFileout(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *c.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	foConfig := defaultConfig()
 	if err := cfg.Unpack(&foConfig); err != nil {
@@ -65,14 +65,14 @@ func makeFileout(
 	_ = cfg.SetInt("bulk_max_size", -1, -1)
 
 	logSelector := "file"
-	eventsLogger := logp.NewLogger(logSelector)
+	sensitiveLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(eventsLoggerCfg)))
-	eventsLogger = eventsLogger.With("logger.type", "sensitive")
+	sensitiveLogger = sensitiveLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(sensitiveLoggerCfg)))
+	sensitiveLogger = sensitiveLogger.With("logger.type", "sensitive")
 
 	fo := &fileOutput{
 		log:          logp.NewLogger(logSelector),
-		eventsLogger: eventsLogger,
+		sensitiveLogger: sensitiveLogger,
 		beat:         beat,
 		observer:     observer,
 	}
@@ -143,7 +143,7 @@ func (out *fileOutput) Publish(_ context.Context, batch publisher.Batch) error {
 				out.log.Warnf("Failed to serialize the event: %+v", err)
 			}
 			out.log.Debug("Event logged to events-data log file")
-			out.eventsLogger.Debugf("Failed event: %v", event)
+			out.sensitiveLogger.Debugf("Failed event: %v", event)
 
 			dropped++
 			continue

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -67,7 +67,9 @@ func makeFileout(
 	logSelector := "file"
 	eventsLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.With("logger.type", "sensitive")
+
 	fo := &fileOutput{
 		log:          logp.NewLogger(logSelector),
 		eventsLogger: eventsLogger,

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -87,7 +87,8 @@ func newKafkaClient(
 ) (*client, error) {
 	eventsLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.With("logger.type", "sensitive")
 
 	c := &client{
 		log:          logp.NewLogger(logSelector),

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -88,7 +88,7 @@ func newKafkaClient(
 	sensitiveLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
 	sensitiveLogger = sensitiveLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(sensitiveLoggerCfg)))
-	sensitiveLogger = sensitiveLogger.With("logger.type", "sensitive")
+	sensitiveLogger = sensitiveLogger.With("log.type", "sensitive")
 
 	c := &client{
 		log:          logp.NewLogger(logSelector),

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -42,7 +42,7 @@ import (
 
 type client struct {
 	log          *logp.Logger
-	eventsLogger *logp.Logger
+	sensitiveLogger *logp.Logger
 	observer     outputs.Observer
 	hosts        []string
 	topic        outil.Selector
@@ -83,16 +83,16 @@ func newKafkaClient(
 	headers []header,
 	writer codec.Codec,
 	cfg *sarama.Config,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (*client, error) {
-	eventsLogger := logp.NewLogger(logSelector)
+	sensitiveLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(eventsLoggerCfg)))
-	eventsLogger = eventsLogger.With("logger.type", "sensitive")
+	sensitiveLogger = sensitiveLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(sensitiveLoggerCfg)))
+	sensitiveLogger = sensitiveLogger.With("logger.type", "sensitive")
 
 	c := &client{
 		log:          logp.NewLogger(logSelector),
-		eventsLogger: eventsLogger,
+		sensitiveLogger: sensitiveLogger,
 		observer:     observer,
 		hosts:        hosts,
 		topic:        topic,
@@ -238,7 +238,7 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 	if err != nil {
 		if c.log.IsDebug() {
 			c.log.Debug("failed event logged to events logger file")
-			c.eventsLogger.Debugf("failed event: %v", event)
+			c.sensitiveLogger.Debugf("failed event: %v", event)
 		}
 		return nil, err
 	}

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -236,8 +236,8 @@ func (c *client) getEventMessage(data *publisher.Event) (*message, error) {
 	serializedEvent, err := c.codec.Encode(c.index, event)
 	if err != nil {
 		if c.log.IsDebug() {
-			c.eventsLogger.Debugf("failed event: %v", event)
 			c.log.Debug("failed event logged to events logger file")
+			c.eventsLogger.Debugf("failed event: %v", event)
 		}
 		return nil, err
 	}

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -73,7 +73,7 @@ func makeKafka(
 		return outputs.Fail(err)
 	}
 
-	client, err := newKafkaClient(observer, hosts, beat.IndexPrefix, kConfig.Key, topic, kConfig.Headers, codec, libCfg)
+	client, err := newKafkaClient(observer, hosts, beat.IndexPrefix, kConfig.Key, topic, kConfig.Headers, codec, libCfg, eventsLoggerCfg)
 	if err != nil {
 		return outputs.Fail(err)
 	}

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -43,7 +43,7 @@ func makeKafka(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *config.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	log := logp.NewLogger(logSelector)
 	log.Debug("initialize kafka output")
@@ -73,7 +73,7 @@ func makeKafka(
 		return outputs.Fail(err)
 	}
 
-	client, err := newKafkaClient(observer, hosts, beat.IndexPrefix, kConfig.Key, topic, kConfig.Headers, codec, libCfg, eventsLoggerCfg)
+	client, err := newKafkaClient(observer, hosts, beat.IndexPrefix, kConfig.Key, topic, kConfig.Headers, codec, libCfg, sensitiveLoggerCfg)
 	if err != nil {
 		return outputs.Fail(err)
 	}

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -43,6 +43,7 @@ func makeKafka(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *config.C,
+	eventsLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	log := logp.NewLogger(logSelector)
 	log.Debug("initialize kafka output")

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -258,7 +258,7 @@ func TestKafkaPublish(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			grp, err := makeKafka(nil, beat.Info{Beat: "libbeat", IndexPrefix: "testbeat"}, outputs.NewNilObserver(), cfg)
+			grp, err := makeKafka(nil, beat.Info{Beat: "libbeat", IndexPrefix: "testbeat"}, outputs.NewNilObserver(), cfg, logp.Config{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -41,7 +41,7 @@ func makeLogstash(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *conf.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	lsConfig, err := readConfig(cfg, beat)
 	if err != nil {

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/transport"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
@@ -40,6 +41,7 @@ func makeLogstash(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *conf.C,
+	eventsLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 	lsConfig, err := readConfig(cfg, beat)
 	if err != nil {

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	"github.com/elastic/beats/v7/libbeat/outputs/outil"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
@@ -193,7 +194,7 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 		t.Fatal("init index management:", err)
 	}
 
-	grp, err := plugin(im, info, outputs.NewNilObserver(), config)
+	grp, err := plugin(im, info, outputs.NewNilObserver(), config, logp.Config{})
 	if err != nil {
 		t.Fatalf("init elasticsearch output plugin failed: %v", err)
 	}

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	v2 "github.com/elastic/go-lumber/server/v2"
 )
@@ -181,7 +182,7 @@ func newTestLumberjackOutput(
 	}
 
 	cfg, _ := conf.NewConfigFrom(config)
-	grp, err := outputs.Load(nil, beat.Info{}, nil, "logstash", cfg)
+	grp, err := outputs.Load(nil, beat.Info{}, nil, "logstash", cfg, logp.Config{})
 	if err != nil {
 		t.Fatalf("init logstash output plugin failed: %v", err)
 	}

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 var outputReg = map[string]Factory{}
@@ -32,7 +33,8 @@ type Factory func(
 	im IndexManager,
 	beat beat.Info,
 	stats Observer,
-	cfg *config.C) (Group, error)
+	cfg *config.C,
+	eventsLogger logp.Config) (Group, error)
 
 // IndexManager provides additional index related services to the outputs.
 type IndexManager interface {
@@ -81,6 +83,7 @@ func Load(
 	stats Observer,
 	name string,
 	config *config.C,
+	eventsLoggerCfg logp.Config,
 ) (Group, error) {
 	factory := FindFactory(name)
 	if factory == nil {
@@ -90,5 +93,5 @@ func Load(
 	if stats == nil {
 		stats = NewNilObserver()
 	}
-	return factory(im, info, stats, config)
+	return factory(im, info, stats, config, eventsLoggerCfg)
 }

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -34,7 +34,7 @@ type Factory func(
 	beat beat.Info,
 	stats Observer,
 	cfg *config.C,
-	eventsLogger logp.Config) (Group, error)
+	sensitiveLoggerCfg logp.Config) (Group, error)
 
 // IndexManager provides additional index related services to the outputs.
 type IndexManager interface {
@@ -83,7 +83,7 @@ func Load(
 	stats Observer,
 	name string,
 	config *config.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (Group, error) {
 	factory := FindFactory(name)
 	if factory == nil {
@@ -93,5 +93,5 @@ func Load(
 	if stats == nil {
 		stats = NewNilObserver()
 	}
-	return factory(im, info, stats, config, eventsLoggerCfg)
+	return factory(im, info, stats, config, sensitiveLoggerCfg)
 }

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -81,7 +81,8 @@ func newClient(
 	logSelector := "redis"
 	eventsLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
-	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(eventsLoggerCfg)))
+	eventsLogger = eventsLogger.With("logger.type", "sensitive")
 
 	return &client{
 		log:          logp.NewLogger(logSelector),

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -82,7 +82,7 @@ func newClient(
 	sensitiveLogger := logp.NewLogger(logSelector)
 	// Set a new Output so it writes to a different file than `log`
 	sensitiveLogger = sensitiveLogger.WithOptions(zap.WrapCore(logp.WithFileOrStderrOutput(sensitiveLoggerCfg)))
-	sensitiveLogger = sensitiveLogger.With("logger.type", "sensitive")
+	sensitiveLogger = sensitiveLogger.With("log.type", "sensitive")
 
 	return &client{
 		log:          logp.NewLogger(logSelector),
@@ -330,7 +330,7 @@ func serializeEvents(
 	for _, d := range data {
 		serializedEvent, err := codec.Encode(index, &d.Content)
 		if err != nil {
-			log.Errorf("Encoding event failed with error: %+v. Look for events-data log file to view the event", err)
+			log.Errorf("Encoding event failed with error: %+v. Look for sensitive-data log file to view the event", err)
 			sensitiveLogger.Debugf("Failed event: %v", d.Content)
 			goto failLoop
 		}
@@ -348,7 +348,7 @@ failLoop:
 	for _, d := range rest {
 		serializedEvent, err := codec.Encode(index, &d.Content)
 		if err != nil {
-			log.Errorf("Encoding event failed with error: %+v. Look for events-data log file to view the event", err)
+			log.Errorf("Encoding event failed with error: %+v. Look for sensitive-data log file to view the event", err)
 			sensitiveLogger.Debugf("Failed event: %v", d.Content)
 			i++
 			continue

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs/codec"
 	"github.com/elastic/beats/v7/libbeat/outputs/outil"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/transport"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
@@ -51,6 +52,7 @@ func makeRedis(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *config.C,
+	eventsLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 
 	if !cfg.HasField("index") {

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -163,7 +163,7 @@ func makeRedis(
 		}
 
 		client := newClient(conn, observer, rConfig.Timeout,
-			pass, rConfig.Db, key, dataType, rConfig.Index, enc)
+			pass, rConfig.Db, key, dataType, rConfig.Index, enc, eventsLoggerCfg)
 		clients[i] = newBackoffClient(client, rConfig.Backoff.Init, rConfig.Backoff.Max)
 	}
 

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -52,7 +52,7 @@ func makeRedis(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *config.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 
 	if !cfg.HasField("index") {
@@ -163,7 +163,7 @@ func makeRedis(
 		}
 
 		client := newClient(conn, observer, rConfig.Timeout,
-			pass, rConfig.Db, key, dataType, rConfig.Index, enc, eventsLoggerCfg)
+			pass, rConfig.Db, key, dataType, rConfig.Index, enc, sensitiveLoggerCfg)
 		clients[i] = newBackoffClient(client, rConfig.Backoff.Init, rConfig.Backoff.Max)
 	}
 

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -330,7 +331,7 @@ func newRedisTestingOutput(t *testing.T, cfg map[string]interface{}) outputs.Cli
 		t.Fatalf("redis output module not registered")
 	}
 
-	out, err := plugin(nil, beat.Info{Beat: testBeatname, Version: testBeatversion}, outputs.NewNilObserver(), config)
+	out, err := plugin(nil, beat.Info{Beat: testBeatname, Version: testBeatversion}, outputs.NewNilObserver(), config, logp.Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialize redis output: %v", err)
 	}

--- a/libbeat/outputs/redis/redis_test.go
+++ b/libbeat/outputs/redis/redis_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -108,7 +109,7 @@ func TestMakeRedis(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cfg, err := config.NewConfigFrom(test.config)
 			assert.NoError(t, err)
-			groups, err := makeRedis(nil, beatInfo, outputs.NewNilObserver(), cfg)
+			groups, err := makeRedis(nil, beatInfo, outputs.NewNilObserver(), cfg, logp.Config{})
 			assert.Equal(t, err == nil, test.valid)
 			if err != nil && test.valid {
 				t.Log(err)

--- a/libbeat/outputs/shipper/shipper.go
+++ b/libbeat/outputs/shipper/shipper.go
@@ -92,7 +92,7 @@ func makeShipper(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *conf.C,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 
 	config := defaultConfig()

--- a/libbeat/outputs/shipper/shipper.go
+++ b/libbeat/outputs/shipper/shipper.go
@@ -92,6 +92,7 @@ func makeShipper(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *conf.C,
+	eventsLoggerCfg logp.Config,
 ) (outputs.Group, error) {
 
 	config := defaultConfig()

--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-shipper-client/pkg/helpers"
 	pb "github.com/elastic/elastic-agent-shipper-client/pkg/proto"
@@ -583,6 +584,7 @@ func createShipperClient(t *testing.T, cfg *config.C, observer outputs.Observer)
 		beat.Info{Beat: "libbeat", IndexPrefix: "testbeat"},
 		observer,
 		cfg,
+		logp.Config{},
 	)
 	require.NoError(t, err)
 	require.Len(t, group.Clients, 1)

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -180,7 +180,7 @@ func (c *outputController) Set(outGrp outputs.Group) {
 // Reload the output
 func (c *outputController) Reload(
 	cfg *reload.ConfigWithMeta,
-	eventsLoggerCfg logp.Config,
+	sensitiveLoggerCfg logp.Config,
 	outFactory func(outputs.Observer, conf.Namespace, logp.Config) (outputs.Group, error),
 ) error {
 	outCfg := conf.Namespace{}
@@ -192,7 +192,7 @@ func (c *outputController) Reload(
 
 	output, err := loadOutput(c.monitors, func(stats outputs.Observer) (string, outputs.Group, error) {
 		name := outCfg.Name()
-		out, err := outFactory(stats, outCfg, eventsLoggerCfg)
+		out, err := outFactory(stats, outCfg, sensitiveLoggerCfg)
 		return name, out, err
 	})
 	if err != nil {

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -180,7 +180,8 @@ func (c *outputController) Set(outGrp outputs.Group) {
 // Reload the output
 func (c *outputController) Reload(
 	cfg *reload.ConfigWithMeta,
-	outFactory func(outputs.Observer, conf.Namespace) (outputs.Group, error),
+	eventsLoggerCfg logp.Config,
+	outFactory func(outputs.Observer, conf.Namespace, logp.Config) (outputs.Group, error),
 ) error {
 	outCfg := conf.Namespace{}
 	if cfg != nil {
@@ -191,7 +192,7 @@ func (c *outputController) Reload(
 
 	output, err := loadOutput(c.monitors, func(stats outputs.Observer) (string, outputs.Group, error) {
 		name := outCfg.Name()
-		out, err := outFactory(stats, outCfg)
+		out, err := outFactory(stats, outCfg, eventsLoggerCfg)
 		return name, out, err
 	})
 	if err != nil {

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -111,7 +111,7 @@ const (
 type OutputReloader interface {
 	Reload(
 		cfg *reload.ConfigWithMeta,
-		eventsLoggerCfg logp.Config,
+		sensitiveLoggerCfg logp.Config,
 		factory func(outputs.Observer, conf.Namespace, logp.Config) (outputs.Group, error),
 	) error
 }

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -111,7 +111,8 @@ const (
 type OutputReloader interface {
 	Reload(
 		cfg *reload.ConfigWithMeta,
-		factory func(outputs.Observer, conf.Namespace) (outputs.Group, error),
+		eventsLoggerCfg logp.Config,
+		factory func(outputs.Observer, conf.Namespace, logp.Config) (outputs.Group, error),
 	) error
 }
 

--- a/libbeat/publisher/pipeline/stress/out.go
+++ b/libbeat/publisher/pipeline/stress/out.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 type testOutput struct {
@@ -55,7 +56,7 @@ func init() {
 	outputs.RegisterType("test", makeTestOutput)
 }
 
-func makeTestOutput(_ outputs.IndexManager, beat beat.Info, observer outputs.Observer, cfg *conf.C) (outputs.Group, error) {
+func makeTestOutput(_ outputs.IndexManager, beat beat.Info, observer outputs.Observer, cfg *conf.C, eventsLoggerCfg logp.Config) (outputs.Group, error) {
 	config := defaultTestOutputConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return outputs.Fail(err)

--- a/libbeat/publisher/pipeline/stress/out.go
+++ b/libbeat/publisher/pipeline/stress/out.go
@@ -56,7 +56,7 @@ func init() {
 	outputs.RegisterType("test", makeTestOutput)
 }
 
-func makeTestOutput(_ outputs.IndexManager, beat beat.Info, observer outputs.Observer, cfg *conf.C, eventsLoggerCfg logp.Config) (outputs.Group, error) {
+func makeTestOutput(_ outputs.IndexManager, beat beat.Info, observer outputs.Observer, cfg *conf.C, sensitiveLoggerCfg logp.Config) (outputs.Group, error) {
 	config := defaultTestOutputConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return outputs.Fail(err)

--- a/libbeat/publisher/pipeline/stress/run.go
+++ b/libbeat/publisher/pipeline/stress/run.go
@@ -76,7 +76,7 @@ func RunTests(
 		processing,
 		func(stat outputs.Observer) (string, outputs.Group, error) {
 			cfg := config.Output
-			out, err := outputs.Load(nil, info, stat, cfg.Name(), cfg.Config())
+			out, err := outputs.Load(nil, info, stat, cfg.Name(), cfg.Config(), logp.Config{})
 			return cfg.Name(), out, err
 		},
 	)

--- a/libbeat/tests/integration/framework.go
+++ b/libbeat/tests/integration/framework.go
@@ -366,7 +366,11 @@ func (b *BeatProc) WriteConfigFile(cfg string) {
 // when the test ends.
 func (b *BeatProc) openLogFile() *os.File {
 	t := b.t
-	glob := fmt.Sprintf("%s-*.ndjson", filepath.Join(b.tempDir, b.beatName))
+	// Beats can produce two different log files, to make sure we're
+	// reading the normal one we add the year to the glob. The default
+	// log file name looks like: filebeat-20240116.ndjson
+	year := time.Now().Year()
+	glob := fmt.Sprintf("%s-%d*.ndjson", filepath.Join(b.tempDir, b.beatName), year)
 	files, err := filepath.Glob(glob)
 	if err != nil {
 		t.Fatalf("could not expand log file glob: %s", err)

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2403,14 +2403,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-events-data
+    #name: metricbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2414,10 +2414,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2394,6 +2394,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/metricbeat
+
+    # The name of the files where the logs are written to.
+    #name: metricbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2395,10 +2395,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2410,7 +2410,7 @@ logging.files:
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-sensitive
+    #name: metricbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -147,14 +147,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-events-data
+    #name: metricbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -154,7 +154,7 @@ processors:
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-sensitive
+    #name: metricbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -142,6 +142,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/metricbeat
+
+    # The name of the files where the logs are written to.
+    #name: metricbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
+++ b/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
@@ -10,4 +10,4 @@ rsa==4.7.2
 s3transfer==0.3.3
 six==1.14.0
 urllib3==1.26.5
-protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,4 +1,4 @@
 kafka-python==1.4.3
 elasticsearch==7.1.0
 semver==2.8.1
-protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2026,7 +2026,7 @@ logging.files:
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-sensitive
+    #name: packetbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2030,10 +2030,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2019,14 +2019,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-events-data
+    #name: packetbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2010,6 +2010,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/packetbeat
+
+    # The name of the files where the logs are written to.
+    #name: packetbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2011,10 +2011,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -282,7 +282,7 @@ processors:
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-sensitive
+    #name: packetbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -270,6 +270,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/packetbeat
+
+    # The name of the files where the logs are written to.
+    #name: packetbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -275,14 +275,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-events-data
+    #name: packetbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring

--- a/packetbeat/tests/system/gen/memcache/requirements.txt
+++ b/packetbeat/tests/system/gen/memcache/requirements.txt
@@ -1,2 +1,2 @@
 pylibmc
-protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1427,10 +1427,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1426,6 +1426,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/winlogbeat
+
+    # The name of the files where the logs are written to.
+    #name: winlogbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1446,10 +1446,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1442,7 +1442,7 @@ logging.files:
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-sensitive
+    #name: winlogbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1435,14 +1435,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-events-data
+    #name: winlogbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -160,14 +160,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-events-data
+    #name: winlogbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -155,6 +155,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/winlogbeat
+
+    # The name of the files where the logs are written to.
+    #name: winlogbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -167,7 +167,7 @@ processors:
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-sensitive
+    #name: winlogbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1620,10 +1620,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1601,10 +1601,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1600,6 +1600,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/auditbeat
+
+    # The name of the files where the logs are written to.
+    #name: auditbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1616,7 +1616,7 @@ logging.files:
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-sensitive
+    #name: auditbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1609,14 +1609,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-events-data
+    #name: auditbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -201,14 +201,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-events-data
+    #name: auditbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -208,7 +208,7 @@ processors:
     #path: /var/log/auditbeat
 
     # The name of the files where the logs are written to.
-    #name: auditbeat-sensitive
+    #name: auditbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -196,6 +196,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/auditbeat
+
+    # The name of the files where the logs are written to.
+    #name: auditbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Auditbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
@@ -74,7 +74,7 @@ func loadNewPipeline(logOptsConfig ContainerOutputConfig, hostname string, log *
 
 	// Ensure the default filename is set
 	if sensitiveLoggerCfg.Files.Name == "" {
-		sensitiveLoggerCfg.Files.Name = "dockerlogbeat-events-data"
+		sensitiveLoggerCfg.Files.Name = "dockerlogbeat-sensitive-data"
 	}
 
 	pipeline, err := pipeline.LoadWithSettings(

--- a/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
@@ -70,11 +70,11 @@ func loadNewPipeline(logOptsConfig ContainerOutputConfig, hostname string, log *
 	// Get the default/current logging configuration
 	// we need some defaults to be populates otherwise Unpack will
 	// fail
-	eventsLoggerCfg := logp.DefaultConfig(configure.GetEnvironment())
+	sensitiveLoggerCfg := logp.DefaultConfig(configure.GetEnvironment())
 
 	// Ensure the default filename is set
-	if eventsLoggerCfg.Files.Name == "" {
-		eventsLoggerCfg.Files.Name = "dockerlogbeat-events-data"
+	if sensitiveLoggerCfg.Files.Name == "" {
+		sensitiveLoggerCfg.Files.Name = "dockerlogbeat-events-data"
 	}
 
 	pipeline, err := pipeline.LoadWithSettings(
@@ -87,7 +87,7 @@ func loadNewPipeline(logOptsConfig ContainerOutputConfig, hostname string, log *
 		pipelineCfg,
 		func(stat outputs.Observer) (string, outputs.Group, error) {
 			cfg := config.Output
-			out, err := outputs.Load(idxMgr, info, stat, cfg.Name(), cfg.Config(), eventsLoggerCfg)
+			out, err := outputs.Load(idxMgr, info, stat, cfg.Name(), cfg.Config(), sensitiveLoggerCfg)
 			return cfg.Name(), out, err
 		},
 		settings,

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -5036,10 +5036,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -5016,6 +5016,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/filebeat
+
+    # The name of the files where the logs are written to.
+    #name: filebeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -5032,7 +5032,7 @@ logging.files:
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-sensitive
+    #name: filebeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -5017,10 +5017,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -5025,14 +5025,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-events-data
+    #name: filebeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -186,6 +186,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/filebeat
+
+    # The name of the files where the logs are written to.
+    #name: filebeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -198,7 +198,7 @@ processors:
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-sensitive
+    #name: filebeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -191,14 +191,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/filebeat
 
     # The name of the files where the logs are written to.
-    #name: filebeat-events-data
+    #name: filebeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Filebeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/filebeat/input/lumberjack/server_test.go
+++ b/x-pack/filebeat/input/lumberjack/server_test.go
@@ -52,8 +52,8 @@ func TestServer(t *testing.T) {
 		c := makeTestConfig()
 		c.TLS = serverConf
 		// Disable mTLS requirements in the server.
-		var clientAuth = tlscommon.TLSClientAuthNone
-		c.TLS.ClientAuth = &clientAuth
+		clientAuth := tlscommon.TLSClientAuthNone
+		c.TLS.ClientAuth = &clientAuth // tls.NoClientCert
 		c.TLS.VerificationMode = tlscommon.VerifyNone
 
 		testSendReceive(t, c, 10, clientConf)
@@ -221,12 +221,12 @@ func tlsSetup(t *testing.T) (clientConfig *tls.Config, serverConfig *tlscommon.S
 		MinVersion:   tls.VersionTLS12,
 	}
 
-	var clientAuth = tlscommon.TLSClientAuthRequired
-
+	clientAuth := tlscommon.TLSClientAuthRequired
 	serverConfig = &tlscommon.ServerConfig{
 		// NOTE: VerifyCertificate is ineffective unless ClientAuth is set to RequireAndVerifyClientCert.
 		VerificationMode: tlscommon.VerifyCertificate,
-		ClientAuth:       &clientAuth, // tls.RequireAndVerifyClientCert
+		// Unfortunately ServerConfig uses an unexported type in an exported field.
+		ClientAuth: &clientAuth, // tls.RequireAndVerifyClientCert
 		CAs: []string{
 			string(certData.ca.CertPEM(t)),
 		},

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1284,10 +1284,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1264,6 +1264,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/functionbeat
+
+    # The name of the files where the logs are written to.
+    #name: functionbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Functionbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1280,7 +1280,7 @@ logging.files:
     #path: /var/log/functionbeat
 
     # The name of the files where the logs are written to.
-    #name: functionbeat-sensitive
+    #name: functionbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1265,10 +1265,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1273,14 +1273,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/functionbeat
 
     # The name of the files where the logs are written to.
-    #name: functionbeat-events-data
+    #name: functionbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -377,7 +377,7 @@ processors:
     #path: /var/log/functionbeat
 
     # The name of the files where the logs are written to.
-    #name: functionbeat-sensitive
+    #name: functionbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Functionbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -365,6 +365,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/functionbeat
+
+    # The name of the files where the logs are written to.
+    #name: functionbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Functionbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -370,14 +370,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/functionbeat
 
     # The name of the files where the logs are written to.
-    #name: functionbeat-events-data
+    #name: functionbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Functionbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/functionbeat/tests/system/requirements.txt
+++ b/x-pack/functionbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1645,14 +1645,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-events-data
+    #name: heartbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1636,6 +1636,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/heartbeat
+
+    # The name of the files where the logs are written to.
+    #name: heartbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1656,10 +1656,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1637,10 +1637,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1652,7 +1652,7 @@ logging.files:
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-sensitive
+    #name: heartbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -152,6 +152,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/heartbeat
+
+    # The name of the files where the logs are written to.
+    #name: heartbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -164,7 +164,7 @@ processors:
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-sensitive
+    #name: heartbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -157,14 +157,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/heartbeat
 
     # The name of the files where the logs are written to.
-    #name: heartbeat-events-data
+    #name: heartbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Heartbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2971,7 +2971,7 @@ logging.files:
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-sensitive
+    #name: metricbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2975,10 +2975,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2956,10 +2956,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2964,14 +2964,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-events-data
+    #name: metricbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2955,6 +2955,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/metricbeat
+
+    # The name of the files where the logs are written to.
+    #name: metricbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -147,14 +147,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-events-data
+    #name: metricbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -154,7 +154,7 @@ processors:
     #path: /var/log/metricbeat
 
     # The name of the files where the logs are written to.
-    #name: metricbeat-sensitive
+    #name: metricbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -142,6 +142,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/metricbeat
+
+    # The name of the files where the logs are written to.
+    #name: metricbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Metricbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -984,10 +984,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -999,7 +999,7 @@ logging.files:
     #path: /var/log/osquerybeat
 
     # The name of the files where the logs are written to.
-    #name: osquerybeat-sensitive
+    #name: osquerybeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -992,14 +992,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/osquerybeat
 
     # The name of the files where the logs are written to.
-    #name: osquerybeat-events-data
+    #name: osquerybeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -983,6 +983,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/osquerybeat
+
+    # The name of the files where the logs are written to.
+    #name: osquerybeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Osquerybeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -1003,10 +1003,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/osquerybeat/osquerybeat.yml
+++ b/x-pack/osquerybeat/osquerybeat.yml
@@ -140,7 +140,7 @@ processors:
     #path: /var/log/osquerybeat
 
     # The name of the files where the logs are written to.
-    #name: osquerybeat-sensitive
+    #name: osquerybeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Osquerybeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/osquerybeat/osquerybeat.yml
+++ b/x-pack/osquerybeat/osquerybeat.yml
@@ -128,6 +128,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/osquerybeat
+
+    # The name of the files where the logs are written to.
+    #name: osquerybeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Osquerybeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/osquerybeat/osquerybeat.yml
+++ b/x-pack/osquerybeat/osquerybeat.yml
@@ -133,14 +133,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/osquerybeat
 
     # The name of the files where the logs are written to.
-    #name: osquerybeat-events-data
+    #name: osquerybeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Osquerybeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2026,7 +2026,7 @@ logging.files:
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-sensitive
+    #name: packetbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2030,10 +2030,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2019,14 +2019,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-events-data
+    #name: packetbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2010,6 +2010,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/packetbeat
+
+    # The name of the files where the logs are written to.
+    #name: packetbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2011,10 +2011,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -282,7 +282,7 @@ processors:
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-sensitive
+    #name: packetbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -270,6 +270,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/packetbeat
+
+    # The name of the files where the logs are written to.
+    #name: packetbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -275,14 +275,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/packetbeat
 
     # The name of the files where the logs are written to.
-    #name: packetbeat-events-data
+    #name: packetbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Packetbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1428,6 +1428,42 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/winlogbeat
+
+    # The name of the files where the logs are written to.
+    #name: winlogbeat-events-data
+
+    # Configure log file size limit. If the limit is reached, log file will be
+    # automatically rotated.
+    #rotateeverybytes: 10485760 # = 10MB
+
+    # Number of rotated log files to keep. The oldest files will be deleted first.
+    #keepfiles: 7
+
+    # The permissions mask to apply when rotating log files. The default value is 0600.
+    # Must be a valid Unix-style file permissions mask expressed in octal notation.
+    #permissions: 0600
+
+    # Enable log file rotation on time intervals in addition to the size-based rotation.
+    # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+    # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+    # reported by the local system clock. All other intervals are calculated from the
+    # Unix epoch. Defaults to disabled.
+    #interval: 0
+
+    # Rotate existing logs on startup rather than appending them to the existing
+    # file. Defaults to true.
+    # rotateonstartup: true
+
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1437,14 +1437,14 @@ logging.files:
 
 # Having a different log file for raw events also prevents event data
 # from drowning out the regular log files.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-events-data
+    #name: winlogbeat-sensitive
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1448,10 +1448,10 @@ logging.files:
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.
-    #rotateeverybytes: 10485760 # = 10MB
+    #rotateeverybytes: 5242880 # = 5MB
 
     # Number of rotated log files to keep. The oldest files will be deleted first.
-    #keepfiles: 7
+    #keepfiles: 5
 
     # The permissions mask to apply when rotating log files. The default value is 0600.
     # Must be a valid Unix-style file permissions mask expressed in octal notation.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1444,7 +1444,7 @@ logging.files:
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-sensitive
+    #name: winlogbeat-sensitive-data
 
     # Configure log file size limit. If the limit is reached, log file will be
     # automatically rotated.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1429,10 +1429,14 @@ logging.files:
   # rotateonstartup: true
 
 # Some outputs will log raw events on errors like indexing errors in the
-# Elasticsearch output, to prevent logging raw events together with other
-# log messages, a different log file, only for log entries containing raw events,
-# is used. It will use the same level, selectors and all other configurations
-# from the default logger, but it will have it's own file configuration.
+# Elasticsearch output, to prevent logging raw events (that may contain
+# sensitive information) together with other log messages, a different
+# log file, only for log entries containing raw events, is used. It will
+# use the same level, selectors and all other configurations from the
+# default logger, but it will have it's own file configuration.
+
+# Having a different log file for raw events also prevents event data
+# from drowning out the regular log files.
 #logging.events:
   #files:
     # Configure the path where the logs are written. The default is the logs directory

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -168,7 +168,7 @@ processors:
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-sensitive
+    #name: winlogbeat-sensitive-data
 
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -161,14 +161,14 @@ processors:
 # log messages, a different log file, only for log entries containing raw events,
 # is used. It will use the same level, selectors and all other configurations
 # from the default logger, but it will have it's own file configuration.
-#logging.events:
+#logging.sensitive:
   #files:
     # Configure the path where the logs are written. The default is the logs directory
     # under the home path (the binary location).
     #path: /var/log/winlogbeat
 
     # The name of the files where the logs are written to.
-    #name: winlogbeat-events-data
+    #name: winlogbeat-sensitive
 
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -156,6 +156,20 @@ processors:
 # "publisher", "service".
 #logging.selectors: ["*"]
 
+# Some outputs will log raw events on errors like indexing errors in the
+# Elasticsearch output, to prevent logging raw events together with other
+# log messages, a different log file, only for log entries containing raw events,
+# is used. It will use the same level, selectors and all other configurations
+# from the default logger, but it will have it's own file configuration.
+#logging.events:
+  #files:
+    # Configure the path where the logs are written. The default is the logs directory
+    # under the home path (the binary location).
+    #path: /var/log/winlogbeat
+
+    # The name of the files where the logs are written to.
+    #name: winlogbeat-events-data
+
 # ============================= X-Pack Monitoring ==============================
 # Winlogbeat can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The


### PR DESCRIPTION
## Proposed commit message

This commit introduces a new logger that can be configured through `logging.sensitive` that can be used to log any message that contains the whole event or could contain any sensitive data

At the moment it is used by multiple outputs to log indexing errors containing the whole event and errors returned by Elasticsearch that can potentially contain the whole event.

## Open questions
### Expected behaviour in a container environment?
When Beats is running in a Container environment we set the log output to stdout (see the [example](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html#_volume_mounted_configuration) in our documentation, however the "sensitive logger" will always log to a file in the default log file.

**Decision:**
In all cases add a new field `log.type: sensitive` for the sensitive  logger and allow it to also log to stderr as well as disabling the logger.

The docker command, note the `-e` CLI flag:
```sh
docker run -d \
  --name=filebeat \
  --user=root \
  --volume="$(pwd)/filebeat.docker.yml:/usr/share/filebeat/filebeat.yml:ro" \
  --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
  --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
  --volume="registry:/usr/share/filebeat/data:rw" \
  docker.elastic.co/beats/filebeat:8.11.4 filebeat -e --strict.perms=false \
  -E output.elasticsearch.hosts=["elasticsearch:9200"]
```

When running the command above, the events log file is created inside the container in `/usr/share/filebeat/logs/`

To have the sensitive logger logging to stderr, add the following CLI flag to Filebeat: `-E logging.sensitive.to_stderr=true -E logging.sensitive.to_files=false`

Generated log file example:
```
root@76af12033efd: /usr/share/filebeatroot@76af12033efd:/usr/share/filebeat# ls -la /usr/share/filebeat/logs/
total 16
drwxrwxr-x 1 root root 4096 Jan 17 08:05 .
drwxr-xr-x 1 root root 4096 Jan 17 07:39 ..
-rw------- 1 root root 2757 Jan 17 08:05 filebeat-sensitive-data-20240117.ndjson
root@76af12033efd: /usr/share/filebeatroot@76af12033efd:/usr/share/filebeat# 
```

### Expected behaviour when running under Elastic-Agent?
The same applies when running under Elastic-Agent: the Elastic-Agent runs Beats passing the the CLI flag `-E logging.sensitive.to_stderr=true -E logging.sensitive.to_files=false`, collects the stderr and stdout from the Beat, wraps every line in a JSON containing some metadata and logs it to the correct log file. The concept of a sensitive log file will be added to the Elastic-Agent.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] Update go.mod after https://github.com/elastic/elastic-agent-libs/pull/171 is merged
- [ ] Create PR on Elastic-Agent to handle the sensitive logs
- [x] Decide what to do when running in a container environment
- [x] Decide what to do for Elastic-Agent
- [x] ~~Test if the Elastic-Agent diagnostics can collect the new log file(s)~~

## How to test this PR locally

### Standalone Filebeat
Start Filebeat with the following configuration
```yaml
filebeat.inputs:
  - type: filestream
    id: filestream-input-id
    enabled: true
    parsers:
      - ndjson:
          target: ""
          overwrite_keys: true
          expand_keys: true
          add_error_key: true
          ignore_decoding_error: false
    paths:
      - /tmp/flog.log

output:
  elasticsearch:
    hosts:
      - localhost:9200
    protocol: https
    username: elastic
    password: changeme
    allow_older_versions: true
    ssl.verification_mode: none

logging:
  level: debug
  events:
    files:
      name: filebeat-events-data # that's the default, change it if you want another name.
```

Create the log file `/tmp/flog.log` with the following content:
```
{"message":"foo bar","int":10,"string":"str"}
{"message":"another message","int":20,"string":"str2"}
{"message":"index failure","int":"not a number","string":10}
{"message":"second index failure","int":"not a number","string":10}
A broken JSON
```

Raw events should be logged to a different log file, in the same folder as the normal logs, the filename matches the glob `filebeat-events-data*.ndjson`.

By default the logs go in a `logs` folder that's created in the same folder you're running Filebeat from, here are the files created when running this branch:
```
% ls -la logs 
-rw------- 1 tiago tiago  65K Jan 16 16:24 filebeat-20240116.ndjson
-rw------- 1 tiago tiago 2.8K Jan 16 16:22 filebeat-sensitive-data-20240116.ndjson
```

If you need to run the test again, either add more data to `/tmp/flog.log` or remove the `data` folder Filebeat created at star up, this will make Filebeat re-ingest the file.

### Under Elastic-Agent
1. Package the Elastic-Agent from https://github.com/elastic/elastic-agent/pull/4129
2. Replace the Filebeat binary by the binary built from this branch/PR
3. Create `/tmp/flog.log` with a few lines, the data is not important
4. Start the Elastic-Agent with the following configuration (adjust if needed)
```yaml
outputs:
  default:
    type: elasticsearch
    hosts:
        - http://localhost:9200
    username: elastic
    password: changeme
    preset: balanced

inputs:
  - type: filestream
    id: your-input-id
    streams:
      - id: your-filestream-stream-id
        data_stream:
          dataset: generic
        paths:
          - /tmp/flog.log

agent.monitoring:
  enabled: false
  logs: false
  metrics: false
  pprof.enabled: false
  use_output: default
  http:
      enabled: false

agent.logging.to_stderr: true
agent.logging.metrics.enabled: false
```

To create ingest failures the easiest way is to close the write index from the datastream, to do that go to Kibana -> Dev Tools

To get the backing index for a datastream:
```
GET /_data_stream/logs-generic-default
```

This will return something like:
```
{
  "data_streams": [
    {
      "name": "logs-generic-default",
      "timestamp_field": {
        "name": "@timestamp"
      },
      "indices": [
        {
          "index_name": ".ds-logs-generic-default-2024.01.22-000001",
          "index_uuid": "0pq-XIYfSjuUQhTxlJKJjQ",
          "prefer_ilm": true,
          "ilm_policy": "logs",
          "managed_by": "Index Lifecycle Management"
        }
      ]
    }
  ]
}
```

Take note of the index_name `.ds-logs-generic-default-2024.01.22-000001`.
Close this index:
```
POST .ds-logs-generic-default-2024.01.22-000001/_close
```

5. Add more data to the file `/tmp/flog.log`
You should see in the logs something like this:
```
{
  "log.level": "warn",
  "@timestamp": "2024-01-24T11:22:43.762+0100",
  "message": "Cannot index event publisher.Event{Content:beat.Event{Timestamp:time.Date(2024, time.January, 24, 11, 22, 32, 671147360, time.Local), Meta:{\"input_id\":\"your-input-id\",\"raw_index\":\"logs-generic-default\",\"stream_id\":\"your-filestream-stream-id\"}, Fields:{\"agent\":{\"ephemeral_id\":\"7ec26fa3-aa6d-4dc9-b49c-4ed359243af7\",\"id\":\"b3f86956-66e9-4b3e-a477-8f21f2778d2b\",\"name\":\"millennium-falcon\",\"type\":\"filebeat\",\"version\":\"8.13.0\"},\"data_stream\":{\"dataset\":\"generic\",\"namespace\":\"default\",\"type\":\"logs\"},\"ecs\":{\"version\":\"8.0.0\"},\"elastic_agent\":{\"id\":\"b3f86956-66e9-4b3e-a477-8f21f2778d2b\",\"snapshot\":true,\"version\":\"8.13.0\"},\"event\":{\"dataset\":\"generic\"},\"host\":{\"architecture\":\"x86_64\",\"containerized\":false,\"hostname\":\"millennium-falcon\",\"id\":\"851f339d77174301b29e417ecb2ec6a8\",\"ip\":[\"42.42.42.42\",\"42.42.42.42\",\"8652:d3d0:3e34:49e8:f7f0:42dd:75e8:7807\",\"42.42.42.42\",\"8652:d3d0:3e34:49e8:f7f0:42dd:75e8:7807\",\"8652:d3d0:3e34:49e8:f7f0:42dd:75e8:7807\",\"42.42.42.42\",\"8652:d3d0:3e34:49e8:f7f0:42dd:75e8:7807\",\"42.42.42.42\",\"mac\":[\"57-A3-02-AD-65-79\"],\"name\":\"millennium-falcon\",\"os\":{\"build\":\"rolling\",\"family\":\"arch\",\"kernel\":\"6.7.0-arch3-1\",\"name\":\"Arch Linux\",\"platform\":\"arch\",\"type\":\"linux\",\"version\":\"\"}},\"input\":{\"type\":\"filestream\"},\"log\":{\"file\":{\"device_id\":\"34\",\"inode\":\"155800\",\"path\":\"/tmp/flog.log\"},\"offset\":446},\"message\":\"123.124.200.160 - - [24/Jan/2024:11:12:39 +0100] \\\"DELETE /unleash/infrastructures HTTP/1.1\\\" 400 16825\"}, Private:(*input_logfile.updateOp)(0xc001477c50), TimeSeries:false}, Flags:0x1, Cache:publisher.EventCache{m:mapstr.M(nil)}} (status=400): {\"type\":\"index_closed_exception\",\"reason\":\"closed\",\"index_uuid\":\"0pq-XIYfSjuUQhTxlJKJjQ\",\"index\":\".ds-logs-generic-default-2024.01.22-000001\"}, dropping event!",
  "component": {
    "binary": "filebeat",
    "dataset": "elastic_agent.filebeat",
    "id": "filestream-default",
    "type": "filestream"
  },
  "log": {
    "source": "filestream-default"
  },
  "log.logger": "elasticsearch",
  "log.origin": {
    "file.line": 461,
    "file.name": "elasticsearch/client.go",
    "function": "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch.(*Client).bulkCollectPublishFails"
  },
  "log.type": "sensitive",
  "ecs.version": "1.6.0"
}
```

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

