### PR TITLE
Make log messages in the file scanner less noisy

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -181,6 +181,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Elide retryable HTTP client construction in Filebeat HTTPJSON and CEL inputs if not needed. {pull}36916[36916]
 - Allow assignment of packetbeat protocols to interfaces. {issue}36574[36564] {pull}36852[36852]
 - Add Active Directory entity collector for Filebeat entity analytics. {pull}37854[37854]
+- Make logs for empty and small files less noisy when using fingerprint file identity in filestream. {pull}38421[38421]
 
 ==== Deprecated
 

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -20,6 +20,7 @@ package filestream
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -43,6 +44,10 @@ const (
 	DefaultFingerprintSize int64 = 1024 // 1KB
 	scannerDebugKey              = "scanner"
 	watcherDebugKey              = "file_watcher"
+)
+
+var (
+	errFileTooSmall = errors.New("file size is too small for ingestion")
 )
 
 type fileWatcherConfig struct {
@@ -202,7 +207,7 @@ func (w *fileWatcher) watch(ctx unison.Canceler) {
 	for path, fd := range newFilesByName {
 		// no need to react on empty new files
 		if fd.Info.Size() == 0 {
-			w.log.Warnf("file %q has no content yet, skipping", fd.Filename)
+			w.log.Debugf("file %q has no content yet, skipping", fd.Filename)
 			delete(paths, path)
 			continue
 		}
@@ -385,6 +390,10 @@ func (s *fileScanner) GetFiles() map[string]loginp.FileDescriptor {
 			}
 
 			fd, err := s.toFileDescriptor(&it)
+			if errors.Is(err, errFileTooSmall) {
+				s.log.Debugf("cannot start ingesting from file %q: %s", filename, err)
+				continue
+			}
 			if err != nil {
 				s.log.Warnf("cannot create a file descriptor for an ingest target %q: %s", filename, err)
 				continue
@@ -473,7 +482,7 @@ func (s *fileScanner) toFileDescriptor(it *ingestTarget) (fd loginp.FileDescript
 		// we should not open the file if we know it's too small
 		minSize := s.cfg.Fingerprint.Offset + s.cfg.Fingerprint.Length
 		if fileSize < minSize {
-			return fd, fmt.Errorf("filesize of %q is %d bytes, expected at least %d bytes for fingerprinting", fd.Filename, fileSize, minSize)
+			return fd, fmt.Errorf("filesize of %q is %d bytes, expected at least %d bytes for fingerprinting: %w", fd.Filename, fileSize, minSize, errFileTooSmall)
 		}
 
 		file, err := os.Open(it.originalFilename)

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -276,17 +276,20 @@ scanner:
 		err := os.WriteFile(filename, nil, 0777)
 		require.NoError(t, err)
 
-		t.Run("issues a warning in logs", func(t *testing.T) {
-			var lastWarning string
+		t.Run("issues a debug message in logs", func(t *testing.T) {
 			expLogMsg := fmt.Sprintf("file %q has no content yet, skipping", filename)
 			require.Eventually(t, func() bool {
-				logs := logp.ObserverLogs().FilterLevelExact(logp.WarnLevel.ZapLevel()).TakeAll()
+				logs := logp.ObserverLogs().FilterLevelExact(logp.DebugLevel.ZapLevel()).TakeAll()
 				if len(logs) == 0 {
 					return false
 				}
-				lastWarning = logs[len(logs)-1].Message
-				return strings.Contains(lastWarning, expLogMsg)
-			}, 100*time.Millisecond, 10*time.Millisecond, "required a warning message %q but got %q", expLogMsg, lastWarning)
+				for _, l := range logs {
+					if strings.Contains(l.Message, expLogMsg) {
+						return true
+					}
+				}
+				return false
+			}, 100*time.Millisecond, 10*time.Millisecond, "required a debug message %q but never found", expLogMsg)
 		})
 
 		t.Run("emits a create event once something is written to the empty file", func(t *testing.T) {
@@ -796,6 +799,25 @@ scanner:
 			requireEqualFiles(t, tc.expDesc, s.GetFiles())
 		})
 	}
+
+	t.Run("does not issue warnings when file is too small", func(t *testing.T) {
+		cfgStr := `
+scanner:
+  fingerprint:
+    enabled: true
+    offset: 0
+    length: 1024
+`
+		logp.DevelopmentSetup(logp.ToObserverOutput())
+
+		// this file is 128 bytes long
+		paths := []string{filepath.Join(dir, undersizedBasename)}
+		s := createScannerWithConfig(t, paths, cfgStr)
+		files := s.GetFiles()
+		require.Empty(t, files)
+		logs := logp.ObserverLogs().FilterLevelExact(logp.WarnLevel.ZapLevel()).TakeAll()
+		require.Empty(t, logs, "there must be no warning logs for files too small")
+	})
 
 	t.Run("returns error when creating scanner with a fingerprint too small", func(t *testing.T) {
 		cfgStr := `


### PR DESCRIPTION
* Demote warning about empty files to the Debug level
* Demote warnings about files too small to the Debug level
* Improve wording, so it does not sound like an error

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
```sh
cd ./filebeat/input/filestream
go test
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/pull/36076
- Relates https://github.com/elastic/beats/pull/35734