### PR TITLE
mergify: replace queue action for queue_rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    merge_method: squash
     conditions:
       - check-success=buildkite/beats
 pull_request_rules:
@@ -72,7 +73,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
     actions:
       queue:
-        method: squash
         name: default
   - name: delete upstream branch after merging changes on testing/environments/snapshot* or it's closed
     conditions:
@@ -116,7 +116,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
     actions:
       queue:
-        method: squash
         name: default
   - name: delete upstream branch with changes on ^.mergify.yml that has been merged or closed
     conditions:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Use queue_rules instead of queue action

## Why

The queue action from workflow automation has deprecated all of its configuration options

https://changelog.mergify.com/changelog/queue-action-options-deprecation
