### PR TITLE
Memory queue: free event data sooner after acknowledgments

### DIFF
--- a/libbeat/publisher/queue/memqueue/runloop.go
+++ b/libbeat/publisher/queue/memqueue/runloop.go
@@ -187,13 +187,8 @@ func (l *runLoop) handleGetReply(req *getRequest) {
 }
 
 func (l *runLoop) handleDelete(count int) {
-	// Clear the internal event pointers so they can be garbage collected
-	for i := 0; i < count; i++ {
-		index := (l.bufPos + i) % len(l.broker.buf)
-		l.broker.buf[index].event = nil
-	}
-
-	// Advance position and counters
+	// Advance position and counters. Event data has already been cleared
+	// by ackLoop.
 	l.bufPos = (l.bufPos + count) % len(l.broker.buf)
 	l.eventCount -= count
 	l.consumedCount -= count


### PR DESCRIPTION
## Proposed commit message

Refactor the memory queue's ackLoop goroutine to allow earlier freeing of event data:
- Previously, each event batch had its own acknowledgment channel, and ackLoop listened to each of them strictly in order. Now, all event batches use a shared acknowledgment channel and ackLoop frees the data for acknowledged events immediately on receiving the signal from that batch, regardless of the order they are received.
- Since acknowledgments no longer happen strictly in queue order, each batch now has a "done" flag owned by the ackLoop goroutine, and this is used to collect acknowledged batches when advancing the queue instead of reading the sequence of acknowledgment channels.

In benchmarks, CPU and ingestion rate were unaffected, while memory used dropped by 0-5% depending on configuration, with the biggest improvements being in the `scale` and `throughput` performance presets.

There is no visible functional difference from this change, except that event pointers are reset to null slightly sooner in the acknowledgment process.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~