### PR TITLE
[Docker] Stop returning errors when there are no metric values

### DIFF
--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -21,6 +21,7 @@ package memory
 
 import (
 	"fmt"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/docker/docker/client"

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -72,7 +72,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 	memoryStats := m.memoryService.getMemoryStatsList(stats, m.dedot)
 	if len(memoryStats) == 0 {
-		return fmt.Errorf("No memory stats data available")
+		// No memory stats available, probably because
+		// no containers are running.
+		return nil
 	}
 	eventsMapping(r, memoryStats)
 

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -30,10 +30,8 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/module/docker"
 )
 
-const metricsetName = "memory"
-
 func init() {
-	mb.Registry.MustAddMetricSet("docker", metricsetName, New,
+	mb.Registry.MustAddMetricSet("docker", "memory", New,
 		mb.WithHostParser(docker.HostParser),
 		mb.DefaultMetricSet(),
 	)
@@ -50,7 +48,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker memory MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logger := logp.NewLogger(metricsetName)
+	logger := logp.NewLogger("docker.memory")
 	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Stop returning errors when there are no metric values for the Docker memory metricset.

The docker metricset returns an error when there are no memory metric values available. This condition can happen when there are no running containers on Docker.

When no containers are running, the metricset returns an error at every collection, creating noise.

## Notes for reviewers

- Is there a use case when we should return an error instead?
- Should I add a logger to log a debug message saying "no memory stats data available"?

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!--
## Disruptive User Impact
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-


<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
