### PR TITLE
package_test.go - Support OCI Image Layout

### DIFF
--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -806,6 +806,7 @@ func getDockerManifest(file string) (*dockerManifest, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	gzipReader, err := gzip.NewReader(f)
 	if err != nil {

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -30,10 +30,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -106,6 +106,7 @@ func TestZip(t *testing.T) {
 func TestDocker(t *testing.T) {
 	dockers := getFiles(t, regexp.MustCompile(`\.docker\.tar\.gz$`))
 	for _, docker := range dockers {
+		t.Log(docker)
 		checkDocker(t, docker)
 	}
 }
@@ -713,13 +714,19 @@ func readZip(t *testing.T, zipFile string, inspectors ...inspector) (*packageFil
 }
 
 func readDocker(dockerFile string) (*packageFile, *dockerInfo, error) {
+	// Read the manifest file first so that the config file and layer
+	// names are known in advance.
+	manifest, err := getDockerManifest(dockerFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	file, err := os.Open(dockerFile)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer file.Close()
 
-	var manifest *dockerManifest
 	var info *dockerInfo
 	layers := make(map[string]*packageFile)
 
@@ -740,22 +747,17 @@ func readDocker(dockerFile string) (*packageFile, *dockerInfo, error) {
 		}
 
 		switch {
-		case header.Name == "manifest.json":
-			manifest, err = readDockerManifest(tarReader)
-			if err != nil {
-				return nil, nil, err
-			}
-		case strings.HasSuffix(header.Name, ".json") && header.Name != "manifest.json":
+		case header.Name == manifest.Config:
 			info, err = readDockerInfo(tarReader)
 			if err != nil {
 				return nil, nil, err
 			}
-		case strings.HasSuffix(header.Name, "/layer.tar"):
+		case slices.Contains(manifest.Layers, header.Name):
 			layer, err := readTarContents(header.Name, tarReader)
 			if err != nil {
 				return nil, nil, err
 			}
-			layers[filepath.Dir(header.Name)] = layer
+			layers[header.Name] = layer
 		}
 	}
 
@@ -769,10 +771,9 @@ func readDocker(dockerFile string) (*packageFile, *dockerInfo, error) {
 	// Read layers in order and for each file keep only the entry seen in the later layer
 	p := &packageFile{Name: filepath.Base(dockerFile), Contents: map[string]packageEntry{}}
 	for _, layer := range manifest.Layers {
-		layerID := filepath.Dir(layer)
-		layerFile, found := layers[layerID]
+		layerFile, found := layers[layer]
 		if !found {
-			return nil, nil, fmt.Errorf("layer not found: %s", layerID)
+			return nil, nil, fmt.Errorf("layer not found: %s", layer)
 		}
 		for name, entry := range layerFile.Contents {
 			// Check only files in working dir and entrypoint
@@ -798,6 +799,43 @@ func readDocker(dockerFile string) (*packageFile, *dockerInfo, error) {
 	return p, info, nil
 }
 
+// getDockerManifest opens a gzipped tar file to read the Docker manifest.json
+// that it is expected to contain.
+func getDockerManifest(file string) (*dockerManifest, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+
+	gzipReader, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+
+	var manifest *dockerManifest
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+
+		if header.Name == "manifest.json" {
+			manifest, err = readDockerManifest(tarReader)
+			if err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
+
+	return manifest, nil
+}
+
 type dockerManifest struct {
 	Config   string
 	RepoTags []string
@@ -805,7 +843,7 @@ type dockerManifest struct {
 }
 
 func readDockerManifest(r io.Reader) (*dockerManifest, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -833,7 +871,7 @@ type dockerInfo struct {
 }
 
 func readDockerInfo(r io.Reader) (*dockerInfo, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Proposed commit message

Modify TestDocker such that it can read both the original docker image layout and the OCI Image Layout. This works by reading the config and layer file names from the manifest.yml instead of assuming their names.

Fixes #37726

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Need to run it on a machine with an older docker and a new docker.

`PLATFORMS=linux/amd64 SNAPSHOT=true mage -v package`

## Related issues

- Fixes #37726

## Notes

This is how the manifest.json looks under a docker export from Docker Engine 20.10.22.
```json
[
  {
    "Config": "9c3a1c54bb292142bd87ab9710574289daf66725b924d6d2d7d2522abfa6c5e8.json",
    "RepoTags": [
      "docker.elastic.co/beats/auditbeat-oss:8.13.0-SNAPSHOT"
    ],
    "Layers": [
      "3889013043c4cd6303c1845ca9fe8ae182b4b4893f0a91f2830b9d42f8a84e3e/layer.tar",
      "17c0b5e4c288157c300ed8179ee331b164c8a8fe05a0122bdaab2bb74d36daaa/layer.tar",
      "886e9544ed7fc95e8ce46a620ba86541ce7559c38fa6600de6fd6bc2a1cabaaf/layer.tar",
      "eac6da820a3347f34d17c82183b41db94d46cae22022ca1a5c8a16cf7bd18091/layer.tar",
      "fd0873a272991097037f3c44b1a71f02cd243484eb65103372def58924604837/layer.tar",
      "a1e3c7b8704488fb882049f29d1208bbc8543094f605db639fbaa53e32747f48/layer.tar",
      "154241032891186627ef580ab1a6c1c9844a47209d96757cb079a329ee5fd46d/layer.tar",
      "fd4811cb85b6e681fcf4b72efaff36c25cd31e94fbef45623adc6627b662ccac/layer.tar",
      "5f6da050cc94f30a92ec75cd0cadcd9e8768c99435bc4a53f7765482ec1b06eb/layer.tar",
      "11ecf32a9786eba93435dc21a87a614e1449caba5395eb146245db32d82ea72e/layer.tar",
      "ada1b4fc98b714d383818dc39ccb40236cd2faacb4fb0d8cdc47e263cfb8e4be/layer.tar",
      "4273aa067d2f453ad799b011bd9d640fc4998cbd40b361d86f27901f7a639c0d/layer.tar"
    ]
  }
]
```

And this is how the manifest.json looks under a docker export from Docker Engine 25.0.1.
```json
[
  {
    "Config": "blobs/sha256/75771bde63fc0e750f060facf4f8e983432438ea10a519539835f390509396a4",
    "RepoTags": [
      "auditbeat:latest"
    ],
    "Layers": [
      "blobs/sha256/b1099d79a48ef6b9eaf12e0083d6510f9d9a5f9085465344247ca2822a9687f0",
      "blobs/sha256/49386a6ffd28a05d5f0a84b9949a6a83cd4ce57c23a2bb11bb4ae37a42215db8",
      "blobs/sha256/0dfede3bba776760119b2987a1f8a472095da848fb9b200fec910a52aaa0c4b0",
      "blobs/sha256/664c054c208307b301a1cc4754b4a9ae0e76c71f2cab90158903d45687389011",
      "blobs/sha256/aa147e557a1f602b1477ea70b6a171104fd2e84be7d4e4c8deb3d5c59d196c07",
      "blobs/sha256/1600e739679c5cbfa4fd03f084c5ba9bd1fa8fbd977535d091b5c0a59607aa33",
      "blobs/sha256/464f69e40f0fe21164fd63a96a511ab749f61d25e36cb21f2b42479d3eeba844",
      "blobs/sha256/22388ba12e4c3cbd5ebde20992198f65b594112cb8e5b6d23c4fe2bd65d53711",
      "blobs/sha256/ebb14e3380c6f51e9928594c786cc47d317ccbfe731af24d95a6c1b9d67be8dd",
      "blobs/sha256/781df5ce7323957257aa66862883bdd2e9c578a899bca601bb411a1fe468089f",
      "blobs/sha256/66157a475ac27298e4b982627556968648c7b8074a500f619c5a747d3a12cc13",
      "blobs/sha256/5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
    ],
    "LayerSources": {
      "sha256:0dfede3bba776760119b2987a1f8a472095da848fb9b200fec910a52aaa0c4b0": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 26624,
        "digest": "sha256:0dfede3bba776760119b2987a1f8a472095da848fb9b200fec910a52aaa0c4b0"
      },
      "sha256:1600e739679c5cbfa4fd03f084c5ba9bd1fa8fbd977535d091b5c0a59607aa33": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 103729152,
        "digest": "sha256:1600e739679c5cbfa4fd03f084c5ba9bd1fa8fbd977535d091b5c0a59607aa33"
      },
      "sha256:22388ba12e4c3cbd5ebde20992198f65b594112cb8e5b6d23c4fe2bd65d53711": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 13824,
        "digest": "sha256:22388ba12e4c3cbd5ebde20992198f65b594112cb8e5b6d23c4fe2bd65d53711"
      },
      "sha256:464f69e40f0fe21164fd63a96a511ab749f61d25e36cb21f2b42479d3eeba844": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 1536,
        "digest": "sha256:464f69e40f0fe21164fd63a96a511ab749f61d25e36cb21f2b42479d3eeba844"
      },
      "sha256:49386a6ffd28a05d5f0a84b9949a6a83cd4ce57c23a2bb11bb4ae37a42215db8": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 51286016,
        "digest": "sha256:49386a6ffd28a05d5f0a84b9949a6a83cd4ce57c23a2bb11bb4ae37a42215db8"
      },
      "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 1024,
        "digest": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
      },
      "sha256:66157a475ac27298e4b982627556968648c7b8074a500f619c5a747d3a12cc13": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 345600,
        "digest": "sha256:66157a475ac27298e4b982627556968648c7b8074a500f619c5a747d3a12cc13"
      },
      "sha256:664c054c208307b301a1cc4754b4a9ae0e76c71f2cab90158903d45687389011": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 4096,
        "digest": "sha256:664c054c208307b301a1cc4754b4a9ae0e76c71f2cab90158903d45687389011"
      },
      "sha256:781df5ce7323957257aa66862883bdd2e9c578a899bca601bb411a1fe468089f": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 6144,
        "digest": "sha256:781df5ce7323957257aa66862883bdd2e9c578a899bca601bb411a1fe468089f"
      },
      "sha256:aa147e557a1f602b1477ea70b6a171104fd2e84be7d4e4c8deb3d5c59d196c07": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 4096,
        "digest": "sha256:aa147e557a1f602b1477ea70b6a171104fd2e84be7d4e4c8deb3d5c59d196c07"
      },
      "sha256:b1099d79a48ef6b9eaf12e0083d6510f9d9a5f9085465344247ca2822a9687f0": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 68108288,
        "digest": "sha256:b1099d79a48ef6b9eaf12e0083d6510f9d9a5f9085465344247ca2822a9687f0"
      },
      "sha256:ebb14e3380c6f51e9928594c786cc47d317ccbfe731af24d95a6c1b9d67be8dd": {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "size": 3010560,
        "digest": "sha256:ebb14e3380c6f51e9928594c786cc47d317ccbfe731af24d95a6c1b9d67be8dd"
      }
    }
  }
]
```
