### PR TITLE
WIP: fix: handle timezones in the official docker images

### DIFF
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -8,6 +8,7 @@ RUN \
          python3-venv \
          librpm-dev \
          iproute2 \
+         tzdata \
       && rm -rf /var/lib/apt/lists/*
 
 # Use a virtualenv to avoid the PEP668 "externally managed environment" error caused by conflicts

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -7,6 +7,7 @@ RUN \
          python3 \
          python3-pip \
          python3-venv \
+         tzdata \
       && rm -rf /var/lib/apt/lists/*
 
 # Use a virtualenv to avoid the PEP668 "externally managed environment" error caused by conflicts

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -13,6 +13,7 @@ RUN \
          unzip \
          libssl-dev \
          libffi-dev \
+         tzdata \
       && rm -rf /var/lib/apt/lists/*
 
 # Use a virtualenv to avoid the PEP668 "externally managed environment" error caused by conflicts

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -9,6 +9,7 @@ RUN \
          librpm-dev \
          netcat-openbsd \
          libpcap-dev \
+         tzdata \
       && rm -rf /var/lib/apt/lists/*
 
 # Use a virtualenv to avoid the PEP668 "externally managed environment" error caused by conflicts


### PR DESCRIPTION
## Proposed commit message

After the migration to the ubuntu:20.04 image the image stopped handling timezones properly, 
this is due to tzdata not being installed by default in the ubuntu images, whereas centos had it
installed by default. Install tzdata in all beats images to retain this behavior.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

## Author's Checklist

- [ ]

## How to test this PR locally

## Related issues

- Closes #31329

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots


## Logs
