### PR TITLE
Update CODEOWNERS to update cloud metrics ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -186,6 +186,25 @@ CHANGELOG*
 /x-pack/metricbeat/module/containerd/ @elastic/obs-cloudnative-monitoring
 /x-pack/metricbeat/module/coredns @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/enterprisesearch @elastic/ent-search-application-backend
+/x-pack/metricbeat/module/gcp @elastic/obs-ds-hosted-services @elastic/obs-infraobs-integrations @elastic/security-external-integrations
+/x-pack/metricbeat/module/gcp/billing @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/cloudrun_metrics @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/cloudsql_mysql @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/cloudsql_postgressql @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/cloudsql_sqlserver @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/carbon @elastic/obs-ds-hosted-services
+/x-pack/metricbeat/module/gcp/compute @elastic/obs-ds-hosted-services
+/x-pack/metricbeat/module/gcp/dataproc @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/dns @elastic/security-external-integrations
+/x-pack/metricbeat/module/gcp/firestore @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/firewall @elastic/security-external-integrations
+/x-pack/metricbeat/module/gcp/gke @elastic/obs-ds-hosted-services
+/x-pack/metricbeat/module/gcp/loadbalancing_logs @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/loadbalancing_metrics @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/pubsub @elastic/obs-ds-hosted-services
+/x-pack/metricbeat/module/gcp/redis @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/gcp/storage @elastic/obs-ds-hosted-services
+/x-pack/metricbeat/module/gcp/vpcflow @elastic/security-external-integrations
 /x-pack/metricbeat/module/ibmmq @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/iis @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/istio/ @elastic/obs-cloudnative-monitoring

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,6 +177,10 @@ CHANGELOG*
 /x-pack/metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /x-pack/metricbeat/module/activemq @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/airflow @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/aws @elastic/obs-ds-hosted-services
+/x-pack/metricbeat/module/awsfargate @elastic/obs-infraobs-integrations
+/x-pack/metricbeat/module/azure @elastic/obs-ds-hosted-services
+/x-pack/metricbeat/module/azure/billing @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/cloudfoundry @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/cockroachdb @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/containerd/ @elastic/obs-cloudnative-monitoring


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Explicitly assign the ownership of AWS, Azure and GCP metricsets to the owning team.

Previously, `/x-pack/metricbeat/module/` was assigned to @elastic/integrations, allowing our team to work on these modules independently.

As a side-effect of a recent [change](https://github.com/elastic/beats/commit/8fe2f53bf1613bf6c0566a7e8e7afda785c51770#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L180), the CODEOWNERS now [falls back](https://github.com/elastic/beats/blob/95f0f85a3edd45799b9928ee48fe00be49e09431/.github/CODEOWNERS#L176C1-L176C1) the AWS, Azure and GCP metricsets to the @elastic/elastic-agent-data-plane.

This change avoids involving additional teams when we only need to update the metricset internals. For example, see https://github.com/elastic/beats/pull/37365#issuecomment-1877641745.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

