### PR TITLE
increase the maximum timeout for x-pack-metricbeat

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -637,7 +637,7 @@ spec:
     spec:
       # branch_configuration: "7.17"         #TODO: uncomment after tests
       pipeline_file: ".buildkite/x-pack/pipeline.xpack.metricbeat.yml"
-      maximum_timeout_in_minutes: 240
+      maximum_timeout_in_minutes: 480
       provider_settings:
         trigger_mode: none # don't trigger jobs from github activity
         build_pull_request_forks: false


### PR DESCRIPTION
## What is the problem this PR solves?

Jenkins->Buildkite pipelines migration 

fix the issue https://buildkite.com/elastic/beats-xpack-metricbeat/builds/459#018df478-5ada-4edc-91ef-a844244217da/956-10365
by increasing the maximum timeout for x-pack/metricbeat pipeline

## Related issues

https://github.com/elastic/ingest-dev/issues/1693

