### PR TITLE
Make Wolfi a part of Docker packaging

### DIFF
--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -466,6 +466,10 @@ func checkDockerEntryPoint(t *testing.T, p *packageFile, info *dockerInfo) {
 	})
 }
 
+// {BeatName}-{OptionalVariantSuffix}-oss-{version}-{os}-{arch}.docker.tar.gz
+// For example, `heartbeat-oss-8.16.0-linux-arm64.docker.tar.gz`
+var ossSuffixRegexp = regexp.MustCompile(`^(\w+)(-\w+)?-oss-.+$`)
+
 func checkDockerLabels(t *testing.T, p *packageFile, info *dockerInfo, file string) {
 	vendor := info.Config.Labels["org.label-schema.vendor"]
 	if vendor != "Elastic" {
@@ -474,12 +478,7 @@ func checkDockerLabels(t *testing.T, p *packageFile, info *dockerInfo, file stri
 
 	t.Run(fmt.Sprintf("%s license labels", p.Name), func(t *testing.T) {
 		expectedLicense := "Elastic License"
-		ossPrefix := strings.Join([]string{
-			info.Config.Labels["org.label-schema.name"],
-			"oss",
-			info.Config.Labels["org.label-schema.version"],
-		}, "-")
-		if strings.HasPrefix(filepath.Base(file), ossPrefix) {
+		if ossSuffixRegexp.MatchString(filepath.Base(file)) {
 			expectedLicense = "ASL 2.0"
 		}
 		licenseLabels := []string{

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -1,25 +1,24 @@
 ---
-
 # This file contains the package specifications for both Community Beats and
 # Official Beats. The shared section contains YAML anchors that are used to
 # define common parts of the package in order to not repeat ourselves.
 
 shared:
   - &common
-    name: '{{.BeatName}}'
-    service_name: '{{.BeatServiceName}}'
-    os: '{{.GOOS}}'
-    arch: '{{.PackageArch}}'
-    vendor: '{{.BeatVendor}}'
-    version: '{{ beat_version }}'
-    license: '{{.BeatLicense}}'
-    url: '{{.BeatURL}}'
-    description: '{{.BeatDescription}}'
+    name: "{{.BeatName}}"
+    service_name: "{{.BeatServiceName}}"
+    os: "{{.GOOS}}"
+    arch: "{{.PackageArch}}"
+    vendor: "{{.BeatVendor}}"
+    version: "{{ beat_version }}"
+    license: "{{.BeatLicense}}"
+    url: "{{.BeatURL}}"
+    description: "{{.BeatDescription}}"
 
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec
     <<: *common
-    post_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/systemd-daemon-reload.sh'
+    post_install_script: "{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/systemd-daemon-reload.sh"
     files:
       /usr/share/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
@@ -28,23 +27,23 @@ shared:
         source: fields.yml
         mode: 0644
       /usr/share/{{.BeatName}}/LICENSE.txt:
-        source: '{{ repo.RootDir }}/LICENSE.txt'
+        source: "{{ repo.RootDir }}/LICENSE.txt"
         mode: 0644
       /usr/share/{{.BeatName}}/NOTICE.txt:
-        source: '{{ repo.RootDir }}/NOTICE.txt'
+        source: "{{ repo.RootDir }}/NOTICE.txt"
         mode: 0644
       /usr/share/{{.BeatName}}/README.md:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl"
         mode: 0644
       /usr/share/{{.BeatName}}/.build_hash.txt:
         content: >
           {{ commit }}
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.reference.yml:
-        source: '{{.BeatName}}.reference.yml'
+        source: "{{.BeatName}}.reference.yml"
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.yml:
-        source: '{{.BeatName}}.yml'
+        source: "{{.BeatName}}.yml"
         mode: 0600
         config: true
       /usr/share/{{.BeatName}}/kibana:
@@ -54,13 +53,13 @@ shared:
         source: build/golang-crossbuild/god-{{.GOOS}}-{{.Platform.Arch}}
         mode: 0755
       /usr/bin/{{.BeatName}}:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/beatname.sh.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/beatname.sh.tmpl"
         mode: 0755
       /lib/systemd/system/{{.BeatServiceName}}.service:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/systemd.unit.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/systemd.unit.tmpl"
         mode: 0644
       /etc/init.d/{{.BeatServiceName}}:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/init.sh.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/init.sh.tmpl"
         mode: 0755
 
   # MacOS pkg spec for community beats.
@@ -70,29 +69,29 @@ shared:
       # OS X 10.8 Mountain Lion is the oldest supported by Go 1.10.
       # https://golang.org/doc/go1.10#ports
       min_supported_osx_version: 10.8
-      identifier: 'co.{{.BeatVendor | tolower}}.beats.{{.BeatName}}'
+      identifier: "co.{{.BeatVendor | tolower}}.beats.{{.BeatName}}"
       install_path: /Library/Application Support
-    pre_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/preinstall.tmpl'
-    post_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/postinstall.tmpl'
+    pre_install_script: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/preinstall.tmpl"
+    post_install_script: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/postinstall.tmpl"
     files:
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
         mode: 0755
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/LICENSE.txt:
-        source: '{{ repo.RootDir }}/LICENSE.txt'
+        source: "{{ repo.RootDir }}/LICENSE.txt"
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/NOTICE.txt:
-        source: '{{ repo.RootDir }}/NOTICE.txt'
+        source: "{{ repo.RootDir }}/NOTICE.txt"
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/README.md:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl"
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/.build_hash.txt:
         content: >
           {{ commit }}
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/{{.identifier}}.plist:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/launchd-daemon.plist.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/launchd-daemon.plist.tmpl"
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/kibana:
         source: _meta/kibana.generated
@@ -101,38 +100,38 @@ shared:
         source: fields.yml
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.reference.yml:
-        source: '{{.BeatName}}.reference.yml'
+        source: "{{.BeatName}}.reference.yml"
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.yml:
-        source: '{{.BeatName}}.yml'
+        source: "{{.BeatName}}.yml"
         mode: 0600
         config: true
 
   - &binary_files
-    '{{.BeatName}}{{.BinaryExt}}':
+    "{{.BeatName}}{{.BinaryExt}}":
       source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
       mode: 0755
     fields.yml:
       source: fields.yml
       mode: 0644
     LICENSE.txt:
-      source: '{{ repo.RootDir }}/LICENSE.txt'
+      source: "{{ repo.RootDir }}/LICENSE.txt"
       mode: 0644
     NOTICE.txt:
-      source: '{{ repo.RootDir }}/NOTICE.txt'
+      source: "{{ repo.RootDir }}/NOTICE.txt"
       mode: 0644
     README.md:
-      template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
+      template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl"
       mode: 0644
     .build_hash.txt:
       content: >
         {{ commit }}
       mode: 0644
-    '{{.BeatName}}.reference.yml':
-      source: '{{.BeatName}}.reference.yml'
+    "{{.BeatName}}.reference.yml":
+      source: "{{.BeatName}}.reference.yml"
       mode: 0644
-    '{{.BeatName}}.yml':
-      source: '{{.BeatName}}.yml'
+    "{{.BeatName}}.yml":
+      source: "{{.BeatName}}.yml"
       mode: 0600
       config: true
     kibana:
@@ -151,44 +150,54 @@ shared:
     files:
       <<: *binary_files
       install-service-{{.BeatName}}.ps1:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/install-service.ps1.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/install-service.ps1.tmpl"
         mode: 0755
       uninstall-service-{{.BeatName}}.ps1:
-        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/uninstall-service.ps1.tmpl'
+        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/uninstall-service.ps1.tmpl"
         mode: 0755
 
   - &docker_spec
     <<: *binary_spec
     extra_vars:
-      from: 'ubuntu:20.04'
-      buildFrom: 'ubuntu:20.04'
-      user: '{{ .BeatName }}'
-      linux_capabilities: ''
+      from: "--platform=linux/amd64 ubuntu:20.04"
+      buildFrom: "--platform=linux/amd64 cgr.dev/chainguard/wolfi-base"
+      user: "{{ .BeatName }}"
+      linux_capabilities: ""
     files:
-      '{{.BeatName}}.yml':
-        source: '{{.BeatName}}.docker.yml'
+      "{{.BeatName}}.yml":
+        source: "{{.BeatName}}.docker.yml"
         mode: 0600
         config: true
 
   - &docker_arm_spec
     <<: *docker_spec
     extra_vars:
-      from: 'arm64v8/ubuntu:20.04'
-      buildFrom: 'arm64v8/ubuntu:20.04'
+      from: "--platform=linux/arm64 ubuntu:20.04"
+      buildFrom: "--platform=linux/arm64 cgr.dev/chainguard/wolfi-base"
 
   - &docker_ubi_spec
     extra_vars:
-      image_name: '{{.BeatName}}-ubi'
-      from: 'docker.elastic.co/ubi9/ubi-minimal'
+      image_name: "{{.BeatName}}-ubi"
+      from: "--platform=linux/amd64 docker.elastic.co/ubi9/ubi-minimal"
 
   - &docker_arm_ubi_spec
     extra_vars:
-      image_name: '{{.BeatName}}-ubi'
-      from: 'registry.access.redhat.com/ubi9/ubi-minimal:9.4'
+      image_name: "{{.BeatName}}-ubi"
+      from: "--platform=linux/arm64 docker.elastic.co/ubi9/ubi-minimal"
+
+  - &docker_wolfi_spec
+    extra_vars:
+      image_name: "{{.BeatName}}-wolfi"
+      from: "--platform=linux/amd64 cgr.dev/chainguard/wolfi-base"
+
+  - &docker_arm_wolfi_spec
+    extra_vars:
+      image_name: "{{.BeatName}}-wolfi"
+      from: "--platform=linux/arm64 cgr.dev/chainguard/wolfi-base"
 
   - &elastic_docker_spec
     extra_vars:
-      repository: 'docker.elastic.co/beats'
+      repository: "docker.elastic.co/beats"
 
   #
   # License modifiers for Apache 2.0
@@ -197,21 +206,21 @@ shared:
     license: "ASL 2.0"
     files:
       LICENSE.txt:
-        source: '{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt'
+        source: "{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt"
         mode: 0644
 
   - &apache_license_for_deb_rpm
     license: "ASL 2.0"
     files:
       /usr/share/{{.BeatName}}/LICENSE.txt:
-        source: '{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt'
+        source: "{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt"
         mode: 0644
 
   - &apache_license_for_macos_pkg
     license: "ASL 2.0"
     files:
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/LICENSE.txt:
-        source: '{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt'
+        source: "{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt"
         mode: 0644
 
   #
@@ -221,21 +230,21 @@ shared:
     license: "Elastic License"
     files:
       LICENSE.txt:
-        source: '{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt'
+        source: "{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt"
         mode: 0644
 
   - &elastic_license_for_deb_rpm
     license: "Elastic License"
     files:
       /usr/share/{{.BeatName}}/LICENSE.txt:
-        source: '{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt'
+        source: "{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt"
         mode: 0644
 
   - &elastic_license_for_macos_pkg
     license: "Elastic License"
     files:
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/LICENSE.txt:
-        source: '{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt'
+        source: "{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt"
         mode: 0644
 
 # specs is a list of named packaging "flavors".
@@ -263,9 +272,16 @@ specs:
         <<: *deb_rpm_spec
 
     - os: linux
+      arch: amd64
       types: [docker]
       spec:
         <<: *docker_spec
+
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_arm_spec
 
     - os: aix
       types: [tgz]
@@ -280,43 +296,77 @@ specs:
       spec:
         <<: *windows_binary_spec
         <<: *apache_license_for_binaries
-        name: '{{.BeatName}}-oss'
+        name: "{{.BeatName}}-oss"
 
     - os: darwin
       types: [tgz]
       spec:
         <<: *binary_spec
         <<: *apache_license_for_binaries
-        name: '{{.BeatName}}-oss'
+        name: "{{.BeatName}}-oss"
 
     - os: linux
       types: [tgz]
       spec:
         <<: *binary_spec
         <<: *apache_license_for_binaries
-        name: '{{.BeatName}}-oss'
+        name: "{{.BeatName}}-oss"
 
     - os: linux
       types: [deb, rpm]
       spec:
         <<: *deb_rpm_spec
         <<: *apache_license_for_deb_rpm
-        name: '{{.BeatName}}-oss'
+        name: "{{.BeatName}}-oss"
 
     - os: linux
       types: [docker]
+      arch: amd64
       spec:
         <<: *docker_spec
         <<: *elastic_docker_spec
         <<: *apache_license_for_binaries
-        name: '{{.BeatName}}-oss'
+        name: "{{.BeatName}}-oss"
+
+    - os: linux
+      types: [docker]
+      arch: amd64
+      spec:
+        <<: *docker_spec
+        <<: *docker_wolfi_spec
+        <<: *elastic_docker_spec
+        <<: *apache_license_for_binaries
+        name: "{{.BeatName}}-wolfi-oss"
+        extra_vars:
+          image_name: "{{.BeatName}}-wolfi-oss"
+
+    - os: linux
+      types: [docker]
+      arch: arm64
+      spec:
+        <<: *docker_arm_spec
+        <<: *elastic_docker_spec
+        <<: *apache_license_for_binaries
+        name: "{{.BeatName}}-oss"
+
+    - os: linux
+      types: [docker]
+      arch: arm64
+      spec:
+        <<: *docker_arm_spec
+        <<: *docker_arm_wolfi_spec
+        <<: *elastic_docker_spec
+        <<: *apache_license_for_binaries
+        name: "{{.BeatName}}-wolfi-oss"
+        extra_vars:
+          image_name: "{{.BeatName}}-wolfi-oss"
 
     - os: aix
       types: [tgz]
       spec:
         <<: *binary_spec
         <<: *apache_license_for_binaries
-        name: '{{.BeatName}}-oss'
+        name: "{{.BeatName}}-oss"
 
   # Elastic Beat with Elastic License and binary taken the current directory.
   elastic_beat_xpack:
@@ -365,6 +415,15 @@ specs:
         <<: *elastic_license_for_binaries
 
     - os: linux
+      arch: amd64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_wolfi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+
+    - os: linux
       arch: arm64
       types: [docker]
       spec:
@@ -378,6 +437,15 @@ specs:
       spec:
         <<: *docker_arm_spec
         <<: *docker_arm_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_arm_spec
+        <<: *docker_arm_wolfi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
 
@@ -427,7 +495,7 @@ specs:
         <<: *windows_binary_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
@@ -436,7 +504,7 @@ specs:
         <<: *binary_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -445,7 +513,7 @@ specs:
         <<: *binary_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -465,7 +533,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -477,7 +545,19 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: linux
+      arch: amd64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_wolfi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+        files:
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -488,7 +568,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -500,7 +580,19 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_arm_spec
+        <<: *docker_arm_wolfi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+        files:
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: aix
@@ -509,7 +601,7 @@ specs:
         <<: *binary_spec
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -522,100 +614,12 @@ specs:
             symlink: true
             mode: 0755
 
-    - os: linux
-      arch: amd64
-      types: [docker]
-      spec:
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    # Complete image gets a 'complete' variant for synthetics and other large
-    # packages too big to fit in the main image
-    - os: linux
-      arch: amd64
-      types: [docker]
-      spec:
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    # Cloud specific docker image
-    - os: linux
-      arch: amd64
-      types: [docker]
-      spec:
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    - os: linux
-      arch: amd64
-      types: [docker]
-      spec:
-        <<: *docker_ubi_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    - os: linux
-      arch: arm64
-      types: [docker]
-      spec:
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    # Complete image gets a 'complete' variant for synthetics and other large
-    # packages too big to fit in the main image
-    - os: linux
-      arch: arm64
-      types: [docker]
-      spec:
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    # Cloud specific docker image
-    - os: linux
-      arch: arm64
-      types: [docker]
-      spec:
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    - os: linux
-      arch: arm64
-      types: [docker]
-      spec:
-        <<: *docker_arm_ubi_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
     - os: aix
       types: [tgz]
       spec:
         <<: *elastic_license_for_binaries
         files:
-          '{{.BeatName}}{{.BinaryExt}}':
+          "{{.BeatName}}{{.BinaryExt}}":
             source: data/{{.BeatName}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}
             symlink: true
             mode: 0755

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -6,6 +6,15 @@
 # the final image because of permission changes.
 FROM {{ .buildFrom }} AS home
 
+{{- if contains .buildFrom "wolfi" }}
+RUN for iter in {1..10}; do \
+        apk update && \
+        apk add --no-interactive --no-progress --no-cache libcap-utils && \
+        exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
+    done; \
+    (exit $exit_code)
+{{- end }}
+
 COPY beat {{ $beatHome }}
 
 RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/logs && \
@@ -18,13 +27,36 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/logs && \
 {{- end }}
     chmod 0775 {{ $beatHome }}/data {{ $beatHome }}/logs
 
+{{- if .linux_capabilities }}
+# Since the beat is stored at the other end of a symlink we must follow the symlink first
+# For security reasons setcap does not support symlinks. This is smart in the general case
+# but in our specific case since we're building a trusted image from trusted binaries this is
+# fine. Thus, we use readlink to follow the link and setcap on the actual binary
+RUN readlink -f {{ $beatBinary }} | xargs setcap {{ .linux_capabilities }}
+{{- end }}
+
 FROM {{ .from }}
 
+{{- if contains .from "wolfi" }}
+RUN for iter in {1..10}; do \
+        apk update && \
+        apk add --no-interactive --no-progress --no-cache curl shadow bash && \
+        exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
+    done; \
+    (exit $exit_code)
+{{- end }}
+
 {{- if contains .from "ubi-minimal" }}
-RUN microdnf -y update && \
-    microdnf -y install findutils shadow-utils && \
-    microdnf clean all
-{{- else }}
+RUN for iter in {1..10}; do \
+        microdnf -y update && \
+        microdnf -y install findutils shadow-utils && \
+        microdnf clean all && \
+        exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; \
+    done; \
+    (exit $exit_code)
+{{- end }}
+
+{{- if contains .from "ubuntu" }}
 RUN for iter in {1..10}; do \
         apt-get update -y && \
         DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes ca-certificates curl gawk libcap2-bin xz-utils && \
@@ -60,7 +92,7 @@ LABEL \
   license="{{ .License }}" \
   description="{{ .BeatDescription }}"
 
-ENV ELASTIC_CONTAINER "true"
+ENV ELASTIC_CONTAINER="true"
 ENV PATH={{ $beatHome }}:$PATH
 ENV GODEBUG="madvdontneed=1"
 
@@ -97,26 +129,22 @@ RUN mkdir /licenses
 COPY --from=home {{ $beatHome }}/LICENSE.txt /licenses
 COPY --from=home {{ $beatHome }}/NOTICE.txt /licenses
 
-{{- if .linux_capabilities }}
-# Since the beat is stored at the other end of a symlink we must follow the symlink first
-# For security reasons setcap does not support symlinks. This is smart in the general case
-# but in our specific case since we're building a trusted image from trusted binaries this is
-# fine. Thus, we use readlink to follow the link and setcap on the actual binary
-RUN readlink -f {{ $beatBinary }} | xargs setcap {{ .linux_capabilities }}
-{{- end }}
-
 {{- if ne .user "root" }}
 RUN groupadd --gid 1000 {{ .BeatName }}
 RUN useradd -M --uid 1000 --gid 1000 --groups 0 --home {{ $beatHome }} {{ .user }}
-
+{{- end }}
 
 {{- if (and (eq .BeatName "heartbeat") (contains .from "wolfi"))  }}
+USER root
 # Install required dependencies from wolfi repository
-RUN apk add --no-interactive --no-progress nodejs-18=18.20.4-r0 npm=10.8.3-r0 glib dbus-glib libatk-1.0 \
-    libatk-bridge-2.0 cups-libs libxcomposite libxdamage libxrandr libxkbcommon pango alsa-lib \
-    font-opensans fontconfig gtk icu-data-full libnss mesa font-noto-cjk font-noto-emoji
-
-USER {{ .user }}
+RUN for iter in {1..10}; do \
+        apk update && \
+        apk add --no-interactive --no-progress --no-cache nodejs-18=18.20.4-r0 npm=10.8.3-r0 glib dbus-glib libatk-1.0 \
+        libatk-bridge-2.0 cups-libs libxcomposite libxdamage libxrandr libxkbcommon pango alsa-lib \
+        font-opensans fontconfig gtk icu-data-full libnss mesa font-noto-cjk font-noto-emoji && \
+        exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
+    done; \
+    (exit $exit_code)
 
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
@@ -130,15 +158,13 @@ RUN echo \
     {{ $beatHome }}/.synthetics \
     {{ $beatHome }}/.npm \
     {{ $beatHome }}/.cache \
-    | xargs -IDIR sh -c 'mkdir -m 0775 -p DIR'
+    | xargs -IDIR sh -c 'mkdir -m 0770 -p DIR && chown -R {{ .user }} DIR'
 
-RUN (npm i -g --loglevel verbose --production --engine-strict  @elastic/synthetics@stack_release || sh -c 'tail -n +1 ${NPM_CONFIG_PREFIX}/_logs/* && exit 1') 
-
-USER root
-
+RUN (npm i -g --loglevel verbose --production --engine-strict  @elastic/synthetics@stack_release || sh -c 'tail -n +1 ${NPM_CONFIG_PREFIX}/_logs/* && exit 1')
 {{- end }}
 
 {{- if (and (eq .BeatName "heartbeat") (contains .from "ubuntu")) }}
+USER root
 ENV NODE_PATH={{ $beatHome }}/.node
 RUN echo \
     $NODE_PATH \
@@ -146,7 +172,7 @@ RUN echo \
     {{ $beatHome }}/.synthetics \
     {{ $beatHome }}/.npm \
     {{ $beatHome }}/.cache \
-    | xargs -IDIR sh -c 'mkdir -p DIR && chmod 0770 DIR'
+    | xargs -IDIR sh -c 'mkdir -m 0770 -p DIR && chown -R {{ .user }} DIR'
 
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
@@ -178,11 +204,10 @@ RUN cd /usr/share/heartbeat/.node \
 
 # Install synthetics as a regular user, installing npm deps as root odesn't work
 RUN chown -R {{ .user }} $NODE_PATH
-USER {{ .user }}
+
 # If this fails dump the NPM logs
 RUN npm i -g --loglevel verbose --production --engine-strict @elastic/synthetics@stack_release || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1'
-RUN chmod ug+rwX -R $NODE_PATH 
-USER root
+RUN chmod ug+rwX -R $NODE_PATH
 
 # Install the deps as needed by the exact version of playwright elastic synthetics uses
 # We don't use npx playwright install-deps because that could pull a newer version
@@ -197,10 +222,8 @@ RUN for iter in {1..10}; do \
 done; \
 (exit $exit_code)
 {{- end }}
-USER 1000
-{{- else }}
-USER 0
-{{- end }}
+
+USER {{ .user }}
 
 {{- range $i, $port := .ExposePorts }}
 EXPOSE {{ $port }}


### PR DESCRIPTION
## Proposed commit message

* New images with `-wolfi` suffix get created
* Wolfi is used for preparing the file structure for Docker images

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Script I use to build all the images:

```sh
#!/bin/bash

set -e

docker rmi -f $(docker images -a -q) || true

BEATS="auditbeat filebeat functionbeat heartbeat metricbeat packetbeat winlogbeat osquerybeat"
ROOT=$PWD

start_date=$(date)
for beat in $BEATS
do
		path="$ROOT/$beat"
		cd $path || echo "$path not found"
		mage clean
		(PLATFORMS=linux/arm64 PACKAGES=docker mage package) || (echo "failed to buid Docker image in $path" && exit 1)

		path="$ROOT/x-pack/$beat"
		cd $path || (echo "$path not found" && continue)
		mage clean
		(PLATFORMS=linux/arm64 PACKAGES=docker mage package) || (echo "failed to buid Docker image in $path" && exit 1)
done
cd $ROOT
end_date=$(date)
echo "started at $start_date and finished at $end_date"
```

List of images before the change:

```
REPOSITORY                                      TAG          IMAGE ID       CREATED          SIZE
docker.elastic.co/beats/auditbeat               8.16.0       47d631028605   33 minutes ago   253MB
docker.elastic.co/beats/auditbeat-oss           8.16.0       8f02578ac6fc   34 minutes ago   243MB
docker.elastic.co/beats/auditbeat-ubi           8.16.0       ed1d4b40ecd4   33 minutes ago   315MB
docker.elastic.co/beats/filebeat                8.16.0       81fc7f34f320   29 minutes ago   313MB
docker.elastic.co/beats/filebeat-oss            8.16.0       ddd6e8a553b4   31 minutes ago   243MB
docker.elastic.co/beats/filebeat-ubi            8.16.0       1ca6dc84362f   29 minutes ago   375MB
docker.elastic.co/beats/heartbeat               8.16.0       e840b42193f7   21 minutes ago   2.09GB
docker.elastic.co/beats/heartbeat-oss           8.16.0       9fe88a922414   25 minutes ago   2.07GB
docker.elastic.co/beats/heartbeat-ubi           8.16.0       ad974323e865   22 minutes ago   434MB
docker.elastic.co/beats/metricbeat              8.16.0       91ebb8e01fc1   16 minutes ago   340MB
docker.elastic.co/beats/metricbeat-oss          8.16.0       4dcdfedcae8d   17 minutes ago   273MB
docker.elastic.co/beats/metricbeat-ubi          8.16.0       79c288da30c4   16 minutes ago   402MB
docker.elastic.co/beats/packetbeat              8.16.0       dcddd3cc7436   13 minutes ago   382MB
docker.elastic.co/beats/packetbeat-oss          8.16.0       79fe32473cbd   14 minutes ago   363MB
docker.elastic.co/beats/packetbeat-ubi          8.16.0       3c0c0f84d3f8   13 minutes ago   444MB
```

List of images after the change:

```
REPOSITORY                                      TAG          IMAGE ID       CREATED          SIZE
docker.elastic.co/beats/auditbeat               8.16.0       cdd7ffd402ed   49 minutes ago   254MB
docker.elastic.co/beats/auditbeat-oss           8.16.0       d56fe6992533   50 minutes ago   243MB
docker.elastic.co/beats/auditbeat-ubi           8.16.0       7359220ecf21   49 minutes ago   249MB
docker.elastic.co/beats/auditbeat-wolfi         8.16.0       9a71ed55c01e   49 minutes ago   173MB
docker.elastic.co/beats/auditbeat-wolfi-oss     8.16.0       94243cbae7ea   50 minutes ago   163MB
docker.elastic.co/beats/filebeat                8.16.0       f2fef76dc249   45 minutes ago   314MB
docker.elastic.co/beats/filebeat-oss            8.16.0       e402f8404540   47 minutes ago   243MB
docker.elastic.co/beats/filebeat-ubi            8.16.0       952633d4345d   45 minutes ago   310MB
docker.elastic.co/beats/filebeat-wolfi          8.16.0       41657e24dbb6   45 minutes ago   234MB
docker.elastic.co/beats/filebeat-wolfi-oss      8.16.0       19cf32e6cab3   47 minutes ago   163MB
docker.elastic.co/beats/heartbeat               8.16.0       1054af2dc45e   38 minutes ago   1.97GB
docker.elastic.co/beats/heartbeat-oss           8.16.0       67f7108b24c6   42 minutes ago   1.96GB
docker.elastic.co/beats/heartbeat-ubi           8.16.0       cce02c244215   39 minutes ago   245MB
docker.elastic.co/beats/heartbeat-wolfi         8.16.0       cfabbd223126   38 minutes ago   1.56GB
docker.elastic.co/beats/heartbeat-wolfi-oss     8.16.0       1ac3fe4fd709   42 minutes ago   1.55GB
docker.elastic.co/beats/metricbeat              8.16.0       c76c12d6be58   34 minutes ago   344MB
docker.elastic.co/beats/metricbeat-oss          8.16.0       ee2bf310f6c4   35 minutes ago   277MB
docker.elastic.co/beats/metricbeat-ubi          8.16.0       355c5d4d8d6b   34 minutes ago   340MB
docker.elastic.co/beats/metricbeat-wolfi        8.16.0       0838b11505ab   34 minutes ago   264MB
docker.elastic.co/beats/metricbeat-wolfi-oss    8.16.0       c7b448a13179   35 minutes ago   197MB
docker.elastic.co/beats/packetbeat              8.16.0       02165d69c245   31 minutes ago   255MB
docker.elastic.co/beats/packetbeat-oss          8.16.0       63fc5f238efa   32 minutes ago   245MB
docker.elastic.co/beats/packetbeat-ubi          8.16.0       3053abbf83b4   31 minutes ago   250MB
docker.elastic.co/beats/packetbeat-wolfi        8.16.0       fe7595f1f10c   31 minutes ago   174MB
docker.elastic.co/beats/packetbeat-wolfi-oss    8.16.0       d77cd6ea972e   32 minutes ago   165MB
```

I made sure that containers are running normally by using this command and observing output:

```sh
docker run -it docker.elastic.co/beats/filebeat-wolfi:8.16.0 -e
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/pull/5062