### PR TITLE
[BK] - Remove certain steps from running for Branches

### DIFF
--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -132,7 +132,7 @@ steps:
     steps:
       - label: ":linux: Auditbeat Ubuntu Integration Tests"
         key: "auditbeat-extended-integ-tests"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*integrations.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*integrations.*/
         command: |
           set -euo pipefail
           cd auditbeat
@@ -153,7 +153,7 @@ steps:
 
       - label: ":linux: Auditbeat Ubuntu arm64 Integration Tests"
         key: "auditbeat-extended-arm64-integ-tests"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*integrations.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*integrations.*/
         command: |
           set -euo pipefail
           cd auditbeat
@@ -194,7 +194,7 @@ steps:
               context: "auditbeat: Linux arm64 Unit Tests"
 
       - label: ":mac: Auditbeat macOS x86_64 Unit Tests"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -214,7 +214,7 @@ steps:
               context: "auditbeat: macOS x86_64 Unit Tests"
 
       - label: ":mac: Auditbeat macOS arm64 ARM Unit Tests"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh

--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -154,7 +154,7 @@ steps:
 
       - label: ":mac: Filebeat macOS arm64 Unit Tests"
         key: "macos-arm64-unit-tests-extended"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -244,7 +244,7 @@ steps:
 
   - group: "Metricbeat Extended MacOS Tests"
     key: "metricbeat-extended-macos-tests"
-    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+    if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
     steps:
       - label: ":mac: MacOS x64_64 Unit Tests"
         key: "extended-macos-x64-64-unit-tests"

--- a/.buildkite/packetbeat/pipeline.packetbeat.yml
+++ b/.buildkite/packetbeat/pipeline.packetbeat.yml
@@ -175,7 +175,7 @@ steps:
     steps:
       - label: ":mac: MacOS x86_64 Unit Tests"
         key: "macos-x86-64-unit-tests-extended"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -196,7 +196,7 @@ steps:
 
       - label: ":mac: MacOS arm64 Unit Tests"
         key: "macos-arm64-unit-tests-extended"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*(macOS|arm).*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*(macOS|arm).*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -184,7 +184,7 @@ steps:
 
   - group: "x-pack/auditbeat MacOS Extended Tests"
     key: "x-pack-auditbeat-extended-tests-macos"
-    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+    if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
     steps:
       - label: ":mac: MacOS x86_64 Unit Tests"
         command: |

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -226,7 +226,7 @@ steps:
     key: "x-pack-filebeat-extended-tests"
     steps:
       - label: ":mac: MacOS x86_64 Unit Tests"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*(macOS).*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*(macOS).*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -246,7 +246,7 @@ steps:
 
       - label: ":mac: MacOS arm64 Unit Tests"
         skip: "https://github.com/elastic/beats/issues/33036"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*(macOS).*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*(macOS).*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -266,7 +266,7 @@ steps:
 
       - label: ":linux: Cloud (MODULE) Tests"
         key: "x-pack-filebeat-extended-cloud-test"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         command: |
           set -euo pipefail
           # defines the MODULE env var based on what's changed in a PR

--- a/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
@@ -197,7 +197,7 @@ steps:
 
   - group: "x-pack/heartbeat macOS Extended Tests"
     key: "x-pack-heartbeat-extended-tests-macos"
-    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+    if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
 
     steps:
       - label: ":mac: x-pack/heartbeat macOS x86_64 Unit Tests"

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -208,7 +208,7 @@ steps:
     if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*(macOS|aws).*/
     steps:
       - label: ":mac: MacOS x86_64 Unit Tests"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*macOS.**/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.**/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -228,7 +228,7 @@ steps:
 
       - label: ":mac: MacOS arm64 Unit Tests"
         skip: "https://github.com/elastic/beats/issues/33036"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*macOS.**/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.**/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -249,7 +249,7 @@ steps:
       - label: ":linux: Cloud (MODULE) Tests"
         key: "x-pack-metricbeat-extended-cloud-test"
         skip: "doesn't belong in a stage in Jenkins, thus skipped"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         # see link in Jenkins: https://github.com/elastic/beats/blob/ccd7b135df70358f8a02393d9bd8b716428b8048/x-pack/metricbeat/Jenkinsfile.yml#L39
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
         command: |
@@ -282,7 +282,7 @@ steps:
         skip: "https://github.com/elastic/beats/issues/36425"
         # see commented out section in Jenkins: https://github.com/elastic/beats/blob/main/x-pack/metricbeat/Jenkinsfile.yml#L41-L52
         # additionally skipping due to https://github.com/elastic/ingest-dev/issues/3170
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false"  || build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*aws.*/
         command: |
           set -euo pipefail
           # defines the MODULE env var based on what's changed in a PR

--- a/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
@@ -264,7 +264,7 @@ steps:
 
   - group: "x-pack/packetbeat MacOS Extended Tests"
     key: "x-pack-packetbeat-extended-macos-tests"
-    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+    if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
     steps:
       - label: ":mac: MacOS Unit Tests"
         key: "extended-macos-unit-tests"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This commit makes some adjustments in the step conditions after reviewing the Jenkins files and how we perform the step validations in Jenkinsfile.

If a key `when` is inside the Jenkinsfile step [1], it will validate the required conditions [2], and if there are no `branches: true`, it will not include that step.

[1]: https://github.com/elastic/apm-pipeline-library/blob/fc2e6901e468e368dd1d44f021cbe55615e48266/vars/beatsStages.groovy#L32

[2]: https://github.com/elastic/apm-pipeline-library/blob/fc2e6901e468e368dd1d44f021cbe55615e48266/vars/beatsWhen.groovy#L35-L43 

I tried to go over the various project and try to consolidate the conditions.