### PR TITLE
.github/CODEOWNERS - remove non-existent metricbeat paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -195,7 +195,7 @@ CHANGELOG*
 /x-pack/metricbeat/module/containerd/ @elastic/obs-cloudnative-monitoring
 /x-pack/metricbeat/module/coredns @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/enterprisesearch @elastic/ent-search-application
-/x-pack/metricbeat/module/gcp @elastic/obs-ds-hosted-services @elastic/obs-infraobs-integrations @elastic/security-service-integrations
+/x-pack/metricbeat/module/gcp @elastic/obs-ds-hosted-services @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/billing @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/cloudrun_metrics @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/cloudsql_mysql @elastic/obs-infraobs-integrations
@@ -204,16 +204,13 @@ CHANGELOG*
 /x-pack/metricbeat/module/gcp/carbon @elastic/obs-ds-hosted-services
 /x-pack/metricbeat/module/gcp/compute @elastic/obs-ds-hosted-services
 /x-pack/metricbeat/module/gcp/dataproc @elastic/obs-infraobs-integrations
-/x-pack/metricbeat/module/gcp/dns @elastic/security-service-integrations
 /x-pack/metricbeat/module/gcp/firestore @elastic/obs-infraobs-integrations
-/x-pack/metricbeat/module/gcp/firewall @elastic/security-service-integrations
 /x-pack/metricbeat/module/gcp/gke @elastic/obs-ds-hosted-services
 /x-pack/metricbeat/module/gcp/loadbalancing_logs @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/loadbalancing_metrics @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/pubsub @elastic/obs-ds-hosted-services
 /x-pack/metricbeat/module/gcp/redis @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/storage @elastic/obs-ds-hosted-services
-/x-pack/metricbeat/module/gcp/vpcflow @elastic/security-service-integrations
 /x-pack/metricbeat/module/ibmmq @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/iis @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/istio/ @elastic/obs-cloudnative-monitoring


### PR DESCRIPTION
## Proposed commit message

These paths do not exist so they should not be part of the codeowners file.

/x-pack/metricbeat/module/gcp/dns
/x-pack/metricbeat/module/gcp/firewall
/x-pack/metricbeat/module/gcp/vpcflow

