### PR TITLE
testing: Fix Docker deprecation warnings

### DIFF
--- a/testing/environments/Dockerfile
+++ b/testing/environments/Dockerfile
@@ -1,7 +1,7 @@
 # Basic debian file with curl, wget and nano installed to fetch files
 # an update config files
 FROM debian:latest
-MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
+LABEL org.opencontainers.image.authors="Nicolas Ruflin <ruflin@elastic.co>"
 
 RUN apt-get update && \
     apt-get install -y curl nano wget zip && \

--- a/testing/environments/Dockerfile
+++ b/testing/environments/Dockerfile
@@ -1,7 +1,6 @@
 # Basic debian file with curl, wget and nano installed to fetch files
 # an update config files
 FROM debian:latest
-LABEL org.opencontainers.image.authors="Nicolas Ruflin <ruflin@elastic.co>"
 
 RUN apt-get update && \
     apt-get install -y curl nano wget zip && \

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -2,7 +2,6 @@
 # This is useful for testing locally with a full elastic stack setup.
 # All services can be reached through localhost like localhost:5601 for Kibana
 # This is not used for CI as otherwise ports conflicts could happen.
-version: '2.3'
 services:
   kibana:
     ports:

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -1,6 +1,5 @@
 # This should start the environment with the latest snapshots.
 
-version: '2.3'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.16.0-07587139-SNAPSHOT


### PR DESCRIPTION
## Proposed commit message

I stumbled upon some warnings when trying to start the integration testing environment. The logs don't cause any harm but they pollute the output of the tool. Warnings include:

```
WARN[0000] /home/mauri870/git/elastic/beats/testing/environments/snapshot.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avo
id potential confusion
WARN[0000] /home/mauri870/git/elastic/beats/testing/environments/local.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid
potential confusion
WARN: MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 4)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- `cd testing/environments; make start ENV=snapshot.yml`