### PR TITLE
Ensure ordered DRA artifacts

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -1,6 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 # TODO: Pre-cache beats-dev/golang-crossbuild container image
 
+# prevent out of order DRA publishing
+# otherwise commits in quick succession will run in parallel and possibly result in our of order DRA artifacts
+agents:
+  queue: "dra-builder-queue"
+
 env:
   ASDF_MAGE_VERSION: 1.15.0
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -12,18 +12,14 @@ env:
   PLATFORMS_ARM: "linux/arm64"
 
 steps:
-  - key: beats_dra_concurrency_group
-    command: echo "Only one DRA job per commit is allowed to run."
-    concurrency_group: beats_dra
-    concurrency: 1
-
   - group: Beats dashboards
     key: dashboards
-    depends_on: beats_dra_concurrency_group
     steps:
       - label: Snapshot dashboards
         if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
         key: dashboards-snapshot
+        concurrency_group: beats-snapshot-dashboards
+        concurrency: 1
         # TODO: container with go and make
         agents:
           provider: gcp
@@ -41,6 +37,8 @@ steps:
       - label: Staging dashboards
         if: build.branch =~ /^\d+\.\d+$$/
         key: dashboards-staging
+        concurrency_group: beats-staging-dashboards
+        concurrency: 1
         # TODO: container with go and make
         agents:
           provider: gcp
@@ -58,9 +56,10 @@ steps:
   - group: Packaging snapshot
     if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
     key: packaging-snapshot
-    depends_on: beats_dra_concurrency_group
     steps:
       - label: "SNAPSHOT: {{matrix}}"
+        concurrency_group: "{{matrix}}-packaging-snapshot"
+        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
@@ -90,6 +89,8 @@ steps:
           - x-pack/winlogbeat
 
       - label: "SNAPSHOT: {{matrix}} docker Linux/arm64"
+        concurrency_group: "{{matrix}}-packaging-docker-snapshot"
+        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
           PACKAGES: "docker"
@@ -117,6 +118,8 @@ steps:
 
       ## Agentbeat needs more CPUs because it builds many other beats
       - label: "SNAPSHOT: x-pack/agentbeat"
+        concurrency_group: "x-pack/agentbeat-packaging-snapshot"
+        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
@@ -131,11 +134,12 @@ steps:
 
   - group: Packaging Staging
     key: packaging-staging
-    depends_on: beats_dra_concurrency_group
     ## Only for release
     if: build.branch =~ /^\d+\.\d+$$/
     steps:
       - label: "STAGING: {{matrix}}"
+        concurrency_group: "{{matrix}}-packaging-staging"
+        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: false
@@ -165,6 +169,8 @@ steps:
           - x-pack/winlogbeat
 
       - label: "STAGING: {{matrix}} docker Linux/arm64"
+        concurrency_group: "{{matrix}}-packaging-docker-staging"
+        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
           PACKAGES: "docker"
@@ -192,6 +198,8 @@ steps:
 
         ## Agentbeat needs more CPUs because it builds many other beats
       - label: "STAGING: x-pack/agentbeat"
+        concurrency_group: "x-pack/agentbeat-packaging-staging"
+        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: false
@@ -206,9 +214,10 @@ steps:
 
   - group: DRA publish
     key: dra
-    depends_on: beats_dra_concurrency_group
     steps:
       - label: DRA Snapshot
+        concurrency_group: "dra-snapshot"
+        concurrency: 1
         ## Only for release branches and main
         if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
         key: dra-snapshot
@@ -227,6 +236,8 @@ steps:
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
 
       - label: DRA Staging
+        concurrency_group: "dra-staging"
+        concurrency: 1
         ## Only for release branches
         if: build.branch =~ /^\d+\.\d+$$/
         key: dra-staging

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -12,14 +12,16 @@ env:
   PLATFORMS_ARM: "linux/arm64"
 
 steps:
-  - key: beats_dra_concurrency_group
-    command: echo "Only one DRA job per commit is allowed to run."
-    concurrency_group: beats_dra
+  - command: echo "--> Start of concurrency gate"
+    concurrency_group: gate
     concurrency: 1
+    key: start-gate
+
+  - wait
 
   - group: Beats dashboards
     key: dashboards
-    depends_on: beats_dra_concurrency_group
+    depends_on: start-gate
     steps:
       - label: Snapshot dashboards
         if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
@@ -58,7 +60,7 @@ steps:
   - group: Packaging snapshot
     if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
     key: packaging-snapshot
-    depends_on: beats_dra_concurrency_group
+    depends_on: start-gate
     steps:
       - label: "SNAPSHOT: {{matrix}}"
         env:
@@ -131,7 +133,7 @@ steps:
 
   - group: Packaging Staging
     key: packaging-staging
-    depends_on: beats_dra_concurrency_group
+    depends_on: start-gate
     ## Only for release
     if: build.branch =~ /^\d+\.\d+$$/
     steps:
@@ -206,7 +208,7 @@ steps:
 
   - group: DRA publish
     key: dra
-    depends_on: beats_dra_concurrency_group
+    depends_on: start-gate
     steps:
       - label: DRA Snapshot
         ## Only for release branches and main
@@ -243,3 +245,8 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+
+  - command: echo "End of concurrency gate <--"
+    concurrency_group: gate
+    concurrency: 1
+    key: end-gate

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -12,19 +12,32 @@ env:
   PLATFORMS_ARM: "linux/arm64"
 
 steps:
-  - command: echo "--> Start of concurrency gate"
-    concurrency_group: gate
+  # we use concurrency gates (https://buildkite.com/blog/concurrency-gates)
+  # to implement two FIFO queues for DRA-snapshot and DRA-staging
+  # this prevents parallel builds and possibility of publishing out of order DRA artifacts if the first job takes longer than the second
+
+  - name: Start of concurrency group for DRA Snapshot
+    if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
+    command: echo "--> Start of concurrency gate dra-snapshot"
+    concurrency_group: "dra-gate-snapshot"
     concurrency: 1
-    key: start-gate
+    key: start-gate-snapshot
+
+  - name: Start of concurrency group for DRA Staging
+    if: build.branch =~ /^\d+\.\d+$$/
+    command: echo "--> Start of concurrency gate dra-staging"
+    concurrency_group: "dra-gate-staging"
+    concurrency: 1
+    key: start-gate-staging
 
   - wait
 
   - group: Beats dashboards
     key: dashboards
-    depends_on: start-gate
     steps:
       - label: Snapshot dashboards
         if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
+        depends_on: start-gate-snapshot
         key: dashboards-snapshot
         # TODO: container with go and make
         agents:
@@ -42,6 +55,7 @@ steps:
 
       - label: Staging dashboards
         if: build.branch =~ /^\d+\.\d+$$/
+        depends_on: start-gate-staging
         key: dashboards-staging
         # TODO: container with go and make
         agents:
@@ -60,7 +74,7 @@ steps:
   - group: Packaging snapshot
     if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
     key: packaging-snapshot
-    depends_on: start-gate
+    depends_on: start-gate-snapshot
     steps:
       - label: "SNAPSHOT: {{matrix}}"
         env:
@@ -133,7 +147,7 @@ steps:
 
   - group: Packaging Staging
     key: packaging-staging
-    depends_on: start-gate
+    depends_on: start-gate-staging
     ## Only for release
     if: build.branch =~ /^\d+\.\d+$$/
     steps:
@@ -208,7 +222,6 @@ steps:
 
   - group: DRA publish
     key: dra
-    depends_on: start-gate
     steps:
       - label: DRA Snapshot
         ## Only for release branches and main
@@ -217,6 +230,7 @@ steps:
         env:
           DRA_WORKFLOW: snapshot
         depends_on:
+          - start-gate-snapshot
           - packaging-snapshot
           - dashboards-snapshot
         command: |
@@ -235,6 +249,7 @@ steps:
         env:
           DRA_WORKFLOW: staging
         depends_on:
+          - start-gate-staging
           - packaging-staging
           - dashboards-staging
         command: |
@@ -248,7 +263,14 @@ steps:
 
   - wait
 
-  - command: echo "End of concurrency gate <--"
-    concurrency_group: gate
+  - command: echo "End of concurrency gate dra-snapshot <--"
+    if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
+    concurrency_group: "dra-gate-snapshot"
     concurrency: 1
-    key: end-gate
+    key: end-gate-snapshot
+
+  - command: echo "End of concurrency gate dra-staging <--"
+    if: build.branch =~ /^\d+\.\d+$$/
+    concurrency_group: "dra-gate-staging"
+    concurrency: 1
+    key: end-gate-staging

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -246,6 +246,8 @@ steps:
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
 
+  - wait
+
   - command: echo "End of concurrency gate <--"
     concurrency_group: gate
     concurrency: 1

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -12,14 +12,18 @@ env:
   PLATFORMS_ARM: "linux/arm64"
 
 steps:
+  - key: beats_dra_concurrency_group
+    command: echo "Only one DRA job per commit is allowed to run."
+    concurrency_group: beats_dra
+    concurrency: 1
+
   - group: Beats dashboards
     key: dashboards
+    depends_on: beats_dra_concurrency_group
     steps:
       - label: Snapshot dashboards
         if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
         key: dashboards-snapshot
-        concurrency_group: beats-snapshot-dashboards
-        concurrency: 1
         # TODO: container with go and make
         agents:
           provider: gcp
@@ -37,8 +41,6 @@ steps:
       - label: Staging dashboards
         if: build.branch =~ /^\d+\.\d+$$/
         key: dashboards-staging
-        concurrency_group: beats-staging-dashboards
-        concurrency: 1
         # TODO: container with go and make
         agents:
           provider: gcp
@@ -56,10 +58,9 @@ steps:
   - group: Packaging snapshot
     if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
     key: packaging-snapshot
+    depends_on: beats_dra_concurrency_group
     steps:
       - label: "SNAPSHOT: {{matrix}}"
-        concurrency_group: "{{matrix}}-packaging-snapshot"
-        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
@@ -89,8 +90,6 @@ steps:
           - x-pack/winlogbeat
 
       - label: "SNAPSHOT: {{matrix}} docker Linux/arm64"
-        concurrency_group: "{{matrix}}-packaging-docker-snapshot"
-        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
           PACKAGES: "docker"
@@ -118,8 +117,6 @@ steps:
 
       ## Agentbeat needs more CPUs because it builds many other beats
       - label: "SNAPSHOT: x-pack/agentbeat"
-        concurrency_group: "x-pack/agentbeat-packaging-snapshot"
-        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
@@ -134,12 +131,11 @@ steps:
 
   - group: Packaging Staging
     key: packaging-staging
+    depends_on: beats_dra_concurrency_group
     ## Only for release
     if: build.branch =~ /^\d+\.\d+$$/
     steps:
       - label: "STAGING: {{matrix}}"
-        concurrency_group: "{{matrix}}-packaging-staging"
-        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: false
@@ -169,8 +165,6 @@ steps:
           - x-pack/winlogbeat
 
       - label: "STAGING: {{matrix}} docker Linux/arm64"
-        concurrency_group: "{{matrix}}-packaging-docker-staging"
-        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
           PACKAGES: "docker"
@@ -198,8 +192,6 @@ steps:
 
         ## Agentbeat needs more CPUs because it builds many other beats
       - label: "STAGING: x-pack/agentbeat"
-        concurrency_group: "x-pack/agentbeat-packaging-staging"
-        concurrency: 1
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: false
@@ -214,10 +206,9 @@ steps:
 
   - group: DRA publish
     key: dra
+    depends_on: beats_dra_concurrency_group
     steps:
       - label: DRA Snapshot
-        concurrency_group: "dra-snapshot"
-        concurrency: 1
         ## Only for release branches and main
         if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
         key: dra-snapshot
@@ -236,8 +227,6 @@ steps:
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
 
       - label: DRA Staging
-        concurrency_group: "dra-staging"
-        concurrency: 1
         ## Only for release branches
         if: build.branch =~ /^\d+\.\d+$$/
         key: dra-staging

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -1,11 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 # TODO: Pre-cache beats-dev/golang-crossbuild container image
 
-# prevent out of order DRA publishing
-# otherwise commits in quick succession will run in parallel and possibly result in our of order DRA artifacts
-agents:
-  queue: "dra-builder-queue"
-
 env:
   ASDF_MAGE_VERSION: 1.15.0
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
@@ -17,8 +12,14 @@ env:
   PLATFORMS_ARM: "linux/arm64"
 
 steps:
+  - key: beats_dra_concurrency_group
+    command: echo "Only one DRA job per commit is allowed to run."
+    concurrency_group: beats_dra
+    concurrency: 1
+
   - group: Beats dashboards
     key: dashboards
+    depends_on: beats_dra_concurrency_group
     steps:
       - label: Snapshot dashboards
         if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
@@ -57,6 +58,7 @@ steps:
   - group: Packaging snapshot
     if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
     key: packaging-snapshot
+    depends_on: beats_dra_concurrency_group
     steps:
       - label: "SNAPSHOT: {{matrix}}"
         env:
@@ -128,8 +130,8 @@ steps:
           - build/distributions/**/*
 
   - group: Packaging Staging
-
     key: packaging-staging
+    depends_on: beats_dra_concurrency_group
     ## Only for release
     if: build.branch =~ /^\d+\.\d+$$/
     steps:
@@ -204,6 +206,7 @@ steps:
 
   - group: DRA publish
     key: dra
+    depends_on: beats_dra_concurrency_group
     steps:
       - label: DRA Snapshot
         ## Only for release branches and main


### PR DESCRIPTION
## Proposed commit message

As things are now we allow parallel builds on the
packaging pipeline, which would result in out of order artifacts (depending on which one takes longer to finish).

This commit leverages a queue to ensure a FIFO queue for DRA artifacts using the design pattern in:
https://buildkite.com/blog/concurrency-gates

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095

## Testing/Screenshots

Using the [latest approach](https://github.com/elastic/beats/pull/39270/commits/d6c7dc2b12955fd819111a77ca53356e07ff5f41), I triggered two DRA `main` snapshot builds in succession using the env vars:

```
DRA_BRANCH="main"
RUN_SNAPSHOT="true"
DRY_RUN="true"
```

and was able to see the [first one triggered](https://buildkite.com/elastic/beats-packaging-pipeline/builds/92) proceed:

![image](https://github.com/elastic/beats/assets/1754575/e9c514d1-b04a-4c77-99e0-50a8a4af0c89)
![image](https://github.com/elastic/beats/assets/1754575/9a4fb4e3-d82e-4f03-8d9e-2fa6f926051f)

whereas the [second one](https://buildkite.com/elastic/beats-packaging-pipeline/builds/93#018f2dcf-e9e6-4688-b74f-89dad137a840) was paused (as desired) waiting for the snapshot concurrency group:

![image](https://github.com/elastic/beats/assets/1754575/1fefc5d3-6494-4e70-a864-39af73b20ca9)

It would have been nice to trigger a staging build at the same time (which should allow one job at a time, since it's a different concurrency gate) but it's not easy given the conditionals.
