### PR TITLE
Update input-aws-s3.asciidoc

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -199,11 +199,6 @@ into separate events.
 ]
 ----
 
-Note: When `expand_event_list_from_field` parameter is given in the config,
-aws-s3 input will assume the logs are in JSON format and decode them as JSON.
-Content type will not be checked. If a file has "application/json" content-type,
-`expand_event_list_from_field` becomes required to read the JSON file.
-
 [float]
 ==== `file_selectors`
 


### PR DESCRIPTION
A file is decoded as JSON only if it has "application/json" content-type (or if the input has `content_type: application/json` configured), independently of `expand_event_list_from_field` parameter.

And `expand_event_list_from_field` is not required to read JSON files if we don't want to expand a list.

