### PR TITLE
azure-eventhub v2: update logging for consistency (and other minor fixes)

### DIFF
--- a/x-pack/filebeat/input/azureeventhub/v2_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input.go
@@ -457,6 +457,10 @@ func (in *eventHubInputV2) processEventsForPartition(ctx context.Context, partit
 		}
 
 		if len(events) == 0 {
+			in.log.Debugw(
+				"no events received",
+				"partition_id", partitionID,
+			)
 			continue
 		}
 

--- a/x-pack/filebeat/input/azureeventhub/v2_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input.go
@@ -388,7 +388,7 @@ func (in *eventHubInputV2) workersLoop(ctx context.Context, processor *azeventhu
 		go func() {
 			in.log.Infow(
 				"starting a partition worker",
-				"partition", partitionID,
+				"partition_id", partitionID,
 			)
 
 			if err := in.processEventsForPartition(ctx, processorPartitionClient); err != nil {
@@ -397,13 +397,13 @@ func (in *eventHubInputV2) workersLoop(ctx context.Context, processor *azeventhu
 				in.log.Infow(
 					"stopping processing events for partition",
 					"reason", err,
-					"partition", partitionID,
+					"partition_id", partitionID,
 				)
 			}
 
 			in.log.Infow(
 				"partition worker exited",
-				"partition", partitionID,
+				"partition_id", partitionID,
 			)
 		}()
 	}
@@ -428,7 +428,10 @@ func (in *eventHubInputV2) processEventsForPartition(ctx context.Context, partit
 		// 3/3 [END] Do cleanup here, like shutting down database clients
 		// or other resources used for processing this partition.
 		shutdownPartitionResources(ctx, partitionClient, pipelineClient)
-		in.log.Debugw("partition resources cleaned up", "partition", partitionID)
+		in.log.Debugw(
+			"partition resources cleaned up",
+			"partition_id", partitionID,
+		)
 	}()
 
 	// 2/3 [CONTINUOUS] Receive events, checkpointing as needed using UpdateCheckpoint.
@@ -444,7 +447,7 @@ func (in *eventHubInputV2) processEventsForPartition(ctx context.Context, partit
 			if errors.As(err, &eventHubError) && eventHubError.Code == azeventhubs.ErrorCodeOwnershipLost {
 				in.log.Infow(
 					"ownership lost for partition, stopping processing",
-					"partition", partitionID,
+					"partition_id", partitionID,
 				)
 
 				return nil
@@ -537,7 +540,7 @@ func initializePartitionResources(ctx context.Context, partitionClient *azeventh
 			if !ok {
 				log.Errorw(
 					"error updating checkpoint",
-					"partition", partitionClient.PartitionID(),
+					"partition_id", partitionClient.PartitionID(),
 					"acked", acked,
 					"error", "invalid data type",
 					"type", fmt.Sprintf("%T", data),
@@ -555,7 +558,7 @@ func initializePartitionResources(ctx context.Context, partitionClient *azeventh
 
 			log.Debugw(
 				"checkpoint updated",
-				"partition", partitionClient.PartitionID(),
+				"partition_id", partitionClient.PartitionID(),
 				"acked", acked,
 				"sequence_number", receivedEventData.SequenceNumber,
 				"offset", receivedEventData.Offset,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Minor changes for logging:

- Always use `partition_id` for consistency.
- Log 'no events received' (at debug level) when a consumer receives no events from its partition.

It also fixes other minor issues:

- Create one eventHubMetadata for each event to avoid eventHubMetadata values from previous events leaking into the current one (for example, partition_key).  

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

No disruptive User Impact is expected.

<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
## Related issues
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->



<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
