### PR TITLE
[Buildkite] Remove x-pack/auditbeat bot trigger

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -98,22 +98,6 @@
         },
         {
             "enabled": true,
-            "pipelineSlug": "beats-xpack-auditbeat",
-            "allow_org_users": true,
-            "allowed_repo_permissions": ["admin", "write"],
-            "allowed_list": [ ],
-            "set_commit_status": true,
-            "build_on_commit": true,
-            "build_on_comment": true,
-            "trigger_comment_regex": "^/test x-pack/auditbeat$",
-            "always_trigger_comment_regex": "^/test x-pack/auditbeat$",
-            "skip_ci_labels": [  ],
-            "skip_target_branches": [ ],
-            "skip_ci_on_only_changed": [ ],
-            "always_require_ci_on_changed": ["^x-pack/auditbeat/.*", "^.buildkite/.*", "^go.mod", "^pytest.ini", "^dev-tools/.*", "^libbeat/.*", "^testing/.*", "^x-pack/libbeat/.*"]
-        },
-        {
-            "enabled": true,
             "pipelineSlug": "beats-xpack-heartbeat",
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],


### PR DESCRIPTION
## Proposed commit message

This commit removes the x-pack/auditbeat BK PR bot trigger in preparation for the migration to the
static pipeline (#38828)

## Related issues

- https://github.com/elastic/ingest-dev/issues/3072

