### PR TITLE
[Heartbeat] Adjust State loader to only retry for failed requests and not for 4xx

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -32,8 +32,6 @@ fields added to events containing the Beats version. {pull}37553[37553]
 
 *Heartbeat*
 
-- Adjust State loader to only retry for failed requests and not for 4xx. {pull}37981[37981]
-
 *Metricbeat*
 
 
@@ -102,6 +100,9 @@ fields added to events containing the Beats version. {pull}37553[37553]
 
 *Heartbeat*
 
+- Fix panics when parsing dereferencing invalid parsed url. {pull}34702[34702]
+- Fix setuid root when running under cgroups v2. {pull}37794[37794]
+- Adjust State loader to only retry for failed requests and not for 4xx. {pull}37981[37981]
 
 *Metricbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -102,7 +102,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 
 - Fix panics when parsing dereferencing invalid parsed url. {pull}34702[34702]
 - Fix setuid root when running under cgroups v2. {pull}37794[37794]
-- Adjust State loader to only retry for failed requests and not for 4xx. {pull}37981[37981]
+- Adjust State loader to only retry when response code status is 5xx {pull}37981[37981]
 
 *Metricbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -32,6 +32,8 @@ fields added to events containing the Beats version. {pull}37553[37553]
 
 *Heartbeat*
 
+- Adjust State loader to only retry for failed requests and not for 4xx. {pull}37981[37981]
+
 *Metricbeat*
 
 

--- a/heartbeat/monitors/wrappers/monitorstate/esloader.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader.go
@@ -104,7 +104,7 @@ func MakeESLoader(esc *eslegclient.Connection, indexPattern string, beatLocation
 		err = json.Unmarshal(body, &sh)
 		if err != nil {
 			sErr := fmt.Errorf("could not unmarshal state hits for %s: %w", sf.ID, err)
-			return nil, LoaderError{err: sErr, Retry: true}
+			return nil, LoaderError{err: sErr, Retry: false}
 		}
 
 		if len(sh.Hits.Hits) == 0 {

--- a/heartbeat/monitors/wrappers/monitorstate/esloader.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader.go
@@ -82,7 +82,7 @@ func MakeESLoader(esc *eslegclient.Connection, indexPattern string, beatLocation
 				},
 			},
 		}
-		status, body, err := esc.Request("POST", strings.Join([]string{"/", indexPattern, "/", "search", "?size=1"}, ""), "", nil, reqBody)
+		status, body, err := esc.Request("POST", strings.Join([]string{"/", indexPattern, "/", "_search", "?size=1"}, ""), "", nil, reqBody)
 		if err != nil || status > 299 {
 			errMsg := fmt.Errorf("error executing state search for %s in loc=%s: %w", sf.ID, runFromID, err).Error()
 			retry := shouldRetry(status)

--- a/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
@@ -21,6 +21,9 @@ package monitorstate
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +36,7 @@ import (
 	"github.com/elastic/beats/v7/heartbeat/config"
 	"github.com/elastic/beats/v7/heartbeat/esutil"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
+	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/processors/util"
 )
 
@@ -89,8 +93,59 @@ func TestStatesESLoader(t *testing.T) {
 	}
 }
 
+func TestMakeESLoaderError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		expected   bool
+	}{
+		{
+			name:       "should return a retryable error",
+			statusCode: http.StatusInternalServerError,
+			expected:   true,
+		},
+		{
+			name:       "should not return a retryable error",
+			statusCode: http.StatusNotFound,
+			expected:   false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			etc := newESTestContext(t)
+			etc.ec.HTTP = fakeHTTPClient{respStatus: test.statusCode}
+			loader := MakeESLoader(etc.ec, "fakeIndexPattern", etc.location)
+
+			// Act
+			_, err := loader(stdfields.StdMonitorFields{})
+
+			// Assert
+			var loaderError LoaderError
+			require.ErrorAs(t, err, &loaderError)
+			require.Equal(t, loaderError.Retry, test.expected)
+		})
+	}
+}
+
+type fakeHTTPClient struct {
+	respStatus int
+}
+
+func (fc fakeHTTPClient) Do(req *http.Request) (resp *http.Response, err error) {
+	return &http.Response{
+		StatusCode: fc.respStatus,
+		Body:       io.NopCloser(strings.NewReader("test response")),
+	}, nil
+}
+
+func (fc fakeHTTPClient) CloseIdleConnections() {
+	// noop
+}
+
 type esTestContext struct {
 	namespace string
+	ec        *eslegclient.Connection
 	esc       *elasticsearch.Client
 	loader    StateLoader
 	tracker   *Tracker
@@ -106,10 +161,12 @@ func newESTestContext(t *testing.T) *esTestContext {
 	}
 	namespace, _ := uuid.NewV4()
 	esc := IntegApiClient(t)
+	ec := IntegES(t)
 	etc := &esTestContext{
 		namespace: namespace.String(),
 		esc:       esc,
-		loader:    IntegESLoader(t, fmt.Sprintf("synthetics-*-%s", namespace.String()), location),
+		ec:        ec,
+		loader:    IntegESLoader(t, ec, fmt.Sprintf("synthetics-*-%s", namespace.String()), location),
 		location:  location,
 	}
 

--- a/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
@@ -109,6 +109,11 @@ func TestMakeESLoaderError(t *testing.T) {
 			statusCode: http.StatusNotFound,
 			expected:   false,
 		},
+		{
+			name:       "should not return a retryable error when handling malformed data",
+			statusCode: http.StatusOK,
+			expected:   false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
@@ -112,15 +112,12 @@ func TestMakeESLoaderError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Arrange
 			etc := newESTestContext(t)
 			etc.ec.HTTP = fakeHTTPClient{respStatus: test.statusCode}
 			loader := MakeESLoader(etc.ec, "fakeIndexPattern", etc.location)
 
-			// Act
 			_, err := loader(stdfields.StdMonitorFields{})
 
-			// Assert
 			var loaderError LoaderError
 			require.ErrorAs(t, err, &loaderError)
 			require.Equal(t, loaderError.Retry, test.expected)

--- a/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
@@ -55,7 +55,7 @@ func TestStatesESLoader(t *testing.T) {
 
 		monID := etc.createTestMonitorStateInES(t, testStatus)
 		// Since we've continued this state it should register the initial state
-		ms := etc.tracker.GetCurrentState(monID)
+		ms := etc.tracker.GetCurrentState(monID, RetryConfig{})
 		require.True(t, ms.StartedAt.After(testStart.Add(-time.Nanosecond)), "timestamp for new state is off")
 		requireMSStatusCount(t, ms, testStatus, 1)
 

--- a/heartbeat/monitors/wrappers/monitorstate/testutil.go
+++ b/heartbeat/monitors/wrappers/monitorstate/testutil.go
@@ -33,8 +33,8 @@ import (
 
 // Helpers for tests here and elsewhere
 
-func IntegESLoader(t *testing.T, indexPattern string, location *config.LocationWithID) StateLoader {
-	return MakeESLoader(IntegES(t), indexPattern, location)
+func IntegESLoader(t *testing.T, esc *eslegclient.Connection, indexPattern string, location *config.LocationWithID) StateLoader {
+	return MakeESLoader(esc, indexPattern, location)
 }
 
 func IntegES(t *testing.T) (esc *eslegclient.Connection) {

--- a/heartbeat/monitors/wrappers/monitorstate/tracker.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker.go
@@ -98,6 +98,10 @@ func (t *Tracker) GetCurrentState(sf stdfields.StdMonitorFields) (state *State) 
 			}
 			break
 		}
+		var loaderError LoaderError
+		if errors.As(err, &loaderError) && !loaderError.Retry {
+			break
+		}
 
 		sleepFor := (time.Duration(i*i) * time.Second) + (time.Duration(rand.Intn(500)) * time.Millisecond)
 		logp.L().Warnf("could not load last externally recorded state, will retry again in %d milliseconds: %w", sleepFor.Milliseconds(), err)

--- a/heartbeat/monitors/wrappers/monitorstate/tracker.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker.go
@@ -111,7 +111,7 @@ func (t *Tracker) GetCurrentState(sf stdfields.StdMonitorFields, rc RetryConfig)
 		}
 		var loaderError LoaderError
 		if errors.As(err, &loaderError) && !loaderError.Retry {
-			logp.L().Warnf("could not load last externally recorded state: %w", err)
+			logp.L().Warnf("could not load last externally recorded state: %v", loaderError)
 			break
 		}
 
@@ -120,7 +120,7 @@ func (t *Tracker) GetCurrentState(sf stdfields.StdMonitorFields, rc RetryConfig)
 		if rc.waitFn != nil {
 			sleepFor = rc.waitFn()
 		}
-		logp.L().Warnf("could not load last externally recorded state, will retry again in %d milliseconds: %w", sleepFor.Milliseconds(), err)
+		logp.L().Warnf("could not load last externally recorded state, will retry again in %d milliseconds: %v", sleepFor.Milliseconds(), err)
 		time.Sleep(sleepFor)
 	}
 	if err != nil {

--- a/heartbeat/monitors/wrappers/monitorstate/tracker.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker.go
@@ -100,6 +100,7 @@ func (t *Tracker) GetCurrentState(sf stdfields.StdMonitorFields) (state *State) 
 		}
 		var loaderError LoaderError
 		if errors.As(err, &loaderError) && !loaderError.Retry {
+			logp.L().Warnf("could not load last externally recorded state: %w", err)
 			break
 		}
 

--- a/heartbeat/monitors/wrappers/monitorstate/tracker.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker.go
@@ -100,7 +100,8 @@ func (t *Tracker) GetCurrentState(sf stdfields.StdMonitorFields, rc RetryConfig)
 
 	var loadedState *State
 	var err error
-	for i := 0; i < attempts; i++ {
+	var i int
+	for i = 0; i < attempts; i++ {
 		loadedState, err = t.stateLoader(sf)
 		if err == nil {
 			if loadedState != nil {
@@ -123,7 +124,7 @@ func (t *Tracker) GetCurrentState(sf stdfields.StdMonitorFields, rc RetryConfig)
 		time.Sleep(sleepFor)
 	}
 	if err != nil {
-		logp.L().Warnf("could not load prior state from elasticsearch after %d attempts, will create new state for monitor: %s", attempts, sf.ID)
+		logp.L().Warnf("could not load prior state from elasticsearch after %d attempts, will create new state for monitor: %s", i+1, sf.ID)
 	}
 
 	if loadedState != nil {

--- a/heartbeat/monitors/wrappers/monitorstate/tracker_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker_test.go
@@ -134,20 +134,34 @@ func TestDeferredStateLoader(t *testing.T) {
 }
 
 func TestStateLoaderRetry(t *testing.T) {
+	// While testing the sleep time between retries should be negligible
+	waitFn := func() time.Duration {
+		return time.Microsecond
+	}
+
 	tests := []struct {
 		name          string
 		retryable     bool
+		rc            RetryConfig
 		expectedCalls int
 	}{
 		{
 			"should retry 3 times when fails with retryable error",
 			true,
+			RetryConfig{waitFn: waitFn},
 			3,
 		},
 		{
 			"should not retry when fails with non-retryable error",
 			false,
+			RetryConfig{waitFn: waitFn},
 			1,
+		},
+		{
+			"should honour the configured number of attempts when fails with retryable error",
+			true,
+			RetryConfig{attempts: 5, waitFn: waitFn},
+			5,
 		},
 	}
 
@@ -160,7 +174,7 @@ func TestStateLoaderRetry(t *testing.T) {
 			}
 
 			mst := NewTracker(errorStateLoader, true)
-			mst.GetCurrentState(stdfields.StdMonitorFields{})
+			mst.GetCurrentState(stdfields.StdMonitorFields{}, tt.rc)
 
 			require.Equal(t, calls, tt.expectedCalls)
 		})

--- a/heartbeat/monitors/wrappers/monitorstate/tracker_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker_test.go
@@ -18,6 +18,7 @@
 package monitorstate
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestStateLoaderRetry(t *testing.T) {
 			calls := 0
 			errorStateLoader := func(_ stdfields.StdMonitorFields) (*State, error) {
 				calls += 1
-				return nil, LoaderError{Message: "test error", Retry: tt.retryable}
+				return nil, LoaderError{err: errors.New("test error"), Retry: tt.retryable}
 			}
 
 			mst := NewTracker(errorStateLoader, true)


### PR DESCRIPTION
## Proposed commit message

Closes https://github.com/elastic/beats/issues/37424

From now on, the state loader will just retry for failed requests (such as a 500 status code) and not for 4xx.

## Additional context

- If the query is valid and returns zero results, there will not be any retry, this was working this way already
- If the API key is invalid, the query will fail returning a 4xx error (this was working this way already), as just can see in the screenshot below:

<img width="1040" alt="screenshot-invalid-api-key" src="https://github.com/elastic/beats/assets/15065076/55742633-31ec-495c-957d-d68cf77ecd04">


## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.