### PR TITLE
[aws/s3]: fix s3_input integration test

### DIFF
--- a/.ci/jobs/docker-compose.yml
+++ b/.ci/jobs/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     image: busybox
     depends_on:
       localstack: { condition: service_healthy }
-      
+
   localstack:
     container_name: "${localstack_integration_test_container}"
-    image: localstack/localstack:2.1.0 # Latest stable release
+    image: localstack/localstack:3.1.0 # Latest stable release
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
     environment:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This PR fixes the following errors captured https://github.com/elastic/ingest-dev/issues/3312
```
input/awss3/input_integration_test.go:138:46: undefined: s3Input
input/awss3/input_integration_test.go:144:19: undefined: s3Input
input/awss3/input_integration_test.go:238:14: undefined: s3Input
```

Initially these tests resulted as broken because of this PR https://github.com/elastic/beats/pull/39353 which quoting from the description

> This change is meant to have no functional effect, it is strictly a cleanup and reorganization in preparation for future changes. The hope is that the new layout makes initialization steps and logical dependencies clearer. 

 split up the pre-existing `s3input` to `s3PollerInput` and `sqsReaderInput` without reflecting this in the `x-pack/filebeat/input/awss3/input_integration_test.go`. However, even when applying the necessary changes in the former, another error surfaces. Specifically this one

>  <?xml version='1.0' encoding='utf-8'?>
>  | <ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Code>InternalError</Code><Message>exception while calling sqs with unknown operation: Traceback (most recent call last):
>  | File &quot;/opt/code/localstack/localstack/aws/chain.py&quot;, line 90, in handle
>  | handler(self, self.context, response)
>  | File &quot;/opt/code/localstack/localstack/aws/handlers/service.py&quot;, line 64, in __call__
>  | return self.parse_and_enrich(context)
>  | File &quot;/opt/code/localstack/localstack/aws/handlers/service.py&quot;, line 77, in parse_and_enrich
>  | operation, instance = parser.parse(context.request)
>  | File &quot;/opt/code/localstack/localstack/aws/protocol/parser.py&quot;, line 172, in wrapper
>  | return func(*args, **kwargs)
>  | File &quot;/opt/code/localstack/localstack/aws/protocol/parser.py&quot;, line 366, in parse
>  | raise ProtocolParserError(
>  | localstack.aws.protocol.parser.ProtocolParserError: Operation detection failed. Missing Action in request for query-protocol service ServiceModel(sqs).

I can trace the above only to the update of aws package dependencies which happened in this https://github.com/elastic/beats/pull/39454 and it wasn't tested with `aws` label. To fix this error the image of localstack, spawned during the aws integration tests, had to be updated to `3.1.0`



<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Open a PR on beats CI and add the `aws` label

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/ingest-dev/issues/3312

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

N/A

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A