### PR TITLE
[Heartbeat] decode base64 synthetics inline journeys

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -78,6 +78,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 *Heartbeat*
 
 - Fix panics when parsing dereferencing invalid parsed url. {pull}34702[34702]
+- Add support for running encoded synthetics inline journeys which fixes the parsing issue in Heartbeat when JavaScript template literals are used on the journey script. {pull}37699[37699]
 
 *Metricbeat*
 

--- a/x-pack/heartbeat/monitors/browser/source/inline.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline.go
@@ -6,8 +6,10 @@
 package source
 
 import (
+	"encoding/base64"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 type InlineSource struct {
@@ -26,6 +28,16 @@ func (s *InlineSource) Validate() error {
 }
 
 func (s *InlineSource) Fetch() (err error) {
+	// backwards compatability, skip decoding if the script is already decoded
+	if strings.Contains(s.Script, "step(") {
+		return nil
+	}
+	// decode the base64 encoded script and replace the original script
+	decodedBytes, err := base64.StdEncoding.DecodeString(s.Script)
+	if err != nil {
+		return fmt.Errorf("could not decode inline script: %w", err)
+	}
+	s.Script = string(decodedBytes)
 	return nil
 }
 

--- a/x-pack/heartbeat/monitors/browser/source/inline.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline.go
@@ -28,7 +28,7 @@ func (s *InlineSource) Validate() error {
 }
 
 func (s *InlineSource) Fetch() (err error) {
-	// backwards compatability, skip decoding if the script is already decoded
+	// backwards compatibility, skip decoding if the script is already decoded
 	if strings.Contains(s.Script, "step(") {
 		return nil
 	}

--- a/x-pack/heartbeat/monitors/browser/source/inline.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline.go
@@ -28,7 +28,9 @@ func (s *InlineSource) Validate() error {
 }
 
 func (s *InlineSource) Fetch() (err error) {
-	// backwards compatibility, skip decoding if the script is already decoded
+	// "step(" is a good indicator that the script is already decoded since `(` is
+	// not a valid base64 character. This ensures backwards compatibility with
+	// older inline scripts that are not encoded.
 	if strings.Contains(s.Script, "step(") {
 		return nil
 	}

--- a/x-pack/heartbeat/monitors/browser/source/inline_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline_test.go
@@ -41,3 +41,39 @@ func TestInlineSourceValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestInlineSourceFetch(t *testing.T) {
+	type testCase struct {
+		name    string
+		source  *InlineSource
+		wantErr bool
+	}
+	testCases := []testCase{
+		{
+			"script w/o encoding",
+			&InlineSource{Script: "step('step', () => {})"},
+			false,
+		},
+		{
+			"encoded script",
+			&InlineSource{Script: "c3RlcChzdGVwLCAoKSA9PiB7fSkK"},
+			false,
+		},
+		{
+			"encoded script error",
+			&InlineSource{Script: "c3RlcChzdwLCAoKSA9PiB7fSkK"},
+			true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.source.Fetch()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed commit message

+ PR adds support for decoding the base64 encoded inline synthetics journeys. This is done to protect against JavaScript template literals that causes parsing error when trying to unpack the monitor journey scripts. More details are on the original Kibana issue - https://github.com/elastic/kibana/issues/169963

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

+ Create an inline journey script and run it like usual 
```
script: |-
  step("load example", async() => {
    await page.goto('https://www.example.com/');
  });
```
+ Change this script to base64 encoded string and try running Heartbeat again.
```
script: c3RlcCgnbG9hZCBleGFtcGxlJywgYXN5bmMgKCkgPT4gewogIGF3YWl0IHBhZ2UuZ290bygnaHR0cHM6Ly93d3cuZXhhbXBsZS5jb20vJywgeyB0aW1lb3V0OiAyMDAwMCB9KTsKfSk7Cg==
```
+ Both should yield same results in the Synthetics/Uptime App. 

