### PR TITLE
Mark add_docker-metadata process as unsupported in packetbeat

### DIFF
--- a/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
+++ b/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
@@ -5,6 +5,11 @@
 <titleabbrev>add_docker_metadata</titleabbrev>
 ++++
 
+ifeval::["{beatname_lc}"=="packetbeat"]
+There is currently extremely limited capability for using {beatname_lc} to monitor and coexist with containers, for example Docker, Podman, or Kubernetes). Using the `add_docker_metadata` processor with {beatname_lc} is not recommended nor supported. 
+endif::[]
+
+ifeval::["{beatname_lc}"!="packetbeat"]
 The `add_docker_metadata` processor annotates each event with relevant metadata
 from Docker containers. At startup it detects a docker environment and caches the metadata.
 The events are annotated with Docker metadata, only if a valid configuration
@@ -88,3 +93,4 @@ forget metadata for a container, 60s by default.
 
 `labels.dedot`:: (Optional) Default to be false. If set to true, replace dots in
  labels with `_`.
+endif::[]

--- a/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
+++ b/libbeat/processors/add_docker_metadata/docs/add_docker_metadata.asciidoc
@@ -6,7 +6,7 @@
 ++++
 
 ifeval::["{beatname_lc}"=="packetbeat"]
-There is currently extremely limited capability for using {beatname_lc} to monitor and coexist with containers, for example Docker, Podman, or Kubernetes). Using the `add_docker_metadata` processor with {beatname_lc} is not recommended nor supported. 
+There is currently extremely limited capability for using {beatname_lc} to monitor and coexist with containers, for example Docker, Podman, or Kubernetes. Using the `add_docker_metadata` processor with {beatname_lc} is not recommended nor supported. 
 endif::[]
 
 ifeval::["{beatname_lc}"!="packetbeat"]


### PR DESCRIPTION
This updates the [Add Docker metadata ](https://www.elastic.co/guide/en/beats/packetbeat/8.13/add-docker-metadata.html) page in the current (8.13) and later Packetbeat docs to note that this processor is not supported, as recommended [here](https://github.com/elastic/enhancements/issues/21415#issuecomment-2079518786).

Rel: https://github.com/elastic/enhancements/issues/21415

These docs are single-sourced across all Beats. The following will appear only on the Packetbeat page:

![Screenshot 2024-04-26 at 2 18 12 PM](https://github.com/elastic/beats/assets/41695641/5baa2df6-da1d-4f50-aa18-07a450dba0a1)
