### PR TITLE
[Filebeat] ETW input - use errgroup

### DIFF
--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -107,7 +107,8 @@ func Test_RunEtwInput_AttachToExistingSessionError(t *testing.T) {
 		mockSession := &etw.Session{
 			Name:       "MySession",
 			Realtime:   true,
-			NewSession: false}
+			NewSession: false,
+		}
 		return mockSession, nil
 	}
 	// Setup the mock behavior for AttachToExistingSession
@@ -146,7 +147,8 @@ func Test_RunEtwInput_CreateRealtimeSessionError(t *testing.T) {
 		mockSession := &etw.Session{
 			Name:       "MySession",
 			Realtime:   true,
-			NewSession: true}
+			NewSession: true,
+		}
 		return mockSession, nil
 	}
 	// Setup the mock behavior for AttachToExistingSession
@@ -189,7 +191,8 @@ func Test_RunEtwInput_StartConsumerError(t *testing.T) {
 		mockSession := &etw.Session{
 			Name:       "MySession",
 			Realtime:   true,
-			NewSession: true}
+			NewSession: true,
+		}
 		return mockSession, nil
 	}
 	// Setup the mock behavior for AttachToExistingSession
@@ -244,7 +247,8 @@ func Test_RunEtwInput_Success(t *testing.T) {
 		mockSession := &etw.Session{
 			Name:       "MySession",
 			Realtime:   true,
-			NewSession: true}
+			NewSession: true,
+		}
 		return mockSession, nil
 	}
 	// Setup the mock behavior for AttachToExistingSession
@@ -471,7 +475,6 @@ func Test_buildEvent(t *testing.T) {
 			assert.Equal(t, tt.expected["event.severity"], mapEv["event.severity"])
 			assert.Equal(t, tt.expected["log.file.path"], mapEv["log.file.path"])
 			assert.Equal(t, tt.expected["log.level"], mapEv["log.level"])
-
 		})
 	}
 }
@@ -495,7 +498,7 @@ func Test_convertFileTimeToGoTime(t *testing.T) {
 		{
 			name:     "TestActualDate",
 			fileTime: 133515900000000000, // February 05, 2024, 7:00:00 AM
-			want:     time.Date(2024, 02, 05, 7, 0, 0, 0, time.UTC),
+			want:     time.Date(2024, 0o2, 0o5, 7, 0, 0, 0, time.UTC),
 		},
 	}
 

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -235,7 +235,7 @@ func Test_RunEtwInput_StartConsumerError(t *testing.T) {
 
 	// Run test
 	err := etwInput.Run(inputCtx, nil)
-	assert.EqualError(t, err, "failed to start consumer: mock error")
+	assert.EqualError(t, err, "failed running ETW consumer: mock error")
 }
 
 func Test_RunEtwInput_Success(t *testing.T) {

--- a/x-pack/libbeat/reader/etw/session.go
+++ b/x-pack/libbeat/reader/etw/session.go
@@ -229,10 +229,8 @@ func (s *Session) StartConsumer() error {
 	// Open an ETW trace processing handle for consuming events
 	// from an ETW real-time trace session or an ETW log file.
 	s.traceHandler, err = s.openTrace(&elf)
-
 	switch {
 	case err == nil:
-
 	// Handle specific errors for trace opening.
 	case errors.Is(err, ERROR_BAD_PATHNAME):
 		return fmt.Errorf("invalid log source when opening trace: %w", err)
@@ -241,10 +239,10 @@ func (s *Session) StartConsumer() error {
 	default:
 		return fmt.Errorf("failed to open trace: %w", err)
 	}
+
 	// Process the trace. This function blocks until processing ends.
 	if err := s.processTrace(&s.traceHandler, 1, nil, nil); err != nil {
 		return fmt.Errorf("failed to process trace: %w", err)
 	}
-
 	return nil
 }


### PR DESCRIPTION
## Proposed commit message

Use errgroup to wait on the ETW consumer routine.

Use sync.OnceFunc to wrap the Close() func for the ETW session.

Clarify a few log messages (follow-up to 36915)
- https://github.com/elastic/beats/pull/36915#discussion_r1486467260
- https://github.com/elastic/beats/pull/36915#discussion_r1486467260

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
