### PR TITLE
Improve conditionals for x-pack/metricbeat BK CI

### DIFF
--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -180,7 +180,7 @@ steps:
     if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*(macOS|aws).*/
     steps:
       - label: ":mac: MacOS x86_64 Unit Tests"
-        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*macOS.**/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -197,7 +197,7 @@ steps:
 
       - label: ":mac: MacOS arm64 Unit Tests"
         skip: "https://github.com/elastic/beats/issues/33036"
-        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*macOS.**/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -215,6 +215,7 @@ steps:
       - label: ":linux: Cloud (MODULE) Tests"
         key: "x-pack-metricbeat-extended-cloud-test"
         skip: "doesn't belong in a stage in Jenkins, thus skipped"
+        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         # see link in Jenkins: https://github.com/elastic/beats/blob/ccd7b135df70358f8a02393d9bd8b716428b8048/x-pack/metricbeat/Jenkinsfile.yml#L39
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
         command: |
@@ -244,10 +245,10 @@ steps:
 
       - label: ":linux: Cloud AWS (MODULE) Tests"
         key: "x-pack-metricbeat-extended-cloud-test-aws"
-        if: build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         skip: "https://github.com/elastic/beats/issues/36425"
         # see commented out section in Jenkins: https://github.com/elastic/beats/blob/main/x-pack/metricbeat/Jenkinsfile.yml#L41-L52
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
+        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         command: |
           set -euo pipefail
           # defines the MODULE env var based on what's changed in a PR

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -214,7 +214,7 @@ steps:
 
       - label: ":linux: Cloud (MODULE) Tests"
         key: "x-pack-metricbeat-extended-cloud-test"
-        skip: "doesn't belong in a stage in Jenkins, thus skipped"
+        #skip: "doesn't belong in a stage in Jenkins, thus skipped"
         if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         # see link in Jenkins: https://github.com/elastic/beats/blob/ccd7b135df70358f8a02393d9bd8b716428b8048/x-pack/metricbeat/Jenkinsfile.yml#L39
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
@@ -245,7 +245,7 @@ steps:
 
       - label: ":linux: Cloud AWS (MODULE) Tests"
         key: "x-pack-metricbeat-extended-cloud-test-aws"
-        skip: "https://github.com/elastic/beats/issues/36425"
+        #skip: "https://github.com/elastic/beats/issues/36425"
         # see commented out section in Jenkins: https://github.com/elastic/beats/blob/main/x-pack/metricbeat/Jenkinsfile.yml#L41-L52
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
         if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -214,7 +214,7 @@ steps:
 
       - label: ":linux: Cloud (MODULE) Tests"
         key: "x-pack-metricbeat-extended-cloud-test"
-        #skip: "doesn't belong in a stage in Jenkins, thus skipped"
+        skip: "doesn't belong in a stage in Jenkins, thus skipped"
         if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         # see link in Jenkins: https://github.com/elastic/beats/blob/ccd7b135df70358f8a02393d9bd8b716428b8048/x-pack/metricbeat/Jenkinsfile.yml#L39
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
@@ -245,7 +245,7 @@ steps:
 
       - label: ":linux: Cloud AWS (MODULE) Tests"
         key: "x-pack-metricbeat-extended-cloud-test-aws"
-        #skip: "https://github.com/elastic/beats/issues/36425"
+        skip: "https://github.com/elastic/beats/issues/36425"
         # see commented out section in Jenkins: https://github.com/elastic/beats/blob/main/x-pack/metricbeat/Jenkinsfile.yml#L41-L52
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
         if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/


### PR DESCRIPTION
## Proposed commit message

PR#38913 had a bug for the extended tests group:
it wouldn't allow to run steps in the extended
group when not using a PR (e.g. merge commits).

This commit allows all steps in the extended
group to run when the trigger is not a PR.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3072

## Logs

