### PR TITLE
[debugPrintProcessor]: exit directly when log doesn't have debug level enabled

### DIFF
--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -199,6 +199,10 @@ func debugPrintProcessor(info beat.Info, log *logp.Logger) *processorFn {
 		EscapeHTML: false,
 	})
 	return newProcessor("debugPrint", func(event *beat.Event) (*beat.Event, error) {
+		if !log.IsDebug() {
+			return event, nil
+		}
+
 		mux.Lock()
 		defer mux.Unlock()
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This PR is the aftermath of profiling the netflow integration test of [this PR](https://github.com/elastic/beats/pull/40080) (PS: the pcap I used as input is ~25MB thus I won't include it in beats repo)

So this is the cpu profile flamegraph before the commit of this PR

<img width="2815" alt="Screenshot 2024-07-02 at 10 38 54 PM" src="https://github.com/elastic/beats/assets/12166023/b5425916-45da-49c4-8ec3-72bb58d11b6b">

As we can see `debugPrintProcessor` is invoked and we pay the "performance" price of encoding every event in json even when our log isn't set up with DEBUG level. 

The respective cpu profile flamegraph after this PR with debugPrintProcessor still being there but exiting directly when log DEBUG is not enabled

<img width="2797" alt="Screenshot 2024-07-02 at 10 42 16 PM" src="https://github.com/elastic/beats/assets/12166023/9c12cc4d-0325-4f2c-9497-b28180b5d3b3">


Extracting the average EPS of the aformentioned netflow integration tested on my local macbook with a local ES inside a container

| Before this PR | With this PR |
|----------------|--------------|
| 18490       | 33760  |


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

N/A

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Help get [this PR](https://github.com/elastic/beats/pull/40080) merged or clone it and apply this small commit there 🙂
```
cd x-pack/filebeat
mage docker:composeUp
```
run go profiler against TestNetFlowIntegration

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/issues/37761

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

N/A

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

Look at description

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A