### PR TITLE
[filebeat][websocket] - Fixed flakey regex test

### DIFF
--- a/x-pack/filebeat/input/websocket/config_test.go
+++ b/x-pack/filebeat/input/websocket/config_test.go
@@ -55,6 +55,17 @@ var configTests = []struct {
 		wantErr: fmt.Errorf("failed to check program: failed compilation: ERROR: <input>:3:79: found no matching overload for '_?_:_' applied to '(bool, list(dyn), null)'\n |      \"events\": has(state.cursor) && inner_body.ts > state.cursor.last_updated ? \n | ..............................................................................^ accessing config"),
 	},
 	{
+		name: "invalid_regexps",
+		config: map[string]interface{}{
+			"regexp": map[string]interface{}{
+				"products":  "(?i)(xq>)d+)",
+				"solutions": "(?i)(Search|Observability|Security)",
+			},
+			"url": "wss://localhost:443/v1/stream",
+		},
+		wantErr: fmt.Errorf("failed to check regular expressions: error parsing regexp: unexpected ): `(?i)(xq>)d+)` accessing config"),
+	},
+	{
 		name: "valid_regexps",
 		config: map[string]interface{}{
 			"regexp": map[string]interface{}{

--- a/x-pack/filebeat/input/websocket/config_test.go
+++ b/x-pack/filebeat/input/websocket/config_test.go
@@ -55,17 +55,6 @@ var configTests = []struct {
 		wantErr: fmt.Errorf("failed to check program: failed compilation: ERROR: <input>:3:79: found no matching overload for '_?_:_' applied to '(bool, list(dyn), null)'\n |      \"events\": has(state.cursor) && inner_body.ts > state.cursor.last_updated ? \n | ..............................................................................^ accessing config"),
 	},
 	{
-		name: "invalid_regexps",
-		config: map[string]interface{}{
-			"regexp": map[string]interface{}{
-				"products":  "(?i)(xq>)d+)",
-				"solutions": "(?)(Sws>(d+)",
-			},
-			"url": "wss://localhost:443/v1/stream",
-		},
-		wantErr: fmt.Errorf("failed to check regular expressions: error parsing regexp: unexpected ): `(?i)(xq>)d+)` accessing config"),
-	},
-	{
 		name: "valid_regexps",
 		config: map[string]interface{}{
 			"regexp": map[string]interface{}{


### PR DESCRIPTION
## Type of change
- Bug


## Proposed commit message
A particular config test was flakey in nature and went unnoticed due to its flakeyness but ultimately caused build failures in the ci pipelines - https://github.com/elastic/beats/issues/37970. This error happened as there were 2 invalid regexes in a config map and either one would fail causing 2 different errors. To fix this only one deterministic path of failure now exists by keeping one regex valid and the other invalid.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #37970



## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
