### PR TITLE
Rename Wolfi images to satisfy the release naming convention

### DIFF
--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -466,9 +466,9 @@ func checkDockerEntryPoint(t *testing.T, p *packageFile, info *dockerInfo) {
 	})
 }
 
-// {BeatName}-{OptionalVariantSuffix}-oss-{version}-{os}-{arch}.docker.tar.gz
+// {BeatName}-oss-{OptionalVariantSuffix}-{version}-{os}-{arch}.docker.tar.gz
 // For example, `heartbeat-oss-8.16.0-linux-arm64.docker.tar.gz`
-var ossSuffixRegexp = regexp.MustCompile(`^(\w+)(-\w+)?-oss-.+$`)
+var ossSuffixRegexp = regexp.MustCompile(`^(\w+)-oss-.+$`)
 
 func checkDockerLabels(t *testing.T, p *packageFile, info *dockerInfo, file string) {
 	vendor := info.Config.Labels["org.label-schema.vendor"]

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -5,20 +5,20 @@
 
 shared:
   - &common
-    name: "{{.BeatName}}"
-    service_name: "{{.BeatServiceName}}"
-    os: "{{.GOOS}}"
-    arch: "{{.PackageArch}}"
-    vendor: "{{.BeatVendor}}"
-    version: "{{ beat_version }}"
-    license: "{{.BeatLicense}}"
-    url: "{{.BeatURL}}"
-    description: "{{.BeatDescription}}"
+    name: '{{.BeatName}}'
+    service_name: '{{.BeatServiceName}}'
+    os: '{{.GOOS}}'
+    arch: '{{.PackageArch}}'
+    vendor: '{{.BeatVendor}}'
+    version: '{{ beat_version }}'
+    license: '{{.BeatLicense}}'
+    url: '{{.BeatURL}}'
+    description: '{{.BeatDescription}}'
 
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec
     <<: *common
-    post_install_script: "{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/systemd-daemon-reload.sh"
+    post_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/systemd-daemon-reload.sh'
     files:
       /usr/share/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
@@ -27,23 +27,23 @@ shared:
         source: fields.yml
         mode: 0644
       /usr/share/{{.BeatName}}/LICENSE.txt:
-        source: "{{ repo.RootDir }}/LICENSE.txt"
+        source: '{{ repo.RootDir }}/LICENSE.txt'
         mode: 0644
       /usr/share/{{.BeatName}}/NOTICE.txt:
-        source: "{{ repo.RootDir }}/NOTICE.txt"
+        source: '{{ repo.RootDir }}/NOTICE.txt'
         mode: 0644
       /usr/share/{{.BeatName}}/README.md:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
         mode: 0644
       /usr/share/{{.BeatName}}/.build_hash.txt:
         content: >
           {{ commit }}
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.reference.yml:
-        source: "{{.BeatName}}.reference.yml"
+        source: '{{.BeatName}}.reference.yml'
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.yml:
-        source: "{{.BeatName}}.yml"
+        source: '{{.BeatName}}.yml'
         mode: 0600
         config: true
       /usr/share/{{.BeatName}}/kibana:
@@ -53,13 +53,13 @@ shared:
         source: build/golang-crossbuild/god-{{.GOOS}}-{{.Platform.Arch}}
         mode: 0755
       /usr/bin/{{.BeatName}}:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/beatname.sh.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/beatname.sh.tmpl'
         mode: 0755
       /lib/systemd/system/{{.BeatServiceName}}.service:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/systemd.unit.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/systemd.unit.tmpl'
         mode: 0644
       /etc/init.d/{{.BeatServiceName}}:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/init.sh.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/init.sh.tmpl'
         mode: 0755
 
   # MacOS pkg spec for community beats.
@@ -69,29 +69,29 @@ shared:
       # OS X 10.8 Mountain Lion is the oldest supported by Go 1.10.
       # https://golang.org/doc/go1.10#ports
       min_supported_osx_version: 10.8
-      identifier: "co.{{.BeatVendor | tolower}}.beats.{{.BeatName}}"
+      identifier: 'co.{{.BeatVendor | tolower}}.beats.{{.BeatName}}'
       install_path: /Library/Application Support
-    pre_install_script: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/preinstall.tmpl"
-    post_install_script: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/postinstall.tmpl"
+    pre_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/preinstall.tmpl'
+    post_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/scripts/postinstall.tmpl'
     files:
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
         mode: 0755
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/LICENSE.txt:
-        source: "{{ repo.RootDir }}/LICENSE.txt"
+        source: '{{ repo.RootDir }}/LICENSE.txt'
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/NOTICE.txt:
-        source: "{{ repo.RootDir }}/NOTICE.txt"
+        source: '{{ repo.RootDir }}/NOTICE.txt'
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/README.md:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/.build_hash.txt:
         content: >
           {{ commit }}
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/{{.identifier}}.plist:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/launchd-daemon.plist.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/darwin/launchd-daemon.plist.tmpl'
         mode: 0644
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/kibana:
         source: _meta/kibana.generated
@@ -100,38 +100,38 @@ shared:
         source: fields.yml
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.reference.yml:
-        source: "{{.BeatName}}.reference.yml"
+        source: '{{.BeatName}}.reference.yml'
         mode: 0644
       /etc/{{.BeatName}}/{{.BeatName}}.yml:
-        source: "{{.BeatName}}.yml"
+        source: '{{.BeatName}}.yml'
         mode: 0600
         config: true
 
   - &binary_files
-    "{{.BeatName}}{{.BinaryExt}}":
+    '{{.BeatName}}{{.BinaryExt}}':
       source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
       mode: 0755
     fields.yml:
       source: fields.yml
       mode: 0644
     LICENSE.txt:
-      source: "{{ repo.RootDir }}/LICENSE.txt"
+      source: '{{ repo.RootDir }}/LICENSE.txt'
       mode: 0644
     NOTICE.txt:
-      source: "{{ repo.RootDir }}/NOTICE.txt"
+      source: '{{ repo.RootDir }}/NOTICE.txt'
       mode: 0644
     README.md:
-      template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl"
+      template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/common/README.md.tmpl'
       mode: 0644
     .build_hash.txt:
       content: >
         {{ commit }}
       mode: 0644
-    "{{.BeatName}}.reference.yml":
-      source: "{{.BeatName}}.reference.yml"
+    '{{.BeatName}}.reference.yml':
+      source: '{{.BeatName}}.reference.yml'
       mode: 0644
-    "{{.BeatName}}.yml":
-      source: "{{.BeatName}}.yml"
+    '{{.BeatName}}.yml':
+      source: '{{.BeatName}}.yml'
       mode: 0600
       config: true
     kibana:
@@ -150,101 +150,101 @@ shared:
     files:
       <<: *binary_files
       install-service-{{.BeatName}}.ps1:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/install-service.ps1.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/install-service.ps1.tmpl'
         mode: 0755
       uninstall-service-{{.BeatName}}.ps1:
-        template: "{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/uninstall-service.ps1.tmpl"
+        template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/windows/uninstall-service.ps1.tmpl'
         mode: 0755
 
   - &docker_spec
     <<: *binary_spec
     extra_vars:
-      from: "--platform=linux/amd64 ubuntu:20.04"
-      buildFrom: "--platform=linux/amd64 cgr.dev/chainguard/wolfi-base"
-      user: "{{ .BeatName }}"
-      linux_capabilities: ""
+      from: '--platform=linux/amd64 ubuntu:20.04'
+      buildFrom: '--platform=linux/amd64 cgr.dev/chainguard/wolfi-base'
+      user: '{{ .BeatName }}'
+      linux_capabilities: ''
     files:
-      "{{.BeatName}}.yml":
-        source: "{{.BeatName}}.docker.yml"
+      '{{.BeatName}}.yml':
+        source: '{{.BeatName}}.docker.yml'
         mode: 0600
         config: true
 
   - &docker_arm_spec
     <<: *docker_spec
     extra_vars:
-      from: "--platform=linux/arm64 ubuntu:20.04"
-      buildFrom: "--platform=linux/arm64 cgr.dev/chainguard/wolfi-base"
+      from: '--platform=linux/arm64 ubuntu:20.04'
+      buildFrom: '--platform=linux/arm64 cgr.dev/chainguard/wolfi-base'
 
   - &docker_ubi_spec
     extra_vars:
-      image_name: "{{.BeatName}}-ubi"
-      from: "--platform=linux/amd64 docker.elastic.co/ubi9/ubi-minimal"
+      image_name: '{{.BeatName}}-ubi'
+      from: '--platform=linux/amd64 docker.elastic.co/ubi9/ubi-minimal'
 
   - &docker_arm_ubi_spec
     extra_vars:
-      image_name: "{{.BeatName}}-ubi"
-      from: "--platform=linux/arm64 docker.elastic.co/ubi9/ubi-minimal"
+      image_name: '{{.BeatName}}-ubi'
+      from: '--platform=linux/arm64 docker.elastic.co/ubi9/ubi-minimal'
 
   - &docker_wolfi_spec
     extra_vars:
-      image_name: "{{.BeatName}}-wolfi"
-      from: "--platform=linux/amd64 cgr.dev/chainguard/wolfi-base"
+      image_name: '{{.BeatName}}-wolfi'
+      from: '--platform=linux/amd64 cgr.dev/chainguard/wolfi-base'
 
   - &docker_arm_wolfi_spec
     extra_vars:
-      image_name: "{{.BeatName}}-wolfi"
-      from: "--platform=linux/arm64 cgr.dev/chainguard/wolfi-base"
+      image_name: '{{.BeatName}}-wolfi'
+      from: '--platform=linux/arm64 cgr.dev/chainguard/wolfi-base'
 
   - &elastic_docker_spec
     extra_vars:
-      repository: "docker.elastic.co/beats"
+      repository: 'docker.elastic.co/beats'
 
   #
   # License modifiers for Apache 2.0
   #
   - &apache_license_for_binaries
-    license: "ASL 2.0"
+    license: 'ASL 2.0'
     files:
       LICENSE.txt:
-        source: "{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt"
+        source: '{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt'
         mode: 0644
 
   - &apache_license_for_deb_rpm
-    license: "ASL 2.0"
+    license: 'ASL 2.0'
     files:
       /usr/share/{{.BeatName}}/LICENSE.txt:
-        source: "{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt"
+        source: '{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt'
         mode: 0644
 
   - &apache_license_for_macos_pkg
-    license: "ASL 2.0"
+    license: 'ASL 2.0'
     files:
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/LICENSE.txt:
-        source: "{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt"
+        source: '{{ repo.RootDir }}/licenses/APACHE-LICENSE-2.0.txt'
         mode: 0644
 
   #
   # License modifiers for the Elastic License
   #
   - &elastic_license_for_binaries
-    license: "Elastic License"
+    license: 'Elastic License'
     files:
       LICENSE.txt:
-        source: "{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt"
+        source: '{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt'
         mode: 0644
 
   - &elastic_license_for_deb_rpm
-    license: "Elastic License"
+    license: 'Elastic License'
     files:
       /usr/share/{{.BeatName}}/LICENSE.txt:
-        source: "{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt"
+        source: '{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt'
         mode: 0644
 
   - &elastic_license_for_macos_pkg
-    license: "Elastic License"
+    license: 'Elastic License'
     files:
       /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/LICENSE.txt:
-        source: "{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt"
+        source: '{{ repo.RootDir }}/licenses/ELASTIC-LICENSE.txt'
         mode: 0644
 
 # specs is a list of named packaging "flavors".
@@ -296,28 +296,28 @@ specs:
       spec:
         <<: *windows_binary_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-oss"
+        name: '{{.BeatName}}-oss'
 
     - os: darwin
       types: [tgz]
       spec:
         <<: *binary_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-oss"
+        name: '{{.BeatName}}-oss'
 
     - os: linux
       types: [tgz]
       spec:
         <<: *binary_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-oss"
+        name: '{{.BeatName}}-oss'
 
     - os: linux
       types: [deb, rpm]
       spec:
         <<: *deb_rpm_spec
         <<: *apache_license_for_deb_rpm
-        name: "{{.BeatName}}-oss"
+        name: '{{.BeatName}}-oss'
 
     - os: linux
       types: [docker]
@@ -326,7 +326,7 @@ specs:
         <<: *docker_spec
         <<: *elastic_docker_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-oss"
+        name: '{{.BeatName}}-oss'
 
     - os: linux
       types: [docker]
@@ -336,9 +336,9 @@ specs:
         <<: *docker_wolfi_spec
         <<: *elastic_docker_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-wolfi-oss"
+        name: '{{.BeatName}}-oss-wolfi'
         extra_vars:
-          image_name: "{{.BeatName}}-wolfi-oss"
+          image_name: '{{.BeatName}}-oss-wolfi'
 
     - os: linux
       types: [docker]
@@ -347,7 +347,7 @@ specs:
         <<: *docker_arm_spec
         <<: *elastic_docker_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-oss"
+        name: '{{.BeatName}}-oss'
 
     - os: linux
       types: [docker]
@@ -357,16 +357,16 @@ specs:
         <<: *docker_arm_wolfi_spec
         <<: *elastic_docker_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-wolfi-oss"
+        name: '{{.BeatName}}-oss-wolfi'
         extra_vars:
-          image_name: "{{.BeatName}}-wolfi-oss"
+          image_name: '{{.BeatName}}-oss-wolfi'
 
     - os: aix
       types: [tgz]
       spec:
         <<: *binary_spec
         <<: *apache_license_for_binaries
-        name: "{{.BeatName}}-oss"
+        name: '{{.BeatName}}-oss'
 
   # Elastic Beat with Elastic License and binary taken the current directory.
   elastic_beat_xpack:
@@ -495,7 +495,7 @@ specs:
         <<: *windows_binary_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
@@ -504,7 +504,7 @@ specs:
         <<: *binary_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -513,7 +513,7 @@ specs:
         <<: *binary_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -533,7 +533,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -545,7 +545,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -557,7 +557,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -568,7 +568,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -580,7 +580,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -592,7 +592,7 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: aix
@@ -601,7 +601,7 @@ specs:
         <<: *binary_spec
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
@@ -619,7 +619,7 @@ specs:
       spec:
         <<: *elastic_license_for_binaries
         files:
-          "{{.BeatName}}{{.BinaryExt}}":
+          '{{.BeatName}}{{.BinaryExt}}':
             source: data/{{.BeatName}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}
             symlink: true
             mode: 0755


### PR DESCRIPTION
For example, `filebeat-wolfi-oss` -> `filebeat-oss-wolfi`

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
```sh
PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

for each Beat yields the following results:

```
REPOSITORY                                      TAG          IMAGE ID       CREATED          SIZE
docker.elastic.co/beats-dev/golang-crossbuild   1.22.6-arm   eae46a040730   2 weeks ago      752MB
docker.elastic.co/beats/auditbeat               9.0.0        70d947064a71   41 minutes ago   254MB
docker.elastic.co/beats/auditbeat-oss           9.0.0        cfa91ec283eb   43 minutes ago   243MB
docker.elastic.co/beats/auditbeat-oss-wolfi     9.0.0        ef92ba55d6e2   42 minutes ago   163MB
docker.elastic.co/beats/auditbeat-ubi           9.0.0        dbf6f1705960   41 minutes ago   249MB
docker.elastic.co/beats/auditbeat-wolfi         9.0.0        da981bab4bf0   41 minutes ago   174MB
docker.elastic.co/beats/filebeat                9.0.0        fc466364911d   37 minutes ago   314MB
docker.elastic.co/beats/filebeat-oss            9.0.0        bb93a46d94f6   40 minutes ago   243MB
docker.elastic.co/beats/filebeat-oss-wolfi      9.0.0        e4cf829cbec1   40 minutes ago   163MB
docker.elastic.co/beats/filebeat-ubi            9.0.0        01508202f444   37 minutes ago   310MB
docker.elastic.co/beats/filebeat-wolfi          9.0.0        7baec8e0e5ce   37 minutes ago   234MB
docker.elastic.co/beats/heartbeat               9.0.0        89aeacc15c11   29 minutes ago   1.97GB
docker.elastic.co/beats/heartbeat-oss           9.0.0        22cc65f4c437   33 minutes ago   1.96GB
docker.elastic.co/beats/heartbeat-oss-wolfi     9.0.0        4a0fd074f0ac   33 minutes ago   1.55GB
docker.elastic.co/beats/heartbeat-ubi           9.0.0        79133c70e7b9   30 minutes ago   245MB
docker.elastic.co/beats/heartbeat-wolfi         9.0.0        402490d84ef7   29 minutes ago   1.56GB
docker.elastic.co/beats/metricbeat              9.0.0        762de725165d   23 minutes ago   357MB
docker.elastic.co/beats/metricbeat-oss          9.0.0        24aa05380fd0   25 minutes ago   277MB
docker.elastic.co/beats/metricbeat-oss-wolfi    9.0.0        cc33c015c6be   25 minutes ago   197MB
docker.elastic.co/beats/metricbeat-ubi          9.0.0        19c002b52a62   23 minutes ago   352MB
docker.elastic.co/beats/metricbeat-wolfi        9.0.0        433af5522f36   23 minutes ago   277MB
docker.elastic.co/beats/packetbeat              9.0.0        6384fe29d12b   21 minutes ago   255MB
docker.elastic.co/beats/packetbeat-oss          9.0.0        b476e9a412f4   22 minutes ago   245MB
docker.elastic.co/beats/packetbeat-oss-wolfi    9.0.0        a7ea3fad96b4   22 minutes ago   165MB
docker.elastic.co/beats/packetbeat-ubi          9.0.0        caedb1ea22e0   21 minutes ago   250MB
docker.elastic.co/beats/packetbeat-wolfi        9.0.0        fee00a2be999   21 minutes ago   174MB
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #40524 