### PR TITLE
Add section on `cgroupns` usage for metricbeat under docker

### DIFF
--- a/metricbeat/docs/running-on-docker.asciidoc
+++ b/metricbeat/docs/running-on-docker.asciidoc
@@ -21,6 +21,7 @@ docker run \
   --mount type=bind,source=/var/run/dbus/system_bus_socket,target=/hostfs/var/run/dbus/system_bus_socket,readonly \ <4>
   --env DBUS_SYSTEM_BUS_ADDRESS='unix:path=/hostfs/var/run/dbus/system_bus_socket' \ <4>
   --net=host \ <5>
+  --cgroupns=host \ <6>
   {dockerimage} -e -system.hostfs=/hostfs
 ----
 
@@ -45,6 +46,7 @@ both require access to dbus. Mount the dbus socket and set the `DBUS_SYSTEM_BUS_
 to make this file contain the host's network devices is to use the `--net=host`
 flag. This is due to Linux namespacing; simply bind mounting the host's `/proc`
 to `/hostfs/proc` is not sufficient.
+<6> Runs the container using the host's cgroup namespace, instead of a private namespace. While this is optional, <<metricbeat-metricset-system-process,system process metricset>> may produce more correct cgroup metrics when running in host mode.
 
 NOTE: The special filesystems +/proc+ and +/sys+ are only available if the
 host system is running Linux. Attempts to bind-mount these filesystems will


### PR DESCRIPTION
## Proposed commit message

This adds a section to the "running on docker" doc to mention the use of `--cgroupns=host`.

While monitoring for private cgroup namespaces technically works (after no small amount of effort), the basic use case of "monitor the host cgroups from within a container with a private cgroup namespace" requires a considerable amount of hacks and should probably be considered best-effort. This adds a section telling the user to select a host namespace.

