### PR TITLE
Enable DRA for main via Buildkite

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
 
-# TODO: uncomment out below when Jenkins packaging has been stopped
-# if [[ "$DRY_RUN" == "true" ]]; then
-#     echo "~~~ Running in dry-run mode -- will NOT publish artifacts"
-#     DRY_RUN="--dry-run"
-# else
-#     echo "~~~ Running in publish mode"
-#     DRY_RUN=""
-# fi
-
-# TODO: delete the conditional below (and replace it with the above, uncommented out, section) after Jenkins packaging has been stopped
-if [[ "$DRY_RUN" == "false" ]]; then
-    echo "~~~ Running in publish mode"
-    DRY_RUN=""
-else
+if [[ "$DRY_RUN" == "true" ]]; then
     echo "~~~ Running in dry-run mode -- will NOT publish artifacts"
     DRY_RUN="--dry-run"
+else
+    echo "~~~ Running in publish mode"
+    DRY_RUN=""
 fi
 
 set -euo pipefail

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -14,7 +14,7 @@
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
           discover-tags: true
-          head-filter-regex: '(main|7\.1[6789]|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          head-filter-regex: '(7\.1[6789]|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
           disable-pr-notifications: true
           notification-context: 'beats-packaging'
           repo: 'beats'

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -28,9 +28,6 @@
               ignore-tags-older-than: -1
               ignore-tags-newer-than: 30
           - named-branches:
-              - exact-name:
-                  name: 'main'
-                  case-sensitive: true
               - regex-name:
                   regex: '7\.1[6789]'
                   case-sensitive: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,3 @@ repos:
     hooks:
     -   id: check-jenkins-pipelines
         files: ^(.ci/(.*\.groovy|Jenkinsfile)|Jenkinsfile)$
-    -   id: check-jjbb

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1040,11 +1040,17 @@ spec:
     spec:
       repository: elastic/beats
       pipeline_file: ".buildkite/packaging.pipeline.yml"
-      branch_configuration: "main 8.* 7.17"
+      branch_configuration: "main"
+      # TODO enable after packaging backports for release branches
+      # branch_configuration: "main 8.* 7.17"
       cancel_intermediate_builds: false
       skip_intermediate_builds: false
       provider_settings:
-        trigger_mode: none
+        trigger_mode: code
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## Proposed commit message

This commit disables automated DRA builds for
the `main` branch via Jenkins, and enables the
same functionality via Buildkite.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
