### PR TITLE
Fix value mapping for min and max aggregation type in Azure Monitor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -104,6 +104,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix EC2 host.cpu.usage {pull}35717[35717]
 - Add option in SQL module to execute queries for all dbs. {pull}35688[35688]
 - Add remaining dimensions for azure storage account to make them available for tsdb enablement. {pull}36331[36331]
+- Fix Azure Resource Metrics missing metrics after upgrade to 8.11.3 {issue}37642[37642] {pull}37643[37643]
 
 *Osquerybeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -104,7 +104,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix EC2 host.cpu.usage {pull}35717[35717]
 - Add option in SQL module to execute queries for all dbs. {pull}35688[35688]
 - Add remaining dimensions for azure storage account to make them available for tsdb enablement. {pull}36331[36331]
-- Fix Azure Resource Metrics missing metrics after upgrade to 8.11.3 {issue}37642[37642] {pull}37643[37643]
+- Fix Azure Resource Metrics missing metrics (min and max aggregations) after upgrade to 8.11.3 {issue}37642[37642] {pull}37643[37643]
 
 *Osquerybeat*
 

--- a/x-pack/metricbeat/module/azure/data.go
+++ b/x-pack/metricbeat/module/azure/data.go
@@ -142,10 +142,10 @@ func mapToKeyValuePoints(metrics []Metric) []KeyValuePoint {
 			switch {
 			case value.min != nil:
 				point.Key = fmt.Sprintf("%s.%s", metricName, "min")
-				point.Value = value.avg
+				point.Value = value.min
 			case value.max != nil:
 				point.Key = fmt.Sprintf("%s.%s", metricName, "max")
-				point.Value = value.avg
+				point.Value = value.max
 			case value.avg != nil:
 				point.Key = fmt.Sprintf("%s.%s", metricName, "avg")
 				point.Value = value.avg

--- a/x-pack/metricbeat/module/azure/data_test.go
+++ b/x-pack/metricbeat/module/azure/data_test.go
@@ -52,7 +52,11 @@ func TestManagePropertyName(t *testing.T) {
 func TestMapToKeyValuePoints(t *testing.T) {
 	timestamp := time.Now().UTC()
 	metricName := "test"
-	metricValue := 42.0
+	minValue := 4.0
+	maxValue := 42.0
+	avgValue := 13.0
+	totalValue := 46.0
+	countValue := 2.0
 	namespace := "test"
 	resourceId := "test"
 	resourceSubId := "test"
@@ -64,7 +68,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 			Namespace:     namespace,
 			Names:         []string{"test"},
 			Aggregations:  "min",
-			Values:        []MetricValue{{name: metricName, min: &metricValue, timestamp: timestamp}},
+			Values:        []MetricValue{{name: metricName, min: &minValue, timestamp: timestamp}},
 			TimeGrain:     timeGrain,
 			ResourceId:    resourceId,
 			ResourceSubId: resourceSubId,
@@ -72,7 +76,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 			Namespace:     namespace,
 			Names:         []string{"test"},
 			Aggregations:  "max",
-			Values:        []MetricValue{{name: metricName, max: &metricValue, timestamp: timestamp}},
+			Values:        []MetricValue{{name: metricName, max: &maxValue, timestamp: timestamp}},
 			TimeGrain:     timeGrain,
 			ResourceId:    resourceId,
 			ResourceSubId: resourceSubId,
@@ -80,7 +84,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 			Namespace:     namespace,
 			Names:         []string{"test"},
 			Aggregations:  "avg",
-			Values:        []MetricValue{{name: metricName, avg: &metricValue, timestamp: timestamp}},
+			Values:        []MetricValue{{name: metricName, avg: &avgValue, timestamp: timestamp}},
 			TimeGrain:     timeGrain,
 			ResourceId:    resourceId,
 			ResourceSubId: resourceSubId,
@@ -88,7 +92,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 			Namespace:     namespace,
 			Names:         []string{"test"},
 			Aggregations:  "total",
-			Values:        []MetricValue{{name: metricName, total: &metricValue, timestamp: timestamp}},
+			Values:        []MetricValue{{name: metricName, total: &totalValue, timestamp: timestamp}},
 			TimeGrain:     timeGrain,
 			ResourceId:    resourceId,
 			ResourceSubId: resourceSubId,
@@ -96,7 +100,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 			Namespace:     namespace,
 			Names:         []string{"test"},
 			Aggregations:  "count",
-			Values:        []MetricValue{{name: metricName, count: &metricValue, timestamp: timestamp}},
+			Values:        []MetricValue{{name: metricName, count: &countValue, timestamp: timestamp}},
 			TimeGrain:     timeGrain,
 			ResourceId:    resourceId,
 			ResourceSubId: resourceSubId,
@@ -107,7 +111,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 		expected := []KeyValuePoint{
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "min"),
-				Value:         &metricValue,
+				Value:         &minValue,
 				Namespace:     namespace,
 				TimeGrain:     timeGrain,
 				Timestamp:     timestamp,
@@ -116,7 +120,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Dimensions:    map[string]interface{}{},
 			}, {
 				Key:           fmt.Sprintf("%s.%s", metricName, "max"),
-				Value:         &metricValue,
+				Value:         &maxValue,
 				Namespace:     namespace,
 				TimeGrain:     timeGrain,
 				Timestamp:     timestamp,
@@ -125,7 +129,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Dimensions:    map[string]interface{}{},
 			}, {
 				Key:           fmt.Sprintf("%s.%s", metricName, "avg"),
-				Value:         &metricValue,
+				Value:         &avgValue,
 				Namespace:     namespace,
 				TimeGrain:     timeGrain,
 				Timestamp:     timestamp,
@@ -135,7 +139,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "total"),
-				Value:         &metricValue,
+				Value:         &totalValue,
 				Namespace:     namespace,
 				TimeGrain:     timeGrain,
 				Timestamp:     timestamp,
@@ -145,7 +149,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "count"),
-				Value:         &metricValue,
+				Value:         &countValue,
 				Namespace:     namespace,
 				TimeGrain:     timeGrain,
 				Timestamp:     timestamp,

--- a/x-pack/metricbeat/module/azure/data_test.go
+++ b/x-pack/metricbeat/module/azure/data_test.go
@@ -5,9 +5,10 @@
 package azure
 
 import (
-	"testing"
-
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
 func TestGetDimensionValue(t *testing.T) {
@@ -45,4 +46,114 @@ func TestManagePropertyName(t *testing.T) {
 
 	result = managePropertyName("Percentage CPU")
 	assert.Equal(t, result, "percentage_cpu")
+}
+
+func TestMapToKeyValuePoints(t *testing.T) {
+	timestamp := time.Now().UTC()
+	metricName := "test"
+	metricValue := 42.0
+	namespace := "test"
+	resourceId := "test"
+	resourceSubId := "test"
+	timeGrain := "PT1M"
+
+	t.Run("test aggregation types", func(t *testing.T) {
+
+		metrics := []Metric{{
+			Namespace:     namespace,
+			Names:         []string{"test"},
+			Aggregations:  "min",
+			Values:        []MetricValue{{name: metricName, min: &metricValue, timestamp: timestamp}},
+			TimeGrain:     timeGrain,
+			ResourceId:    resourceId,
+			ResourceSubId: resourceSubId,
+		}, {
+			Namespace:     namespace,
+			Names:         []string{"test"},
+			Aggregations:  "max",
+			Values:        []MetricValue{{name: metricName, max: &metricValue, timestamp: timestamp}},
+			TimeGrain:     timeGrain,
+			ResourceId:    resourceId,
+			ResourceSubId: resourceSubId,
+		}, {
+			Namespace:     namespace,
+			Names:         []string{"test"},
+			Aggregations:  "avg",
+			Values:        []MetricValue{{name: metricName, avg: &metricValue, timestamp: timestamp}},
+			TimeGrain:     timeGrain,
+			ResourceId:    resourceId,
+			ResourceSubId: resourceSubId,
+		}, {
+			Namespace:     namespace,
+			Names:         []string{"test"},
+			Aggregations:  "total",
+			Values:        []MetricValue{{name: metricName, total: &metricValue, timestamp: timestamp}},
+			TimeGrain:     timeGrain,
+			ResourceId:    resourceId,
+			ResourceSubId: resourceSubId,
+		}, {
+			Namespace:     namespace,
+			Names:         []string{"test"},
+			Aggregations:  "count",
+			Values:        []MetricValue{{name: metricName, count: &metricValue, timestamp: timestamp}},
+			TimeGrain:     timeGrain,
+			ResourceId:    resourceId,
+			ResourceSubId: resourceSubId,
+		}}
+
+		actual := mapToKeyValuePoints(metrics)
+
+		expected := []KeyValuePoint{
+			{
+				Key:           fmt.Sprintf("%s.%s", metricName, "min"),
+				Value:         &metricValue,
+				Namespace:     namespace,
+				TimeGrain:     timeGrain,
+				Timestamp:     timestamp,
+				ResourceId:    resourceId,
+				ResourceSubId: resourceSubId,
+				Dimensions:    map[string]interface{}{},
+			}, {
+				Key:           fmt.Sprintf("%s.%s", metricName, "max"),
+				Value:         &metricValue,
+				Namespace:     namespace,
+				TimeGrain:     timeGrain,
+				Timestamp:     timestamp,
+				ResourceId:    resourceId,
+				ResourceSubId: resourceSubId,
+				Dimensions:    map[string]interface{}{},
+			}, {
+				Key:           fmt.Sprintf("%s.%s", metricName, "avg"),
+				Value:         &metricValue,
+				Namespace:     namespace,
+				TimeGrain:     timeGrain,
+				Timestamp:     timestamp,
+				ResourceId:    resourceId,
+				ResourceSubId: resourceSubId,
+				Dimensions:    map[string]interface{}{},
+			},
+			{
+				Key:           fmt.Sprintf("%s.%s", metricName, "total"),
+				Value:         &metricValue,
+				Namespace:     namespace,
+				TimeGrain:     timeGrain,
+				Timestamp:     timestamp,
+				ResourceId:    resourceId,
+				ResourceSubId: resourceSubId,
+				Dimensions:    map[string]interface{}{},
+			},
+			{
+				Key:           fmt.Sprintf("%s.%s", metricName, "count"),
+				Value:         &metricValue,
+				Namespace:     namespace,
+				TimeGrain:     timeGrain,
+				Timestamp:     timestamp,
+				ResourceId:    resourceId,
+				ResourceSubId: resourceSubId,
+				Dimensions:    map[string]interface{}{},
+			},
+		}
+
+		assert.Equal(t, expected, actual)
+	})
 }

--- a/x-pack/metricbeat/module/azure/data_test.go
+++ b/x-pack/metricbeat/module/azure/data_test.go
@@ -6,9 +6,10 @@ package azure
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDimensionValue(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Fix mapping of metric values from `Metric` to `KeyValuePoint`. Unfortunately, I didn't notice the code for `min` and `max` aggregations picked up the value from the `avg` field. This is a silly mistake with nasty consequences.

I added a basic unit test to check the expected behavior. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Set up the Azure Monitor metricset with the following Metricbeat module configuration:

```
- module: azure
  metricsets:
  - monitor
  enabled: true
  period: 300s
  client_id: '...'
  client_secret: '...'
  tenant_id: '...'
  subscription_id: '...'
  refresh_list_interval: 600s
  resources:
  - resource_query: resourceType eq 'Microsoft.Cache/redis'
     metrics:
      - dimensions:
          - name: ShardId
            value: '*'
          - name: Port
            value: '*'
          - name: Primary
            value: '*'
        ignore_unsupported: true
        name:
          - allcachehits
          - allcachemisses
          - allcacheRead
          - allcacheWrite
          - allconnectedclients
          - allevictedkeys
          - allexpiredkeys
          - allgetcommands
          - alloperationsPerSecond
          - allpercentprocessortime
          - allserverLoad
          - allsetcommands
          - alltotalcommandsprocessed
          - alltotalkeys
          - allusedmemory
          - allusedmemorypercentage
          - allusedmemoryRss
          - ConnectedClientsUsingAADToken
        namespace: Microsoft.Cache/redis
        timegrain: PT1M
```

Run the metricset to collect some metrics.

The collected documents must contain metrics having `min` and `max` aggregation types (for example, `azure.metrics.server_load.max`).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Close https://github.com/elastic/beats/issues/37642

<!-- Recommended

## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

With the fix, I am able to successfully collect metric with `max` aggregation:

![CleanShot 2024-01-16 at 17 17 35@2x](https://github.com/elastic/beats/assets/25941/fbadaa66-32d8-437a-b407-953e304b098b)


<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
