### PR TITLE
auditbeat TestExeObjParser - fix errors.Is argument order

### DIFF
--- a/auditbeat/module/file_integrity/exeobjparser_test.go
+++ b/auditbeat/module/file_integrity/exeobjparser_test.go
@@ -48,7 +48,7 @@ func TestExeObjParser(t *testing.T) {
 				}
 
 				if _, ci := os.LookupEnv("CI"); ci {
-					if _, err := os.Stat(target); err != nil && errors.Is(fs.ErrNotExist, err) {
+					if _, err := os.Stat(target); err != nil && errors.Is(err, fs.ErrNotExist) {
 						t.Skip("skipping test because target binary was not found: see https://github.com/elastic/beats/issues/38211")
 					}
 				}
@@ -56,7 +56,7 @@ func TestExeObjParser(t *testing.T) {
 				got := make(mapstr.M)
 				err := exeObjParser(nil).Parse(got, target)
 				if err != nil {
-					t.Errorf("unexpected error calling exeObjParser.Parse: %v", err)
+					t.Fatalf("unexpected error calling exeObjParser.Parse: %v", err)
 				}
 
 				fields := []struct {


### PR DESCRIPTION
## Proposed commit message

The arguments to `errors.Is` are in the wrong order so the check is not working as designed and the test was never skipped.

Also stop the test after `exeObjParser.Parse` fails.

Relates: #38211

## How to test this PR locally

```
cd auditbeat/module/file_integrity
rm ./testdata/garble_macho_executable
CI=true go test -run TestExeObjParser -v .
```
