### PR TITLE
Document updated default for `output.elasticsearch.allow_older_versions`

### DIFF
--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -60,8 +60,8 @@ This output works with all compatible versions of Elasticsearch. See the
 https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
 Matrix].
 
-For optimal experience, {beatname_uc} only connects to instances that are at least on the
-same version as the Beat. The check can be disabled by setting `output.elasticsearch.allow_older_versions`.
+Optionally, you can set {beatname_uc} to only connect to instances that are at least on the
+same version as the Beat. The check can be enabled by setting `output.elasticsearch.allow_older_versions` to `false`. Leaving the setting at it's default value of `true` avoids an issue where {beatname_uc} cannot connect to {es} after having been upgraded to a version higher than the {stack}.
 
 ==== Configuration options
 


### PR DESCRIPTION
In the Elasticsearch output page for each of the Beats, the "Compatibility" section notes that you can only connect to Elasticsearch instances at the same or a newer version as the Beat. The default behaviour is changed via https://github.com/elastic/beats/pull/36884 so this updates the Beats docs accordingly:

![Screenshot 2024-07-24 at 2 20 13 PM](https://github.com/user-attachments/assets/466a9935-8798-48dc-bbcd-e941812de8e4)

---

Rel: https://github.com/elastic/ingest-docs/issues/1135
Related Fleet & Agent docs PR: https://github.com/elastic/ingest-docs/pull/1205






 