### PR TITLE
Move around librpm calls, add `setreuid()` safety net

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,7 +33,7 @@ jobs:
           go-version-file: .go-version
 
       - name: Install Apt Package
-        run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+        run: sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev
 
       - name: golangci-lint
         env:

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -205,12 +205,13 @@ auditbeat.modules:
   # socket.state.period: 12h
   # user.state.period: 12h
 
-  # use suid() to drop out of root before making any calls to the RPM backend.
-  # This is primarily useful for older rpm versions that rely on BDB as a backend;
-  # when running with elevated permissions, BDB will read/write from a number 
-  # of database state files, which can conflict with other applications
-  # that may be using librpm in parallel.
-  # package.rpm_drop_to_suid: 1000
+  # Use setreuid() to drop out of root before making any calls to the RPM backend.
+  # This is exclusively useful for older rpm versions that rely on BDB as a backend;
+  # BDB does not parallize well, and multiple applications attempting to connect to
+  # RPM's BDB backend may result in crashes and database corruption. By dropping out of root,
+  # we eliminate the chances of any corruption happening should auditbeat conflict with any other
+  # application attempting to use RPM/BDB
+  # package.rpm_drop_to_uid: 1000
 
   # Average file read rate for hashing of the process executable. Default is "50 MiB".
   process.hash.scan_rate_per_sec: 50 MiB

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -207,7 +207,7 @@ auditbeat.modules:
 
   # Use setreuid() to drop out of root before making any calls to the RPM backend.
   # This is exclusively useful for older rpm versions that rely on BDB as a backend;
-  # BDB does not parallize well, and multiple applications attempting to connect to
+  # BDB does not parallelize well, and multiple applications attempting to connect to
   # RPM's BDB backend may result in crashes and database corruption. By dropping out of root,
   # we eliminate the chances of any corruption happening should auditbeat conflict with any other
   # application attempting to use RPM/BDB

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -205,6 +205,13 @@ auditbeat.modules:
   # socket.state.period: 12h
   # user.state.period: 12h
 
+  # use suid() to drop out of root before making any calls to the RPM backend.
+  # This is primarily useful for older rpm versions that rely on BDB as a backend;
+  # when running with elevated permissions, BDB will read/write from a number 
+  # of database state files, which can conflict with other applications
+  # that may be using librpm in parallel.
+  # package.rpm_drop_to_suid: 1000
+
   # Average file read rate for hashing of the process executable. Default is "50 MiB".
   process.hash.scan_rate_per_sec: 50 MiB
 

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -45,12 +45,13 @@
   # user.state.period: 12h
   {{- end }}
 
-  # Use suid() to drop out of root before making any calls to the RPM backend.
-  # This is primarily useful for older rpm versions that rely on BDB as a backend;
-  # when running with elevated permissions, BDB will read/write from a number 
-  # of database state files, which can conflict with other applications
-  # that may be using librpm in parallel.
-  # package.rpm_drop_to_suid: 1000
+  # Use setreuid() to drop out of root before making any calls to the RPM backend.
+  # This is exclusively useful for older rpm versions that rely on BDB as a backend;
+  # BDB does not parallize well, and multiple applications attempting to connect to
+  # RPM's BDB backend may result in crashes and database corruption. By dropping out of root,
+  # we eliminate the chances of any corruption happening should auditbeat conflict with any other
+  # application attempting to use RPM/BDB
+  # package.rpm_drop_to_uid: 1000
 
   # Average file read rate for hashing of the process executable. Default is "50 MiB".
   process.hash.scan_rate_per_sec: 50 MiB

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -45,6 +45,13 @@
   # user.state.period: 12h
   {{- end }}
 
+  # Use suid() to drop out of root before making any calls to the RPM backend.
+  # This is primarily useful for older rpm versions that rely on BDB as a backend;
+  # when running with elevated permissions, BDB will read/write from a number 
+  # of database state files, which can conflict with other applications
+  # that may be using librpm in parallel.
+  # package.rpm_drop_to_suid: 1000
+
   # Average file read rate for hashing of the process executable. Default is "50 MiB".
   process.hash.scan_rate_per_sec: 50 MiB
 

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -47,7 +47,7 @@
 
   # Use setreuid() to drop out of root before making any calls to the RPM backend.
   # This is exclusively useful for older rpm versions that rely on BDB as a backend;
-  # BDB does not parallize well, and multiple applications attempting to connect to
+  # BDB does not parallelize well, and multiple applications attempting to connect to
   # RPM's BDB backend may result in crashes and database corruption. By dropping out of root,
   # we eliminate the chances of any corruption happening should auditbeat conflict with any other
   # application attempting to use RPM/BDB

--- a/x-pack/auditbeat/module/system/package/config.go
+++ b/x-pack/auditbeat/module/system/package/config.go
@@ -14,6 +14,9 @@ import (
 type config struct {
 	StatePeriod        time.Duration `config:"state.period"`
 	PackageStatePeriod time.Duration `config:"package.state.period"`
+	// PackageSuidDrop runs RPM queries with suid to drop out of root
+	// see the comment in package.go for more context
+	PackageSuidDrop *int64 `config:"package.rpm_drop_to_suid"`
 }
 
 func (c *config) effectiveStatePeriod() time.Duration {

--- a/x-pack/auditbeat/module/system/package/config.go
+++ b/x-pack/auditbeat/module/system/package/config.go
@@ -16,7 +16,7 @@ type config struct {
 	PackageStatePeriod time.Duration `config:"package.state.period"`
 	// PackageSuidDrop runs RPM queries with suid to drop out of root
 	// see the comment in package.go for more context
-	PackageSuidDrop *int64 `config:"package.rpm_drop_to_suid"`
+	PackageSuidDrop *int64 `config:"package.rpm_drop_to_uid"`
 }
 
 func (c *config) effectiveStatePeriod() time.Duration {

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -237,7 +237,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	if config.PackageSuidDrop != nil {
 		if os.Getuid() != 0 && int(*ms.config.PackageSuidDrop) != os.Getuid() {
-			return nil, fmt.Errorf("package.rpm_drop_to_suid is set to %d, but we're running as a different non-root user", config.PackageSuidDrop)
+			return nil, fmt.Errorf("package.rpm_drop_to_suid is set to %d, but we're running as a different non-root user", *config.PackageSuidDrop)
 		}
 		ms.log.Debugf("Dropping to EUID %d for RPM API calls", *ms.config.PackageSuidDrop)
 	}

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -235,6 +235,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		ms.log.Debug("No state timestamp found.")
 	}
 
+	if config.PackageSuidDrop != nil {
+		if os.Getuid() != 0 && int(*config.PackageSuidDrop) != os.Getuid() {
+			return nil, fmt.Errorf("package.rpm_drop_to_suid is set to %d, but we're running as a different non-root user", config.PackageSuidDrop)
+		}
+		ms.log.Debugf("Dropping to EUID %d for RPM API calls", *ms.config.PackageSuidDrop)
+	}
+
 	packages, err := loadPackages(ms.bucket)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load persisted package metadata from disk: %w", err)
@@ -488,75 +495,55 @@ func (ms *MetricSet) getPackages() ([]*Package, error) {
 	var foundPackageManager bool
 	_, statErr := os.Stat(rpmPath)
 	if statErr == nil {
-
 		foundPackageManager = true
 		if ms.config.PackageSuidDrop != nil {
-			ms.log.Debugf("Dropping to EUID %d for RPM API calls", *ms.config.PackageSuidDrop)
 
-			// This is rather horrible.
+			// This is rather ugly.
 			// Basically, older RPM setups will use BDB as a database for the RPM state, and
 			// BDB is incredibly easy to corrupt and does not handle parallel operations well.
 			// see https://github.com/rpm-software-management/rpm/issues/232
 			// The easiest way around this is to drop perms to non-root, so librpm can't write to any of the DB files.
 			// this means we can't corrupt anything, and it also means that BDB won't perform any of the failchk()
 			// operations that exibit some parallel access issues
-			//
-			// We could potentially make the SYS_SETUID call just in getPackages() without spawning a child thread,
-			// but suid() is irreversible, and I'd rather have control over the context that we're running it in
+			// HOWEVER this is technically non-POSIX-compliant, as posix expects all threads in the process to
+			// have identical perms.
 
-			// time, cancel := context.WithTimeout(context.Background(), time.Minute*2)
-			// defer cancel()
-			// pkgUpdate := make(chan []*Package)
-			// pkgErr := make(chan error)
-
-			//go func(chUpdate chan []*Package, chErr chan error) {
-			// lock to a system thread and drop permissions
-			// we don't need to release the OS thread, since this goroutine will die anyway
+			// lock our setreuid to one thread
 			runtime.LockOSThread()
-			defer runtime.UnlockOSThread()
-			minus1 := -1
+			doUnlock := true
+			defer func() {
+				// if for some reason the second setreuid call fails, we don't
+				// want to release the OS thread, as we'll have a non-root thread floating around that
+				// the go scheduler could assign to something that expects root permissions.
+				if doUnlock {
+					runtime.UnlockOSThread()
+				} else {
+					ms.log.Debugf("setreuid has failed; package query thread will remain locked")
+				}
+			}()
 
+			minus1 := -1
 			currentUID := os.Getuid()
-			fmt.Printf("before 1st syscall: %v\n", currentUID)
-			//_, _, serr := syscall.Syscall(syscall.SYS_SETUID, uintptr(*ms.config.PackageSuidDrop), 0, 0)
 			_, _, serr := syscall.Syscall(syscall.SYS_SETREUID, uintptr(minus1), uintptr(*ms.config.PackageSuidDrop), uintptr(minus1))
 			if serr != 0 {
 				return nil, fmt.Errorf("got error from setreuid trying to drop out of root: %w", serr)
-				//pkgErr <- fmt.Errorf("error calling setresuid: %w\n", serr)
-				//return
 			}
 
-			rpmPackages, err := listRPMPackages()
+			rpmPackages, err := listRPMPackages(true)
 			if err != nil {
 				return nil, fmt.Errorf("got error listing RPM packages: %w", err)
-				//pkgErr <- err
-				//return
 			}
-			fmt.Printf("after 1st syscall: %v\n", os.Geteuid())
+
 			_, _, serr = syscall.Syscall(syscall.SYS_SETREUID, uintptr(minus1), uintptr(currentUID), uintptr(minus1))
 			if serr != 0 {
+				doUnlock = false
 				return nil, fmt.Errorf("got error from setreuid trying to reset euid: %w", serr)
-				//pkgErr <- fmt.Errorf("error calling setresuid to reset UID: %w", serr)
-				//return
 			}
-			fmt.Printf("after 2nd syscall: %v\n", os.Geteuid())
-			// on success, return here so we don't clash with any error values
-			//pkgUpdate <- rpmPackages
 
-			//}(pkgUpdate, pkgErr)
-
-			// select {
-			// case <-time.Done():
-			// case err := <-pkgErr:
-			// 	return nil, fmt.Errorf("error collecting packages: %w", err)
-			// case update := <-pkgUpdate:
-			// 	packages = append(packages, update...)
-			// }
 			packages = append(packages, rpmPackages...)
 		} else {
-			rpmPackages, err := listRPMPackages()
+			rpmPackages, err := listRPMPackages(false)
 			if err != nil {
-				//return nil, fmt.Errorf("error getting RPM packages: %w", err)
 				return nil, fmt.Errorf("error listing RPM packages: %w", err)
 			}
 			packages = append(packages, rpmPackages...)

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -239,7 +239,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		if os.Getuid() != 0 && int(*ms.config.PackageSuidDrop) != os.Getuid() {
 			return nil, fmt.Errorf("package.rpm_drop_to_suid is set to %d, but we're running as a different non-root user", *config.PackageSuidDrop)
 		}
-		ms.log.Debugf("Dropping to EUID %d for RPM API calls", *ms.config.PackageSuidDrop)
+		ms.log.Debugf("Dropping to EUID %d from UID %d for RPM API calls", *ms.config.PackageSuidDrop, os.Getuid())
 	}
 
 	packages, err := loadPackages(ms.bucket)

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -302,7 +302,7 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 
 	for _, pkg := range packages {
 		event := ms.packageEvent(pkg, eventTypeState, eventActionExistingPackage)
-		event.RootFields.Put("event.id", stateID.String()) //nolint:errcheck // This will not return an error as long as 'event' remains as a map.
+		_, _ = event.RootFields.Put("event.id", stateID.String())
 		report.Event(event)
 	}
 

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -236,7 +236,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	if config.PackageSuidDrop != nil {
-		if os.Getuid() != 0 && int(*config.PackageSuidDrop) != os.Getuid() {
+		if os.Getuid() != 0 && int(*ms.config.PackageSuidDrop) != os.Getuid() {
 			return nil, fmt.Errorf("package.rpm_drop_to_suid is set to %d, but we're running as a different non-root user", config.PackageSuidDrop)
 		}
 		ms.log.Debugf("Dropping to EUID %d for RPM API calls", *ms.config.PackageSuidDrop)

--- a/x-pack/auditbeat/module/system/package/package_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/package_linux_test.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build linux
+
+package pkg
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system/user"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithSuid(t *testing.T) {
+	currentUID := os.Getuid()
+	if currentUID != 0 {
+		t.Skipf("can only run as root")
+	}
+	// pick a user to drop to
+	userList, err := user.GetUsers(false)
+	require.NoError(t, err)
+
+	var useUID int64
+	for _, user := range userList {
+		if user.UID != "0" {
+			newUID, err := strconv.ParseInt(user.UID, 10, 64)
+			require.NoError(t, err)
+			useUID = newUID
+			break
+		}
+	}
+
+	testMs := MetricSet{
+		log: logp.L(),
+		config: config{
+			PackageSuidDrop: &useUID,
+		},
+	}
+
+	packages, err := testMs.getPackages()
+	require.NoError(t, err)
+
+	require.NotZero(t, packages)
+	t.Logf("got %d packages", len(packages))
+}

--- a/x-pack/auditbeat/module/system/package/package_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/package_linux_test.go
@@ -9,6 +9,7 @@ package pkg
 import (
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,11 +18,63 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
+func TestRPMParallel(t *testing.T) {
+	currentUID := os.Getuid()
+	if currentUID != 0 {
+		t.Skipf("can only run as root")
+	}
+	logp.DevelopmentSetup()
+
+	count := 20
+	waiter := sync.WaitGroup{}
+	waiter.Add(count)
+
+	useUID := getUser(t)
+
+	t.Logf("Starting...")
+	for i := 0; i < count; i++ {
+		inner := i
+		go func() {
+			defer waiter.Done()
+			testMs := MetricSet{
+				log: logp.L(),
+				config: config{
+					PackageSuidDrop: &useUID,
+				},
+			}
+
+			pkgList, err := testMs.getPackages()
+			require.NoError(t, err)
+
+			t.Logf("got %d packages from %d", len(pkgList), inner)
+		}()
+
+	}
+	waiter.Wait()
+}
+
 func TestWithSuid(t *testing.T) {
 	currentUID := os.Getuid()
 	if currentUID != 0 {
 		t.Skipf("can only run as root")
 	}
+
+	useUID := getUser(t)
+	testMs := MetricSet{
+		log: logp.L(),
+		config: config{
+			PackageSuidDrop: &useUID,
+		},
+	}
+
+	packages, err := testMs.getPackages()
+	require.NoError(t, err)
+
+	require.NotZero(t, packages)
+	t.Logf("got %d packages", len(packages))
+}
+
+func getUser(t *testing.T) int64 {
 	// pick a user to drop to
 	userList, err := user.GetUsers(false)
 	require.NoError(t, err)
@@ -35,17 +88,5 @@ func TestWithSuid(t *testing.T) {
 			break
 		}
 	}
-
-	testMs := MetricSet{
-		log: logp.L(),
-		config: config{
-			PackageSuidDrop: &useUID,
-		},
-	}
-
-	packages, err := testMs.getPackages()
-	require.NoError(t, err)
-
-	require.NotZero(t, packages)
-	t.Logf("got %d packages", len(packages))
+	return useUID
 }

--- a/x-pack/auditbeat/module/system/package/package_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/package_linux_test.go
@@ -58,7 +58,6 @@ func TestWithSuid(t *testing.T) {
 	if currentUID != 0 {
 		t.Skipf("can only run as root")
 	}
-
 	useUID := getUser(t)
 	testMs := MetricSet{
 		log: logp.L(),

--- a/x-pack/auditbeat/module/system/package/package_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/package_linux_test.go
@@ -11,9 +11,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system/user"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"github.com/stretchr/testify/require"
+
 )
 
 func TestWithSuid(t *testing.T) {

--- a/x-pack/auditbeat/module/system/package/package_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/package_linux_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system/user"
 	"github.com/elastic/elastic-agent-libs/logp"
-
 )
 
 func TestWithSuid(t *testing.T) {

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +27,6 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system"
-	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system/user"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -55,39 +53,6 @@ func TestRPMParallel(t *testing.T) {
 
 	}
 	waiter.Wait()
-}
-
-func TestWithSuid(t *testing.T) {
-	currentUID := os.Getuid()
-	if currentUID != 0 {
-		t.Skipf("can only run as root")
-	}
-	// pick a user to drop to
-	userList, err := user.GetUsers(false)
-	require.NoError(t, err)
-
-	var useUID int64
-	for _, user := range userList {
-		if user.UID != "0" {
-			newUID, err := strconv.ParseInt(user.UID, 10, 64)
-			require.NoError(t, err)
-			useUID = newUID
-			break
-		}
-	}
-
-	testMs := MetricSet{
-		log: logp.L(),
-		config: config{
-			PackageSuidDrop: &useUID,
-		},
-	}
-
-	packages, err := testMs.getPackages()
-	require.NoError(t, err)
-
-	require.NotZero(t, packages)
-	t.Logf("got %d packages", len(packages))
 }
 
 func TestData(t *testing.T) {

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -12,12 +12,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/auditbeat/ab"
 	"github.com/elastic/beats/v7/auditbeat/core"
@@ -29,31 +27,6 @@ import (
 	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
-
-func TestRPMParallel(t *testing.T) {
-	logp.DevelopmentSetup()
-
-	count := 20
-	waiter := sync.WaitGroup{}
-	waiter.Add(count)
-	t.Logf("Starting...")
-	for i := 0; i < count; i++ {
-		inner := i
-		go func() {
-			defer waiter.Done()
-			testMs := MetricSet{
-				log: logp.L(),
-			}
-
-			pkgList, err := testMs.getPackages()
-			require.NoError(t, err)
-
-			t.Logf("got %d packages from %d", len(pkgList), inner)
-		}()
-
-	}
-	waiter.Wait()
-}
 
 func TestData(t *testing.T) {
 	defer abtest.SetupDataDir(t)()

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -87,6 +87,7 @@ func TestWithSuid(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotZero(t, packages)
+	t.Logf("got %d packages", len(packages))
 }
 
 func TestData(t *testing.T) {

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -12,20 +12,82 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/auditbeat/ab"
 	"github.com/elastic/beats/v7/auditbeat/core"
 	"github.com/elastic/beats/v7/auditbeat/datastore"
 	abtest "github.com/elastic/beats/v7/auditbeat/testing"
+
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system"
+	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system/user"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
+
+func TestRPMParallel(t *testing.T) {
+	logp.DevelopmentSetup()
+
+	count := 20
+	waiter := sync.WaitGroup{}
+	waiter.Add(count)
+	t.Logf("Starting...")
+	for i := 0; i < count; i++ {
+		inner := i
+		go func() {
+			defer waiter.Done()
+			testMs := MetricSet{
+				log: logp.L(),
+			}
+
+			pkgList, err := testMs.getPackages()
+			require.NoError(t, err)
+
+			t.Logf("got %d packages from %d", len(pkgList), inner)
+		}()
+
+	}
+	waiter.Wait()
+}
+
+func TestWithSuid(t *testing.T) {
+	currentUID := os.Getuid()
+	if currentUID != 0 {
+		t.Skipf("can only run as root")
+	}
+	// pick a user to drop to
+	userList, err := user.GetUsers(false)
+	require.NoError(t, err)
+
+	var useUID int64
+	for _, user := range userList {
+		if user.UID != "0" {
+			newUID, err := strconv.ParseInt(user.UID, 10, 64)
+			require.NoError(t, err)
+			useUID = newUID
+			break
+		}
+	}
+
+	testMs := MetricSet{
+		log: logp.L(),
+		config: config{
+			PackageSuidDrop: &useUID,
+		},
+	}
+
+	packages, err := testMs.getPackages()
+	require.NoError(t, err)
+
+	require.NotZero(t, packages)
+}
 
 func TestData(t *testing.T) {
 	defer abtest.SetupDataDir(t)()

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -266,7 +266,7 @@ func openLibrpm() (*librpm, error) {
 
 	librpm.handle, err = dlopen.GetHandle(librpmNames)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't open %v: %v", librpmNames, err)
+		return nil, fmt.Errorf("couldn't open %v: %w", librpmNames, err)
 	}
 
 	librpm.rpmtsCreate, err = librpm.handle.GetSymbolPointer("rpmtsCreate")
@@ -325,11 +325,11 @@ func openLibrpm() (*librpm, error) {
 	}
 
 	// Only available in librpm>=4.13.0
-	librpm.rpmsqSetInterruptSafety, err = librpm.handle.GetSymbolPointer("rpmsqSetInterruptSafety")
+	librpm.rpmsqSetInterruptSafety, _ = librpm.handle.GetSymbolPointer("rpmsqSetInterruptSafety")
 	// no error check
 
 	// Only available in librpm>=4.6.0
-	librpm.rpmFreeMacros, err = librpm.handle.GetSymbolPointer("rpmFreeMacros")
+	librpm.rpmFreeMacros, _ = librpm.handle.GetSymbolPointer("rpmFreeMacros")
 	// no error check
 
 	librpm.rpmtsSetRootDir, err = librpm.handle.GetSymbolPointer("rpmtsSetRootDir")
@@ -388,7 +388,7 @@ func listRPMPackages(ownsThread bool) ([]*Package, error) {
 	}
 	defer C.my_rpmdbFreeIterator(openedLibrpm.rpmdbFreeIterator, mi)
 
-	var packages []*Package
+	packages := make([]*Package, 0)
 	for header := C.my_rpmdbNextIterator(openedLibrpm.rpmdbNextIterator, mi); header != nil; header = C.my_rpmdbNextIterator(openedLibrpm.rpmdbNextIterator, mi) {
 
 		pkg, err := packageFromHeader(header, openedLibrpm)

--- a/x-pack/auditbeat/module/system/package/rpm_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux_test.go
@@ -34,3 +34,11 @@ func TestRPMPackages(t *testing.T) {
 
 	assert.EqualValues(t, packagesExpected, packages)
 }
+
+// func TestRPMPackagesRaw(t *testing.T) {
+// 	packages, err := listRPMPackages()
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	t.Logf("got packages: %d", len(packages))
+// }

--- a/x-pack/auditbeat/module/system/package/rpm_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux_test.go
@@ -27,18 +27,10 @@ func TestRPMPackages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	packages, err := listRPMPackages()
+	packages, err := listRPMPackages(false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assert.EqualValues(t, packagesExpected, packages)
 }
-
-// func TestRPMPackagesRaw(t *testing.T) {
-// 	packages, err := listRPMPackages()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	t.Logf("got packages: %d", len(packages))
-// }

--- a/x-pack/auditbeat/module/system/package/rpm_others.go
+++ b/x-pack/auditbeat/module/system/package/rpm_others.go
@@ -8,7 +8,7 @@ package pkg
 
 import "errors"
 
-func listRPMPackages() ([]*Package, error) {
+func listRPMPackages(_ bool) ([]*Package, error) {
 	return nil, errors.New("listing RPM packages is only supported on Linux")
 }
 

--- a/x-pack/auditbeat/seccomp_linux.go
+++ b/x-pack/auditbeat/seccomp_linux.go
@@ -19,6 +19,7 @@ func init() {
 		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall,
 			"mremap",
 			"umask",
+			"setreuid",
 		); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Proposed commit message

This is an odd one. It turns out that the BDB backend used by older `rpm` installs is...really easy to corrupt, and also prone to a variety of crashes should you get too aggressive with spinning up multiple threads to access the RPM backend. The only way I've found to actually solve this in auditbeat is to use `setreuid()` to drop out of root before we make any librpm calls; this prevents librpm from touching any lock files or opening any database files in write mode, which means we can't corrupt the DB if auditbeat stops/crashes, and it also seems to reduce the odds of certain crashes originating from within the guts of librpm/libdb, as we can't perform any of the integrity checking/cleanup operations that we would if the database state files were writable. 

The resulting `package.rpm_drop_to_uid` is not enabled by default, as we need a UID to drop to, and also setting one thread to a different user is (according to the man page for `setuid`) not POSIX-compliant. This is meant as a safety net for users on older linux distros that haven't migrated to sqlite for the RPM backend.

This also moves around some of the librpm calls, we now call `rpmReadConfigFiles()` earlier in the startup process, and we also call `rpmtsSetRootDir()`. This mostly prevents a few confusing error messages when librpm fails, but I woudn't be surprised if it was causing some more subtle bugs as well.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

This will not alter any default behavior. 

## How to test

You can test this on any linux distro to confirm that no existing behavior has changed. 

However, to test what this is actually meant to prevent, you'll need to spin up a Linux box that uses rpm/BDB. This should be RHEL8 or any RHEL8-derivatives (Rocky8, etc). Then:

1)  Set run `go test -c` in the `package` directory
2) run multiple instances of the `TestWithSuid` test as root: `sudo ./package.test -test.v -test.run TestWithSuid` at once: `for i in {1..30}; do ./package.test -test.v -test.run TestWithSuid & done`
3) Make sure nothing crashes
4) If librpm segfaults anyway, make sure the DB isnt't corrupted: `sudo rpm -qa`.

