### PR TITLE
[8.14](backport #39255) Add IronBank validation to cron schedule

### DIFF
--- a/.buildkite/pipeline-scheduler.yml
+++ b/.buildkite/pipeline-scheduler.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+# this intermediate pipeline is required because we can't specify a custom agent (k8s image) yet
+# in catalog-info: https://github.com/elastic/ci/blob/71e83d340e3b93ab43fcf16a7a70ac33bdeec6e9/terrazzo/terrazzo/constructs/buildkite/pipelines.py#L787-L842
+
+steps:
+  - label: ":pipeline: Generate trigger steps for $PIPELINES_TO_TRIGGER"
+    command: |
+      set -eo pipefail
+      .buildkite/pipeline-scheduler.py >steps.yml
+      echo "~~~ Printing pipeline steps"
+      yq . steps.yml
+      echo "~~~ Uploading steps"
+      buildkite-agent pipeline upload steps.yml
+    agents:
+      image: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:0.1"
+      useCustomGlobalHooks: true


### PR DESCRIPTION
## Proposed commit message

This commit is a follow up to #39254 and adds
a schedule for the IronBank validation pipeline
to the centralized scheduling pipeline.

## Related issues

Relates: https://github.com/elastic/ingest-dev/issues/3235

This is a backport of https://github.com/elastic/beats/pull/39255