### PR TITLE
Fix missing vars in buildkite changesets.sh

### DIFF
--- a/.buildkite/scripts/changesets.sh
+++ b/.buildkite/scripts/changesets.sh
@@ -2,6 +2,9 @@
 
 # This script contains helper functions related to what should be run depending on Git changes
 
+OSS_MODULE_PATTERN="^[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*"
+XPACK_MODULE_PATTERN="^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*"
+
 are_paths_changed() {
   local patterns=("${@}")
   local changelist=()


### PR DESCRIPTION
## Proposed commit message

PR #38814 missed a couple of patterns required
by the defineModuleFromTheChangeSet() function.

This commit adds the missing regex patters
needed for identifying module changesets.
