### PR TITLE
Update SQL and Oracle module docs regarding Oracle DSNs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -135,6 +135,7 @@ Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will d
 
 *Filebeat*
 
+- Update SQL input documentation regarding Oracle DSNs {pull}37590[37590]
 - add documentation for decode_xml_wineventlog processor field mappings.  {pull}32456[32456]
 - httpjson input: Add request tracing logger. {issue}32402[32402] {pull}32412[32412]
 - Add cloudflare R2 to provider list in AWS S3 input. {pull}32620[32620]

--- a/metricbeat/docs/modules/oracle.asciidoc
+++ b/metricbeat/docs/modules/oracle.asciidoc
@@ -60,19 +60,24 @@ Then, Metricbeat can be launched.
 
 *Host Configuration*
 
-The following two types of host configurations are supported:
+The following types of host configuration are supported:
 
-1. Old style host configuration for backwards compatibility:
+1. An old-style Oracle connection string, for backwards compatibility:
     a. `hosts: ["user/pass@0.0.0.0:1521/ORCLPDB1.localdomain"]`
     b. `hosts: ["user/password@0.0.0.0:1521/ORCLPDB1.localdomain as sysdba"]`
 
-2. DSN host configuration:
+2. DSN configuration as a URL:
+    a. `hosts: ["oracle://user:pass@0.0.0.0:1521/ORCLPDB1.localdomain?sysdba=1"]`
+
+3. DSN configuration as a logfmt-encoded parameter list:
     a. `hosts: ['user="user" password="pass" connectString="0.0.0.0:1521/ORCLPDB1.localdomain"']`
     b. `hosts: ['user="user" password="password" connectString="host:port/service_name" sysdba=true']`
 
-DSN host configuration is the recommended way to configure the Oracle Metricbeat Module as it supports the usage of special characters in the password.
+DSN host configuration is the recommended configuration type as it supports the use of special characters in the password.
 
-Note: If the password contains the backslash (`\`) character, it must be escaped with a backslash. For example, if the password is `my\_password`, it should be written as `my\\_password`.
+In a URL any special characters should be URL encoded.
+
+In the logfmt-encoded DSN format, if the password contains a backslash character (`\`), it must be escaped with another backslash. For example, if the password is `my\_password`, it must be written as `my\\_password`.
 
 [float]
 == Metricsets

--- a/metricbeat/docs/modules/sql.asciidoc
+++ b/metricbeat/docs/modules/sql.asciidoc
@@ -871,19 +871,26 @@ Then, Metricbeat can be launched.
 
 ===== Host Configuration for Oracle
 
-The following two types of host configurations are supported:
+The following types of host configuration are supported:
 
-1. DSN host configuration as URL:
+1. An old-style Oracle connection string, for backwards compatibility:
     a. `hosts: ["user/pass@0.0.0.0:1521/ORCLPDB1.localdomain"]`
     b. `hosts: ["user/password@0.0.0.0:1521/ORCLPDB1.localdomain as sysdba"]`
 
-2. DSN host configuration:
+2. DSN configuration as a URL:
+    a. `hosts: ["oracle://user:pass@0.0.0.0:1521/ORCLPDB1.localdomain?sysdba=1"]`
+
+3. DSN configuration as a logfmt-encoded parameter list:
     a. `hosts: ['user="user" password="pass" connectString="0.0.0.0:1521/ORCLPDB1.localdomain"']`
     b. `hosts: ['user="user" password="password" connectString="host:port/service_name" sysdba=true']`
 
-Note: If the password contains the backslash (`\`) character, it must be escaped with a backslash. For example, if the password is `my\_password`, it should be written as `my\\_password`.
+DSN host configuration is the recommended configuration type as it supports the use of special characters in the password.
 
-The username and password to connect to the database can be provided as values to `username` and `password` keys of `sql.yml`. 
+In a URL any special characters should be URL encoded.
+
+In the logfmt-encoded DSN format, if the password contains a backslash character (`\`), it must be escaped with another backslash. For example, if the password is `my\_password`, it must be written as `my\\_password`.
+
+The username and password to connect to the database can be provided as values to the `username` and `password` keys of `sql.yml`.
 
 [source,yml]
 ----
@@ -900,6 +907,7 @@ The username and password to connect to the database can be provided as values t
   - query: SELECT METRIC_NAME, VALUE FROM V$SYSMETRIC WHERE GROUP_ID = 2 and METRIC_NAME LIKE '%'
     response_format: variables 
 ----
+
 
 :edit_url:
 

--- a/x-pack/metricbeat/module/oracle/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/oracle/_meta/docs.asciidoc
@@ -48,19 +48,24 @@ Then, Metricbeat can be launched.
 
 *Host Configuration*
 
-The following two types of host configurations are supported:
+The following types of host configuration are supported:
 
-1. Old style host configuration for backwards compatibility:
+1. An old-style Oracle connection string, for backwards compatibility:
     a. `hosts: ["user/pass@0.0.0.0:1521/ORCLPDB1.localdomain"]`
     b. `hosts: ["user/password@0.0.0.0:1521/ORCLPDB1.localdomain as sysdba"]`
 
-2. DSN host configuration:
+2. DSN configuration as a URL:
+    a. `hosts: ["oracle://user:pass@0.0.0.0:1521/ORCLPDB1.localdomain?sysdba=1"]`
+
+3. DSN configuration as a logfmt-encoded parameter list:
     a. `hosts: ['user="user" password="pass" connectString="0.0.0.0:1521/ORCLPDB1.localdomain"']`
     b. `hosts: ['user="user" password="password" connectString="host:port/service_name" sysdba=true']`
 
-DSN host configuration is the recommended way to configure the Oracle Metricbeat Module as it supports the usage of special characters in the password.
+DSN host configuration is the recommended configuration type as it supports the use of special characters in the password.
 
-Note: If the password contains the backslash (`\`) character, it must be escaped with a backslash. For example, if the password is `my\_password`, it should be written as `my\\_password`.
+In a URL any special characters should be URL encoded.
+
+In the logfmt-encoded DSN format, if the password contains a backslash character (`\`), it must be escaped with another backslash. For example, if the password is `my\_password`, it must be written as `my\\_password`.
 
 [float]
 == Metricsets

--- a/x-pack/metricbeat/module/sql/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/sql/_meta/docs.asciidoc
@@ -859,19 +859,26 @@ Then, Metricbeat can be launched.
 
 ===== Host Configuration for Oracle
 
-The following two types of host configurations are supported:
+The following types of host configuration are supported:
 
-1. DSN host configuration as URL:
+1. An old-style Oracle connection string, for backwards compatibility:
     a. `hosts: ["user/pass@0.0.0.0:1521/ORCLPDB1.localdomain"]`
     b. `hosts: ["user/password@0.0.0.0:1521/ORCLPDB1.localdomain as sysdba"]`
 
-2. DSN host configuration:
+2. DSN configuration as a URL:
+    a. `hosts: ["oracle://user:pass@0.0.0.0:1521/ORCLPDB1.localdomain?sysdba=1"]`
+
+3. DSN configuration as a logfmt-encoded parameter list:
     a. `hosts: ['user="user" password="pass" connectString="0.0.0.0:1521/ORCLPDB1.localdomain"']`
     b. `hosts: ['user="user" password="password" connectString="host:port/service_name" sysdba=true']`
 
-Note: If the password contains the backslash (`\`) character, it must be escaped with a backslash. For example, if the password is `my\_password`, it should be written as `my\\_password`.
+DSN host configuration is the recommended configuration type as it supports the use of special characters in the password.
 
-The username and password to connect to the database can be provided as values to `username` and `password` keys of `sql.yml`. 
+In a URL any special characters should be URL encoded.
+
+In the logfmt-encoded DSN format, if the password contains a backslash character (`\`), it must be escaped with another backslash. For example, if the password is `my\_password`, it must be written as `my\\_password`.
+
+The username and password to connect to the database can be provided as values to the `username` and `password` keys of `sql.yml`.
 
 [source,yml]
 ----


### PR DESCRIPTION
## Proposed commit message

```
Update SQL and Oracle module docs regarding Oracle DSNs (#37590)

- Add 'oracle://' URL format.
- Add note about encoding of special characters in URLs.
- Align the SQL module and the Oracle module documentation.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

The SQL and Oracle modules both use the [GO DRiver for ORacle DB](https://github.com/godror/godror) to parse Oracle DSNs. I tested the parsing of the DSN formats with the following script.

<details>
<summary>DSN parsing script</summary>

Script:
```go
package main

import (
	"fmt"

	"github.com/godror/godror"
)

func main() {
	params, err := godror.ParseDSN("oracle://user:pa%20ss@0.0.0.0:1521/ORCLPDB1.localdomain?sysdba=1") // ok
	// params, err := godror.ParseDSN("user/pa%20ss@0.0.0.0:1521/ORCLPDB1.localdomain?sysdba=1") // not ok
	// params, err := godror.ParseDSN("user/pass@0.0.0.0:1521/ORCLPDB1.localdomain?sysdba=1") // ok
	// params, err := godror.ParseDSN("user/password@0.0.0.0:1521/ORCLPDB1.localdomain as sysdba") // ok
	// params, err := godror.ParseDSN("user=\"user\" password=\"pass\" connectString=\"0.0.0.0:1521/ORCLPDB1.localdomain\"") // ok
	// params, err := godror.ParseDSN("user=\"user\" password=\"pass\\\\word\" connectString=\"host:port/service_name\" sysdba=true") // ok

	if err != nil {
		fmt.Println(err)
	} else {
		fmt.Println(params)
		fmt.Println(params.Password.Secret())
	}
}
```

Output:
```
user=user password=SECRET-*** connectString=0.0.0.0:1521/ORCLPDB1.localdomain
configDir= connectionClass= enableEvents=0 externalAuth=0 heterogeneousPool=0
libDir= noTimezoneCheck=0 poolIncrement=1 poolMaxSessions=1000 poolMinSessions=1
poolSessionMaxLifetime=1h0m0s poolSessionTimeout=5m0s poolWaitTimeout=30s
prelim=0 standaloneConnection=0 sysasm=0 sysdba=1 sysoper=0 timezone=
pa ss
```
</details>

## Related issues

- Superseds #37582