### PR TITLE
Introduce add_fields to add_kubernetes_metadata processor

### DIFF
--- a/libbeat/processors/add_kubernetes_metadata/config.go
+++ b/libbeat/processors/add_kubernetes_metadata/config.go
@@ -42,6 +42,7 @@ type kubeAnnotatorConfig struct {
 	DefaultIndexers Enabled       `config:"default_indexers"`
 
 	AddResourceMetadata *metadata.AddResourceMetadataConfig `config:"add_resource_metadata"`
+	AddFields           *config.C                           `config:"add_fields"`
 }
 
 type Enabled struct {

--- a/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
+++ b/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
@@ -21,6 +21,8 @@ Each event is annotated with:
 
 In addition, the node and namespace metadata are added to the pod metadata.
 
+A custom field can also be annotated to the event using `add_fields`. This field works same as the `add_fields` processor. Refer to <<add-fields>> for additional information.
+
 The `add_kubernetes_metadata` processor has two basic building blocks:
 
 * Indexers
@@ -126,6 +128,17 @@ level. Possible values are `node` and `cluster`. Scope is `node` by default.
 `namespace`:: (Optional) Select the namespace from which to collect the
 metadata. If it is not set, the processor collects metadata from all namespaces.
 It is unset by default.
+`add_fields`:: (Optional) Specify additional fields that will be added to the event. Refer to  <<add-fields>> for configuration parameters.
++
+Example:
+[source,yaml]
+------------------------------------------------------------------------------
+  add_fields:
+    target: project
+    fields:
+      name: myproject
+      id: '574734885120952459'
+------------------------------------------------------------------------------
 `add_resource_metadata`:: (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
  - `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output.
  Note: wildcards are not supported for those settings.

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors/actions"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -127,6 +128,81 @@ func TestAnnotatorWithNoKubernetesAvailable(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, intialEventMap, event.Fields)
+}
+
+// Test field is being added correctly based on indexer and matcher
+func TestAddField(t *testing.T) {
+	cfg := config.MustNewConfigFrom(map[string]interface{}{
+		"matchers": []map[string]interface{}{
+			{
+				"field_format": map[string]interface{}{
+					"format": "%{[destination.ip]}:%{[destination.port]}",
+				},
+			},
+		},
+		"add_fields": map[string]interface{}{
+			"target": "flow",
+			"fields": map[string]interface{}{
+				"destination": "destination",
+			},
+		},
+	})
+
+	processorConfig, err := newProcessorConfig(cfg, NewRegister())
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher := NewMatchers(processorConfig.Matchers)
+
+	annotatorCache := newCache(10 * time.Second)
+	// add an indexer that we want to test
+	// Since the test is for ip_port, add ip:port as the key
+	annotatorCache.set("192.16.2.13:53", mapstr.M{})
+
+	addFieldProcessor, err := actions.CreateAddFields(processorConfig.AddFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	processor := kubernetesAnnotator{
+		log:   logp.NewLogger(selector).With("libbeat.processor", "add_kubernetes_metadata_test"),
+		cache: annotatorCache,
+		matchers: &Matchers{
+			matchers: []Matcher{matcher},
+		},
+		kubernetesAvailable: true,
+		addFieldProcessor:   addFieldProcessor,
+	}
+
+	intialEventMap := mapstr.M{
+		"testMap": "test",
+		"destination": mapstr.M{
+			"port":    53,
+			"bytes":   408,
+			"ip":      "192.16.2.13",
+			"packets": 2,
+		},
+	}
+
+	expectedEventMap := mapstr.M{
+		"testMap": "test",
+		"destination": mapstr.M{
+			"port":    53,
+			"bytes":   408,
+			"ip":      "192.16.2.13",
+			"packets": 2,
+		},
+		"flow": mapstr.M{
+			"destination": "destination",
+		},
+	}
+
+	event, err := processor.Run(&beat.Event{
+		Fields: intialEventMap.Clone(),
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedEventMap, event.Fields)
 }
 
 // TestNewProcessorConfigDefaultIndexers validates the behaviour of default indexers and


### PR DESCRIPTION
## Proposed commit message

This PR adds the ability to add custom fields to the events as part of the add_kuberentes_metadata processor. This reuses the add_fields processor that already exists and simply calls the add_fields processor from the add_kubernetes_metadata processor. 

The motivation behind this change to help scenarios where with packetbeat we want to see if the packet was recorded at the source or destination. By adding a custom field to denote where the packet was recorded based on the ip_port indexer in add_kubernetes_metadata processor we are able to then deduplicate some of the packets that we see on packetbeat based on the packet being recorded on the source or destination.


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

This can be tested locally by using a config file like below 
```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: packetbeat-dynamic-config
  namespace: kube-system
  labels:
    k8s-app: packetbeat-dynamic
    kubernetes.io/cluster-service: "true"
data:
  packetbeat.yml: |-
    logging.level: info
    
    setup.dashboards.enabled: true
    setup.template.enabled: true
    setup.template.settings:
      index.number_of_shards: 2
    packetbeat.interfaces.device: any
    packetbeat.interfaces.type: af_packet
    packetbeat.protocols:
    - type: dns
      ports: [53]
      include_authorities: true
      include_additionals: true
    - type: http
      ports: [80, 8000, 8080, 9200]
    - type: tls
      ports: [8443]  
    - type: mysql
      ports: [3306]
    - type: redis
      ports: [6379]
    packetbeat.flows:
      enabled: true
      timeout: 30s
      period: 10s
      kill_flow_on_timeout: true
      processors:
        - community_id:
    processors:
      - add_cloud_metadata:     
      - add_kubernetes_metadata:
          node: ${HOSTNAME}
          indexers:
          - ip_port:
          matchers:
          - field_format:
              format: '%{[destination.ip]}:%{[destination.port]}'
          add_fields:
            target: PacketRecorded
            fields:
              destination: true
    cloud.auth: elastic:${ELASTIC_PASSWORD}
    cloud.id: ${CLOUD_ID}
    output.elasticsearch:
---
```

