### PR TITLE
Change maintainer label to opencontainers in Dockerfile

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -82,8 +82,8 @@ LABEL \
   org.opencontainers.image.licenses="{{ .License }}" \
   org.opencontainers.image.title="{{ .BeatName | title }}" \
   org.opencontainers.image.vendor="{{ .BeatVendor }}" \
+  org.opencontainers.image.authors="infra@elastic.co" \
   name="{{ .BeatName }}" \
-  maintainer="infra@elastic.co" \
   vendor="{{ .BeatVendor }}" \
   version="{{ beat_version }}{{if .Snapshot}}-SNAPSHOT{{end}}" \
   release="1" \


### PR DESCRIPTION
## Proposed commit message

The old way of specifying maintainers in a Dockerfile was to use the MAINTAINER instruction. This is now deprecated and the maintainer label was used instead.

Nowadays the recommended way to set a maintainer is through the `org.opencontainers.image.authors` label.

See https://docs.docker.com/reference/build-checks/maintainer-deprecated/.

## Author's Checklist

- I wonder if we look for a maintainer label in the images somewhere, if that is the case this can be a breaking change.
