### PR TITLE
Skip failing/flaky nginx stubstatus integration test

### DIFF
--- a/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("Skipping due to flakiness, see 'https://github.com/elastic/beats/issues/38569'")
 	service := compose.EnsureUp(t, "nginx")
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
@@ -46,6 +47,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
+	t.Skip("Skipping due to flakiness, see 'https://github.com/elastic/beats/issues/38569'")
 	service := compose.EnsureUp(t, "nginx")
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))


### PR DESCRIPTION
## Proposed commit message

The integration test is failing and blocking CI, hence we're skipping it for now. More details on
https://github.com/elastic/beats/issues/38569.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
