### PR TITLE
[filebeat][threatintel] MISP pagination fixes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -89,6 +89,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 - Fix m365_defender cursor value and query building. {pull}37116[37116]
 - Fix TCP/UDP metric queue length parsing base. {pull}37714[37714]
 - Update github.com/lestrrat-go/jwx dependency. {pull}37799[37799]
+- [threatintel] MISP pagination fixes {pull}37898[37898]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/threatintel/misp/config/config.yml
+++ b/x-pack/filebeat/module/threatintel/misp/config/config.yml
@@ -32,8 +32,20 @@ request.transforms:
     value: json
 - set:
     target: body.timestamp
-    value: '[[.cursor.timestamp]]'
-    default: '[[ formatDate (now (parseDuration "-{{ .first_interval }}")) "UnixDate" ]]'
+    value: >-
+      [[- if index .cursor "timestamp" -]]
+        [[- .cursor.timestamp -]]
+      [[- else -]]
+        [[- .last_response.url.params.Get "timestamp" -]]
+      [[- end -]]
+    default: '[[ (now (parseDuration "-{{ .first_interval }}")).Unix ]]'
+- set:
+    target: body.order
+    value: timestamp
+- set:
+    # Ignored by MISP, set as a workaround to make it available in response.pagination.
+    target: url.params.timestamp
+    value: '[[.body.timestamp]]'
 
 response.split:
   target: body.response
@@ -51,8 +63,15 @@ response.request_body_on_pagination: true
 response.pagination:
 - set:
     target: body.page
-    value: '[[if (ne (len .last_response.body.response) 0)]][[add .last_response.page 1]][[end]]'
+    # Add 2 because the httpjson page counter is zero-based while the MISP page parameter starts at 1.
+    value: '[[if (ne (len .last_response.body.response) 0)]][[add .last_response.page 2]][[end]]'
     fail_on_template_error: true
+- set:
+    target: body.timestamp
+    value: '[[.last_response.url.params.Get "timestamp"]]'
+- set:
+    target: url.params.timestamp
+    value: '[[.last_response.url.params.Get "timestamp"]]'
 cursor:
   timestamp:
     value: '[[.last_event.Event.timestamp]]'


### PR DESCRIPTION
Update the Filebeat Threat Intel module's `misp` fileset with fixes from the [MISP integration](https://docs.elastic.co/en/integrations/ti_misp).

## Proposed commit message

```
[filebeat][threatintel] MISP pagination fixes (#)

Update the HTTP JSON input configuration for the Threat Intel module's
misp fileset with pagination fixes that were done earlier in the
Agent-based MISP integration, in these PRs:

- Fix timestamp format sent to API
  https://github.com/elastic/integrations/pull/6482

- Fix duplicate requests for page 1
  https://github.com/elastic/integrations/pull/6495

- Keep the same timestamp for later pages
  https://github.com/elastic/integrations/pull/6649

- Pagination fixes
  https://github.com/elastic/integrations/pull/9073

```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

To run existing tests for the Threat Intel module:
```
cd x-pack/filebeat
mage pythonIntegTest
```

For a guide to running against a local instance of MISP, please refer to the "How to test this PR locally" section of https://github.com/elastic/integrations/pull/9073.

## Related issues

This issue has discussion of these bugs (and links to a [user report specific to the Threat Intel module](https://discuss.elastic.co/t/bug-threatintel-misp-plugin-runs-in-endless-loop/344798/2)):

- Relates https://github.com/elastic/integrations/issues/8554

PRs with the corresponding changes in the Agent-based integration:

- Relates https://github.com/elastic/integrations/pull/6482
- Relates https://github.com/elastic/integrations/pull/6495
- Relates https://github.com/elastic/integrations/pull/6649
- Relates https://github.com/elastic/integrations/pull/9073
