### PR TITLE
[main] Fix handling of custom Endpoint when using S3 + SQS

### DIFF
--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -76,6 +76,19 @@ func TestRegionSelection(t *testing.T) {
 			want:       "us-east-2",
 		},
 		{
+			name:     "abc.xyz_and_domain_with_matching_s3_endpoint",
+			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint: "https://s3.us-east-1.abc.xyz",
+			want:     "us-east-1",
+		},
+		{
+			name:       "abc.xyz_and_domain_with_matching_s3_endpoint_region_override",
+			queueURL:   "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint:   "https://s3.us-east-1.abc.xyz",
+			regionName: "us-west-3",
+			want:       "us-west-3",
+		},
+		{
 			name:     "abc.xyz_and_domain_with_matching_endpoint",
 			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
 			endpoint: "abc.xyz",


### PR DESCRIPTION
Fix issues described in https://github.com/elastic/beats/issues/39706 that prevent using a custom endpoint with S3 + SQS.

Users can workaround this issue via S3 bucket polling. The S3 bucket polling still works just fine with a custom endpoint, it's just adding in SQS where it breaks. We need to publish a https://github.com/elastic/integrations/pull/9865

Work required for Main:
- [ ] Only use a custom Endpoint Resolver if the Endpoint doesn't start with S3.
- [ ] Parse Endpoints with custom domains in the format of `https://s3.us-east-1.abc.xyz` so users don't have to specify a region