### PR TITLE
[Backport] [main] [40631] [RELEASE NOTES] Known issue azure-eventhub in Windows / 8.15

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,6 +7,12 @@
 === Beats version 8.15.0
 https://github.com/elastic/beats/compare/v8.14.3\...v8.15.0[View commits]
 
+==== Known issues
+
+*Filebeat*
+
+- The Azure EventHub input in Filebeat is not found when running on Windows. Please refrain from upgrading to 8.15. See {issue}40608[40608] for details.
+
 ==== Breaking changes
 
 *Filebeat*


### PR DESCRIPTION
Manual forward-port of #40631 to main

This just makes sure the change will appear in the 8.15 Release Notes for later docs versions (8.16, ...).