### PR TITLE
skip agent downloaders that fail initialization

### DIFF
--- a/x-pack/elastic-agent/pkg/artifact/download/composed/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/composed/downloader_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/program"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
 type FailingDownloader struct {
@@ -58,7 +59,9 @@ func TestComposed(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		d := NewDownloader(tc.downloaders[0], tc.downloaders[1])
+		log, _ := logger.New("", false)
+
+		d := NewDownloader(log, tc.downloaders[0], tc.downloaders[1])
 		r, _ := d.Download(context.TODO(), program.Spec{Name: "a", Cmd: "a", Artifact: "a/a"}, "b")
 
 		assert.Equal(t, tc.expectedResult, r == "succ")

--- a/x-pack/elastic-agent/pkg/artifact/download/localremote/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/localremote/downloader.go
@@ -37,5 +37,5 @@ func NewDownloader(log *logger.Logger, config *artifact.Config) (download.Downlo
 	}
 
 	downloaders = append(downloaders, httpDownloader)
-	return composed.NewDownloader(downloaders...), nil
+	return composed.NewDownloader(log, downloaders...), nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This change allows `elastic-agent upgrade` to proceed even if some of the artifact downloaders (snapshot or http) fail initializing. The failed downloaders will be skipped and an error log will be printed but the agent will try to fetch the required artifacts from the remaining downloaders.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Package elastic-agent using a version that does not appear on https://artifacts-api.elastic.co/v1/versions/, place it somewhere on the filesystem and trigger an upgrade using the `--source-uri` option to point at the new version package on the filesystem, for example

```shell
root@elastic-agent-dev:/opt/Elastic/Agent# elastic-agent upgrade --skip-verify --source-uri="file:///home/vagrant/elastic-agent/" 8.15.2-SNAPSHOT
```

Without this change, the agent will print an error similar to:
```
Error: Failed trigger upgrade of daemon: initiating fetcher: failed to detect remote snapshot repo, proceeding with configured: checking artifacts api response: unsuccessful status code 404 in artifactsURI
full response:
HTTP/1.1 404 Not Found
Transfer-Encoding: chunked
Connection: keep-alive
Content-Security-Policy: object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;
Content-Type: application/json;charset=utf-8
Date: Fri, 06 Sep 2024 08:22:00 GMT
Strict-Transport-Security: max-age=15724800; includeSubDomains
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: DENY
X-Permitted-Cross-Domain-Policies: none
X-Xss-Protection: 1; mode=block

32
{"error-message":"Build/Branch/Version not found"}
0
```

The upgrade is possible because we have the necessary package on the filesystem but the upgrade terminates early because we are failing to initialize the snapshot downloader.

Using the change in this PR, the upgrade succeeds (skipping the failed snapshot downloader) as expected
```
oot@elastic-agent-dev:/opt/Elastic/Agent/data/elastic-agent-bc2cbf# elastic-agent upgrade --skip-verify --source-uri="file:///home/vagrant/elastic-agent/" 8.15.2-SNAPSHOT
Upgrade triggered to version 8.15.2-SNAPSHOT, Elastic Agent is currently restarting
root@elastic-agent-dev:/opt/Elastic/Agent/data/elastic-agent-bc2cbf# elastic-agent version
sh: 0: getcwd() failed: No such file or directory
Binary: 8.15.2-SNAPSHOT (build: cb8d8ec6979c16e63640ea90b9a8a9e05eb4b950 at 2024-09-05 18:47:59 +0000 UTC)
Daemon: 8.15.2-SNAPSHOT (build: cb8d8ec6979c16e63640ea90b9a8a9e05eb4b950 at 2024-09-05 18:47:59 +0000 UTC)
```



<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
