### PR TITLE
Include metricbeat modules directory into agentbeat build

### DIFF
--- a/metricbeat/scripts/mage/package.go
+++ b/metricbeat/scripts/mage/package.go
@@ -40,7 +40,7 @@ const (
 // not supported. You must declare a dependency on either
 // PrepareModulePackagingOSS or PrepareModulePackagingXPack.
 func CustomizePackaging() {
-	mg.Deps(customizeLightModulesPackaging)
+	mg.Deps(CustomizeLightModulesPackaging)
 
 	var (
 		modulesDTarget = "modules.d"
@@ -104,7 +104,7 @@ func CustomizePackaging() {
 // PrepareModulePackagingOSS generates build/package/modules and
 // build/package/modules.d directories for use in packaging.
 func PrepareModulePackagingOSS() error {
-	err := prepareLightModulesPackaging("module")
+	err := PrepareLightModulesPackaging("module")
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func PrepareModulePackagingOSS() error {
 // PrepareModulePackagingXPack generates build/package/modules and
 // build/package/modules.d directories for use in packaging.
 func PrepareModulePackagingXPack() error {
-	err := prepareLightModulesPackaging("module", devtools.OSSBeatDir("module"))
+	err := PrepareLightModulesPackaging("module", devtools.OSSBeatDir("module"))
 	if err != nil {
 		return err
 	}
@@ -201,8 +201,8 @@ func GenerateDirModulesD() error {
 	return nil
 }
 
-// customizeLightModulesPackaging customizes packaging to add light modules
-func customizeLightModulesPackaging() error {
+// CustomizeLightModulesPackaging customizes packaging to add light modules
+func CustomizeLightModulesPackaging() error {
 	var (
 		moduleTarget = "module"
 		module       = devtools.PackageFile{
@@ -225,8 +225,8 @@ func customizeLightModulesPackaging() error {
 	return nil
 }
 
-// prepareLightModulesPackaging generates light modules
-func prepareLightModulesPackaging(paths ...string) error {
+// PrepareLightModulesPackaging generates light modules
+func PrepareLightModulesPackaging(paths ...string) error {
 	err := devtools.Clean([]string{dirModulesGenerated})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Fixes issue where `module` directory from metricbeat was not included into the `agentbeat` build.

`module` directory is required for metricbeat lightweight modules to work.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #39223

