### PR TITLE
Disable 7.17 DRA packaging from Jenkins

### DIFF
--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -14,7 +14,7 @@
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
           discover-tags: true
-          head-filter-regex: '(7\.17|PR-.*)'
+          head-filter-regex: '(PR-.*)'
           disable-pr-notifications: true
           notification-context: 'beats-packaging'
           repo: 'beats'
@@ -28,9 +28,6 @@
               ignore-tags-older-than: -1
               ignore-tags-newer-than: 30
           - named-branches:
-              - regex-name:
-                  regex: '7\.17'
-                  case-sensitive: true
           - change-request:
               ignore-target-only-changes: true
           clean:

--- a/.ci/jobs/packaging.yml
+++ b/.ci/jobs/packaging.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-strategy: 'merge-current'
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
-          discover-tags: true
+          discover-tags: false
           head-filter-regex: '(PR-.*)'
           disable-pr-notifications: true
           notification-context: 'beats-packaging'
@@ -27,7 +27,6 @@
           - tags:
               ignore-tags-older-than: -1
               ignore-tags-newer-than: 30
-          - named-branches:
           - change-request:
               ignore-target-only-changes: true
           clean:


### PR DESCRIPTION
## Proposed commit message

This commit disables triggering DRA packaging builds for the 7.17 branch via Jenkins.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095
