### PR TITLE
x-pack/filebeat/input/cometd - Skip flaky TestInputStop_Wait

### DIFF
--- a/x-pack/filebeat/input/cometd/input_test.go
+++ b/x-pack/filebeat/input/cometd/input_test.go
@@ -117,6 +117,8 @@ func TestSingleInput(t *testing.T) {
 }
 
 func TestInputStop_Wait(t *testing.T) {
+	t.Skip("Flaky test https://github.com/elastic/beats/issues/37987")
+
 	expectedHTTPEventCount = 1
 	defer atomic.StoreUint64(&called, 0)
 	eventsCh := make(chan beat.Event)


### PR DESCRIPTION
## Proposed commit message

Skip flaky test for the Filebeat cometd input.

Relates #37987

