### PR TITLE
`aws-s3` input: fix SQS region selection

### DIFF
--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -5,8 +5,10 @@
 package awss3
 
 import (
+	"errors"
 	"testing"
 
+	aws "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,11 +53,12 @@ func TestGetProviderFromDomain(t *testing.T) {
 
 func TestGetRegionFromQueueURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		queueURL string
-		endpoint string
-		want     string
-		wantErr  error
+		name       string
+		queueURL   string
+		regionName string
+		endpoint   string
+		want       string
+		wantErr    error
 	}{
 		{
 			name:     "amazonaws.com_domain_with_blank_endpoint",
@@ -63,10 +66,22 @@ func TestGetRegionFromQueueURL(t *testing.T) {
 			want:     "us-east-1",
 		},
 		{
+			name:       "amazonaws.com_domain_with_region_override",
+			queueURL:   "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			regionName: "us-east-2",
+			want:       "us-east-2",
+		},
+		{
 			name:     "abc.xyz_and_domain_with_matching_endpoint",
 			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
 			endpoint: "abc.xyz",
 			want:     "us-east-1",
+		},
+		{
+			name:       "abc.xyz_with_region_override",
+			queueURL:   "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			regionName: "us-west-3",
+			want:       "us-west-3",
 		},
 		{
 			name:     "abc.xyz_and_domain_with_blank_endpoint",
@@ -79,33 +94,50 @@ func TestGetRegionFromQueueURL(t *testing.T) {
 			want:     "us-east-2",
 		},
 		{
+			name:       "vpce_endpoint_with_region_override",
+			queueURL:   "https://vpce-test.sqs.us-east-2.vpce.amazonaws.com/12345678912/sqs-queue",
+			regionName: "us-west-1",
+			want:       "us-west-1",
+		},
+		{
 			name:     "vpce_endpoint_with_endpoint",
 			queueURL: "https://vpce-test.sqs.us-east-1.vpce.amazonaws.com/12345678912/sqs-queue",
 			endpoint: "amazonaws.com",
 			want:     "us-east-1",
 		},
+		{
+			name:     "non_aws_vpce_with_endpoint",
+			queueURL: "https://vpce-test.sqs.us-east-1.vpce.abc.xyz/12345678912/sqs-queue",
+			endpoint: "abc.xyz",
+			want:     "us-east-1",
+		},
+		{
+			name:     "non_aws_vpce_without_endpoint",
+			queueURL: "https://vpce-test.sqs.us-east-1.vpce.abc.xyz/12345678912/sqs-queue",
+			wantErr:  errBadQueueURL,
+		},
+		{
+			name:       "non_aws_vpce_with_region_override",
+			queueURL:   "https://vpce-test.sqs.us-east-1.vpce.abc.xyz/12345678912/sqs-queue",
+			regionName: "us-west-1",
+			want:       "us-west-1",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := getRegionFromQueueURL(test.queueURL, test.endpoint)
-			if !sameError(err, test.wantErr) {
+			config := config{
+				QueueURL:   test.queueURL,
+				RegionName: test.regionName,
+				AWSConfig:  aws.ConfigAWS{Endpoint: test.endpoint},
+			}
+			got, err := chooseRegion(nil, config)
+			if !errors.Is(err, test.wantErr) {
 				t.Errorf("unexpected error: got:%v want:%v", err, test.wantErr)
 			}
 			if got != test.want {
 				t.Errorf("unexpected result: got:%q want:%q", got, test.want)
 			}
 		})
-	}
-}
-
-func sameError(a, b error) bool {
-	switch {
-	case a == nil && b == nil:
-		return true
-	case a == nil, b == nil:
-		return false
-	default:
-		return a.Error() == b.Error()
 	}
 }


### PR DESCRIPTION
Fix an error in region selection that was introduced in a previous cleanup (https://github.com/elastic/beats/pull/38958). When the configured region disagrees with the region detected from the queue URL, the configured region is supposed to take precedence. Due to a misreading, my code instead chose the URL region when there is a conflict.

I've broken region selection out into another helper function to make this logic easier to test, and added several unit test cases that would have caught this mistake.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
