### PR TITLE
remove darwin arm64 from packaging

### DIFF
--- a/.buildkite/auditbeat/scripts/package-step.sh
+++ b/.buildkite/auditbeat/scripts/package-step.sh
@@ -18,7 +18,7 @@ if are_files_changed "$changeset"; then
       - label: ":ubuntu: Packaging Linux X86"
         key: "package-linux-x86"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
+          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64"
         command:
           - ".buildkite/auditbeat/scripts/package.sh"
         notify:

--- a/.buildkite/filebeat/scripts/package-step.sh
+++ b/.buildkite/filebeat/scripts/package-step.sh
@@ -18,7 +18,7 @@ if are_files_changed "$changeset"; then
       - label: ":ubuntu: Packaging Linux X86"
         key: "package-linux-x86"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
+          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64"
         command:
           - ".buildkite/filebeat/scripts/package.sh"
         notify:

--- a/.buildkite/heartbeat/scripts/package-step.sh
+++ b/.buildkite/heartbeat/scripts/package-step.sh
@@ -18,7 +18,7 @@ if are_files_changed "$changeset"; then
       - label: ":ubuntu: Packaging Linux X86"
         key: "package-linux-x86"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
+          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64"
         command:
           - ".buildkite/heartbeat/scripts/package.sh"
         notify:


### PR DESCRIPTION
## What is the problem this PR solves?

Jenkins->Buildkite pipelines migration 

Fix errors:
https://buildkite.com/elastic/auditbeat/builds/1848#018dcc3d-c30d-49a6-87af-7dc2643bf087/340-402
https://buildkite.com/elastic/filebeat/builds/3176#018dcc40-20e5-4f4e-ac2f-184be9b07ab2/339-403
https://buildkite.com/elastic/heartbeat/builds/1837#018dcc3e-983e-40ba-8015-292aa9b167f1/340-401


## Related issues

https://github.com/elastic/ingest-dev/issues/1693

