### PR TITLE
Fix Filestream store GC, entries are now removed when they TTL expires

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -98,7 +98,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Rename `activity_guid` to `activity_id` in ETW input events to suit other Windows inputs. {pull}38530[38530]
 - Add missing provider registration and fix published entity for Active Directory entityanalytics provider. {pull}38645[38645]
 - Fix handling of un-parsed JSON in O365 module. {issue}37800[37800] {pull}38709[38709]
-- Fix `clean_removed` on Filestream input. {issue}36761[36761] {pull}38488[38488]
 - Fix filestream's registry GC: registry entries are now removed from the in-memory and disk store when they're older than the set TTL {issue}36761[36761] {pull}38488[38488]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,6 +99,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add missing provider registration and fix published entity for Active Directory entityanalytics provider. {pull}38645[38645]
 - Fix handling of un-parsed JSON in O365 module. {issue}37800[37800] {pull}38709[38709]
 - Fix `clean_removed` on Filestream input. {issue}36761[36761] {pull}38488[38488]
+- Fix filestream's registry GC: registry entries are now removed from the in-memory and disk store when they're older than the set TTL {issue}36761[36761] {pull}38488[38488]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -98,6 +98,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Rename `activity_guid` to `activity_id` in ETW input events to suit other Windows inputs. {pull}38530[38530]
 - Add missing provider registration and fix published entity for Active Directory entityanalytics provider. {pull}38645[38645]
 - Fix handling of un-parsed JSON in O365 module. {issue}37800[37800] {pull}38709[38709]
+- Fix `clean_removed` on Filestream input. {issue}36761[36761] {pull}38488[38488]
 
 *Heartbeat*
 

--- a/filebeat/input/filestream/internal/input-logfile/clean.go
+++ b/filebeat/input/filestream/internal/input-logfile/clean.go
@@ -79,6 +79,10 @@ func gcStore(log *logp.Logger, started time.Time, store *store) {
 	if err := gcClean(store, keys); err != nil {
 		log.Errorf("Failed to remove all entries from the registry: %+v", err)
 	}
+
+	// The main reason for this log entry is to enable tests that want to observe
+	// if the resources are correctly removed from the store.
+	log.Debugf("%d entries removed", len(keys))
 }
 
 // gcFind searches the store of resources that can be removed. A set of keys to delete is returned.

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -335,6 +335,7 @@ func (s *store) updateMetadata(key string, meta interface{}) error {
 	resource.cursorMeta = meta
 
 	s.writeState(resource)
+	resource.Release()
 	return nil
 }
 
@@ -384,6 +385,7 @@ func (s *store) remove(key string) error {
 		return fmt.Errorf("resource '%s' not found", key)
 	}
 	s.UpdateTTL(resource, 0)
+	resource.Release()
 	return nil
 }
 

--- a/filebeat/tests/integration/store_test.go
+++ b/filebeat/tests/integration/store_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package integration
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+)
+
+var testStoreCfg = `
+filebeat.inputs:
+  - type: filestream
+    id: test-clean-removed
+    enabled: true
+    clean_removed: true
+    close.on_state_change.inactive: 8s
+    ignore_older: 9s
+    prospector.scanner.check_interval: 1s
+    paths:
+      - %s
+
+filebeat.registry:
+  cleanup_interval: 5s
+  flush: 1s
+
+queue.mem:
+  flush.min_events: 8
+  flush.timeout: 0.1s
+
+path.home: %s
+
+output.file:
+  path: ${path.home}
+  filename: "output-file"
+  rotate_every_kb: 10000
+
+logging:
+  level: debug
+  selectors:
+    - input
+    - input.filestream
+`
+
+func TestStore(t *testing.T) {
+	numLogFiles := 10
+	filebeat := integration.NewBeat(
+		t,
+		"filebeat",
+		"../../filebeat.test",
+	)
+	tempDir := filebeat.TempDir()
+
+	// 1. Create some log files and write data to them
+	logsFolder := filepath.Join(tempDir, "logs")
+	if err := os.MkdirAll(logsFolder, 0755); err != nil {
+		t.Fatalf("could not create logs folder '%s': %s", logsFolder, err)
+	}
+
+	logFiles := []string{}
+	for i := 0; i < numLogFiles; i++ {
+		logFile := path.Join(logsFolder, fmt.Sprintf("log-%d.log", i))
+		logFiles = append(logFiles, logFile)
+		integration.GenerateLogFile(t, logFile, 10, false)
+	}
+	logsFolderGlob := filepath.Join(logsFolder, "*")
+	filebeat.WriteConfigFile(fmt.Sprintf(testStoreCfg, logsFolderGlob, tempDir))
+
+	// 2. Ingest the file and stop Filebeat
+	filebeat.Start()
+
+	for i := 0; i < numLogFiles; i++ {
+		// Files can be ingested out of order, so we cannot specify their path.
+		// There will be more than one log line per file, but that at least gives us
+		// some assurance the files were read
+		filebeat.WaitForLogs("Closing reader of filestream", 30*time.Second, "Filebeat did not finish reading the log file")
+	}
+
+	// 3. Remove files so their state can be cleaned
+	if err := os.RemoveAll(logsFolder); err != nil {
+		t.Fatalf("could not remove logs folder '%s': %s", logsFolder, err)
+	}
+	filebeat.WaitForLogs(fmt.Sprintf("%d entries removed", numLogFiles), 30*time.Second, "store entries not removed")
+	filebeat.Stop()
+
+	registryLogFile := filepath.Join(tempDir, "data/registry/filebeat/log.json")
+	readFilestreamRegistryLog(t, registryLogFile, "remove", 10)
+}
+
+func readFilestreamRegistryLog(t *testing.T, path, op string, expectedCount int) {
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("could not open file '%s': %s", path, err)
+	}
+
+	s := bufio.NewScanner(file)
+	count := 0
+	for s.Scan() {
+		line := s.Bytes()
+
+		registryOp := struct {
+			Op string `json:"op"`
+			ID int    `json:"id"`
+		}{}
+
+		if err := json.Unmarshal(line, &registryOp); err != nil {
+			t.Fatalf("could not read line '%s': %s", string(line), err)
+		}
+
+		// Skips registry log entries that are not operation count
+		if registryOp.Op == "" {
+			continue
+		}
+
+		if registryOp.Op == op {
+			count++
+		}
+	}
+
+	if count != expectedCount {
+		t.Errorf("expecting %d '%s' operations, got %d instead", expectedCount, op, count)
+	}
+}

--- a/filebeat/tests/integration/store_test.go
+++ b/filebeat/tests/integration/store_test.go
@@ -81,10 +81,8 @@ func TestStore(t *testing.T) {
 		t.Fatalf("could not create logs folder '%s': %s", logsFolder, err)
 	}
 
-	logFiles := []string{}
 	for i := 0; i < numLogFiles; i++ {
 		logFile := path.Join(logsFolder, fmt.Sprintf("log-%d.log", i))
-		logFiles = append(logFiles, logFile)
 		integration.GenerateLogFile(t, logFile, 10, false)
 	}
 	logsFolderGlob := filepath.Join(logsFolder, "*")

--- a/filebeat/tests/integration/store_test.go
+++ b/filebeat/tests/integration/store_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 //go:build integration
 
 package integration

--- a/libbeat/tests/integration/framework.go
+++ b/libbeat/tests/integration/framework.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -525,7 +524,7 @@ func (b *BeatProc) LoadMeta() (Meta, error) {
 	}
 	defer metaFile.Close()
 
-	metaBytes, err := ioutil.ReadAll(metaFile)
+	metaBytes, err := io.ReadAll(metaFile)
 	require.NoError(b.t, err, "error reading meta file")
 	err = json.Unmarshal(metaBytes, &m)
 	require.NoError(b.t, err, "error unmarshalling meta data")


### PR DESCRIPTION
## Proposed commit message

The `resources` from Filestream registry have a counter to indicate how many 'owners' have got a hold of that resource, this counter was not correctly decremented. Because it never reached zero, no entry was ever removed from the in-memory store and even though the store GC would run periodically, no resource could be removed. That caused the in-memory store to be ever growing and the `op: remove` never to be seen in the registry log file.

This commit fixes this bug by correctly calling `Released` in every resource that is retained.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally
### 1. Create the following configuration file
```yaml
filebeat.inputs:
  - type: filestream
    id: "PR-38488"
    paths:
      - /tmp/logs/*.log
    
    clean_removed: true
    close.on_state_change.inactive: 1s
    prospector.scanner.check_interval: 1s

filebeat:
  registry:
    cleanup_interval: 5s

output:
  file:
    enabled: true
    codec.json:
      pretty: false
    path: ${path.home}
    filename: "output"
    rotate_on_startup: false

queue.mem:
  flush:
    timeout: 1s
    min_events: 32

filebeat.registry.flush: 1s

logging:
  level: debug
  selectors:
    - input
    - input.filestream
  metrics:
    enabled: false
```

### 2. Build and start Filebeat
```
cd filebeat
go build .
./filebeat -e
```

### 3. Create a log file and add some data
```
mkdir -p /tmp/logs
echo "fist file">> /tmp/log.log
```

### 4. Wait a few seconds until the file is harvested
You can check the output file or look the logs for the logs stating the harvester has been closed
```
{"log.level":"debug","@timestamp":"2024-03-22T14:18:35.465+0100","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*logFile).Read","file.name":"filestream/filestream.go","file.line":131},"message":"End of file reached: /tmp/logs/log.log; Backoff now.","service.name":"filebeat","id":"PR-38488","source_file":"filestream::PR-38488::native::142572-34","path":"/tmp/logs/log.log","state-id":"native::142572-34","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-03-22T14:18:39.465+0100","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*filestream).readFromSource","file.name":"filestream/input.go","file.line":336},"message":"Reader was closed. Closing. Path='/tmp/logs/log.log'","service.name":"filebeat","id":"PR-38488","source_file":"filestream::PR-38488::native::142572-34","path":"/tmp/logs/log.log","state-id":"native::142572-34","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-03-22T14:18:39.465+0100","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.startHarvester.func1","file.name":"input-logfile/harvester.go","file.line":247},"message":"Stopped harvester for file","service.name":"filebeat","id":"PR-38488","source_file":"filestream::PR-38488::native::142572-34","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-03-22T14:18:39.465+0100","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*filestream).Run.func1","file.name":"filestream/input.go","file.line":151},"message":"Closing reader of filestream","service.name":"filebeat","id":"PR-38488","source_file":"filestream::PR-38488::native::142572-34","path":"/tmp/logs/log.log","state-id":"native::142572-34","ecs.version":"1.6.0"}
```
### 5. Delete the file
```
rm /tmp/logs/log.log
```

### 6. Wait for the store cleanup logs
```
{"log.level":"debug","@timestamp":"2024-03-22T14:20:00.464+0100","log.logger":"input","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.gcStore","file.name":"input-logfile/clean.go","file.line":67},"message":"Start store cleanup","service.name":"filebeat","input_type":"filestream","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-03-22T14:20:00.464+0100","log.logger":"input","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.gcStore","file.name":"input-logfile/clean.go","file.line":86},"message":"1 entries removed","service.name":"filebeat","input_type":"filestream","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-03-22T14:20:00.464+0100","log.logger":"input","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.gcStore","file.name":"input-logfile/clean.go","file.line":87},"message":"Done store cleanup","service.name":"filebeat","input_type":"filestream","ecs.version":"1.6.0"}
```

### 7. Assert that the entry has also been removed from the registy
You should be able to find the following lines in the registry:
```
{"op":"set","id":4}
{"k":"filestream::PR-38488::native::142572-34","v":{"ttl":0,"updated":[258163407648,1711113513],"cursor":{"offset":11},"meta":{"source":"/tmp/logs/log.log","identifier_name":"native"}}}
{"op":"remove","id":5}
{"k":"filestream::PR-38488::native::142572-34"}
```

* The `set` operation is setting `ttl:0`. That is how the entry is "removed" from the registry
* The `remove` operation removes any reference to that state and also removes all in-memory references to the [`resource`](https://github.com/elastic/beats/blob/62235efd7aa2ea74031981962580cac1dbf48977/filebeat/input/filestream/internal/input-logfile/store.go#L74-L115) pointing to this file.

## Related issues

- Closes https://github.com/elastic/beats/issues/36761
- Closes https://github.com/elastic/beats/issues/36056

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
