### PR TITLE
Remove BK PR Bot trigger for packetbeat

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -18,22 +18,6 @@
         },
         {
             "enabled": true,
-            "pipelineSlug": "beats-packetbeat",
-            "allow_org_users": true,
-            "allowed_repo_permissions": ["admin", "write"],
-            "allowed_list": [ ],
-            "set_commit_status": true,
-            "build_on_commit": true,
-            "build_on_comment": true,
-            "trigger_comment_regex": "^/test packetbeat$",
-            "always_trigger_comment_regex": "^/test packetbeat$",
-            "skip_ci_labels": [  ],
-            "skip_target_branches": [ ],
-            "skip_ci_on_only_changed": [ ],
-            "always_require_ci_on_changed": ["^packetbeat/.*", ".buildkite/packetbeat/.*", "^go.mod", "^pytest.ini", "^dev-tools/.*", "^libbeat/.*", "^testing/.*"]
-        },
-        {
-            "enabled": true,
             "pipelineSlug": "beats-xpack-elastic-agent",
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],


### PR DESCRIPTION
## Proposed commit message

In preparation for the migration to a static pipeline for packetbeat, this commit removes the Buildkite PR Bot trigger.

## Related issues

- elastic/ingest-dev#3072
