### PR TITLE
Revert branch_configuration for beats pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -39,7 +39,7 @@ spec:
       name: beats
       description: "Beats Main pipeline"
     spec:
-      branch_configuration: "main 7.17 8.* mergify*"
+      branch_configuration: "main 7.17 8.*"
       pipeline_file: ".buildkite/pipeline.yml"
       provider_settings:
         build_pull_request_forks: false


### PR DESCRIPTION
## Proposed commit message

Revert the changes done from https://github.com/elastic/beats/pull/38875

The reason is that when raising a backport PR, it's handled as a normal branch, which was wrong.