### PR TITLE
x-pack/filebeat/input/httpjson: Apply rate limiting to all responses

### DIFF
--- a/x-pack/filebeat/input/httpjson/rate_limiter.go
+++ b/x-pack/filebeat/input/httpjson/rate_limiter.go
@@ -42,35 +42,37 @@ func (r *rateLimiter) execute(ctx context.Context, f func() (*http.Response, err
 	for {
 		resp, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("failed to read http.response.body: %w", err)
+			return nil, err
 		}
 
-		if r == nil || resp.StatusCode == http.StatusOK {
+		if r == nil {
 			return resp, nil
 		}
 
-		if resp.StatusCode != http.StatusTooManyRequests {
-			return nil, fmt.Errorf("http request was unsuccessful with a status code %d", resp.StatusCode)
+		applied, err := r.applyRateLimit(ctx, resp)
+		if err != nil {
+			return nil, fmt.Errorf("error applying rate limit: %w", err)
 		}
 
-		if err := r.applyRateLimit(ctx, resp); err != nil {
-			return nil, err
+		if resp.StatusCode == http.StatusOK || !applied {
+			return resp, nil
 		}
 	}
 }
 
-// applyRateLimit applies appropriate rate limit if specified in the HTTP Header of the response
-func (r *rateLimiter) applyRateLimit(ctx context.Context, resp *http.Response) error {
-	epoch, err := r.getRateLimit(resp)
+// applyRateLimit applies appropriate rate limit if specified in the HTTP Header of the response.
+// It returns a bool indicating whether a limit was reached.
+func (r *rateLimiter) applyRateLimit(ctx context.Context, resp *http.Response) (bool, error) {
+	limitReached, resumeAt, err := r.getRateLimit(resp)
 	if err != nil {
-		return err
+		return limitReached, err
 	}
 
-	t := time.Unix(epoch, 0)
+	t := time.Unix(resumeAt, 0)
 	w := time.Until(t)
-	if epoch == 0 || w <= 0 {
+	if resumeAt == 0 || w <= 0 {
 		r.log.Debugf("Rate Limit: No need to apply rate limit.")
-		return nil
+		return limitReached, nil
 	}
 	r.log.Debugf("Rate Limit: Wait until %v for the rate limit to reset.", t)
 	timer := time.NewTimer(w)
@@ -80,24 +82,25 @@ func (r *rateLimiter) applyRateLimit(ctx context.Context, resp *http.Response) e
 			<-timer.C
 		}
 		r.log.Info("Context done.")
-		return nil
+		return limitReached, nil
 	case <-timer.C:
 		r.log.Debug("Rate Limit: time is up.")
-		return nil
+		return limitReached, nil
 	}
 }
 
 // getRateLimit gets the rate limit value if specified in the response,
-// and returns an int64 value in seconds since unix epoch for rate limit reset time.
+// and returns a bool indicating whether a limit was reached, and
+// an int64 value in seconds since unix epoch for rate limit reset time.
 // When there is a remaining rate limit quota, or when the rate limit reset time has expired, it
 // returns 0 for the epoch value.
-func (r *rateLimiter) getRateLimit(resp *http.Response) (int64, error) {
+func (r *rateLimiter) getRateLimit(resp *http.Response) (bool, int64, error) {
 	if r == nil {
-		return 0, nil
+		return false, 0, nil
 	}
 
 	if r.remaining == nil {
-		return 0, nil
+		return false, 0, nil
 	}
 
 	tr := transformable{}
@@ -106,16 +109,16 @@ func (r *rateLimiter) getRateLimit(resp *http.Response) (int64, error) {
 
 	remaining, _ := r.remaining.Execute(ctx, tr, "rate-limit_remaining", nil, r.log)
 	if remaining == "" {
-		return 0, errors.New("remaining value is empty")
+		return false, 0, errors.New("remaining value is empty")
 	}
 	m, err := strconv.ParseInt(remaining, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse rate-limit remaining value: %w", err)
+		return false, 0, fmt.Errorf("failed to parse rate-limit remaining value: %w", err)
 	}
 
 	// by default, httpjson will continue requests until Limit is 0
 	// can optionally stop requests "early"
-	var activeLimit int64 = 0
+	var minRemaining int64 = 0
 	if r.earlyLimit != nil {
 		earlyLimit := *r.earlyLimit
 		if earlyLimit > 0 && earlyLimit < 1 {
@@ -123,37 +126,37 @@ func (r *rateLimiter) getRateLimit(resp *http.Response) (int64, error) {
 			if limit != "" {
 				l, err := strconv.ParseInt(limit, 10, 64)
 				if err == nil {
-					activeLimit = l - int64(earlyLimit*float64(l))
+					minRemaining = l - int64(earlyLimit*float64(l))
 				}
 			}
 		} else if earlyLimit >= 1 {
-			activeLimit = int64(earlyLimit)
+			minRemaining = int64(earlyLimit)
 		}
 	}
 
-	r.log.Debugf("Rate Limit: Using active Early Limit: %f", activeLimit)
-	if m > activeLimit {
-		return 0, nil
+	r.log.Debugf("Rate Limit: Using active Early Limit: %f", minRemaining)
+	if m > minRemaining {
+		return false, 0, nil
 	}
 
 	if r.reset == nil {
 		r.log.Warn("reset rate limit is not set")
-		return 0, nil
+		return false, 0, nil
 	}
 
 	reset, _ := r.reset.Execute(ctx, tr, "rate-limit_reset", nil, r.log)
 	if reset == "" {
-		return 0, errors.New("reset value is empty")
+		return false, 0, errors.New("reset value is empty")
 	}
 
-	epoch, err := strconv.ParseInt(reset, 10, 64)
+	resumeAt, err := strconv.ParseInt(reset, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse rate-limit reset value: %w", err)
+		return false, 0, fmt.Errorf("failed to parse rate-limit reset value: %w", err)
 	}
 
-	if timeNow().Unix() > epoch {
-		return 0, nil
+	if timeNow().Unix() > resumeAt {
+		return true, 0, nil
 	}
 
-	return epoch, nil
+	return true, resumeAt, nil
 }

--- a/x-pack/filebeat/input/httpjson/rate_limiter.go
+++ b/x-pack/filebeat/input/httpjson/rate_limiter.go
@@ -109,7 +109,8 @@ func (r *rateLimiter) getRateLimit(resp *http.Response) (bool, int64, error) {
 
 	remaining, _ := r.remaining.Execute(ctx, tr, "rate-limit_remaining", nil, r.log)
 	if remaining == "" {
-		return false, 0, errors.New("remaining value is empty")
+		r.log.Infow("get rate limit", "error", errors.New("remaining value is empty"))
+		return false, 0, nil
 	}
 	m, err := strconv.ParseInt(remaining, 10, 64)
 	if err != nil {
@@ -134,7 +135,7 @@ func (r *rateLimiter) getRateLimit(resp *http.Response) (bool, int64, error) {
 		}
 	}
 
-	r.log.Debugf("Rate Limit: Using active Early Limit: %f", minRemaining)
+	r.log.Debugf("Rate Limit: Using active Early Limit: %d", minRemaining)
 	if m > minRemaining {
 		return false, 0, nil
 	}
@@ -146,7 +147,8 @@ func (r *rateLimiter) getRateLimit(resp *http.Response) (bool, int64, error) {
 
 	reset, _ := r.reset.Execute(ctx, tr, "rate-limit_reset", nil, r.log)
 	if reset == "" {
-		return false, 0, errors.New("reset value is empty")
+		r.log.Infow("get rate limit", "error", errors.New("reset value is empty"))
+		return false, 0, nil
 	}
 
 	resumeAt, err := strconv.ParseInt(reset, 10, 64)

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -236,18 +236,16 @@ func (rf *requestFactory) collectResponse(ctx context.Context, trCtx *transformC
 
 func (c *httpClient) do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	resp, err := c.limiter.execute(ctx, func() (*http.Response, error) {
-		return c.client.Do(req)
+		resp, err := c.client.Do(req)
+		if err == nil {
+			// Read the whole resp.Body so we can release the connection.
+			// This implementation is inspired by httputil.DumpResponse
+			resp.Body, err = drainBody(resp.Body)
+		}
+		return resp, err
 	})
 	if err != nil {
 		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// Read the whole resp.Body so we can release the connection.
-	// This implementation is inspired by httputil.DumpResponse
-	resp.Body, err = drainBody(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
@@ -939,6 +937,8 @@ func cloneResponse(source *http.Response) (*http.Response, error) {
 //
 // This function is a modified version of drainBody from the http/httputil package.
 func drainBody(b io.ReadCloser) (r1 io.ReadCloser, err error) {
+	defer b.Close()
+
 	if b == nil || b == http.NoBody {
 		// No copying needed. Preserve the magic sentinel meaning of NoBody.
 		return http.NoBody, nil
@@ -946,10 +946,10 @@ func drainBody(b io.ReadCloser) (r1 io.ReadCloser, err error) {
 
 	var buf bytes.Buffer
 	if _, err = buf.ReadFrom(b); err != nil {
-		return b, err
+		return b, fmt.Errorf("failed to read http.response.body: %w", err)
 	}
 	if err = b.Close(); err != nil {
-		return b, err
+		return b, fmt.Errorf("failed to close http.response.body: %w", err)
 	}
 
 	return io.NopCloser(&buf), nil


### PR DESCRIPTION
## Draft discussion

I didn't find a solution to the failing `request_honors_rate_limit` test. The context is okay when processing the first response, and remains okay after the wait time is applied, then it appears as cancelled after the retry request is run (that is, after [this line](https://github.com/chrisberkhout/elastic-beats/blob/23b974983b113318371dff52222cbc326ff69c69/x-pack/filebeat/input/httpjson/rate_limiter.go#L43)).

## Proposed commit message

```
x-pack/filebeat/input/httpjson: Apply rate limiting to all responses (#)

- Drain the body before rate limiting.
- Apply rate limiting to all responses, waiting immediately. Retry if
  the response was not successful and there was a rate limit wait (even
  if immediately expired), otherwise return.
- Improve names of variables `epoch` and `activeLimit`.
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #36207