### PR TITLE
Lower logging level when unpacking config in autodiscover (revert #36919)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -57,6 +57,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Support Elastic Agent control protocol chunking support {pull}37343[37343]
 - Upgrade elastic-agent-libs to v0.7.5. Removes obsolete "Treating the CommonName field on X.509 certificates as a host name..." deprecation warning for 8.0. {pull}37755[37755]
 - aws: Add credential caching for `AssumeRole` session tokens. {issue}37787[37787]
+- Lower logging level to debug when attempting to configure beats with unknown fields from autodiscovered events/environments {pull}[37816][37816]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/template/config.go
+++ b/libbeat/autodiscover/template/config.go
@@ -154,7 +154,7 @@ func ApplyConfigTemplate(event bus.Event, configs []*conf.C, options ...ucfg.Opt
 		var unpacked map[string]interface{}
 		err = c.Unpack(&unpacked, opts...)
 		if err != nil {
-			logp.Warn("autodiscover: Configuration template cannot be resolved: %v", err)
+			logp.Debug("autodiscover", "Configuration template cannot be resolved: %v", err)
 			continue
 		}
 		// Repack again:


### PR DESCRIPTION
## Proposed commit message

When unpacking a config while applying the autodiscover config template, sometimes a configuration template cannot be resolved at that moment but will be resolved at a later stage. This commit brings the logging level of this error back to debug as it can become too verbose and not always means the config is invalid.



## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~


## How to test this PR locally
1. Build Filebeat
2. Deploy it on Kubernetes using the following autodiscover configuration
    ```yaml
    filebeat.autodiscover:
      providers:
        - type: kubernetes
          hints.enabled: true
          hints.default_config:
            type: container
            paths:
              - /var/lib/docker/containers/*_${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log
    ```
3. Assert that log messages containing
    ```
    Configuration template cannot be resolved: field 'data.kubernetes.container.name' not available in event or environment accessing 'paths'
    ```
    Are logged in debug level.


## Related issues
- Reverts https://github.com/elastic/beats/pull/36919

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~