### PR TITLE
Add a note when using `expand_event_list_from_field`, `content_type` is required to set to `application/json`

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -120,7 +120,7 @@ characters. This only applies to non-JSON logs. See <<_encoding_3>>.
 ==== `decoding`
 
 The file decoding option is used to specify a codec that will be used to
-decode the file contents. This can apply to any file stream data.  
+decode the file contents. This can apply to any file stream data.
 An example config is shown below:
 
 [source,yaml]
@@ -131,17 +131,17 @@ An example config is shown below:
 Currently supported codecs are given below:-
 
     1. <<attrib-decoding-parquet,Parquet>>: This codec decodes parquet compressed data streams.
- 
+
 [id="attrib-decoding-parquet"]
 [float]
 ==== `the parquet codec`
 The `parquet` codec is used to decode parquet compressed data streams.
 Only enabling the codec will use the default codec options. The parquet codec supports
-two sub attributes which can make parquet decoding more efficient. The `batch_size` attribute and 
+two sub attributes which can make parquet decoding more efficient. The `batch_size` attribute and
 the `process_parallel` attribute. The `batch_size` attribute can be used to specify the number of
-records to read from the parquet stream at a time. By default the `batch size` is set to `1` and 
-`process_parallel` is set to `false`. If the `process_parallel` attribute is set to `true` then functions 
-which read multiple columns will read those columns in parallel from the parquet stream with a 
+records to read from the parquet stream at a time. By default the `batch size` is set to `1` and
+`process_parallel` is set to `false`. If the `process_parallel` attribute is set to `true` then functions
+which read multiple columns will read those columns in parallel from the parquet stream with a
 number of readers equal to the number of columns. Setting `process_parallel` to `true` will greatly
 increase the rate of processing at the cost of increased memory usage. Having a larger `batch_size`
 also helps to increase the rate of processing. An example config is shown below:
@@ -161,6 +161,8 @@ under a specific field or an array of objects then the config option `expand_eve
 value can be assigned the name of the field or `.[]`. This setting will be able to split
 the messages under the group value into separate events. For example, CloudTrail
 logs are in JSON format and events are found under the JSON object "Records".
+
+Note: when using `expand_event_list_from_field`, `content_type` config parameter has to set to `application/json`.
 
 ["source","json"]
 ----

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -162,7 +162,7 @@ value can be assigned the name of the field or `.[]`. This setting will be able 
 the messages under the group value into separate events. For example, CloudTrail
 logs are in JSON format and events are found under the JSON object "Records".
 
-Note: when using `expand_event_list_from_field`, `content_type` config parameter has to set to `application/json`.
+Note: when using `expand_event_list_from_field`, `content_type` config parameter has to be set to `application/json`.
 
 ["source","json"]
 ----

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -162,7 +162,7 @@ value can be assigned the name of the field or `.[]`. This setting will be able 
 the messages under the group value into separate events. For example, CloudTrail
 logs are in JSON format and events are found under the JSON object "Records".
 
-Note: when using `expand_event_list_from_field`, `content_type` config parameter has to be set to `application/json`.
+NOTE: When using `expand_event_list_from_field`, `content_type` config parameter has to be set to `application/json`.
 
 ["source","json"]
 ----


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This PR is to enhance documentation on `expand_event_list_from_field` parameter. When using `expand_event_list_from_field`, `content_type` is required to set to `application/json`.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
