### PR TITLE
Adding missing comma in packaging.groovy, add agentbeat for arm.

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -204,7 +204,7 @@ def generateSteps() {
     'metricbeat',
     'packetbeat',
     'winlogbeat',
-    'x-pack/agentbeat'
+    'x-pack/agentbeat',
     'x-pack/auditbeat',
     'x-pack/dockerlogbeat',
     'x-pack/filebeat',
@@ -222,6 +222,7 @@ def generateSteps() {
     'heartbeat',
     'metricbeat',
     'packetbeat',
+    'x-pack/agentbeat',
     'x-pack/auditbeat',
     'x-pack/dockerlogbeat',
     'x-pack/filebeat',


### PR DESCRIPTION
Follow up from https://github.com/elastic/beats/pull/38951 to fix the failures in https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fpackaging/detail/main/4035/pipeline

```
[2024-04-17T01:56:48.997Z] Started by user Craig MacKenzie
[2024-04-17T01:56:49.074Z] Connecting to https://api.github.com/ using Jenkins - beats-ci
[2024-04-17T01:56:49.571Z] Obtained .ci/packaging.groovy from 3f06575996bc91402a5c330c18b0e7451c43785b
[2024-04-17T01:56:49.571Z] Resume disabled by user, switching to high-performance, low-durability mode.
[2024-04-17T01:56:49.587Z] org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
[2024-04-17T01:56:49.587Z] WorkflowScript: 208: expecting ']', found 'x-pack/auditbeat' @ line 208, column 5.
[2024-04-17T01:56:49.587Z]        'x-pack/auditbeat',
[2024-04-17T01:56:49.587Z]        ^
[2024-04-17T01:56:49.587Z] 
[2024-04-17T01:56:49.587Z] 1 error
```