### PR TITLE
Initial buildkite configuration for elastic-agent

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -127,6 +127,22 @@
             "skip_target_branches": [ ],
             "skip_ci_on_only_changed": [ ],
             "always_require_ci_on_changed": ["^packetbeat/.*", ".buildkite/packetbeat/.*", "^go.mod", "^pytest.ini", "^dev-tools/.*", "^libbeat/.*", "^testing/.*"]
+        },
+        {
+            "enabled": true,
+            "pipelineSlug": "xpack-elastic-agent",
+            "allow_org_users": true,
+            "allowed_repo_permissions": ["admin", "write"],
+            "allowed_list": [ ],
+            "set_commit_status": true,
+            "build_on_commit": true,
+            "build_on_comment": true,
+            "trigger_comment_regex": "^/test elastic-agent$",
+            "always_trigger_comment_regex": "^/test elastic-agent$",
+            "skip_ci_labels": [  ],
+            "skip_target_branches": [ ],
+            "skip_ci_on_only_changed": ["^xpack/elastic-agent/README.md", "^xpack/elastic-agent/docs/.*", "^xpack/elastic-agent/devtools/.*" ],
+            "always_require_ci_on_changed": ["^xpack/elastic-agent/.*", ".buildkite/xpack/elastic-agent/.*", "^go.mod", "^pytest.ini", "^dev-tools/.*", "^libbeat/.*", "^testing/.*"]
         }
     ]
 }

--- a/.buildkite/xpack/elastic-agent/pipeline.xpack.elastic-agent.yml
+++ b/.buildkite/xpack/elastic-agent/pipeline.xpack.elastic-agent.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+steps:
+  - label: "Example test"
+    command: echo "Hello!"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -377,3 +377,48 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-beats-xpack-elastic-agent
+  description: "Beats xpack elastic agent"
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/beats-xpack-elastic-agent
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: beats-xpack-elastic-agent
+      description: "Beats xpack elastic agent pipeline"
+    spec:
+      branch_configuration: "7.17"
+      pipeline_file: ".buildkite/xpack/elastic-agent/pipeline.xpack.elastic-agent.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_tags: true
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/beats
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: "!main !7.17 !8.*"
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: "!main !7.17 !8.*"
+      # env:
+      #   ELASTIC_PR_COMMENTS_ENABLED: "true" TODO: uncomment when pipeline is ready
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+          


### PR DESCRIPTION
## Proposed commit message
Initial buildkite configuration for `xpack/elastic-agent`

It requires `catalog-info.yml`, `pull-requests.json` and a sample pipeline to be merged to the destination branch `7.17`

