### PR TITLE
Osquerybeat: Strip osqueryd binary for linux

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -333,6 +333,19 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
+	)
+
+	// Ensure the proper platform is passed
+	// This fixes an issue where during linux build for the currently used docker image
+	// docker.elastic.co/beats-dev/golang-crossbuild:1.21.9-arm the image for x64_64 arch is pulled
+	// and causes problems when using native arch tools on the binaries that are built for arm64 arch.
+	if strings.HasPrefix(b.Platform, "linux/") {
+		args = append(args,
+			"--platform", b.Platform,
+		)
+	}
+
+	args = append(args,
 		image,
 
 		// Arguments for docker crossbuild entrypoint. For details see


### PR DESCRIPTION
## Proposed commit message

Strip osqueryd binary for linux that is unstripped in the official osquery tar.gz distro.
Size reduction 
ARM: 273,418,504 -> 78,956,480 bytes
x86: 270,282,072 -> 86,097,240 bytes

Changed dev-tools code for linux crossbuilds. 
Noticed that the image docker.elastic.co/beats-dev/golang-crossbuild:1.21.9-arm currently exists for both ARM and x86 archs and is being used randomly, which cases a problem for ```strip``` tool when arch of binaries are mismatches with the arch of the tool. This affects only linux builds. 

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Ensure that everything builds as before. The size of ```osqueryd``` is 3x smaller than before on linux OS, currently is under 90M.

## Related issues

- Closes https://github.com/elastic/beats/issues/38890

## Screenshots

Before:
<img width="674" alt="Screenshot 2024-04-15 at 2 21 00 PM" src="https://github.com/elastic/beats/assets/872351/d9b5224f-8532-4887-99e5-3195de1f6f1d">

After:
<img width="653" alt="Screenshot 2024-04-15 at 12 44 19 PM" src="https://github.com/elastic/beats/assets/872351/6646a4fc-49e2-4fc4-8b3d-169eda28819e">
