### PR TITLE
Fix mockbeat stop

### DIFF
--- a/libbeat/tests/integration/http_test.go
+++ b/libbeat/tests/integration/http_test.go
@@ -64,7 +64,7 @@ output.console:
 	require.Equal(t, http.StatusOK, r.StatusCode, "incorrect status code")
 
 	body, err := io.ReadAll(r.Body)
-	r.Body.Close()
+	_ = r.Body.Close()
 	require.NoError(t, err)
 	var m map[string]interface{}
 	err = json.Unmarshal(body, &m)
@@ -90,14 +90,13 @@ output.console:
 	mockbeat.WriteConfigFile(cfg)
 	mockbeat.Start()
 	mockbeat.WaitForLogs("Starting stats endpoint", 60*time.Second)
-	time.Sleep(time.Second)
 
 	r, err := http.Get("http://localhost:5066/stats") //nolint:noctx // fine for tests
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, r.StatusCode, "incorrect status code")
 
 	body, err := io.ReadAll(r.Body)
-	r.Body.Close()
+	_ = r.Body.Close()
 	require.NoError(t, err)
 	var m Stats
 
@@ -125,11 +124,10 @@ output.console:
 	mockbeat.WriteConfigFile(cfg)
 	mockbeat.Start()
 	mockbeat.WaitForLogs("Starting stats endpoint", 60*time.Second)
-	time.Sleep(time.Second)
 
 	r, err := http.Get("http://localhost:5066/not-exist") //nolint:noctx // fine for tests
-	r.Body.Close()
 	require.NoError(t, err)
+	_ = r.Body.Close()
 	require.Equal(t, http.StatusNotFound, r.StatusCode, "incorrect status code")
 }
 
@@ -149,10 +147,9 @@ output.console:
 	mockbeat.WriteConfigFile(cfg)
 	mockbeat.Start()
 	mockbeat.WaitForLogs("Starting stats endpoint", 60*time.Second)
-	time.Sleep(time.Second)
 
 	r, err := http.Get("http://localhost:5066/debug/pprof/") //nolint:noctx // fine for tests
-	r.Body.Close()
 	require.NoError(t, err)
+	_ = r.Body.Close()
 	require.Equal(t, http.StatusNotFound, r.StatusCode, "incorrect status code")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
fix mockbeat Stop Functionality

* Refactor mockbeat Stop into two functions: 
    * `stopNonsynced`: performs the actual stop logic
    * `Stop`: synchronizes the `stop` function, allowing usage within methods that have already acquired the `cmdMutex`
* Implement wait logic in `stopNonsynced` to ensure the beat process fully stops before proceeding. This relies on the `"beatName stopped."` log message for confirmation.
* Remove the `time.Sleep` workaround from `./libbeat/tests/integration/http_test.go`, which was previously necessary due to incomplete beat stopping between tests. 
```


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

None


## How to test this PR locally

```
cd libbeat
mage buildSystemTestBinary && go test -v -tags integration -run TestHttp ./tests/integration
```

## Related issues

- N/A
