### PR TITLE
fix the packetbeat bk pipeline init config

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -356,7 +356,7 @@ spec:
       description: "Beats packetbeat pipeline"
     spec:
 #      branch_configuration: "main 7.17 8.* v7.17 v8.*" TODO: temporarily commented to build PRs from forks
-      pipeline_file: ".buildkite/libbeat/pipeline.packetbeat.yml"
+      pipeline_file: ".buildkite/libbeat/pipeline.libbeat.yml"
 #      maximum_timeout_in_minutes: 120 TODO: uncomment when pipeline is ready
       provider_settings:
         build_pull_request_forks: false

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -356,7 +356,7 @@ spec:
       description: "Beats packetbeat pipeline"
     spec:
 #      branch_configuration: "main 7.17 8.* v7.17 v8.*" TODO: temporarily commented to build PRs from forks
-      pipeline_file: ".buildkite/libbeat/pipeline.libbeat.yml"
+      pipeline_file: ".buildkite/packetbeat/pipeline.packetbeat.yml"
 #      maximum_timeout_in_minutes: 120 TODO: uncomment when pipeline is ready
       provider_settings:
         build_pull_request_forks: false


### PR DESCRIPTION
## What is the problem this PR solves?

Jenkins->Buildkite pipelines migration 
fix the pipeline initialisation - https://buildkite.com/elastic/beats-packetbeat/builds/1#018d36a9-d0ff-47a9-8f23-5cc47472366e

## How does this PR solve the problem?

changed the pipeline name

## Related issues

https://github.com/elastic/ingest-dev/issues/1693
