### PR TITLE
refactor fleet mode detection and storage

### DIFF
--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -18,6 +18,7 @@
 package cfgfile
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -97,6 +98,8 @@ func GetDefaultCfgfile() string {
 }
 
 // HandleFlags adapts default config settings based on command line flags.
+// This also stores if -E management.enabled=true was set on command line
+// to determine if running the Beat under agent.
 func HandleFlags() error {
 	// default for the home path is the binary location
 	home, err := filepath.Abs(filepath.Dir(os.Args[0]))
@@ -114,6 +117,27 @@ func HandleFlags() error {
 		common.PrintConfigDebugf(overwrites, "CLI setting overwrites (-E flag):")
 	}
 
+	// Enable check to see if beat is running under Agent
+	// This is stored in a package so the modules which don't have
+	// access to the config can check this value.
+	type management struct {
+		Enabled bool `config:"management.enabled"`
+	}
+	var managementSettings management
+	cfgFlag := flag.Lookup("E")
+	if cfgFlag == nil {
+		fleetmode.SetAgentMode(false)
+		return nil
+	}
+	cfgObject, _ := cfgFlag.Value.(*config.SettingsFlag)
+	cliCfg := cfgObject.Config()
+
+	err = cliCfg.Unpack(&managementSettings)
+	if err != nil {
+		fleetmode.SetAgentMode(false)
+		return nil
+	}
+	fleetmode.SetAgentMode(managementSettings.Enabled)
 	return nil
 }
 

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -135,7 +135,7 @@ func HandleFlags() error {
 	err = cliCfg.Unpack(&managementSettings)
 	if err != nil {
 		fleetmode.SetAgentMode(false)
-		return nil
+		return nil //nolint:nilerr // unpacking failing isn't an error for this case
 	}
 	fleetmode.SetAgentMode(managementSettings.Enabled)
 	return nil

--- a/libbeat/common/fleetmode/fleet_mode.go
+++ b/libbeat/common/fleetmode/fleet_mode.go
@@ -17,33 +17,18 @@
 
 package fleetmode
 
-import (
-	"flag"
+var managementEnabled bool
 
-	"github.com/elastic/elastic-agent-libs/config"
-)
+// SetAgentMode stores if the Beat is running under Elastic Agent.
+// Normally this is called when the command line flags are parsed.
+// This is stored as a package level variable because some components
+// (like filebeat/metricbeat modules) don't have access to the
+// configuration information to determine this on their own.
+func SetAgentMode(enabled bool) {
+	managementEnabled = enabled
+}
 
-// Enabled checks to see if filebeat/metricbeat is running under Agent
-// The management setting is stored in the main Beat runtime object, but we can't see that from a module
-// So instead we check the CLI flags, since Agent starts filebeat/metricbeat with "-E", "management.enabled=true"
+// Enabled returns true if the Beat is running under Elastic Agent.
 func Enabled() bool {
-	type management struct {
-		Enabled bool `config:"management.enabled"`
-	}
-	var managementSettings management
-
-	cfgFlag := flag.Lookup("E")
-	if cfgFlag == nil {
-		return false
-	}
-
-	cfgObject, _ := cfgFlag.Value.(*config.SettingsFlag)
-	cliCfg := cfgObject.Config()
-
-	err := cliCfg.Unpack(&managementSettings)
-	if err != nil {
-		return false
-	}
-
-	return managementSettings.Enabled
+	return managementEnabled
 }


### PR DESCRIPTION
## Proposed commit message

refactor fleet mode detection and storage

Currently the fleet mode is only detected by looking at the command
line flags.  This refactor keeps that behavior but also adds the
ability to set the value based independently.  This is important if
you were to embed a Beat within elastic-agent and have it behave as
fleet managed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

There should be no user observed change.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

- run `elastic-agent` test suite with agentbeat built from this patch.

## Related issues

- Relates #40110

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
