### PR TITLE
Azure Monitor: fix metric timespan to restore Storage Account PT1H metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -189,6 +189,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add GCP 'instance_id' resource label in ECS cloud fields. {issue}40033[40033] {pull}40062[40062]
 - Fix missing metrics from CloudWatch when include_linked_accounts set to false. {issue}40071[40071] {pull}40135[40135]
 - Update beat module with apm-server monitoring metrics fields {pull}40127[40127]
+- Fix Azure Monitor metric timespan to restore Storage Account PT1H metrics {issue}40376[40376] {pull}40367[40367]
 
 *Osquerybeat*
 

--- a/x-pack/metricbeat/module/azure/azure.go
+++ b/x-pack/metricbeat/module/azure/azure.go
@@ -102,7 +102,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	//
 	// See "Round outer limits" and "Round inner limits" tests in
 	// the metric_registry_test.go for more information.
-	//referenceTime := time.Now().UTC().Round(time.Second)
 	referenceTime := time.Now().UTC()
 
 	// Initialize cloud resources and monitor metrics

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -120,12 +120,78 @@ func (client *Client) InitResources(fn mapResourceMetrics) error {
 	return nil
 }
 
-// buildTimespan returns the timespan for the metric values.
+// buildTimespan returns the timespan for the metric values given the reference time,
+// time grain and collection period.
+//
+// (1) When the collection period is greater than the time grain, the timespan
+// will be:
+//
+// |                                            time grain
+// │                                          │◀──(PT1M)──▶ │
+// │                                                        │
+// ├──────────────────────────────────────────┼─────────────┼─────────────
+// │                                                        │
+// │                       timespan           │             │
+// |◀───────────────────────(5min)─────────────────────────▶│
+// │                                          │             │
+// |                        period                          │
+// │◀───────────────────────(5min)────────────┼────────────▶│
+// │                                                        │
+// │                                          │             │
+// |                                                        │
+// |                                                       Now
+// |                                                        │
+//
+// In this case, the API will return five metric values, because
+// the time grain is 1 minute and the timespan is 5 minutes.
+//
+// (2) When the collection period is equal to the time grain,
+// the timespan will be:
+//
+// |
+// │                       time grain                       │
+// |◀───────────────────────(5min)─────────────────────────▶│
+// │                                                        │
+// ├────────────────────────────────────────────────────────┼─────────────
+// │                                                        │
+// │                       timespan                         │
+// |◀───────────────────────(5min)─────────────────────────▶│
+// │                                                        │
+// |                        period                          │
+// │◀───────────────────────(5min)─────────────────────────▶│
+// │                                                        │
+// │                                                        │
+// |                                                        │
+// |                                                       Now
+// |                                                        │
+//
+// In this case, the API will return one metric value.
+//
+// (3) When the collection period is less than the time grain,
+// the timespan will be:
+//
+// |                                              period
+// │                                          │◀──(5min)──▶ │
+// │                                                        │
+// ├──────────────────────────────────────────┼─────────────┼─────────────
+// │                                                        │
+// │                       timespan           │             │
+// |◀───────────────────────(60min)────────────────────────▶│
+// │                                          │             │
+// |                      time grain                        │
+// │◀───────────────────────(PT1H)────────────┼────────────▶│
+// │                                                        │
+// │                                          │             │
+// |                                                       Now
+// |                                                        │
+// |
+//
+// In this case, the API will return one metric value.
 func buildTimespan(referenceTime time.Time, timeGrain string, collectionPeriod time.Duration) string {
-	interval := max(collectionPeriod, convertTimeGrainToDuration(timeGrain))
+	timespanDuration := max(asDuration(timeGrain), collectionPeriod)
 
 	endTime := referenceTime
-	startTime := endTime.Add(interval * -1)
+	startTime := endTime.Add(timespanDuration * -1)
 
 	return fmt.Sprintf("%s/%s", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
 }

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -6,11 +6,13 @@ package azure
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/elastic-agent-libs/logp"
 )

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -122,14 +122,6 @@ func (client *Client) InitResources(fn mapResourceMetrics) error {
 
 // buildTimespan returns the timespan for the metric values.
 func buildTimespan(referenceTime time.Time, timeGrain string, collectionPeriod time.Duration) string {
-	//interval := period
-	//
-	//// Some metrics have a high latency, so we need to fetch the data
-	//// with a larger interval.
-	//if t := convertTimeGrainToDuration(timeGrain); t > interval {
-	//	interval = t
-	//}
-
 	interval := max(collectionPeriod, convertTimeGrainToDuration(timeGrain))
 
 	endTime := referenceTime
@@ -143,21 +135,6 @@ func (client *Client) GetMetricValues(referenceTime time.Time, metrics []Metric,
 	var result []Metric
 
 	for _, metric := range metrics {
-		//// Same end time for all metrics in the same batch.
-		//interval := client.Config.Period
-		//
-		//// Some metrics have a high latency, so we need to fetch the data
-		//// with a larger interval.
-		//if t := convertTimeGrainToDuration(metric.TimeGrain); t > interval*2 {
-		//	interval = t
-		//}
-		//
-		//// Fetch in the range [{-2 x INTERVAL},{-1 x INTERVAL}) with a delay of {INTERVAL}.
-		//endTime := referenceTime.Add(interval * (-1))
-		//startTime := endTime.Add(interval * (-1))
-		//
-		//timespan := fmt.Sprintf("%s/%s", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
-
 		timespan := buildTimespan(referenceTime, metric.TimeGrain, client.Config.Period)
 
 		//

--- a/x-pack/metricbeat/module/azure/client_test.go
+++ b/x-pack/metricbeat/module/azure/client_test.go
@@ -271,7 +271,17 @@ func TestGetMetricValues(t *testing.T) {
 }
 
 func TestBuildBuildTimespan(t *testing.T) {
-	t.Run("PT1M metric every 1 minutes", func(t *testing.T) {
+	t.Run("Collection period greater than the time grain (PT1M metric every 5 minutes)", func(t *testing.T) {
+		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
+		timeGain := "PT1M"
+		collectionPeriod := 5 * time.Minute
+
+		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
+
+		assert.Equal(t, "2024-07-30T18:51:00Z/2024-07-30T18:56:00Z", timespan)
+	})
+
+	t.Run("Collection period equal to time grain (PT1M metric every 1 minutes)", func(t *testing.T) {
 		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
 		timeGain := "PT1M"
 		collectionPeriod := 1 * time.Minute
@@ -281,17 +291,7 @@ func TestBuildBuildTimespan(t *testing.T) {
 		assert.Equal(t, "2024-07-30T18:55:00Z/2024-07-30T18:56:00Z", timespan)
 	})
 
-	t.Run("PT1M metric every 5 minutes", func(t *testing.T) {
-		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
-		timeGain := "PT1M"
-		collectionPeriod := 5 * time.Minute
-
-		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
-
-		assert.Equal(t, "2024-07-30T18:51:00Z/2024-07-30T18:56:00Z", timespan)
-	})
-
-	t.Run("PT5M metric every 5 minutes", func(t *testing.T) {
+	t.Run("Collection period equal to time grain (PT5M metric every 5 minutes)", func(t *testing.T) {
 		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
 		timeGain := "PT5M"
 		collectionPeriod := 5 * time.Minute
@@ -301,7 +301,17 @@ func TestBuildBuildTimespan(t *testing.T) {
 		assert.Equal(t, "2024-07-30T18:51:00Z/2024-07-30T18:56:00Z", timespan)
 	})
 
-	t.Run("PT1H metric every 5 minutes", func(t *testing.T) {
+	t.Run("Collection period equal to time grain (PT1H metric every 60 minutes)", func(t *testing.T) {
+		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
+		timeGain := "PT1H"
+		collectionPeriod := 60 * time.Minute
+
+		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
+
+		assert.Equal(t, "2024-07-30T17:56:00Z/2024-07-30T18:56:00Z", timespan)
+	})
+
+	t.Run("Collection period is less that time grain (PT1H metric every 5 minutes)", func(t *testing.T) {
 		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
 		timeGain := "PT1H"
 		collectionPeriod := 5 * time.Minute
@@ -311,13 +321,4 @@ func TestBuildBuildTimespan(t *testing.T) {
 		assert.Equal(t, "2024-07-30T17:56:00Z/2024-07-30T18:56:00Z", timespan)
 	})
 
-	t.Run("PT1H metric every 60 minutes", func(t *testing.T) {
-		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
-		timeGain := "PT1H"
-		collectionPeriod := 60 * time.Minute
-
-		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
-
-		assert.Equal(t, "2024-07-30T17:56:00Z/2024-07-30T18:56:00Z", timespan)
-	})
 }

--- a/x-pack/metricbeat/module/azure/client_test.go
+++ b/x-pack/metricbeat/module/azure/client_test.go
@@ -269,3 +269,55 @@ func TestGetMetricValues(t *testing.T) {
 		m.AssertExpectations(t)
 	})
 }
+
+func TestBuildBuildTimespan(t *testing.T) {
+	t.Run("PT1M metric every 1 minutes", func(t *testing.T) {
+		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
+		timeGain := "PT1M"
+		collectionPeriod := 1 * time.Minute
+
+		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
+
+		assert.Equal(t, "2024-07-30T18:55:00Z/2024-07-30T18:56:00Z", timespan)
+	})
+
+	t.Run("PT1M metric every 5 minutes", func(t *testing.T) {
+		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
+		timeGain := "PT1M"
+		collectionPeriod := 5 * time.Minute
+
+		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
+
+		assert.Equal(t, "2024-07-30T18:51:00Z/2024-07-30T18:56:00Z", timespan)
+	})
+
+	t.Run("PT5M metric every 5 minutes", func(t *testing.T) {
+		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
+		timeGain := "PT5M"
+		collectionPeriod := 5 * time.Minute
+
+		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
+
+		assert.Equal(t, "2024-07-30T18:51:00Z/2024-07-30T18:56:00Z", timespan)
+	})
+
+	t.Run("PT1H metric every 5 minutes", func(t *testing.T) {
+		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
+		timeGain := "PT1H"
+		collectionPeriod := 5 * time.Minute
+
+		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
+
+		assert.Equal(t, "2024-07-30T17:56:00Z/2024-07-30T18:56:00Z", timespan)
+	})
+
+	t.Run("PT1H metric every 60 minutes", func(t *testing.T) {
+		referenceTime, _ := time.Parse(time.RFC3339, "2024-07-30T18:56:00Z")
+		timeGain := "PT1H"
+		collectionPeriod := 60 * time.Minute
+
+		timespan := buildTimespan(referenceTime, timeGain, collectionPeriod)
+
+		assert.Equal(t, "2024-07-30T17:56:00Z/2024-07-30T18:56:00Z", timespan)
+	})
+}

--- a/x-pack/metricbeat/module/azure/client_utils.go
+++ b/x-pack/metricbeat/module/azure/client_utils.go
@@ -222,28 +222,3 @@ func getVM(vmName string, vms []VmResource) (VmResource, bool) {
 	}
 	return VmResource{}, false
 }
-
-// convertTimeGrainToDuration will convert azure timegrain options to actual duration values
-func convertTimeGrainToDuration(timegrain string) time.Duration {
-	var duration time.Duration
-	switch timegrain {
-	case "PT1M":
-		duration = time.Minute
-	case "PT5M":
-		duration = 5 * time.Minute
-	case "PT15M":
-		duration = 15 * time.Minute
-	case "PT30M":
-		duration = 30 * time.Minute
-	case "PT1H":
-		duration = time.Hour
-	case "PT6H":
-		duration = 6 * time.Hour
-	case "PT12H":
-		duration = 12 * time.Hour
-	case "PT1D":
-		duration = 24 * time.Hour
-	default:
-	}
-	return duration
-}

--- a/x-pack/metricbeat/module/azure/client_utils.go
+++ b/x-pack/metricbeat/module/azure/client_utils.go
@@ -222,3 +222,28 @@ func getVM(vmName string, vms []VmResource) (VmResource, bool) {
 	}
 	return VmResource{}, false
 }
+
+// convertTimeGrainToDuration will convert azure timegrain options to actual duration values
+func convertTimeGrainToDuration(timegrain string) time.Duration {
+	var duration time.Duration
+	switch timegrain {
+	case "PT1M":
+		duration = time.Minute
+	case "PT5M":
+		duration = 5 * time.Minute
+	case "PT15M":
+		duration = 15 * time.Minute
+	case "PT30M":
+		duration = 30 * time.Minute
+	case "PT1H":
+		duration = time.Hour
+	case "PT6H":
+		duration = 6 * time.Hour
+	case "PT12H":
+		duration = 12 * time.Hour
+	case "PT1D":
+		duration = 24 * time.Hour
+	default:
+	}
+	return duration
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Move the timespan logic into a dedicated `buildTimespan()` function with a test for each supported use case. 

Some Azure services have longer latency between service usage and metric availability. For example, the Storage Account capacity metrics (Blob capacity, etc.) have a PT1H time grain and become available after one hour. Service X also has PT1H metrics, however become available after a few minutes.

This PR restores the core of the [older timespan logic](https://github.com/elastic/beats/blob/d3facc808d2ba293a42b2ad3fc8e21b66c5f2a7f/x-pack/metricbeat/module/azure/client.go#L110-L116) the Azure Monitor metricset was using before the regression introduced by the PR https://github.com/elastic/beats/pull/36823. 

However, the `buildTimespan()` does not restore the `interval * (-2)` part because doubling the interval causes duplicates. 



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!--
## Disruptive User Impact
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Test with `Microsoft.ContainerRegistry/registries` metrics (PT1M and PT1H)
- [x] Test with `Microsoft.ContainerInstance/containerGroups` metrics (PT5M)
- [x] Test with `Microsoft.KeyVault/vaults` metrics (PT1M)
- [x] Test with Storage Account metrics (PT5M and PT1H)
- [x] Test with Virtual Machines metrics (PT5M)


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/40376


<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
