### PR TITLE
x-pack/filebeat/input/etw: Rename activity_guid to activity_id in ETW events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -104,7 +104,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 - Fix HTTPJSON handling of empty object bodies in POST requests. {issue}33961[33961] {pull}38290[38290]
 - Fix PEM key validation for CEL and HTTPJSON inputs. {pull}38405[38405]
 - Fix filebeat gcs input panic {pull}38407[38407]
-- Rename `activity_guid` to `activity_id` in ETW input events. {pull}38530[38530]
+- Rename `activity_guid` to `activity_id` in ETW input events to suit other Windows inputs. {pull}38530[38530]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -104,6 +104,7 @@ fields added to events containing the Beats version. {pull}37553[37553]
 - Fix HTTPJSON handling of empty object bodies in POST requests. {issue}33961[33961] {pull}38290[38290]
 - Fix PEM key validation for CEL and HTTPJSON inputs. {pull}38405[38405]
 - Fix filebeat gcs input panic {pull}38407[38407]
+- Rename `activity_guid` to `activity_id` in ETW input events. {pull}38530[38530]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-etw.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-etw.asciidoc
@@ -99,7 +99,7 @@ Multiple providers example:
   provider.name: Microsoft-Windows-DNSServer
   session_name: DNSServer-Analytical
   trace_level: verbose
-  match_any_keyword: 0xfffffffffffffffff
+  match_any_keyword: 0xffffffffffffffff
   match_all_keyword: 0
 - type: etw
   id: etw-security
@@ -107,7 +107,7 @@ Multiple providers example:
   provider.name: Microsoft-Windows-Security-Auditing
   session_name: Security-Auditing
   trace_level: warning
-  match_any_keyword: 0xffffffffffffffff
+  match_any_keyword: 0xfffffffffffffff
   match_all_keyword: 0
 ----
 
@@ -145,14 +145,14 @@ using the provider ID prefixed by 'Elastic-'.
 ==== `trace_level`
 
 Defines the filtering level for events based on severity. Valid options include
-critical, error, warning, informational, and verbose.
+critical, error, warning, information, and verbose.
 
 [float]
 ==== `match_any_keyword`
 
 An 8-byte bitmask used for filtering events from specific provider subcomponents
 based on keyword matching. Any matching keyword will enable the event to be
-written. Default value is `0xfffffffffffffffff` so it matches every available
+written. Default value is `0xffffffffffffffff` so it matches every available
 keyword.
 
 Run `logman query providers "<provider.name>"` to list the available keywords

--- a/x-pack/filebeat/input/etw/config.go
+++ b/x-pack/filebeat/input/etw/config.go
@@ -35,7 +35,7 @@ type config struct {
 	SessionName string `config:"session_name"`
 	// TraceLevel filters all provider events with a level value
 	// that is less than or equal to this level.
-	// Allowed values are critical, error, warning, informational, and verbose.
+	// Allowed values are critical, error, warning, information, and verbose.
 	TraceLevel string `config:"trace_level"`
 	// MatchAnyKeyword is an 8-byte bitmask that enables the filtering of
 	// events from specific provider subcomponents. The provider will write

--- a/x-pack/filebeat/input/etw/input.go
+++ b/x-pack/filebeat/input/etw/input.go
@@ -182,7 +182,7 @@ var (
 // buildEvent builds the final beat.Event emitted by this input.
 func buildEvent(data map[string]any, h etw.EventHeader, session *etw.Session, cfg config) beat.Event {
 	winlog := map[string]any{
-		"activity_guid": h.ActivityId.String(),
+		"activity_id":   h.ActivityId.String(),
 		"channel":       strconv.FormatUint(uint64(h.EventDescriptor.Channel), 10),
 		"event_data":    data,
 		"flags":         strconv.FormatUint(uint64(h.Flags), 10),

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -367,8 +367,8 @@ func Test_buildEvent(t *testing.T) {
 
 			expected: mapstr.M{
 				"winlog": map[string]any{
-					"activity_guid": "{12345678-1234-1234-1234-123456789ABC}",
-					"channel":       "10",
+					"activity_id": "{12345678-1234-1234-1234-123456789ABC}",
+					"channel":     "10",
 					"event_data": map[string]any{
 						"key": "value",
 					},
@@ -435,8 +435,8 @@ func Test_buildEvent(t *testing.T) {
 
 			expected: mapstr.M{
 				"winlog": map[string]any{
-					"activity_guid": "{12345678-1234-1234-1234-123456789ABC}",
-					"channel":       "10",
+					"activity_id": "{12345678-1234-1234-1234-123456789ABC}",
+					"channel":     "10",
 					"event_data": map[string]any{
 						"key": "value",
 					},
@@ -461,7 +461,7 @@ func Test_buildEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			evt := buildEvent(tt.data, tt.header, tt.session, tt.cfg)
-			assert.Equal(t, tt.expected["winlog"].(map[string]any)["activity_guid"], evt.Fields["winlog"].(map[string]any)["activity_guid"])
+			assert.Equal(t, tt.expected["winlog"].(map[string]any)["activity_id"], evt.Fields["winlog"].(map[string]any)["activity_id"])
 			assert.Equal(t, tt.expected["winlog"].(map[string]any)["channel"], evt.Fields["winlog"].(map[string]any)["channel"])
 			assert.Equal(t, tt.expected["winlog"].(map[string]any)["event_data"], evt.Fields["winlog"].(map[string]any)["event_data"])
 			assert.Equal(t, tt.expected["winlog"].(map[string]any)["flags"], evt.Fields["winlog"].(map[string]any)["flags"])


### PR DESCRIPTION
## Proposed commit message

Rename `activity_guid` to `activity_id` in generated ETW events to match [mapping](https://github.com/elastic/beats/blob/c91eaeecc669cfa12df0292f26da855b638d3da6/x-pack/filebeat/input/etw/_meta/fields.yml#L13) and other [Windows inputs](https://github.com/elastic/beats/blob/c91eaeecc669cfa12df0292f26da855b638d3da6/winlogbeat/_meta/fields.common.yml#L33).

It also fixes some typos in the ETW docs and comments.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
