### PR TITLE
Remove modules from Filebeat

### DIFF
--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -43,19 +43,6 @@ steps:
 
       - label: ":ubuntu: Ubuntu Go Integration Tests"
         command: |
-          set -euo pipefail
-          # defines the MODULE env var based on what's changed in a PR
-          source .buildkite/scripts/changesets.sh
-          defineModuleFromTheChangeSet filebeat
-          echo "~~~ Will run tests with env var MODULE=$$MODULE"
-          # TODO move this section to base image / pre-command hook
-          echo "~~~ Installing kind"
-          asdf plugin add kind
-          asdf install kind $ASDF_KIND_VERSION
-          .buildkite/deploy/kubernetes/scripts/kind-setup.sh
-
-          export KUBECONFIG="$$PWD/kubecfg"
-          echo "~~~ Running tests"
           cd filebeat
           mage goIntegTest
         agents:
@@ -71,19 +58,6 @@ steps:
 
       - label: ":ubuntu: Ubuntu Python Integration Tests"
         command: |
-          set -euo pipefail
-          # defines the MODULE env var based on what's changed in a PR
-          source .buildkite/scripts/changesets.sh
-          defineModuleFromTheChangeSet filebeat
-          echo "~~~ Will run tests with env var MODULE=$$MODULE"
-          # TODO move this section to base image / pre-command hook
-          echo "~~~ Installing kind"
-          asdf plugin add kind
-          asdf install kind $ASDF_KIND_VERSION
-          .buildkite/deploy/kubernetes/scripts/kind-setup.sh
-
-          export KUBECONFIG="$$PWD/kubecfg"
-          echo "~~~ Running tests"
           cd filebeat
           mage pythonIntegTest
         agents:


### PR DESCRIPTION
## Proposed commit message

As we migrated the Filebeat pipeline into the central triggering pipeline we added the MODULEs changeset for the Filebeat project, which looking at the original Jenkins it was never the case. 

This PR fixes the above inconsistency.