### PR TITLE
Remove Buildkite pipeline trigger

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -18,22 +18,6 @@
         },
         {
             "enabled": true,
-            "pipelineSlug": "filebeat",
-            "allow_org_users": true,
-            "allowed_repo_permissions": ["admin", "write"],
-            "allowed_list": [ ],
-            "set_commit_status": true,
-            "build_on_commit": true,
-            "build_on_comment": true,
-            "trigger_comment_regex": "^/test filebeat(for (arm|macos|windows|extended support))?$|^/packag[ing|e]$",
-            "always_trigger_comment_regex": "^/test filebeat(for (arm|macos|windows|extended support))?$|^/packag[ing|e]$",
-            "skip_ci_labels": [ ],
-            "skip_target_branches": [ ],
-            "skip_ci_on_only_changed": [ ],
-            "always_require_ci_on_changed": ["^filebeat/.*", ".buildkite/filebeat/.*", "^go.mod", "^pytest.ini", "^dev-tools/.*", "^libbeat/.*", "^testing/.*" ]
-        },
-        {
-            "enabled": true,
             "pipelineSlug": "beats-metricbeat",
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This needs to land in the main branch before migrating the pipeline because the bot expects to find it there.
Follow-up work will happen to migrate the pipeline.


Part of the work needed for https://github.com/elastic/ingest-dev/issues/3072