### PR TITLE
Automatically label PRs to `main` with `backport-v8.x`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -147,6 +147,11 @@ pull_request_rules:
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
           * `backport-v8./d.0` is the label to automatically backport to the `8./d` branch. `/d` is the digit
+
+          **NOTE**: `backport-v8.x` has been added to help with the transition to the new branch 8.x.
+      label:
+        add:
+          - backport-8.x
   - name: notify the backport has not been merged yet
     conditions:
       - -merged

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -148,7 +148,7 @@ pull_request_rules:
           branches, such as:
           * `backport-v8./d.0` is the label to automatically backport to the `8./d` branch. `/d` is the digit
 
-          **NOTE**: `backport-v8.x` has been added to help with the transition to the new branch 8.x.
+          **NOTE**: `backport-8.x` has been added to help with the transition to the new branch 8.x.
       label:
         add:
           - backport-8.x

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -148,10 +148,10 @@ pull_request_rules:
           branches, such as:
           * `backport-v8./d.0` is the label to automatically backport to the `8./d` branch. `/d` is the digit
 
-          **NOTE**: `backport-8.x` has been added to help with the transition to the new branch 8.x.
+          **NOTE**: `backport-v8.x` has been added to help with the transition to the new branch 8.x.
       label:
         add:
-          - backport-8.x
+          - backport-v8.x
   - name: notify the backport has not been merged yet
     conditions:
       - -merged


### PR DESCRIPTION
When the `main` branch switches over to `9.0`, we will want most PRs that are merged into `main` to also be backported to `8.x`. This PR makes this process easier by automatically adding the `backport-8.x` label to all PRs targeting the `main` branch.

The exceptions will be PRs for changes that should _only_ be present in `9.0`.  For such PRs, authors should simply remove the `backport-8.x` label from their PR.
