### PR TITLE
x-pack/packetbeat: skip npcap installation when running on CI

### DIFF
--- a/x-pack/packetbeat/magefile.go
+++ b/x-pack/packetbeat/magefile.go
@@ -165,7 +165,12 @@ func TestPackages() error {
 }
 
 func SystemTest(ctx context.Context) error {
-	mg.SerialDeps(getNpcapInstaller, devtools.BuildSystemTestBinary)
+	// Buildkite (CI) images have preinstalled npcap
+	if os.Getenv("CI") == "true" {
+		mg.SerialDeps(devtools.BuildSystemTestBinary)
+	} else {
+		mg.SerialDeps(getNpcapInstaller, devtools.BuildSystemTestBinary)
+	}
 
 	args := devtools.DefaultGoTestIntegrationArgs()
 	args.Packages = []string{"./tests/system/..."}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
Npcap is pre-installed on all agent images on Buildkite, so no need to install it during CI run.
Added condition in magefile to skip `getNpcapInstaller` dependency when running on Buildkite.

In addition `x-pack/packetbeat/magefile.go func getNpcapInstaller()` on [CI fails](https://buildkite.com/elastic/beats-xpack-packetbeat/builds/5702#019145d8-bfed-42dd-9d32-c546d3a93f62) with:
```https://buildkite.com/elastic/beats-xpack-packetbeat/builds/5702#019145d8-bfed-42dd-9d32-c546d3a93f62/109-114```

<!-- Mandatory

Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates: https://github.com/elastic/ingest-dev/issues/3637 

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
