### PR TITLE
Allow mergify bot to trigger builds

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,7 +5,7 @@
             "pipelineSlug": "beats",
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],
-            "allowed_list": [ ],
+            "allowed_list": [ "mergify[bot]" ],
             "set_commit_status": true,
             "build_on_commit": true,
             "build_on_comment": true,


### PR DESCRIPTION
## Proposed commit message

This commit allows the mergify bot to trigger automatically builds of backport PRs.