### PR TITLE
add .asc downloads to elastic-agent-package-7.17

### DIFF
--- a/dev-tools/mage/manifest/manifest.go
+++ b/dev-tools/mage/manifest/manifest.go
@@ -87,6 +87,11 @@ func resolveManifestPackage(project artifacts.Project, pkg string, reqPackage st
 	if !ok {
 		return nil
 	}
+	// Check if val.AscURL is empty and update it if necessary
+	if val.AscURL == "" {
+		val.AscURL = val.URL + ".asc"
+	}
+
 	if mg.Verbose() {
 		log.Printf(">>>>>>>>>>> Project branch/commit [%s, %s]", project.Branch, project.CommitHash)
 	}


### PR DESCRIPTION
Adds `.asc` files to package pipeline, to fix `7.x` packaging bug
![image](https://github.com/elastic/beats/assets/16253938/8f1adcd2-dcff-489e-a3c5-b679e18221b8)

list of resulting tar.gz after mage package concludes.
![image](https://github.com/elastic/beats/assets/16253938/868686cc-56d2-419a-84ec-650f5738bf80)


Signed-off-by: DaveSys911 <David.Natachanny@elastic.co>