### PR TITLE
Filtered node stats collection to required metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -191,6 +191,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix Azure Monitor metric timespan to restore Storage Account PT1H metrics {issue}40376[40376] {pull}40367[40367]
 - Remove excessive info-level logs in cgroups setup {pull}40491[40491]
 - Add missing ECS Cloud fields in GCP `metrics` metricset when using `exclude_labels: true` {issue}40437[40437] {pull}40467[40467]
+- Filtered node stats collection to required metrics for elasticsearch module. {issue}40183[40183] {pull}40664[40664]
 
 *Osquerybeat*
 

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -35,8 +35,8 @@ func init() {
 }
 
 const (
-	nodeLocalStatsPath = "/_nodes/_local/stats"
-	nodesAllStatsPath  = "/_nodes/_all/stats"
+	nodeLocalStatsPath = "/_nodes/_local/stats/jvm,indices,fs,os,process,thread_pool,indexing_pressure,ingest"
+	nodesAllStatsPath  = "/_nodes/_all/stats/jvm,indices,fs,os,process,thread_pool,indexing_pressure,ingest"
 )
 
 // MetricSet type defines all fields of the MetricSet


### PR DESCRIPTION
## Proposed commit message

Aim of the enhancement :
- Reduce resources needs by node stats API call by reducing number of metrics
- By extension when an elasticsearch node is very close to parent circuit breaker limit, reducing amount of stats collected reduces change of node failure to return node stats due to parent circuit breaker trip
- In case a specific metric collection fail for a node (example snapshot repository stats collection failure), this causes the node to return a failure and no stats is returned at all when requesting all metricsets

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - N/A
- [x] I have made corresponding change to the default configuration files - N/A
- [x] I have added tests that prove my fix is effective or that my feature works - N/A
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

Tested metricbeat elasticsearch module with all metricsets and saw no error and monitoring data is retrieved in stack monitoring 

## Author's Checklist

- [ ] I am not a developer so did not know if I should create an array with the metrics, create a method to join, I just appended the hardcoded comma-separated metrics to previously hardcoded URL for node/cluster scope for node stats API
- [x] I checked that with default scope `GET /_nodes/_local/stats/jvm,indices,fs,os,process,thread_pool,indexing_pressure,ingest` is sent to elasticsearch, and with `cluster` scope `GET /_nodes/_all/stats/jvm,indices,fs,os,process,thread_pool,indexing_pressure,ingest`

## How to test this PR locally

- Check code compiles
- Test with node stats on `local` and `cluster` scope

## Related issues

- Closes #40183