### PR TITLE
Clarify that the keystore obfuscates secrets only.

### DIFF
--- a/libbeat/docs/keystore.asciidoc
+++ b/libbeat/docs/keystore.asciidoc
@@ -18,7 +18,7 @@
 
 When you configure {beatname_uc}, you might need to specify sensitive settings,
 such as passwords. Rather than relying on file system permissions to protect
-these values, you can use the {beatname_uc} keystore to securely store secret
+these values, you can use the {beatname_uc} keystore to obfuscate stored secret
 values for use in configuration settings.
 
 After adding a key and its secret value to the keystore, you can use the key in


### PR DESCRIPTION
The keystore uses a default, unchangeable password to encrypt data. In this sense it is not secure, only obfuscated on disk. Change the documentation to make this clear.