### PR TITLE
Remove verbose debug logs from acker

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -67,6 +67,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - `queue.ACKListener` has been removed. Queue configurations now accept an explicit callback function for ACK handling. {pull}35078[35078]
 - Split split httpmon out of x-pack/filebeat/input/internal/httplog. {pull}36385[36385]
 - Beats publishing pipeline does not propagate the close signal to its clients any more. It's responsibility of the user to close the pipeline client. {issue}38197[38197] {pull}38556[38556]
+- Debug log entries from the acker (`stateful ack ...` or `stateless ack ...`) removed. {pull}39672[39672]
 
 ==== Bugfixes
 

--- a/filebeat/beater/acker.go
+++ b/filebeat/beater/acker.go
@@ -21,7 +21,6 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input/file"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common/acker"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 type statefulLogger interface {
@@ -35,8 +34,6 @@ type statelessLogger interface {
 // eventAcker handles publisher pipeline ACKs and forwards
 // them to the registrar or directly to the stateless logger.
 func eventACKer(statelessOut statelessLogger, statefulOut statefulLogger) beat.EventListener {
-	log := logp.NewLogger("acker")
-
 	return acker.EventPrivateReporter(func(_ int, data []interface{}) {
 		stateless := 0
 		states := make([]file.State, 0, len(data))
@@ -56,12 +53,10 @@ func eventACKer(statelessOut statelessLogger, statefulOut statefulLogger) beat.E
 		}
 
 		if len(states) > 0 {
-			log.Debugw("stateful ack", "count", len(states))
 			statefulOut.Published(states)
 		}
 
 		if stateless > 0 {
-			log.Debugw("stateless ack", "count", stateless)
 			statelessOut.Published(stateless)
 		}
 	})


### PR DESCRIPTION
## Proposed commit message

Remove some debug log entries about acked events. Those log entries turn out to be very verbose and of very little use. They do not carry any information about the acked events, and we already have metrics about acked events in the 30s metrics and monitoring HTTP endpoint.


## Checklist


- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~
## How to test this PR locally
1. Build Filebeat from this PR
2. Start Filebeat with `filestream` or `log` input configured and debug logs enabled (at least the `acker` selector)
3. Assert no `stateful ack ...` or `stateless ack ...` messages are logged

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~