### PR TITLE
chore: add debug histograms for s3 object size and events per processed s3 object

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -203,6 +203,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Refactor x-pack/filebeat/input/websocket for generalisation. {pull}40308[40308]
 - Add a configuration option for TCP/UDP network type. {issue}40407[40407] {pull}40623[40623]
 - Added debug logging to parquet reader in x-pack/libbeat/reader. {pull}40651[40651]
+- Added filebeat debug histograms for s3 object size and events per processed s3 object. {pull}40775[40775]
 
 ==== Deprecated
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Journald: `include_matches.match` now behaves in the same way as matchers in `journalctl`. Users should carefully update their input configuration. {pull}40061[40061]
 - Journald: `seek` and `since` behaviour have been simplified, if there is a cursor (state) `seek` and `since` are ignored and the cursor is used. {pull}40061[40061]
 - Added `container.image.name` to `journald` Filebeat input's Docker-specific translated fields. {pull}40450[40450]
+- Added debug histograms for s3 object size and events per processed s3 object. {pull}40775[40775]
 
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,7 +43,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Journald: `include_matches.match` now behaves in the same way as matchers in `journalctl`. Users should carefully update their input configuration. {pull}40061[40061]
 - Journald: `seek` and `since` behaviour have been simplified, if there is a cursor (state) `seek` and `since` are ignored and the cursor is used. {pull}40061[40061]
 - Added `container.image.name` to `journald` Filebeat input's Docker-specific translated fields. {pull}40450[40450]
-- Added debug histograms for s3 object size and events per processed s3 object. {pull}40775[40775]
 
 
 *Heartbeat*

--- a/x-pack/filebeat/input/awss3/s3_objects.go
+++ b/x-pack/filebeat/input/awss3/s3_objects.go
@@ -101,6 +101,14 @@ func (f *s3ObjectProcessorFactory) Create(ctx context.Context, log *logp.Logger,
 	}
 }
 
+// s3DownloadedObject encapsulate downloaded s3 object for internal processing
+type s3DownloadedObject struct {
+	body        io.ReadCloser
+	length      int64
+	contentType string
+	metadata    map[string]interface{}
+}
+
 type s3ObjectProcessor struct {
 	*s3ObjectProcessorFactory
 
@@ -112,6 +120,7 @@ type s3ObjectProcessor struct {
 	s3Obj        s3EventV2                  // S3 object information.
 	s3ObjHash    string
 	s3RequestURL string
+	eventCount   int64
 
 	s3Metadata map[string]interface{} // S3 object metadata.
 }
@@ -138,23 +147,25 @@ func (p *s3ObjectProcessor) ProcessS3Object() error {
 	}()
 
 	// Request object (download).
-	contentType, meta, body, err := p.download()
+	s3Obj, err := p.download()
 	if err != nil {
 		// Wrap downloadError in the result so the caller knows it's not a
 		// permanent failure.
 		return fmt.Errorf("%w: %w", errS3DownloadFailed, err)
 	}
-	defer body.Close()
-	p.s3Metadata = meta
+	defer s3Obj.body.Close()
 
-	reader, err := p.addGzipDecoderIfNeeded(newMonitoredReader(body, p.metrics.s3BytesProcessedTotal))
+	p.s3Metadata = s3Obj.metadata
+	p.metrics.s3ObjectSizeInBytes.Update(s3Obj.length)
+
+	reader, err := p.addGzipDecoderIfNeeded(newMonitoredReader(s3Obj.body, p.metrics.s3BytesProcessedTotal))
 	if err != nil {
 		return fmt.Errorf("failed checking for gzip content: %w", err)
 	}
 
 	// Overwrite with user configured Content-Type.
 	if p.readerConfig.ContentType != "" {
-		contentType = p.readerConfig.ContentType
+		s3Obj.contentType = p.readerConfig.ContentType
 	}
 
 	// try to create a decoder from the using the codec config
@@ -183,7 +194,7 @@ func (p *s3ObjectProcessor) ProcessS3Object() error {
 		// This is the legacy path. It will be removed in future and clubbed together with the decoder.
 		// Process object content stream.
 		switch {
-		case strings.HasPrefix(contentType, contentTypeJSON) || strings.HasPrefix(contentType, contentTypeNDJSON):
+		case strings.HasPrefix(s3Obj.contentType, contentTypeJSON) || strings.HasPrefix(s3Obj.contentType, contentTypeNDJSON):
 			err = p.readJSON(reader)
 		default:
 			err = p.readFile(reader)
@@ -194,20 +205,20 @@ func (p *s3ObjectProcessor) ProcessS3Object() error {
 			time.Since(start).Nanoseconds(), err)
 	}
 
+	p.metrics.s3EventsPerObject.Update(p.eventCount)
 	return nil
 }
 
 // download requests the S3 object from AWS and returns the object's
-// Content-Type and reader to get the object's contents. The caller must
-// close the returned reader.
-func (p *s3ObjectProcessor) download() (contentType string, metadata map[string]interface{}, body io.ReadCloser, err error) {
+// Content-Type and reader to get the object's contents.
+// The caller must close the reader embedded in s3DownloadedObject.
+func (p *s3ObjectProcessor) download() (obj *s3DownloadedObject, err error) {
 	getObjectOutput, err := p.s3.GetObject(p.ctx, p.s3Obj.AWSRegion, p.s3Obj.S3.Bucket.Name, p.s3Obj.S3.Object.Key)
 	if err != nil {
-		return "", nil, nil, err
+		return nil, err
 	}
-
 	if getObjectOutput == nil {
-		return "", nil, nil, fmt.Errorf("empty response from s3 get object: %w", err)
+		return nil, fmt.Errorf("empty response from s3 get object: %w", err)
 	}
 	s3RequestURL := getObjectOutput.ResultMetadata.Get(s3RequestURLMetadataKey)
 	if s3RequestURLAsString, ok := s3RequestURL.(string); ok {
@@ -215,10 +226,20 @@ func (p *s3ObjectProcessor) download() (contentType string, metadata map[string]
 	}
 
 	meta := s3Metadata(getObjectOutput, p.readerConfig.IncludeS3Metadata...)
-	if getObjectOutput.ContentType == nil {
-		return "", meta, getObjectOutput.Body, nil
+
+	ctType := ""
+	if getObjectOutput.ContentType != nil {
+		ctType = *getObjectOutput.ContentType
 	}
-	return *getObjectOutput.ContentType, meta, getObjectOutput.Body, nil
+
+	s := &s3DownloadedObject{
+		body:        getObjectOutput.Body,
+		length:      *getObjectOutput.ContentLength,
+		contentType: ctType,
+		metadata:    meta,
+	}
+
+	return s, nil
 }
 
 func (p *s3ObjectProcessor) addGzipDecoderIfNeeded(body io.Reader) (io.Reader, error) {
@@ -391,9 +412,11 @@ func (p *s3ObjectProcessor) readFile(r io.Reader) error {
 	return nil
 }
 
+// publish the generated event and perform necessary tracking
 func (p *s3ObjectProcessor) publish(ack *awscommon.EventACKTracker, event *beat.Event) {
 	ack.Add()
 	event.Private = ack
+	p.eventCount += 1
 	p.metrics.s3EventsCreatedTotal.Inc()
 	p.publisher.Publish(*event)
 }


### PR DESCRIPTION
## Proposed commit message

Fixes #40306 by adding `s3_events_per_object` & `s3_object_size_in_bytes` histograms. These histograms provide valuable insights on the size of S3 objects filebeat processed and the number of events produced by each S3 object. 

Consider below screenshot,

![image](https://github.com/user-attachments/assets/94a3d458-c421-45fc-a32e-f637e4dfaceb)

- Uploads two documents with 15 total logs (10 logs in one and another with 5 logs)
- See how `s3_events_per_object` tracks events (logs) per object with max, min and count
- See how `s3_object_size_in_bytes` tracks object size with max and min and count 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Run filebeat with AWS S3 connectivity
- Access debug metrics through http://<http.host>:<http.port>/inputs/?type=aws-s3
- Observe `s3_object_size_in_bytes` & `s3_events_per_object` histograms

## Related issues

- Closes #40306