### PR TITLE
Adjust Elastic Agent 7.17 to launch upgrade watcher version

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -31,6 +31,10 @@ Fix CVE-2023-25173 by updating github.com/containerd/containerd to v1.5.18 {pull
 
 *Functionbeat*
 
+*Elastic Agent*
+
+- Fixes the issue where upgrading from 7.17 to a 8.x+ version only runs the 7.17 watcher for the latest 8.x release.
+
 ==== Bugfixes
 
 *Affecting all Beats*

--- a/x-pack/elastic-agent/pkg/agent/application/paths/common.go
+++ b/x-pack/elastic-agent/pkg/agent/application/paths/common.go
@@ -169,6 +169,13 @@ func SetInstall(path string) {
 	installPath = path
 }
 
+// TopBinaryPath returns the path to the Elastic Agent binary that is inside the Top directory.
+//
+// This always points to the symlink that points to the latest Elastic Agent version.
+func TopBinaryPath() string {
+	return filepath.Join(Top(), BinaryName)
+}
+
 // initialTop returns the initial top-level path for the binary
 //
 // When nested in top-level/data/elastic-agent-${hash}/ the result is top-level/.

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
@@ -104,8 +104,7 @@ func InvokeWatcher(log *logger.Logger) error {
 		return nil
 	}
 
-	versionedHome := paths.VersionedHome(paths.Top())
-	cmd := invokeCmd(versionedHome)
+	cmd := invokeCmd()
 	defer func() {
 		if cmd.Process != nil {
 			log.Debugf("releasing watcher %v", cmd.Process.Pid)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
@@ -201,9 +201,7 @@ func (p *noopPidProvider) Name() string { return "noop" }
 func (p *noopPidProvider) PID(ctx context.Context) (int, error) { return 0, nil }
 
 func invokeCmd(topPath string) *exec.Cmd {
-	homeExePath := filepath.Join(topPath, agentName)
-
-	cmd := exec.Command(homeExePath, watcherSubcommand,
+	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
@@ -200,7 +200,7 @@ func (p *noopPidProvider) Name() string { return "noop" }
 
 func (p *noopPidProvider) PID(ctx context.Context) (int, error) { return 0, nil }
 
-func invokeCmd(topPath string) *exec.Cmd {
+func invokeCmd() *exec.Cmd {
 	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service_darwin.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service_darwin.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -114,10 +113,8 @@ func (p *darwinPidProvider) piderFromCmd(ctx context.Context, name string, args 
 	}
 }
 
-func invokeCmd(topPath string) *exec.Cmd {
-	homeExePath := filepath.Join(topPath, agentName)
-
-	cmd := exec.Command(homeExePath, watcherSubcommand,
+func invokeCmd() *exec.Cmd {
+	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
@@ -10,7 +10,6 @@ package upgrade
 import (
 	"context"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	"golang.org/x/sys/windows/svc/mgr"
@@ -63,9 +62,7 @@ func (p *pidProvider) PID(ctx context.Context) (int, error) {
 }
 
 func invokeCmd(topPath string) *exec.Cmd {
-	homeExePath := filepath.Join(topPath, agentName)
-
-	cmd := exec.Command(homeExePath, watcherSubcommand,
+	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),
 	)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
@@ -61,7 +61,7 @@ func (p *pidProvider) PID(ctx context.Context) (int, error) {
 	return int(status.ProcessId), nil
 }
 
-func invokeCmd(topPath string) *exec.Cmd {
+func invokeCmd() *exec.Cmd {
 	cmd := exec.Command(paths.TopBinaryPath(), watcherSubcommand,
 		"--path.config", paths.Config(),
 		"--path.home", paths.Top(),

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -168,6 +168,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, a Action, reexecNow bool, skipVe
 		return nil, err
 	}
 
+	// InvokeWatcher invokes the watcher using the symlink that is rotated above with ChangeSymlink
 	if err := InvokeWatcher(u.log); err != nil {
 		rollbackInstall(ctx, newHash)
 		return nil, errors.New("failed to invoke rollback watcher", err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Adjust Elastic Agent 7.17 to launch upgrade watcher version.

This fixes the issue where upgrading from 7.17 to a 8.x+ version only runs the 7.17 watcher for the latest 8.x release. The latest watcher should be ran instead.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

None

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/5259
