### PR TITLE
Fix missing docker staging DRA artifacts

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -192,7 +192,7 @@ steps:
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
         artifact_paths:
-          - build/distributions/**
+          - build/distributions/**/*
         matrix:
           - auditbeat
           - filebeat


### PR DESCRIPTION
## Proposed commit message

The DRA staging release is failing because the Buildkite step isn't capturing the right artifacts.
This commit fixes the issue by adjusting the artifact_paths to match the other steps.

## Logs

Example of failure: https://buildkite.com/elastic/beats-packaging-pipeline/builds/96#018f2e52-8eda-4311-91fc-662353604f29