### PR TITLE
Add prev-minor/next-major tests for filebeat 7.17

### DIFF
--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -84,6 +84,59 @@ steps:
           - github_commit_status:
               context: "filebeat: Python Integration Tests"
 
+      - label: "Module compat tests: previous minor"
+        # Runs module integration tests under previous minor of ES to ensure ingest pipeline compatibility
+        env:
+          STACK_ENVIRONMENT: "prev-minor"
+          TESTING_FILEBEAT_SKIP_DIFF: 1
+          PYTEST_ADDOPTS: "-k test_xpack_modules"
+        command: |
+          set -euo pipefail
+          source .buildkite/scripts/changesets.sh
+          defineModuleFromTheChangeSet filbeat
+          echo "~~~ Running tests"
+          cd filebeat
+          mage pythonIntegTest
+        retry:
+          automatic:
+           - limit: 3
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+        artifact_paths:
+          - "filebeat/build/*.xml"
+          - "filebeat/build/*.json"
+        notify:
+          - github_commit_status:
+              context: "filebeat: Module compat tests / previous minor"
+
+      - label: "Module compat tests: next major"
+        # Run module integration tests under next major of Elastic stack.
+        env:
+          STACK_ENVIRONMENT: "next-major"
+          TESTING_FILEBEAT_SKIP_DIFF: 1
+        command: |
+          set -euo pipefail
+          source .buildkite/scripts/changesets.sh
+          defineModuleFromTheChangeSet filebeat
+          echo "~~~ Running tests"
+          cd filebeat
+          mage pythonIntegTest
+        retry:
+          automatic:
+           - limit: 3
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+        artifact_paths:
+          - "filebeat/build/*.xml"
+          - "filebeat/build/*.json"
+        notify:
+          - github_commit_status:
+              context: "filebeat: Module compat tests / next major"
+
       - label: ":windows: Windows 2016 Unit Tests"
         key: "windows-2016-unit-tests"
         command: |

--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -93,7 +93,7 @@ steps:
         command: |
           set -euo pipefail
           source .buildkite/scripts/changesets.sh
-          defineModuleFromTheChangeSet filbeat
+          defineModuleFromTheChangeSet filebeat
           echo "~~~ Running tests"
           cd filebeat
           mage pythonIntegTest


### PR DESCRIPTION
## Proposed commit message

This commit adds missing mandatory checks on Buildkite, specifically on the 7.17 branch for filebeat. They can be found defined in Jenkins in https://github.com/elastic/beats/blob/b5f369062719b350dc31ed6768c25be4b95f2f6f/filebeat/Jenkinsfile.yml#L39-L53

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
