### PR TITLE
filebeat/input/{tcp,udp}: relax requirements that proc entries be present when an address is

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -169,6 +169,7 @@ Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will d
 - Add support for user-defined query selection in EntraID entity analytics provider. {pull}37653[37653]
 - Update CEL extensions library to v1.8.0 to provide runtime error location reporting. {issue}37304[37304] {pull}37718[37718]
 - Add request trace logging for chained API requests. {issue}37551[36551] {pull}37682[37682]
+- Relax TCP/UDP metric polling expectations to improve metric collection. {pull}37714[37714]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix handling of Juniper SRX structured data when there is no leading junos element. {issue}36270[36270] {pull}36308[36308]
 - Fix Filebeat Cisco module with missing escape character {issue}36325[36325] {pull}36326[36326]
 - Added a fix for Crowdstrike pipeline handling process arrays {pull}36496[36496]
+- Fix TCP/UDP metric queue length parsing base. {pull}37714[37714]
 
 *Heartbeat*
 

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -342,10 +342,10 @@ func procNetTCP(path string, addr []string, hasUnspecified bool, addrIsUnspecifi
 			}
 			found = true
 
-			// queue lengths are decimal, e.g.:
+			// queue lengths are hex, e.g.:
 			// - https://elixir.bootlin.com/linux/v6.2.11/source/net/ipv4/tcp_ipv4.c#L2643
 			// - https://elixir.bootlin.com/linux/v6.2.11/source/net/ipv6/tcp_ipv6.c#L1987
-			v, err := strconv.ParseInt(string(r), 10, 64)
+			v, err := strconv.ParseInt(string(r), 16, 64)
 			if err != nil {
 				return 0, fmt.Errorf("failed to parse rx_queue: %w", err)
 			}

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -238,31 +238,50 @@ func (m *inputMetrics) poll(addr, addr6 []string, each time.Duration, log *logp.
 	// base level for the rx_queue values and ensures that if the
 	// constructed address values are malformed we panic early
 	// within the period of system testing.
+	want4 := true
 	rx, err := procNetTCP("/proc/net/tcp", addr, hasUnspecified, addrIsUnspecified)
 	if err != nil {
-		log.Warnf("failed to get initial tcp stats from /proc: %v", err)
+		want4 = false
+		log.Infof("did not get initial tcp stats from /proc: %v", err)
 	}
+	want6 := true
 	rx6, err := procNetTCP("/proc/net/tcp6", addr6, hasUnspecified6, addrIsUnspecified6)
 	if err != nil {
-		log.Warnf("failed to get initial tcp6 stats from /proc: %v", err)
+		want6 = false
+		log.Infof("did not get initial tcp6 stats from /proc: %v", err)
 	}
-	m.rxQueue.Set(uint64(rx + rx6))
+	if !want4 && !want6 {
+		log.Warnf("failed to get initial tcp or tcp6 stats from /proc: %v", err)
+	} else {
+		m.rxQueue.Set(uint64(rx + rx6))
+	}
 
 	t := time.NewTicker(each)
 	for {
 		select {
 		case <-t.C:
+			var found bool
 			rx, err := procNetTCP("/proc/net/tcp", addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
-				log.Warnf("failed to get tcp stats from /proc: %v", err)
-				continue
+				if want4 {
+					log.Warnf("failed to get tcp stats from /proc: %v", err)
+				}
+			} else {
+				found = true
+				want4 = true
 			}
 			rx6, err := procNetTCP("/proc/net/tcp6", addr6, hasUnspecified6, addrIsUnspecified6)
 			if err != nil {
-				log.Warnf("failed to get tcp6 stats from /proc: %v", err)
-				continue
+				if want6 {
+					log.Warnf("failed to get tcp6 stats from /proc: %v", err)
+				}
+			} else {
+				found = true
+				want6 = true
 			}
-			m.rxQueue.Set(uint64(rx + rx6))
+			if found {
+				m.rxQueue.Set(uint64(rx + rx6))
+			}
 		case <-m.done:
 			t.Stop()
 			return

--- a/filebeat/input/udp/input.go
+++ b/filebeat/input/udp/input.go
@@ -231,33 +231,52 @@ func (m *inputMetrics) poll(addr, addr6 []string, each time.Duration, log *logp.
 	// base level for the rx_queue and drops values and ensures that
 	// if the constructed address values are malformed we panic early
 	// within the period of system testing.
+	want4 := true
 	rx, drops, err := procNetUDP("/proc/net/udp", addr, hasUnspecified, addrIsUnspecified)
 	if err != nil {
-		log.Warnf("failed to get initial udp stats from /proc: %v", err)
+		want4 = false
+		log.Infof("did not get initial udp stats from /proc: %v", err)
 	}
+	want6 := true
 	rx6, drops6, err := procNetUDP("/proc/net/udp6", addr6, hasUnspecified6, addrIsUnspecified6)
 	if err != nil {
-		log.Warnf("failed to get initial udp6 stats from /proc: %v", err)
+		want6 = false
+		log.Infof("did not get initial udp6 stats from /proc: %v", err)
 	}
-	m.rxQueue.Set(uint64(rx + rx6))
-	m.drops.Set(uint64(drops + drops6))
+	if !want4 && !want6 {
+		log.Warnf("failed to get initial udp or udp6 stats from /proc: %v", err)
+	} else {
+		m.rxQueue.Set(uint64(rx + rx6))
+		m.drops.Set(uint64(drops + drops6))
+	}
 
 	t := time.NewTicker(each)
 	for {
 		select {
 		case <-t.C:
+			var found bool
 			rx, drops, err := procNetUDP("/proc/net/udp", addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
-				log.Warnf("failed to get udp stats from /proc: %v", err)
-				continue
+				if want4 {
+					log.Warnf("failed to get udp stats from /proc: %v", err)
+				}
+			} else {
+				found = true
+				want4 = true
 			}
 			rx6, drops6, err := procNetUDP("/proc/net/udp6", addr6, hasUnspecified6, addrIsUnspecified6)
 			if err != nil {
-				log.Warnf("failed to get udp6 stats from /proc: %v", err)
-				continue
+				if want6 {
+					log.Warnf("failed to get udp6 stats from /proc: %v", err)
+				}
+			} else {
+				found = true
+				want6 = true
 			}
-			m.rxQueue.Set(uint64(rx + rx6))
-			m.drops.Set(uint64(drops + drops6))
+			if found {
+				m.rxQueue.Set(uint64(rx + rx6))
+				m.drops.Set(uint64(drops + drops6))
+			}
 		case <-m.done:
 			t.Stop()
 			return

--- a/filebeat/input/udp/input.go
+++ b/filebeat/input/udp/input.go
@@ -340,10 +340,10 @@ func procNetUDP(path string, addr []string, hasUnspecified bool, addrIsUnspecifi
 			}
 			found = true
 
-			// queue lengths and drops are decimal, e.g.:
+			// queue lengths and drops are hex, e.g.:
 			// - https://elixir.bootlin.com/linux/v6.2.11/source/net/ipv4/udp.c#L3110
 			// - https://elixir.bootlin.com/linux/v6.2.11/source/net/ipv6/datagram.c#L1048
-			v, err := strconv.ParseInt(string(r), 10, 64)
+			v, err := strconv.ParseInt(string(r), 16, 64)
 			if err != nil {
 				return 0, 0, fmt.Errorf("failed to parse rx_queue: %w", err)
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The previous logic required that if an address is present according to net.LookupIP, then it must be present in the /proc/net entries. This may not the case when a tcp/udp listener is created without specifying tcp4/udp4 for an IPv4 host address and there is an expectation of finding the socket in the /proc/net/{tcp,udp} table. So only complain if the entry has ever been found and never skip storing a metric even when there is a legitimate reason to expect its presence — because it has been seen in the past. This second part is an extension to reduce the loss of metric data, even if it is only partial.

Also fix the parse base of the receive queue which was incorrectly thought to be decimal from an incorrect reading of the kernel source.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
