### PR TITLE
Update Docker setup instructions to discard setup container

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,6 +106,7 @@ Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will d
 - Raise up logging level to warning when attempting to configure beats with unknown fields from autodiscovered events/environments
 - elasticsearch output now supports `idle_connection_timeout`. {issue}35616[35615] {pull}36843[36843]
 Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will disable the netinfo.enabled option of add_host_metadata processor
+- Update container install docs to remove setup container automatically on completion. {pull}38677[38677]
 
 *Auditbeat*
 

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -73,7 +73,7 @@ and machine learning jobs.  Run this command:
 ifeval::["{beatname_lc}"=="filebeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
@@ -83,7 +83,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="metricbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
@@ -93,7 +93,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="heartbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 --cap-add=NET_RAW \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
@@ -104,7 +104,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="packetbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 --cap-add=NET_ADMIN \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
@@ -115,7 +115,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="auditbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
   --cap-add="AUDIT_CONTROL" \
   --cap-add="AUDIT_READ" \
   {dockerimage} \


### PR DESCRIPTION
## Proposed commit message

Add `--rm` to the setup command to automatically remove the container used to setup. This prevents leaving behind a single-use container instance.

## Checklist

- [X] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [X] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

