### PR TITLE
[BK] - Remove osx steps from branch execution

### DIFF
--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -133,7 +133,7 @@ steps:
     steps:
       - label: ":mac: Filebeat macOS x86_64 Unit Tests"
         key: "macos-unit-tests-extended"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh
@@ -154,7 +154,7 @@ steps:
 
       - label: ":mac: Filebeat macOS arm64 Unit Tests"
         key: "macos-arm64-unit-tests-extended"
-        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
+        if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
         command: |
           set -euo pipefail
           source .buildkite/scripts/install_macos_tools.sh

--- a/.buildkite/heartbeat/heartbeat-pipeline.yml
+++ b/.buildkite/heartbeat/heartbeat-pipeline.yml
@@ -166,8 +166,7 @@ steps:
 
   - group: "Heartbeat Extended Testing MacOS"
     key: "heartbeat-extended-tests-macos"
-    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
-
+    if: build.env("GITHUB_PR_LABELS") =~ /.*macOS.*/
     steps:
       - label: ":mac: Heartbeat MacOS Unit Tests"
         key: "macos-extended"


### PR DESCRIPTION
While adjusting the triggering conditions for https://github.com/elastic/beats/pull/39533 I missed the filebeat and heartbeat pipelines. 

This commit fixes that.