### PR TITLE
[Kubernetes Provider] Apply namespace filter to watchers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -157,6 +157,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix `namespace` filter option at Kubernetes provider level. {pull}39881[39881]
 - Fix Azure Monitor 429 error by causing metricbeat to retry the request again. {pull}38294[38294]
 - Fix fields not being parsed correctly in postgresql/database {issue}25301[25301] {pull}37720[37720]
 - rabbitmq/queue - Change the mapping type of `rabbitmq.queue.consumers.utilisation.pct` to `scaled_float` from `long` because the values fall within the range of `[0.0, 1.0]`. Previously, conversion to integer resulted in reporting either `0` or `1`.

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -74,8 +74,9 @@ func NewServiceEventer(uuid uuid.UUID, cfg *conf.C, client k8s.Interface, publis
 
 	if metaConf.Namespace.Enabled() || config.Hints.Enabled() {
 		namespaceWatcher, err = kubernetes.NewNamedWatcher("namespace", client, &kubernetes.Namespace{}, kubernetes.WatchOptions{
-			SyncTimeout: config.SyncPeriod,
-			Namespace:   config.Namespace,
+			SyncTimeout:  config.SyncPeriod,
+			Namespace:    config.Namespace,
+			HonorReSyncs: true,
 		}, nil)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create watcher for %T due to error %w", &kubernetes.Namespace{}, err)

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -141,9 +141,9 @@ The `kubernetes` autodiscover provider has the following configuration settings:
   cannot be accurately detected, as when running {beatname_lc} in host network
   mode.
 `namespace`:: (Optional) Select the namespace from which to collect the
-  metadata. If it is not set, the processor collects metadata from all
+  data. If it is not set, the processor collects data from all
   namespaces. It is unset by default. The namespace configuration only applies to
-  kubernetes resources that are namespace scoped.
+  kubernetes resources that are namespace scoped and if `unique` field is set to `false`.
 `cleanup_timeout`:: (Optional) Specify the time of inactivity before stopping the
 running configuration for a container,
 ifeval::["{beatname_lc}"=="filebeat"]
@@ -196,7 +196,7 @@ Example:
 
 `unique`:: (Optional) Defaults to `false`. Marking an autodiscover provider as unique results into
   making the provider to enable the provided templates only when it will gain the leader lease.
-  This setting can only be combined with `cluster` scope. When `unique` is enabled enabled, `resource`
+  This setting can only be combined with `cluster` scope. When `unique` is enabled, `resource`
   and `add_resource_metadata` settings are not taken into account.
 `leader_lease`:: (Optional) Defaults to +{beatname_lc}-cluster-leader+. This will be name of the lock lease.
   One can monitor the status of the lease with `kubectl describe lease beats-cluster-leader`.

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -140,10 +140,7 @@ The `kubernetes` autodiscover provider has the following configuration settings:
 `node`:: (Optional) Specify the node to scope {beatname_lc} to in case it
   cannot be accurately detected, as when running {beatname_lc} in host network
   mode.
-`namespace`:: (Optional) Select the namespace from which to collect the
-  data. If it is not set, the processor collects data from all
-  namespaces. It is unset by default. The namespace configuration only applies to
-  kubernetes resources that are namespace scoped and if `unique` field is set to `false`.
+`namespace`:: (Optional) Select the namespace from which to collect the events from the resources. If it is not set, the provider collects them from all namespaces. It is unset by default. The namespace configuration only applies to kubernetes resources that are namespace scoped and if `unique` field is set to `false`.
 `cleanup_timeout`:: (Optional) Specify the time of inactivity before stopping the
 running configuration for a container,
 ifeval::["{beatname_lc}"=="filebeat"]


### PR DESCRIPTION
## Proposed commit message

- WHAT: Apply namespace filter to the watchers of kubernetes provider.
- WHY:  please check https://github.com/elastic/beats/issues/38978 for details.

I also added the option `HonorReSyncs` to [make sure we don't lose any events](https://github.com/elastic/elastic-agent-autodiscover/blob/15147343f9fe5b15d90f756fc1447843101792be/kubernetes/watcher.go#L158-L166).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Run your own metricbeat as stated [here](https://github.com/elastic/beats/tree/main/dev-tools/kubernetes). The way I tested this change is better explained in **Results** section.


## Related issues

- Relates https://github.com/elastic/beats/issues/38978


## Results


I have a cluster with the following resources:
```
c@c:~/$ kubectl get pods --all-namespaces
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
default              nginx                                        1/1     Running   0          14s
default              redis-deployment-648bf5585b-2dcr2            1/1     Running   0          14s
default              redis-deployment-648bf5585b-ll9nd            1/1     Running   0          14s
default              redis-deployment-648bf5585b-w96c2            1/1     Running   0          14s
kube-system          coredns-5d78c9869d-xn6x6                     1/1     Running   0          46m
kube-system          coredns-5d78c9869d-ztcd8                     1/1     Running   0          46m
kube-system          etcd-kind-control-plane                      1/1     Running   0          47m
kube-system          kindnet-968kl                                1/1     Running   0          46m
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          47m
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          47m
kube-system          kube-proxy-wlcfk                             1/1     Running   0          46m
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          47m
kube-system          kube-state-metrics-5f89fb6d84-dtxwd          1/1     Running   0          46m
kube-system          metricbeat-qdwn6                             1/1     Running   0          10m
local-path-storage   local-path-provisioner-6bc4bddd6b-cmvxd      1/1     Running   0          46m
```

If I apply `namespace: default`, I expect to only see pods from that namespace. I have deployed 3 resources in the default namespace: a cronjob, a deployment and a pod (to test all three watchers).

<details>
<summary>The resources manifest used is this one.</summary>

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
    ports:
    - containerPort: 80
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis-deployment
  labels:
    app: redis
spec:
  replicas: 3
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
    spec:
      containers:
      - name: redis
        image: redis:latest
        ports:
        - containerPort: 6379
        resources:
          requests:
            memory: "64Mi"
            cpu: "250m"
          limits:
            memory: "128Mi"
            cpu: "500m"
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: hello-world-cronjob
spec:
  schedule: "*/5 * * * *"  # This schedule runs the job every 5 minutes
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: hello
            image: busybox
            args:
            - /bin/sh
            - -c
            - echo "Hello, World!"
          restartPolicy: OnFailure
```

</details>

#### Filtering by namespace

<details>
<summary>I set `namespace: default` in the Kubernetes provider like this.</summary>

```yaml
    metricbeat.autodiscover:
      providers:
        - type: kubernetes
          scope: cluster
          unique: false
          namespace: default
          add_resource_metadata:
            deployment: true
            cronjob: true
          templates:
            - config:
                - module: kubernetes
                  metricsets:
                    - pod
                  period: 10s
                  host: ${NODE_NAME}
                  hosts: ["https://${NODE_NAME}:10250"]
                  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                  ssl.verification_mode: "none"
```
</details>

I left my metricbeat running for a while. Then I checked how many pods were emitting events and from which namespaces they come from:

![Screenshot from 2024-06-12 15-53-29](https://github.com/elastic/beats/assets/113898685/7ea03135-05fd-4bfa-96bd-060db0e683d4)


They all come from `default` namespace as expected.

#### Not filtering by namespace

I now removed the `namespace: default` from my kubernetes provider.

I let metricbeat run for a while. This time I can see:


![image](https://github.com/elastic/beats/assets/113898685/78a4214f-98b0-4479-87fe-0c87e2d2a332)


We receive events from all namespaces, since it is not filtered.
