### PR TITLE
[AWS] [S3] Remove url.QueryUnescape() from aws-s3 input in polling mode

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -97,6 +97,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 - [threatintel] MISP pagination fixes {pull}37898[37898]
 - Fix file handle leak when handling errors in filestream {pull}37973[37973]
 - Prevent HTTPJSON holding response bodies between executions. {issue}35219[35219] {pull}38116[38116]
+- Fix "failed processing S3 event for object key" error on aws-s3 input when key contains the "+" character {issue}38012[38012] {pull}38125[38125]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/awss3/s3.go
+++ b/x-pack/filebeat/input/awss3/s3.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"sync"
 	"time"
 
@@ -208,14 +207,7 @@ func (p *s3Poller) GetS3Objects(ctx context.Context, s3ObjectPayloadChan chan<- 
 		// Metrics
 		p.metrics.s3ObjectsListedTotal.Add(uint64(totListedObjects))
 		for _, object := range page.Contents {
-			// Unescape s3 key name. For example, convert "%3D" back to "=".
-			filename, err := url.QueryUnescape(*object.Key)
-			if err != nil {
-				p.log.Errorw("Error when unescaping object key, skipping.", "error", err, "s3_object", *object.Key)
-				continue
-			}
-
-			state := newState(bucketName, filename, *object.ETag, p.listPrefix, *object.LastModified)
+			state := newState(bucketName, *object.Key, *object.ETag, p.listPrefix, *object.LastModified)
 			if p.states.MustSkip(state, p.store) {
 				p.log.Debugw("skipping state.", "state", state)
 				continue
@@ -240,7 +232,7 @@ func (p *s3Poller) GetS3Objects(ctx context.Context, s3ObjectPayloadChan chan<- 
 				s3ObjectHandler: s3Processor,
 				s3ObjectInfo: s3ObjectInfo{
 					name:         bucketName,
-					key:          filename,
+					key:          *object.Key,
 					etag:         *object.ETag,
 					lastModified: *object.LastModified,
 					listingID:    listingID.String(),

--- a/x-pack/filebeat/input/awss3/s3_test.go
+++ b/x-pack/filebeat/input/awss3/s3_test.go
@@ -93,6 +93,11 @@ func TestS3Poller(t *testing.T) {
 							Key:          aws.String("key5"),
 							LastModified: aws.Time(time.Now()),
 						},
+						{
+							ETag:         aws.String("etag6"),
+							Key:          aws.String("2024-02-08T08:35:00+00:02.json.gz"),
+							LastModified: aws.Time(time.Now()),
+						},
 					},
 				}, nil
 			})
@@ -122,6 +127,10 @@ func TestS3Poller(t *testing.T) {
 
 		mockAPI.EXPECT().
 			GetObject(gomock.Any(), gomock.Eq(bucket), gomock.Eq("key5")).
+			Return(nil, errFakeConnectivityFailure)
+
+		mockAPI.EXPECT().
+			GetObject(gomock.Any(), gomock.Eq(bucket), gomock.Eq("2024-02-08T08:35:00+00:02.json.gz")).
 			Return(nil, errFakeConnectivityFailure)
 
 		s3ObjProc := newS3ObjectProcessorFactory(logp.NewLogger(inputName), nil, mockAPI, nil, backupConfig{}, numberOfWorkers)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Remove `url.QueryUnescape()` from aws-s3 input in polling mode because it is not required.

We [introduced](https://github.com/elastic/beats/pull/18370) the `url.QueryUnescape()` function to unescape object keys from S3 notifications in SQS messages when the input runs in SQS. We also used it for object keys from the S3 list objects when the input runs in polling mode. However, the object keys in the S3 list object responses (polling mode) do [not require unescape](https://github.com/elastic/beats/issues/38012#issuecomment-1946440453).

We must remove the unescape to avoid unintended changes to the S3 object key.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ] 
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
go test -v ./x-pack/filebeat/input/awss3/... -run TestS3Poller
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/38012

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
