### PR TITLE
Add a tracer to send (legacy) Azure Event Hub SDK logs to logp

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10908,6 +10908,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/devigned/tab
+Version: v0.1.2-0.20190607222403-0c15cf42f9a2
+Licence type (autodetected): MIT
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/devigned/tab@v0.1.2-0.20190607222403-0c15cf42f9a2/LICENSE:
+
+MIT License
+
+Copyright (c) 2019 David Justice
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/dgraph-io/badger/v3
 Version: v3.2103.1
 Licence type (autodetected): Apache-2.0
@@ -37207,37 +37238,6 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-
---------------------------------------------------------------------------------
-Dependency : github.com/devigned/tab
-Version: v0.1.2-0.20190607222403-0c15cf42f9a2
-Licence type (autodetected): MIT
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/devigned/tab@v0.1.2-0.20190607222403-0c15cf42f9a2/LICENSE:
-
-MIT License
-
-Copyright (c) 2019 David Justice
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 
 --------------------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/denisenkom/go-mssqldb v0.12.3
-	github.com/devigned/tab v0.1.2-0.20190607222403-0c15cf42f9a2 // indirect
+	github.com/devigned/tab v0.1.2-0.20190607222403-0c15cf42f9a2
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/digitalocean/go-libvirt v0.0.0-20240709142323-d8406205c752
 	github.com/docker/docker v26.1.5+incompatible

--- a/x-pack/filebeat/include/list.go
+++ b/x-pack/filebeat/include/list.go
@@ -15,6 +15,7 @@ import (
 	// Import packages that perform 'func init()'.
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/awscloudwatch"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/awss3"
+	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/azureeventhub"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/cometd"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/etw"
 	_ "github.com/elastic/beats/v7/x-pack/filebeat/input/gcppubsub"

--- a/x-pack/filebeat/input/azureeventhub/tracer.go
+++ b/x-pack/filebeat/input/azureeventhub/tracer.go
@@ -1,0 +1,84 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !aix
+
+package azureeventhub
+
+import (
+	"context"
+	"github.com/devigned/tab"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func init() {
+	tab.Register(&tracer{})
+}
+
+type tracer struct{}
+
+type noOpSpanner struct{}
+
+type logpLogger struct{}
+
+// StartSpan returns the input context and a no op Spanner
+func (nt *tracer) StartSpan(ctx context.Context, operationName string, opts ...interface{}) (context.Context, tab.Spanner) {
+	return ctx, new(noOpSpanner)
+}
+
+// StartSpanWithRemoteParent returns the input context and a no op Spanner
+func (nt *tracer) StartSpanWithRemoteParent(ctx context.Context, operationName string, carrier tab.Carrier, opts ...interface{}) (context.Context, tab.Spanner) {
+	return ctx, new(noOpSpanner)
+}
+
+// FromContext returns a no op Spanner without regard to the input context
+func (nt *tracer) FromContext(ctx context.Context) tab.Spanner {
+	return new(noOpSpanner)
+}
+
+// NewContext returns the parent context
+func (nt *tracer) NewContext(parent context.Context, span tab.Spanner) context.Context {
+	return parent
+}
+
+// AddAttributes is a nop
+func (ns *noOpSpanner) AddAttributes(attributes ...tab.Attribute) {}
+
+// End is a nop
+func (ns *noOpSpanner) End() {}
+
+// Logger returns a nopLogger
+func (ns *noOpSpanner) Logger() tab.Logger {
+	return new(logpLogger)
+}
+
+// Inject is a nop
+func (ns *noOpSpanner) Inject(carrier tab.Carrier) error {
+	return nil
+}
+
+// InternalSpan returns nil
+func (ns *noOpSpanner) InternalSpan() interface{} {
+	return nil
+}
+
+// Info nops log entry
+func (sl logpLogger) Info(msg string, attributes ...tab.Attribute) {
+	logp.L().Info(msg)
+}
+
+// Error nops log entry
+func (sl logpLogger) Error(err error, attributes ...tab.Attribute) {
+	logp.L().Error(err)
+}
+
+// Fatal nops log entry
+func (sl logpLogger) Fatal(msg string, attributes ...tab.Attribute) {
+	logp.L().Fatal(msg)
+}
+
+// Debug nops log entry
+func (sl logpLogger) Debug(msg string, attributes ...tab.Attribute) {
+	logp.L().Debug(msg)
+}

--- a/x-pack/filebeat/input/azureeventhub/tracer.go
+++ b/x-pack/filebeat/input/azureeventhub/tracer.go
@@ -8,7 +8,9 @@ package azureeventhub
 
 import (
 	"context"
+
 	"github.com/devigned/tab"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Add a tracer for the github.com/devigned/tab package to route logs from the legacy event hub SDK to the logp package.

The legacy event hub SDK uses the [github.com/devigned/tab](http://github.com/devigned/tab) package to handle traces and logs.

However, this package is old and seems unmaintained (last commit: 3 years ago). Since it only supports OpenTracing or OpenCensus, in Beats, the library defaults to a `NoOpTracer`, so we don’t see anything happening inside the legacy processor.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

I don't expect the trace to impact users or other Beats components. It seems the legacy event hub SDK is the only dependency using this old package:

```shell
$ go mod why -m github.com/devigned/tab

# github.com/devigned/tab
github.com/elastic/beats/v7/x-pack/filebeat/input/azureeventhub
github.com/Azure/azure-event-hubs-go/v3
github.com/devigned/tab
```


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Close https://github.com/elastic/beats/issues/40449


<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

Start Filebeat using a valid azure-eventhub config, and you will be able to read the log messages from the processor and the leaser/checkpointer components:

```shell
$ pbpaste | grep '^{' | jq -r 'select(."log.origin"."file.name" == "azureeventhub/tracer.go") | [."@timestamp",."log.level",.message] | @tsv'

2024-08-07T16:17:12.305+0200	debug	successful rpc on link 494e91ef-8e06-4460-b89b-361d44c64f75: status code 200 and description:
2024-08-07T16:17:17.306+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb": running scan
2024-08-07T16:17:19.667+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb": acquired: [{"partitionID":"1","epoch":21,"owner":"86edc94f-dd34-44d3-8a43-ecf3cf4c77fb","checkpoint":{"offset":"201863710488","sequenceNumber":8568,"enqueueTime":"2024-08-07T13:35:51.837Z"},"state":"available","token":"32ab10ca-cc08-42a8-83fd-1dc436f25abc"} {"partitionID":"0","epoch":23,"owner":"86edc94f-dd34-44d3-8a43-ecf3cf4c77fb","checkpoint":{"offset":"206158444904","sequenceNumber":8565,"enqueueTime":"2024-08-07T13:26:15.225Z"},"state":"available","token":"e4aa4ecd-ab0f-4984-92cd-a4c6dbcfa433"}], not acquired: []
2024-08-07T16:17:19.667+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb", partition "1", epoch 21: running...
2024-08-07T16:17:19.667+0200	debug	creating a new receiver
2024-08-07T16:17:21.349+0200	debug	negotiating claim for audience amqps://mbranca-general.servicebus.windows.net/activitylogs/ConsumerGroups/$Default/Partitions/1 with token type servicebus.windows.net:sastoken and expiry of 1723047441
2024-08-07T16:17:21.562+0200	debug	successful rpc on link 3f9e7e50-f012-4692-8172-8b8d5c9dde17: status code 202 and description: Accepted
2024-08-07T16:17:21.563+0200	debug	negotiated with response code 202 and message: Accepted
2024-08-07T16:17:22.293+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb", partition "0", epoch 23: running...
2024-08-07T16:17:22.293+0200	debug	creating a new receiver
2024-08-07T16:17:24.705+0200	debug	negotiating claim for audience amqps://mbranca-general.servicebus.windows.net/activitylogs/ConsumerGroups/$Default/Partitions/0 with token type servicebus.windows.net:sastoken and expiry of 1723047445
2024-08-07T16:17:25.013+0200	debug	successful rpc on link 6bb4086b-b8ae-46ca-87dc-ef4e18c15db2: status code 202 and description: Accepted
2024-08-07T16:17:25.013+0200	debug	negotiated with response code 202 and message: Accepted
2024-08-07T16:17:30.261+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb", partition "1", epoch 21: lease renewed
2024-08-07T16:17:32.620+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb", partition "0", epoch 23: lease renewed
2024-08-07T16:17:35.807+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb": running scan
2024-08-07T16:17:36.566+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb": acquired: [], not acquired: [{"partitionID":"0","epoch":23,"owner":"86edc94f-dd34-44d3-8a43-ecf3cf4c77fb","checkpoint":{"offset":"206158444904","sequenceNumber":8565,"enqueueTime":"2024-08-07T13:26:15.225Z"},"state":"leased","token":"e4aa4ecd-ab0f-4984-92cd-a4c6dbcfa433"} {"partitionID":"1","epoch":21,"owner":"86edc94f-dd34-44d3-8a43-ecf3cf4c77fb","checkpoint":{"offset":"201863710488","sequenceNumber":8568,"enqueueTime":"2024-08-07T13:35:51.837Z"},"state":"leased","token":"32ab10ca-cc08-42a8-83fd-1dc436f25abc"}]
2024-08-07T16:17:43.233+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb", partition "0", epoch 23: lease renewed
2024-08-07T16:17:46.407+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb": running scan
2024-08-07T16:17:47.382+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb": acquired: [], not acquired: [{"partitionID":"0","epoch":23,"owner":"86edc94f-dd34-44d3-8a43-ecf3cf4c77fb","checkpoint":{"offset":"206158444904","sequenceNumber":8565,"enqueueTime":"2024-08-07T13:26:15.225Z"},"state":"leased","token":"e4aa4ecd-ab0f-4984-92cd-a4c6dbcfa433"} {"partitionID":"1","epoch":21,"owner":"86edc94f-dd34-44d3-8a43-ecf3cf4c77fb","checkpoint":{"offset":"201863710488","sequenceNumber":8568,"enqueueTime":"2024-08-07T13:35:51.837Z"},"state":"leased","token":"32ab10ca-cc08-42a8-83fd-1dc436f25abc"}]
2024-08-07T16:17:50.100+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb", partition "1", epoch 21: lease renewed
2024-08-07T16:17:52.965+0200	debug	eph "86edc94f-dd34-44d3-8a43-ecf3cf4c77fb", partition "0", epoch 23: lease renewed
```