### PR TITLE
Release event pointers faster as they go through the pipeline

### DIFF
--- a/libbeat/publisher/pipeline/ttl_batch.go
+++ b/libbeat/publisher/pipeline/ttl_batch.go
@@ -93,10 +93,12 @@ func (b *ttlBatch) Events() []publisher.Event {
 }
 
 func (b *ttlBatch) ACK() {
+	b.events = nil
 	b.done()
 }
 
 func (b *ttlBatch) Drop() {
+	b.events = nil
 	b.done()
 }
 

--- a/libbeat/publisher/pipeline/ttl_batch.go
+++ b/libbeat/publisher/pipeline/ttl_batch.go
@@ -93,11 +93,13 @@ func (b *ttlBatch) Events() []publisher.Event {
 }
 
 func (b *ttlBatch) ACK() {
+	// Help the garbage collector clean up the event data a little faster
 	b.events = nil
 	b.done()
 }
 
 func (b *ttlBatch) Drop() {
+	// Help the garbage collector clean up the event data a little faster
 	b.events = nil
 	b.done()
 }

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -403,8 +403,10 @@ func (b *batch) Entry(i int) interface{} {
 }
 
 func (b *batch) FreeEntries() {
-	// Memory queue can't release event references until they're fully acknowledged,
-	// so do nothing.
+	for i := 0; i < b.count; i++ {
+		index := (b.start + i) % len(b.queue.buf)
+		b.queue.buf[index].event = nil
+	}
 }
 
 func (b *batch) Done() {

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -403,6 +403,8 @@ func (b *batch) Entry(i int) interface{} {
 }
 
 func (b *batch) FreeEntries() {
+	// This signals that the event data has been copied out of the batch, and is
+	// safe to free from the queue buffer, so set all the event pointers to nil.
 	for i := 0; i < b.count; i++ {
 		index := (b.start + i) % len(b.queue.buf)
 		b.queue.buf[index].event = nil

--- a/libbeat/publisher/queue/memqueue/runloop.go
+++ b/libbeat/publisher/queue/memqueue/runloop.go
@@ -187,13 +187,8 @@ func (l *runLoop) handleGetReply(req *getRequest) {
 }
 
 func (l *runLoop) handleDelete(count int) {
-	// Clear the internal event pointers so they can be garbage collected
-	for i := 0; i < count; i++ {
-		index := (l.bufPos + i) % len(l.broker.buf)
-		l.broker.buf[index].event = nil
-	}
-
-	// Advance position and counters
+	// Advance position and counters. Event data was already cleared in
+	// batch.FreeEntries when the events were vended.
 	l.bufPos = (l.bufPos + count) % len(l.broker.buf)
 	l.eventCount -= count
 	l.consumedCount -= count


### PR DESCRIPTION
## Proposed commit message

Make two changes to allow event data to be freed from memory faster:
- Free event pointers from the memory queue buffer when they are vended instead of when they're acknowledged. (The data will be preserved in the event batch structure until acknowledgment.)
- Free event pointers from the batch structure immediately after it is acknowledged instead of waiting for the batch to be freed naturally.

In benchmarks of Filebeat with saturated Filestream input going to an Elasticsearch output, this lowered average memory footprint by ~10%.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
