### PR TITLE
azure-eventhub input v2: Add processor_log_events config option

### DIFF
--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -50,6 +50,18 @@ type azureInputConfig struct {
 	// ProcessorStartPosition Controls the start position for all partitions
 	// (processor v2 only). Default is "earliest".
 	ProcessorStartPosition string `config:"processor_start_position"`
+	// ProcessorLogEvents controls if the processor should log
+	// internal events using the debug log level (processor v2 only).
+	// Default is false.
+	//
+	// When enabled, the processor logs the following events:
+	//
+	// - azeventhubs.EventConn
+	// - azeventhubs.EventAuth
+	// - azeventhubs.EventConsumer
+	//
+	// This option is useful for debugging purposes.
+	ProcessorLogEvents bool `config:"processor_log_events"`
 	// PartitionReceiveTimeout controls the batching of incoming messages together
 	// with `PartitionReceiveCount` (processor v2 only). Default is 5s.
 	//

--- a/x-pack/filebeat/input/azureeventhub/v2_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/checkpoints"
@@ -60,9 +61,23 @@ type eventHubInputV2 struct {
 // newEventHubInputV2 creates a new instance of the Azure Event Hub input v2,
 // that uses the modern Azure Event Hub SDK for Go.
 func newEventHubInputV2(config azureInputConfig, log *logp.Logger) (v2.Input, error) {
+	logger := log.Named(inputName)
+
+	if config.ProcessorLogEvents {
+		azlog.SetEvents(
+			azeventhubs.EventConn,
+			azeventhubs.EventAuth,
+			azeventhubs.EventConsumer,
+		)
+
+		azlog.SetListener(func(event azlog.Event, msg string) {
+			logger.Debugw(msg, "event", event)
+		})
+	}
+
 	return &eventHubInputV2{
 		config: config,
-		log:    log.Named(inputName),
+		log:    logger,
 	}, nil
 }
 

--- a/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
@@ -53,6 +53,10 @@ processor_update_interval: {{ .processor_update_interval }}
 processor_start_position: {{ .processor_start_position }}
 {{ end }}
 
+{{ if .processor_log_events }}
+processor_log_events: {{ .processor_log_events }}
+{{ end }}
+
 {{ if .partition_receive_timeout }}
 partition_receive_timeout: {{ .partition_receive_timeout }}
 {{ end }}

--- a/x-pack/filebeat/module/azure/activitylogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/manifest.yml
@@ -23,6 +23,8 @@ var:
     default: "10s"
   - name: processor_start_position
     default: "earliest"
+  - name: processor_log_events
+    default: no
   - name: partition_receive_timeout
     default: "5s"
   - name: partition_receive_count

--- a/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
@@ -51,6 +51,10 @@ processor_start_position: {{ .processor_start_position }}
 partition_receive_timeout: {{ .partition_receive_timeout }}
 {{ end }}
 
+{{ if .processor_log_events }}
+processor_log_events: {{ .processor_log_events }}
+{{ end }}
+
 {{ if .partition_receive_count }}
 partition_receive_count: {{ .partition_receive_count }}
 {{ end }}

--- a/x-pack/filebeat/module/azure/auditlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/manifest.yml
@@ -23,6 +23,8 @@ var:
     default: "10s"
   - name: processor_start_position
     default: "earliest"
+  - name: processor_log_events
+    default: no
   - name: partition_receive_timeout
     default: "5s"
   - name: partition_receive_count

--- a/x-pack/filebeat/module/azure/platformlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/platformlogs/config/azure-eventhub.yml
@@ -47,6 +47,10 @@ processor_update_interval: {{ .processor_update_interval }}
 processor_start_position: {{ .processor_start_position }}
 {{ end }}
 
+{{ if .processor_log_events }}
+processor_log_events: {{ .processor_log_events }}
+{{ end }}
+
 {{ if .partition_receive_timeout }}
 partition_receive_timeout: {{ .partition_receive_timeout }}
 {{ end }}

--- a/x-pack/filebeat/module/azure/platformlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/platformlogs/manifest.yml
@@ -22,6 +22,8 @@ var:
     default: "10s"
   - name: processor_start_position
     default: "earliest"
+  - name: processor_log_events
+    default: no
   - name: partition_receive_timeout
     default: "5s"
   - name: partition_receive_count

--- a/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
@@ -47,6 +47,10 @@ processor_update_interval: {{ .processor_update_interval }}
 processor_start_position: {{ .processor_start_position }}
 {{ end }}
 
+{{ if .processor_log_events }}
+processor_log_events: {{ .processor_log_events }}
+{{ end }}
+
 {{ if .partition_receive_timeout }}
 partition_receive_timeout: {{ .partition_receive_timeout }}
 {{ end }}

--- a/x-pack/filebeat/module/azure/signinlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/manifest.yml
@@ -23,6 +23,8 @@ var:
     default: "10s"
   - name: processor_start_position
     default: "earliest"
+  - name: processor_log_events
+    default: no
   - name: partition_receive_timeout
     default: "5s"
   - name: partition_receive_count


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

If `processor_log_events` is enabled, the input logs the following events:

- azeventhubs.EventConn
- azeventhubs.EventAuth
- azeventhubs.EventConsumer

Giving more visibility into the azeventhubs SDK internal activities.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
