### PR TITLE
auditbeat - skip TestExeObjParser on CI

### DIFF
--- a/auditbeat/module/file_integrity/exeobjparser_test.go
+++ b/auditbeat/module/file_integrity/exeobjparser_test.go
@@ -19,8 +19,11 @@
 package file_integrity
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"math"
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -42,6 +45,12 @@ func TestExeObjParser(t *testing.T) {
 			t.Run(fmt.Sprintf("executableObject_%s_%s", format, builder), func(t *testing.T) {
 				if builder == "garble" && format == "pe" {
 					t.Skip("skipping test on garbled PE file: see https://github.com/elastic/beats/issues/35705")
+				}
+
+				if _, ci := os.LookupEnv("CI"); ci {
+					if _, err := os.Stat(target); err != nil && errors.Is(fs.ErrNotExist, err) {
+						t.Skip("skipping test because target binary was not found: see https://github.com/elastic/beats/issues/38211")
+					}
 				}
 
 				got := make(mapstr.M)


### PR DESCRIPTION
## Proposed commit message

TestExeObjParser fails on Windows because Defender is removing the testdata that is required by the test. This adds a conditional test skip for CI when those files are missing.

Closes #38211

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

