### PR TITLE
Add PeriodicReportingFetchV2Error to fetch metrics multiple times

### DIFF
--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -373,7 +373,7 @@ func (r *CapturingPushReporterV2) capture(waitEvents int) []mb.Event {
 
 // BlockingCapture blocks until waitEvents n of events are captured
 func (r *CapturingPushReporterV2) BlockingCapture(waitEvents int) []mb.Event {
-	var events []mb.Event
+	events := make([]mb.Event, 0, waitEvents)
 
 	for e := range r.eventsC {
 		events = append(events, e)

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -64,7 +64,6 @@ import (
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 type TestModule struct {
@@ -279,46 +278,6 @@ func ReportingFetchV2WithContext(metricSet mb.ReportingMetricSetV2WithContext) (
 		r.errs = append(r.errs, err)
 	}
 	return r.events, r.errs
-}
-
-// NewPushMetricSet instantiates a new PushMetricSet using the given
-// configuration. The ModuleFactory and MetricSetFactory are obtained from the
-// global Registry.
-func NewPushMetricSet(t testing.TB, config interface{}) mb.PushMetricSet {
-	metricSet := NewMetricSet(t, config)
-
-	pushMetricSet, ok := metricSet.(mb.PushMetricSet)
-	if !ok {
-		t.Fatal("MetricSet does not implement PushMetricSet")
-	}
-
-	return pushMetricSet
-}
-
-type capturingReporter struct {
-	events []mapstr.M
-	errs   []error
-	done   chan struct{}
-}
-
-func (r *capturingReporter) Event(event mapstr.M) bool {
-	r.events = append(r.events, event)
-	return true
-}
-
-func (r *capturingReporter) ErrorWith(err error, meta mapstr.M) bool {
-	r.events = append(r.events, meta)
-	r.errs = append(r.errs, err)
-	return true
-}
-
-func (r *capturingReporter) Error(err error) bool {
-	r.errs = append(r.errs, err)
-	return true
-}
-
-func (r *capturingReporter) Done() <-chan struct{} {
-	return r.done
 }
 
 // NewPushMetricSetV2 instantiates a new PushMetricSetV2 using the given

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -167,7 +167,7 @@ func NewReportingMetricSetV2Error(t testing.TB, config interface{}) mb.Reporting
 // NewReportingMetricSetV2Errors returns an array of new ReportingMetricSetV2 instances.
 func NewReportingMetricSetV2Errors(t testing.TB, config interface{}) []mb.ReportingMetricSetV2Error {
 	metricSets := NewMetricSets(t, config)
-	var reportingMetricSets []mb.ReportingMetricSetV2Error
+	reportingMetricSets := make([]mb.ReportingMetricSetV2Error, 0, len(metricSets))
 	for _, metricSet := range metricSets {
 		rMS, ok := metricSet.(mb.ReportingMetricSetV2Error)
 		if !ok {
@@ -374,15 +374,15 @@ func (r *CapturingPushReporterV2) capture(waitEvents int) []mb.Event {
 // BlockingCapture blocks until waitEvents n of events are captured
 func (r *CapturingPushReporterV2) BlockingCapture(waitEvents int) []mb.Event {
 	var events []mb.Event
-	for {
-		select {
-		case e := <-r.eventsC:
-			events = append(events, e)
-			if waitEvents > 0 && len(events) >= waitEvents {
-				return events
-			}
+
+	for e := range r.eventsC {
+		events = append(events, e)
+		if waitEvents > 0 && len(events) >= waitEvents {
+			return events
 		}
 	}
+
+	return events
 }
 
 // RunPushMetricSetV2 run the given push metricset for the specific amount of

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -57,10 +57,11 @@ package testing
 
 import (
 	"context"
-	"github.com/elastic/go-concert/timed"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/elastic/go-concert/timed"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	conf "github.com/elastic/elastic-agent-libs/config"

--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -240,8 +240,14 @@ func ReportingFetchV2Error(metricSet mb.ReportingMetricSetV2Error) ([]mb.Event, 
 	return r.events, r.errs
 }
 
-// PeriodicReportingFetchV2Error runs the given metricset and returns all the
-// events and errors that occur during that period.
+// PeriodicReportingFetchV2Error runs the given metricset and returns
+// the first batch of events or errors that occur during that period.
+//
+// `period` is the time between each fetch.
+// `timeout` is the maximum time to wait for the first event.
+//
+// The function tries to fetch the metrics every `period` until it gets
+// the first batch of metrics or the `timeout` is reached.
 func PeriodicReportingFetchV2Error(metricSet mb.ReportingMetricSetV2Error, period time.Duration, timeout time.Duration) ([]mb.Event, []error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -17,34 +17,6 @@ import (
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"
 )
 
-//func TestFetch(t *testing.T) {
-//	var events []mb.Event
-//	var errs []error
-//
-//	config := mtest.GetConfigForTest(t, "sqs", "300s")
-//	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
-//
-//	retries := 5
-//	for i := 0; i < retries; i++ {
-//		// The CloudWatch metrics can take a few minutes to appear,
-//		// so we retry a few times
-//		events, errs = mbtest.ReportingFetchV2Error(metricSet)
-//		if len(errs) > 0 {
-//			t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
-//		}
-//
-//		if len(events) > 0 {
-//			break
-//		}
-//
-//		// No metrics yet, wait and retry
-//		time.Sleep(1 * time.Minute)
-//	}
-//
-//	assert.NotEmpty(t, events)
-//	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
-//}
-
 func TestFetch(t *testing.T) {
 	config := mtest.GetConfigForTest(t, "sqs", "300s")
 

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -25,7 +25,7 @@ func TestFetch(t *testing.T) {
 	config := mtest.GetConfigForTest(t, "sqs", "300s")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 
-	retries := 2
+	retries := 5
 	for i := 0; i < retries; i++ {
 		// The CloudWatch metrics can take a few minutes to appear,
 		// so we retry a few times
@@ -39,7 +39,7 @@ func TestFetch(t *testing.T) {
 		}
 
 		// No metrics yet, wait and retry
-		time.Sleep(5 * time.Minute)
+		time.Sleep(1 * time.Minute)
 	}
 
 	assert.NotEmpty(t, events)

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -13,11 +13,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	_ "github.com/elastic/beats/v7/libbeat/processors/actions"
+	"github.com/elastic/beats/v7/metricbeat/mb"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"
 )
 
 func TestFetch(t *testing.T) {
+	var events []mb.Event
+	var errs []error
+
 	config := mtest.GetConfigForTest(t, "sqs", "300s")
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 
@@ -25,7 +29,7 @@ func TestFetch(t *testing.T) {
 	for i := 0; i < retries; i++ {
 		// The CloudWatch metrics can take a few minutes to appear,
 		// so we retry a few times
-		events, errs := mbtest.ReportingFetchV2Error(metricSet)
+		events, errs = mbtest.ReportingFetchV2Error(metricSet)
 		if len(errs) > 0 {
 			t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 		}

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	_ "github.com/elastic/beats/v7/libbeat/processors/actions"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -13,33 +13,45 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	_ "github.com/elastic/beats/v7/libbeat/processors/actions"
-	"github.com/elastic/beats/v7/metricbeat/mb"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"
 )
 
+//func TestFetch(t *testing.T) {
+//	var events []mb.Event
+//	var errs []error
+//
+//	config := mtest.GetConfigForTest(t, "sqs", "300s")
+//	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
+//
+//	retries := 5
+//	for i := 0; i < retries; i++ {
+//		// The CloudWatch metrics can take a few minutes to appear,
+//		// so we retry a few times
+//		events, errs = mbtest.ReportingFetchV2Error(metricSet)
+//		if len(errs) > 0 {
+//			t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
+//		}
+//
+//		if len(events) > 0 {
+//			break
+//		}
+//
+//		// No metrics yet, wait and retry
+//		time.Sleep(1 * time.Minute)
+//	}
+//
+//	assert.NotEmpty(t, events)
+//	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
+//}
+
 func TestFetch(t *testing.T) {
-	var events []mb.Event
-	var errs []error
-
 	config := mtest.GetConfigForTest(t, "sqs", "300s")
+
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
-
-	retries := 5
-	for i := 0; i < retries; i++ {
-		// The CloudWatch metrics can take a few minutes to appear,
-		// so we retry a few times
-		events, errs = mbtest.ReportingFetchV2Error(metricSet)
-		if len(errs) > 0 {
-			t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
-		}
-
-		if len(events) > 0 {
-			break
-		}
-
-		// No metrics yet, wait and retry
-		time.Sleep(1 * time.Minute)
+	events, errs := mbtest.PeriodicReportingFetchV2Error(metricSet, 1*time.Minute, 8*time.Minute)
+	if len(errs) > 0 {
+		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
 
 	assert.NotEmpty(t, events)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Try to fetch CloudWatch metrics multiple times instead of just once. 

CloudWatch metrics can take time to appear after creating a brand-new resource. So, the tests must fetch the metrics multiple times until they find the metric values or reach the time limit.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


<!--
## Disruptive User Impact
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

<!-- Recommended
## How to test this PR locally

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/beats/issues/40242

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
