### PR TITLE
Update aws-s3 known issue in 8.12 to include units in workaround

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,9 +15,9 @@ Performance regression in AWS S3 inputs using SQS notification.
 
 In 8.12 the default memory queue flush interval was raised from 1 second to 10 seconds. In many configurations this improves performance because it allows the output to batch more events per round trip, which improves efficiency. However, the SQS input has an extra bottleneck that interacts badly with the new value. For more details see {issue}37754[37754].
 
-If you are using the Elasticsearch output, and your output configuration uses a performance preset, switch it to `preset: latency`. If you use no preset or use `preset: custom`, then set `queue.mem.flush.timeout: 1` in your queue or output configuration.
+If you are using the Elasticsearch output, and your output configuration uses a performance preset, switch it to `preset: latency`. If you use no preset or use `preset: custom`, then set `queue.mem.flush.timeout: 1s` in your queue or output configuration.
 
-If you are not using the Elasticsearch output, set `queue.mem.flush.timeout: 1` in your queue or output configuration.
+If you are not using the Elasticsearch output, set `queue.mem.flush.timeout: 1s` in your queue or output configuration.
 
 ==== Breaking changes
 


### PR DESCRIPTION
Port of https://github.com/elastic/ingest-docs/pull/871 to Beats.

Use `queue.mem.flush.timeout: 1s` instead of `queue.mem.flush.timeout: 1` to ensure the correct behavior and match the rest of our documentation.