### PR TITLE
[Kubernetes] Docs: update control plane toleration from master toleration

### DIFF
--- a/auditbeat/docs/running-on-kubernetes.asciidoc
+++ b/auditbeat/docs/running-on-kubernetes.asciidoc
@@ -57,17 +57,17 @@ may want to change that behavior, so just edit the YAML file and modify them:
 ------------------------------------------------
 
 [float]
-===== Running {beatname_uc} on master nodes
+===== Running {beatname_uc} on control plane nodes
 
-Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
-to limit the workloads that can run on them. To run {beatname_uc} on master nodes you may need to
+Kubernetes control plane nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
+to limit the workloads that can run on them. To run {beatname_uc} on control plane nodes you may need to
 update the Daemonset spec to include proper tolerations:
 
 [source,yaml]
 ------------------------------------------------
 spec:
  tolerations:
- - key: node-role.kubernetes.io/master
+ - key: node-role.kubernetes.io/control-plane
    effect: NoSchedule
 ------------------------------------------------
 

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -61,17 +61,17 @@ in the manifest file:
 ------------------------------------------------
 
 [float]
-===== Running {beatname_uc} on master nodes
+===== Running {beatname_uc} on control plane nodes
 
-Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
-to limit the workloads that can run on them. To run {beatname_uc} on master nodes you may need to
+Kubernetes control plane nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
+to limit the workloads that can run on them. To run {beatname_uc} on control plane nodes you may need to
 update the Daemonset spec to include proper tolerations:
 
 [source,yaml]
 ------------------------------------------------
 spec:
  tolerations:
- - key: node-role.kubernetes.io/master
+ - key: node-role.kubernetes.io/control-plane
    effect: NoSchedule
 ------------------------------------------------
 
@@ -110,7 +110,7 @@ oc patch namespace kube-system -p \
 ----
 +
 This command sets the node selector for the project to an empty string. If you
-don't run this command, the default node selector will skip master nodes.
+don't run this command, the default node selector will skip control plane nodes.
 
 In order to support runtime environments with Openshift (eg. CRI-O, containerd) you need to configure following path:
 
@@ -137,7 +137,7 @@ filebeat.autodiscover:
           - /var/log/containers/*.log
 ----
 
-NOTE: `/var/log/containers/\*.log` is normally a symlink to `/var/log/pods/*/*.log`, 
+NOTE: `/var/log/containers/\*.log` is normally a symlink to `/var/log/pods/*/*.log`,
 so above paths can be edited accordingly
 
 

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -70,17 +70,17 @@ in the manifest file:
 ------------------------------------------------
 
 [float]
-===== Running {beatname_uc} on master nodes
+===== Running {beatname_uc} on control plane nodes
 
-Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
-to limit the workloads that can run on them. To run {beatname_uc} on master nodes you may need to
+Kubernetes control plane nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
+to limit the workloads that can run on them. To run {beatname_uc} on control plane nodes you may need to
 update the Daemonset spec to include proper tolerations:
 
 [source,yaml]
 ------------------------------------------------
 spec:
  tolerations:
- - key: node-role.kubernetes.io/master
+ - key: node-role.kubernetes.io/control-plane
    effect: NoSchedule
 ------------------------------------------------
 
@@ -166,7 +166,7 @@ oc patch namespace kube-system -p \
 ----
 +
 This command sets the node selector for the project to an empty string. If you
-don't run this command, the default node selector will skip master nodes.
+don't run this command, the default node selector will skip control plane nodes.
 
 NOTE: for openshift versions prior to the version 4.x additionally you need to modify the `DaemonSet` container spec in the manifest file to enable the container to run as privileged:
 [source,yaml]


### PR DESCRIPTION
Update `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane` and associated references.

This toleration was [deprecated in 1.24](https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/):
> The master label is no longer present on kubeadm control plane nodes. For new clusters, the label 'node-role.kubernetes.io/master' will no longer be added to control plane nodes, only the label 'node-role.kubernetes.io/control-plane' will be added. For more information, refer to KEP-2067: Rename the kubeadm "master" label and taint.

And 1.24 is no longer part of the [versions we support](https://github.com/elastic/beats/blob/main/metricbeat/docs/modules/kubernetes.asciidoc#compatibility):
> The Kubernetes module is tested with the following versions of Kubernetes: 1.26.x, 1.27.x, 1.28.x and 1.29.x.
