### PR TITLE
[Kafka output] Disable dynamic topic selection under Elastic-Agent 

### DIFF
--- a/libbeat/management/agent.go
+++ b/libbeat/management/agent.go
@@ -52,5 +52,10 @@ func UnderAgent() bool {
 // It always returns true when not running under Elastic Agent.
 // Otherwise it returns true when the trace level is enabled
 func TraceLevelEnabled() bool {
-	return underAgentTrace.Load()
+	if underAgent.Load() {
+		return underAgentTrace.Load()
+	}
+
+	// Always true when not running under the Elastic Agent.
+	return true
 }

--- a/libbeat/management/agent.go
+++ b/libbeat/management/agent.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package publisher
+package management
 
 import (
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
@@ -47,14 +47,10 @@ func UnderAgent() bool {
 	return underAgent.Load()
 }
 
-// LogWithTrace returns true when not running under Elastic Agent always or
-// only true if running under Elastic Agent with trace logging enabled.
-func LogWithTrace() bool {
-	agent := underAgent.Load()
-	if agent {
-		trace := underAgentTrace.Load()
-		return trace
-	}
-	// Always true when not running under the Elastic Agent.
-	return true
+// TraceLevelEnabled returns true when the "trace log level" is enabled.
+//
+// It always returns true when not running under Elastic Agent.
+// Otherwise it returns true when the trace level is enabled
+func TraceLevelEnabled() bool {
+	return underAgentTrace.Load()
 }

--- a/libbeat/outputs/kafka/kafka_test.go
+++ b/libbeat/outputs/kafka/kafka_test.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+func TestBuildTopicSelector(t *testing.T) {
+	testCases := []struct {
+		name       string
+		topic      string
+		expected   string
+		underAgent bool
+	}{
+		{
+			name:       "static topic",
+			topic:      "a test",
+			expected:   "a test",
+			underAgent: true,
+		},
+		{
+			name:       "dynamic topic under agent",
+			topic:      "%{[foo]}",
+			expected:   "%{[foo]}",
+			underAgent: true,
+		},
+		{
+			name:       "dynamic topic standalone",
+			topic:      "%{[foo]}",
+			expected:   "bar",
+			underAgent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			topicCfg := struct {
+				Topic string `config:"topic" yaml:"topic"`
+			}{
+				Topic: tc.topic,
+			}
+
+			configC := config.MustNewConfigFrom(topicCfg)
+			if tc.underAgent {
+				previous := management.UnderAgent()
+				management.SetUnderAgent(true)
+				defer management.SetUnderAgent(previous)
+			}
+
+			selector, err := buildTopicSelector(configC)
+			if err != nil {
+				t.Fatalf("could not build topic selector: %s", err)
+			}
+
+			event := beat.Event{Fields: mapstr.M{"foo": "bar"}}
+			topic, err := selector.Select(&event)
+			if err != nil {
+				t.Fatalf("could not use selector: %s", err)
+			}
+
+			if topic != tc.expected {
+				t.Fatalf("expecting topic to be '%s', got '%s' instead", tc.expected, topic)
+			}
+		})
+	}
+
+	t.Run("fail unpacking config", func(t *testing.T) {
+		_, err := buildTopicSelector(nil)
+		if err == nil {
+			t.Error("unpack must fail with a nil *config.C")
+		}
+	})
+}

--- a/libbeat/outputs/util.go
+++ b/libbeat/outputs/util.go
@@ -20,7 +20,7 @@ package outputs
 import (
 	"fmt"
 
-	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
@@ -46,7 +46,7 @@ func Success(cfg config.Namespace, batchSize, retry int, clients ...Client) (Gro
 			}
 			q = memqueue.FactoryForSettings(settings)
 		case diskqueue.QueueType:
-			if publisher.UnderAgent() {
+			if management.UnderAgent() {
 				return Group{}, fmt.Errorf("disk queue not supported under agent")
 			}
 			settings, err := diskqueue.SettingsForUserConfig(cfg.Config())

--- a/libbeat/processors/actions/append.go
+++ b/libbeat/processors/actions/append.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -82,7 +82,7 @@ func (f *appendProcessor) Run(event *beat.Event) (*beat.Event, error) {
 	err := f.appendValues(f.config.TargetField, f.config.Fields, f.config.Values, event)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to append fields in append processor: %w", err)
-		if publisher.LogWithTrace() {
+		if management.TraceLevelEnabled() {
 			f.logger.Debug(errMsg.Error())
 		}
 		if f.config.FailOnError {

--- a/libbeat/processors/actions/copy_fields.go
+++ b/libbeat/processors/actions/copy_fields.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -79,7 +79,7 @@ func (f *copyFields) Run(event *beat.Event) (*beat.Event, error) {
 		err := f.copyField(field.From, field.To, event)
 		if err != nil {
 			errMsg := fmt.Errorf("Failed to copy fields in copy_fields processor: %w", err)
-			if publisher.LogWithTrace() {
+			if management.TraceLevelEnabled() {
 				f.logger.Debug(errMsg.Error())
 			}
 			if f.config.FailOnError {

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	cfg "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -84,7 +84,7 @@ func (f *decodeBase64Field) Run(event *beat.Event) (*beat.Event, error) {
 	err := f.decodeField(event)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to decode base64 fields in processor: %w", err)
-		if publisher.LogWithTrace() {
+		if management.TraceLevelEnabled() {
 			f.log.Debug(errMsg.Error())
 		}
 		if f.config.FailOnError {

--- a/libbeat/processors/actions/decompress_gzip_field.go
+++ b/libbeat/processors/actions/decompress_gzip_field.go
@@ -25,9 +25,9 @@ import (
 	"io"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -76,7 +76,7 @@ func (f *decompressGzipField) Run(event *beat.Event) (*beat.Event, error) {
 	err := f.decompressGzipField(event)
 	if err != nil {
 		errMsg := fmt.Errorf("Failed to decompress field in decompress_gzip_field processor: %w", err)
-		if publisher.LogWithTrace() {
+		if management.TraceLevelEnabled() {
 			f.log.Debug(errMsg.Error())
 		}
 		if f.config.FailOnError {

--- a/libbeat/processors/actions/rename.go
+++ b/libbeat/processors/actions/rename.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -84,7 +84,7 @@ func (f *renameFields) Run(event *beat.Event) (*beat.Event, error) {
 		err := f.renameField(field.From, field.To, event)
 		if err != nil {
 			errMsg := fmt.Errorf("Failed to rename fields in processor: %w", err)
-			if publisher.LogWithTrace() {
+			if management.TraceLevelEnabled() {
 				f.logger.Debug(errMsg.Error())
 			}
 			if f.config.FailOnError {

--- a/libbeat/processors/actions/replace.go
+++ b/libbeat/processors/actions/replace.go
@@ -23,10 +23,10 @@ import (
 	"regexp"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -86,7 +86,7 @@ func (f *replaceString) Run(event *beat.Event) (*beat.Event, error) {
 		err := f.replaceField(field.Field, field.Pattern, field.Replacement, event)
 		if err != nil {
 			errMsg := fmt.Errorf("Failed to replace fields in processor: %w", err)
-			if publisher.LogWithTrace() {
+			if management.TraceLevelEnabled() {
 				f.log.Debug(errMsg.Error())
 			}
 			if f.config.FailOnError {

--- a/libbeat/processors/urldecode/urldecode.go
+++ b/libbeat/processors/urldecode/urldecode.go
@@ -23,10 +23,10 @@ import (
 	"net/url"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -83,7 +83,7 @@ func (p *urlDecode) Run(event *beat.Event) (*beat.Event, error) {
 		err := p.decodeField(field.From, field.To, event)
 		if err != nil {
 			errMsg := fmt.Errorf("failed to decode fields in urldecode processor: %w", err)
-			if publisher.LogWithTrace() {
+			if management.TraceLevelEnabled() {
 				p.log.Debug(errMsg.Error())
 			}
 			if p.config.FailOnError {

--- a/libbeat/publisher/processing/default.go
+++ b/libbeat/publisher/processing/default.go
@@ -25,11 +25,11 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/fleetmode"
 	"github.com/elastic/beats/v7/libbeat/ecs"
 	"github.com/elastic/beats/v7/libbeat/features"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/mapping"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/actions"
 	"github.com/elastic/beats/v7/libbeat/processors/timeseries"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -388,7 +388,7 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 	}
 
 	// setup 10: debug print final event (P)
-	if b.log.IsDebug() || publisher.UnderAgent() {
+	if b.log.IsDebug() || management.UnderAgent() {
 		processors.add(debugPrintProcessor(b.info, b.log))
 	}
 

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -102,7 +102,7 @@ func (p *group) Close() error {
 }
 
 func (p *group) String() string {
-	var s []string
+	s := make([]string, len(p.list))
 	for _, p := range p.list {
 		s = append(s, p.String())
 	}

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/outputs/codec/json"
 	"github.com/elastic/beats/v7/libbeat/processors"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -200,7 +200,7 @@ func debugPrintProcessor(info beat.Info, log *logp.Logger) *processorFn {
 		EscapeHTML: false,
 	})
 	return newProcessor("debugPrint", func(event *beat.Event) (*beat.Event, error) {
-		if publisher.LogWithTrace() {
+		if management.TraceLevelEnabled() {
 			mux.Lock()
 			defer mux.Unlock()
 

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -102,7 +102,7 @@ func (p *group) Close() error {
 }
 
 func (p *group) String() string {
-	s := make([]string, len(p.list))
+	s := make([]string, 0, len(p.list))
 	for _, p := range p.list {
 		s = append(s, p.String())
 	}

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -26,7 +26,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/beats/v7/libbeat/features"
 	lbmanagement "github.com/elastic/beats/v7/libbeat/management"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
@@ -187,7 +186,7 @@ func NewV2AgentManager(config *conf.C, registry *reload.Registry) (lbmanagement.
 	// officially running under the elastic-agent; we set the publisher pipeline
 	// to inform it that we are running under elastic-agent (used to ensure "Publish event: "
 	// debug log messages are only outputted when running in trace mode
-	publisher.SetUnderAgent(true)
+	lbmanagement.SetUnderAgent(true)
 
 	return NewV2AgentManagerWithClient(c, registry, agentClient)
 }
@@ -611,7 +610,7 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 	// set the new log level (if nothing has changed is a noop)
 	ll, trace := getZapcoreLevel(lowestLevel)
 	logp.SetLevel(ll)
-	publisher.SetUnderAgentTrace(trace)
+	lbmanagement.SetUnderAgentTrace(trace)
 
 	// reload the output configuration
 	restartBeat, err := cm.reloadOutput(outputUnit)


### PR DESCRIPTION
## Proposed commit message

This commit disables the dynamic topic selection for the Kafka output
when running under Elastic-Agent. The key `topics` is ignored and the
`topic` is treated as a constant string.

## Notes for reviewers
I did some refactoring to move `libbeat/publisher/agent.go` to `libbeat/management/agent.go`. Effectively moving functions like `LogWithTrace` and `UnderAgent`. There are two core commits in this PR:
- Just the refactoring: https://github.com/elastic/beats/pull/37902/commits/65cdcdd1354be11dd25063e401976b138516418f
- The actual change/feature: https://github.com/elastic/beats/pull/37902/commits/b6de96c4dae23649e32dc44bf4d7893c57587a1e
- The other commits are a fix in the refactoring that does not affect this feature and fixing lint errors.

The links should land you in the review page for each commit if you prefer to look/review them individually.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist
- [x] Make sure this works as expected under Elastic-Agent.

## How to test this PR locally
**Under Elastic-Agent:**
1. Start a Kafka cluster (instructions below)
2. Build Filebeat
3. Download and extract the Elastic-Agent
4. Replace its filebeat by the one you built
5. Generate some logs in the file `/tmp/flog.log`
6. Start a standalone Elastic-Agent
7. Assert Filebeat fails to send data to Kafka with an error like
    ```
    {"log.level":"error","@timestamp":"2024-02-09T17:04:21.851Z","message":"Kafka (topic=%{[host.name]}): kafka server: The request attempted to perform an operation on an invalid topic.","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"filestream-default","type":"filestream"},"log":{"source":"filestream-default"},"log.logger":"kafka","log.origin":{"file.line":337,"file.name":"kafka/client.go","function":"github.com/elastic/beats/v7/libbeat/outputs/kafka.(*client).errorWorker"},"service.name":"filebeat","ecs.version":"1.6.0","ecs.version":"1.6.0"}
    ```

Because dynamic topic selection is disabled, the topic configuration is passed as a string instead of being resolved using the event's data, hence Kafka fails with an invalid topic. `%{[host.name]}` violates Kafaka's topic naming requirements.

**Standalone Beats (Filebeat):**
1. Start a Kafka cluster (instructions below)
9. Use the `filebeat.yml` below to start Filebeat
10. Generate some logs in the file `/tmp/flog.log`
11. Use Kafdrop on `http://localhost:9000/` to assert the events are being delivered to Kafka in the topic `foo-bar`.
12. Stop Filebeat
13. Change the topic to `'%{[host.name]}'`
14. Start Filebeat
15. Assert the events are being delivered to a topic matching your hostname

### Running a Kafka cluster
1. Copy the  `docker-compose.yml` provided below
2. Replace `<YOUR LOCAL IP>` by your IP address (e.g: `10.0.0.42`). Do not use a loopback address
3. Start the containers `docker-compose up`
4. Open Kafdrop (`http://localhost:9000/`) on your browser. You can use it to manage topics and look at the messages.

### Configuration files
Bear in mind you will have to add your local IP address on those files.
<details><summary>filebeat.yml</summary>
<p>

```yaml
filebeat.inputs:
    - id: filestream-input-id
      type: filestream
      paths:
        - /tmp/flog.log
output:
    kafka:
        hosts:
            - <YOUR LOCAL IP>:9091
        # topic: '%{[host.name]}'
        topic: "foo-bar"

queue.mem:
  flush.timeout: 1s

logging:
  level: debug
  selectors:
    - kafka
```

</p>
</details> 

<details><summary>elastic-agent.yml</summary>
<p>

```
outputs:
  default:
    type: kafka
    hosts:
        - <YOUR IP>:9091
    topic: "%{[host.name]}"

inputs:
  - type: filestream
    id: your-input-id
    logging.level: debug
    streams:
      - id: your-filestream-stream-id
        data_stream:
          dataset: generic
        paths:
          - /tmp/flog.log

```

</p>
</details> 

<details><summary>docker-compose.yml</summary>
<p>

```yaml
version: '3'
services:
  zookeeper:
    image: zookeeper:3.4.9
    hostname: zookeeper
    ports:
      - "2181:2181"
    environment:
      ZOO_MY_ID: 1
      ZOO_PORT: 2181
      ZOO_SERVERS: server.1=zookeeper:2888:3888
    volumes:
      - ./data/zookeeper/data:/data
      - ./data/zookeeper/datalog:/datalog
  kafka1:
    image: confluentinc/cp-kafka:5.3.0
    hostname: kafka1
    ports:
      - "9091:9091"
    environment:
      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka1:19091,LISTENER_DOCKER_EXTERNAL://<YOUR LOCAL IP>:9091
      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
      KAFKA_BROKER_ID: 1
      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
    volumes:
      - ./data/kafka1/data:/var/lib/kafka/data
    depends_on:
      - zookeeper
  kafka2:
    image: confluentinc/cp-kafka:5.3.0
    hostname: kafka2
    ports:
      - "9092:9092"
    environment:
      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka2:19092,LISTENER_DOCKER_EXTERNAL://<YOUR LOCAL IP>:9092
      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
      KAFKA_BROKER_ID: 2
    volumes:
      - ./data/kafka2/data:/var/lib/kafka/data
    depends_on:
      - zookeeper 
  kafka3:
    image: confluentinc/cp-kafka:5.3.0
    hostname: kafka3
    ports:
      - "9093:9093"
    environment:
      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka3:19093,LISTENER_DOCKER_EXTERNAL://<YOUR LOCAL IP>:9093
      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
      KAFKA_BROKER_ID: 3
      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
    volumes:
      - ./data/kafka3/data:/var/lib/kafka/data
    depends_on:
      - zookeeper
  kafdrop:
    image: obsidiandynamics/kafdrop
    restart: "no"
    ports:
      - "9000:9000"
    environment:
      KAFKA_BROKERCONNECT: "kafka1:19091,kafka2:19092,kafka3:19093"
    depends_on:
      - kafka1
      - kafka2
      - kafka3
```

</p>
</details> 

Tutorial on running a Kafka cluster with Docker: https://betterprogramming.pub/a-simple-apache-kafka-cluster-with-docker-kafdrop-and-python-cf45ab99e2b9

## Question for reviewers
**Does this PR need a changelog entry? If so, where does it go?**

This PR makes Beats conform with a more strict feature set that is exposed via Elastic-Agent, so it's not an added feature, nor it is a breaking change.



~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
