### PR TITLE
[aws] Update max_number_of_messages doc

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -268,13 +268,13 @@ The default is `10 MiB`.
 ==== `max_number_of_messages`
 
 The maximum number of SQS messages that can be inflight at any time. Defaults
-to 5. When processing large amount of large size S3 objects and each object has
-large amount of events, if this parameter sets too high, it can cause the input
-to process too many messages concurrently, overload the agent and cause ingest failure.
-We recommend to keep the default value 5 and use the
+to 5. Setting this parameter too high can overload Elastic Agent and cause
+ingest failures in situations where the SQS messages contain many S3 objects
+or the S3 objects themselves contain large numbers of messages.
+We recommend to keep the default value 5 and use the `Balanced` or `Optimized for
+Throughput` setting in the
 {fleet-guide}/es-output-settings.html#es-output-settings-performance-tuning-settings[preset]
-option to tune your Elastic Agent performance. You can optimize for throughput,
-scale, latency, or you can choose a balanced (the default) set of performance specifications.
+options to tune your Elastic Agent performance.
 
 [id="input-{type}-parsers"]
 [float]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR is to update the documentation for max_number_of_messages to inform users to keep default 5 for this parameter and use the `Balanced` or `Optimized for Throughput` presets in the Performance tuning settings to tune your Elastic Agent performance.

This is a followup change after https://github.com/elastic/beats/pull/40231.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

