### PR TITLE
Branch specific concurrency gates

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -19,14 +19,14 @@ steps:
   - name: Start of concurrency group for DRA Snapshot
     if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
     command: echo "--> Start of concurrency gate dra-snapshot"
-    concurrency_group: "dra-gate-snapshot"
+    concurrency_group: "dra-gate-snapshot-$BUILDKITE_BRANCH"
     concurrency: 1
     key: start-gate-snapshot
 
   - name: Start of concurrency group for DRA Staging
     if: build.branch =~ /^\d+\.\d+$$/
     command: echo "--> Start of concurrency gate dra-staging"
-    concurrency_group: "dra-gate-staging"
+    concurrency_group: "dra-gate-staging-$BUILDKITE_BRANCH"
     concurrency: 1
     key: start-gate-staging
 
@@ -265,12 +265,12 @@ steps:
 
   - command: echo "End of concurrency gate dra-snapshot <--"
     if: build.branch =~ /^\d+\.\d+$$/ || build.branch == 'main' || build.env('RUN_SNAPSHOT') == "true"
-    concurrency_group: "dra-gate-snapshot"
+    concurrency_group: "dra-gate-snapshot-$BUILDKITE_BRANCH"
     concurrency: 1
     key: end-gate-snapshot
 
   - command: echo "End of concurrency gate dra-staging <--"
     if: build.branch =~ /^\d+\.\d+$$/
-    concurrency_group: "dra-gate-staging"
+    concurrency_group: "dra-gate-staging-$BUILDKITE_BRANCH"
     concurrency: 1
     key: end-gate-staging


### PR DESCRIPTION
## Proposed commit message

PR #39293 introduced one concurrency queue per staging/snapshot but this slows down unnecessarily concurrent DRA builds for main and other release branches.

This commit makes the concurrency gates specific per branch.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095

## Logs

Example run: https://buildkite.com/elastic/beats-packaging-pipeline/builds/99#018f2ed1-88f4-4f2a-9604-e29c51eba3a3

## Screenshots

First run:

![image](https://github.com/elastic/beats/assets/1754575/dec0b420-6e64-416e-bb3e-a8b71f581b10)

Blocked second run (as expected):

![image](https://github.com/elastic/beats/assets/1754575/1d179eb0-cd51-4b42-9443-8def292519c6)
