### PR TITLE
Prevent race condition on TestRecoverFromInvalidOutputConfiguration

### DIFF
--- a/x-pack/filebeat/tests/integration/managerV2_test.go
+++ b/x-pack/filebeat/tests/integration/managerV2_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -505,17 +506,15 @@ func TestRecoverFromInvalidOutputConfiguration(t *testing.T) {
 	// if `success` is never closed, then the test will fail with a timeout.
 	success := make(chan struct{})
 
-	// succeededChannelClosed is set to true whenever the `success`
-	// channel is closed. The Filestream input now is reporting its state
-	// to the Elastic-Agent, which cases more checkins to happen, thus the
-	// `success` channel was being close twice. `succeededChannelClosed`
+	// closeSucceededOnce The Filestream input is now reporting its state
+	// to the Elastic-Agent, which makes more checkins to happen, thus the
+	// `success` channel was being close twice. `closeSucceededOnce`
 	// prevents that from happening.
-	succeededChannelClosed := atomic.Bool{}
+	closeSucceededOnce := sync.Once{}
 	// The test is successful when we reach the last element of `protoUnits`
 	onObserved := func(observed *proto.CheckinObserved, protoUnitsIdx int) {
-		if protoUnitsIdx == len(protos)-1 && !succeededChannelClosed.Load() {
-			succeededChannelClosed.Store(true)
-			close(success)
+		if protoUnitsIdx == len(protos)-1 {
+			closeSucceededOnce.Do(func() { close(success) })
 		}
 	}
 


### PR DESCRIPTION
:warning: **Auto-merge is enabled** :warning:

## Proposed commit message

TestRecoverFromInvalidOutputConfiguration could cause a race condition and close a channel twice, this commit replaces the original implementation by a sync.Once when closing the channel.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

None, this PR only fixes a broken test

~~## Author's Checklist~~
## How to test this PR locally
Run the test that was failing: 
```
cd x-pack/filebeat
mage clean buildSystemTestBinary
go test -tags=integration ./tests/integration -count=1 -run=TestRecoverFromInvalidOutputConfiguration
```


~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~