### PR TITLE
[Auditbeat]: Cleanup a couple of log messages formatters

### DIFF
--- a/x-pack/auditbeat/processors/sessionmd/provider/ebpf_provider/ebpf_provider.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/ebpf_provider/ebpf_provider.go
@@ -217,7 +217,7 @@ func (s prvdr) SyncDB(ev *beat.Event, pid uint32) error {
 		}
 		if waited >= maxWaitLimit {
 			e := fmt.Errorf("process %v was not seen after %v", pid, waited)
-			s.logger.Warnf("%w", e)
+			s.logger.Warnf("%v", e)
 			combinedWait = combinedWait + waited
 			return e
 		}

--- a/x-pack/auditbeat/processors/sessionmd/provider/procfs_provider/procfs_provider.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/procfs_provider/procfs_provider.go
@@ -60,7 +60,7 @@ func (s prvdr) SyncDB(ev *beat.Event, pid uint32) error {
 			pe.Env = proc_info.Env
 			pe.Filename = proc_info.Filename
 		} else {
-			s.logger.Warnf("couldn't get process info from proc for pid %v: %w", pid, err)
+			s.logger.Warnf("couldn't get process info from proc for pid %v: %v", pid, err)
 			// If process info couldn't be taken from procfs, populate with as much info as
 			// possible from the event
 			pe.PIDs.Tgid = pid


### PR DESCRIPTION
## Proposed commit message

Cleanup a couple of log messages formatters.

Noticed a couple of wrong formatters in the log messages resulting in the messages like this:

```
{"log.level":"warn","@timestamp":"2024-07-25T16:15:25.261-0400","log.logger":"processor.add_session_metadata","log.origin":{"function":"github.com/elastic/beats/v7/x-pack/auditbeat/processors/sessionmd/provider/ebpf_provider.prvdr.SyncDB","file.name":"ebpf_provider/ebpf_provider.go","file.line":220},
"message":"%!w(*errors.errorString=&{process 59414 was not seen after 281.383636ms})","service.name":"auditbeat","ecs.version":"1.6.0"}
```


```
{"log.level":"warn","@timestamp":"2024-07-25T16:45:05.690-0400","log.logger":"processor.add_session_metadata","log.origin":{"function":"github.com/elastic/beats/v7/x-pack/auditbeat/processors/sessionmd/provider/procfs_provider.prvdr.SyncDB","file.name":"procfs_provider/procfs_provider.go","file.line":63},
"message":"couldn't get process info from proc for pid 119514: %!w(*fs.PathError=&{stat /proc/119514 2})","service.name":"auditbeat","ecs.version":"1.6.0"}
```

After the cleanup they look like this:

```
{"log.level":"warn","@timestamp":"2024-07-25T17:06:31.449-0400","log.logger":"processor.add_session_metadata","log.origin":{"function":"github.com/elastic/beats/v7/x-pack/auditbeat/processors/sessionmd/provider/ebpf_provider.prvdr.SyncDB","file.name":"ebpf_provider/ebpf_provider.go","file.line":220},
"message":"process 163540 was not seen after 281.147615ms","service.name":"auditbeat","ecs.version":"1.6.0"}
```

```
{"log.level":"warn","@timestamp":"2024-07-25T17:00:26.122-0400","log.logger":"processor.add_session_metadata","log.origin":{"function":"github.com/elastic/beats/v7/x-pack/auditbeat/processors/sessionmd/provider/procfs_provider.prvdr.SyncDB","file.name":"procfs_provider/procfs_provider.go","file.line":63},
"message":"couldn't get process info from proc for pid 151115: stat /proc/151115: no such file or directory","service.name":"auditbeat","ecs.version":"1.6.0"}
```

## Checklist

- [x] My code follows the style guidelines of this project

