### PR TITLE
[ES output] Correctly log event fields in events log file

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -149,6 +149,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix crashes in the journald input. {pull}40061[40061]
 - Fix order of configuration for EntraID entity analytics provider. {pull}40487[40487]
 - Ensure Entra ID request bodies are not truncated and trace logs are rotated before 100MB. {pull}40494[40494]
+- The Elasticsearch output now correctly logs the event fields to the event log file {issue}40509[40509] {pull}40512[40512]
 
 *Heartbeat*
 

--- a/filebeat/tests/integration/event_log_file_test.go
+++ b/filebeat/tests/integration/event_log_file_test.go
@@ -123,7 +123,7 @@ func TestEventsLoggerESOutput(t *testing.T) {
 	}
 
 	strData := string(data)
-	eventMsg := "not a number"
+	eventMsg := `\"int\":\"not a number\"`
 	if !strings.Contains(strData, eventMsg) {
 		t.Errorf("expecting to find '%s' on '%s'", eventMsg, eventsLogFile)
 		t.Errorf("Contents:\n%s", strData)

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -507,14 +507,14 @@ func (client *Client) applyItemStatus(
 			// Fatal error while sending an already-failed event to the dead letter
 			// index, drop.
 			client.pLogDeadLetter.Add()
-			client.log.Errorw(fmt.Sprintf("Can't deliver to dead letter index event %#v (status=%v): %s", event, itemStatus, itemMessage), logp.TypeKey, logp.EventType)
+			client.log.Errorw(fmt.Sprintf("Can't deliver to dead letter index event '%s' (status=%v): %s", encodedEvent, itemStatus, itemMessage), logp.TypeKey, logp.EventType)
 			stats.nonIndexable++
 			return false
 		}
 		if client.deadLetterIndex == "" {
 			// Fatal error and no dead letter index, drop.
 			client.pLogIndex.Add()
-			client.log.Warnw(fmt.Sprintf("Cannot index event %#v (status=%v): %s, dropping event!", event, itemStatus, itemMessage), logp.TypeKey, logp.EventType)
+			client.log.Warnw(fmt.Sprintf("Cannot index event '%s' (status=%v): %s, dropping event!", encodedEvent, itemStatus, itemMessage), logp.TypeKey, logp.EventType)
 			stats.nonIndexable++
 			return false
 		}
@@ -523,7 +523,7 @@ func (client *Client) applyItemStatus(
 		// ingestion succeeds it is counted in the "deadLetter" counter
 		// rather than the "acked" counter.
 		client.pLogIndexTryDeadLetter.Add()
-		client.log.Warnw(fmt.Sprintf("Cannot index event %#v (status=%v): %s, trying dead letter index", event, itemStatus, itemMessage), logp.TypeKey, logp.EventType)
+		client.log.Warnw(fmt.Sprintf("Cannot index event '%s' (status=%v): %s, trying dead letter index", encodedEvent, itemStatus, itemMessage), logp.TypeKey, logp.EventType)
 		encodedEvent.setDeadLetter(client.deadLetterIndex, itemStatus, string(itemMessage))
 	}
 

--- a/libbeat/outputs/elasticsearch/event_encoder.go
+++ b/libbeat/outputs/elasticsearch/event_encoder.go
@@ -151,3 +151,10 @@ func (e *encodedEvent) setDeadLetter(
 	}
 	e.encoding = []byte(deadLetterReencoding.String())
 }
+
+// String converts e.encoding to string and returns it.
+// The goal of this method is to provide an easy way to log
+// the event encoded.
+func (e *encodedEvent) String() string {
+	return string(e.encoding)
+}


### PR DESCRIPTION
## Proposed commit message

The Elasticsearch output, when faced with ingestion errors was logging the raw publisher.Event that had already been encoded, hence no event fields were present in the logs.

This commit fixes it by adding a String method to the encodedEvent type and using the encodedEvent in the logs instead of the publisher.Event.

Closes: https://github.com/elastic/beats/issues/40509

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None, it fixes a bug.

~~## Author's Checklist~~

## How to test this PR locally
Start Filebeat with the following configuration
```yaml
filebeat.inputs:
  - type: filestream
    id: filestream-input-id
    enabled: true
    parsers:
      - ndjson:
          target: ""
          overwrite_keys: true
          expand_keys: true
          add_error_key: true
          ignore_decoding_error: false
    paths:
      - /tmp/flog.log

output:
  elasticsearch:
    hosts:
      - localhost:9200
    protocol: https
    username: elastic
    password: changeme
    allow_older_versions: true
    ssl.verification_mode: none

logging:
  level: debug
  event_data:
    files:
      name: filebeat-events-data # that's the default, change it if you want another name.
```

Create the log file `/tmp/flog.log` with the following content:
```
{"message":"foo bar","int":10,"string":"str"}
{"message":"another message","int":20,"string":"str2"}
{"message":"index failure","int":"not a number","string":10}
{"message":"second index failure","int":"not a number","string":10}
A broken JSON
```

Look for the event log file: `logs/filebeat-events-data*.ndjson` and ensure the logged events contains their fields.

Here is an example of how the content of the event log file should look like:
```json
{
  "log.level": "warn",
  "@timestamp": "2024-08-13T16:42:09.008-0400",
  "log.logger": "elasticsearch",
  "log.origin": {
    "function": "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch.(*Client).applyItemStatus",
    "file.name": "elasticsearch/client.go",
    "file.line": 490
  },
  "message": "Cannot index event '{\"@timestamp\":\"2024-08-13T20:42:05.928Z\",\"host\":{\"name\":\"millennium-falcon\"},\"agent\":{\"version\":\"8.16.0\",\"ephemeral_id\":\"6d195bff-27a4-40c4-9b3e-c3ecb068f06e\",\"id\":\"6a760df8-a3e6-4369-886a-3f499c792302\",\"name\":\"millennium-falcon\",\"type\":\"filebeat\"},\"log\":{\"file\":{\"device_id\":\"40\",\"inode\":\"51817\",\"path\":\"/tmp/flog.log\"},\"offset\":101},\"string\":10,\"message\":\"index failure\",\"int\":\"not a number\",\"input\":{\"type\":\"filestream\"},\"ecs\":{\"version\":\"8.0.0\"}}\n' (status=400): {\"type\":\"document_parsing_exception\",\"reason\":\"[1:380] failed to parse field [int] of type [long] in document with id 'iVl6TZEBA82tHj8dCPpP'. Preview of field's value: 'not a number'\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"For input string: \\\"not a number\\\"\"}}, dropping event!",
  "service.name": "filebeat",
  "log.type": "event",
  "ecs.version": "1.6.0"
}
{
  "log.level": "warn",
  "@timestamp": "2024-08-13T16:42:09.009-0400",
  "log.logger": "elasticsearch",
  "log.origin": {
    "function": "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch.(*Client).applyItemStatus",
    "file.name": "elasticsearch/client.go",
    "file.line": 490
  },
  "message": "Cannot index event '{\"@timestamp\":\"2024-08-13T20:42:05.928Z\",\"host\":{\"name\":\"millennium-falcon\"},\"agent\":{\"name\":\"millennium-falcon\",\"type\":\"filebeat\",\"version\":\"8.16.0\",\"ephemeral_id\":\"6d195bff-27a4-40c4-9b3e-c3ecb068f06e\",\"id\":\"6a760df8-a3e6-4369-886a-3f499c792302\"},\"ecs\":{\"version\":\"8.0.0\"},\"log\":{\"offset\":162,\"file\":{\"path\":\"/tmp/flog.log\",\"device_id\":\"40\",\"inode\":\"51817\"}},\"message\":\"second index failure\",\"int\":\"not a number\",\"string\":10,\"input\":{\"type\":\"filestream\"}}\n' (status=400): {\"type\":\"document_parsing_exception\",\"reason\":\"[1:401] failed to parse field [int] of type [long] in document with id 'ill6TZEBA82tHj8dCPpP'. Preview of field's value: 'not a number'\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"For input string: \\\"not a number\\\"\"}}, dropping event!",
  "service.name": "filebeat",
  "log.type": "event",
  "ecs.version": "1.6.0"
}
```

~~## Use cases~~
~~## Screenshots~~