### PR TITLE
[Draft] [AWS] Support pulling region from arbitrary domains for aws-s3 input SQS queue url

### DIFF
--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -91,7 +91,13 @@ func TestRegionSelection(t *testing.T) {
 		{
 			name:     "abc.xyz_and_domain_with_blank_endpoint",
 			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
-			wantErr:  errBadQueueURL,
+			want:     "us-east-1",
+		},
+		{
+			name:     "non_aws_vpce_with_endpoint",
+			queueURL: "https://vpce-test.sqs.us-east-1.vpce.abc.xyz/12345678912/sqs-queue",
+			endpoint: "abc.xyz",
+			want:     "us-east-1",
 		},
 		{
 			name:     "vpce_endpoint",

--- a/x-pack/filebeat/input/awss3/sqs.go
+++ b/x-pack/filebeat/input/awss3/sqs.go
@@ -35,6 +35,7 @@ func getRegionFromQueueURL(queueURL, endpoint string) string {
 	// get region from queueURL
 	// Example for sqs queue: https://sqs.us-east-1.amazonaws.com/12345678912/test-s3-logs
 	// Example for vpce: https://vpce-test.sqs.us-east-1.vpce.amazonaws.com/12345678912/sqs-queue
+	// Example for other domains: https://sqs.us-east-1.subdomain.domain.com/12345678912/sqs-queue
 	u, err := url.Parse(queueURL)
 	if err != nil {
 		return ""
@@ -53,6 +54,16 @@ func getRegionFromQueueURL(queueURL, endpoint string) string {
 	if len(host) == 5 && host[1] == "sqs" {
 		if host[4] == endpoint || (endpoint == "" && strings.HasPrefix(host[4], "amazonaws.")) {
 			return host[2]
+		}
+	}
+
+	// check for sqs urls with region and custom domains
+	host = strings.Split(u.Host, ".")
+	if len(host) >= 4 && host[0] == "sqs" {
+
+		// make sure the second last part of split host is "amazonaws"
+		if endpoint == "" && !strings.HasPrefix(host[len(host)-2], "amazonaws.") {
+			return host[1]
 		}
 	}
 


### PR DESCRIPTION
## Proposed commit message

Explain here the changes you made on the PR.
Parse arbitrary non-amazonaws domains to retrieve the region.

- WHY:  the rationale/motivation for the changes

https://github.com/elastic/enhancements/issues/21469

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None

## Author's Checklist

- [ ]

## How to test this PR locally

```
filebeat.inputs:
- type: aws-s3
  queue_url: https://sqs.ap-southeast-1.subdomain.domain.com/1234/test-s3-queue
  access_key_id: 'tomato'
  secret_access_key: 'tomato'
  session_token: 'tomato'
```

Ensure you do not see a region from queue_url parsing errors

## Related issues

Relates https://github.com/elastic/enhancements/issues/21469
