### PR TITLE
Fix panic when more than 32767 pipeline clients are active

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -66,6 +66,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Rename `queue.Batch.ACK()` to `queue.Batch.Done()`. {pull}31903[31903]
 - `queue.ACKListener` has been removed. Queue configurations now accept an explicit callback function for ACK handling. {pull}35078[35078]
 - Split split httpmon out of x-pack/filebeat/input/internal/httplog. {pull}36385[36385]
+- Beats publishing pipeline does not propagate the close signal to its clients any more. It's responsibility of the user to close the pipeline client. {issue}38197[38197] {pull}38556[38556]
 
 ==== Bugfixes
 
@@ -93,6 +94,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Make winlogbeat/sys/wineventlog follow the unsafe.Pointer rules. {pull}36650[36650]
 - Cleaned up documentation errors & fixed a minor bug in Filebeat Azure blob storage input. {pull}36714[36714]
 - Fix copy arguments for strict aligned architectures. {pull}36976[36976]
+- Fix panic when more than 32767 pipeline clients are active. {issue}38197[38197] {pull}38556[38556]
 
 ==== Added
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -101,6 +101,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix filestream's registry GC: registry entries are now removed from the in-memory and disk store when they're older than the set TTL {issue}36761[36761] {pull}38488[38488]
 - Fix indexing failures by re-enabling event normalisation in netflow input. {issue}38703[38703] {pull}38780[38780]
 - Fix handling of truncated files in Filestream {issue}38070[38070] {pull}38416[38416]
+- Fix panic when more than 32767 pipeline clients are active. {issue}38197[38197] {pull}38556[38556]
 
 *Heartbeat*
 

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -219,7 +219,7 @@ func startHarvester(
 		defer releaseResource(resource)
 
 		client, err := hg.pipeline.ConnectWith(beat.ClientConfig{
-			CloseRef:      ctx.Cancelation,
+			// CloseRef:      ctx.Cancelation,
 			EventListener: newInputACKHandler(hg.ackCH),
 		})
 		if err != nil {

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -219,7 +219,6 @@ func startHarvester(
 		defer releaseResource(resource)
 
 		client, err := hg.pipeline.ConnectWith(beat.ClientConfig{
-			// CloseRef:      ctx.Cancelation,
 			EventListener: newInputACKHandler(hg.ackCH),
 		})
 		if err != nil {

--- a/filebeat/input/kafka/input.go
+++ b/filebeat/input/kafka/input.go
@@ -120,12 +120,13 @@ func (input *kafkaInput) Run(ctx input.Context, pipeline beat.Pipeline) error {
 				}
 			}),
 		),
-		CloseRef:  ctx.Cancelation,
+		// CloseRef:  ctx.Cancelation,
 		WaitClose: input.config.WaitClose,
 	})
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	log.Info("Starting Kafka input")
 	defer log.Info("Kafka input stopped")

--- a/filebeat/input/kafka/input.go
+++ b/filebeat/input/kafka/input.go
@@ -120,7 +120,6 @@ func (input *kafkaInput) Run(ctx input.Context, pipeline beat.Pipeline) error {
 				}
 			}),
 		),
-		// CloseRef:  ctx.Cancelation,
 		WaitClose: input.config.WaitClose,
 	})
 	if err != nil {

--- a/filebeat/input/v2/input-cursor/input.go
+++ b/filebeat/input/v2/input-cursor/input.go
@@ -146,7 +146,6 @@ func (inp *managedInput) runSource(
 	}()
 
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		// CloseRef:      ctx.Cancelation,
 		EventListener: newInputACKHandler(ctx.Logger),
 	})
 	if err != nil {

--- a/filebeat/input/v2/input-cursor/input.go
+++ b/filebeat/input/v2/input-cursor/input.go
@@ -146,7 +146,7 @@ func (inp *managedInput) runSource(
 	}()
 
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		CloseRef:      ctx.Cancelation,
+		// CloseRef:      ctx.Cancelation,
 		EventListener: newInputACKHandler(ctx.Logger),
 	})
 	if err != nil {

--- a/filebeat/input/v2/input-stateless/stateless.go
+++ b/filebeat/input/v2/input-stateless/stateless.go
@@ -87,7 +87,7 @@ func (si configuredInput) Run(ctx v2.Context, pipeline beat.PipelineConnector) (
 		PublishMode: beat.DefaultGuarantees,
 
 		// configure pipeline to disconnect input on stop signal.
-		CloseRef: ctx.Cancelation,
+		// CloseRef: ctx.Cancelation,
 	})
 	if err != nil {
 		return err

--- a/filebeat/input/v2/input-stateless/stateless.go
+++ b/filebeat/input/v2/input-stateless/stateless.go
@@ -85,9 +85,6 @@ func (si configuredInput) Run(ctx v2.Context, pipeline beat.PipelineConnector) (
 
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
 		PublishMode: beat.DefaultGuarantees,
-
-		// configure pipeline to disconnect input on stop signal.
-		// CloseRef: ctx.Cancelation,
 	})
 	if err != nil {
 		return err

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -49,8 +49,6 @@ type ClientConfig struct {
 
 	Processing ProcessingConfig
 
-	CloseRef CloseRef
-
 	// WaitClose sets the maximum duration to wait on ACK, if client still has events
 	// active non-acknowledged events in the publisher pipeline.
 	// WaitClose is only effective if one of ACKCount, ACKEvents and ACKLastEvents
@@ -89,13 +87,6 @@ type EventListener interface {
 	// to suppress any ACK event propagation if required.
 	// Close might be called from another go-routine than AddEvent and ACKEvents.
 	ClientClosed()
-}
-
-// CloseRef allows users to close the client asynchronously.
-// A CloseRef implements a subset of function required for context.Context.
-type CloseRef interface {
-	Done() <-chan struct{}
-	Err() error
 }
 
 // ProcessingConfig provides additional event processing settings a client can

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -42,10 +42,8 @@ type client struct {
 	eventWaitGroup *sync.WaitGroup
 
 	// Open state, signaling, and sync primitives for coordinating client Close.
-	isOpen    atomic.Bool   // set to false during shutdown, such that no new events will be accepted anymore.
-	closeOnce sync.Once     // closeOnce ensure that the client shutdown sequence is only executed once
-	closeRef  beat.CloseRef // extern closeRef for sending a signal that the client should be closed.
-	// done      chan struct{} // the done channel will be closed if the closeReg gets closed, or Close is run.
+	isOpen    atomic.Bool // set to false during shutdown, such that no new events will be accepted anymore.
+	closeOnce sync.Once   // closeOnce ensure that the client shutdown sequence is only executed once
 
 	observer       observer
 	eventListener  beat.EventListener

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -135,10 +135,6 @@ func (c *client) Close() error {
 	// first stop ack handling. ACK handler might block on wait (with timeout), waiting
 	// for pending events to be ACKed.
 	c.closeOnce.Do(func() {
-		// This is not needed any more as the pipeline does not
-		// keep any list of clients
-		// close(c.done)
-
 		c.isOpen.Store(false)
 		c.onClosing()
 

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -45,7 +45,7 @@ type client struct {
 	isOpen    atomic.Bool   // set to false during shutdown, such that no new events will be accepted anymore.
 	closeOnce sync.Once     // closeOnce ensure that the client shutdown sequence is only executed once
 	closeRef  beat.CloseRef // extern closeRef for sending a signal that the client should be closed.
-	done      chan struct{} // the done channel will be closed if the closeReg gets closed, or Close is run.
+	// done      chan struct{} // the done channel will be closed if the closeReg gets closed, or Close is run.
 
 	observer       observer
 	eventListener  beat.EventListener
@@ -137,7 +137,9 @@ func (c *client) Close() error {
 	// first stop ack handling. ACK handler might block on wait (with timeout), waiting
 	// for pending events to be ACKed.
 	c.closeOnce.Do(func() {
-		close(c.done)
+		// This is not needed any more as the pipeline does not
+		// keep any list of clients
+		// close(c.done)
 
 		c.isOpen.Store(false)
 		c.onClosing()

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -18,7 +18,6 @@
 package pipeline
 
 import (
-	"context"
 	"errors"
 	"io"
 	"sync"
@@ -95,15 +94,7 @@ func TestClient(t *testing.T) {
 				pipeline := makePipeline(t, Settings{}, makeTestQueue())
 				defer pipeline.Close()
 
-				var ctx context.Context
-				var cancel func()
-				if test.context {
-					ctx, cancel = context.WithCancel(context.Background())
-				}
-
-				client, err := pipeline.ConnectWith(beat.ClientConfig{
-					CloseRef: ctx,
-				})
+				client, err := pipeline.ConnectWith(beat.ClientConfig{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -116,7 +107,9 @@ func TestClient(t *testing.T) {
 					client.Publish(beat.Event{})
 				}()
 
-				test.close(client, cancel)
+				test.close(client, func() {
+					client.Close()
+				})
 				wg.Wait()
 			})
 		}

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -236,8 +236,7 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	}
 
 	client := &client{
-		logger: p.monitors.Logger,
-		// closeRef:       cfg.CloseRef,
+		logger:         p.monitors.Logger,
 		isOpen:         atomic.MakeBool(true),
 		clientListener: cfg.ClientListener,
 		processors:     processors,

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -22,7 +22,6 @@ package pipeline
 
 import (
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -197,9 +196,6 @@ func (p *Pipeline) Close() error {
 	p.outputController.Close()
 
 	p.observer.cleanup()
-	if p.sigNewClient != nil {
-		close(p.sigNewClient)
-	}
 	return nil
 }
 
@@ -212,6 +208,8 @@ func (p *Pipeline) Connect() (beat.Client, error) {
 // The client behavior on close and ACK handling can be configured by setting
 // the appropriate fields in the passed ClientConfig.
 // If not set otherwise the defaut publish mode is OutputChooses.
+//
+// It is responsibility of the caller to close the client.
 func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	var (
 		canDrop    bool
@@ -238,9 +236,8 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	}
 
 	client := &client{
-		logger:         p.monitors.Logger,
-		closeRef:       cfg.CloseRef,
-		done:           make(chan struct{}),
+		logger: p.monitors.Logger,
+		// closeRef:       cfg.CloseRef,
 		isOpen:         atomic.MakeBool(true),
 		clientListener: cfg.ClientListener,
 		processors:     processors,
@@ -295,91 +292,7 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	}
 
 	p.observer.clientConnected()
-
-	if client.closeRef != nil {
-		p.registerSignalPropagation(client)
-	}
-
 	return client, nil
-}
-
-func (p *Pipeline) registerSignalPropagation(c *client) {
-	p.guardStartSigPropagation.Do(func() {
-		p.sigNewClient = make(chan *client, 1)
-		go p.runSignalPropagation()
-	})
-	p.sigNewClient <- c
-}
-
-func (p *Pipeline) runSignalPropagation() {
-	var channels []reflect.SelectCase
-	var clients []*client
-
-	channels = append(channels, reflect.SelectCase{
-		Dir:  reflect.SelectRecv,
-		Chan: reflect.ValueOf(p.sigNewClient),
-	})
-
-	for {
-		chosen, recv, recvOK := reflect.Select(channels)
-		if chosen == 0 {
-			if !recvOK {
-				// sigNewClient was closed
-				return
-			}
-
-			// new client -> register client for signal propagation.
-			if client := recv.Interface().(*client); client != nil {
-				channels = append(channels,
-					reflect.SelectCase{
-						Dir:  reflect.SelectRecv,
-						Chan: reflect.ValueOf(client.closeRef.Done()),
-					},
-					reflect.SelectCase{
-						Dir:  reflect.SelectRecv,
-						Chan: reflect.ValueOf(client.done),
-					},
-				)
-				clients = append(clients, client)
-			}
-			continue
-		}
-
-		// find client we received a signal for. If client.done was closed, then
-		// we have to remove the client only. But if closeRef did trigger the signal, then
-		// we have to propagate the async close to the client.
-		// In either case, the client will be removed
-
-		i := (chosen - 1) / 2
-		isSig := (chosen & 1) == 1
-		if isSig {
-			client := clients[i]
-			client.Close()
-		}
-
-		// remove:
-		last := len(clients) - 1
-		ch1 := i*2 + 1
-		ch2 := ch1 + 1
-		lastCh1 := last*2 + 1
-		lastCh2 := lastCh1 + 1
-
-		clients[i], clients[last] = clients[last], nil
-		channels[ch1], channels[lastCh1] = channels[lastCh1], reflect.SelectCase{}
-		channels[ch2], channels[lastCh2] = channels[lastCh2], reflect.SelectCase{}
-
-		clients = clients[:last]
-		channels = channels[:lastCh1]
-		if cap(clients) > 10 && len(clients) <= cap(clients)/2 {
-			clientsTmp := make([]*client, len(clients))
-			copy(clientsTmp, clients)
-			clients = clientsTmp
-
-			channelsTmp := make([]reflect.SelectCase, len(channels))
-			copy(channelsTmp, channels)
-			channels = channelsTmp
-		}
-	}
 }
 
 func (p *Pipeline) createEventProcessing(cfg beat.ProcessingConfig, noPublish bool) (beat.Processor, error) {

--- a/libbeat/publisher/pipeline/pipeline_test.go
+++ b/libbeat/publisher/pipeline/pipeline_test.go
@@ -30,10 +30,6 @@ import (
 )
 
 func TestPipelineAcceptsAnyNumberOfClients(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping because short is enabled")
-	}
-
 	routinesChecker := resources.NewGoroutinesChecker()
 	defer routinesChecker.Check(t)
 
@@ -60,13 +56,15 @@ func TestPipelineAcceptsAnyNumberOfClients(t *testing.T) {
 	}
 
 	// Close the first 105 clients
-	nn := 6
-	tmpC := clients[:n]
+	nn := 105
+	clientsToClose := clients[:n]
 	clients = clients[nn:]
 
-	for _, c := range tmpC {
+	for _, c := range clientsToClose {
 		c.Close()
 	}
+
+	// Let other goroutines run
 	runtime.Gosched()
 	runtime.Gosched()
 

--- a/libbeat/publisher/pipeline/pipeline_test.go
+++ b/libbeat/publisher/pipeline/pipeline_test.go
@@ -98,8 +98,7 @@ func makeDiscardQueue() queue.Queue {
 			// count is a counter that increments on every published event
 			// it's also the returned Event ID
 			count := uint64(0)
-			var producer *testProducer
-			producer = &testProducer{
+			producer := &testProducer{
 				publish: func(try bool, event interface{}) (queue.EntryID, bool) {
 					count++
 					return queue.EntryID(count), true

--- a/libbeat/publisher/pipeline/pipeline_test.go
+++ b/libbeat/publisher/pipeline/pipeline_test.go
@@ -41,7 +41,7 @@ func TestPipelineAcceptsAnyNumberOfClients(t *testing.T) {
 
 	defer pipeline.Close()
 
-	n := 66000 //35000 // This needs to be more than 10
+	n := 66000
 	clients := []beat.Client{}
 	for i := 0; i < n; i++ {
 		c, err := pipeline.ConnectWith(beat.ClientConfig{})

--- a/libbeat/publisher/pipeline/pipeline_test.go
+++ b/libbeat/publisher/pipeline/pipeline_test.go
@@ -18,7 +18,6 @@
 package pipeline
 
 import (
-	"context"
 	"runtime"
 	"sync"
 	"testing"
@@ -41,14 +40,11 @@ func TestPipelineAcceptsAnyNumberOfClients(t *testing.T) {
 	pipeline := makePipeline(t, Settings{}, makeDiscardQueue())
 
 	defer pipeline.Close()
-	ctx, cancel := context.WithCancel(context.Background())
 
-	n := 20 //35000 // This needs to be more than 10
+	n := 66000 //35000 // This needs to be more than 10
 	clients := []beat.Client{}
 	for i := 0; i < n; i++ {
-		c, err := pipeline.ConnectWith(beat.ClientConfig{
-			CloseRef: ctx,
-		})
+		c, err := pipeline.ConnectWith(beat.ClientConfig{})
 		if err != nil {
 			t.Fatalf("Could not connect to pipeline: %s", err)
 		}
@@ -73,8 +69,6 @@ func TestPipelineAcceptsAnyNumberOfClients(t *testing.T) {
 	}
 	runtime.Gosched()
 	runtime.Gosched()
-
-	cancel()
 
 	// Make sure all clients are closed
 	for _, c := range clients {

--- a/libbeat/publisher/pipeline/pipeline_test.go
+++ b/libbeat/publisher/pipeline/pipeline_test.go
@@ -18,11 +18,112 @@
 package pipeline
 
 import (
+	"context"
+	"runtime"
 	"sync"
+	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
+	"github.com/elastic/elastic-agent-libs/mapstr"
 )
+
+func TestPipelineAcceptsAnyNumberOfClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping because short is enabled")
+	}
+
+	routinesChecker := resources.NewGoroutinesChecker()
+	defer routinesChecker.Check(t)
+
+	pipeline := makePipeline(t, Settings{}, makeDiscardQueue())
+
+	defer pipeline.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	n := 20 //35000 // This needs to be more than 10
+	clients := []beat.Client{}
+	for i := 0; i < n; i++ {
+		c, err := pipeline.ConnectWith(beat.ClientConfig{
+			CloseRef: ctx,
+		})
+		if err != nil {
+			t.Fatalf("Could not connect to pipeline: %s", err)
+		}
+		clients = append(clients, c)
+	}
+
+	for i, c := range clients {
+		c.Publish(beat.Event{
+			Fields: mapstr.M{
+				"count": i,
+			},
+		})
+	}
+
+	// Close the first 105 clients
+	nn := 6
+	tmpC := clients[:n]
+	clients = clients[nn:]
+
+	for _, c := range tmpC {
+		c.Close()
+	}
+	runtime.Gosched()
+	runtime.Gosched()
+
+	cancel()
+
+	// Make sure all clients are closed
+	for _, c := range clients {
+		c.Close()
+	}
+}
+
+// makeDiscardQueue returns a queue that always discards all events
+// the producers are assigned an unique incremental ID, when their
+// close method is called, this ID is returned
+func makeDiscardQueue() queue.Queue {
+	var wg sync.WaitGroup
+	producerID := atomic.NewInt(0)
+
+	return &testQueue{
+		close: func() error {
+			//  Wait for all producers to finish
+			wg.Wait()
+			return nil
+		},
+		get: func(count int) (queue.Batch, error) {
+			return nil, nil
+		},
+
+		producer: func(cfg queue.ProducerConfig) queue.Producer {
+			producerID.Inc()
+			id := producerID.Load()
+
+			// count is a counter that increments on every published event
+			// it's also the returned Event ID
+			count := uint64(0)
+			var producer *testProducer
+			producer = &testProducer{
+				publish: func(try bool, event interface{}) (queue.EntryID, bool) {
+					count++
+					return queue.EntryID(count), true
+				},
+				cancel: func() int {
+
+					wg.Done()
+					return id
+				},
+			}
+
+			wg.Add(1)
+			return producer
+		},
+	}
+}
 
 type testQueue struct {
 	close        func() error

--- a/libbeat/publisher/pipeline/pipeline_test.go
+++ b/libbeat/publisher/pipeline/pipeline_test.go
@@ -99,7 +99,7 @@ func makeDiscardQueue() queue.Queue {
 			// it's also the returned Event ID
 			count := uint64(0)
 			producer := &testProducer{
-				publish: func(try bool, event interface{}) (queue.EntryID, bool) {
+				publish: func(try bool, event queue.Entry) (queue.EntryID, bool) {
 					count++
 					return queue.EntryID(count), true
 				},

--- a/libbeat/publisher/testing/testing.go
+++ b/libbeat/publisher/testing/testing.go
@@ -19,6 +19,8 @@ package testing
 
 // ChanClient implements Client interface, forwarding published events to some
 import (
+	"sync"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 )
 
@@ -31,6 +33,7 @@ type ChanClient struct {
 	done            chan struct{}
 	Channel         chan beat.Event
 	publishCallback func(event beat.Event)
+	closeOnce       sync.Once
 }
 
 func PublisherWithClient(client beat.Client) beat.Pipeline {
@@ -68,7 +71,9 @@ func NewChanClientWith(ch chan beat.Event) *ChanClient {
 }
 
 func (c *ChanClient) Close() error {
-	close(c.done)
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
 	return nil
 }
 

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -112,7 +112,6 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 
 	// Create client for publishing events and receive notification of their ACKs.
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		// CloseRef:      inputContext.Cancelation,
 		EventListener: awscommon.NewEventACKHandler(),
 	})
 	if err != nil {

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -112,7 +112,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 
 	// Create client for publishing events and receive notification of their ACKs.
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		CloseRef:      inputContext.Cancelation,
+		// CloseRef:      inputContext.Cancelation,
 		EventListener: awscommon.NewEventACKHandler(),
 	})
 	if err != nil {

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -156,7 +156,7 @@ func (in *s3Input) Run(inputContext v2.Context, pipeline beat.Pipeline) error {
 	if in.config.BucketARN != "" || in.config.NonAWSBucketName != "" {
 		// Create client for publishing events and receive notification of their ACKs.
 		client, err := pipeline.ConnectWith(beat.ClientConfig{
-			CloseRef:      inputContext.Cancelation,
+			// CloseRef:      inputContext.Cancelation,
 			EventListener: awscommon.NewEventACKHandler(),
 			Processing: beat.ProcessingConfig{
 				// This input only produces events with basic types so normalization

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -156,7 +156,6 @@ func (in *s3Input) Run(inputContext v2.Context, pipeline beat.Pipeline) error {
 	if in.config.BucketARN != "" || in.config.NonAWSBucketName != "" {
 		// Create client for publishing events and receive notification of their ACKs.
 		client, err := pipeline.ConnectWith(beat.ClientConfig{
-			// CloseRef:      inputContext.Cancelation,
 			EventListener: awscommon.NewEventACKHandler(),
 			Processing: beat.ProcessingConfig{
 				// This input only produces events with basic types so normalization

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/input.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/input.go
@@ -65,9 +65,13 @@ func (n *input) Run(runCtx v2.Context, connector beat.PipelineConnector) (err er
 	}()
 
 	client, err := connector.ConnectWith(beat.ClientConfig{
-		CloseRef:      runCtx.Cancelation,
+		// CloseRef:      runCtx.Cancelation,
 		EventListener: NewTxACKHandler(),
 	})
+	if err != nil {
+		return fmt.Errorf("could not connect to publishing pipeline: %s", err)
+	}
+	defer client.Close()
 
 	dataDir := paths.Resolve(paths.Data, "kvstore")
 	if err = os.MkdirAll(dataDir, 0700); err != nil {

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/input.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/input.go
@@ -68,7 +68,7 @@ func (n *input) Run(runCtx v2.Context, connector beat.PipelineConnector) (err er
 		EventListener: NewTxACKHandler(),
 	})
 	if err != nil {
-		return fmt.Errorf("could not connect to publishing pipeline: %s", err)
+		return fmt.Errorf("could not connect to publishing pipeline: %w", err)
 	}
 	defer client.Close()
 

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/input.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/input.go
@@ -65,7 +65,6 @@ func (n *input) Run(runCtx v2.Context, connector beat.PipelineConnector) (err er
 	}()
 
 	client, err := connector.ConnectWith(beat.ClientConfig{
-		// CloseRef:      runCtx.Cancelation,
 		EventListener: NewTxACKHandler(),
 	})
 	if err != nil {

--- a/x-pack/filebeat/input/lumberjack/input.go
+++ b/x-pack/filebeat/input/lumberjack/input.go
@@ -62,7 +62,7 @@ func (i *lumberjackInput) Run(inputCtx inputv2.Context, pipeline beat.Pipeline) 
 
 	// Create client for publishing events and receive notification of their ACKs.
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		CloseRef:      inputCtx.Cancelation,
+		// CloseRef:      inputCtx.Cancelation,
 		EventListener: newEventACKHandler(),
 	})
 	if err != nil {

--- a/x-pack/filebeat/input/lumberjack/input.go
+++ b/x-pack/filebeat/input/lumberjack/input.go
@@ -62,7 +62,6 @@ func (i *lumberjackInput) Run(inputCtx inputv2.Context, pipeline beat.Pipeline) 
 
 	// Create client for publishing events and receive notification of their ACKs.
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		// CloseRef:      inputCtx.Cancelation,
 		EventListener: newEventACKHandler(),
 	})
 	if err != nil {

--- a/x-pack/filebeat/input/netflow/input.go
+++ b/x-pack/filebeat/input/netflow/input.go
@@ -118,7 +118,7 @@ func (n *netflowInput) Run(ctx v2.Context, connector beat.PipelineConnector) err
 		Processing: beat.ProcessingConfig{
 			EventNormalization: boolPtr(true),
 		},
-		CloseRef:      ctx.Cancelation,
+		// CloseRef:      ctx.Cancelation,
 		EventListener: nil,
 	})
 	if err != nil {
@@ -126,6 +126,7 @@ func (n *netflowInput) Run(ctx v2.Context, connector beat.PipelineConnector) err
 		n.stop()
 		return err
 	}
+	defer client.Close()
 
 	const pollInterval = time.Minute
 	udpMetrics := netmetrics.NewUDP("netflow", ctx.ID, n.cfg.Host, uint64(n.cfg.ReadBuffer), pollInterval, n.logger)

--- a/x-pack/filebeat/input/netflow/input.go
+++ b/x-pack/filebeat/input/netflow/input.go
@@ -118,7 +118,6 @@ func (n *netflowInput) Run(ctx v2.Context, connector beat.PipelineConnector) err
 		Processing: beat.ProcessingConfig{
 			EventNormalization: boolPtr(true),
 		},
-		// CloseRef:      ctx.Cancelation,
 		EventListener: nil,
 	})
 	if err != nil {

--- a/x-pack/filebeat/input/shipper/input.go
+++ b/x-pack/filebeat/input/shipper/input.go
@@ -174,11 +174,12 @@ func (in *shipperInput) Run(inputContext v2.Context, pipeline beat.Pipeline) err
 				DisableType: true,
 			},
 
-			CloseRef: inputContext.Cancelation,
+			// CloseRef: inputContext.Cancelation,
 		})
 		if err != nil {
 			return fmt.Errorf("error creating client for stream %s: %w", streamID, err)
 		}
+		defer client.Close()
 		in.log.Infof("Creating beat client for stream %s", streamID)
 
 		newStreamData := streamData{client: client, index: in.streams[streamID].index, processors: in.streams[streamID].processors}

--- a/x-pack/filebeat/input/shipper/input.go
+++ b/x-pack/filebeat/input/shipper/input.go
@@ -173,8 +173,6 @@ func (in *shipperInput) Run(inputContext v2.Context, pipeline beat.Pipeline) err
 				DisableHost: true,
 				DisableType: true,
 			},
-
-			// CloseRef: inputContext.Cancelation,
 		})
 		if err != nil {
 			return fmt.Errorf("error creating client for stream %s: %w", streamID, err)


### PR DESCRIPTION
## Proposed commit message

The publishing pipeline would panic when more than 32767 clients were active, that happened because each client would add two channels to a slice and an infinity loop would use `reflect.Select` on this list. `reflect.Select` supports a maximum of 65536 cases, if there are more it panics.

This PR fixes this by removing the need for this list. The pipeline used an infinity loop to detect if the `CloseRef` from the pipeline client was closed, if it happened, then it would call `client.Close`. By analysing the code setting `CloseRef` we identified there was no need for the pipeline to be responsible for propagating this signal, most of the times the pipeline client was created, there was already a defer to close it, in the few places where it was not present we added one.

Now the pipeline is not responsible for closing any client, whomever creates a client is responsible for correctly closing it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally
This PR fixes a bug by removing a feature that is not needed. That said, it is easy to reproduce the situation that would lead to the crash.

All configuration files and scripts are at the end of this section.

1. Create at least 33.000 files, you can use `./gen-logs.sh 33000`
2. Start Filebeat with Filestream input reading those files. Use `filebeat.yml`
3. Wait until all events are ingested, you can do this by checking the number of lines in the output file: `wc -l output*.ndjson`, it should report 33.000.000 entries.
4. Ensure Filebeat does not panic.
5. Remove all created log files from your system: `rm -rf /tmp/too-many-logs`

<details><summary>filebeat.yml</summary>
<p>

```yaml
filebeat.inputs:
  - type: filestream
    id: do-not-panic
    paths:
      - /tmp/too-many-logs/*

output:
  file:
    enabled: true
    codec.json:
      pretty: false
    path: ${path.home}
    filename: "output"
    rotate_on_startup: false
    rotate_every_kb: 1000000
```

</p>
</details> 

## Related issues

- Closes https://github.com/elastic/beats/issues/38197

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~