### PR TITLE
Migrate left over to buildkite

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - check-success=beats-ci/pr-merge
+      - check-success=buildkite/beats
 pull_request_rules:
   - name: self-assign PRs
     conditions:
@@ -57,7 +57,7 @@ pull_request_rules:
   - name: automatic approval for automated pull requests with bump updates
     conditions:
       - author=apmmachine
-      - check-success=beats-ci/pr-merge
+      - check-success=buildkite/beats
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$
     actions:
@@ -66,7 +66,7 @@ pull_request_rules:
         message: Automatically approving mergify
   - name: automatic squash and merge with success checks and the files matching the regex ^testing/environments/snapshot* are modified.
     conditions:
-      - check-success=beats-ci/pr-merge
+      - check-success=buildkite/beats
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$
       - "#approved-reviews-by>=1"
@@ -99,7 +99,7 @@ pull_request_rules:
   - name: automatic approval for mergify pull requests with changes in bump-rules
     conditions:
       - author=mergify[bot]
-      - check-success=beats-ci/pr-merge
+      - check-success=buildkite/beats
       - label=automation
       - files~=^\.mergify\.yml$
       - head~=^add-backport-next.*
@@ -109,7 +109,7 @@ pull_request_rules:
         message: Automatically approving mergify
   - name: automatic squash and merge with success checks and the files matching the regex ^.mergify.yml is modified.
     conditions:
-      - check-success=beats-ci/pr-merge
+      - check-success=buildkite/beats
       - label=automation
       - files~=^\.mergify\.yml$
       - head~=^add-backport-next.*


### PR DESCRIPTION
This PR updates the Mergify configuration to look for the buildkite required checks and not the Jenkins ones.