### PR TITLE
Adjust the Beats pipelines branch configuraiton

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -39,7 +39,7 @@ spec:
       name: beats
       description: "Beats Main pipeline"
     spec:
-      branch_configuration: "main 7.17 8.*"
+      branch_configuration: "main 7.17 8.* mergify*"
       pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
         build_pull_request_forks: false


### PR DESCRIPTION
## Proposed commit message

This commit adjusts the branch configuration of the Beats Buildkite pipelines so that they can be triggerable from branches existing upstream coming from Mergify.
