### PR TITLE
Update opendashboards.asciidoc to rename index pattern to data view

### DIFF
--- a/libbeat/docs/shared/opendashboards.asciidoc
+++ b/libbeat/docs/shared/opendashboards.asciidoc
@@ -13,7 +13,7 @@ include::{libbeat-dir}/tab-widgets/open-kibana-widget.asciidoc[]
 --
 
 . In the side navigation, click *Discover*. To see {beatname_uc} data, make
-sure the predefined +{beatname_lc}-*+ index pattern is selected.
+sure the predefined +{beatname_lc}-*+ data view is selected.
 +
 --
 TIP: If you don’t see data in {kib}, try changing the time filter to a larger


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

From version 8.0 index pattern was renamed to data view https://www.elastic.co/guide/en/kibana/8.0/index-patterns.html
