### PR TITLE
Reduce the number of node_stats metrics that are fetched and not collected

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -35,8 +35,10 @@ func init() {
 }
 
 const (
-	nodeLocalStatsPath = "/_nodes/_local/stats"
-	nodesAllStatsPath  = "/_nodes/_all/stats"
+	nodeLocalStatsPath   = "/_nodes/_local/stats"
+	nodesAllStatsPath    = "/_nodes/_all/stats"
+	metricsToGather      = "jvm,indices,fs,os,process,thread_pool,indexing_pressure,ingest"
+	indexMetricsToGather = "bulk,docs,fielddata,indexing,query_cache,request_cache,search,shard_stats,store,segments"
 )
 
 // MetricSet type defines all fields of the MetricSet
@@ -94,6 +96,7 @@ func getServiceURI(currURI string, scope elasticsearch.Scope) (string, error) {
 	if scope == elasticsearch.ScopeCluster {
 		u.Path = nodesAllStatsPath
 	}
+	u.Path += "/" + metricsToGather + "/" + indexMetricsToGather
 
 	return u.String(), nil
 }

--- a/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats_test.go
@@ -32,11 +32,11 @@ func TestGetServiceURI(t *testing.T) {
 	}{
 		"scope_node": {
 			scope:       elasticsearch.ScopeNode,
-			expectedURI: "/_nodes/_local/stats",
+			expectedURI: "/_nodes/_local/stats/jvm,indices,fs,os,process,thread_pool,indexing_pressure,ingest/bulk,docs,fielddata,indexing,query_cache,request_cache,search,shard_stats,store,segments",
 		},
 		"scope_cluster": {
 			scope:       elasticsearch.ScopeCluster,
-			expectedURI: "/_nodes/_all/stats",
+			expectedURI: "/_nodes/_all/stats/jvm,indices,fs,os,process,thread_pool,indexing_pressure,ingest/bulk,docs,fielddata,indexing,query_cache,request_cache,search,shard_stats,store,segments",
 		},
 	}
 


### PR DESCRIPTION

## Proposed commit message

node_stats API returns a lot of fields by default, most of which are currently not needed to be collected by the metricbeat elasticsearch module. We should specify the high level fields that we need to reduce the cost of the API call.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
Closes https://github.com/elastic/beats/issues/40183