### PR TITLE
Add disruptive change mitigations section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,6 +44,14 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
 
+## Breaking Change Mitigations
+
+<!--
+If this PR introduces a breaking change for end users, describe what changes they could make on
+their end to nullify or minimize the impacts of this change. Consider impacts in related systems, not
+just directly when using Beats.
+-->
+
 ## Author's Checklist
 
 <!-- Recommended
@@ -67,7 +75,7 @@ Link related issues below. Insert the issue link or reference after the word "Cl
 - Requires #123
 - Superseds #123
 -->
-- 
+-
 
 ## Use cases
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,12 +44,12 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
 
-## Breaking Change Mitigations
+## Disruptive User Impact
 
 <!--
-If this PR introduces a breaking change for end users, describe what changes they could make on
-their end to nullify or minimize the impacts of this change. Consider impacts in related systems, not
-just directly when using Beats.
+Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
+could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
+when using Beats.
 -->
 
 ## Author's Checklist


### PR DESCRIPTION
This PR adds a new section to the PR template for describing any steps users could take to mitigate disruptive changes, when a PR introduces such changes.  