### PR TITLE
[x-pack][tests] - switch to t.TempDir

### DIFF
--- a/x-pack/libbeat/management/tests/init.go
+++ b/x-pack/libbeat/management/tests/init.go
@@ -50,7 +50,7 @@ func fleetClientFactory(srv MockV2Handler) lbmanagement.ManagerFactory {
 // SetupTestEnv is a helper to initialize the common files and handlers for metricbeat.
 // This returns a string to the tmpdir location
 func SetupTestEnv(t *testing.T, config *proto.UnitExpectedConfig, runtime time.Duration) (string, MockV2Handler) {
-	tmpdir := os.TempDir()
+	tmpdir := t.TempDir()
 	filename := fmt.Sprintf("test-%d", time.Now().Unix())
 	outPath := filepath.Join(tmpdir, filename)
 	t.Logf("writing output to file %s", outPath)


### PR DESCRIPTION
## Proposed commit message

We're relying on `os.TmpDir` and `unix.Now()` to get us a unique directory for a test env.
This leads to a CI failure [here](https://buildkite.com/elastic/beats-xpack-libbeat/builds/4835) because we're relying on  seconds resolution.
This PR fixes this behaviour and uses `t.TmpDir`. Each subsequent call to `t.TempDir` returns a unique directory and it's also automatically removed once test is executed

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
