### PR TITLE
[7.17] Fix Prometheus remote write test.

### DIFF
--- a/metricbeat/module/prometheus/docker-compose.yml
+++ b/metricbeat/module/prometheus/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       context: ./_meta
       args:
         PROMETHEUS_VERSION: ${PROMETHEUS_VERSION:-2.6.0}
-    ports:
-      - 9090
   # this service is to be used by system-tests for remote_write metricset, so as
   # Prometheus service to send metrics to Metricbeat running on the host.
   prometheus-host-network:


### PR DESCRIPTION
When using host network mode port mappings are ignored, the container is binding to the port on the host already.

I'm not sure why this passing on main but not 7.17. There must be some difference in the docker version.

- Closes https://github.com/elastic/beats/issues/38854
