### PR TITLE
Making linter happy

### DIFF
--- a/x-pack/filebeat/tests/integration/managerV2_test.go
+++ b/x-pack/filebeat/tests/integration/managerV2_test.go
@@ -241,7 +241,7 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 	waitDeadlineOr5Min := func() time.Duration {
 		deadline, deadileSet := t.Deadline()
 		if deadileSet {
-			left := deadline.Sub(time.Now())
+			left := time.Until(deadline)
 			final := left - 500*time.Millisecond
 			if final <= 0 {
 				return left


### PR DESCRIPTION
What it says on the tin.

Without this change, the linter complains like so:

```
S1024: should use time.Until instead of t.Sub(time.Now()) (gosimple)
```

See https://github.com/elastic/beats/pull/40030/files#diff-df9d93045b24b2f8f834d399fb096632e419254901cb9f0c504636c7662c369dL244