### PR TITLE
x-pack/filebeat/input/httpjson: allow elision of set and append failure logging

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -278,6 +278,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add user group membership support to Okta entity analytics provider. {issue}39814[39814] {pull}39815[39815]
 - Add request trace support for Okta and EntraID entity analytics providers. {pull}39821[39821]
 - Fix handling of infinite rate values in CEL rate limit handling logic. {pull}39940[39940]
+- Allow elision of set and append failure logging. {issue}34544[34544] {pull}39929[39929]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -146,6 +146,7 @@ Appends a value to an array. If the field does not exist, the first entry will c
 - `default` defines the fallback value whenever `value` is empty or the template parsing fails. Default templates do not have access to any state, only to functions.
 - `value_type` defines the type of the resulting value. Possible values are: `string`, `json`, and `int`. Default is `string`.
 - `fail_on_template_error` if set to `true` an error will be returned and the request will be aborted when the template evaluation fails. Default is `false`.
+- `do_not_log_failure` if set to true a `fail_on_template_error` will not be logged except at DEBUG level. This should be used when template failure is expected in normal operation as control flow.
 
 [float]
 ==== `delete`
@@ -178,6 +179,7 @@ Sets a value.
 - `default` defines the fallback value whenever `value` is empty or the template parsing fails. Default templates do not have access to any state, only to functions.
 - `value_type` defines how the resulting value will be treated. Possible values are: `string`, `json`, and `int`. Default is `string`.
 - `fail_on_template_error` if set to `true` an error will be returned and the request will be aborted when the template evaluation fails. Default is `false`.
+- `do_not_log_failure` if set to true a `fail_on_template_error` will not be logged except at DEBUG level. This should be used when template failure is expected in normal operation as control flow.
 
 [[value-templates]]
 ==== Value templates
@@ -619,6 +621,7 @@ does not exist at the root level, please use the clause `.first_response.` to ac
           target: body.page
           value: '[[ .last_response.body.page ]]'
           fail_on_template_error: true
+          do_not_log_failure: true
     chain:
     - step:
           request.url: http://xyz.com/services/data/v1.0/$.exportId/export_ids/$.files[:].id/info

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -588,6 +588,10 @@ func (p *chainProcessor) handleEvent(ctx context.Context, msg mapstr.M) {
 	// for each pagination response, we repeat all the chain steps / blocks
 	n, err := p.req.processChainPaginationEvents(ctx, p.trCtx, p.pub, &response, p.idx, p.req.log)
 	if err != nil {
+		if errors.Is(err, notLogged{}) {
+			p.req.log.Debugf("ignored error processing chain event: %w", err)
+			return
+		}
 		p.req.log.Errorf("error processing chain event: %w", err)
 		return
 	}
@@ -600,7 +604,21 @@ func (p *chainProcessor) handleEvent(ctx context.Context, msg mapstr.M) {
 }
 
 func (p *chainProcessor) handleError(err error) {
+	if errors.Is(err, notLogged{}) {
+		p.req.log.Debugf("ignored error processing response: %v", err)
+		return
+	}
 	p.req.log.Errorf("error processing response: %v", err)
+}
+
+// notLogged is an error that is not logged except at DEBUG.
+type notLogged struct {
+	error
+}
+
+func (notLogged) Is(target error) bool {
+	_, ok := target.(notLogged)
+	return ok
 }
 
 // eventCount returns the number of events that have been processed.
@@ -776,6 +794,10 @@ func (p *publisher) handleEvent(_ context.Context, msg mapstr.M) {
 
 // handleError logs err.
 func (p *publisher) handleError(err error) {
+	if errors.Is(err, notLogged{}) {
+		p.log.Debugf("ignored error processing response: %v", err)
+		return
+	}
 	p.log.Errorf("error processing response: %v", err)
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

See title.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

In the httpjson package run the following commands. The first should show a set of messages at DEBUG level and none at ERROR level. The second should show no output.
```
go test -run 'TestInput/.*_not_log_fail' -v | grep ignored
```
```
go test -run 'TestInput/.*[^_][^n][^o][^t][^_][^l][^o][^g][^_][^f][^a][^i][^l]$' -v | grep ignored # ¯\_(ツ)_/¯
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #34544
- Closes #38291

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
