### PR TITLE
[Metricbeat] Compare previous/current cluster state in the `elasticsearch.shard` metricset

### DIFF
--- a/changelog/fragments/1786619647-skip-unchanged-elasticsearch-shard-docs.yaml
+++ b/changelog/fragments/1786619647-skip-unchanged-elasticsearch-shard-docs.yaml
@@ -1,0 +1,26 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Skip unchanged elasticsearch.shard docs when cluster state UUID is unchanged
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# OPTIONAL
+pr: https://github.com/elastic/beats/pull/40731
+
+# OPTIONAL
+issue: https://github.com/elastic/beats/issues/39058

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -20,12 +20,12 @@ package shard
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
-
-	"fmt"
 
 	s "github.com/elastic/beats/v7/libbeat/common/schema"
 	c "github.com/elastic/beats/v7/libbeat/common/schema/mapstriface"
@@ -57,11 +57,28 @@ type stateStruct struct {
 	} `json:"routing_table"`
 }
 
-func eventsMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
+func eventsMapping(r mb.ReporterV2, content []byte, isXpack bool, prev *lastClusterState, log *logp.Logger) error {
 	stateData := &stateStruct{}
 	err := json.Unmarshal(content, stateData)
 	if err != nil {
 		return fmt.Errorf("failure parsing Elasticsearch Cluster State API response: %w", err)
+	}
+
+	// Only proceed if the cluster state has changed.
+	// See https://github.com/elastic/beats/issues/39058
+	if prev != nil && prev.ok && prev.id == stateData.StateID {
+		return nil
+	}
+	if log != nil {
+		prevID := ""
+		if prev != nil && prev.ok {
+			prevID = prev.id
+		}
+		log.Debugf("cluster state has changed from %q to %q, sending new shard data", prevID, stateData.StateID)
+	}
+	if prev != nil {
+		prev.id = stateData.StateID
+		prev.ok = true
 	}
 
 	var errs []error
@@ -160,9 +177,9 @@ func getSourceNode(nodeID string, stateData *stateStruct) (mapstr.M, error) {
 	}, nil
 }
 
-// Note: This function may generate duplicate IDs, but those will be dropped since libbeat
-// ignores the 409 status code
-// https://github.com/elastic/beats/blob/main/libbeat/outputs/elasticsearch/client.go#L396
+// Note: This function will not generate duplicate IDs when eventsMapping skips unchanged
+// cluster states (same state_uuid), thus preserving bandwidth and ES resources.
+// See https://github.com/elastic/beats/issues/39058
 func generateHashForEvent(stateID string, shard mapstr.M, index int) (string, error) {
 	var nodeID string
 	if shard["node"] == nil {

--- a/metricbeat/module/elasticsearch/shard/data_test.go
+++ b/metricbeat/module/elasticsearch/shard/data_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
+	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/stretchr/testify/require"
 
@@ -36,15 +37,69 @@ func TestStats(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range files {
-		input, err := os.ReadFile(f)
-		require.NoError(t, err)
+		t.Run(filepath.Base(f), func(t *testing.T) {
+			input, err := os.ReadFile(f)
+			require.NoError(t, err)
 
-		reporter := &mbtest.CapturingReporterV2{}
-		eventsMapping(reporter, input, true)
+			reporter := &mbtest.CapturingReporterV2{}
+			_ = eventsMapping(reporter, input, true, &lastClusterState{}, logp.NewLogger("test"))
 
-		require.True(t, len(reporter.GetEvents()) >= 1)
-		require.Equal(t, 0, len(reporter.GetErrors()))
+			require.True(t, len(reporter.GetEvents()) >= 1)
+			require.Equal(t, 0, len(reporter.GetErrors()))
+		})
 	}
+}
+
+func TestEventsMappingSkipsUnchangedClusterState(t *testing.T) {
+	input, err := os.ReadFile("./_meta/test/routing_table.710.json")
+	require.NoError(t, err)
+
+	prev := &lastClusterState{}
+	log := logp.NewLogger("test")
+
+	first := &mbtest.CapturingReporterV2{}
+	require.NoError(t, eventsMapping(first, input, true, prev, log))
+	require.NotEmpty(t, first.GetEvents())
+	require.True(t, prev.ok)
+	require.Equal(t, "n-UoXaqYRoOe9qAC76IG6A", prev.id)
+
+	second := &mbtest.CapturingReporterV2{}
+	require.NoError(t, eventsMapping(second, input, true, prev, log))
+	require.Empty(t, second.GetEvents())
+	require.Equal(t, "n-UoXaqYRoOe9qAC76IG6A", prev.id)
+}
+
+func TestEventsMappingEmitsWhenClusterStateChanges(t *testing.T) {
+	input, err := os.ReadFile("./_meta/test/routing_table.710.json")
+	require.NoError(t, err)
+
+	prev := &lastClusterState{}
+	log := logp.NewLogger("test")
+
+	first := &mbtest.CapturingReporterV2{}
+	require.NoError(t, eventsMapping(first, input, true, prev, log))
+	require.NotEmpty(t, first.GetEvents())
+	require.Equal(t, "n-UoXaqYRoOe9qAC76IG6A", prev.id)
+
+	changed := []byte(`{"cluster_name":"docker-cluster","cluster_uuid":"tMjf3CQ_TyCXNfcoR9eTWw","state_uuid":"changed-state-uuid","master_node":"hx-oJ1-aT_-5pRG22JMI1Q","nodes":{"hx-oJ1-aT_-5pRG22JMI1Q":{"name":"1fb2aa83efac"}},"routing_table":{"indices":{"test":{"shards":{"0":[{"state":"STARTED","primary":true,"node":"hx-oJ1-aT_-5pRG22JMI1Q","relocating_node":null,"shard":0,"index":"test"}]}}}}}`)
+	second := &mbtest.CapturingReporterV2{}
+	require.NoError(t, eventsMapping(second, changed, true, prev, log))
+	require.NotEmpty(t, second.GetEvents())
+	require.Equal(t, "changed-state-uuid", prev.id)
+}
+
+func TestEventsMappingEmitsFirstFetchWithEmptyStateUUID(t *testing.T) {
+	// Fixtures without state_uuid must still emit on the first fetch; an empty
+	// initial tracker must not be treated as "unchanged".
+	input, err := os.ReadFile("./_meta/test/routing_table.623.json")
+	require.NoError(t, err)
+
+	prev := &lastClusterState{}
+	reporter := &mbtest.CapturingReporterV2{}
+	_ = eventsMapping(reporter, input, true, prev, logp.NewLogger("test"))
+	require.NotEmpty(t, reporter.GetEvents())
+	require.True(t, prev.ok)
+	require.Equal(t, "", prev.id)
 }
 
 func TestData(t *testing.T) {

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -37,6 +37,14 @@ const (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*elasticsearch.MetricSet
+	lastClusterState lastClusterState
+}
+
+// lastClusterState tracks the most recently observed cluster state UUID for this
+// metricset instance so unchanged states can be skipped.
+type lastClusterState struct {
+	id string
+	ok bool
 }
 
 // New create a new instance of the MetricSet
@@ -64,5 +72,5 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return err
 	}
 
-	return eventsMapping(r, content, m.XPackEnabled)
+	return eventsMapping(r, content, m.XPackEnabled, &m.lastClusterState, m.Logger())
 }


### PR DESCRIPTION
This PR adds logic to compare the cluster state UUID between two runs and only send `elasticsearch.shard` documents if the cluster state has effectively changed. Doing so not only helps save bandwidth as well as ES resources (CPU, thread pools, etc) but also prevents the `indexing_failed` counter from increasing upon each HTTP 409.

## Proposed commit message

Only index `elasticsearch.shard` documents if there are changes in the cluster state

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None, as no new `shard` documents are indexed unless the cluster state changes.

## Related issues

Closes https://github.com/elastic/beats/issues/39058
