### PR TITLE
Expose output disk queue settings when running under agent

### DIFF
--- a/libbeat/outputs/util.go
+++ b/libbeat/outputs/util.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // Fail helper can be used by output factories, to create a failure response when
@@ -47,7 +48,8 @@ func Success(cfg config.Namespace, batchSize, retry int, encoderFactory queue.En
 			q = memqueue.FactoryForSettings(settings)
 		case diskqueue.QueueType:
 			if management.UnderAgent() {
-				return Group{}, fmt.Errorf("disk queue not supported under agent")
+				logger := logp.NewLogger("output")
+				logger.Warn("Disk queue configuration found while running under agent: this configuration is unsupported and in technical preview.")
 			}
 			settings, err := diskqueue.SettingsForUserConfig(cfg.Config())
 			if err != nil {

--- a/libbeat/outputs/util_test.go
+++ b/libbeat/outputs/util_test.go
@@ -1,0 +1,103 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package outputs
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/management"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestDiskQueueUnderAgent(t *testing.T) {
+
+	type args struct {
+		cfg            string
+		batchSize      int
+		retry          int
+		encoderFactory queue.EncoderFactory
+		clients        []Client
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Group
+		wantErr bool
+	}{
+		{
+			name: "Happy path",
+			args: args{
+				cfg: `
+                    disk:
+                        max_size: 100MB
+                        path: %s
+                `,
+				clients:   []Client{},
+				batchSize: 10,
+				retry:     3,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousUnderAgent := management.UnderAgent()
+			t.Cleanup(func() {
+				management.SetUnderAgent(previousUnderAgent)
+			})
+
+			tempDir := t.TempDir()
+
+			queueConfig := config.Namespace{}
+			conf, err := config.NewConfigFrom(fmt.Sprintf(tt.args.cfg, tempDir))
+			require.NoError(t, err, "error parsing queue config")
+			err = queueConfig.Unpack(conf)
+			require.NoError(t, err, "error unpacking queue config")
+
+			management.SetUnderAgent(true)
+
+			actualGroup, err := Success(queueConfig, tt.args.batchSize, tt.args.retry, tt.args.encoderFactory, tt.args.clients...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Success() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				// if an error was expected, we need no more assertions: return
+				return
+			}
+
+			require.NotNil(t, actualGroup)
+			require.NotNil(t, actualGroup.QueueFactory)
+
+			testlogger, _ /*logBuffer*/ := logp.NewInMemory("test-diskqueue", zapcore.EncoderConfig{})
+
+			actualQueue, err := actualGroup.QueueFactory(testlogger, nil, 1, nil)
+			require.NoError(t, err)
+			require.NotNil(t, actualQueue)
+			// assert that the file exists in the path we specified
+			assert.FileExists(t, filepath.Join(tempDir, "state.dat"))
+		})
+	}
+}

--- a/libbeat/outputs/util_test.go
+++ b/libbeat/outputs/util_test.go
@@ -22,13 +22,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestDiskQueueUnderAgent(t *testing.T) {

--- a/libbeat/outputs/util_test.go
+++ b/libbeat/outputs/util_test.go
@@ -91,7 +91,7 @@ func TestDiskQueueUnderAgent(t *testing.T) {
 			require.NotNil(t, actualGroup)
 			require.NotNil(t, actualGroup.QueueFactory)
 
-			testlogger, _ /*logBuffer*/ := logp.NewInMemory("test-diskqueue", zapcore.EncoderConfig{})
+			testlogger, _ := logp.NewInMemory("test-diskqueue", zapcore.EncoderConfig{})
 
 			actualQueue, err := actualGroup.QueueFactory(testlogger, nil, 1, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

See title

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

No disruption as the disk queue was already unsupported when running under agent

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Package agent using beats binaries that include this change.
Install agent as standalone and modify the `output` in `elastic-agent.yml`

```yaml
outputs:
  default:
    type: elasticsearch
    hosts: [127.0.0.1:9200]
    api_key: "example-key"
    #username: "elastic"
    #password: "changeme"
## Note: we need to disable the preset otherwise it will override queue.disk with queue.mem setting
    #preset: balanced
    queue.disk:
        max_size: 1GB
```

Add a beats input (filebeat or other) that uses the output and the disk queue will appear under the input data directory, for example:

```shell
root@elastic-agent-dev:/opt/Elastic/Agent/data/elastic-agent-9.0.0-SNAPSHOT-d99b09/run/filestream-default/diskqueue# ll
total 8
drwxr-xr-x 2 root root 4096 Sep 17 09:18 ./
drwxrwx--- 4 root root 4096 Sep 17 09:18 ../
-rw------- 1 root root    0 Sep 17 09:18 state.dat
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
