### PR TITLE
fix packetbeat dynamic pipeline

### DIFF
--- a/.buildkite/scripts/generate_packetbeat_pipeline.sh
+++ b/.buildkite/scripts/generate_packetbeat_pipeline.sh
@@ -150,7 +150,7 @@ if are_conditions_met_packaging; then
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
+          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64"
 
       - label: ":linux: Packaging ARM"
         key: "packaging-arm"


### PR DESCRIPTION
## What is the problem this PR solves?

Jenkins->Buildkite pipelines migration 

Packetbeat packaging fix

## How does this PR solve the problem?

Exclude darwin/arm64 package from the build because this platform is unsupported

Example of the error:
https://buildkite.com/elastic/beats-packetbeat/builds/1197#018d8e8a-c9cc-4f5f-8e2a-f26fc94ccc7c/421-511

```
>> Building using: cmd='build/mage-linux-amd64 buildGoDaemon', env=[CC=gcc, CXX=g++, GOARCH=amd64, GOARM=, GOOS=linux, PLATFORM_ID=linux-amd64]
--
  | /tmp/ccgSaqPI.o: In function `main':
  | adb73258c8ab: Pull complete
  | Digest: sha256:b28467475b52ee1a5ea108c4bf7041c562b0cea9c065813dac587988a5f36437
  | Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.21.7-darwin-debian10
  | >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=o64-clang, CXX=o64-clang++, GOARCH=amd64, GOARM=, GOOS=darwin, PLATFORM_ID=darwin-amd64]
  | package ran for 1m44.93844247s
  | Error: unsupported cross build platform darwin/arm64
  | 🚨 Error: The command exited with status 1
  | user command error: exit status 1
```

## Related issues

https://github.com/elastic/ingest-dev/issues/1693

