### PR TITLE
Remove X-PACK Filebeat bot trigger

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -130,22 +130,6 @@
         },
         {
             "enabled": true,
-            "pipelineSlug": "beats-xpack-filebeat",
-            "allow_org_users": true,
-            "allowed_repo_permissions": ["admin", "write"],
-            "allowed_list": [ ],
-            "set_commit_status": true,
-            "build_on_commit": true,
-            "build_on_comment": true,
-            "trigger_comment_regex": "^/test x-pack/filebeat$",
-            "always_trigger_comment_regex": "^/test x-pack/filebeat$",
-            "skip_ci_labels": [  ],
-            "skip_target_branches": [ ],
-            "skip_ci_on_only_changed": [ ],
-            "always_require_ci_on_changed": ["^x-pack/filebeat/.*", "^.buildkite/.*", "^go.mod", "^pytest.ini", "^dev-tools/.*", "^libbeat/.*", "^testing/.*", "^x-pack/libbeat/.*"]
-        },
-        {
-            "enabled": true,
             "pipelineSlug": "beats-xpack-heartbeat",
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],


### PR DESCRIPTION

## Proposed commit message

This commit removes the trigger configuration of the x-pack filebeat from main.

This is done in prep for the https://github.com/elastic/beats/pull/38941

Related: https://github.com/elastic/ingest-dev/issues/3072