### PR TITLE
(+Doc) FB "index" means ingesting target

### DIFF
--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -223,7 +223,9 @@ Additional headers to send to proxies during CONNECT requests.
 
 // Begin exclude for APM Server docs
 ifndef::apm-server[]
-The index name to write events to when you're using daily indices. The default is
+The indexing target to write events to. 
+Can point to an {ref}/index-mgmt.html[index], {ref}/aliases.html[alias], or {ref}/data-streams.html[data stream]. 
+When using daily indices, this will be the index name. The default is
 +"{beatname_lc}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"+, for example,
 +"{beatname_lc}-{version}-{localdate}"+. If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options


### PR DESCRIPTION
👋 Playing forward https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1179, our client-side docs think `index` indicates a literal Elasticsearch index when in now this means any ingest target (index, alias, or data stream). cc: @dakrone @anniegale9538 

## Proposed commit message

Doc update to clarify that Elasticsearch output `index` indicates ingest target (so index, alias, or data stream). 


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

NA

## Author's Checklist

NA

## How to test this PR locally

NA

## Related issues

NA

## Use cases

NA

## Screenshots

Will port to saying like [Logstash Elasticsearch output](https://www.elastic.co/guide/en/logstash/master/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-index) now does for `index` the highlighted text: 

<img width="438" alt="image" src="https://github.com/elastic/beats/assets/26751266/1b4a6566-6c2e-47c6-881c-b55ffb999940">


## Logs

NA
