### PR TITLE
Update chocolatey to latest version

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -14,6 +14,10 @@ curl --version >nul 2>&1 && (
 REM Set the USERPROFILE to the previous location to fix issues with chocolatey in windows 2019
 SET PREVIOUS_USERPROFILE=%USERPROFILE%
 SET USERPROFILE=%OLD_USERPROFILE%
+
+echo "Upgrade chocolatey to latest version"
+choco upgrade chocolatey -y
+
 IF NOT EXIST C:\Python38\python.exe (
     REM Install python 3.8
     choco install python -y -r --no-progress --version 3.8.5 || exit /b 1


### PR DESCRIPTION
## Proposed commit message

This commit ensures that chocolatey is the latest version before installing Python on the Jenkins Windows workers. It fixes errors due to outdated chocolatey versions looking like:

```
Failures
  - python (exited 1) - python not installed. An error occurred during installation:
  Unable to resolve dependency 'python3 (= 3.8.5)'.
```
