### PR TITLE
.golangci.yml - Disallow OSS -> x-pack dependencies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,9 +66,19 @@ linters:
     - wastedassign # wastedassign finds wasted assignment statements.
     - gomodguard # check for blocked dependencies
     - prealloc # Finds slice declarations that could potentially be pre-allocated
+    - depguard
 
 # all available settings of specific linters
 linters-settings:
+  depguard:
+    rules:
+      apache-licensed-code:
+        list-mode: lax
+        files:
+          - '!**/x-pack/**/*.go'
+        deny:
+          - pkg: github.com/elastic/beats/v7/x-pack
+            desc: Apache 2.0 licensed code cannot depend on Elastic licensed code (x-pack/).
   errcheck:
     # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     check-type-assertions: false


### PR DESCRIPTION
## Proposed commit message

According to LICENSE.txt, the Beats project uses both Apache 2.0 (OSS) and Elastic licenses. The OSS code may not depend on the Elastic License code otherwise the OSS-only binaries become tainted.

This makes golangci-lint emit warnings for OSS code that depends on x-pack code.

Closes #38719

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

