### PR TITLE
[Metricbeat][Kubernetes] Remove mandatory permissions for namespace and node

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -2108,6 +2108,96 @@ func TestNodePodUpdater(t *testing.T) {
 	}
 }
 
+func TestPodEventer_Namespace_Node_Watcher(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		cfg         mapstr.M
+		expectedNil bool
+		name        string
+		msg         string
+	}{
+		{
+			cfg: mapstr.M{
+				"resource": "pod",
+				"node":     "node-1",
+				"add_resource_metadata": mapstr.M{
+					"namespace.enabled": false,
+					"node.enabled":      false,
+				},
+				"hints.enabled": false,
+				"builders": []mapstr.M{
+					{
+						"mock": mapstr.M{},
+					},
+				},
+			},
+			expectedNil: true,
+			name:        "add_resource_metadata.namespace and add_resource_metadata.node disabled and hints disabled.",
+			msg:         "Watcher should be nil.",
+		},
+		{
+			cfg: mapstr.M{
+				"resource": "pod",
+				"node":     "node-1",
+				"add_resource_metadata": mapstr.M{
+					"namespace.enabled": false,
+					"node.enabled":      false,
+				},
+				"hints.enabled": true,
+			},
+			expectedNil: false,
+			name:        "add_resource_metadata.namespace and add_resource_metadata.node disabled and hints enabled.",
+			msg:         "Watcher should not be nil.",
+		},
+		{
+			cfg: mapstr.M{
+				"resource": "pod",
+				"node":     "node-1",
+				"add_resource_metadata": mapstr.M{
+					"namespace.enabled": true,
+					"node.enabled":      true,
+				},
+				"hints.enabled": false,
+				"builders": []mapstr.M{
+					{
+						"mock": mapstr.M{},
+					},
+				},
+			},
+			expectedNil: false,
+			name:        "add_resource_metadata.namespace and add_resource_metadata.node enabled and hints disabled.",
+			msg:         "Watcher should not be nil.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := conf.MustNewConfigFrom(&test.cfg)
+
+			eventer, err := NewPodEventer(uuid, config, client, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			namespaceWatcher := eventer.(*pod).namespaceWatcher
+			nodeWatcher := eventer.(*pod).nodeWatcher
+
+			if test.expectedNil {
+				assert.Equalf(t, nil, namespaceWatcher, "Namespace "+test.msg)
+				assert.Equalf(t, nil, nodeWatcher, "Node "+test.msg)
+			} else {
+				assert.NotEqualf(t, nil, namespaceWatcher, "Namespace "+test.msg)
+				assert.NotEqualf(t, nil, nodeWatcher, "Node "+test.msg)
+			}
+		})
+	}
+}
+
 type mockUpdaterHandler struct {
 	objects []interface{}
 }

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -70,16 +70,18 @@ func NewServiceEventer(uuid uuid.UUID, cfg *conf.C, client k8s.Interface, publis
 	var namespaceMeta metadata.MetaGen
 	var namespaceWatcher kubernetes.Watcher
 
-	metaConf := metadata.GetDefaultResourceMetadataConfig()
-	namespaceWatcher, err = kubernetes.NewNamedWatcher("namespace", client, &kubernetes.Namespace{}, kubernetes.WatchOptions{
-		SyncTimeout: config.SyncPeriod,
-		Namespace:   config.Namespace,
-	}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't create watcher for %T due to error %w", &kubernetes.Namespace{}, err)
-	}
+	metaConf := config.AddResourceMetadata
 
-	namespaceMeta = metadata.NewNamespaceMetadataGenerator(metaConf.Namespace, namespaceWatcher.Store(), client)
+	if metaConf.Namespace.Enabled() || config.Hints.Enabled() {
+		namespaceWatcher, err = kubernetes.NewNamedWatcher("namespace", client, &kubernetes.Namespace{}, kubernetes.WatchOptions{
+			SyncTimeout: config.SyncPeriod,
+			Namespace:   config.Namespace,
+		}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't create watcher for %T due to error %w", &kubernetes.Namespace{}, err)
+		}
+		namespaceMeta = metadata.NewNamespaceMetadataGenerator(metaConf.Namespace, namespaceWatcher.Store(), client)
+	}
 
 	p := &service{
 		config:           config,

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -166,7 +166,14 @@ func getResource(resourceName string) kubernetes.Resource {
 func getExtraWatchers(resourceName string, addResourceMetadata *metadata.AddResourceMetadataConfig) []string {
 	switch resourceName {
 	case PodResource:
-		extra := []string{NamespaceResource, NodeResource}
+		extra := []string{}
+		if addResourceMetadata.Node.Enabled() {
+			extra = append(extra, NodeResource)
+		}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+
 		// We need to create watchers for ReplicaSets and Jobs that it might belong to,
 		// in order to be able to retrieve 2nd layer Owner metadata like in case of:
 		// Deployment -> Replicaset -> Pod
@@ -179,23 +186,55 @@ func getExtraWatchers(resourceName string, addResourceMetadata *metadata.AddReso
 		}
 		return extra
 	case ServiceResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case DeploymentResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case ReplicaSetResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case StatefulSetResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case DaemonSetResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case JobResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case CronJobResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case PersistentVolumeResource:
 		return []string{}
 	case PersistentVolumeClaimResource:
-		return []string{NamespaceResource}
+		extra := []string{}
+		if addResourceMetadata.Namespace.Enabled() {
+			extra = append(extra, NamespaceResource)
+		}
+		return extra
 	case StorageClassResource:
 		return []string{}
 	case NodeResource:


### PR DESCRIPTION
## Proposed commit message

Issue of the PR is https://github.com/elastic/beats/issues/37179.

Currently, we need to have permissions for namespace and nodes, because we create watchers for these resources.
This makes the option `add_resource_metadata.*.enabled` useless in this case.

To fix this issue, we need to prevent the creation of watchers in two places:

- When using autodiscover
  - In this case, we also need to make sure `hints.enabled` is set to false. Otherwise, the watchers will be created.
- When creating the enrichers
  - Only create the namespace watcher if `add_resource_metadata.namespace.enabled` is set to true
  - Do the same for node
  - **Exception**: if `state_namespace` is enabled, then we create the watcher for that resource, regardless of the block `add_resource_metadata`. Same for node metricsets.

This means having this in the configuration of the kubernetes provider:

```yaml
add_resource_metadata:
    namespace:
      enabled: false
      node: false
```

And making sure:
```yaml
hints.enabled: false
```


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
1. Clone this branch.
2. Deploy the metricbeat built from this branch in a kubernetes cluster.
3. Make sure to remove namespace permissions from the ClusterRole.

Configure the provider as:

```yaml
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      hints.enabled: false
      add_resource_metadata:
        namespace:
          enabled: false
        node:
          enabled: false
```

## Results

We no longer have logs with:

```log
W0408 10:14:45.477767       1 reflector.go:324] pkg/mod/k8s.io/client-go@v0.23.4/tools/cache/reflector.go:167: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kube-system:metricbeat" cannot list resource "namespaces" in API group "" at the cluster scope
E0408 10:14:45.477909       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.23.4/tools/cache/reflector.go:167: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kube-system:metricbeat" cannot list resource "namespaces" in API group "" at the cluster scope
```




## Related issues

- Closes https://github.com/elastic/beats/issues/37179

