### PR TITLE
change trigger_mode for all pipelines except the main pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -88,6 +88,7 @@ spec:
       pipeline_file: ".buildkite/metricbeat/pipeline.yml"
       maximum_timeout_in_minutes: 120
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -133,6 +134,7 @@ spec:
       pipeline_file: ".buildkite/filebeat/filebeat-pipeline.yml"
       maximum_timeout_in_minutes: 120
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -178,6 +180,7 @@ spec:
       pipeline_file: ".buildkite/auditbeat/auditbeat-pipeline.yml"
       #      maximum_timeout_in_minutes: 120 TODO: uncomment when pipeline is ready
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -223,6 +226,7 @@ spec:
       pipeline_file: ".buildkite/heartbeat/heartbeat-pipeline.yml"
       maximum_timeout_in_minutes: 120
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -268,6 +272,7 @@ spec:
       pipeline_file: ".buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml"
       #      maximum_timeout_in_minutes: 120 TODO: uncomment when pipeline is ready
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -313,6 +318,7 @@ spec:
       pipeline_file: ".buildkite/libbeat/pipeline.libbeat.yml"
       maximum_timeout_in_minutes: 120
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -358,6 +364,7 @@ spec:
       pipeline_file: ".buildkite/packetbeat/pipeline.packetbeat.yml"
       maximum_timeout_in_minutes: 120
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -402,6 +409,7 @@ spec:
       branch_configuration: "7.17"
       pipeline_file: ".buildkite/x-pack/elastic-agent/pipeline.xpack.elastic-agent.yml"
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -447,6 +455,7 @@ spec:
       pipeline_file: ".buildkite/winlogbeat/pipeline.winlogbeat.yml"
       maximum_timeout_in_minutes: 120
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -492,6 +501,7 @@ spec:
       pipeline_file: ".buildkite/x-pack/pipeline.xpack.winlogbeat.yml"
       # maximum_timeout_in_minutes: 120         #TODO: uncomment after tests
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -537,6 +547,7 @@ spec:
       pipeline_file: ".buildkite/x-pack/pipeline.xpack.packetbeat.yml"
       # maximum_timeout_in_minutes: 120         #TODO: uncomment after tests
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -582,6 +593,7 @@ spec:
       pipeline_file: ".buildkite/x-pack/pipeline.xpack.libbeat.yml"
       # maximum_timeout_in_minutes: 120         #TODO: uncomment after tests
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true
@@ -627,6 +639,7 @@ spec:
       pipeline_file: ".buildkite/x-pack/pipeline.xpack.metricbeat.yml"
       # maximum_timeout_in_minutes: 120         #TODO: uncomment after tests
       provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
         build_tags: true


### PR DESCRIPTION
## What is the problem this PR solves?

Jenkins->Buildkite pipelines migration 

Fix the issue: https://buildkite.com/elastic/terrazzo/builds/41476#018d9cb3-327f-458f-9b38-16c7516ecf7b/42-433

## How does this PR solve the problem?

change the option in the `catalog-info`. 

```
      provider_settings:
        trigger_mode: none 
```

## Related issues

https://github.com/elastic/ingest-dev/issues/1693

