### PR TITLE
Auto trigger DRA for all 8.x branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1040,7 +1040,7 @@ spec:
     spec:
       repository: elastic/beats
       pipeline_file: ".buildkite/packaging.pipeline.yml"
-      branch_configuration: "main 8.14"
+      branch_configuration: "main 8.*"
       # TODO enable after packaging backports for release branches
       # branch_configuration: "main 8.* 7.17"
       cancel_intermediate_builds: false


### PR DESCRIPTION
## Proposed commit message

Now that DRA support via Buildkite has also been backported to 8.13[^1] this commit widens the whitelisted branches that can trigger Buildkite DRA builds to include all 8.x branches.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095
## Use cases

[^1]: https://github.com/elastic/beats/pull/39198
