### PR TITLE
x-pack/filebeat/input/{cel,websocket}: prevent addition of regexp extension when no patterns are provided

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,6 +99,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 - Fix a race condition that could crash Filebeat with a "negative WaitGroup counter" error {pull}38094[38094]
 - Prevent HTTPJSON holding response bodies between executions. {issue}35219[35219] {pull}38116[38116]
 - Fix "failed processing S3 event for object key" error on aws-s3 input when key contains the "+" character {issue}38012[38012] {pull}38125[38125]
+- Fix duplicated addition of regexp extension in CEL input. {pull}38181[38181]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/cel/config_test.go
+++ b/x-pack/filebeat/input/cel/config_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/oauth2/google"
@@ -35,6 +36,19 @@ func TestGetProviderIsCanonical(t *testing.T) {
 	got := oAuth2Config{Provider: "GOogle"}.getProvider()
 	if got != want {
 		t.Errorf("unexpected provider from getProvider: got:%s want:%s", got, want)
+	}
+}
+
+func TestRegexpConfig(t *testing.T) {
+	cfg := config{
+		Interval: time.Minute,
+		Program:  `{}`,
+		Resource: &ResourceConfig{URL: &urlConfig{URL: &url.URL{}}},
+		Regexps:  map[string]string{"regex_cve": `[Cc][Vv][Ee]-[0-9]{4}-[0-9]{4,7}`},
+	}
+	err := cfg.Validate()
+	if err != nil {
+		t.Errorf("failed to validate config with regexps: %v", err)
 	}
 }
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -918,7 +918,6 @@ func newProgram(ctx context.Context, src, root string, client *http.Client, limi
 		lib.Debug(debug(log, trace)),
 		lib.File(mimetypes),
 		lib.MIME(mimetypes),
-		lib.Regexp(patterns),
 		lib.Limit(limitPolicies),
 		lib.Globals(map[string]interface{}{
 			"useragent": userAgent,

--- a/x-pack/filebeat/input/websocket/cel.go
+++ b/x-pack/filebeat/input/websocket/cel.go
@@ -63,10 +63,12 @@ func newProgram(ctx context.Context, src, root string, patterns map[string]*rege
 		lib.Try(),
 		lib.Debug(debug(log)),
 		lib.MIME(mimetypes),
-		lib.Regexp(patterns),
 		lib.Globals(map[string]interface{}{
 			"useragent": userAgent,
 		}),
+	}
+	if len(patterns) != 0 {
+		opts = append(opts, lib.Regexp(patterns))
 	}
 
 	env, err := cel.NewEnv(opts...)

--- a/x-pack/filebeat/input/websocket/config_test.go
+++ b/x-pack/filebeat/input/websocket/config_test.go
@@ -6,6 +6,7 @@ package websocket
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,5 +118,17 @@ func TestConfig(t *testing.T) {
 				// no error
 			}
 		})
+	}
+}
+
+func TestRegexpConfig(t *testing.T) {
+	cfg := config{
+		Program: `{}`,
+		URL:     &urlConfig{URL: &url.URL{Scheme: "ws"}},
+		Regexps: map[string]string{"regex_cve": `[Cc][Vv][Ee]-[0-9]{4}-[0-9]{4,7}`},
+	}
+	err := cfg.Validate()
+	if err != nil {
+		t.Errorf("failed to validate config with regexps: %v", err)
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

In the case of cel, the extension was always being added, and then was conditionally added when a pattern was configured, resulting in a failed configuration. In the case of websocket the conditional addition was not being performed, so no failure occured, but additional look-up load was being added. So unify the approaches to the correct conditional addition.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
