### PR TITLE
Fix file handle leak when handling errors in filestream

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -90,6 +90,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 - Fix TCP/UDP metric queue length parsing base. {pull}37714[37714]
 - Update github.com/lestrrat-go/jwx dependency. {pull}37799[37799]
 - [threatintel] MISP pagination fixes {pull}37898[37898]
+- Fix file handle leak when handling errors in filestream {pull}37973[37973]
 
 *Heartbeat*
 

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -282,7 +282,6 @@ func (inp *filestream) openFile(log *logp.Logger, path string, offset int64) (*o
 
 	encoding, err := inp.encodingFactory(f)
 	if err != nil {
-		f.Close()
 		if errors.Is(err, transform.ErrShortSrc) {
 			return nil, nil, fmt.Errorf("initialising encoding for '%v' failed due to file being too short", f)
 		}

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -179,6 +179,9 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, fs fileSo
 		return nil, err
 	}
 
+	ok := false // used for cleanup
+	defer cleanup.IfNot(&ok, cleanup.IgnoreError(f.Close))
+
 	log.Debug("newLogFileReader with config.MaxBytes:", inp.readerConfig.MaxBytes)
 
 	// if the file is archived, it means that it is not going to be updated in the future
@@ -203,7 +206,6 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, fs fileSo
 
 	dbgReader, err := debug.AppendReaders(logReader)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 
@@ -221,7 +223,6 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, fs fileSo
 		MaxBytes:   encReaderMaxBytes,
 	})
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 
@@ -233,6 +234,7 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, fs fileSo
 
 	r = readfile.NewLimitReader(r, inp.readerConfig.MaxBytes)
 
+	ok = true // no need to close the file
 	return r, nil
 }
 
@@ -252,11 +254,11 @@ func (inp *filestream) openFile(log *logp.Logger, path string, offset int64) (*o
 		return nil, nil, fmt.Errorf("failed to open file %s, named pipes are not supported", fi.Name())
 	}
 
-	ok := false
 	f, err := file.ReadOpen(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed opening %s: %w", path, err)
 	}
+	ok := false
 	defer cleanup.IfNot(&ok, cleanup.IgnoreError(f.Close))
 
 	fi, err = f.Stat()
@@ -286,8 +288,8 @@ func (inp *filestream) openFile(log *logp.Logger, path string, offset int64) (*o
 		}
 		return nil, nil, fmt.Errorf("initialising encoding for '%v' failed: %w", f, err)
 	}
-	ok = true
 
+	ok = true // no need to close the file
 	return f, encoding, nil
 }
 


### PR DESCRIPTION
Files were not closed properly in some rare error cases.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
The existing tests should make sure that the existing functionality is not broken.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to https://github.com/elastic/beats/pull/37814