### PR TITLE
beats: import time/tzdata explicitly in main

### DIFF
--- a/auditbeat/main.go
+++ b/auditbeat/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/auditbeat/cmd"
 )

--- a/filebeat/main.go
+++ b/filebeat/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/filebeat/cmd"
 	inputs "github.com/elastic/beats/v7/filebeat/input/default-inputs"

--- a/heartbeat/main.go
+++ b/heartbeat/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/heartbeat/cmd"
 

--- a/metricbeat/main.go
+++ b/metricbeat/main.go
@@ -26,6 +26,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/metricbeat/cmd"
 )

--- a/packetbeat/main.go
+++ b/packetbeat/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/packetbeat/cmd"
 )

--- a/winlogbeat/main.go
+++ b/winlogbeat/main.go
@@ -26,6 +26,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/winlogbeat/cmd"
 )

--- a/x-pack/agentbeat/main.go
+++ b/x-pack/agentbeat/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd"

--- a/x-pack/auditbeat/main.go
+++ b/x-pack/auditbeat/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/x-pack/auditbeat/cmd"
 )

--- a/x-pack/dockerlogbeat/main.go
+++ b/x-pack/dockerlogbeat/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/docker/go-plugins-helpers/sdk"
 

--- a/x-pack/filebeat/main.go
+++ b/x-pack/filebeat/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/cmd"
 )

--- a/x-pack/functionbeat/main.go
+++ b/x-pack/functionbeat/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	_ "github.com/elastic/beats/v7/x-pack/functionbeat/include" // imports features
 	"github.com/elastic/beats/v7/x-pack/functionbeat/manager/cmd"

--- a/x-pack/heartbeat/main.go
+++ b/x-pack/heartbeat/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/x-pack/heartbeat/cmd"
 )

--- a/x-pack/metricbeat/main.go
+++ b/x-pack/metricbeat/main.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/cmd"
 )

--- a/x-pack/osquerybeat/main.go
+++ b/x-pack/osquerybeat/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/cmd"
 )

--- a/x-pack/packetbeat/main.go
+++ b/x-pack/packetbeat/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/x-pack/packetbeat/cmd"
 )

--- a/x-pack/winlogbeat/main.go
+++ b/x-pack/winlogbeat/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata" // for timezone handling
 
 	"github.com/elastic/beats/v7/x-pack/winlogbeat/cmd"
 )


### PR DESCRIPTION
## Proposed commit message

In order to handle timezones we import Go's own timezone database. This
import is done indirectly by libbeat/common/cfgtype. We trust that this
package will end up being required by the dependency chain of every beats
main binary.

To ensure that the binaries continue to handle timezones correctly even if the
indirect import is removed let's import time/tzdata explicitly in the main packages.

See discussion at https://github.com/elastic/beats/pull/40326.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] All main packages expected to handle timezones should import time/tzdata.

## How to test this PR locally

## Related issues

- Relates #31329

## Use cases

## Screenshots

## Logs
