### PR TITLE
Disable 8.x DRA packaging from Jenkins

### DIFF
--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -14,7 +14,7 @@
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
           discover-tags: true
-          head-filter-regex: '(7\.1[6789]|8\.13|PR-.*|v8\.13\.\d+)'
+          head-filter-regex: '(7\.1[6789]|PR-.*|)'
           disable-pr-notifications: true
           notification-context: 'beats-packaging'
           repo: 'beats'
@@ -28,9 +28,6 @@
               ignore-tags-older-than: -1
               ignore-tags-newer-than: 30
           - named-branches:
-              - exact-name:
-                  name: '8.13'
-                  case-sensitive: true
               - regex-name:
                   regex: '7\.1[6789]'
                   case-sensitive: true

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -29,7 +29,7 @@
               ignore-tags-newer-than: 30
           - named-branches:
               - regex-name:
-                  regex: '7\.1[6789]'
+                  regex: '7\.1[7]'
                   case-sensitive: true
           - change-request:
               ignore-target-only-changes: true

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -29,7 +29,7 @@
               ignore-tags-newer-than: 30
           - named-branches:
               - regex-name:
-                  regex: '7\.1[7]'
+                  regex: '7\.17'
                   case-sensitive: true
           - change-request:
               ignore-target-only-changes: true

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -14,7 +14,7 @@
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
           discover-tags: true
-          head-filter-regex: '(7\.1[6789]|PR-.*|)'
+          head-filter-regex: '(7\.17|PR-.*)'
           disable-pr-notifications: true
           notification-context: 'beats-packaging'
           repo: 'beats'


### PR DESCRIPTION
## Proposed commit message

This commit disables triggering DRA packaging builds for the 8.x branch via Jenkins.

## Related issues

Relates: https://github.com/elastic/ingest-dev/issues/3095
