### PR TITLE
[auditbeat/fim/kprobes] Correct seccomp policy for arm64

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -101,7 +101,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Prevent scenario of losing children-related file events in a directory for recursive fsnotify backend of auditbeat file integrity module {pull}39133[39133]
 - Allow extra syscalls by auditbeat required in FIM with kprobes back-end {pull}39361[39361]
 - Fix losing events in FIM for OS X by allowing always to walk an added directory to monitor {pull}39362[39362]
-
+- Fix seccomp policy of FIM kprobes backend on arm64 {pull}39759[39759]
 
 
 

--- a/auditbeat/module/file_integrity/kprobes/seccomp_linux_amd64.go
+++ b/auditbeat/module/file_integrity/kprobes/seccomp_linux_amd64.go
@@ -18,27 +18,21 @@
 package kprobes
 
 import (
-	"runtime"
-
 	"github.com/elastic/beats/v7/libbeat/common/seccomp"
 )
 
 func init() {
-	switch runtime.GOARCH {
-	case "amd64", "386", "arm64":
-		// The module/file_integrity with kprobes BE uses additional syscalls
-		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall,
-			"eventfd2",        // required by auditbeat/tracing
-			"mount",           // required by auditbeat/tracing
-			"perf_event_open", // required by auditbeat/tracing
-			"ppoll",           // required by auditbeat/tracing
-			"umount2",         // required by auditbeat/tracing
-			"truncate",        // required during kprobes verification
-			"utime",           // required during kprobes verification
-			"utimensat",       // required during kprobes verification
-			"setxattr",        // required during kprobes verification
-		); err != nil {
-			panic(err)
-		}
+	if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall,
+		"eventfd2",        // required by auditbeat/tracing
+		"mount",           // required by auditbeat/tracing
+		"perf_event_open", // required by auditbeat/tracing
+		"ppoll",           // required by auditbeat/tracing
+		"umount2",         // required by auditbeat/tracing
+		"truncate",        // required during kprobes verification
+		"utime",           // required during kprobes verification
+		"utimensat",       // required during kprobes verification
+		"setxattr",        // required during kprobes verification
+	); err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
`seccomp.ModifyDefaultPolicy` for amd64 whitelists the specified syscalls. On the contrary, for arm64  the same function blacklists them 🙂 Thus this PR adjusts the code of `kprobes` Backend of FIM to add the missing syscalls only for amd64.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->
N/A

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
N/A

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
N/A

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
N/A