### PR TITLE
Fix macOS failures with auditbeat

### DIFF
--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -2,11 +2,8 @@
 name: "beats-auditbeat"
 
 env:
-  BEATS_PROJECT_NAME: "auditbeat"
-
-  ASDF_MAGE_VERSION: 1.15.0
-
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
+
   AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
@@ -23,13 +20,8 @@ env:
   IMAGE_WIN_2019: "family/platform-ingest-beats-windows-2019"
   IMAGE_WIN_2022: "family/platform-ingest-beats-windows-2022"
 
-  #Packaging
-  PACKAGING_ARM_PLATFORMS: "linux/arm64"
-  PACKAGING_PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
-
-notify:
-  - github_commit_status:
-      context: "$BEATS_PROJECT_NAME"
+  # Other deps
+  ASDF_MAGE_VERSION: 1.15.0
 
 steps:
   - group: "Auditbeat Mandatory Testing"
@@ -37,7 +29,9 @@ steps:
 
     steps:
       - label: ":ubuntu: Auditbeat Unit Tests"
-        command: "cd $BEATS_PROJECT_NAME && mage build unitTest"
+        command: |
+          cd auditbeat
+          mage build unitTest
         agents:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
@@ -47,7 +41,9 @@ steps:
           - "auditbeat/build/*.json"
 
       - label: ":ubuntu: Auditbeat Unit Tests"
-        command: "cd $BEATS_PROJECT_NAME && mage build unitTest"
+        command: |
+          cd auditbeat
+          mage build unitTest
         agents:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
@@ -57,7 +53,9 @@ steps:
           - "auditbeat/build/*.json"
 
       - label: ":rhel: Auditbeat Unit Tests"
-        command: "cd $BEATS_PROJECT_NAME && mage build unitTest"
+        command: |
+          cd auditbeat
+          mage build unitTest
         agents:
           provider: "gcp"
           image: "${IMAGE_RHEL9}"
@@ -68,7 +66,7 @@ steps:
 
       - label: ":windows: Auditbeat Win-2016 Unit Tests"
         command: |
-          Set-Location -Path $BEATS_PROJECT_NAME
+          Set-Location -Path auditbeat
           mage build unitTest
         agents:
           provider: "gcp"
@@ -82,7 +80,7 @@ steps:
 
       - label: ":windows: Auditbeat Win-2022 Unit Tests"
         command: |
-          Set-Location -Path $BEATS_PROJECT_NAME
+          Set-Location -Path auditbeat
           mage build unitTest
         agents:
           provider: "gcp"
@@ -95,7 +93,8 @@ steps:
           - "auditbeat/build/*.json"
 
       - label: ":linux: Auditbeat Crosscompile"
-        command: "make -C $BEATS_PROJECT_NAME crosscompile"
+        command: |
+          make -C auditbeat crosscompile
         env:
           GOX_FLAGS: "-arch amd64"
         agents:
@@ -109,80 +108,102 @@ steps:
     steps:
       - label: ":arm: ARM64 Unit Tests"
         key: "auditbeat-extended-arm64-unit-tests"
-        command: "cd ${BEATS_PROJECT_NAME} && mage build unitTest"
+        command: |
+          set -euo pipefail
+          cd auditbeat
+          mage unitTest
         agents:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
-        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.*"
+        artifact_paths: "auditbeat/build/*.*"
 
   - group: "Auditbeat MacOS Extended"
     if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
     steps:
       - label: ":mac: MacOS Unit Tests"
-        command: "cd ${BEATS_PROJECT_NAME} && mage unitTest"
+        command: |
+          set -euo pipefail
+          source .buildkite/scripts/install_macos_tools.sh
+          cd auditbeat
+          mage unitTest
         agents:
           provider: "orka"
           imagePrefix: "${IMAGE_MACOS_X86_64}"
-        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.*"
+        artifact_paths: "auditbeat/build/*.*"
 
       - label: ":mac: MacOS ARM Unit Tests"
-        command: "cd ${BEATS_PROJECT_NAME} && mage unitTest"
+        command: |
+          set -euo pipefail
+          source .buildkite/scripts/install_macos_tools.sh
+          cd auditbeat
+          mage unitTest
         agents:
           provider: "orka"
           imagePrefix: "${IMAGE_MACOS_ARM}"
-        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.*"
+        artifact_paths: "auditbeat/build/*.*"
 
   - group: "Auditbeat Windows Extended Testing"
     key: "auditbeat-extended-tests-win"
-    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*windows.*/
+    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*[Ww]indows.*/
     steps:
       - label: ":windows: Auditbeat Win-2019 Unit Tests"
         key: "auditbeat-extended-win-2019-unit-tests"
-        command: "mage -d ${BEATS_PROJECT_NAME} unitTest"
+        command: |
+          Set-Location -Path auditbeat
+          mage build unitTest
         agents:
           provider: "gcp"
           image: "${IMAGE_WIN_2019}"
           machine_type: "${GCP_WIN_MACHINE_TYPE}"
           disk_size: 100
           disk_type: "pd-ssd"
-        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.*"
+        artifact_paths: "auditbeat/build/*.*"
 
       - label: ":windows: Auditbeat Win-10 Unit Tests"
         key: "auditbeat-extended-win-10-unit-tests"
-        command: "mage -d ${BEATS_PROJECT_NAME} unitTest"
+        command: |
+          Set-Location -Path auditbeat
+          mage build unitTest
         agents:
           provider: "gcp"
           image: "${IMAGE_WIN_10}"
           machine_type: "${GCP_WIN_MACHINE_TYPE}"
           disk_size: 100
           disk_type: "pd-ssd"
-        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.*"
+        artifact_paths: "auditbeat/build/*.*"
 
       - label: ":windows: Auditbeat Win-11 Unit Tests"
         key: "auditbeat-extended-win-11-unit-tests"
-        command: "mage -d ${BEATS_PROJECT_NAME} unitTest"
+        command: |
+          Set-Location -Path auditbeat
+          mage build unitTest
         agents:
           provider: "gcp"
           image: "${IMAGE_WIN_11}"
           machine_type: "${GCP_WIN_MACHINE_TYPE}"
           disk_size: 100
           disk_type: "pd-ssd"
-        artifact_paths: "${BEATS_PROJECT_NAME}/build/*.*"
+        artifact_paths: "auditbeat/build/*.*"
+
+  - wait: ~
+    # with PRs, we want to run packaging only if mandatory tests succeed
+    # for other cases, e.g. merge commits, we want to run packaging (and publish) independently of other tests
+    # this allows building DRA artifacts even if there is flakiness in mandatory tests
+    if: build.env("BUILDKITE_PULL_REQUEST") != "false"
+    depends_on: "auditbeat-mandatory-tests"
 
   - group: "Auditbeat Packaging"
     key: "auditbeat-packaging"
-    if: build.env("BUILDKITE_PULL_REQUEST") != "false"
-    depends_on:
-      - "auditbeat-mandatory-tests"
-
     steps:
       - label: ":ubuntu: Auditbeat/Packaging Linux X86"
         key: "auditbeat-package-linux-x86"
         env:
-          PLATFORMS: "${PACKAGING_PLATFORMS}"
+          PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
           SNAPSHOT: true
-        command: "cd $BEATS_PROJECT_NAME && mage package"
+        command: |
+          cd auditbeat
+          mage package
         agents:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
@@ -191,10 +212,12 @@ steps:
       - label: ":linux: Auditbeat/Packaging Linux ARM"
         key: "auditbeat-package-linux-arm"
         env:
-          PLATFORMS: "${PACKAGING_ARM_PLATFORMS}"
+          PLATFORMS: "linux/arm64"
           PACKAGES: "docker"
           SNAPSHOT: true
-        command: "cd $BEATS_PROJECT_NAME && mage package"
+        command: |
+          cd auditbeat
+          mage package
         agents:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"

--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -109,7 +109,7 @@ steps:
     key: "auditbeat-extended-tests-linux-arm64"
     if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*arm.*/
     steps:
-      - label: ":arm: Linux ARM Unit Tests"
+      - label: ":linux: Auditbeat Linux arm64 Unit Tests"
         key: "auditbeat-extended-arm64-unit-tests"
         command: |
           set -euo pipefail
@@ -127,7 +127,7 @@ steps:
   - group: "Auditbeat MacOS Extended"
     if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
     steps:
-      - label: ":mac: MacOS x86_64 Unit Tests"
+      - label: ":mac: Auditbeat macOS x86_64 Unit Tests"
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -141,7 +141,7 @@ steps:
           - github_commit_status:
               context: "auditbeat: Extended MacOS x86_64 Unit Tests"
 
-      - label: ":mac: MacOS arm64 Unit Tests"
+      - label: ":mac: Auditbeat macOS arm64 Unit Tests"
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh

--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -39,18 +39,9 @@ steps:
         artifact_paths:
           - "auditbeat/build/*.xml"
           - "auditbeat/build/*.json"
-
-      - label: ":ubuntu: Auditbeat Unit Tests"
-        command: |
-          cd auditbeat
-          mage build unitTest
-        agents:
-          provider: "gcp"
-          image: "${IMAGE_UBUNTU_X86_64}"
-          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
-        artifact_paths:
-          - "auditbeat/build/*.xml"
-          - "auditbeat/build/*.json"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Ubuntu Unit Tests"
 
       - label: ":rhel: Auditbeat Unit Tests"
         command: |
@@ -63,6 +54,9 @@ steps:
         artifact_paths:
           - "auditbeat/build/*.xml"
           - "auditbeat/build/*.json"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: RHEL Unit Tests"
 
       - label: ":windows: Auditbeat Win-2016 Unit Tests"
         command: |
@@ -77,6 +71,9 @@ steps:
         artifact_paths:
           - "auditbeat/build/*.xml"
           - "auditbeat/build/*.json"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Windows 2016 Unit Tests"
 
       - label: ":windows: Auditbeat Win-2022 Unit Tests"
         command: |
@@ -91,6 +88,9 @@ steps:
         artifact_paths:
           - "auditbeat/build/*.xml"
           - "auditbeat/build/*.json"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Windows 2022 Unit Tests"
 
       - label: ":linux: Auditbeat Crosscompile"
         command: |
@@ -101,12 +101,15 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Cross compile"
 
-  - group: "Auditbeat ARM Tests"
-    key: "auditbeat-extended-tests-arm"
+  - group: "Auditbeat Linux arm64 Tests"
+    key: "auditbeat-extended-tests-linux-arm64"
     if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*arm.*/
     steps:
-      - label: ":arm: ARM64 Unit Tests"
+      - label: ":arm: Linux ARM Unit Tests"
         key: "auditbeat-extended-arm64-unit-tests"
         command: |
           set -euo pipefail
@@ -117,11 +120,14 @@ steps:
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
         artifact_paths: "auditbeat/build/*.*"
+        notify:
+          - github_commit_status:
+              context: "metricbeat: Linux arm64 tests"
 
   - group: "Auditbeat MacOS Extended"
     if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
     steps:
-      - label: ":mac: MacOS Unit Tests"
+      - label: ":mac: MacOS x86_64 Unit Tests"
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -131,8 +137,11 @@ steps:
           provider: "orka"
           imagePrefix: "${IMAGE_MACOS_X86_64}"
         artifact_paths: "auditbeat/build/*.*"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Extended MacOS x86_64 Unit Tests"
 
-      - label: ":mac: MacOS ARM Unit Tests"
+      - label: ":mac: MacOS arm64 Unit Tests"
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -142,6 +151,9 @@ steps:
           provider: "orka"
           imagePrefix: "${IMAGE_MACOS_ARM}"
         artifact_paths: "auditbeat/build/*.*"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Extended MacOS arm64 Unit Tests"
 
   - group: "Auditbeat Windows Extended Testing"
     key: "auditbeat-extended-tests-win"
@@ -159,6 +171,9 @@ steps:
           disk_size: 100
           disk_type: "pd-ssd"
         artifact_paths: "auditbeat/build/*.*"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Extended Windows 2019 Unit Tests"
 
       - label: ":windows: Auditbeat Win-10 Unit Tests"
         key: "auditbeat-extended-win-10-unit-tests"
@@ -172,6 +187,9 @@ steps:
           disk_size: 100
           disk_type: "pd-ssd"
         artifact_paths: "auditbeat/build/*.*"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Extended Windows 10 Unit Tests"
 
       - label: ":windows: Auditbeat Win-11 Unit Tests"
         key: "auditbeat-extended-win-11-unit-tests"
@@ -185,6 +203,9 @@ steps:
           disk_size: 100
           disk_type: "pd-ssd"
         artifact_paths: "auditbeat/build/*.*"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Extended Windows 11 Unit Tests"
 
   - wait: ~
     # with PRs, we want to run packaging only if mandatory tests succeed
@@ -196,7 +217,7 @@ steps:
   - group: "Auditbeat Packaging"
     key: "auditbeat-packaging"
     steps:
-      - label: ":ubuntu: Auditbeat/Packaging Linux X86"
+      - label: ":ubuntu: Auditbeat/Packaging Linux"
         key: "auditbeat-package-linux-x86"
         env:
           PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
@@ -208,9 +229,12 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Packaging Linux"
 
-      - label: ":linux: Auditbeat/Packaging Linux ARM"
-        key: "auditbeat-package-linux-arm"
+      - label: ":linux: Auditbeat/Packaging Linux arm64"
+        key: "auditbeat-package-linux-arm64"
         env:
           PLATFORMS: "linux/arm64"
           PACKAGES: "docker"
@@ -222,3 +246,6 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Packaging Linux arm64"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
                 - auditbeat/
                 - .buildkite/auditbeat/
                 - .buildkite/scripts
+                - .buildkite/hooks/
                 #OSS
                 - go.mod
                 - pytest.ini


### PR DESCRIPTION
## Proposed commit message

Fix macOS failures with auditbeat and refactor
the pipeline to be similar to other ones wrt notifications,
build commands and no usage of BEATS_PROJECT_NAME.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3072

## Screenshots

## Logs

Buildkite runs:

- default labels: https://buildkite.com/elastic/auditbeat/builds/3824
- `:Windows` && `:macOS` && `:arm`: https://buildkite.com/elastic/auditbeat/builds/3828