### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/azuread: fix configuration ordering

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -144,6 +144,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Relax requirements in Okta entity analytics provider user and device profile data shape. {pull}40359[40359]
 - Fix bug in Okta entity analytics rate limit logic. {issue}40106[40106] {pull}40267[40267]
 - Fix crashes in the journald input. {pull}40061[40061]
+- Fix order of configuration for EntraID entity analytics provider. {pull}40487[40487]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -42,6 +42,7 @@ var _ provider.Provider = &azure{}
 type azure struct {
 	*kvstore.Manager
 
+	cfg  *config.C
 	conf conf
 
 	metrics *inputMetrics
@@ -74,8 +75,20 @@ func (p *azure) Test(testCtx v2.TestContext) error {
 func (p *azure) Run(inputCtx v2.Context, store *kvstore.Store, client beat.Client) error {
 	p.logger = inputCtx.Logger.With("tenant_id", p.conf.TenantID, "provider", Name)
 	p.ctx = inputCtx
+
+	var err error
+	p.auth, err = oauth2.New(p.cfg, p.Manager.Logger)
+	if err != nil {
+		return fmt.Errorf("unable to create authenticator: %w", err)
+	}
 	p.auth.SetLogger(p.logger)
+
+	p.fetcher, err = graph.New(ctxtool.FromCanceller(p.ctx.Cancelation), p.ctx.ID, p.cfg, p.Manager.Logger, p.auth)
+	if err != nil {
+		return fmt.Errorf("unable to create fetcher: %w", err)
+	}
 	p.fetcher.SetLogger(p.logger)
+
 	p.metrics = newMetrics(inputCtx.ID, nil)
 	defer p.metrics.Close()
 
@@ -569,19 +582,10 @@ func (p *azure) publishDevice(d *fetcher.Device, state *stateStore, inputID stri
 
 // configure configures this provider using the given configuration.
 func (p *azure) configure(cfg *config.C) (kvstore.Input, error) {
-	var err error
-
-	if err = cfg.Unpack(&p.conf); err != nil {
+	if err := cfg.Unpack(&p.conf); err != nil {
 		return nil, fmt.Errorf("unable to unpack %s input config: %w", Name, err)
 	}
-
-	if p.auth, err = oauth2.New(cfg, p.Manager.Logger); err != nil {
-		return nil, fmt.Errorf("unable to create authenticator: %w", err)
-	}
-	if p.fetcher, err = graph.New(ctxtool.FromCanceller(p.ctx.Cancelation), p.ctx.ID, cfg, p.Manager.Logger, p.auth); err != nil {
-		return nil, fmt.Errorf("unable to create fetcher: %w", err)
-	}
-
+	p.cfg = cfg
 	return p, nil
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Previously, the configuration was eager, this caused a panic when the request trace logging option was turned on since it was started without a context.

Move the construction of components to when we have all the parts we need.

---

Tested locally by building at this commit and injecting the agentbeat into a running ep stack with [request trace logging enabled](https://github.com/elastic/integrations/pull/10765). Outputs this to the trace log:

```
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.840Z","message":"HTTP request","transaction.id":"B0PCS4IRTNL1E-1","url.original":"http://svc-entra_id:8080/v1.0/users/delta?%24select=accountEnabled%2CuserPrincipalName%2Cmail%2CdisplayName%2CgivenName%2Csurname%2CjobTitle%2CofficeLocation%2CmobilePhone%2CbusinessPhones","url.scheme":"http","url.path":"/v1.0/users/delta","url.domain":"svc-entra_id","url.port":"8080","url.query":"%24select=accountEnabled%2CuserPrincipalName%2Cmail%2CdisplayName%2CgivenName%2Csurname%2CjobTitle%2CofficeLocation%2CmobilePhone%2CbusinessPhones","http.request.method":"GET","user_agent.original":"","http.request.body.content":"","http.request.body.truncated":false,"http.request.body.bytes":0,"http.request.mime_type":"","event.original":"GET /v1.0/users/delta?%24select=accountEnabled%2CuserPrincipalName%2Cmail%2CdisplayName%2CgivenName%2Csurname%2CjobTitle%2CofficeLocation%2CmobilePhone%2CbusinessPhones HTTP/1.1\r\nHost: svc-entra_id:8080\r\nUser-Agent: Go-http-client/1.1\r\nAuthorization: Bearer TEST\r\nAccept-Encoding: gzip\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.842Z","message":"HTTP response","transaction.id":"B0PCS4IRTNL1E-1","http.response.status_code":200,"http.response.body.content":"","http.response.body.truncated":true,"http.response.body.bytes":855,"http.response.mime_type":"text/plain; charset=utf-8","event.original":"HTTP/1.1 200 OK\r\nContent-Length: 855\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Mon, 12 Aug 2024 08:19:42 GMT\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.842Z","message":"HTTP request","transaction.id":"B0PCS4IRTNL1E-2","url.original":"http://svc-entra_id:8080/v1.0/devices/delta?%24select=accountEnabled%2CdeviceId%2CdisplayName%2CoperatingSystem%2CoperatingSystemVersion%2CphysicalIds%2CextensionAttributes%2CalternativeSecurityIds","url.scheme":"http","url.path":"/v1.0/devices/delta","url.domain":"svc-entra_id","url.port":"8080","url.query":"%24select=accountEnabled%2CdeviceId%2CdisplayName%2CoperatingSystem%2CoperatingSystemVersion%2CphysicalIds%2CextensionAttributes%2CalternativeSecurityIds","http.request.method":"GET","user_agent.original":"","http.request.body.content":"","http.request.body.truncated":false,"http.request.body.bytes":0,"http.request.mime_type":"","event.original":"GET /v1.0/devices/delta?%24select=accountEnabled%2CdeviceId%2CdisplayName%2CoperatingSystem%2CoperatingSystemVersion%2CphysicalIds%2CextensionAttributes%2CalternativeSecurityIds HTTP/1.1\r\nHost: svc-entra_id:8080\r\nUser-Agent: Go-http-client/1.1\r\nAuthorization: Bearer TEST\r\nAccept-Encoding: gzip\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.843Z","message":"HTTP response","transaction.id":"B0PCS4IRTNL1E-2","http.response.status_code":200,"http.response.body.content":"","http.response.body.truncated":true,"http.response.body.bytes":422,"http.response.mime_type":"text/plain; charset=utf-8","event.original":"HTTP/1.1 200 OK\r\nContent-Length: 422\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Mon, 12 Aug 2024 08:19:42 GMT\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.843Z","message":"HTTP request","transaction.id":"B0PCS4IRTNL1E-3","url.original":"http://svc-entra_id:8080/v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners","url.scheme":"http","url.path":"/v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners","url.domain":"svc-entra_id","url.port":"8080","url.query":"","http.request.method":"GET","user_agent.original":"","http.request.body.content":"","http.request.body.truncated":false,"http.request.body.bytes":0,"http.request.mime_type":"","event.original":"GET /v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners HTTP/1.1\r\nHost: svc-entra_id:8080\r\nUser-Agent: Go-http-client/1.1\r\nAuthorization: Bearer TEST\r\nAccept-Encoding: gzip\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.843Z","message":"HTTP response","transaction.id":"B0PCS4IRTNL1E-3","http.response.status_code":301,"http.response.body.content":"","http.response.body.truncated":false,"http.response.body.bytes":0,"http.response.mime_type":"","event.original":"HTTP/1.1 301 Moved Permanently\r\nDate: Mon, 12 Aug 2024 08:19:42 GMT\r\nLocation: /v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners\r\nContent-Length: 0\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.843Z","message":"HTTP request","transaction.id":"B0PCS4IRTNL1E-4","url.original":"http://svc-entra_id:8080/v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners","url.scheme":"http","url.path":"/v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners","url.domain":"svc-entra_id","url.port":"8080","url.query":"","http.request.method":"GET","user_agent.original":"","http.request.body.content":"","http.request.body.truncated":false,"http.request.body.bytes":0,"http.request.mime_type":"","event.original":"GET /v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners HTTP/1.1\r\nHost: svc-entra_id:8080\r\nUser-Agent: Go-http-client/1.1\r\nAuthorization: Bearer TEST\r\nReferer: http://svc-entra_id:8080/v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredOwners\r\nAccept-Encoding: gzip\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.844Z","message":"HTTP response","transaction.id":"B0PCS4IRTNL1E-4","http.response.status_code":404,"http.response.body.content":"","http.response.body.truncated":false,"http.response.body.bytes":0,"http.response.mime_type":"","event.original":"HTTP/1.1 404 Not Found\r\nDate: Mon, 12 Aug 2024 08:19:42 GMT\r\nContent-Length: 0\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.844Z","message":"HTTP request","transaction.id":"B0PCS4IRTNL1E-5","url.original":"http://svc-entra_id:8080/v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers","url.scheme":"http","url.path":"/v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers","url.domain":"svc-entra_id","url.port":"8080","url.query":"","http.request.method":"GET","user_agent.original":"","http.request.body.content":"","http.request.body.truncated":false,"http.request.body.bytes":0,"http.request.mime_type":"","event.original":"GET /v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers HTTP/1.1\r\nHost: svc-entra_id:8080\r\nUser-Agent: Go-http-client/1.1\r\nAuthorization: Bearer TEST\r\nAccept-Encoding: gzip\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.844Z","message":"HTTP response","transaction.id":"B0PCS4IRTNL1E-5","http.response.status_code":301,"http.response.body.content":"","http.response.body.truncated":false,"http.response.body.bytes":0,"http.response.mime_type":"","event.original":"HTTP/1.1 301 Moved Permanently\r\nDate: Mon, 12 Aug 2024 08:19:42 GMT\r\nLocation: /v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers\r\nContent-Length: 0\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.844Z","message":"HTTP request","transaction.id":"B0PCS4IRTNL1E-6","url.original":"http://svc-entra_id:8080/v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers","url.scheme":"http","url.path":"/v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers","url.domain":"svc-entra_id","url.port":"8080","url.query":"","http.request.method":"GET","user_agent.original":"","http.request.body.content":"","http.request.body.truncated":false,"http.request.body.bytes":0,"http.request.mime_type":"","event.original":"GET /v1.0/devices/c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers HTTP/1.1\r\nHost: svc-entra_id:8080\r\nUser-Agent: Go-http-client/1.1\r\nAuthorization: Bearer TEST\r\nReferer: http://svc-entra_id:8080/v1.0/devices//c9d9f9b3-0c91-4080-b392-78f775903b3a/registeredUsers\r\nAccept-Encoding: gzip\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.845Z","message":"HTTP response","transaction.id":"B0PCS4IRTNL1E-6","http.response.status_code":404,"http.response.body.content":"","http.response.body.truncated":false,"http.response.body.bytes":0,"http.response.mime_type":"","event.original":"HTTP/1.1 404 Not Found\r\nDate: Mon, 12 Aug 2024 08:19:42 GMT\r\nContent-Length: 0\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.845Z","message":"HTTP request","transaction.id":"B0PCS4IRTNL1E-7","url.original":"http://svc-entra_id:8080/v1.0/groups/delta?%24select=displayName%2Cmembers","url.scheme":"http","url.path":"/v1.0/groups/delta","url.domain":"svc-entra_id","url.port":"8080","url.query":"%24select=displayName%2Cmembers","http.request.method":"GET","user_agent.original":"","http.request.body.content":"","http.request.body.truncated":false,"http.request.body.bytes":0,"http.request.mime_type":"","event.original":"GET /v1.0/groups/delta?%24select=displayName%2Cmembers HTTP/1.1\r\nHost: svc-entra_id:8080\r\nUser-Agent: Go-http-client/1.1\r\nAuthorization: Bearer TEST\r\nAccept-Encoding: gzip\r\n\r\n","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2024-08-12T08:19:42.845Z","message":"HTTP response","transaction.id":"B0PCS4IRTNL1E-7","http.response.status_code":200,"http.response.body.content":"","http.response.body.truncated":true,"http.response.body.bytes":485,"http.response.mime_type":"text/plain; charset=utf-8","event.original":"HTTP/1.1 200 OK\r\nContent-Length: 485\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Mon, 12 Aug 2024 08:19:42 GMT\r\n\r\n","ecs.version":"1.6.0"}
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For elastic/integrations#10498

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
