### PR TITLE
Fix 'make beats-dashboards' target

### DIFF
--- a/auditbeat/tests/system/requirements.txt
+++ b/auditbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/dev-tools/requirements.txt
+++ b/dev-tools/requirements.txt
@@ -1,3 +1,3 @@
 elasticsearch
 requests
-protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/heartbeat/tests/system/requirements.txt
+++ b/heartbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
+++ b/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
@@ -10,4 +10,4 @@ rsa==4.7.2
 s3transfer==0.3.3
 six==1.14.0
 urllib3==1.26.5
-protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,4 +1,4 @@
 kafka-python==1.4.3
 elasticsearch==7.1.0
 semver==2.8.1
-protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/packetbeat/tests/system/gen/memcache/requirements.txt
+++ b/packetbeat/tests/system/gen/memcache/requirements.txt
@@ -1,2 +1,2 @@
 pylibmc
-protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/x-pack/functionbeat/tests/system/requirements.txt
+++ b/x-pack/functionbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.5 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051


### PR DESCRIPTION
A previous dependabot update for Python missed updating the requirements.txt files of each individual beat, creating a dependency conflict on the protobuf package.