### PR TITLE
Remove fields not needed for session view in add_session_view processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -202,6 +202,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add container id to file events (Linux only, eBPF backend). {pull}38328[38328]
 - Add procfs backend to the `add_session_metadata` processor. {pull}38799[38799]
 - Add process.entity_id, process.group.name and process.group.id in add_process_metadata processor. Make fim module with kprobes backend to always add an appropriately configured add_process_metadata processor to enrich file events {pull}38776[38776]
+- Reduce data size for add_session_metadata processor by removing unneeded fields {pull}39500[39500]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/processors/sessionmd/types/process.go
+++ b/x-pack/auditbeat/processors/sessionmd/types/process.go
@@ -356,18 +356,6 @@ func (p *Process) ToMap() mapstr.M {
 		"pid":  p.PID,
 		"vpid": p.Vpid,
 		"args": p.Args,
-		"thread": mapstr.M{
-			"capabilities": mapstr.M{
-				"permitted": p.Thread.Capabilities.Permitted,
-				"effective": p.Thread.Capabilities.Effective,
-			},
-		},
-		"tty": mapstr.M{
-			"char_device": mapstr.M{
-				"major": p.TTY.CharDevice.Major,
-				"minor": p.TTY.CharDevice.Minor,
-			},
-		},
 		"parent": mapstr.M{
 			"entity_id":         p.Parent.EntityID,
 			"executable":        p.Parent.Executable,
@@ -384,12 +372,6 @@ func (p *Process) ToMap() mapstr.M {
 			},
 			"pid":  p.Parent.PID,
 			"args": p.Parent.Args,
-			"thread": mapstr.M{
-				"capabilities": mapstr.M{
-					"permitted": p.Parent.Thread.Capabilities.Permitted,
-					"effective": p.Parent.Thread.Capabilities.Effective,
-				},
-			},
 		},
 		"group_leader": mapstr.M{
 			"entity_id":         p.GroupLeader.EntityID,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

In order to reduce event data size, remove all fields from the add_session_metadata processor that are not required for the Kibana session viewer to function.

The unnecessary fields that are removed here are thread and tty fields.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

These removed fields might have been used for other reasons than session view, but given this processor is in beta, there can be breaking changes. The `add_process_metadata` processor can also be used to get these fields.

## Author's Checklist
- Checked that session view is still working without these fields
- Checked that the fields were removed from the enriched document  