### PR TITLE
Fix docs build break from SSL module page

### DIFF
--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -101,6 +101,8 @@ metricbeat.modules:
   
   # Client certificate key file
   #ssl.key: "/etc/pki/client/cert.key"----
+----
+
 
 [float]
 === Metricsets

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -100,7 +100,7 @@ metricbeat.modules:
   #ssl.certificate: "/etc/pki/client/cert.crt"
   
   # Client certificate key file
-  #ssl.key: "/etc/pki/client/cert.key"----
+  #ssl.key: "/etc/pki/client/cert.key"
 ----
 
 

--- a/metricbeat/docs/modules/mysql.asciidoc
+++ b/metricbeat/docs/modules/mysql.asciidoc
@@ -98,11 +98,10 @@ metricbeat.modules:
 
   # Certificate for SSL/TLS client authentication
   #ssl.certificate: "/etc/pki/client/cert.crt"
-  
+
   # Client certificate key file
   #ssl.key: "/etc/pki/client/cert.key"
 ----
-
 
 [float]
 === Metricsets

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -772,9 +772,10 @@ metricbeat.modules:
 
   # Certificate for SSL/TLS client authentication
   #ssl.certificate: "/etc/pki/client/cert.crt"
-  
+
   # Client certificate key file
   #ssl.key: "/etc/pki/client/cert.key"
+
 #--------------------------------- NATS Module ---------------------------------
 - module: nats
   metricsets:

--- a/metricbeat/module/mysql/_meta/config.reference.yml
+++ b/metricbeat/module/mysql/_meta/config.reference.yml
@@ -30,6 +30,6 @@
 
   # Certificate for SSL/TLS client authentication
   #ssl.certificate: "/etc/pki/client/cert.crt"
-  
+
   # Client certificate key file
   #ssl.key: "/etc/pki/client/cert.key"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1180,9 +1180,10 @@ metricbeat.modules:
 
   # Certificate for SSL/TLS client authentication
   #ssl.certificate: "/etc/pki/client/cert.crt"
-  
+
   # Client certificate key file
   #ssl.key: "/etc/pki/client/cert.key"
+
 #--------------------------------- NATS Module ---------------------------------
 - module: nats
   metricsets:


### PR DESCRIPTION
This hopefully will fix several docs build errors due to an unterminated block in [metricbeat/docs/modules/mysql.asciidoc](https://github.com/elastic/beats/pull/37997/files#diff-664b0a2cdf45536df5e40ecb0df5e1ccbe646c8586f02d98a3eaf7463985bce0)