### PR TITLE
filebeat,x-pack/filebeat: prevent master=>event.original rename failures

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -271,6 +271,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Improve logging of request and response with request trace logging in error conditions. {pull}39455[39455]
 - Add HTTP metrics to CEL input. {issue}39501[39501] {pull}39503[39503]
 - Add default user-agent to CEL HTTP requests. {issue}39502[39502] {pull}39587[39587]
+- Improve reindexing support in security module pipelines. {issue}38224[38224] {pull}[]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -272,6 +272,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add HTTP metrics to CEL input. {issue}39501[39501] {pull}39503[39503]
 - Add default user-agent to CEL HTTP requests. {issue}39502[39502] {pull}39587[39587]
 - Improve reindexing support in security module pipelines. {issue}38224[38224] {pull}[]
+- Improve reindexing support in security module pipelines. {issue}38224[38224] {pull}39588[39588]
 
 *Auditbeat*
 

--- a/filebeat/module/santa/log/ingest/pipeline.yml
+++ b/filebeat/module/santa/log/ingest/pipeline.yml
@@ -13,6 +13,8 @@ processors:
 - rename:
     field: message
     target_field: event.original
+    ignore_missing: true
+    if: ctx.event?.original == null
 - date:
     field: process.start
     target_field: process.start

--- a/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
@@ -11,6 +11,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - grok:
       field: event.original
       patterns:

--- a/x-pack/filebeat/module/cisco/umbrella/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cisco/umbrella/ingest/pipeline.yml
@@ -12,6 +12,7 @@ processors:
 - set:
     field: event.original
     value: "{{message}}"
+    if: ctx.event?.original == null
 ############
 # DNS Logs #
 ############

--- a/x-pack/filebeat/module/coredns/log/ingest/pipeline-json.yml
+++ b/x-pack/filebeat/module/coredns/log/ingest/pipeline-json.yml
@@ -5,6 +5,7 @@ processors:
       field: message
       target_field: event.original
       ignore_failure: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: json

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -54,6 +54,7 @@ processors:
 - rename:
     field: message
     target_field: event.original
+    if: ctx.event?.original == null
 - grok:
     field: iptables.ubiquiti.rule_set
     ignore_missing: true

--- a/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/panw/panos/ingest/pipeline.yml
@@ -14,6 +14,7 @@ processors:
       field: message
       target_field: event.original
       ignore_failure: true
+      if: ctx.event?.original == null
 
 # Get the timezone from the IETF header if present. Otherwise the timezone
 # value added by the add_locale processor will be used.

--- a/x-pack/filebeat/module/threatintel/abusemalware/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/abusemalware/ingest/pipeline.yml
@@ -24,6 +24,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: abusech.malware

--- a/x-pack/filebeat/module/threatintel/abuseurl/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/abuseurl/ingest/pipeline.yml
@@ -24,6 +24,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: abusech.url

--- a/x-pack/filebeat/module/threatintel/anomali/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/anomali/ingest/pipeline.yml
@@ -24,6 +24,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: anomali.limo

--- a/x-pack/filebeat/module/threatintel/malwarebazaar/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/malwarebazaar/ingest/pipeline.yml
@@ -24,6 +24,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: abusech.malwarebazaar

--- a/x-pack/filebeat/module/threatintel/misp/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/misp/ingest/pipeline.yml
@@ -24,6 +24,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: json

--- a/x-pack/filebeat/module/threatintel/otx/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/otx/ingest/pipeline.yml
@@ -24,6 +24,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: otx

--- a/x-pack/filebeat/module/threatintel/threatq/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/threatq/ingest/pipeline.yml
@@ -24,6 +24,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: ctx.event?.original == null
   - json:
       field: event.original
       target_field: json


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

```
Prevent rename of message to event.original failing when event.original
already exists as can be the case when documents are being ingested via
logstash.
```
This makes the change for all modules listed as owned by security-service-integrations and sec-deployment-and-devices that still exist (some don't) and have this specific rename*. Some modules already make the check or use another already safe mechanism. 

Note that tthe cisco umbrella pipeline uses a set processor which will not fail, but would clobber `event.original`, so it also includes the check.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #38224

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
