### PR TITLE
Test fix for BK packaging failure

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -339,7 +339,7 @@ func (b GolangCrossBuilder) Build() error {
 	// This fixes an issue where during arm64 linux build for the currently used docker image
 	// docker.elastic.co/beats-dev/golang-crossbuild:1.21.9-arm the image for amd64 arch is pulled
 	// and causes problems when using native arch tools on the binaries that are built for arm64 arch.
-	if strings.HasPrefix(b.Platform, "linux/") {
+	if strings.HasPrefix(b.Platform, "linux/") && strings.Contains(b.Platform, "arm64") {
 		args = append(args,
 			"--platform", b.Platform,
 		)

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -339,7 +339,7 @@ func (b GolangCrossBuilder) Build() error {
 	// This fixes an issue where during arm64 linux build for the currently used docker image
 	// docker.elastic.co/beats-dev/golang-crossbuild:1.21.9-arm the image for amd64 arch is pulled
 	// and causes problems when using native arch tools on the binaries that are built for arm64 arch.
-	if strings.HasPrefix(b.Platform, "linux/") && strings.Contains(b.Platform, "arm64") {
+	if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
 		args = append(args,
 			"--platform", b.Platform,
 		)

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -327,7 +327,7 @@ func (b GolangCrossBuilder) Build() error {
 
 	args = append(args,
 		"--rm",
-		"--env", "GOFLAGS=-mod=readonly -buildvcs=false",
+		"--env", "'GOFLAGS=-mod=readonly -buildvcs=false'",
 		"--env", "MAGEFILE_VERBOSE="+verbose,
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),


### PR DESCRIPTION
## Proposed commit message

PR #38952 surfaced a bug with #38366 where
the parameters weren't enclosed in doublet quotes.

Failed logs: https://buildkite.com/elastic/beats-xpack-osquerybeat/builds/1973#018f06dd-19fd-40e0-ba21-960d195f178e/131-316

## Related issues

- #38952
- #38366
