### PR TITLE
Fix auto triggered packaging builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1040,16 +1040,19 @@ spec:
     spec:
       repository: elastic/beats
       pipeline_file: ".buildkite/packaging.pipeline.yml"
-      branch_configuration: "main"
+      branch_configuration: "main 8.14"
       # TODO enable after packaging backports for release branches
       # branch_configuration: "main 8.* 7.17"
       cancel_intermediate_builds: false
       skip_intermediate_builds: false
       provider_settings:
-        build_branches: false
+        build_branches: true
         build_pull_request_forks: false
         build_pull_requests: false
         build_tags: false
+        filter_condition: >-
+          build.branch =~ /^[0-9]+\.[0-9]+$$/ || build.branch == "main"
+        filter_enabled: true
         trigger_mode: code
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'


### PR DESCRIPTION
## Proposed commit message

PR#39263 introduced a bug causing on packaging DRA builds to be triggered.

This commit fixes the issue and also allowed
triggered builds for `8.14`
