### PR TITLE
Enable DRA for 8.14 on Buildkite

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
 
-# TODO: uncomment out below when Jenkins packaging has been stopped
-# if [[ "$DRY_RUN" == "true" ]]; then
-#     echo "~~~ Running in dry-run mode -- will NOT publish artifacts"
-#     DRY_RUN="--dry-run"
-# else
-#     echo "~~~ Running in publish mode"
-#     DRY_RUN=""
-# fi
-
-# TODO: delete the conditional below (and replace it with the above, uncommented out, section) after Jenkins packaging has been stopped
-if [[ "$DRY_RUN" == "false" ]]; then
-    echo "~~~ Running in publish mode"
-    DRY_RUN=""
-else
+if [[ "$DRY_RUN" == "true" ]]; then
     echo "~~~ Running in dry-run mode -- will NOT publish artifacts"
     DRY_RUN="--dry-run"
+else
+    echo "~~~ Running in publish mode"
+    DRY_RUN=""
 fi
 
 set -euo pipefail

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -14,7 +14,7 @@
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
           discover-tags: true
-          head-filter-regex: '(main|7\.1[6789]|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          head-filter-regex: '(7\.1[6789]|8\.13|PR-.*|v8\.13\.\d+)'
           disable-pr-notifications: true
           notification-context: 'beats-packaging'
           repo: 'beats'
@@ -29,13 +29,10 @@
               ignore-tags-newer-than: 30
           - named-branches:
               - exact-name:
-                  name: 'main'
+                  name: '8.13'
                   case-sensitive: true
               - regex-name:
                   regex: '7\.1[6789]'
-                  case-sensitive: true
-              - regex-name:
-                  regex: '8\.\d+'
                   case-sensitive: true
           - change-request:
               ignore-target-only-changes: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,3 @@ repos:
     hooks:
     -   id: check-jenkins-pipelines
         files: ^(.ci/(.*\.groovy|Jenkinsfile)|Jenkinsfile)$
-    -   id: check-jjbb


### PR DESCRIPTION
## Proposed commit message

This commit disables automated DRA builds for
the 8.14 branch via Jenkins, and enables the
same functionality via Buildkite.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095#issuecomment-2085726889