### PR TITLE
Add MSI installer change to 8.12 release notes.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ If you are not using the Elasticsearch output, set `queue.mem.flush.timeout: 1` 
 
 *Heartbeat*
 - Decrease the ES default timeout to 10 for the load monitor state requests.
+- Windows MSI installers now store configuration in C:\Program Files instead of C:\ProgramData. https://github.com/elastic/elastic-stack-installers/pull/209
 
 *Osquerybeat*
 


### PR DESCRIPTION
Add the change made in https://github.com/elastic/elastic-stack-installers/pull/209 to stop using C:\ProgramData as a breaking change for the MSI installers.