### PR TITLE
Fix metricbeat packaging on 7.17

### DIFF
--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -255,7 +255,7 @@ steps:
           disk_size: 100
           disk_type: "pd-ssd"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
+          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64"
         notify:
           - github_commit_status:
               context: "metricbeat: Packaging Linux"

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -234,6 +234,7 @@ steps:
           - github_commit_status:
               context: "metricbeat: Extended MacOS Unit Tests"
 
+  # temporarily disabled to speed up packaging tests
   - wait: ~
     # with PRs, we want to run packaging only if mandatory tests succeed
     # for other cases, e.g. merge commits, we want to run packaging (and publish) independently of other tests

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -235,12 +235,12 @@ steps:
               context: "metricbeat: Extended MacOS Unit Tests"
 
   # temporarily disabled to speed up packaging tests
-  - wait: ~
-    # with PRs, we want to run packaging only if mandatory tests succeed
-    # for other cases, e.g. merge commits, we want to run packaging (and publish) independently of other tests
-    # this allows building DRA artifacts even if there is flakiness in mandatory tests
-    if: build.env("BUILDKITE_PULL_REQUEST") != "false"
-    depends_on: "metricbeat-mandatory-tests"
+  # - wait: ~
+  #   # with PRs, we want to run packaging only if mandatory tests succeed
+  #   # for other cases, e.g. merge commits, we want to run packaging (and publish) independently of other tests
+  #   # this allows building DRA artifacts even if there is flakiness in mandatory tests
+  #   if: build.env("BUILDKITE_PULL_REQUEST") != "false"
+  #   depends_on: "metricbeat-mandatory-tests"
 
   - group: "Metricbeat Packaging"
     key: "metricbeat-packaging"

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -234,13 +234,12 @@ steps:
           - github_commit_status:
               context: "metricbeat: Extended MacOS Unit Tests"
 
-  # temporarily disabled to speed up packaging tests
-  # - wait: ~
-  #   # with PRs, we want to run packaging only if mandatory tests succeed
-  #   # for other cases, e.g. merge commits, we want to run packaging (and publish) independently of other tests
-  #   # this allows building DRA artifacts even if there is flakiness in mandatory tests
-  #   if: build.env("BUILDKITE_PULL_REQUEST") != "false"
-  #   depends_on: "metricbeat-mandatory-tests"
+  - wait: ~
+    # with PRs, we want to run packaging only if mandatory tests succeed
+    # for other cases, e.g. merge commits, we want to run packaging (and publish) independently of other tests
+    # this allows building DRA artifacts even if there is flakiness in mandatory tests
+    if: build.env("BUILDKITE_PULL_REQUEST") != "false"
+    depends_on: "metricbeat-mandatory-tests"
 
   - group: "Metricbeat Packaging"
     key: "metricbeat-packaging"


### PR DESCRIPTION
## Proposed commit message

Currently the Packaging Linux group for metricbeat on 7.17
fails with[^1]:

```
Error: unsupported cross build platform darwin/arm64
```

[^1] https://buildkite.com/elastic/beats-metricbeat/builds/4805#018ed1f7-4925-42e7-b043-de3c64f968ac/119-318

This commit fixes it by not including this target, since we don't publish macOS arm64 artifacts on `7.17`.

## Related issues

https://github.com/elastic/ingest-dev/issues/3072

## Logs

Successful build example: https://buildkite.com/elastic/beats-metricbeat/builds/4818#018ed246-3a5a-48d0-b17b-259a8a64d4c6/130-443