### PR TITLE
[filebeat] Deprecate syslog input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -261,7 +261,7 @@ Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will d
 
 *Filebeat*
 
-- Deprecate `syslog` input in favor of `syslog` processor. {issue}37555[37555] {pull}1[1]
+- Deprecate `syslog` input in favor of `syslog` processor. {issue}37555[37555] {pull}38277[38277]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -261,6 +261,7 @@ Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will d
 
 *Filebeat*
 
+- Deprecate `syslog` input in favor of `syslog` processor. {issue}37555[37555] {pull}1[1]
 
 *Heartbeat*
 

--- a/filebeat/docs/inputs/input-syslog.asciidoc
+++ b/filebeat/docs/inputs/input-syslog.asciidoc
@@ -3,6 +3,10 @@
 [id="{beatname_lc}-input-{type}"]
 === Syslog input
 
+deprecated:[8.14.0]
+
+The syslog input is deprecated. Please use the <<syslog, `syslog`>> processor for processing syslog messages.
+
 ++++
 <titleabbrev>Syslog</titleabbrev>
 ++++

--- a/filebeat/input/syslog/input.go
+++ b/filebeat/input/syslog/input.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -85,6 +86,8 @@ var (
 		"local6",
 		"local7",
 	}
+
+	deprecatedNotificationOnce sync.Once
 )
 
 func init() {
@@ -111,6 +114,10 @@ func NewInput(
 	context input.Context,
 ) (input.Input, error) {
 	log := logp.NewLogger("syslog")
+
+	deprecatedNotificationOnce.Do(func() {
+		cfgwarn.Deprecate("8.14.0", "Syslog input. Use Syslog processor instead.")
+	})
 
 	out, err := outlet.Connect(cfg)
 	if err != nil {

--- a/filebeat/input/syslog/input.go
+++ b/filebeat/input/syslog/input.go
@@ -187,7 +187,7 @@ func GetCbByConfig(cfg config, forwarder *harvester.Forwarder, log *logp.Logger)
 	case syslogFormatRFC5424:
 		return func(data []byte, metadata inputsource.NetworkMetadata) {
 			ev := parseAndCreateEvent5424(data, metadata, cfg.Timezone.Location(), log)
-			forwarder.Send(ev)
+			_ = forwarder.Send(ev)
 		}
 
 	case syslogFormatAuto:
@@ -198,7 +198,7 @@ func GetCbByConfig(cfg config, forwarder *harvester.Forwarder, log *logp.Logger)
 			} else {
 				ev = parseAndCreateEvent3164(data, metadata, cfg.Timezone.Location(), log)
 			}
-			forwarder.Send(ev)
+			_ = forwarder.Send(ev)
 		}
 	case syslogFormatRFC3164:
 		break
@@ -206,7 +206,7 @@ func GetCbByConfig(cfg config, forwarder *harvester.Forwarder, log *logp.Logger)
 
 	return func(data []byte, metadata inputsource.NetworkMetadata) {
 		ev := parseAndCreateEvent3164(data, metadata, cfg.Timezone.Location(), log)
-		forwarder.Send(ev)
+		_ = forwarder.Send(ev)
 	}
 }
 

--- a/filebeat/input/syslog/input.go
+++ b/filebeat/input/syslog/input.go
@@ -116,7 +116,7 @@ func NewInput(
 	log := logp.NewLogger("syslog")
 
 	deprecatedNotificationOnce.Do(func() {
-		cfgwarn.Deprecate("8.14.0", "Syslog input. Use Syslog processor instead.")
+		cfgwarn.Deprecate("", "Syslog input. Use Syslog processor instead.")
 	})
 
 	out, err := outlet.Connect(cfg)


### PR DESCRIPTION
## Proposed commit message

- The syslog input has been deprecated in favor of the syslog processor.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #37555 

## Logs

```
{"log.level":"warn","@timestamp":"2024-03-18T13:34:27.685Z","log.logger":"cfgwarn","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/syslog.NewInput.func1","file.name":"syslog/input.go","file.line":119},"message":"DEPRECATED: Syslog input. Use Syslog processor instead.","service.name":"filebeat","ecs.version":"1.6.0"}
```