### PR TITLE
x-pack/filebeat/i.../entitya.../.../okta: Avoid a negative request rate

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -165,6 +165,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Prevent panic in CEL and salesforce inputs when github.com/hashicorp/go-retryablehttp exceeds maximum retries. {pull}40144[40144]
 - Fix bug in CEL input rate limit logic. {issue}40106[40106] {pull}40270[40270]
 - Relax requirements in Okta entity analytics provider user and device profile data shape. {pull}40359[40359]
+- Fix bug in Okta entity analytics rate limit logic. {issue}40106[40106] {pull}40267[40267]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta.go
@@ -385,7 +385,7 @@ func oktaRateLimit(h http.Header, window time.Duration, limiter *rate.Limiter, l
 	rateLimit := rate.Limit(rem / per)
 
 	// Process reset if we need to wait until reset to avoid a request against a zero quota.
-	if rateLimit == 0 {
+	if rateLimit <= 0 {
 		waitUntil := resetTime.UTC()
 		// next gives us a sane next window estimate, but the
 		// estimate will be overwritten when we make the next


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/i.../entitya.../.../okta: Avoid a negative request rate (#)

This is the minimal change necessary to fix the following problem.

Around the time of a rate limit reset, if current time is after the
reset time returned in response headers, the rate limiting code will
set a negative target rate, and if that's done at a time when no
request budget has accumulated, it will not recover and will wait
forever.
```

The issue linked below lists other fixes and improvements that could be made the the Okta entity analytics rate limiting code. This PR is a version that should go into the next release to relieve the impact if the other changes aren't ready yet.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #40106
