### PR TITLE
Osquerybeat: Translate osqueryd INFO level logs into osquerybeat DEBUG level logs

### DIFF
--- a/x-pack/osquerybeat/beater/logger_plugin.go
+++ b/x-pack/osquerybeat/beater/logger_plugin.go
@@ -81,7 +81,7 @@ func (m *osqueryLogMessage) Log(typ logger.LogType, log *logp.Logger) {
 	case severityWarning:
 		log.Warnw(m.Message, args...)
 	case severityInfo:
-		log.Infow(m.Message, args...)
+		log.Debugw(m.Message, args...)
 	default:
 		log.Debugw(m.Message, args...)
 	}


### PR DESCRIPTION
## Proposed commit message

Osquerybeat: Translate osqueryd INFO level logs into osquerybeat DEBUG level logs. 

The osqueryd doesn't have DEBUG level logging and the lowest level is INFO. This was causing too many unwanted log messages captured from osqueryd at the default INFO logging level. 

This addresses the request for reduce the number of logs emitted from osqueryd at the default INFO logging level:
https://github.com/elastic/ingest-dev/issues/2385#issuecomment-2161583521

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/ingest-dev/issues/2385
