### PR TITLE
Disable DRY_RUN for 7.17 packaging on Buildkite

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
 
-# TODO: uncomment out below when Jenkins packaging has been stopped
-# if [[ "$DRY_RUN" == "true" ]]; then
-#     echo "~~~ Running in dry-run mode -- will NOT publish artifacts"
-#     DRY_RUN="--dry-run"
-# else
-#     echo "~~~ Running in publish mode"
-#     DRY_RUN=""
-# fi
-
-# TODO: delete the conditional below (and replace it with the above, uncommented out, section) after Jenkins packaging has been stopped
-if [[ "$DRY_RUN" == "false" ]]; then
-    echo "~~~ Running in publish mode"
-    DRY_RUN=""
-else
+if [[ "$DRY_RUN" == "true" ]]; then
     echo "~~~ Running in dry-run mode -- will NOT publish artifacts"
     DRY_RUN="--dry-run"
+else
+    echo "~~~ Running in publish mode"
+    DRY_RUN=""
 fi
 
 set -euo pipefail


### PR DESCRIPTION
## Proposed commit message

This commit is the counterpart of #39391 for the 7.17 branch and disables the default DRY_RUN mode when running DRA packaging on Buildkite for the 7.17 branch.

## Related issues

- #39391
- elastic/ingest-dev#3095
