### PR TITLE
Remove footnote to fix broken docs build

### DIFF
--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -16,13 +16,15 @@ The following cloud providers are supported:
 - Google Compute Engine (GCE)
 - https://www.qcloud.com/?lang=en[Tencent Cloud] (QCloud)
 - Alibaba Cloud (ECS)
-- Huawei Cloud (ECS)footnote:[`huawei` is an alias for `openstack`. Huawei cloud runs on OpenStack platform, and when
-viewed from a metadata API standpoint, it is impossible to differentiate it from OpenStack. If you know that your
-deployments run on Huawei Cloud exclusively, and you wish to have `cloud.provider` value as `huawei`, you can achieve
-this by overwriting the value using an `add_fields` processor.]
+- Huawei Cloud (ECS)
 - Azure Virtual Machine
 - Openstack Nova
 - Hetzner Cloud
+
+NOTE: `Huawei` is an alias for `OpenStack`. Huawei cloud runs on OpenStack platform, and when
+viewed from a metadata API standpoint, it is impossible to differentiate it from OpenStack. If you know that your
+deployments run on Huawei Cloud exclusively, and you wish to have `cloud.provider` value as `huawei`, you can achieve
+this by overwriting the value using an `add_fields` processor.
 
 The Alibaba Cloud and Tencent cloud providers are disabled by default, because
 they require to access a remote host. The `providers` setting allows users to


### PR DESCRIPTION
This removes the footnote added in https://github.com/elastic/beats/pull/35184 which is breaking the docs build:

```
09:47:06 INFO:build_docs:/docs_build/resources/asciidoctor/lib/docbook_compat/convert_lists.rb:52:in `block in munge_list_items': Couldn't remove <p> for Huawei Cloud (ECS)<sup class="footnote">[<a id="_footnoteref_3" class="footnote" href="#_footnotedef_3" title="View footnote.">3</a>]</sup> in <div class="ulist itemizedlist"> (RuntimeError)
```

Strangely, I've tested footnotes following the [Asciidoctor docs](https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/#ex-footnote) and can't get them to work at all. So instead I've put the footnote into a separate note:

![Screenshot 2024-02-01 at 1 38 17 PM](https://github.com/elastic/beats/assets/41695641/ea31a696-27d5-44f4-a372-3771f7ec41b8)



