### PR TITLE
[Metricbeat][Azure] Azure monitor/storage: Fix 429 Too Many Requests error

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -113,6 +113,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 
 *Metricbeat*
 
+- Fix Azure Monitor 429 error by causing metricbeat to retry the request again. {pull}38294[38294]
 - Fix fields not being parsed correctly in postgresql/database {issue}25301[25301] {pull}37720[37720]
 
 *Osquerybeat*

--- a/x-pack/metricbeat/module/azure/mock_service.go
+++ b/x-pack/metricbeat/module/azure/mock_service.go
@@ -35,6 +35,11 @@ func (client *MockService) GetMetricDefinitions(resourceId string, namespace str
 	return args.Get(0).(armmonitor.MetricDefinitionCollection), args.Error(1)
 }
 
+// GetMetricDefinitionsWithRetry is a mock function for the azure service
+func (client *MockService) GetMetricDefinitionsWithRetry(resource *armresources.GenericResourceExpanded, namespace string) (armmonitor.MetricDefinitionCollection, error) {
+	return client.GetMetricDefinitions(*resource.ID, namespace)
+}
+
 // GetMetricNamespaces is a mock function for the azure service
 func (client *MockService) GetMetricNamespaces(resourceId string) (armmonitor.MetricNamespaceCollection, error) {
 	args := client.Called(resourceId)

--- a/x-pack/metricbeat/module/azure/mock_service.go
+++ b/x-pack/metricbeat/module/azure/mock_service.go
@@ -29,15 +29,10 @@ func (client *MockService) GetResourceDefinitions(id []string, group []string, r
 	return args.Get(0).([]*armresources.GenericResourceExpanded), args.Error(1)
 }
 
-// GetMetricDefinitions is a mock function for the azure service
-func (client *MockService) GetMetricDefinitions(resourceId string, namespace string) (armmonitor.MetricDefinitionCollection, error) {
+// GetMetricDefinitionsWithRetry is a mock function for the azure service
+func (client *MockService) GetMetricDefinitionsWithRetry(resourceId string, namespace string) (armmonitor.MetricDefinitionCollection, error) {
 	args := client.Called(resourceId, namespace)
 	return args.Get(0).(armmonitor.MetricDefinitionCollection), args.Error(1)
-}
-
-// GetMetricDefinitionsWithRetry is a mock function for the azure service
-func (client *MockService) GetMetricDefinitionsWithRetry(resource *armresources.GenericResourceExpanded, namespace string) (armmonitor.MetricDefinitionCollection, error) {
-	return client.GetMetricDefinitions(*resource.ID, namespace)
 }
 
 // GetMetricNamespaces is a mock function for the azure service

--- a/x-pack/metricbeat/module/azure/monitor/client_helper.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper.go
@@ -21,43 +21,60 @@ import (
 
 const missingNamespace = "no metric definitions were found for resource %s and namespace %s. Verify if the namespace is spelled correctly or if it is supported by the resource in case."
 
+func getMetricsDefinitionsWithRetry(client *azure.Client, resource *armresources.GenericResourceExpanded, namespace string) (armmonitor.MetricDefinitionCollection, error) {
+	for {
+
+		metricDefinitions, err := client.AzureMonitorService.GetMetricDefinitions(*resource.ID, namespace)
+		if err != nil {
+			errorMsg := "no metric definitions were found for resource " + *resource.ID + " and namespace " + namespace
+
+			var respError *azcore.ResponseError
+			ok := errors.As(err, &respError)
+			if !ok {
+				return metricDefinitions, fmt.Errorf("%s, %w", errorMsg, err)
+			}
+
+			// Check if the error has the header Retry After.
+			// If it is present, then we should try to make this request again.
+			retryAfter := respError.RawResponse.Header.Get("Retry-After")
+			if retryAfter == "" {
+				return metricDefinitions, fmt.Errorf("%s %w", errorMsg, err)
+			}
+
+			duration, errD := time.ParseDuration(retryAfter + "s")
+			if errD != nil {
+				return metricDefinitions, fmt.Errorf("%s, failed to parse duration %s from header retry after", errorMsg, retryAfter)
+			}
+
+			client.Log.Infof("%s, metricbeat will try again after %s seconds", errorMsg, retryAfter)
+			time.Sleep(duration)
+		} else {
+			return metricDefinitions, err
+		}
+	}
+}
+
 // mapMetrics should validate and map the metric related configuration to relevant azure monitor api parameters
 func mapMetrics(client *azure.Client, resources []*armresources.GenericResourceExpanded, resourceConfig azure.ResourceConfig) ([]azure.Metric, error) {
 	var metrics []azure.Metric
+
 	for _, resource := range resources {
+
+		// We use this map to avoid calling the metrics definition function for the same namespace and same resource
+		// multiple times.
+		namespaceMetrics := make(map[string]armmonitor.MetricDefinitionCollection)
+
 		for _, metric := range resourceConfig.Metrics {
-			// get all metrics supported by the namespace provided
-			var metricDefinitions armmonitor.MetricDefinitionCollection
+
 			var err error
 
-			for {
-				metricDefinitions, err = client.AzureMonitorService.GetMetricDefinitions(*resource.ID, metric.Namespace)
+			metricDefinitions, ok := namespaceMetrics[metric.Namespace]
+			if !ok {
+				metricDefinitions, err = getMetricsDefinitionsWithRetry(client, resource, metric.Namespace)
 				if err != nil {
-					errorMsg := "no metric definitions were found for resource " + *resource.ID + " and namespace " + metric.Namespace
-
-					var respError *azcore.ResponseError
-					ok := errors.As(err, &respError)
-					if !ok {
-						return nil, fmt.Errorf("%s, %w", errorMsg, err)
-					}
-
-					// Check if the error has the header Retry After.
-					// If it is present, then we should try to make this request again.
-					retryAfter := respError.RawResponse.Header.Get("Retry-After")
-					if retryAfter == "" {
-						return nil, fmt.Errorf("%s %w", errorMsg, err)
-					}
-
-					duration, errD := time.ParseDuration(retryAfter + "s")
-					if errD != nil {
-						return nil, fmt.Errorf("%s, failed to parse duration %s from header retry after", errorMsg, retryAfter)
-					}
-
-					client.Log.Infof("%s, metricbeat will try again after %s seconds", errorMsg, retryAfter)
-					time.Sleep(duration)
-				} else {
-					break
+					return nil, err
 				}
+				namespaceMetrics[metric.Namespace] = metricDefinitions
 			}
 
 			if len(metricDefinitions.Value) == 0 {

--- a/x-pack/metricbeat/module/azure/monitor/client_helper.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper.go
@@ -33,7 +33,7 @@ func mapMetrics(client *azure.Client, resources []*armresources.GenericResourceE
 
 			metricDefinitions, exists := namespaceMetrics[metric.Namespace]
 			if !exists {
-				metricDefinitions, err = client.AzureMonitorService.GetMetricDefinitionsWithRetry(resource, metric.Namespace)
+				metricDefinitions, err = client.AzureMonitorService.GetMetricDefinitionsWithRetry(*resource.ID, metric.Namespace)
 				if err != nil {
 					return nil, err
 				}

--- a/x-pack/metricbeat/module/azure/monitor/client_helper.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper.go
@@ -40,6 +40,8 @@ func mapMetrics(client *azure.Client, resources []*armresources.GenericResourceE
 						return nil, fmt.Errorf("%s, %w", errorMsg, err)
 					}
 
+					// Check if the error has the header Retry After.
+					// If it is present, then we should try to make this request again.
 					retryAfter := respError.RawResponse.Header.Get("Retry-After")
 					if retryAfter == "" {
 						return nil, fmt.Errorf("%s %w", errorMsg, err)

--- a/x-pack/metricbeat/module/azure/monitor/client_helper.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper.go
@@ -7,9 +7,10 @@ package monitor
 import (
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"strings"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 

--- a/x-pack/metricbeat/module/azure/monitor/client_helper.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper.go
@@ -5,13 +5,8 @@
 package monitor
 
 import (
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
-	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 
@@ -21,43 +16,6 @@ import (
 )
 
 const missingNamespace = "no metric definitions were found for resource %s and namespace %s. Verify if the namespace is spelled correctly or if it is supported by the resource in case."
-
-func getMetricsDefinitionsWithRetry(client *azure.Client, resource *armresources.GenericResourceExpanded, namespace string) (armmonitor.MetricDefinitionCollection, error) {
-	for {
-
-		metricDefinitions, err := client.AzureMonitorService.GetMetricDefinitions(*resource.ID, namespace)
-		if err != nil {
-			errorMsg := "no metric definitions were found for resource " + *resource.ID + " and namespace " + namespace
-
-			var respError *azcore.ResponseError
-			ok := errors.As(err, &respError)
-			if !ok {
-				return metricDefinitions, fmt.Errorf("%s, failed to cast error to azcore.ResponseError", errorMsg)
-			}
-			// Check for TooManyRequests error and retry if it is the case
-			if respError.StatusCode != http.StatusTooManyRequests {
-				return metricDefinitions, fmt.Errorf("%s, %w", errorMsg, err)
-			}
-
-			// Check if the error has the header Retry After.
-			// If it is present, then we should try to make this request again.
-			retryAfter := respError.RawResponse.Header.Get("Retry-After")
-			if retryAfter == "" {
-				return metricDefinitions, fmt.Errorf("%s %w, failed to find Retry-After header", errorMsg, err)
-			}
-
-			duration, errD := time.ParseDuration(retryAfter + "s")
-			if errD != nil {
-				return metricDefinitions, fmt.Errorf("%s, failed to parse duration %s from header retry after", errorMsg, retryAfter)
-			}
-
-			client.Log.Infof("%s, metricbeat will try again after %s seconds", errorMsg, retryAfter)
-			time.Sleep(duration)
-		} else {
-			return metricDefinitions, err
-		}
-	}
-}
 
 // mapMetrics should validate and map the metric related configuration to relevant azure monitor api parameters
 func mapMetrics(client *azure.Client, resources []*armresources.GenericResourceExpanded, resourceConfig azure.ResourceConfig) ([]azure.Metric, error) {
@@ -73,9 +31,9 @@ func mapMetrics(client *azure.Client, resources []*armresources.GenericResourceE
 
 			var err error
 
-			metricDefinitions, ok := namespaceMetrics[metric.Namespace]
-			if !ok {
-				metricDefinitions, err = getMetricsDefinitionsWithRetry(client, resource, metric.Namespace)
+			metricDefinitions, exists := namespaceMetrics[metric.Namespace]
+			if !exists {
+				metricDefinitions, err = client.AzureMonitorService.GetMetricDefinitionsWithRetry(resource, metric.Namespace)
 				if err != nil {
 					return nil, err
 				}

--- a/x-pack/metricbeat/module/azure/monitor/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper_test.go
@@ -88,7 +88,7 @@ func TestMapMetric(t *testing.T) {
 	client := azure.NewMockClient()
 	t.Run("return error when no metric definitions were found", func(t *testing.T) {
 		m := &azure.MockService{}
-		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(armmonitor.MetricDefinitionCollection{}, fmt.Errorf("invalid resource ID"))
+		m.On("GetMetricDefinitionsWithRetry", mock.Anything, mock.Anything).Return(armmonitor.MetricDefinitionCollection{}, fmt.Errorf("invalid resource ID"))
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig)
 		assert.Error(t, err)
@@ -97,7 +97,7 @@ func TestMapMetric(t *testing.T) {
 	})
 	t.Run("return all metrics when all metric names and aggregations were configured", func(t *testing.T) {
 		m := &azure.MockService{}
-		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
+		m.On("GetMetricDefinitionsWithRetry", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
 		client.AzureMonitorService = m
 		metricConfig.Name = []string{"*"}
 		resourceConfig.Metrics = []azure.MetricConfig{metricConfig}
@@ -112,7 +112,7 @@ func TestMapMetric(t *testing.T) {
 	})
 	t.Run("return all metrics when specific metric names and aggregations were configured", func(t *testing.T) {
 		m := &azure.MockService{}
-		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
+		m.On("GetMetricDefinitionsWithRetry", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
 		client.AzureMonitorService = m
 		metricConfig.Name = []string{"TotalRequests", "Capacity"}
 		metricConfig.Aggregations = []string{"Average"}

--- a/x-pack/metricbeat/module/azure/monitor_service.go
+++ b/x-pack/metricbeat/module/azure/monitor_service.go
@@ -248,19 +248,15 @@ func (service *MonitorService) GetMetricDefinitionsWithRetry(resourceId string, 
 	metricDefinitionCollection := armmonitor.MetricDefinitionCollection{}
 
 	for pager.More() {
-
-		for {
-			nextPage, err := pager.NextPage(service.context)
-			if err != nil {
-				retryError := service.sleepIfPossible(err, resourceId, namespace)
-				if retryError != nil {
-					return armmonitor.MetricDefinitionCollection{}, err
-				}
-			} else {
-				metricDefinitionCollection.Value = append(metricDefinitionCollection.Value, nextPage.Value...)
-				break
+		nextPage, err := pager.NextPage(service.context)
+		if err != nil {
+			retryError := service.sleepIfPossible(err, resourceId, namespace)
+			if retryError != nil {
+				return armmonitor.MetricDefinitionCollection{}, err
 			}
+			continue
 		}
+		metricDefinitionCollection.Value = append(metricDefinitionCollection.Value, nextPage.Value...)
 	}
 
 	return metricDefinitionCollection, nil

--- a/x-pack/metricbeat/module/azure/service_interface.go
+++ b/x-pack/metricbeat/module/azure/service_interface.go
@@ -13,8 +13,7 @@ import (
 type Service interface {
 	GetResourceDefinitionById(id string) (armresources.GenericResource, error)
 	GetResourceDefinitions(id []string, group []string, rType string, query string) ([]*armresources.GenericResourceExpanded, error)
-	GetMetricDefinitions(resourceId string, namespace string) (armmonitor.MetricDefinitionCollection, error)
-	GetMetricDefinitionsWithRetry(resource *armresources.GenericResourceExpanded, namespace string) (armmonitor.MetricDefinitionCollection, error)
+	GetMetricDefinitionsWithRetry(resourceId string, namespace string) (armmonitor.MetricDefinitionCollection, error)
 	GetMetricNamespaces(resourceId string) (armmonitor.MetricNamespaceCollection, error)
 	GetMetricValues(resourceId string, namespace string, timegrain string, timespan string, metricNames []string, aggregations string, filter string) ([]armmonitor.Metric, string, error)
 }

--- a/x-pack/metricbeat/module/azure/service_interface.go
+++ b/x-pack/metricbeat/module/azure/service_interface.go
@@ -14,6 +14,7 @@ type Service interface {
 	GetResourceDefinitionById(id string) (armresources.GenericResource, error)
 	GetResourceDefinitions(id []string, group []string, rType string, query string) ([]*armresources.GenericResourceExpanded, error)
 	GetMetricDefinitions(resourceId string, namespace string) (armmonitor.MetricDefinitionCollection, error)
+	GetMetricDefinitionsWithRetry(resource *armresources.GenericResourceExpanded, namespace string) (armmonitor.MetricDefinitionCollection, error)
 	GetMetricNamespaces(resourceId string) (armmonitor.MetricNamespaceCollection, error)
 	GetMetricValues(resourceId string, namespace string, timegrain string, timespan string, metricNames []string, aggregations string, filter string) ([]armmonitor.Metric, string, error)
 }

--- a/x-pack/metricbeat/module/azure/storage/client_helper.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper.go
@@ -41,13 +41,13 @@ func mapMetrics(client *azure.Client, resources []*armresources.GenericResourceE
 			}
 
 			// get all metric definitions supported by the namespace provided
-			metricDefinitions, err := client.AzureMonitorService.GetMetricDefinitions(resourceID, namespace)
+			metricDefinitions, err := client.AzureMonitorService.GetMetricDefinitionsWithRetry(resourceID, namespace)
 			if err != nil {
-				return nil, fmt.Errorf("no metric definitions were found for resource %s and namespace %s %w", resourceID, namespace, err)
+				return nil, err
 			}
 
 			if len(metricDefinitions.Value) == 0 {
-				return nil, fmt.Errorf("no metric definitions were found for resource %s and namespace %s %w", resourceID, namespace, err)
+				return nil, err
 			}
 
 			var filteredMetricDefinitions []armmonitor.MetricDefinition

--- a/x-pack/metricbeat/module/azure/storage/client_helper.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper.go
@@ -47,7 +47,7 @@ func mapMetrics(client *azure.Client, resources []*armresources.GenericResourceE
 			}
 
 			if len(metricDefinitions.Value) == 0 {
-				return nil, err
+				return nil, fmt.Errorf("no metric definitions were found for resource %s and namespace %s", resourceID, namespace)
 			}
 
 			var filteredMetricDefinitions []armmonitor.MetricDefinition

--- a/x-pack/metricbeat/module/azure/storage/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper_test.go
@@ -119,17 +119,17 @@ func TestMapMetric(t *testing.T) {
 	client := azure.NewMockClient()
 	t.Run("return error when no metric definitions were found", func(t *testing.T) {
 		m := &azure.MockService{}
-		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(emptyMetricDefinitions, nil)
+		m.On("GetMetricDefinitionsWithRetry", mock.Anything, mock.Anything).Return(emptyMetricDefinitions, nil)
 		client.AzureMonitorService = m
 		metric, err := mapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig)
 		assert.Error(t, err)
-		assert.Equal(t, err.Error(), "no metric definitions were found for resource 123 and namespace Microsoft.Storage/storageAccounts %!w(<nil>)")
+		assert.Equal(t, err.Error(), "no metric definitions were found for resource 123 and namespace Microsoft.Storage/storageAccounts")
 		assert.Equal(t, metric, []azure.Metric(nil))
 		m.AssertExpectations(t)
 	})
 	t.Run("return mapped metrics correctly", func(t *testing.T) {
 		m := &azure.MockService{}
-		m.On("GetMetricDefinitions", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
+		m.On("GetMetricDefinitionsWithRetry", mock.Anything, mock.Anything).Return(metricDefinitions, nil)
 		client.AzureMonitorService = m
 		metrics, err := mapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Proposed commit message

Please see the issue https://github.com/elastic/integrations/issues/8575.

Metricsets affected by this change: storage and monitor.

This PR fixes the issue the following way:

1. We check if the error produced has the header "Retry After".
2. If this header is present then we use `time.sleep` for the seconds given by the header and try again after the time is up.
3. If the header is not present, then it is likely another error and we return.

This is also the retry suggestion given by [Retry Usage Guidance](https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#retry-usage-guidance) from Azure.

For monitor metricset, the previous implementation also had a different problem affecting the number of calls: we were trying to get the metrics definition for every metric, without checking if we had done that already for the combination namespace + resource ID. So, for example, this configuration:

```
    - resource_query: "resourceType eq 'Microsoft.ContainerRegistry/registries'"
      metrics:
        - name: [ "TotalPullCount", "SuccessfulPullCount", "TotalPushCount", "SuccessfulPushCount","RunDuration", "AgentPoolCPUTime" ]
          namespace: "Microsoft.ContainerRegistry/registries"
          timegrain: "PT1M"
        - name: [ "StorageUsed" ]
          namespace: "Microsoft.ContainerRegistry/registries"
          timegrain: "PT1H"
          dimensions:
            - name: "Geolocation"
              value: "*"
```

Would lead to 2 calls for each resource, even though the namespace is the same for every metric group. This is also fixed in this PR.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally


Enable azure monitor metricset, like in [this example configuration](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-azure.html#_example_configuration_7).

To reproduce the error you can change the code a bit to force it to make many requests. You can put the `getMetricsDefinitionsWithRetry` inside a for cycle for that.

</details>

I added some printing lines to the code. You should see an output like this:

```logs
[...]
>> Trying request  400
>> Trying request  401
>> Trying request  402
>> Metricbeat will sleep for 309 seconds and retry again.
>> Trying request  402  <---------- Same request as before
>> Trying request  403
[...]
```

Please notice that running this takes around 7 minutes to first encounter the error. After that time you have to wait for the sleep time, and only then you start making requests again.


## Related issues

Closes https://github.com/elastic/integrations/issues/8575.

