### PR TITLE
[winlogbeat] Recover from error 87 if found

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -331,6 +331,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 *Winlogbeat*
 
 - Use fixed size buffer at first pass for event parsing, improving throughput {issue}39530[39530] {pull}39544[39544]
+- Add ERROR_INVALID_PARAMETER to the list of recoverable errors. {pull}39781[39781]
 
 *Functionbeat*
 

--- a/winlogbeat/eventlog/errors_windows.go
+++ b/winlogbeat/eventlog/errors_windows.go
@@ -29,7 +29,9 @@ import (
 //
 //nolint:errorlint // These are never wrapped.
 func IsRecoverable(err error) bool {
-	return err == win.ERROR_INVALID_HANDLE || err == win.RPC_S_SERVER_UNAVAILABLE || err == win.RPC_S_CALL_CANCELLED || err == win.ERROR_EVT_QUERY_RESULT_STALE
+	return err == win.ERROR_INVALID_HANDLE || err == win.RPC_S_SERVER_UNAVAILABLE ||
+		err == win.RPC_S_CALL_CANCELLED || err == win.ERROR_EVT_QUERY_RESULT_STALE ||
+		err == win.ERROR_INVALID_PARAMETER
 }
 
 // IsChannelNotFound returns true if the error indicates the channel was not found.

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -41,6 +41,7 @@ const NilHandle EvtHandle = 0
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
 const (
 	ERROR_INVALID_HANDLE        syscall.Errno = 6
+	ERROR_INVALID_PARAMETER     syscall.Errno = 87
 	ERROR_INSUFFICIENT_BUFFER   syscall.Errno = 122
 	ERROR_NO_MORE_ITEMS         syscall.Errno = 259
 	RPC_S_SERVER_UNAVAILABLE    syscall.Errno = 1722


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Adds ERROR_INVALID_PARAMETER as a recoverable error type.

There have been some reports that under heavy load and when automatic event log backups, a race condition can happen where the handle is reported as invalid when doing the call to EvtNext. This will prevent users from needing to restart winlogbeat when this happens.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

