### PR TITLE
[Heartbeat] Remove containerized check from setuid logic

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 *Heartbeat*
 
 - Fix panics when parsing dereferencing invalid parsed url. {pull}34702[34702]
+- Fix setuid root when running under cgroups v2. {pull}37794[37794]
 
 *Metricbeat*
 

--- a/heartbeat/security/security.go
+++ b/heartbeat/security/security.go
@@ -26,8 +26,6 @@ import (
 	"strconv"
 	"syscall"
 
-	sysinfo "github.com/elastic/go-sysinfo"
-
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 )
 
@@ -36,13 +34,7 @@ func init() {
 	// In the context of a container, where users frequently run as root, we follow BEAT_SETUID_AS to setuid/gid
 	// and add capabilities to make this actually run as a regular user. This also helps Node.js in synthetics, which
 	// does not want to run as root. It's also just generally more secure.
-	sysInfo, err := sysinfo.Host()
-	isContainer := false
-	if err == nil && sysInfo.Info().Containerized != nil {
-		isContainer = *sysInfo.Info().Containerized
-	}
-
-	if localUserName := os.Getenv("BEAT_SETUID_AS"); isContainer && localUserName != "" && syscall.Geteuid() == 0 {
+	if localUserName := os.Getenv("BEAT_SETUID_AS"); localUserName != "" && syscall.Geteuid() == 0 {
 		err := setNodeProcAttr(localUserName)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Removed `isContainerized` from `setuid` check, as it fails to detect containers running under `cgroups v2` and prevents switching users when running as root.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

