### PR TITLE
Auto trigger DRA for all 8.x branches (#39386)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1040,9 +1040,7 @@ spec:
     spec:
       repository: elastic/beats
       pipeline_file: ".buildkite/packaging.pipeline.yml"
-      branch_configuration: "main 8.*"
-      # TODO enable after packaging backports for release branches
-      # branch_configuration: "main 8.* 7.17"
+      branch_configuration: "main 8.* 7.17"
       cancel_intermediate_builds: false
       skip_intermediate_builds: false
       maximum_timeout_in_minutes: 90


### PR DESCRIPTION
## Proposed commit message

This commit adds 7.17 to the whitelist of branches that may trigger Buildkite DRA builds.

## Related issues

- https://github.com/elastic/ingest-dev/issues/3095
