### PR TITLE
[Filebeat] Fix id for config map 

### DIFF
--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -121,7 +121,6 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
-          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -113,7 +113,7 @@ data:
   filebeat.yml: |-
     filebeat.inputs:
     - type: filestream
-      id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+      id: kubernetes-container-logs
       paths:
         - /var/log/containers/*.log
       parsers:
@@ -121,14 +121,15 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
+          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:
         - add_kubernetes_metadata:
             host: ${NODE_NAME}
             matchers:
-            - logs_path:
-                logs_path: "/var/log/containers/"
+              - logs_path:
+                  logs_path: "/var/log/containers/"
 
     # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
     # filebeat.autodiscover:

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -128,8 +128,8 @@ data:
         - add_kubernetes_metadata:
             host: ${NODE_NAME}
             matchers:
-              - logs_path:
-                  logs_path: "/var/log/containers/"
+            - logs_path:
+                logs_path: "/var/log/containers/"
 
     # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
     # filebeat.autodiscover:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -17,7 +17,6 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
-          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -24,8 +24,8 @@ data:
         - add_kubernetes_metadata:
             host: ${NODE_NAME}
             matchers:
-              - logs_path:
-                  logs_path: "/var/log/containers/"
+            - logs_path:
+                logs_path: "/var/log/containers/"
 
     # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
     # filebeat.autodiscover:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -9,7 +9,7 @@ data:
   filebeat.yml: |-
     filebeat.inputs:
     - type: filestream
-      id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+      id: kubernetes-container-logs
       paths:
         - /var/log/containers/*.log
       parsers:
@@ -17,14 +17,15 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
+          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:
         - add_kubernetes_metadata:
             host: ${NODE_NAME}
             matchers:
-            - logs_path:
-                logs_path: "/var/log/containers/"
+              - logs_path:
+                  logs_path: "/var/log/containers/"
 
     # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
     # filebeat.autodiscover:

--- a/dev-tools/kubernetes/filebeat/manifest.debug.yaml
+++ b/dev-tools/kubernetes/filebeat/manifest.debug.yaml
@@ -121,7 +121,6 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
-          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:

--- a/dev-tools/kubernetes/filebeat/manifest.debug.yaml
+++ b/dev-tools/kubernetes/filebeat/manifest.debug.yaml
@@ -113,7 +113,7 @@ data:
   filebeat.yml: |-
     filebeat.inputs:
     - type: filestream
-      id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+      id: kubernetes-container-logs
       paths:
         - /var/log/containers/*.log
       parsers:
@@ -121,6 +121,7 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
+          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:

--- a/dev-tools/kubernetes/filebeat/manifest.run.yaml
+++ b/dev-tools/kubernetes/filebeat/manifest.run.yaml
@@ -121,7 +121,6 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
-          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:

--- a/dev-tools/kubernetes/filebeat/manifest.run.yaml
+++ b/dev-tools/kubernetes/filebeat/manifest.run.yaml
@@ -113,7 +113,7 @@ data:
   filebeat.yml: |-
     filebeat.inputs:
     - type: filestream
-      id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
+      id: kubernetes-container-logs
       paths:
         - /var/log/containers/*.log
       parsers:
@@ -121,6 +121,7 @@ data:
       prospector:
         scanner:
           fingerprint.enabled: true
+          fingerprint.length: 300
           symlinks: true
       file_identity.fingerprint: ~
       processors:


### PR DESCRIPTION
This PR is a fix to a bug introduced in https://github.com/elastic/beats/pull/37401.

Defining the `id` as

```yaml
id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
```

Causes the error:

```logs
{"log.level":"error","@timestamp":"2024-01-04T13:13:02.933Z","log.origin":{"file.name":"instance/beat.go","file.line":1307},"message":"Exiting: failed to read input configuration: failed to unpack input configuration: missing field accessing 'filebeat.inputs.0.id' (source:'/etc/filebeat.yml')","service.name":"filebeat","ecs.version":"1.6.0"}
Exiting: failed to read input configuration: failed to unpack input configuration: missing field accessing 'filebeat.inputs.0.id' (source:'/etc/filebeat.yml')
```

We need to remove the fields `${data.*}` in the `id` to fix it.

