### PR TITLE
Remove references to min_events in bulk_max_size docs.

### DIFF
--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -666,10 +666,8 @@ endif::[]
 
 The maximum number of events to bulk in a single Elasticsearch bulk API index request. The default is 1600.
 
-Events can be collected into batches. When using the memory queue with `queue.mem.flush.min_events`
-set to a value greater than `1`, the maximum batch is is the value of `queue.mem.flush.min_events`.
-{beatname_uc} will split batches read from the queue which are larger than `bulk_max_size` into
-multiple batches.
+Events can be collected into batches.{beatname_uc} will split batches read from the queue which are
+larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -666,7 +666,7 @@ endif::[]
 
 The maximum number of events to bulk in a single Elasticsearch bulk API index request. The default is 1600.
 
-Events can be collected into batches.{beatname_uc} will split batches read from the queue which are
+Events can be collected into batches. {beatname_uc} will split batches read from the queue which are
 larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -381,10 +381,8 @@ endif::[]
 
 The maximum number of events to bulk in a single {ls} request. The default is 2048.
 
-Events can be collected into batches. When using the memory queue with `queue.mem.flush.min_events`
-set to a value greater than `1`, the maximum batch is is the value of `queue.mem.flush.min_events`.
-{beatname_uc} will split batches read from the queue which are larger than `bulk_max_size` into
-multiple batches.
+Events can be collected into batches.{beatname_uc} will split batches read from the queue which are
+larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -381,7 +381,7 @@ endif::[]
 
 The maximum number of events to bulk in a single {ls} request. The default is 2048.
 
-Events can be collected into batches.{beatname_uc} will split batches read from the queue which are
+Events can be collected into batches. {beatname_uc} will split batches read from the queue which are
 larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -216,7 +216,7 @@ endif::[]
 
 The maximum number of events to bulk in a single Redis request or pipeline. The default is 2048.
 
-Events can be collected into batches.{beatname_uc} will split batches read from the queue which are
+Events can be collected into batches. {beatname_uc} will split batches read from the queue which are
 larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -216,10 +216,8 @@ endif::[]
 
 The maximum number of events to bulk in a single Redis request or pipeline. The default is 2048.
 
-Events can be collected into batches. When using the memory queue with `queue.mem.flush.min_events`
-set to a value greater than `1`, the maximum batch is is the value of `queue.mem.flush.min_events`.
-{beatname_uc} will split batches read from the queue which are larger than `bulk_max_size` into
-multiple batches.
+Events can be collected into batches.{beatname_uc} will split batches read from the queue which are
+larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead
 of sending events. However big batch sizes can also increase processing times,


### PR DESCRIPTION
As of https://github.com/elastic/beats/pull/37795/files in 8.13.0 queue.flush.min_events is no longer relevant.

