### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/okta: add user group membership support

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -289,6 +289,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Make HTTP Endpoint input GA. {issue}38979[38979] {pull}39410[39410]
 - Update CEL mito extensions to v1.12.2. {pull}39755[39755]
 - Add support for base64-encoded HMAC headers to HTTP Endpoint. {pull}39655[39655]
+- Add user group membership support to Okta entity analytics provider. {issue}39814[39814] {pull}39815[39815]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta_test.go
@@ -86,6 +86,31 @@ func Test(t *testing.T) {
 				return
 			}
 
+			t.Run("my_groups", func(t *testing.T) {
+				query := make(url.Values)
+				query.Set("limit", "200")
+				groups, _, err := GetUserGroupDetails(context.Background(), http.DefaultClient, host, key, me.ID, limiter, window)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(groups) == 0 {
+					t.Fatalf("unexpected len(groups): got:%d want:1", len(groups))
+				}
+
+				if omit&OmitCredentials != 0 && me.Credentials != nil {
+					t.Errorf("unexpected credentials with %s: %#v", omit, me.Credentials)
+				}
+
+				if !*logResponses {
+					return
+				}
+				b, err := json.Marshal(groups)
+				if err != nil {
+					t.Errorf("failed to marshal groups for logging: %v", err)
+				}
+				t.Logf("groups: %s", b)
+			})
+
 			t.Run("user", func(t *testing.T) {
 				if me.Profile.Login == "" {
 					b, _ := json.Marshal(me)

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
@@ -18,6 +18,7 @@ import (
 
 	"golang.org/x/time/rate"
 
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -49,11 +50,13 @@ func TestOktaDoFetch(t *testing.T) {
 				window  = time.Minute
 				key     = "token"
 				users   = `[{"id":"USERID","status":"STATUS","created":"2023-05-14T13:37:20.000Z","activated":null,"statusChanged":"2023-05-15T01:50:30.000Z","lastLogin":"2023-05-15T01:59:20.000Z","lastUpdated":"2023-05-15T01:50:32.000Z","passwordChanged":"2023-05-15T01:50:32.000Z","type":{"id":"typeid"},"profile":{"firstName":"name","lastName":"surname","mobilePhone":null,"secondEmail":null,"login":"name.surname@example.com","email":"name.surname@example.com"},"credentials":{"password":{"value":"secret"},"emails":[{"value":"name.surname@example.com","status":"VERIFIED","type":"PRIMARY"}],"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://localhost/api/v1/users/USERID"}}}]`
+				groups  = `[{"id":"USERID","profile":{"description":"All users in your organization","name":"Everyone"}}]`
 				devices = `[{"id":"DEVICEID","status":"STATUS","created":"2019-10-02T18:03:07.000Z","lastUpdated":"2019-10-02T18:03:07.000Z","profile":{"displayName":"Example Device name 1","platform":"WINDOWS","serialNumber":"XXDDRFCFRGF3M8MD6D","sid":"S-1-11-111","registered":true,"secureHardwarePresent":false,"diskEncryptionType":"ALL_INTERNAL_VOLUMES"},"resourceType":"UDDevice","resourceDisplayName":{"value":"Example Device name 1","sensitive":false},"resourceAlternateId":null,"resourceId":"DEVICEID","_links":{"activate":{"href":"https://localhost/api/v1/devices/DEVICEID/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://localhost/api/v1/devices/DEVICEID","hints":{"allow":["GET","PATCH","PUT"]}},"users":{"href":"https://localhost/api/v1/devices/DEVICEID/users","hints":{"allow":["GET"]}}}}]`
 			)
 
 			data := map[string]string{
 				"users":   users,
+				"groups":  groups,
 				"devices": devices,
 			}
 
@@ -62,6 +65,14 @@ func TestOktaDoFetch(t *testing.T) {
 				err := json.Unmarshal([]byte(users), &wantUsers)
 				if err != nil {
 					t.Fatalf("failed to unmarshal user data: %v", err)
+				}
+				var wantGroups []okta.Group
+				err = json.Unmarshal([]byte(groups), &wantGroups)
+				if err != nil {
+					t.Fatalf("failed to unmarshal user data: %v", err)
+				}
+				for i, u := range wantUsers {
+					wantUsers[i].Groups = append(u.Groups, wantGroups...)
 				}
 			}
 			var wantDevices []Device
@@ -83,6 +94,12 @@ func TestOktaDoFetch(t *testing.T) {
 				w.Header().Add("x-rate-limit-remaining", "49")
 				w.Header().Add("x-rate-limit-reset", fmt.Sprint(time.Now().Add(time.Minute).Unix()))
 
+				if strings.HasPrefix(r.URL.Path, "/api/v1/users") && strings.HasSuffix(r.URL.Path, "groups") {
+					// Give the groups if this is a get user groups request.
+					userid := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/users/"), "/groups")
+					fmt.Fprintln(w, strings.ReplaceAll(data["groups"], "USERID", userid))
+					return
+				}
 				if strings.HasPrefix(r.URL.Path, "/api/v1/device") && strings.HasSuffix(r.URL.Path, "users") {
 					// Give one user if this is a get device users request.
 					fmt.Fprintln(w, data["users"])
@@ -158,8 +175,14 @@ func TestOktaDoFetch(t *testing.T) {
 					t.Errorf("unexpected number of results: got:%d want:%d", len(got), wantCount(repeats, test.wantUsers))
 				}
 				for i, g := range got {
-					if wantID := fmt.Sprintf("userid%d", i+1); g.ID != wantID {
+					wantID := fmt.Sprintf("userid%d", i+1)
+					if g.ID != wantID {
 						t.Errorf("unexpected user ID for user %d: got:%s want:%s", i, g.ID, wantID)
+					}
+					for j, gg := range g.Groups {
+						if gg.ID != wantID {
+							t.Errorf("unexpected used ID for user group %d in %d: got:%s want:%s", j, i, gg.ID, wantID)
+						}
 					}
 					if g.State != wantStates[g.ID] {
 						t.Errorf("unexpected user state for user %s: got:%s want:%s", g.ID, g.State, wantStates[g.ID])

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/statestore.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/statestore.go
@@ -39,7 +39,8 @@ const (
 
 type User struct {
 	okta.User `json:"properties"`
-	State     State `json:"state"`
+	Groups    []okta.Group `json:"groups"`
+	State     State        `json:"state"`
 }
 
 type Device struct {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

See title.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

To test the internal package, you will need to obtain an okta account and then run the following in that package's directory:
```
$ OKTA_HOST=dev-<REDACTED>-admin.okta.com OKTA_TOKEN=<REDACTED> go test -log_response -v -run Test$
```
Replacing the redacted parts with the appropriate values.

This should result in output similar to the following. In particular, the output for Test/none/my_groups.
```
=== RUN   Test
=== RUN   Test/none
=== RUN   Test/none/me
    okta_test.go:83: user: {"id":"<REDACTED>","status":"ACTIVE","created":"1066-10-13T20:57:12Z","activated":"0001-01-01T00:00:00Z","statusChanged":"1066-10-13T04:37:39Z","lastLogin":"1066-10-13T02:50:06Z","lastUpdated":"1066-10-13T04:37:39Z","passwordChanged":"1066-10-13T04:37:39Z","type":{"id":"<REDACTED>"},"profile":{"login":"efd6@github.oktaidp","email":"harold.godwinson@angeland.co","firstName":"Harold","lastName":"Godwinson"},"credentials":{"password":{},"recovery_question":{},"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"changePassword":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>/credentials/change_password","method":"POST"},"changeRecoveryQuestion":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>/credentials/change_recovery_question","method":"POST"},"deactivate":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>/lifecycle/deactivate","method":"POST"},"expirePassword":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>/lifecycle/expire_password","method":"POST"},"forgotPassword":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>/credentials/forgot_password","method":"POST"},"resetPassword":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>/lifecycle/reset_password","method":"POST"},"schema":{"href":"https://dev-<REDACTED>.okta.com/api/v1/meta/schemas/user/<REDACTED>"},"self":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>"},"suspend":{"href":"https://dev-<REDACTED>.okta.com/api/v1/users/<REDACTED>/lifecycle/suspend","method":"POST"},"type":{"href":"https://dev-<REDACTED>.okta.com/api/v1/meta/types/user/<REDACTED>"}}}
=== RUN   Test/none/my_groups
    okta_test.go:111: groups: [{"id":"<REDACTED>","profile":{"description":"All users in your organization","name":"Everyone"}}]
<more>
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #39814

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
