### PR TITLE
Enable Slack notifications for main BK CI Job

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -57,6 +57,10 @@ spec:
       env:
         # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
         ELASTIC_PR_COMMENTS_ENABLED: "false"
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+        SLACK_NOTIFICATIONS_ALL_BRANCHES: "false"  # only notify for failures on `main` or \d+.\d+ (release) branches
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## Proposed commit message

This commit enables Slack alerts for the main Beats Buildkite CI job. We only allow notifications for merge commit triggers i.e. the main and release branches and not for CI for PRs.
