### PR TITLE
The elastic-agent-autodiscover library is updated to version 0.6.4, disabling metadata for deployment and cronjob

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -178,8 +178,8 @@ Configuration parameters:
  * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output.
  Note: wildcards are not supported for those settings.
  The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
- * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is added, this can be disabled by setting `deployment: false`.
- * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is added, this can be disabled by setting `cronjob: false`.
+ * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is not added, this can be enabled by setting `deployment: true`.
+ * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is not added, this can be enabled by setting `cronjob: true`.
 +
 Example:
 ["source","yaml",subs="attributes"]


### PR DESCRIPTION
## Proposed commit message

Starting with 8.11, the elastic-agent-autodiscover library is updated to version 0.6.4, disabling metadata for deployment and cronjob. Pods that will be created from deployments or cronjobs will not have the extra metadata field for kubernetes.deployment or kubernetes.cronjob, respectively. This commit updates the documentation to align with this new change in 8.11. 

This commit should also be back-ported to version 8.11. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- https://github.com/elastic/beats/pull/36879
