### PR TITLE
Auditbeat: Add placeholder for new docs directory and file

### DIFF
--- a/x-pack/auditbeat/processors/sessionmd/docs/add_session_metadata.asciidoc
+++ b/x-pack/auditbeat/processors/sessionmd/docs/add_session_metadata.asciidoc
@@ -1,0 +1,6 @@
+[[add-session-metadata]]
+=== Add session metadata
+
+PLACEHOLDER
+
+


### PR DESCRIPTION
We need a placeholder for accurate testing and to break docs-ci gridlock between repos

* [Doc: Add docs for Auditbeat add_session_metadata processor #40252](https://github.com/elastic/beats/pull/40252) won't pass docs-ci because doc build is not pulling from the new repo. 
* [Add x-pack-auditbeat to conf.yaml docs#3038](https://github.com/elastic/docs/pull/3038) won't pass docs-ci because the files we're trying to pull in haven't been merged.  