### PR TITLE
[Auditbeat/FIM/fsnotify]: prevent losing events for recursive mode on OS X

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -97,6 +97,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix failing to enrich process events in sessionmd processor {issue}38955[38955] {pull}39173[39173] {pull}39243[39243]
 - Prevent scenario of losing children-related file events in a directory for recursive fsnotify backend of auditbeat file integrity module {pull}39133[39133]
 - Allow extra syscalls by auditbeat required in FIM with kprobes back-end {pull}39361[39361]
+- Fix losing events in FIM for OS X by allowing always to walk an added directory to monitor {pull}39362[39362]
 
 
 *Filebeat*

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -192,7 +192,7 @@ func TestRecursiveSubdirPermissions(t *testing.T) {
 
 	ev, err := readTimeout(t, watcher)
 	assert.Equal(t, errReadTimeout, err)
-	if err != errReadTimeout {
+	if !errors.Is(err, errReadTimeout) {
 		t.Fatalf("Expected timeout, got event %+v", ev)
 	}
 

--- a/auditbeat/module/file_integrity/monitor/recursive.go
+++ b/auditbeat/module/file_integrity/monitor/recursive.go
@@ -113,11 +113,11 @@ func (watcher *recursiveWatcher) addRecursive(path string) error {
 		return nil
 	}
 
+	var errs multierror.Errors
 	if err := watcher.watchFile(path, nil); err != nil {
-		return fmt.Errorf("failed adding watcher to '%s': %w", path, err)
+		errs = append(errs, fmt.Errorf("failed adding watcher to '%s': %w", path, err))
 	}
 
-	var errs multierror.Errors
 	err := filepath.Walk(path, func(walkPath string, info os.FileInfo, fnErr error) error {
 		if walkPath == path {
 			return nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This PR prevents FIM from losing events for recursive mode on Mac OS X even when the `watchFile` of the root dir, added to be monitored, returns an error by always walking the dir. Specifically, this discrepancy, between Linux and OS X oses, is due to the fact that in the latter the underlying library, namely fsnotify, when you add a watch of a directory it walks the directory and adds the respective sub-dir watchers. If any of these fail, e.g. with EACCESS, it returns an error.  However, auditbeat's wrapper of this library emits created events by walking the directory. So, in order not to lose any events we need to guarantee that we won't interrupt this flow - we will always walk the directory - and accumulate any errors during this process which we will return only at the end.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Already tested [here](https://buildkite.com/elastic/auditbeat/builds/4593#018f3900-f651-42e4-bc2f-d62a14092e22)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/ingest-dev/issues/3268

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

N/A

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A