### PR TITLE
[libbeat] Small cleanup of unused code in monitoring initialization

### DIFF
--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -64,7 +64,7 @@ func New(
 	cfg *conf.C,
 	outputs conf.Namespace,
 ) (Reporter, error) {
-	name, cfg, err := getReporterConfig(cfg, settings, outputs)
+	name, cfg, err := getReporterConfig(cfg, outputs)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,6 @@ func New(
 
 func getReporterConfig(
 	monitoringConfig *conf.C,
-	settings Settings,
 	outputs conf.Namespace,
 ) (string, *conf.C, error) {
 	cfg := collectSubObject(monitoringConfig)
@@ -96,10 +95,6 @@ func getReporterConfig(
 
 		// merge reporter config with output config if both are present
 		if outCfg := outputs.Config(); outputs.Name() == name && outCfg != nil {
-			// require monitoring to not configure any hosts if output is configured:
-			hosts := hostsCfg{}
-			rc.Unpack(&hosts)
-
 			merged, err := conf.MergeConfigs(outCfg, rc)
 			if err != nil {
 				return "", nil, err


### PR DESCRIPTION
Delete an unused parameter and some unused decoding results in the beats monitoring initialization. This PR doesn't change behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
