### PR TITLE
Manual porting changes for buildkite clean

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -67,7 +67,7 @@ pull_request_rules:
             ```
   - name: Automatic squash and merge with success checks and the files matching the regex ^testing/environments/snapshot* are modified.
     conditions:
-      - check-success=beats-ci/pr-merge
+      - check-success=buildkite/beats
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$
     actions:


### PR DESCRIPTION
Manually port the changes from #39591 to 7.17 as the original PR cannot be backported cleanly.


Part of the original PR #39591 but for 7.17.