### PR TITLE
[filebeat] Add a configuration option for TCP/UDP network type

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -201,6 +201,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Added `ignore_empty_values` flag in `decode_cef` Filebeat processor. {pull}40268[40268]
 - Bump version of elastic/toutoumomoma to remove internal forks of stdlib debug packages. {pull}40325[40325]
 - Refactor x-pack/filebeat/input/websocket for generalisation. {pull}40308[40308]
+- Add a configuration option for TCP/UDP network type. {issue}40407[40407] {pull}40623[40623]
 
 ==== Deprecated
 

--- a/filebeat/docs/inputs/input-common-tcp-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-tcp-options.asciidoc
@@ -17,6 +17,12 @@ The maximum size of the message received over TCP. The default is `20MiB`.
 The host and TCP port to listen on for event streams.
 
 [float]
+[id="{beatname_lc}-input-{type}-tcp-network"]
+==== `network`
+
+The network type. Acceptable values are: "tcp" (default), "tcp4", "tcp6"
+
+[float]
 [id="{beatname_lc}-input-{type}-tcp-framing"]
 ==== `framing`
 

--- a/filebeat/docs/inputs/input-common-udp-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-udp-options.asciidoc
@@ -17,6 +17,12 @@ The maximum size of the message received over UDP. The default is `10KiB`.
 The host and UDP port to listen on for event streams.
 
 [float]
+[id="{beatname_lc}-input-{type}-udp-network"]
+==== `network`
+
+The network type. Acceptable values are: "udp" (default), "udp4", "udp6"
+
+[float]
 [id="{beatname_lc}-input-{type}-udp-read-buffer"]
 ==== `read_buffer`
 

--- a/filebeat/inputsource/tcp/config.go
+++ b/filebeat/inputsource/tcp/config.go
@@ -20,7 +20,6 @@ package tcp
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
@@ -40,11 +39,11 @@ type Config struct {
 	Network        string                  `config:"network"`
 }
 
-var validTCPNetworkValues = []string{
-	"tcp",
-	"tcp4",
-	"tcp6",
-}
+const (
+	networkTCP  = "tcp"
+	networkTCP4 = "tcp4"
+	networkTCP6 = "tcp6"
+)
 
 var (
 	ErrInvalidNetwork  = errors.New("invalid network value")
@@ -56,8 +55,10 @@ func (c *Config) Validate() error {
 	if len(c.Host) == 0 {
 		return ErrMissingHostPort
 	}
-	if c.Network != "" && !slices.Contains(validTCPNetworkValues, c.Network) {
-		return fmt.Errorf("%w: %s, expected: %v", ErrInvalidNetwork, c.Network, validTCPNetworkValues)
+	switch c.Network {
+	case "", networkTCP, networkTCP4, networkTCP6:
+	default:
+		return fmt.Errorf("%w: %s, expected: %v or %v or %v ", ErrInvalidNetwork, c.Network, networkTCP, networkTCP4, networkTCP6)
 	}
 	return nil
 }

--- a/filebeat/inputsource/tcp/config_test.go
+++ b/filebeat/inputsource/tcp/config_test.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tcp
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestValidate(t *testing.T) {
+	type testCfg struct {
+		name    string
+		cfg     Config
+		wantErr error
+	}
+
+	tests := []testCfg{
+		{
+			name: "ok",
+			cfg: Config{
+				Host: "localhost:9000",
+			},
+		},
+		{
+			name:    "nohost",
+			wantErr: ErrMissingHostPort,
+		},
+		{
+			name: "invalidnetwork",
+			cfg: Config{
+				Host:    "localhost:9000",
+				Network: "foo",
+			},
+			wantErr: ErrInvalidNetwork,
+		},
+	}
+
+	for _, network := range validTCPNetworkValues {
+		tests = append(tests, testCfg{
+			name: "network_" + network,
+			cfg: Config{
+				Host:    "localhost:9000",
+				Network: network,
+			},
+		})
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors())
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/filebeat/inputsource/tcp/config_test.go
+++ b/filebeat/inputsource/tcp/config_test.go
@@ -52,7 +52,7 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	for _, network := range validTCPNetworkValues {
+	for _, network := range []string{networkTCP, networkTCP4, networkTCP6} {
 		tests = append(tests, testCfg{
 			name: "network_" + network,
 			cfg: Config{

--- a/filebeat/inputsource/tcp/server.go
+++ b/filebeat/inputsource/tcp/server.go
@@ -91,5 +91,5 @@ func (s *Server) network() string {
 	if s.config.Network != "" {
 		return s.config.Network
 	}
-	return "tcp"
+	return networkTCP
 }

--- a/filebeat/inputsource/tcp/server.go
+++ b/filebeat/inputsource/tcp/server.go
@@ -67,14 +67,15 @@ func New(
 func (s *Server) createServer() (net.Listener, error) {
 	var l net.Listener
 	var err error
+	network := s.network()
 	if s.tlsConfig != nil {
 		t := s.tlsConfig.BuildServerConfig(s.config.Host)
-		l, err = tls.Listen("tcp", s.config.Host, t)
+		l, err = tls.Listen(network, s.config.Host, t)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		l, err = net.Listen("tcp", s.config.Host)
+		l, err = net.Listen(network, s.config.Host)
 		if err != nil {
 			return nil, err
 		}
@@ -84,4 +85,11 @@ func (s *Server) createServer() (net.Listener, error) {
 		return netutil.LimitListener(l, s.config.MaxConnections), nil
 	}
 	return l, nil
+}
+
+func (u *Server) network() string {
+	if u.config.Network != "" {
+		return u.config.Network
+	}
+	return "tcp"
 }

--- a/filebeat/inputsource/tcp/server.go
+++ b/filebeat/inputsource/tcp/server.go
@@ -87,9 +87,9 @@ func (s *Server) createServer() (net.Listener, error) {
 	return l, nil
 }
 
-func (u *Server) network() string {
-	if u.config.Network != "" {
-		return u.config.Network
+func (s *Server) network() string {
+	if s.config.Network != "" {
+		return s.config.Network
 	}
 	return "tcp"
 }

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -54,7 +54,8 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 }
 
 func TestReceiveEventsAndMetadata(t *testing.T) {
-	for _, network := range validTCPNetworkValues {
+	// Excluding tcp6 for now, since it fails in our CI
+	for _, network := range []string{networkTCP, networkTCP4} {
 		testReceiveEventsAndMetadata(t, network)
 	}
 }

--- a/filebeat/inputsource/udp/config.go
+++ b/filebeat/inputsource/udp/config.go
@@ -18,6 +18,9 @@
 package udp
 
 import (
+	"errors"
+	"fmt"
+	"slices"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
@@ -29,4 +32,21 @@ type Config struct {
 	MaxMessageSize cfgtype.ByteSize `config:"max_message_size" validate:"positive,nonzero"`
 	Timeout        time.Duration    `config:"timeout"`
 	ReadBuffer     cfgtype.ByteSize `config:"read_buffer" validate:"positive"`
+	Network        string           `config:"network"`
+}
+
+var validUDPNetworkValues = []string{
+	"udp",
+	"udp4",
+	"udp6",
+}
+
+var ErrInvalidNetwork = errors.New("invalid network value")
+
+// Validate validates the Config option for the udp input.
+func (c *Config) Validate() error {
+	if c.Network != "" && !slices.Contains(validUDPNetworkValues, c.Network) {
+		return fmt.Errorf("%w: %s, expected: %v", ErrInvalidNetwork, c.Network, validUDPNetworkValues)
+	}
+	return nil
 }

--- a/filebeat/inputsource/udp/config.go
+++ b/filebeat/inputsource/udp/config.go
@@ -20,7 +20,6 @@ package udp
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
@@ -35,18 +34,20 @@ type Config struct {
 	Network        string           `config:"network"`
 }
 
-var validUDPNetworkValues = []string{
-	"udp",
-	"udp4",
-	"udp6",
-}
+const (
+	networkUDP  = "udp"
+	networkUDP4 = "udp4"
+	networkUDP6 = "udp6"
+)
 
 var ErrInvalidNetwork = errors.New("invalid network value")
 
 // Validate validates the Config option for the udp input.
 func (c *Config) Validate() error {
-	if c.Network != "" && !slices.Contains(validUDPNetworkValues, c.Network) {
-		return fmt.Errorf("%w: %s, expected: %v", ErrInvalidNetwork, c.Network, validUDPNetworkValues)
+	switch c.Network {
+	case "", networkUDP, networkUDP4, networkUDP6:
+	default:
+		return fmt.Errorf("%w: %s, expected: %v or %v or %v", ErrInvalidNetwork, c.Network, networkUDP, networkUDP4, networkUDP6)
 	}
 	return nil
 }

--- a/filebeat/inputsource/udp/config_test.go
+++ b/filebeat/inputsource/udp/config_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package udp
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestValidate(t *testing.T) {
+	type testCfg struct {
+		name    string
+		cfg     Config
+		wantErr error
+	}
+
+	tests := []testCfg{
+		{
+			name: "ok",
+			cfg: Config{
+				Host: "localhost:8080",
+			},
+		},
+		{
+			name: "invalidnetwork",
+			cfg: Config{
+				Host:    "localhost:8080",
+				Network: "foo",
+			},
+			wantErr: ErrInvalidNetwork,
+		},
+	}
+
+	for _, network := range validUDPNetworkValues {
+		tests = append(tests, testCfg{
+			name: "network_" + network,
+			cfg: Config{
+				Host:    "localhost:8080",
+				Network: network,
+			},
+		})
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors())
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/filebeat/inputsource/udp/config_test.go
+++ b/filebeat/inputsource/udp/config_test.go
@@ -48,7 +48,7 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	for _, network := range validUDPNetworkValues {
+	for _, network := range []string{networkUDP, networkUDP4, networkUDP6} {
 		tests = append(tests, testCfg{
 			name: "network_" + network,
 			cfg: Config{

--- a/filebeat/inputsource/udp/server.go
+++ b/filebeat/inputsource/udp/server.go
@@ -77,5 +77,5 @@ func (u *Server) network() string {
 	if u.config.Network != "" {
 		return u.config.Network
 	}
-	return "udp"
+	return networkUDP
 }

--- a/filebeat/inputsource/udp/server.go
+++ b/filebeat/inputsource/udp/server.go
@@ -53,11 +53,12 @@ func New(config *Config, callback inputsource.NetworkFunc) *Server {
 
 func (u *Server) createConn() (net.PacketConn, error) {
 	var err error
-	udpAdddr, err := net.ResolveUDPAddr("udp", u.config.Host)
+	network := u.network()
+	udpAdddr, err := net.ResolveUDPAddr(network, u.config.Host)
 	if err != nil {
 		return nil, err
 	}
-	listener, err := net.ListenUDP("udp", udpAdddr)
+	listener, err := net.ListenUDP(network, udpAdddr)
 	if err != nil {
 		return nil, err
 	}
@@ -70,4 +71,11 @@ func (u *Server) createConn() (net.PacketConn, error) {
 	u.localaddress = listener.LocalAddr().String()
 
 	return listener, err
+}
+
+func (u *Server) network() string {
+	if u.config.Network != "" {
+		return u.config.Network
+	}
+	return "udp"
 }

--- a/filebeat/inputsource/udp/server_test.go
+++ b/filebeat/inputsource/udp/server_test.go
@@ -41,7 +41,7 @@ type info struct {
 
 func TestReceiveEventFromUDP(t *testing.T) {
 	// Excluding udp6 for now, since it fails in our CI
-	for _, network := range []string{networkUDP, networkUDP6} {
+	for _, network := range []string{networkUDP, networkUDP4} {
 		t.Run(network, func(t *testing.T) {
 			testReceiveEventFromUDPWithNetwork(t, network)
 		})

--- a/filebeat/inputsource/udp/server_test.go
+++ b/filebeat/inputsource/udp/server_test.go
@@ -40,6 +40,14 @@ type info struct {
 }
 
 func TestReceiveEventFromUDP(t *testing.T) {
+	for _, network := range validUDPNetworkValues {
+		t.Run(network, func(t *testing.T) {
+			testReceiveEventFromUDPWithNetwork(t, network)
+		})
+	}
+}
+
+func testReceiveEventFromUDPWithNetwork(t *testing.T, network string) {
 	tests := []struct {
 		name     string
 		message  []byte
@@ -64,6 +72,7 @@ func TestReceiveEventFromUDP(t *testing.T) {
 		MaxMessageSize: maxMessageSize,
 		Timeout:        timeout,
 		ReadBuffer:     maxSocketSize,
+		Network:        network,
 	}
 	fn := func(message []byte, metadata inputsource.NetworkMetadata) {
 		ch <- info{message: message, mt: metadata}
@@ -77,7 +86,7 @@ func TestReceiveEventFromUDP(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			conn, err := net.Dial("udp", s.localaddress)
+			conn, err := net.Dial(s.network(), s.localaddress)
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/filebeat/inputsource/udp/server_test.go
+++ b/filebeat/inputsource/udp/server_test.go
@@ -40,7 +40,8 @@ type info struct {
 }
 
 func TestReceiveEventFromUDP(t *testing.T) {
-	for _, network := range validUDPNetworkValues {
+	// Excluding udp6 for now, since it fails in our CI
+	for _, network := range []string{networkUDP, networkUDP6} {
 		t.Run(network, func(t *testing.T) {
 			testReceiveEventFromUDPWithNetwork(t, network)
 		})


### PR DESCRIPTION
## Proposed commit message

Add a configuration option for TCP/UDP network type.

Description below is copied from the ticket https://github.com/elastic/beats/issues/40407:

The TCP input would accept these values for the network type:
- `tcp` (default)
- `tcp4`
- `tcp6`

The UDP input would accept these values for the network type:
- `udp` (default)
- `udp4`
- `udp6`

## Examples

```
filebeat.inputs:
- type: tcp
  max_message_size: 10MiB
  host: "localhost:9000"
  network: tcp4
```

```
filebeat.inputs:
- type: udp
  max_message_size: 10KiB
  host: "localhost:8080"
  network: udp4
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/40407

## Screenshots

<img width="747" alt="Screenshot 2024-08-26 at 2 24 51 PM" src="https://github.com/user-attachments/assets/49f42c1d-dda6-4112-b3b9-5396234814c0">

<img width="715" alt="Screenshot 2024-08-26 at 2 25 21 PM" src="https://github.com/user-attachments/assets/4a3267b8-7e9e-4ffa-8463-acd7c21f27e2">

<img width="751" alt="Screenshot 2024-08-26 at 2 41 42 PM" src="https://github.com/user-attachments/assets/c583d7dc-0228-4e1f-8ba1-67c8b5e49135">

