### PR TITLE
[aws] Fix missing metrics bug when include_linked_accounts set to false

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -174,7 +174,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix behavior of pagetypeinfo metrics {pull}39985[39985]
 - Fix query logic for temp and non-temp tablespaces in Oracle module. {issue}38051[38051] {pull}39787[39787]
 - Set GCP metrics config period to the default (60s) when the value is below the minimum allowed period. {issue}30434[30434] {pull}40020[40020]
-
+- Fix missing metrics from CloudWatch when include_linked_accounts set to false. {issue}40071[40071] {pull}40135[40135]
 
 *Osquerybeat*
 

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -85,11 +85,10 @@ func GetListMetricsOutput(namespace string, regionName string, period time.Durat
 			for _, metric := range page.Metrics {
 				metricWithAccountID = append(metricWithAccountID, MetricWithID{metric, monitoringAccountID})
 			}
-			return metricWithAccountID, nil
-		}
-
-		for i, metric := range page.Metrics {
-			metricWithAccountID = append(metricWithAccountID, MetricWithID{metric, page.OwningAccounts[i]})
+		} else {
+			for i, metric := range page.Metrics {
+				metricWithAccountID = append(metricWithAccountID, MetricWithID{metric, page.OwningAccounts[i]})
+			}
 		}
 	}
 	return metricWithAccountID, nil

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -81,14 +81,12 @@ func GetListMetricsOutput(namespace string, regionName string, period time.Durat
 		}
 
 		// when IncludeLinkedAccounts is set to false, ListMetrics API does not return any OwningAccounts
-		if page.OwningAccounts == nil {
-			for _, metric := range page.Metrics {
-				metricWithAccountID = append(metricWithAccountID, MetricWithID{metric, monitoringAccountID})
+		for i, metric := range page.Metrics {
+			owningAccount := monitoringAccountID
+			if page.OwningAccounts != nil {
+				owningAccount = page.OwningAccounts[i]
 			}
-		} else {
-			for i, metric := range page.Metrics {
-				metricWithAccountID = append(metricWithAccountID, MetricWithID{metric, page.OwningAccounts[i]})
-			}
+			metricWithAccountID = append(metricWithAccountID, MetricWithID{metric, owningAccount})
 		}
 	}
 	return metricWithAccountID, nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR is to fix a bug in cloudwatch metricbeat module when include_linked_accounts is false. Because where the wrongly put return, we are missing metrics in pagination. I also added a test for the case when there is more than one page of results from ListMetrics API.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->
No disruptive user impact.

## How to test this PR locally

1. Setup your AWS account to have multiple RDS clusters and make sure we have metrics in CloudWatch.
2. Start Metricbeat with `aws.yml` looks like this:
```
- module: aws
  period: 1m
  credential_profile_name: elastic-observability
  metricsets:
    - cloudwatch
  regions: eu-west-3
  latency: 10m
  include_linked_accounts: false
  metrics:
    - namespace: AWS/RDS
      name: ["CPUUtilization"]
      resource_type: rds
      statistic: ["Average"]
```
You should see metrics only being collected from 2 RDS clusters. But if you change the `include_linked_accounts` to `true`, then you will get metrics from all clusters (5 in this case).
3. Apply the changes from this PR and rebuild metricbeat locally. Run with the same `aws.yml` with `include_linked_accounts` equals to `false` and you should see metrics from all clusters now.
<img width="1490" alt="Screenshot 2024-07-08 at 12 04 59 AM" src="https://github.com/elastic/beats/assets/14081635/306820c1-dafd-4216-b5ef-59fd937cd5a0">

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

- Closes https://github.com/elastic/beats/issues/40071