### PR TITLE
Don't create kprobes with more than 128 args in auditbeat's guess subsystem

### DIFF
--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -82,7 +82,7 @@ func (g *guessInetSockIPv4) Probes() ([]helper.ProbeDef, error) {
 				Type:      tracing.TypeKRetProbe,
 				Name:      "inet_sock_guess",
 				Address:   "inet_csk_accept",
-				Fetchargs: helper.MakeMemoryDump("{{.RET}}", 0, 1024),
+				Fetchargs: helper.MakeMemoryDump("{{.RET}}", 0, inetSockDumpSize),
 			},
 			Decoder: tracing.NewDumpDecoder,
 		},

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -82,7 +82,7 @@ func (g *guessInetSockIPv4) Probes() ([]helper.ProbeDef, error) {
 				Type:      tracing.TypeKRetProbe,
 				Name:      "inet_sock_guess",
 				Address:   "inet_csk_accept",
-				Fetchargs: helper.MakeMemoryDump("{{.RET}}", 0, 2048),
+				Fetchargs: helper.MakeMemoryDump("{{.RET}}", 0, 1024),
 			},
 			Decoder: tracing.NewDumpDecoder,
 		},

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -149,10 +149,10 @@ func (g *guessInetSockIPv4) Extract(ev interface{}) (mapstr.M, bool) {
 	raddr := g.remote.Addr[:]
 	rport := make([]byte, 2)
 	binary.BigEndian.PutUint16(rport, uint16(g.remote.Port))
-	var laddrHits []int
-	var lportHits []int
-	var raddrHits []int
-	var rportHits []int
+	laddrHits := make([]int, 0)
+	lportHits := make([]int, 0)
+	raddrHits := make([]int, 0)
+	rportHits := make([]int, 0)
 
 	off := indexAligned(data, laddr, 0, 4)
 	for off != -1 {

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -100,7 +100,7 @@ import (
 	INET_SOCK_V6_LADDR_B: +80
 */
 
-const inetSockDumpSize = 8 * 256
+const inetSockDumpSize = 4 * 256
 
 func init() {
 	if err := Registry.AddGuess(func() Guesser { return &guessInetSockIPv6{} }); err != nil {

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/elastic/beats/v7/auditbeat/tracing"
 	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system/socket/helper"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -191,7 +192,7 @@ func (g *guessInetSockIPv6) Probes() (probes []helper.ProbeDef, err error) {
 	raddrOffsets := g.offsets
 	g.offsets = nil
 	const sizePtr = int(sizeOfPtr)
-	var fetch []string
+	fetch := make([]string, 0)
 	for _, off := range raddrOffsets {
 		// the pointer we're looking for is after a field of sizeof(struct sock)
 		if off < sizePtr*2 {
@@ -237,7 +238,11 @@ func (g *guessInetSockIPv6) Prepare(ctx Context) (err error) {
 	}
 	defer func() {
 		if err != nil {
-			g.loopback.Cleanup()
+			err := g.loopback.Cleanup()
+			if err != nil {
+				logp.L().Errorf("error cleaning up loopback addresses: %s", err)
+			}
+
 		}
 	}()
 	clientIP, err := g.loopback.AddRandomAddress()

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
@@ -1,3 +1,10 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build (linux && 386) || (linux && amd64)
+// +build linux,386 linux,amd64
+
 package guess
 
 import (

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
@@ -1,0 +1,35 @@
+package guess
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInet4ProbeCorrectKretprobeBody(t *testing.T) {
+	// test to make sure guessInetSockIPv4 produces a valid kprobe
+	testGuess := guessInetSockIPv4{}
+
+	probes, err := testGuess.Probes()
+	require.NoError(t, err)
+
+	for _, probe := range probes {
+		probeArgs := strings.Split(probe.Probe.Fetchargs, " ")
+		require.LessOrEqual(t, len(probeArgs), 128)
+	}
+
+}
+
+func TestInet6ProbeCorrectKretprobeBody(t *testing.T) {
+	// test to make sure guessInetSockIPv6 produces a valid kprobe
+	testGuess6 := guessInetSockIPv6{}
+	probes, err := testGuess6.Probes()
+	require.NoError(t, err)
+
+	for _, probe := range probes {
+		probeArgs := strings.Split(probe.Probe.Fetchargs, " ")
+		require.LessOrEqual(t, len(probeArgs), 128)
+	}
+
+}

--- a/x-pack/auditbeat/module/system/socket/helper/probes.go
+++ b/x-pack/auditbeat/module/system/socket/helper/probes.go
@@ -48,6 +48,7 @@ func NewStructDecoder(allocator tracing.AllocateFn) func(tracing.ProbeFormat) (t
 
 // MakeMemoryDump returns a kprobe fetchargs definition that reads a region
 // of memory using a sequence of 8-byte fields.
+// Creating more than 128 args is undefined.
 func MakeMemoryDump(address string, from, to int) string {
 	var params []string
 	for off := from; off < to; off += 8 {

--- a/x-pack/auditbeat/module/system/socket/helper/probes.go
+++ b/x-pack/auditbeat/module/system/socket/helper/probes.go
@@ -50,7 +50,7 @@ func NewStructDecoder(allocator tracing.AllocateFn) func(tracing.ProbeFormat) (t
 // of memory using a sequence of 8-byte fields.
 // Creating more than 128 args is undefined.
 func MakeMemoryDump(address string, from, to int) string {
-	var params []string
+	params := make([]string, 0)
 	for off := from; off < to; off += 8 {
 		params = append(params, fmt.Sprintf("+%d(%s):u64", off, address))
 	}


### PR DESCRIPTION

## Proposed commit message
This is a little silly. We have a few kprobes in auditbeat that will attempt to create up to _256_ args to read the return value from the register of a kretprobe; according to the kernel docs, only 128 args are supported. On older kernel releases, it would silently cut off any args greater than 128 (meaning this code never really worked as intended), but sometime around kernel 6.9, the kernel will throw an oops: https://bugzilla.redhat.com/show_bug.cgi?id=2303876. On older kernels, this technically doesn't change anything, as the kernel would just throw out any arguments over 128.

This modifies the kprobe creation so we're not trying to read from over 128 args.

If you want to test this behavior, you'll need Fedora, Arch, or another edge distro. The link above has some C code to reproduce the issue.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

