### PR TITLE
x-pack/filebeat/inputs/awss3 - Handle SQS notification without region

### DIFF
--- a/x-pack/filebeat/input/awss3/interfaces.go
+++ b/x-pack/filebeat/input/awss3/interfaces.go
@@ -305,7 +305,7 @@ func (a *awsS3API) clientFor(region string) *s3.Client {
 	// Conditionally replace the client if the region of
 	// the request does not match the pre-prepared client.
 	opts := a.client.Options()
-	if opts.Region == region {
+	if region == "" || opts.Region == region {
 		return a.client
 	}
 	// Use a cached client if we have already seen this region.

--- a/x-pack/filebeat/input/awss3/interfaces_test.go
+++ b/x-pack/filebeat/input/awss3/interfaces_test.go
@@ -1,0 +1,25 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awss3
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestAWSS3API_clientFor(t *testing.T) {
+	// When SQS notifications do not contain a region (like Crowdstrike FDR's
+	// custom notifications), then the default pre-made S3 client should be used.
+	t.Run("empty_region_uses_pre_made_client", func(t *testing.T) {
+		want := s3.New(s3.Options{Region: "us-east-1"})
+		api := newAWSs3API(want)
+		got := api.clientFor("")
+
+		if want != got {
+			t.Errorf("Empty region should return the default premade client: want %p, got %p", want, got)
+		}
+	})
+}


### PR DESCRIPTION
## Proposed commit message

When a region is not specified in the SQS notification then reuse the existing S3 client instead of creating a new one based on an empty (unspecified) AWS region name. This problem affected custom SQS notification formats that did not specify a region name (like Crowdstrike FDR notifications).

This addresses errors like:
    
    S3 download failure: s3 GetObject failed: operation error S3: GetObject, resolve auth scheme: resolve endpoint: endpoint rule error, Invalid region: region was not a valid DNS name.


Fixes: elastic/integrations/#10647
Relates: elastic/beats#40309

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Fixes: elastic/integrations/#10647
- Relates: elastic/beats#40309
