### PR TITLE
Replace docker-compose by 'docker compose'

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -70,6 +70,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Debug log entries from the acker (`stateful ack ...` or `stateless ack ...`) removed. {pull}39672[39672]
 - Rename x-pack/filebeat websocket input to streaming. {issue}40264[40264] {pull}40421[40421]
 - Journald input now calls `journalctl` instead of using `github.com/coreos/go-systemd/v22@v22.5.0/sdjournal`, the CGO dependency has been removed from Filebeat {pull}40061[40061]
+- Use Docker Compose V2 (`docker compose`) instead of Compose V1 (`docker-compose`) {pull}40890[40890]
 
 ==== Bugfixes
 

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -216,12 +216,12 @@ func dockerInfo() (*DockerInfo, error) {
 	return &info, nil
 }
 
-// HaveDockerCompose returns an error if docker-compose is not found on the
+// HaveDockerCompose returns an error if docker is not found on the
 // PATH.
 func HaveDockerCompose() error {
-	_, err := exec.LookPath("docker-compose")
+	_, err := exec.LookPath("docker")
 	if err != nil {
-		return fmt.Errorf("docker-compose is not available")
+		return fmt.Errorf("docker is not available")
 	}
 	return nil
 }

--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -141,8 +141,8 @@ func (d *DockerIntegrationTester) Test(dir string, mageTarget string, env map[st
 		composeEnv,
 		os.Stdout,
 		os.Stderr,
-		"docker-compose",
-		args...,
+		"docker",
+		append([]string{"compose"}, args...)...,
 	)
 
 	err = saveDockerComposeLogs(dir, mageTarget)
@@ -313,8 +313,8 @@ func BuildIntegTestContainers() error {
 		composeEnv,
 		out,
 		os.Stderr,
-		"docker-compose", args...,
-	)
+		"docker",
+		append([]string{"compose"}, args...)...)
 
 	// This sleep is to avoid hitting the docker build issues when resources are not available.
 	if err != nil {
@@ -324,8 +324,8 @@ func BuildIntegTestContainers() error {
 			composeEnv,
 			out,
 			os.Stderr,
-			"docker-compose", args...,
-		)
+			"docker",
+			append([]string{"compose"}, args...)...)
 	}
 	return err
 }
@@ -348,8 +348,8 @@ func StartIntegTestContainers() error {
 		composeEnv,
 		os.Stdout,
 		os.Stderr,
-		"docker-compose",
-		args...,
+		"docker",
+		append([]string{"compose"}, args...)...,
 	)
 	return err
 }
@@ -370,7 +370,7 @@ func StopIntegTestContainers() error {
 		composeEnv,
 		ioutil.Discard,
 		out,
-		"docker-compose",
+		"docker", "compose",
 		"-p", DockerComposeProjectName(),
 		"rm", "--stop", "--force",
 	)
@@ -428,7 +428,7 @@ func saveDockerComposeLogs(rootDir string, mageTarget string) error {
 		composeEnv,
 		composeLogFile, // stdout
 		composeLogFile, // stderr
-		"docker-compose",
+		"docker", "compose",
 		"-p", DockerComposeProjectName(),
 		"logs",
 		"--no-color",

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -168,7 +168,7 @@ func (d *wrapperDriver) cmd(ctx context.Context, command string, arg ...string) 
 	}
 	args = append(args, command)
 	args = append(args, arg...)
-	cmd := exec.CommandContext(ctx, "docker-compose", args...)
+	cmd := exec.CommandContext(ctx, "docker", append([]string{"compose"}, args...)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if len(d.Environment) > 0 {

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -174,6 +174,10 @@ func (d *wrapperDriver) cmd(ctx context.Context, command string, arg ...string) 
 	if len(d.Environment) > 0 {
 		cmd.Env = append(os.Environ(), d.Environment...)
 	}
+
+	// Debug message
+	fmt.Println(">>>>", "docker", strings.Join(append([]string{"compose"}, args...), " "))
+
 	return cmd
 }
 

--- a/testing/environments/Makefile
+++ b/testing/environments/Makefile
@@ -1,5 +1,5 @@
 ENV?=snapshot.yml
-BASE_COMMAND=docker-compose -f ${ENV} -f local.yml
+BASE_COMMAND=docker compose -f ${ENV} -f local.yml
 
 start:
 	# This is run every time to make sure the environment is up-to-date

--- a/x-pack/winlogbeat/module/testing.go
+++ b/x-pack/winlogbeat/module/testing.go
@@ -81,7 +81,7 @@ func testIngestPipeline(t *testing.T, pipeline, pattern string, p *params) {
 		t.Fatal(err)
 	}
 	if *wintest.KeepRunning {
-		fmt.Fprintln(os.Stdout, "Use this to manually cleanup containers: docker-compose", "-p", devtools.DockerComposeProjectName(), "rm", "--stop", "--force")
+		fmt.Fprintln(os.Stdout, "Use this to manually cleanup containers: docker compose", "-p", devtools.DockerComposeProjectName(), "rm", "--stop", "--force")
 	}
 	t.Cleanup(func() {
 		stop := !*wintest.KeepRunning

--- a/x-pack/winlogbeat/module/wintest/docker.go
+++ b/x-pack/winlogbeat/module/wintest/docker.go
@@ -78,7 +78,7 @@ func saveLogs(env map[string]string, root, target string) error {
 		env,
 		f, // stdout
 		f, // stderr
-		"docker-compose",
+		"docker", "compose",
 		"-p", devtools.DockerComposeProjectName(),
 		"logs",
 		"--no-color",
@@ -140,7 +140,8 @@ func dockerCompose(env map[string]string, verbose bool) error {
 			env,
 			out,
 			os.Stderr,
-			"docker-compose", args...,
+			"docker",
+			append([]string{"compose"}, args...)...,
 		)
 		if err == nil {
 			break

--- a/x-pack/winlogbeat/module/wintest/simulate_test.go
+++ b/x-pack/winlogbeat/module/wintest/simulate_test.go
@@ -48,7 +48,7 @@ func TestSimulate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if *wintest.KeepRunning {
-		fmt.Fprintln(os.Stdout, "docker-compose", "-p", devtools.DockerComposeProjectName(), "rm", "--stop", "--force")
+		fmt.Fprintln(os.Stdout, "docker compose", "-p", devtools.DockerComposeProjectName(), "rm", "--stop", "--force")
 	}
 	t.Cleanup(func() {
 		stop := !*wintest.KeepRunning


### PR DESCRIPTION
## Proposed commit message

The docker Compose V1 (docker-compose) stopped receiving updates on July 2023, this PR updates our automation tools to use the new Compose V2 (docker compose). Compose V2 has been GA since April 2022.

More information on
https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

There is no disruptive user impact

~~## Author's Checklist~~
## How to test this PR locally

Run any mage /make target that uses docker, like the python integration tests
```
mage docker:composeUp
mage pythonIntegTest
```

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
