### PR TITLE
Add support for installing Node.js on macOS

### DIFF
--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -220,9 +220,6 @@ steps:
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
-          # TODO remove below two lines, needed just for testing nodejs
-          withNodeJSEnv "18.17.1"
-          installNodeJsDependencies
           cd metricbeat && mage build unitTest
         agents:
           provider: "orka"
@@ -236,13 +233,10 @@ steps:
 
       - label: ":mac: MacOS arm64 Unit Tests"
         key: "extended-macos-arm64-unit-tests"
-        #skip: "due to https://github.com/elastic/beats/issues/33035"
+        skip: "due to https://github.com/elastic/beats/issues/33035"
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
-          # TODO remove below two lines, needed just for testing nodejs
-          withNodeJSEnv "18.17.1"
-          installNodeJsDependencies
           cd metricbeat && mage build unitTest
         agents:
           provider: "orka"

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -220,6 +220,9 @@ steps:
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
+          # TODO remove below two lines, needed just for testing nodejs
+          withNodeJSEnv "18.17.1"
+          installNodeJsDependencies
           cd metricbeat && mage build unitTest
         agents:
           provider: "orka"
@@ -233,10 +236,13 @@ steps:
 
       - label: ":mac: MacOS arm64 Unit Tests"
         key: "extended-macos-arm64-unit-tests"
-        skip: "due to https://github.com/elastic/beats/issues/33035"
+        #skip: "due to https://github.com/elastic/beats/issues/33035"
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
+          # TODO remove below two lines, needed just for testing nodejs
+          withNodeJSEnv "18.17.1"
+          installNodeJsDependencies
           cd metricbeat && mage build unitTest
         agents:
           provider: "orka"

--- a/.buildkite/scripts/install_macos_tools.sh
+++ b/.buildkite/scripts/install_macos_tools.sh
@@ -106,6 +106,28 @@ config_git() {
   fi
 }
 
+withNodeJSEnv() {
+  local version=$1
+  echo "Installing nvm"
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+  echo "~~~ Installing Node.js version: $version"
+  nvm install "$version"
+  # export PATH="${nvmPath}:${PATH}"
+  nvm use "$version"
+  node --version
+  echo "~~~ Resuming commands"
+}
+
+installNodeJsDependencies() {
+  echo "~~~ Installing Node.js packages"
+  # needed for beats-xpack-heartbeat
+  echo "Install @elastic/synthetics"
+  npm i -g @elastic/synthetics
+  echo "~~~ Resuming commands"
+}
+
 add_bin_path
 with_go "${GO_VERSION}"
 with_mage

--- a/.buildkite/scripts/install_macos_tools.sh
+++ b/.buildkite/scripts/install_macos_tools.sh
@@ -108,11 +108,11 @@ config_git() {
 
 withNodeJSEnv() {
   local version=$1
-  echo "Installing nvm"
+  echo "~~~ Installing nvm and Node.js"
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
   export NVM_DIR="$HOME/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
-  echo "~~~ Installing Node.js version: $version"
+  echo "Installing Node.js version: $version"
   nvm install "$version"
   # export PATH="${nvmPath}:${PATH}"
   nvm use "$version"


### PR DESCRIPTION
## Proposed commit message

This commit adds two new functions in
`install_macos_tools.sh` that install nodejs
and common nodejs dependencies.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3072


## Screenshots

## Testing/Logs

This has been tested using the dummy commit (now reverted) that triggered the installation of Node.js and node packages on both macOS x86_64 and arm64 agents:

```
        command: |
          set -euo pipefail
          source .buildkite/scripts/install_macos_tools.sh
          # TODO remove below two lines, needed just for testing nodejs
          withNodeJSEnv "18.17.1"
          installNodeJsDependencies
          cd metricbeat && mage build unitTest
```

In the future, when nodejs is required (AFAIU it's only needed for xpack-heartbeat, hence we don't install it always by default) we should just add
```
          withNodeJSEnv "18.17.1"
          installNodeJsDependencies
```

after `source .buildkite/scripts/install_macos_tools.sh`

Log links:

- macOS x86_64: https://buildkite.com/elastic/beats-metricbeat/builds/4855#018ed309-48f2-4c6e-a9f2-eab1a08364b9/531-568
- macOS arm64: https://buildkite.com/elastic/beats-metricbeat/builds/4855#018ed309-48ee-4895-a942-14b19e00771a/526-563 (nodejs/node package installation works, test itself is failing due to https://github.com/elastic/beats/issues/33035)

