### PR TITLE
Fix invalid URL and add metricsets and scope to elasticsearch-xpack.yml.disabled

### DIFF
--- a/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
@@ -1,11 +1,24 @@
 # Module: elasticsearch
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-elasticsearch.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
+  #metricsets:
+  #  - ccr
+  #  - cluster_stats
+  #  - enrich
+  #  - index
+  #  - index_recovery
+  #  - index_summary
+  #  - ingest_pipeline
+  #  - ml_job
+  #  - node
+  #  - node_stats
+  #  - pending_tasks
+  #  - shard
   xpack.enabled: true
   period: 10s
   hosts: ["http://localhost:9200"]
   #username: "user"
   #password: "secret"
   #api_key: "foo:bar"
-
+  #scope: node


### PR DESCRIPTION
## Proposed commit message

- elasticsearch-xpack.yml.disabled contains an invalid hyperlink which is fixed
- Also adding metricsets and scope commented-out settings for convenience/completeness
- I wasn't sure to use `doc` label given the file is part of the metricbeat release I used `enhancement`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas - N/A
- [x] I have made corresponding changes to the documentation / N/A
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works - N/A
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`. - No release notes change needed (added commented-out settings on a disabled template file and fixed a documentation URL)

## Disruptive User Impact

No impact

## Author's Checklist

- [x] Checked metricsets are the currently supported list (versus no list previously)

## How to test this PR locally

- check metricbeat compiles - there is no used file modified in this PR