### PR TITLE
Add `include_message` to the list of Filestream parsers

### DIFF
--- a/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
@@ -153,6 +153,7 @@ Available parsers:
 * `ndjson`
 * `container`
 * `syslog`
+* `include_message`
 
 In this example, {beatname_uc} is reading multiline messages that consist of 3 lines
 and are encapsulated in single-line JSON objects.


### PR DESCRIPTION
## Proposed commit message

Add `include_message` to the list of Filestream parsers

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~
## How to test this PR locally
1. Make sure you have https://github.com/elastic/docs cloned at the same level as Beats
2. Export `$GIT_HOME` as the folder where you have cloned `docs` and `beats`
3. Build the docs/start the web server:
    ```
    $GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/filebeat/docs --chunk 1 --open
    ```
4. Navigate to http://localhost:8000/guide/filebeat-input-filestream.html#_parsers
5. Ensure `include_message` is in the list of parsers.
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

