### PR TITLE
[Docs] Fix shared monitoring config to list the monitoring.elasticsearch settings under the monitoring.elasticsearch setting

### DIFF
--- a/libbeat/docs/monitoring/shared-monitor-config.asciidoc
+++ b/libbeat/docs/monitoring/shared-monitor-config.asciidoc
@@ -27,14 +27,14 @@ If set to `true`, monitoring is enabled.
 
 The default value is `false`.
 
+==== `monitoring.cluster_uuid`
+
+The `monitoring.cluster_uuid` config identifies the {es} cluster under which the monitoring data will appear in the Stack Monitoring UI.
+
 ==== `monitoring.elasticsearch`
 
 The {es} instances that you want to ship your {beatname_uc} metrics to. This
 configuration option contains the following fields:
-
-==== `monitoring.cluster_uuid`
-
-The `monitoring.cluster_uuid` config identifies the {es} cluster under which the monitoring data will appear in the Stack Monitoring UI. 
 
 ===== `api_key`
 


### PR DESCRIPTION
## Proposed commit message

[Docs] Fix shared monitoring config

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

## Use cases

## Screenshots

<img width="553" alt="image" src="https://github.com/elastic/beats/assets/6976484/46d60ec5-bc90-47e7-8aa5-72b2628cf1a3">
