### PR TITLE
migrate xpack dockerlogbeat pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -34,7 +34,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "filebeat" || "$BUILDKITE_PIPELINE_SLUG" == 
   fi
 fi
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "beats-metricbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-libbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-packetbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-winlogbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-xpack-libbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-xpack-metricbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-xpack-packetbeat" ]]; then
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "beats-metricbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-libbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-packetbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-winlogbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-xpack-libbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-xpack-metricbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-xpack-packetbeat" || "$BUILDKITE_PIPELINE_SLUG" == "beats-xpack-dockerlogbeat"  ]]; then
   source .buildkite/scripts/setenv.sh
   if [[ "${BUILDKITE_COMMAND}" =~ ^buildkite-agent ]]; then
     echo "Skipped pre-command when running the Upload pipeline"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -41,6 +41,10 @@ winlogbeat_changeset=(
   "^winlogbeat/.*"
   )
 
+xpack_dockerlogbeat_changeset=(
+  "^x-pack/dockerlogbeat/.*"
+  )
+
 xpack_libbeat_changeset=(
   "^x-pack/libbeat/.*"
   )
@@ -100,6 +104,9 @@ case "${BUILDKITE_PIPELINE_SLUG}" in
     ;;
   "beats-winlogbeat")
     BEAT_CHANGESET_REFERENCE=${winlogbeat_changeset[@]}
+    ;;
+  "beats-xpack-dockerlogbeat")
+    BEAT_CHANGESET_REFERENCE=${xpack_dockerlogbeat_changeset[@]}
     ;;
   "beats-xpack-libbeat")
     BEAT_CHANGESET_REFERENCE=${xpack_libbeat_changeset[@]}
@@ -499,6 +506,11 @@ fi
 
 if are_paths_changed "${packaging_changeset[@]}" ; then
   export PACKAGING_CHANGES="true"
+fi
+
+if [[ "$BUILDKITE_STEP_KEY" == "xpack-winlogbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "xpack-metricbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "xpack-dockerlogbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "metricbeat-pipeline" ]]; then
+  # Set the MODULE env variable if possible, it should be defined before generating pipeline's steps. It is used in multiple pipelines.
+  defineModuleFromTheChangeSet "${BEATS_PROJECT_NAME}"
 fi
 
 check_and_set_beat_vars

--- a/.buildkite/scripts/generate_xpack_dockerlogbeat_pipeline.sh
+++ b/.buildkite/scripts/generate_xpack_dockerlogbeat_pipeline.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+source .buildkite/scripts/common.sh
+
+set -euo pipefail
+
+pipelineName="pipeline.xpack-dockerlogbeat-dynamic.yml"
+
+echo "Add the mandatory and extended tests without additional conditions into the pipeline"
+if are_conditions_met_mandatory_tests; then
+  cat > $pipelineName <<- YAML
+
+steps:
+
+  - group: "Mandatory Tests"
+    key: "mandatory-tests"
+    steps:
+      - label: ":linux: Ubuntu Unit Tests"
+        key: "mandatory-linux-unit-test"
+        command: "cd $BEATS_PROJECT_NAME && mage build unitTest"
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.xml"
+
+      - label: ":go: Go Integration Tests"
+        key: "mandatory-int-test"
+        command: "cd $BEATS_PROJECT_NAME && mage goIntegTest"
+        env:
+          MODULE: $MODULE
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.xml"
+
+YAML
+fi
+
+echo "Check and add the Packaging into the pipeline"
+if are_conditions_met_packaging; then
+  cat >> $pipelineName <<- YAML
+
+  - wait: ~
+    depends_on:
+      - step: "mandatory-tests"
+        allow_failure: false
+
+  - group: "Packaging"    # TODO: check conditions for future the main pipeline migration: https://github.com/elastic/beats/pull/28589
+    key: "packaging"
+    steps:
+      - label: ":linux: Packaging Linux"
+        key: "packaging-linux"
+        command: "cd $BEATS_PROJECT_NAME && mage package"
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          disk_size: 100
+          disk_type: "pd-ssd"
+        env:
+          PLATFORMS: "${PACKAGING_PLATFORMS}"
+
+      - label: ":linux: Packaging ARM"
+        key: "packaging-arm"
+        command: "cd $BEATS_PROJECT_NAME && mage package"
+        agents:
+          provider: "aws"
+          imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        env:
+          PLATFORMS: "${PACKAGING_ARM_PLATFORMS}"
+          PACKAGES: "docker"
+
+YAML
+fi
+
+echo "--- Printing dynamic steps"     #TODO: remove if the pipeline is public
+cat $pipelineName
+
+echo "--- Loading dynamic steps"
+buildkite-agent pipeline upload $pipelineName

--- a/.buildkite/scripts/setenv.sh
+++ b/.buildkite/scripts/setenv.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source .buildkite/scripts/common.sh
+
 set -euo pipefail
 REPO="beats"
 TMP_FOLDER="tmp.${REPO}"
@@ -62,4 +64,9 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "beats-metricbeat" || "$BUILDKITE_PIPELINE_S
   export TEST_COVERAGE="true"
   export DOCKER_PULL="0"
   export TEST_TAGS="${TEST_TAGS:+$TEST_TAGS,}oracle"
+fi
+
+if [[ "$BUILDKITE_STEP_KEY" == "xpack-winlogbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "xpack-metricbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "xpack-dockerlogbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "metricbeat-pipeline" ]]; then
+  # Set the MODULE env variable if possible, it should be defined before generating pipeline's steps. It is used in multiple pipelines.
+  defineModuleFromTheChangeSet "${BEATS_PROJECT_NAME}"
 fi

--- a/.buildkite/scripts/setenv.sh
+++ b/.buildkite/scripts/setenv.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-source .buildkite/scripts/common.sh
-
 set -euo pipefail
 REPO="beats"
 TMP_FOLDER="tmp.${REPO}"
@@ -68,5 +66,6 @@ fi
 
 if [[ "$BUILDKITE_STEP_KEY" == "xpack-winlogbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "xpack-metricbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "xpack-dockerlogbeat-pipeline" || "$BUILDKITE_STEP_KEY" == "metricbeat-pipeline" ]]; then
   # Set the MODULE env variable if possible, it should be defined before generating pipeline's steps. It is used in multiple pipelines.
+  source .buildkite/scripts/common.sh
   defineModuleFromTheChangeSet "${BEATS_PROJECT_NAME}"
 fi

--- a/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
@@ -1,6 +1,37 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 name: "beats-xpack-dockerlogbeat"
 
+env:
+  IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
+  DEFAULT_UBUNTU_X86_64_IMAGE: "family/core-ubuntu-2204"
+  IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64"
+  GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
+  GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
+  BEATS_PROJECT_NAME: "x-pack/dockerlogbeat"
+
 steps:
-  - label: "Example test"
-    command: echo "Hello!"
+
+  - input: "Input Parameters"
+    key: "force-run-stages"
+    fields:
+    - select: "Dockerlogbeat - run_xpack_dockerlogbeat"
+      key: "run_xpack_dockerlogbeat"
+      options:
+        - label: "True"
+          value: "true"
+        - label: "False"
+          value: "false"
+      default: "false"
+
+    if: "build.source == 'ui'"
+
+  - wait: ~
+    if: "build.source == 'ui'"
+    allow_dependency_failure: false
+
+  - label: ":linux: Load dynamic x-pack dockerlogbeat pipeline"
+    key: "dockerlogbeat-pipeline"
+    command: ".buildkite/scripts/generate_xpack_dockerlogbeat_pipeline.sh"
+    notify:
+      - github_commit_status:
+          context: "${BEATS_PROJECT_NAME}: Load dynamic pipeline's steps"

--- a/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
@@ -7,6 +7,7 @@ env:
   IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64"
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
+  AWS_ARM_INSTANCE_TYPE: "t4g.xlarge"
   BEATS_PROJECT_NAME: "x-pack/dockerlogbeat"
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
@@ -30,7 +30,7 @@ steps:
     allow_dependency_failure: false
 
   - label: ":linux: Load dynamic x-pack dockerlogbeat pipeline"
-    key: "dockerlogbeat-pipeline"
+    key: "xpack-dockerlogbeat-pipeline"
     command: ".buildkite/scripts/generate_xpack_dockerlogbeat_pipeline.sh"
     notify:
       - github_commit_status:


### PR DESCRIPTION
## What is the problem this PR solves?

Jenkins->Buildkite pipelines migration 

Migrate `x-pack dockerlogbeat` pipeline

Example of the pipeline:
https://buildkite.com/elastic/beats-xpack-dockerlogbeat/builds/94

## Related issues
https://github.com/elastic/ingest-dev/issues/1693
https://github.com/elastic/ingest-dev/issues/2993 - related to MODULE
