### PR TITLE
Remove references to `export template --index`

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -336,8 +336,8 @@ If {kib} is not running on `localhost:5061`, you must also adjust the
 endif::no_dashboards[]
 
 [[template-subcommand]]*`template`*::
-Exports the index template to stdout. You can specify the `--es.version` and
-`--index` flags to further define what gets exported. Furthermore you can export
+Exports the index template to stdout. You can specify the `--es.version`
+flag to further define what gets exported. Furthermore you can export
 the template to a file instead of `stdout` by defining a directory via `--dir`.
 
 [[ilm-policy-subcommand]]
@@ -388,10 +388,6 @@ endif::export_pipeline[]
 *`-h, --help`*::
 Shows help for the `export` command.
 
-*`--index BASE_NAME`*::
-When used with <<template-subcommand,`template`>>, sets the base name to use for
-the index template. If this flag is not specified, the default base name is
-+{beatname_lc}+.
 
 *`--dir DIRNAME`*::
 
@@ -412,7 +408,7 @@ ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
-{beatname_lc} export template --es.version {version} --index myindexname
+{beatname_lc} export template --es.version {version}
 {beatname_lc} export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 -----
 endif::no_dashboards[]
@@ -421,7 +417,7 @@ ifdef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
-{beatname_lc} export template --es.version {version} --index myindexname
+{beatname_lc} export template --es.version {version}
 -----
 endif::no_dashboards[]
 endif::serverless[]
@@ -430,7 +426,7 @@ ifdef::serverless[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
-{beatname_lc} export template --es.version {version} --index myindexname
+{beatname_lc} export template --es.version {version}
 {beatname_lc} export function cloudwatch
 -----
 endif::serverless[]


### PR DESCRIPTION
## Proposed commit message

So, [a PR in 2019](https://github.com/elastic/beats/pull/11777) removed the `--index` flag for `export template`. However, we never updated the docs.

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


