### PR TITLE
Update ubi version to 9.4 in Ironbank Dockerfile

### DIFF
--- a/dev-tools/packaging/templates/ironbank/auditbeat/Dockerfile
+++ b/dev-tools/packaging/templates/ironbank/auditbeat/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi9
-ARG BASE_TAG=9.3
+ARG BASE_TAG=9.4
 
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as builder

--- a/dev-tools/packaging/templates/ironbank/elastic-agent/Dockerfile
+++ b/dev-tools/packaging/templates/ironbank/elastic-agent/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi9
-ARG BASE_TAG=9.3
+ARG BASE_TAG=9.4
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as prep_files
 

--- a/dev-tools/packaging/templates/ironbank/filebeat/Dockerfile
+++ b/dev-tools/packaging/templates/ironbank/filebeat/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi9
-ARG BASE_TAG=9.3
+ARG BASE_TAG=9.4
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as builder
 

--- a/dev-tools/packaging/templates/ironbank/heartbeat/Dockerfile
+++ b/dev-tools/packaging/templates/ironbank/heartbeat/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi9
-ARG BASE_TAG=9.3
+ARG BASE_TAG=9.4
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as prep_files
 

--- a/dev-tools/packaging/templates/ironbank/metricbeat/Dockerfile
+++ b/dev-tools/packaging/templates/ironbank/metricbeat/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi9
-ARG BASE_TAG=9.3
+ARG BASE_TAG=9.4
 
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as builder

--- a/dev-tools/packaging/templates/ironbank/packetbeat/Dockerfile
+++ b/dev-tools/packaging/templates/ironbank/packetbeat/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi9
-ARG BASE_TAG=9.3
+ARG BASE_TAG=9.4
 
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as builder


### PR DESCRIPTION
Change ubi base image from 9.3 to 9.4 used in Ironbank Docker images for all 7.17 Beats + Elastic Agent