### PR TITLE
Cleanup: Remove unused ACK tracking in `awscloudwatch` input

### DIFF
--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -111,9 +111,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	defer cancelInputCtx()
 
 	// Create client for publishing events and receive notification of their ACKs.
-	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		EventListener: awscommon.NewEventACKHandler(),
-	})
+	client, err := pipeline.ConnectWith(beat.ClientConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to create pipeline client: %w", err)
 	}

--- a/x-pack/filebeat/input/awscloudwatch/input_integration_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/input_integration_test.go
@@ -32,7 +32,6 @@ import (
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	pubtest "github.com/elastic/beats/v7/libbeat/publisher/testing"
-	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -163,12 +162,6 @@ func TestInputWithLogGroupNamePrefix(t *testing.T) {
 
 	client := pubtest.NewChanClient(0)
 	defer close(client.Channel)
-	go func() {
-		for event := range client.Channel {
-			// Fake the ACK handling that's not implemented in pubtest.
-			event.Private.(*awscommon.EventACKTracker).ACK()
-		}
-	}()
 
 	var errGroup errgroup.Group
 	errGroup.Go(func() error {


### PR DESCRIPTION
Remove `EventACKTracker` from `awscloudwatch` event handling.

`EventACKTracker` is buggy (see https://github.com/elastic/beats/issues/38961) but in the `awscloudwatch` input it's also never used -- its callbacks are attached to events, but their result doesn't affect any of the event handling.

This PR doesn't change any functional behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
