### PR TITLE
Disable 8.14 DRA on Jenkins

### DIFF
--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -14,7 +14,7 @@
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
           discover-tags: true
-          head-filter-regex: '(7\.1[6789]|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          head-filter-regex: '(7\.1[6789]|8\.13|PR-.*|v8\.13\.\d+)'
           disable-pr-notifications: true
           notification-context: 'beats-packaging'
           repo: 'beats'
@@ -28,8 +28,8 @@
               ignore-tags-older-than: -1
               ignore-tags-newer-than: 30
           - named-branches:
-              - regex-name:
-                  regex: '7\.1[6789]'
+              - exact-name:
+                  regex: '8\.13'
                   case-sensitive: true
               - regex-name:
                   regex: '8\.\d+'

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -32,7 +32,7 @@
                   regex: '8\.13'
                   case-sensitive: true
               - regex-name:
-                  regex: '8\.\d+'
+                  regex: '7\.1[6789]'
                   case-sensitive: true
           - change-request:
               ignore-target-only-changes: true

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -29,7 +29,7 @@
               ignore-tags-newer-than: 30
           - named-branches:
               - exact-name:
-                  regex: '8\.13'
+                  name: '8.13'
                   case-sensitive: true
               - regex-name:
                   regex: '7\.1[6789]'


### PR DESCRIPTION
## Proposed commit message

This commit is complementing PR #39321 and is needed to disable the execution of 8.14 DRA on Jenkins.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095#issuecomment-2085726889

(this PR should **not** be backported)
