### PR TITLE
golangci-lint - disable prealloc linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,6 @@ linters:
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.
     - gomodguard # check for blocked dependencies
-    - prealloc # Finds slice declarations that could potentially be pre-allocated
     - depguard
 
 # all available settings of specific linters


### PR DESCRIPTION
## Proposed commit message

This disables the prealloc linter. Having prealloc enabled on CI leads to false positives which cause build failures, and those are often addressed in ways that are worse for the codebase. For example, allocating an empty slice like `make([]string, 0)` resolves the linter finding but goes against best practices.

It can also be seen as a form of premature optimization, where you are making changes in the name of performance before you have done the performance profiling.

If you still want to check your code locally, you can use `--enable=prealloc` when running golangci-lint.

References

https://go.dev/wiki/CodeReviewComments#declaring-empty-slices

https://golangci-lint.run/usage/linters/#prealloc


