### PR TITLE
[7.17] Fix Python systems tests with forked docker-compose package

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -5,8 +5,8 @@ cached-property==1.4.2
 certifi==2018.1.18
 chardet==3.0.4
 deepdiff==4.2.0
-docker==4.1.0
-docker-compose==1.25.3
+docker==6.1.3
+docker-compose @ git+https://github.com/pkoutsovasilis/compose@v1_fix
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
@@ -38,7 +38,7 @@ pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
 PyYAML==5.3.1
 redis==2.10.6
-requests==2.25.1
+requests==2.31.0
 semver==2.8.1
 setuptools==47.3.2
 six==1.15.0

--- a/libbeat/tests/system/requirements_aix.txt
+++ b/libbeat/tests/system/requirements_aix.txt
@@ -5,7 +5,8 @@ cached-property==1.4.2
 certifi==2018.1.18
 chardet==3.0.4
 deepdiff==4.2.0
-docker==4.1.0
+docker==6.1.3
+docker-compose @ git+https://github.com/pkoutsovasilis/compose@v1_fix
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
@@ -37,7 +38,7 @@ pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
 PyYAML==5.3.1
 redis==2.10.6
-requests==2.25.1
+requests==2.31.0
 semver==2.8.1
 setuptools==47.3.2
 six==1.15.0
@@ -49,3 +50,4 @@ urllib3==1.26.18
 wcwidth==0.2.5
 websocket-client==0.47.0
 zipp>=1.2.0,<=3.1.0
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.21.8
+COPY --from=docker:26.0.0-alpine3.19 /usr/local/bin/docker /usr/local/bin/
 
 RUN \
     apt update \
@@ -8,6 +9,8 @@ RUN \
          python3-dev \
          python3-pip \
          python3-venv \
+         libssl-dev \
+         libffi-dev \
       && rm -rf /var/lib/apt/lists/*
 
 # Use a virtualenv to avoid the PEP668 "externally managed environment" error caused by conflicts
@@ -17,9 +20,12 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip3 install --upgrade pip==20.1.1
-RUN pip3 install --upgrade docker-compose==1.23.2
 RUN pip3 install --upgrade setuptools==47.3.2
 RUN pip3 install --upgrade PyYAML==5.3.1
+RUN pip3 install requests==2.31.0
+RUN pip3 install urllib3==1.26.18
+RUN pip3 install docker==6.1.3
+RUN pip3 install git+https://github.com/pkoutsovasilis/compose@v1_fix
 
 # Add healthcheck for the docker/healthcheck metricset to check during testing.
 HEALTHCHECK CMD exit 0


### PR DESCRIPTION
This is a manual backport of the fix for the Python systems tests contained in https://github.com/elastic/beats/pull/38199, which uses a fork of the docker-compose Python package as a work around.