### PR TITLE
[input/awscloudwatch] Set startTime to 0 for the first iteration of retrieving log events from CloudWatch

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -76,6 +76,7 @@ https://github.com/elastic/beats/compare/v8.13.4\...v8.14.0[View commits]
 - Fix concurrency/error handling bugs in the AWS S3 input that could drop data and prevent ingestion of large buckets. {pull}39131[39131]
 - Fix EntraID query handling. {issue}39419[39419] {pull}39420[39420]
 - Expand ID patterns in request trace logger for HTTP Endpoint. {pull}39656[39656]
+- Fix awscloudwarch input: set startTime to `0` for the first iteration of retrieving log events from CloudWatch
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -76,7 +76,7 @@ https://github.com/elastic/beats/compare/v8.13.4\...v8.14.0[View commits]
 - Fix concurrency/error handling bugs in the AWS S3 input that could drop data and prevent ingestion of large buckets. {pull}39131[39131]
 - Fix EntraID query handling. {issue}39419[39419] {pull}39420[39420]
 - Expand ID patterns in request trace logger for HTTP Endpoint. {pull}39656[39656]
-- Fix awscloudwarch input: set startTime to `0` for the first iteration of retrieving log events from CloudWatch
+- Fix awscloudwarch input: set startTime to `0` for the first iteration of retrieving log events from CloudWatch. {pull}40079[40079]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
@@ -187,7 +187,7 @@ func (p *cloudwatchPoller) receive(ctx context.Context, logGroupNames []string, 
 }
 
 // unixMsFromTime converts time to unix milliseconds.
-// Returns 0 both for the init time - time.Time{} (instead of -6795364578871)
+// Returns 0 both the init time `time.Time{}`, instead of -6795364578871
 func unixMsFromTime(v time.Time) int64 {
 	if v.IsZero() {
 		return 0

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
@@ -104,8 +104,8 @@ func (p *cloudwatchPoller) getLogEventsFromCloudWatch(svc *cloudwatchlogs.Client
 func (p *cloudwatchPoller) constructFilterLogEventsInput(startTime, endTime time.Time, logGroup string) *cloudwatchlogs.FilterLogEventsInput {
 	filterLogEventsInput := &cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName: awssdk.String(logGroup),
-		StartTime:    awssdk.Int64(startTime.UnixNano() / int64(time.Millisecond)),
-		EndTime:      awssdk.Int64(endTime.UnixNano() / int64(time.Millisecond)),
+		StartTime:    awssdk.Int64(unixMsFromTime(startTime)),
+		EndTime:      awssdk.Int64(unixMsFromTime(endTime)),
 	}
 
 	if len(p.config.LogStreams) > 0 {
@@ -184,4 +184,13 @@ func (p *cloudwatchPoller) receive(ctx context.Context, logGroupNames []string, 
 		// Advance to the next time span
 		startTime, endTime = endTime, clock().Add(-p.config.Latency)
 	}
+}
+
+// unixMsFromTime converts time to unix milliseconds.
+// Returns 0 both for the init time - time.Time{} (instead of -6795364578871)
+func unixMsFromTime(v time.Time) int64 {
+	if v.IsZero() {
+		return 0
+	}
+	return v.UnixNano() / int64(time.Millisecond)
 }


### PR DESCRIPTION
## Proposed commit message

- WHAT: Set `startTime` to `0` for the first iteration when retrieving log events from CloudWatch
- WHY:  to fix error:
```
InvalidParameterException: 1 validation error detected: Value '-6795364578871' at 'startTime' failed to satisfy constraint: Member must have value greater than or equal to 0"
```
as mentioned in https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartQuery.html#API_StartQuery_RequestSyntax:
```
startTime
    The beginning of the time range to query. The range is inclusive, so the specified start time is included in the query. Specified as epoch time, the number of seconds since January 1, 1970, 00:00:00 UTC.
    Type: Long
    Valid Range: Minimum value of 0.
    Required: Yes
```
and in https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs#FilterLogEventsInput:
```
// The start of the time range, expressed as the number of milliseconds after Jan
// 1, 1970 00:00:00 UTC . Events with a timestamp before this time are not returned.
StartTime *[int64](https://pkg.go.dev/builtin#int64)
```
invalid value cause missed log event for the first iteration.

Changes in PR align with our documentation - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-cloudwatch.html#_start_position


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
