### PR TITLE
Fix the annotating for snapshot and staging

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -78,5 +78,5 @@ if [[ "$DRY_RUN" != "--dry-run" ]]; then
   rm rm-output.txt
 
   # and make it easily clickable as a Builkite annotation
-  printf "**Summary link:** [${SUMMARY_URL}](${SUMMARY_URL})\n" | buildkite-agent annotate --style=success 
+  printf "**Summary link:** [${SUMMARY_URL}](${SUMMARY_URL})\n" | buildkite-agent annotate --style=success --append
 fi

--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -78,5 +78,5 @@ if [[ "$DRY_RUN" != "--dry-run" ]]; then
   rm rm-output.txt
 
   # and make it easily clickable as a Builkite annotation
-  printf "**Summary link:** [${SUMMARY_URL}](${SUMMARY_URL})\n" | buildkite-agent annotate --style=success --append
+  printf "**${DRA_WORKFLOW} summary link:** [${SUMMARY_URL}](${SUMMARY_URL})\n" | buildkite-agent annotate --style=success --append
 fi


### PR DESCRIPTION
## Proposed commit message

This commit adds the `--append` flag to the buildkite-annotate so that when it is called by the snapshot and staging steps will not overwrite the other annotation.

