### PR TITLE
Add Agent diagnostic hook to dump beat metrics

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -893,6 +893,16 @@ func (b *Beat) configure(settings Settings) error {
 
 	b.Manager.RegisterDiagnosticHook("global processors", "a list of currently configured global beat processors",
 		"global_processors.txt", "text/plain", b.agentDiagnosticHook)
+	b.Manager.RegisterDiagnosticHook("beat_metrics", "Metrics from the default monitoring namespace and expvar.",
+		"beat_metrics.json", "application/json", func() []byte {
+			m := monitoring.CollectStructSnapshot(monitoring.Default, monitoring.Full, true)
+			data, err := json.MarshalIndent(m, "", "  ")
+			if err != nil {
+				logp.L().Warnw("Failed to collect beat metric snapshot for Agent diagnostics.", "error", err)
+				return []byte(err.Error())
+			}
+			return data
+		})
 
 	return err
 }


### PR DESCRIPTION
## Proposed commit message

Register an Agent diagnostic hook that will dump all metrics registered into the default monitoring namespace as well as expvar. The hook is registered within libbeat so this change will affect all Beats operating under Agent.

The file will be named `beat_metrics.json` and will contain a single pretty JSON object.



Closes #37929

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #37929

## Sample output

```json
{
  "badger_v3_blocked_puts_total": 0,
  "badger_v3_compactions_current": 0,
  "badger_v3_disk_reads_total": 0,
  "badger_v3_disk_writes_total": 0,
  "badger_v3_gets_total": 0,
  "badger_v3_memtable_gets_total": 0,
  "badger_v3_puts_total": 0,
  "badger_v3_read_bytes": 0,
  "badger_v3_written_bytes": 0,
  "beat": {
    "cpu": {
      "system": {
        "ticks": 5,
        "time": {
          "ms": 5
        }
      },
      "total": {
        "ticks": 12,
        "time": {
          "ms": 12
        },
        "value": 12
      },
      "user": {
        "ticks": 7,
        "time": {
          "ms": 7
        }
      }
    },
    "info": {
      "ephemeral_id": "467812aa-6bf7-476d-a49b-ecb69b9ab3ff",
      "name": "filebeat",
      "uptime": {
        "ms": 440145
      },
      "version": "8.14.0"
    },
    "memstats": {
      "gc_next": 42288728,
      "memory_alloc": 30397816,
      "memory_sys": 67536136,
      "memory_total": 203446584,
      "rss": 97517568
    },
    "runtime": {
      "goroutines": 117
    }
  },
  "filebeat": {
    "events": {
      "active": 0,
      "added": 682,
      "done": 682
    },
    "harvester": {
      "closed": 23,
      "open_files": 18,
      "running": 18,
      "skipped": 0,
      "started": 41
    },
    "input": {
      "log": {
        "files": {
          "renamed": 0,
          "truncated": 0
        }
      }
    }
  },
  "libbeat": {
    "config": {
      "module": {
        "running": 0,
        "starts": 0,
        "stops": 0
      },
      "reloads": 0,
      "scans": 0
    },
    "output": {
      "batches": {
        "split": 0
      },
      "events": {
        "acked": 585,
        "active": 0,
        "batches": 2,
        "dropped": 0,
        "duplicates": 0,
        "failed": 0,
        "toomany": 0,
        "total": 585
      },
      "read": {
        "bytes": 0,
        "errors": 0
      },
      "type": "file",
      "write": {
        "bytes": 317465,
        "errors": 0,
        "latency": {
          "histogram": {
            "count": 585,
            "max": 4,
            "mean": 0.006837606837606838,
            "median": 0,
            "min": 0,
            "p75": 0,
            "p95": 0,
            "p99": 0,
            "p999": 4,
            "stddev": 0.16523823553633854
          }
        }
      }
    },
    "pipeline": {
      "clients": 1,
      "events": {
        "active": 0,
        "dropped": 0,
        "failed": 0,
        "filtered": 97,
        "published": 585,
        "retry": 0,
        "total": 682
      },
      "queue": {
        "acked": 585,
        "max_events": 3200
      }
    }
  },
  "registrar": {
    "states": {
      "cleanup": 1,
      "current": 32,
      "update": 682
    },
    "writes": {
      "fail": 0,
      "success": 6,
      "total": 6
    }
  },
  "system": {
    "cpu": {
      "cores": 10
    },
    "load": {
      "1": 2.6714,
      "15": 3.2993,
      "5": 3.2432,
      "norm": {
        "1": 0.2671,
        "15": 0.3299,
        "5": 0.3243
      }
    }
  }
}
```