### PR TITLE
Dump artifact uri response body when fail decoding

### DIFF
--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
@@ -107,9 +108,13 @@ func snapshotURI(versionOverride string, config *artifact.Config) (string, error
 		Packages map[string]interface{} `json:"packages"`
 	}{}
 
-	dec := json.NewDecoder(resp.Body)
-	if err := dec.Decode(&body); err != nil {
-		return "", err
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading artifactsURI response: %w", err)
+	}
+
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		return "", fmt.Errorf("decoding artifactsURI response %s: %w", string(bodyBytes), err)
 	}
 
 	if len(body.Packages) == 0 {

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
@@ -179,7 +179,7 @@ func checkResponse(resp *gohttp.Response) ([]byte, error) {
 	}
 
 	if mediatype != "application/json" {
-		return nil, fmt.Errorf("unexpected media type in artifacts API response %q (parsed from %q)", mediatype, responseContentType)
+		return nil, fmt.Errorf("unexpected media type in artifacts API response %q (parsed from %q), body: %s", mediatype, responseContentType, bodyBytes)
 	}
 
 	return bodyBytes, nil

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
@@ -100,7 +100,12 @@ func snapshotURI(versionOverride string, config *artifact.Config) (string, error
 	}
 
 	artifactsURI := fmt.Sprintf("https://artifacts-api.elastic.co/v1/search/%s-SNAPSHOT/elastic-agent", version)
-	resp, err := client.Get(artifactsURI)
+	req, err := gohttp.NewRequestWithContext(context.Background(), gohttp.MethodGet, artifactsURI, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating artifacts API request to %q: %w", artifactsURI, err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
@@ -18,7 +18,6 @@ func Test_checkResponse(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []byte
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
@@ -33,7 +32,6 @@ func Test_checkResponse(t *testing.T) {
 					Body: io.NopCloser(strings.NewReader(`{"good": "job"}`)),
 				},
 			},
-			want:    []byte(`{"good": "job"}`),
 			wantErr: assert.NoError,
 		},
 		{
@@ -48,7 +46,6 @@ func Test_checkResponse(t *testing.T) {
 					Body: io.NopCloser(strings.NewReader(`{"not feeling": "too well"}`)),
 				},
 			},
-			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusInternalServerError), "error should contain http status code")
 				retval = assert.ErrorContains(t, err, `{"not feeling": "too well"}`, "error should contain response body") && retval
@@ -67,7 +64,6 @@ func Test_checkResponse(t *testing.T) {
 					Body: io.NopCloser(strings.NewReader(`{"bad": "gateway"}`)),
 				},
 			},
-			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusBadGateway), "error should contain http status code")
 				retval = assert.ErrorContains(t, err, `{"bad": "gateway"}`, "error should contain response body") && retval
@@ -86,7 +82,6 @@ func Test_checkResponse(t *testing.T) {
 					Body: io.NopCloser(bytes.NewReader([]byte{})),
 				},
 			},
-			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusServiceUnavailable), "error should contain http status code")
 			},
@@ -103,7 +98,6 @@ func Test_checkResponse(t *testing.T) {
 					Body: io.NopCloser(strings.NewReader(`{"gateway": "never got back to me"}`)),
 				},
 			},
-			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusGatewayTimeout), "error should contain http status code")
 				retval = assert.ErrorContains(t, err, `{"gateway": "never got back to me"}`, "error should contain response body") && retval
@@ -122,7 +116,6 @@ func Test_checkResponse(t *testing.T) {
 					Body: io.NopCloser(strings.NewReader(`<?xml version='1.0' encoding='UTF-8'?><note>Those who cannot remember the past are condemned to repeat it.</note>`)),
 				},
 			},
-			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				retval := assert.ErrorContains(t, err, "application/xml")
 				retval = assert.ErrorContains(t, err, `<?xml version='1.0' encoding='UTF-8'?><note>Those who cannot remember the past are condemned to repeat it.</note>`)
@@ -141,7 +134,6 @@ func Test_checkResponse(t *testing.T) {
 					Body: io.NopCloser(strings.NewReader(`<!DOCTYPE html><html><body>Hello world!</body></html>`)),
 				},
 			},
-			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				retval := assert.ErrorContains(t, err, "text/html")
 				retval = assert.ErrorContains(t, err, `<!DOCTYPE html><html><body>Hello world!</body></html>`)
@@ -151,12 +143,9 @@ func Test_checkResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := checkResponse(tt.args.resp)
+			err := checkResponse(tt.args.resp)
 			if !tt.wantErr(t, err) {
 				return
-			}
-			if !bytes.Equal(got, tt.want) {
-				t.Errorf("checkResponse() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package snapshot
 
 import (

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
@@ -51,9 +51,8 @@ func Test_checkResponse(t *testing.T) {
 				},
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusInternalServerError), "error should contain http status code")
-				retval = assert.ErrorContains(t, err, `{"not feeling": "too well"}`, "error should contain response body") && retval
-				return retval
+				return assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusInternalServerError), "error should contain http status code") &&
+					assert.ErrorContains(t, err, `{"not feeling": "too well"}`, "error should contain response body")
 			},
 		},
 		{
@@ -69,9 +68,8 @@ func Test_checkResponse(t *testing.T) {
 				},
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusBadGateway), "error should contain http status code")
-				retval = assert.ErrorContains(t, err, `{"bad": "gateway"}`, "error should contain response body") && retval
-				return retval
+				return assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusBadGateway), "error should contain http status code") &&
+					assert.ErrorContains(t, err, `{"bad": "gateway"}`, "error should contain response body")
 			},
 		},
 		{
@@ -103,9 +101,8 @@ func Test_checkResponse(t *testing.T) {
 				},
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusGatewayTimeout), "error should contain http status code")
-				retval = assert.ErrorContains(t, err, `{"gateway": "never got back to me"}`, "error should contain response body") && retval
-				return retval
+				return assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusGatewayTimeout), "error should contain http status code") &&
+					assert.ErrorContains(t, err, `{"gateway": "never got back to me"}`, "error should contain response body")
 			},
 		},
 		{
@@ -121,9 +118,8 @@ func Test_checkResponse(t *testing.T) {
 				},
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				retval := assert.ErrorContains(t, err, "application/xml")
-				retval = assert.ErrorContains(t, err, `<?xml version='1.0' encoding='UTF-8'?><note>Those who cannot remember the past are condemned to repeat it.</note>`)
-				return retval
+				return assert.ErrorContains(t, err, "application/xml") &&
+					assert.ErrorContains(t, err, `<?xml version='1.0' encoding='UTF-8'?><note>Those who cannot remember the past are condemned to repeat it.</note>`)
 			},
 		},
 		{
@@ -139,9 +135,8 @@ func Test_checkResponse(t *testing.T) {
 				},
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				retval := assert.ErrorContains(t, err, "text/html")
-				retval = assert.ErrorContains(t, err, `<!DOCTYPE html><html><body>Hello world!</body></html>`)
-				return retval
+				return assert.ErrorContains(t, err, "text/html") &&
+					assert.ErrorContains(t, err, `<!DOCTYPE html><html><body>Hello world!</body></html>`)
 			},
 		},
 	}

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader_test.go
@@ -1,0 +1,163 @@
+package snapshot
+
+import (
+	"bytes"
+	"io"
+	gohttp "net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_checkResponse(t *testing.T) {
+	type args struct {
+		resp *gohttp.Response
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Valid http response",
+			args: args{
+				resp: &gohttp.Response{
+					Status:     "OK",
+					StatusCode: gohttp.StatusOK,
+					Header: map[string][]string{
+						"Content-Type": {"application/json; charset=UTF-8"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"good": "job"}`)),
+				},
+			},
+			want:    []byte(`{"good": "job"}`),
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Bad http status code - 500",
+			args: args{
+				resp: &gohttp.Response{
+					Status:     "Not OK",
+					StatusCode: gohttp.StatusInternalServerError,
+					Header: map[string][]string{
+						"Content-Type": {"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"not feeling": "too well"}`)),
+				},
+			},
+			want: nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusInternalServerError), "error should contain http status code")
+				retval = assert.ErrorContains(t, err, `{"not feeling": "too well"}`, "error should contain response body") && retval
+				return retval
+			},
+		},
+		{
+			name: "Bad http status code - 502",
+			args: args{
+				resp: &gohttp.Response{
+					Status:     "Bad Gateway",
+					StatusCode: gohttp.StatusBadGateway,
+					Header: map[string][]string{
+						"Content-Type": {"application/json; charset=UTF-8"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"bad": "gateway"}`)),
+				},
+			},
+			want: nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusBadGateway), "error should contain http status code")
+				retval = assert.ErrorContains(t, err, `{"bad": "gateway"}`, "error should contain response body") && retval
+				return retval
+			},
+		},
+		{
+			name: "Bad http status code - 503",
+			args: args{
+				resp: &gohttp.Response{
+					Status:     "Service Unavailable",
+					StatusCode: gohttp.StatusServiceUnavailable,
+					Header: map[string][]string{
+						"Content-Type": {"application/json"},
+					},
+					Body: io.NopCloser(bytes.NewReader([]byte{})),
+				},
+			},
+			want: nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusServiceUnavailable), "error should contain http status code")
+			},
+		},
+		{
+			name: "Bad http status code - 504",
+			args: args{
+				resp: &gohttp.Response{
+					Status:     "Gateway timed out",
+					StatusCode: gohttp.StatusGatewayTimeout,
+					Header: map[string][]string{
+						"Content-Type": {"application/json; charset=UTF-8"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"gateway": "never got back to me"}`)),
+				},
+			},
+			want: nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				retval := assert.ErrorContains(t, err, strconv.Itoa(gohttp.StatusGatewayTimeout), "error should contain http status code")
+				retval = assert.ErrorContains(t, err, `{"gateway": "never got back to me"}`, "error should contain response body") && retval
+				return retval
+			},
+		},
+		{
+			name: "Wrong content type: XML",
+			args: args{
+				resp: &gohttp.Response{
+					Status:     "XML is back in, baby",
+					StatusCode: gohttp.StatusOK,
+					Header: map[string][]string{
+						"Content-Type": {"application/xml"},
+					},
+					Body: io.NopCloser(strings.NewReader(`<?xml version='1.0' encoding='UTF-8'?><note>Those who cannot remember the past are condemned to repeat it.</note>`)),
+				},
+			},
+			want: nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				retval := assert.ErrorContains(t, err, "application/xml")
+				retval = assert.ErrorContains(t, err, `<?xml version='1.0' encoding='UTF-8'?><note>Those who cannot remember the past are condemned to repeat it.</note>`)
+				return retval
+			},
+		},
+		{
+			name: "Wrong content type: HTML",
+			args: args{
+				resp: &gohttp.Response{
+					Status:     "HTML is always (not) machine-friendly",
+					StatusCode: gohttp.StatusOK,
+					Header: map[string][]string{
+						"Content-Type": {"text/html"},
+					},
+					Body: io.NopCloser(strings.NewReader(`<!DOCTYPE html><html><body>Hello world!</body></html>`)),
+				},
+			},
+			want: nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				retval := assert.ErrorContains(t, err, "text/html")
+				retval = assert.ErrorContains(t, err, `<!DOCTYPE html><html><body>Hello world!</body></html>`)
+				return retval
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkResponse(tt.args.resp)
+			if !tt.wantErr(t, err) {
+				return
+			}
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("checkResponse() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Add http response validation and dumpt the response in case of error when handling artifact URI response.
This should allow for easier investigation and debugging in case of wrong responses from `artifacts-api.elastic.co`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/5047

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
