### PR TITLE
[8.13](backport #38484) Filebeat sync the groups/stages/steps testing from Jenkins

### DIFF
--- a/filebeat/buildkite.yml
+++ b/filebeat/buildkite.yml
@@ -1,53 +1,60 @@
 when:
-    changeset: ## when PR contains any of those entries in the changeset
-        - "filebeat/**"
-        - "@ci" ## special token regarding the changeset for the ci
-        - "@oss" ## special token regarding the changeset for the oss
+  branches: true             ## for all the branches
+  changeset: ## when PR contains any of those entries in the changeset
+    - "filebeat/**"
+    - "@ci" ## special token regarding the changeset for the ci
+    - "@oss" ## special token regarding the changeset for the oss
 stages:
-    # default stage - it runs always for:
-    #   - branches/tags
-    #   - on PRs
-    #   - GitHub comment /test filebeat
-    #   - GitHub label filebeat
-    mandatory:
-        # NOTE: stage name should be unique!
-        unitTest:
-            command: "mage unitTest"
-            platform: "family/platform-ingest-beats-ubuntu-2204"
-        crosscompile:
-            command: "make crosscompile"
-            platform: "family/platform-ingest-beats-ubuntu-2204"
-            env:
-              GOX_FLAGS: "-arch amd64"
-        goIntegTest:
-            command: "mage goIntegTest"
-            platform: "family/platform-ingest-beats-ubuntu-2204"
-        pythonIntegTest:
-            command: "mage pythonIntegTest"
-            platform: "family/platform-ingest-beats-ubuntu-2204"
-        rhel-9:
-            command: "mage unitTest"
-            platform: "family/platform-ingest-beats-rhel-9"
-        unitTest-windows-2022:
-            command: "mage build unitTest"
-            platform: "family/platform-ingest-beats-windows-2022"
-        unitTest-windows-2016:
-            command: "mage build unitTest"
-            platform: "family/platform-ingest-beats-windows-2016"
-    # optional stage - it runs on:
-    #   - branches/tags
-    #   - on PRs if:
-    #       - GitHub comment /test filebeat <sub-stage-name> . i.e: /test filebeat integTest
-    #       - GitHub label <sub-stage-name> . i.e: integTest or unitTest-arm or unitTest-macos ...
-    extended:
-        unitTest-arm:
-            command: ".buildkite/filebeat/scripts/unit-tests.sh"
-            platform: "platform-ingest-beats-ubuntu-2204-aarch64"
-            provider: "aws"
-        unitTest-macos:
-            command: ".buildkite/filebeat/scripts/unit-tests.sh"
-            platform: "generic-13-ventura-x64"
-            provider: "orka"
-        unitTest-windows-2019:
-            command: ".buildkite/filebeat/scripts/unit-tests-win.ps1"
-            platform: "family/platform-ingest-beats-windows-2019"
+  mandatory:
+    unitTest:
+      command: "mage unitTest"
+      platform: "family/platform-ingest-beats-ubuntu-2204"
+    goIntegTest:
+      command: "mage goIntegTest"
+      platform: "family/platform-ingest-beats-ubuntu-2204"
+    pythonIntegTest:
+      command: "mage pythonIntegTest"
+      platform: "family/platform-ingest-beats-ubuntu-2204"
+    unitTest-windows-2022:
+      command: "mage build unitTest"
+      platform: "family/platform-ingest-beats-windows-2022"
+    unitTest-windows-2016:
+      command: "mage build unitTest"
+      platform: "family/platform-ingest-beats-windows-2016"
+
+  extended_win:
+    unitTest-windows-2019:
+      command: "mage build unitTest"
+      platform: "family/platform-ingest-beats-windows-2019"
+    unitTest-windows-11:
+      command: "mage build unitTest"
+      platform: "family/platform-ingest-beats-windows-11"
+    unitTest-windows-10:
+      command: "mage build unitTest"
+      platform: "family/platform-ingest-beats-windows-10"
+  extended:
+    unitTest-arm:
+      command: "mage build unitTest"
+      platform: "platform-ingest-beats-ubuntu-2204-aarch64"
+      provider: "aws" # move this inside the platform leaf
+      when:
+        comments:
+          - "/test filebeat for arm"
+        labels:
+          - "arm"
+        parameters:
+          - "armTest"
+        branches: true     ## for all the branches
+        tags: true         ## for all the tags
+    unitTest-macos:
+      command: ".buildkite/filebeat/scripts/unit-tests.sh"
+      platform: "generic-13-ventura-x64"
+      provider: "orka"
+      when:
+        comments:
+          - "/test filebeat for macos"
+        labels:
+          - "macOS"
+        parameters:
+          - "macosTest"
+        tags: true         ## for all the tags


### PR DESCRIPTION
Proposed commit message
This PR adds the missing steps and make sure its similar with the ones from the Jenkinsfile.yaml

This is part of the Buildkite migration.

Related issues
Related:https://github.com/elastic/ingest-dev/issues/2992

--- 
this is a backport PR