### PR TITLE
filebeat: Fix flaky test case on macOS

### DIFF
--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -485,7 +485,7 @@ class Test(BaseTest):
         self.wait_until(
             lambda: self.log_contains(
                 "Start next scan"),
-            max_timeout=5)
+            max_timeout=10)
 
         with open(testfile, 'a') as f:
             # write additional lines
@@ -596,7 +596,7 @@ class Test(BaseTest):
         # run filebeat
         filebeat = self.start_beat()
         self.wait_until(lambda: self.output_has(lines=len(encodings)),
-                        max_timeout=15)
+                        max_timeout=25)
 
         # write another line in all files
         for _, enc_py, text in encodings:

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -858,6 +858,6 @@ class Test(BaseTest):
 
         # 13 on unix, 14 on windows.
         self.wait_until(lambda: self.log_contains(re.compile(
-            'Matching null byte found at offset (13|14)')), max_timeout=5)
+            'Matching null byte found at offset (13|14)')), max_timeout=10)
 
         filebeat.check_kill_and_wait()

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -252,6 +252,8 @@ class Test(BaseTest):
 
         self.assertEqual(self.file_permissions(os.path.join(registry_path, "log.json")), "0o600")
 
+        registry_home = "a/b/c/d/registry_x"
+        registry_path = os.path.join(registry_home, "filebeat")
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             registry_home=registry_home,
@@ -266,10 +268,10 @@ class Test(BaseTest):
         # the logging and actual writing the file. Seems to happen on Windows.
         self.wait_until(
             lambda: self.has_registry(registry_path),
-            max_timeout=1)
+            max_timeout=10)
 
         # Wait a moment to make sure registry is completely written
-        time.sleep(10)
+        time.sleep(1)
 
         filebeat.check_kill_and_wait()
 
@@ -975,8 +977,8 @@ class Test(BaseTest):
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            clean_inactive="20s",
-            ignore_older="10s"
+            clean_inactive="10s",
+            ignore_older="9s"
         )
         os.mkdir(self.working_dir + "/log/")
 
@@ -1002,8 +1004,8 @@ class Test(BaseTest):
         # No config file which does not match the existing state
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/test2.log",
-            clean_inactive="20s",
-            ignore_older="10s",
+            clean_inactive="10s",
+            ignore_older="9s",
         )
 
         filebeat = self.start_beat(output="filebeat2.log")
@@ -1136,8 +1138,8 @@ class Test(BaseTest):
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/test.log",
-            clean_inactive="20s",
-            ignore_older="10s"
+            clean_inactive="10s",
+            ignore_older="9s"
         )
         os.mkdir(self.working_dir + "/log/")
 
@@ -1158,7 +1160,7 @@ class Test(BaseTest):
         # Check that ttl > 0 was set because of clean_inactive
         data = self.get_registry()
         assert len(data) == 1
-        assert data[0]["ttl"] == 20 * 1000 * 1000 * 1000
+        assert data[0]["ttl"] == 10 * 1000 * 1000 * 1000
 
         # New config without clean_inactive
         self.render_config_template(

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -254,7 +254,7 @@ class Test(BaseTest):
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            registry_home="a/b/c/registry_x",
+            registry_home=registry_home,
             registry_file_permissions=0o640
         )
 
@@ -269,7 +269,7 @@ class Test(BaseTest):
             max_timeout=1)
 
         # Wait a moment to make sure registry is completely written
-        time.sleep(1)
+        time.sleep(10)
 
         filebeat.check_kill_and_wait()
 
@@ -975,8 +975,8 @@ class Test(BaseTest):
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            clean_inactive="10s",
-            ignore_older="5s"
+            clean_inactive="20s",
+            ignore_older="10s"
         )
         os.mkdir(self.working_dir + "/log/")
 
@@ -1002,8 +1002,8 @@ class Test(BaseTest):
         # No config file which does not match the existing state
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/test2.log",
-            clean_inactive="10s",
-            ignore_older="5s",
+            clean_inactive="20s",
+            ignore_older="10s",
         )
 
         filebeat = self.start_beat(output="filebeat2.log")
@@ -1136,8 +1136,8 @@ class Test(BaseTest):
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/test.log",
-            clean_inactive="10s",
-            ignore_older="5s"
+            clean_inactive="20s",
+            ignore_older="10s"
         )
         os.mkdir(self.working_dir + "/log/")
 
@@ -1158,7 +1158,7 @@ class Test(BaseTest):
         # Check that ttl > 0 was set because of clean_inactive
         data = self.get_registry()
         assert len(data) == 1
-        assert data[0]["ttl"] == 10 * 1000 * 1000 * 1000
+        assert data[0]["ttl"] == 20 * 1000 * 1000 * 1000
 
         # New config without clean_inactive
         self.render_config_template(

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -952,7 +952,7 @@ class Test(BaseTest):
             path=os.path.abspath(self.working_dir) + "/log/*",
             close_inactive="200ms",
             ignore_older="2000ms",
-            clean_inactive="3s",
+            clean_inactive="10s",
         )
 
         filebeat = self.start_beat()

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -30,7 +30,7 @@ class Test(BaseTest):
 
             # Flaky on MacOS, see https://github.com/elastic/beats/issues/39613#issuecomment-2158812325
             # we need to wait a bit longer for filebeat to start
-            if platform.system() == "Darwin" :
+            if platform.system() == "Darwin":
                 time.sleep(10)
             else:
                 time.sleep(.5)

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -27,7 +27,13 @@ class Test(BaseTest):
         )
         for i in range(1, 5):
             proc = self.start_beat(logging_args=["-e", "-v"])
-            time.sleep(.5)
+
+            # Flaky on MacOS, see https://github.com/elastic/beats/issues/39613#issuecomment-2158812325
+            # we need to wait a bit longer for filebeat to start
+            if platform.system() == "Darwin" :
+                time.sleep(10)
+            else:
+                time.sleep(.5)
             proc.check_kill_and_wait()
 
     @unittest.skip("Skipped as flaky: https://github.com/elastic/beats/issues/14647")


### PR DESCRIPTION
## Proposed commit message

This PR fixes following test cases which are flaky for macOS:

- tests/system/test_harvester.py::Test::test_debug_reader
- tests/system/test_crawler.py::Test::test_tail_files
- tests/system/test_crawler.py::Test::test_encodings
- tests/system/test_registrar.py::Test::test_restart_state_reset_ttl_no_clean_inactive
- tests/system/test_registrar.py::Test::test_restart_state_reset
- tests/system/test_registrar.py::Test::test_restart_state
- tests/system/test_registrar.py::Test::test_registry_file_update_permissions
- tests/system/test_shutdown.py::Test::test_shutdown

On MacOS, the FQDN lookup takes some time (~5 seconds) before signal handlers are set up 
  - the lingering FQDN lookup code is [here](https://github.com/elastic/beats/blob/main/libbeat/cmd/instance/beat.go#L836-L844)
To make sure that the tests are passed, we need to increase the timeout by few seconds in each of the failing cases.

You can view the full discussion https://elastic.slack.com/archives/C047NDNGUMU/p1717091056290869.



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Fixes https://github.com/elastic/beats/issues/39613