### PR TITLE
Add next-major tests for auditbeat 7.17

### DIFF
--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -69,6 +69,31 @@ steps:
           - github_commit_status:
               context: "auditbeat: RHEL Unit Tests"
 
+      - label: "Module compat tests: next major"
+        # Run module integration tests under next major of Elastic stack.
+        env:
+          STACK_ENVIRONMENT: "next-major"
+        command: |
+          set -euo pipefail
+          source .buildkite/scripts/changesets.sh
+          defineModuleFromTheChangeSet auditbeat
+          echo "~~~ Running tests"
+          cd auditbeat
+          mage pythonIntegTest
+        retry:
+          automatic:
+           - limit: 3
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+        artifact_paths:
+          - "auditbeat/build/*.xml"
+          - "auditbeat/build/*.json"
+        notify:
+          - github_commit_status:
+              context: "auditbeat: Module compat tests / next major"
+
       - label: ":windows: Auditbeat Win-2016 Unit Tests"
         command: |
           Set-Location -Path auditbeat


### PR DESCRIPTION
## Proposed commit message

This commit adds missing mandatory checks on Buildkite, on the 7.17 branch for auditbeat. They can be found defined in Jenkins in https://github.com/elastic/beats/blob/b5f369062719b350dc31ed6768c25be4b95f2f6f/auditbeat/Jenkinsfile.yml#L36
