### PR TITLE
Enhancement: Update module name to v8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elastic/beats/v7
+module github.com/elastic/beats/v8
 
 go 1.21
 


### PR DESCRIPTION
## Proposed commit message
The go module require version that matches release version
beats used to updated version in this issue
https://github.com/elastic/beats/pull/15853
But forget to update to v8

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
