### PR TITLE
[WIP] Improved and consistent logging for Filebeat & Filestream input status reporting

### DIFF
--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -144,10 +144,26 @@ func (c *crawler) startInput(
 
 	c.inputs[id] = runner
 
-	c.log.Infof("Starting input (ID: %d)", id)
+	idFields := getRunnerID(runner)
+
+	c.log.Infow(fmt.Sprintf("Starting input (ID: %d)", id), idFields...)
 	runner.Start()
 
 	return nil
+}
+
+func getRunnerID(r cfgfile.Runner) []any {
+	type inputIDer interface {
+		InputID() string
+	}
+
+	idFields := []any{}
+	idRunner, ok := r.(inputIDer)
+	if ok {
+		idFields = append(idFields, "input_id", idRunner.InputID())
+	}
+
+	return idFields
 }
 
 func (c *crawler) Stop() {

--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -66,9 +66,8 @@ func (c *crawler) Start(
 	configInputs *conf.C,
 	configModules *conf.C,
 ) error {
-	log := c.log
 
-	log.Infof("Loading Inputs: %d", len(c.inputConfigs))
+	c.log.Infof("Loading Inputs: %d", len(c.inputConfigs))
 
 	// Prospect the globs/paths given on the command line and launch harvesters
 	for _, inputConfig := range c.inputConfigs {
@@ -103,7 +102,7 @@ func (c *crawler) Start(
 		}()
 	}
 
-	log.Infof("Loading and starting Inputs completed. Enabled inputs: %d", len(c.inputs))
+	c.log.Infof("Loading and starting Inputs completed. Enabled inputs: %d", len(c.inputs))
 
 	return nil
 }
@@ -152,7 +151,7 @@ func (c *crawler) startInput(
 }
 
 func (c *crawler) Stop() {
-	logp.Info("Stopping Crawler")
+	c.log.Info("Stopping Crawler")
 
 	asyncWaitStop := func(stop func()) {
 		c.wg.Add(1)
@@ -162,7 +161,7 @@ func (c *crawler) Stop() {
 		}()
 	}
 
-	logp.Info("Stopping %d inputs", len(c.inputs))
+	c.log.Infof("Stopping %d inputs", len(c.inputs))
 	// Stop inputs in parallel
 	for id, p := range c.inputs {
 		id, p := id, p
@@ -182,7 +181,7 @@ func (c *crawler) Stop() {
 
 	c.WaitForCompletion()
 
-	logp.Info("Crawler stopped")
+	c.log.Info("Crawler stopped")
 }
 
 func (c *crawler) WaitForCompletion() {

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -92,12 +92,8 @@ func newScannerWatcher(paths []string, c *conf.C, id string) (loginp.FSWatcher, 
 		return nil, err
 	}
 
-	// logger := logp.NewLogger(watcherDebugKey).With("id", id)
-	// logger.Info("here")
-
 	return &fileWatcher{
-		// log:     logger,
-		log:     logp.NewLogger(watcherDebugKey).With("id", id),
+		log:     logp.NewLogger(watcherDebugKey).With("input_id", id),
 		cfg:     config,
 		prev:    make(map[string]loginp.FileDescriptor, 0),
 		scanner: scanner,
@@ -304,7 +300,7 @@ func newFileScanner(paths []string, config fileScannerConfig, id string) (*fileS
 	s := fileScanner{
 		paths:  paths,
 		cfg:    config,
-		log:    logp.NewLogger(scannerDebugKey).With("id", id),
+		log:    logp.NewLogger(scannerDebugKey).With("input_id", id),
 		hasher: sha256.New(),
 	}
 

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -68,9 +68,20 @@ type fileSource struct {
 	identifierGenerator string
 }
 
+// File returns the complete file path for this source
+func (f fileSource) File() string {
+	return f.newPath
+}
+
 // Name returns the registry identifier of the file.
 func (f fileSource) Name() string {
 	return f.fileID
+}
+
+// OSID returns the OS ID for this source, on Linux it is
+// <inode>-<device ID>
+func (f fileSource) OSID() string {
+	return f.desc.Info.GetOSState().String()
 }
 
 // newFileIdentifier creates a new state identifier for a log input.

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -133,7 +133,7 @@ func (inp *filestream) Run(
 		return fmt.Errorf("not file source")
 	}
 
-	log := ctx.Logger.With("path", fs.newPath).With("state-id", src.Name())
+	log := ctx.Logger
 	state := initState(log, cursor, fs)
 
 	r, truncated, err := inp.open(log, ctx.Cancelation, fs, state.Offset)

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -380,8 +380,6 @@ func (inp *filestream) readFromSource(
 		}
 
 		ctx.UpdateStatus(status.Failed, "Failed on purpose")
-		return errors.New("Failed on purpose")
-
 		s.Offset += int64(message.Bytes)
 
 		metrics.MessagesRead.Inc()

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -135,7 +135,12 @@ type defaultHarvesterGroup struct {
 func (hg *defaultHarvesterGroup) Start(ctx inputv2.Context, src Source) {
 	sourceName := hg.identifier.ID(src)
 
-	ctx.Logger = ctx.Logger.With("source_file", sourceName)
+	ctx.Logger = ctx.Logger.With(
+		"source_file", sourceName,
+		"state_id", src.Name(),
+		"path", src.File(),
+		"os_id", src.OSID(),
+	)
 	ctx.Logger.Debug("Starting harvester for file")
 
 	if err := hg.tg.Go(startHarvester(ctx, hg, src, false, hg.metrics)); err != nil {

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -79,7 +79,15 @@ type InputManager struct {
 // The `Name` method must return an unique name, that will be used to identify
 // the source in the persistent state store.
 type Source interface {
+	// Name returns a unique name that will be used to identify
+	//the source in the persistent store
 	Name() string
+
+	// File returns the complete file path for this source
+	File() string
+
+	// OSID returns the OS ID for this source
+	OSID() string
 }
 
 var errNoInputRunner = errors.New("no input runner available")

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -25,13 +25,13 @@ import (
 func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Source) *logp.Logger {
 	log := logger.With(
 		"operation", event.Op.String(),
-		"source_name", src.Name(),
+		"state_id", src.Name(),
 	)
 	if event.Descriptor.Fingerprint != "" {
 		log = log.With("fingerprint", event.Descriptor.Fingerprint)
 	}
 	if event.Descriptor.Info != nil {
-		osID := event.Descriptor.Info.GetOSState().String()
+		osID := src.OSID()
 		if osID != "" {
 			log = log.With("os_id", osID)
 		}

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -176,7 +176,7 @@ func (p *fileProspector) onFSEvent(
 	switch event.Op {
 	case loginp.OpCreate, loginp.OpWrite:
 		if event.Op == loginp.OpCreate {
-			log.Debugf("A new file %s has been found", event.NewPath)
+			log.Debugw(fmt.Sprintf("A new file %s has been found", event.NewPath), "path", event.NewPath)
 
 			err := updater.UpdateMetadata(src, fileMeta{Source: event.NewPath, IdentifierName: p.identifier.Name()})
 			if err != nil {

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -55,7 +55,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 
 	logp.L().
 		Named("prospector").
-		With("filestream_id", config.ID).
+		With("input_id", config.ID).
 		Debugf("file identity is set to %s", identifier.Name())
 
 	fileprospector := fileProspector{

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -43,7 +43,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 		return nil, err
 	}
 
-	filewatcher, err := newFileWatcher(config.Paths, config.FileWatcher)
+	filewatcher, err := newFileWatcher(config.Paths, config.FileWatcher, config.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating filewatcher %w", err)
 	}
@@ -54,6 +54,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 	}
 
 	logp.L().
+		Named("prospector").
 		With("filestream_id", config.ID).
 		Debugf("file identity is set to %s", identifier.Name())
 

--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -103,12 +103,16 @@ func (f *factory) Create(
 
 	return &runner{
 		id:        id,
-		log:       f.log.Named(input.Name()).With("id", id),
+		log:       f.log.Named(input.Name()).With("input_id", id),
 		agent:     &f.info,
 		sig:       ctxtool.WithCancelContext(context.Background()),
 		input:     input,
 		connector: p,
 	}, nil
+}
+
+func (r *runner) InputID() string {
+	return r.id
 }
 
 func (r *runner) SetStatusReporter(reported status.StatusReporter) {

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -186,12 +186,12 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 }
 
 func getRunnerID(r Runner) []any {
-	type ider interface {
+	type inputIDer interface {
 		InputID() string
 	}
 
 	idFields := []any{}
-	idRunner, ok := r.(ider)
+	idRunner, ok := r.(inputIDer)
 	if ok {
 		idFields = append(idFields, "input_id", idRunner.InputID())
 	}

--- a/libbeat/monitoring/inputmon/input.go
+++ b/libbeat/monitoring/inputmon/input.go
@@ -60,14 +60,14 @@ func NewInputRegistry(inputType, id string, optionalParent *monitoring.Registry)
 	log := logp.NewLogger("metric_registry")
 	// Make an orthogonal ID to allow tracking register/deregister pairs.
 	uuid := uuid.New().String()
-	log.Infow("registering", "input_type", inputType, "id", id, "key", key, "uuid", uuid)
+	log.Infow("registering", "input_type", inputType, "input_id", id, "key", key, "uuid", uuid)
 
 	reg = parentRegistry.NewRegistry(key)
 	monitoring.NewString(reg, "input").Set(inputType)
 	monitoring.NewString(reg, "id").Set(id)
 
 	return reg, func() {
-		log.Infow("unregistering", "input_type", inputType, "id", id, "key", key, "uuid", uuid)
+		log.Infow("unregistering", "input_type", inputType, "input_id", id, "key", key, "uuid", uuid)
 		parentRegistry.Remove(key)
 	}
 }


### PR DESCRIPTION
## Proposed commit message

This commit improves Filebeat's input lifecycle logging as well as Filestream logs. All logs related to input starting/stopping now contain the `input_id` key, with the value coming from the defined input ID in the configuration file or sent by the Elastic-Agent.

The `input_id` is also propagated to all Filestream sub-components, and their logging is now enhanced with a consistent set of fields about the file being ingested, those fields are:
- `os_id`: The file ID as identified by the OS, the pair [inode, device ID]
- `state_id`: The file state ID, it is part of the ID used in the registry log and checkpoint related to the file. When using fingerprint file identity it contains the fingerprint, when using native file identity it contains the [inode, device ID] pair.
- `source_file` The key used in the registry (in-memory, log and checkpoint). This contains the input type and input ID
- `path`: The full file path from the file.

The input status reprorting when running under Elastic-Agent is also implemented for the Filestream input.

Full logs example from before and after are in the [logs](#logs) section
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Filebeat
```yaml
filebeat.inputs:
  - type: filestream
    paths:
      - /tmp/logs/1*
    id: ID-Native
    close.on_state_change.inactive: 5s

  - type: filestream
    paths:
      - /tmp/logs/2*
    id: ID-Fingerprint
    file_identity.fingerprint: ~
    close.on_state_change.inactive: 5s
    prospector.scanner.fingerprint:
      enabled: true

path.home: /tmp/filebeat/

output:
  discard:
    enabled: true

queue.mem:
  flush.min_events: 0
  flush.timeout: 1s

logging:
  to_files: true
  level: debug
  selectors:
    - centralmgmt
    - file_watcher
    - filestream
    - input.filestream
    - metric_registry
    - prospector
```


Elastic-Agent
```yaml
outputs:
  default:
    type: elasticsearch
    hosts:
      - http://localhost:9200
    username: "elastic"
    password: "changeme"
    preset: latency

inputs:
  - type: filestream
    id: Input-ID
    streams:
      - id: ID-Native
        paths:
          - /tmp/logs/1*
        close.on_state_change.inactive: 5s
      - id: ID-Fingerprint
        paths:
          - /tmp/logs/2*
        file_identity.fingerprint: ~
        close.on_state_change.inactive: 5s
        prospector.scanner.fingerprint:
          enabled: true

agent.logging:
  level: debug
  selectors:
    - "*"
```
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<h2 id="logs">
Logs
</h2>

The fields not relevant to this PR are redacted.

Single log example for file identity native and fingerprint:
Fingerprint:
```json
{
  "@timestamp": "2024-05-31T16:54:45.340-0400",
  "log.level": "debug",
  "log.logger": "input.filestream",
  "message": "End of file reached: /tmp/logs/2.ndjson; Backoff now.",
  "input_id": "ID-Fingerprint",
  "os_id": "43116-34",
  "state_id": "fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d",
  "source_file": "filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d",
  "path": "/tmp/logs/2.ndjson"
}
```
Native:
```json
{
  "@timestamp": "2024-05-31T16:54:45.338-0400",
  "log.level": "debug",
  "log.logger": "input.filestream",
  "message": "End of file reached: /tmp/logs/1.ndjson; Backoff now.",
  "input_id": "ID-Native",
  "os_id": "43127-34",
  "state_id": "native::43127-34",
  "source_file": "filestream::ID-Native::native::43127-34",
  "path": "/tmp/logs/1.ndjson"
}
```

Full logs from two Filestrams input running:

<details><summary>Logs before the change</summary>
<p>

```json
{"@timestamp":"2024-05-31T17:02:38.532-0400","log.level":"info","log.logger":null,"message":"Home path: [/home/tiago/devel/beats/x-pack/filebeat] Config path: [/home/tiago/devel/beats/x-pack/filebeat] Data path: [/home/tiago/devel/beats/x-pack/filebeat/data] Logs path: [/home/tiago/devel/beats/x-pack/filebeat/logs]","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.556-0400","log.level":"info","log.logger":null,"message":"Beat ID: df6ff8fd-80c9-4cec-833e-1f47d7cc8d3f","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.588-0400","log.level":"info","log.logger":"seccomp","message":"Syscall filter successfully installed","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.588-0400","log.level":"info","log.logger":"beat","message":"Beat info","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.588-0400","log.level":"info","log.logger":"beat","message":"Build info","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.588-0400","log.level":"info","log.logger":"beat","message":"Go runtime info","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.589-0400","log.level":"info","log.logger":"beat","message":"Host info","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.589-0400","log.level":"info","log.logger":"beat","message":"Process info","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.589-0400","log.level":"info","log.logger":null,"message":"Setup Beat: filebeat; Version: 8.15.0","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.591-0400","log.level":"info","log.logger":"discard","message":"Initialized discard output","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.591-0400","log.level":"info","log.logger":"publisher","message":"Beat name: millennium-falcon","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.591-0400","log.level":"info","log.logger":"modules","message":"Enabled modules/filesets: ","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.591-0400","log.level":"warn","log.logger":null,"message":"Filebeat is unable to load the ingest pipelines for the configured modules because the Elasticsearch output is not configured/enabled. If you have already loaded the ingest pipelines or are using Logstash pipelines, you can ignore this warning.","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.591-0400","log.level":"info","log.logger":"monitoring","message":"Starting metrics logging every 30s","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.591-0400","log.level":"info","log.logger":null,"message":"filebeat start running.","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.598-0400","log.level":"info","log.logger":null,"message":"Finished loading transaction log file for '/home/tiago/devel/beats/x-pack/filebeat/data/registry/filebeat'. Active transaction id=0","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.605-0400","log.level":"info","log.logger":null,"message":"Finished loading transaction log file for '/home/tiago/devel/beats/x-pack/filebeat/data/registry/filebeat'. Active transaction id=0","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.605-0400","log.level":"warn","log.logger":null,"message":"Filebeat is unable to load the ingest pipelines for the configured modules because the Elasticsearch output is not configured/enabled. If you have already loaded the ingest pipelines or are using Logstash pipelines, you can ignore this warning.","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.605-0400","log.level":"info","log.logger":"registrar","message":"States Loaded from registrar: 0","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.605-0400","log.level":"info","log.logger":"crawler","message":"Loading Inputs: 2","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.605-0400","log.level":"info","log.logger":"crawler","message":"starting input, keys present on the config: [filebeat.inputs.0.close.on_state_change.inactive filebeat.inputs.0.id filebeat.inputs.0.paths.0 filebeat.inputs.0.type]","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"crawler","message":"Starting input (ID: 1843310979670678291)","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"crawler","message":"starting input, keys present on the config: [filebeat.inputs.1.close.on_state_change.inactive filebeat.inputs.1.id filebeat.inputs.1.paths.0 filebeat.inputs.1.prospector.scanner.fingerprint.enabled filebeat.inputs.1.type]","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' starting","id":"ID-Native","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"metric_registry","message":"registering","id":"ID-Native","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting prospector","id":"ID-Native","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"crawler","message":"Starting input (ID: 15291939220401959268)","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"crawler","message":"Loading and starting Inputs completed. Enabled inputs: 2","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' starting","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"info","log.logger":"metric_registry","message":"registering","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting prospector","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"A new file /tmp/logs/1.ndjson has been found","id":"ID-Native","os_id":"43127-34","source_name":"native::43127-34","source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"A new file /tmp/logs/2.ndjson has been found","id":"ID-Fingerprint","os_id":"43116-34","source_name":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":null}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting harvester for file","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"newLogFileReader with config.MaxBytes:10485760","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting harvester for file","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:38.606-0400","log.level":"debug","log.logger":"input.filestream","message":"newLogFileReader with config.MaxBytes:10485760","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:38.610-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/1.ndjson; Backoff now.","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:38.611-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/2.ndjson; Backoff now.","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:40.619-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/2.ndjson; Backoff now.","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:40.619-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/1.ndjson; Backoff now.","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:44.623-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/2.ndjson; Backoff now.","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:44.623-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/1.ndjson; Backoff now.","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:48.607-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:48.607-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:48.607-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:48.607-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:52.629-0400","log.level":"info","log.logger":"input.filestream","message":"Reader was closed. Closing. Path='/tmp/logs/2.ndjson'","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:52.629-0400","log.level":"debug","log.logger":"input.filestream","message":"Stopped harvester for file","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:52.629-0400","log.level":"info","log.logger":"input.filestream","message":"Reader was closed. Closing. Path='/tmp/logs/1.ndjson'","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:52.629-0400","log.level":"debug","log.logger":"input.filestream","message":"Closing reader of filestream","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d"}
{"@timestamp":"2024-05-31T17:02:52.629-0400","log.level":"debug","log.logger":"input.filestream","message":"Stopped harvester for file","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:52.629-0400","log.level":"debug","log.logger":"input.filestream","message":"Closing reader of filestream","id":"ID-Native","os_id":null,"source_name":null,"source_file":"filestream::ID-Native::native::43127-34"}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":"service","message":"Received signal \"terminated\", stopping","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":null,"message":"Stopping filebeat","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":null,"message":"Stopping Crawler","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":null,"message":"Stopping 2 inputs","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":"crawler","message":"Stopping input: 15291939220401959268","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":"crawler","message":"Stopping input: 1843310979670678291","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"debug","log.logger":"input.filestream","message":"Prospector has stopped","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":"metric_registry","message":"unregistering","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (goroutine)","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (runner)","id":"ID-Fingerprint","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.427-0400","log.level":"debug","log.logger":"input.filestream","message":"Prospector has stopped","id":"ID-Native","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":"metric_registry","message":"unregistering","id":"ID-Native","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (goroutine)","id":"ID-Native","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (runner)","id":"ID-Native","os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":null,"message":"Crawler stopped","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":null,"message":"Stopping filebeat","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":"registrar","message":"Stopping Registrar","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":"registrar","message":"Ending Registrar","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.428-0400","log.level":"info","log.logger":"registrar","message":"Registrar stopped","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.439-0400","log.level":"info","log.logger":"monitoring","message":"Total metrics","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.439-0400","log.level":"info","log.logger":"monitoring","message":"Uptime: 18.918011727s","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.439-0400","log.level":"info","log.logger":"monitoring","message":"Stopping metrics logging.","id":null,"os_id":null,"source_name":null,"source_file":null}
{"@timestamp":"2024-05-31T17:02:57.439-0400","log.level":"info","log.logger":null,"message":"filebeat stopped.","id":null,"os_id":null,"source_name":null,"source_file":null}
```


</p>
</details> 

<details><summary>Logs after the change</summary>
<p>

```json
{"@timestamp":"2024-05-31T16:54:45.241-0400","log.level":"info","log.logger":null,"message":"Home path: [/home/tiago/devel/beats/x-pack/filebeat] Config path: [/home/tiago/devel/beats/x-pack/filebeat] Data path: [/home/tiago/devel/beats/x-pack/filebeat/data] Logs path: [/home/tiago/devel/beats/x-pack/filebeat/logs]","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.264-0400","log.level":"info","log.logger":null,"message":"Beat ID: eec2bc7a-0384-45a5-a7c2-0ce85c3d2df4","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.317-0400","log.level":"info","log.logger":"seccomp","message":"Syscall filter successfully installed","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.317-0400","log.level":"info","log.logger":"beat","message":"Beat info","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.317-0400","log.level":"info","log.logger":"beat","message":"Build info","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.317-0400","log.level":"info","log.logger":"beat","message":"Go runtime info","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.318-0400","log.level":"info","log.logger":"beat","message":"Host info","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.318-0400","log.level":"info","log.logger":"beat","message":"Process info","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.318-0400","log.level":"info","log.logger":null,"message":"Setup Beat: filebeat; Version: 8.15.0","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.320-0400","log.level":"info","log.logger":"discard","message":"Initialized discard output","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.320-0400","log.level":"info","log.logger":"publisher","message":"Beat name: millennium-falcon","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.320-0400","log.level":"info","log.logger":"modules","message":"Enabled modules/filesets: ","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.320-0400","log.level":"warn","log.logger":null,"message":"Filebeat is unable to load the ingest pipelines for the configured modules because the Elasticsearch output is not configured/enabled. If you have already loaded the ingest pipelines or are using Logstash pipelines, you can ignore this warning.","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.320-0400","log.level":"info","log.logger":"monitoring","message":"Starting metrics logging every 30s","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.320-0400","log.level":"info","log.logger":null,"message":"filebeat start running.","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.328-0400","log.level":"info","log.logger":null,"message":"Finished loading transaction log file for '/home/tiago/devel/beats/x-pack/filebeat/data/registry/filebeat'. Active transaction id=0","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.334-0400","log.level":"info","log.logger":null,"message":"Finished loading transaction log file for '/home/tiago/devel/beats/x-pack/filebeat/data/registry/filebeat'. Active transaction id=0","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"warn","log.logger":null,"message":"Filebeat is unable to load the ingest pipelines for the configured modules because the Elasticsearch output is not configured/enabled. If you have already loaded the ingest pipelines or are using Logstash pipelines, you can ignore this warning.","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"registrar","message":"States Loaded from registrar: 0","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"crawler","message":"Loading Inputs: 2","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"crawler","message":"starting input, keys present on the config: [filebeat.inputs.0.close.on_state_change.inactive filebeat.inputs.0.id filebeat.inputs.0.paths.0 filebeat.inputs.0.type]","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"prospector","message":"file identity is set to native","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"crawler","message":"Starting input (ID: 1843310979670678291)","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"crawler","message":"starting input, keys present on the config: [filebeat.inputs.1.close.on_state_change.inactive filebeat.inputs.1.id filebeat.inputs.1.paths.0 filebeat.inputs.1.prospector.scanner.fingerprint.enabled filebeat.inputs.1.type]","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"prospector","message":"file identity is set to fingerprint","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' starting","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"crawler","message":"Starting input (ID: 15291939220401959268)","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"metric_registry","message":"registering","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"crawler","message":"Loading and starting Inputs completed. Enabled inputs: 2","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' starting","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"info","log.logger":"metric_registry","message":"registering","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting prospector","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting prospector","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"A new file /tmp/logs/1.ndjson has been found","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":null,"path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"A new file /tmp/logs/2.ndjson has been found","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":null,"path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting harvester for file","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"newLogFileReader with config.MaxBytes:10485760","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"Starting harvester for file","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:45.335-0400","log.level":"debug","log.logger":"input.filestream","message":"newLogFileReader with config.MaxBytes:10485760","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:45.338-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/1.ndjson; Backoff now.","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:45.340-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/2.ndjson; Backoff now.","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:47.339-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/1.ndjson; Backoff now.","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:47.348-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/2.ndjson; Backoff now.","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:51.343-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/1.ndjson; Backoff now.","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:51.349-0400","log.level":"debug","log.logger":"input.filestream","message":"End of file reached: /tmp/logs/2.ndjson; Backoff now.","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:55.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:55.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:55.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:55.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:54:59.363-0400","log.level":"info","log.logger":"input.filestream","message":"Reader was closed. Closing. Path='/tmp/logs/1.ndjson'","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:59.363-0400","log.level":"debug","log.logger":"input.filestream","message":"Stopped harvester for file","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:59.363-0400","log.level":"debug","log.logger":"input.filestream","message":"Closing reader of filestream","input_id":"ID-Native","os_id":"43127-34","state_id":"native::43127-34","source_file":"filestream::ID-Native::native::43127-34","path":"/tmp/logs/1.ndjson"}
{"@timestamp":"2024-05-31T16:54:59.363-0400","log.level":"info","log.logger":"input.filestream","message":"Reader was closed. Closing. Path='/tmp/logs/2.ndjson'","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:59.363-0400","log.level":"debug","log.logger":"input.filestream","message":"Stopped harvester for file","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:54:59.363-0400","log.level":"debug","log.logger":"input.filestream","message":"Closing reader of filestream","input_id":"ID-Fingerprint","os_id":"43116-34","state_id":"fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","source_file":"filestream::ID-Fingerprint::fingerprint::fea2922758a60439a9f7e683783331f0d07fce9fec955fc46f4e60e2f83bb36d","path":"/tmp/logs/2.ndjson"}
{"@timestamp":"2024-05-31T16:55:05.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:05.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:05.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:05.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:15.322-0400","log.level":"info","log.logger":"monitoring","message":"Non-zero metrics in the last 30s","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:15.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:15.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:15.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:15.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:25.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:25.336-0400","log.level":"debug","log.logger":"file_watcher","message":"Start next scan","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:25.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:25.336-0400","log.level":"debug","log.logger":"file_watcher","message":"File scan complete","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"service","message":"Received signal \"terminated\", stopping","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":null,"message":"Stopping filebeat","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"crawler","message":"Stopping Crawler","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"crawler","message":"Stopping 2 inputs","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"crawler","message":"Stopping input: 15291939220401959268","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"debug","log.logger":"input.filestream","message":"Prospector has stopped","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"metric_registry","message":"unregistering","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"crawler","message":"Stopping input: 1843310979670678291","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (goroutine)","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (runner)","input_id":"ID-Fingerprint","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"debug","log.logger":"input.filestream","message":"Prospector has stopped","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"metric_registry","message":"unregistering","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (goroutine)","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"input.filestream","message":"Input 'filestream' stopped (runner)","input_id":"ID-Native","os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"crawler","message":"Crawler stopped","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":null,"message":"Stopping filebeat","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"registrar","message":"Stopping Registrar","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"registrar","message":"Ending Registrar","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.907-0400","log.level":"info","log.logger":"registrar","message":"Registrar stopped","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.913-0400","log.level":"info","log.logger":"monitoring","message":"Total metrics","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.913-0400","log.level":"info","log.logger":"monitoring","message":"Uptime: 41.67822786s","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.913-0400","log.level":"info","log.logger":"monitoring","message":"Stopping metrics logging.","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
{"@timestamp":"2024-05-31T16:55:26.913-0400","log.level":"info","log.logger":null,"message":"filebeat stopped.","input_id":null,"os_id":null,"state_id":null,"source_file":null,"path":null}
```

</p>
</details> 