### PR TITLE
add benchmark input to agentbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -208,6 +208,10 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add persistent volume claim name to volume if available {pull}38839[38839]
 - Raw events are now logged to a different file, this prevents potentially sensitive information from leaking into log files {pull}38767[38767]
 
+*Agentbeat*
+
+- Added `benchmark` processor. {pull}39789[39789]
+
 *Auditbeat*
 
 - Added `add_session_metadata` processor, which enables session viewer on Auditbeat data. {pull}37640[37640]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -208,10 +208,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add persistent volume claim name to volume if available {pull}38839[38839]
 - Raw events are now logged to a different file, this prevents potentially sensitive information from leaking into log files {pull}38767[38767]
 
-*Agentbeat*
-
-- Added `benchmark` processor. {pull}39789[39789]
-
 *Auditbeat*
 
 - Added `add_session_metadata` processor, which enables session viewer on Auditbeat data. {pull}37640[37640]

--- a/x-pack/agentbeat/agentbeat.spec.yml
+++ b/x-pack/agentbeat/agentbeat.spec.yml
@@ -100,6 +100,11 @@ inputs:
     platforms: *platforms
     outputs: *outputs
     command: *filebeat_command
+  - name: benchmark
+    description: "Benchmark Input"
+    platforms: *platforms
+    outputs: *outputs
+    command: *filebeat_command
   - name: cel
     description: "Common Expression Language Input"
     platforms: *platforms


### PR DESCRIPTION
## Proposed commit message

Add filebeat benchmark input to agentbeat.  This can be used to
generate events to send to the configured output.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Write an integration that uses the benchmark input

https://github.com/elastic/integrations/pull/8733


## Related issues

- Relates #37437

## Use cases

- Benchmark an output so it isn't constrained by the input

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
