### PR TITLE
Clean BK scripts

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -35,12 +35,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "filebeat" || "$BUILDKITE_PIPELINE_SLUG" == 
     with_mage
   fi
 
-  if [[ "$BUILDKITE_STEP_KEY" == windows* ]]; then
-    git config core.autocrlf false
-    git rm --quiet --cached -r .
-    git reset --quiet --hard
-  fi
-
   if [[ "$BUILDKITE_STEP_KEY" == package* ]]; then
     DOCKER_USERNAME_SECRET=$(retry_with_count 5 vault kv get -field user "${DOCKER_REGISTRY_SECRET_PATH}")
     DOCKER_PASSWORD_SECRET=$(retry_with_count 5 vault kv get -field password "${DOCKER_REGISTRY_SECRET_PATH}")

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -475,13 +475,6 @@ are_conditions_met_packaging() {
   return 1
 }
 
-config_git() {
-  if [ -z "$(git config --get user.email)" ]; then
-    git config --global user.email "beatsmachine@users.noreply.github.com"
-    git config --global user.name "beatsmachine"
-  fi
-}
-
 defineModuleFromTheChangeSet() {
   # This method gathers the module name, if required, in order to run the ITs only if the changeset affects a specific module.
   # For such, it's required to look for changes under the module folder and exclude anything else such as asciidoc and png files.


### PR DESCRIPTION

## Proposed commit message

This commit removes the need to configure git for Windows since we migrated to the custom Windows images. It also removes the config_git, which was defined twice in a single file.

