### PR TITLE
x-pack/filebeat/input/httpjson: Fix nil pointer deref

### DIFF
--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -316,13 +316,8 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger, met
 			if err != nil {
 				return nil, fmt.Errorf("failed in creating chain http client with error: %w", err)
 			}
-			if ch.Step.Auth != nil && ch.Step.Auth.Basic.isEnabled() {
-				rf.user = ch.Step.Auth.Basic.User
-				rf.password = ch.Step.Auth.Basic.Password
-			}
 
 			responseProcessor := newChainResponseProcessor(ch, client, xmlDetails, metrics, log)
-
 			rf = &requestFactory{
 				url:                    *ch.Step.Request.URL.URL,
 				method:                 ch.Step.Request.Method,
@@ -336,6 +331,10 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger, met
 				chainClient:            client,
 				chainResponseProcessor: responseProcessor,
 			}
+			if ch.Step.Auth != nil && ch.Step.Auth.Basic.isEnabled() {
+				rf.user = ch.Step.Auth.Basic.User
+				rf.password = ch.Step.Auth.Basic.Password
+			}
 		} else if ch.While != nil {
 			ts, _ := newBasicTransformsFromConfig(registeredTransforms, ch.While.Request.Transforms, requestNamespace, log)
 			policy := newHTTPPolicy(evaluateResponse, ch.While.Until, log)
@@ -343,10 +342,6 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger, met
 			client, err := newChainHTTPClient(ctx, ch.While.Auth, ch.While.Request, log, reg, policy)
 			if err != nil {
 				return nil, fmt.Errorf("failed in creating chain http client with error: %w", err)
-			}
-			if ch.While.Auth != nil && ch.While.Auth.Basic.isEnabled() {
-				rf.user = ch.While.Auth.Basic.User
-				rf.password = ch.While.Auth.Basic.Password
 			}
 
 			responseProcessor := newChainResponseProcessor(ch, client, xmlDetails, metrics, log)
@@ -363,6 +358,10 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger, met
 				isChain:                true,
 				chainClient:            client,
 				chainResponseProcessor: responseProcessor,
+			}
+			if ch.While.Auth != nil && ch.While.Auth.Basic.isEnabled() {
+				rf.user = ch.While.Auth.Basic.User
+				rf.password = ch.While.Auth.Basic.Password
 			}
 		}
 		rfs = append(rfs, rf)


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/input/httpjson: Fix basic auth nil pointer deref (#)

For chained requests, setting user and password values for basic
authentication via a pointer to a requestFactory struct was done before
the struct was initialized, resulting in a nil pointer dereference and
runtime panic. Moving it to after the initialization resolved the issue.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

For manual testing, there's a `filebeat.yml` file below that will trigger the issue. The input fails before any requests are made.

Run `./filebeat -c filebeat.yml -v` and check the logs for the error. When the requests are successfully made they can be seen on [that webhook's page](https://webhook.site/#!/8d8e2d6d-4a79-4b9c-8b8d-f6641588ac52/684e1c06-a38b-4564-9aa5-0f6c0f891d1a).

```yaml
filebeat.inputs:
- type: httpjson
  id: my-test-httpjson-id
  enabled: true
  interval: 1m
  auth.basic.user: basicuser
  auth.basic.password: basicpass
  request.url: 'https://webhook.site/8d8e2d6d-4a79-4b9c-8b8d-f6641588ac52'
  request.method: POST
  request.body:
    message: "some message"
  request.ssl:
    verification_mode: none
  request.encode_as: application/json
  request.tracer.filename: http-request-trace-*.ndjson
  request.tracer.maxbackups: 5
  response.decode_as: application/json
  publisher_pipeline.disable_host: true
  chain:
    - step:
        request.url: >-
          https://webhook.site/8d8e2d6d-4a79-4b9c-8b8d-f6641588ac52/$.records[:].id
        request.method: GET
        replace: '$.records[:].id'
output.elasticsearch:
  hosts: ["localhost:9200"]
```