### PR TITLE
fix invalid bitSize in strconv.ParseFloat

### DIFF
--- a/libbeat/processors/ratelimit/limit.go
+++ b/libbeat/processors/ratelimit/limit.go
@@ -46,7 +46,7 @@ func (l *rate) Unpack(str string) error {
 	valueStr := strings.TrimSpace(parts[0])
 	unitStr := strings.TrimSpace(parts[1])
 
-	v, err := strconv.ParseFloat(valueStr, 8)
+	v, err := strconv.ParseFloat(valueStr, 64)
 	if err != nil {
 		return fmt.Errorf(`rate's value component is not numeric: %v`, valueStr)
 	}


### PR DESCRIPTION
## Proposed commit message

The bitSize argument in strconv.ParseFloat should be either 32 or 64. 
Any value other than 32 will default to 64 in the current implementation, 
though this behavior is undocumented, making it undefined.

See https://cs.opensource.google/go/go/+/refs/tags/go1.23.0:src/strconv/atof.go;l=704-708.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.