### PR TITLE
[draft] Fix keepalive initialization in awss3 input

### DIFF
--- a/x-pack/filebeat/input/awss3/sqs_s3_event.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event.go
@@ -201,6 +201,9 @@ func (p *sqsS3EventProcessor) keepalive(ctx context.Context, log *logp.Logger, w
 	t := time.NewTicker(p.sqsVisibilityTimeout / 2)
 	defer t.Stop()
 
+	log.Debugw("Initializing SQS message visibility timeout.",
+		"visibility_timeout", p.sqsVisibilityTimeout,
+		"expires_at", time.Now().UTC().Add(p.sqsVisibilityTimeout))
 	for {
 		// Renew visibility.
 		if err := p.sqs.ChangeMessageVisibility(ctx, msg, p.sqsVisibilityTimeout); err != nil {
@@ -225,7 +228,6 @@ func (p *sqsS3EventProcessor) keepalive(ctx context.Context, log *logp.Logger, w
 				"visibility_timeout", p.sqsVisibilityTimeout,
 				"expires_at", time.Now().UTC().Add(p.sqsVisibilityTimeout))
 			p.metrics.sqsVisibilityTimeoutExtensionsTotal.Inc()
-
 		}
 	}
 }


### PR DESCRIPTION
## Proposed commit message

The `visibility_timeout` flag in the SQS input isn't initialized correctly. It is used when extending visibility timeouts, but not when initially fetching the message, so the first timeout defaults to the global queue setting (which is configured by the user when creating the SQS queue). If the client-side timeout is higher than the AWS-side timeout, then Agent will not extend the visibility in time, and any objects that aren't processed by the AWS-side timeout will be returned to the queue.

The intention is for the visibility timeout to be applied regardless of the SQS-side defaults. The solution is to call the SQS `ChangeMessageVisibility` API at the _beginning_ of the keepalive helper, rather than waiting until the first timeout expires.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
