### PR TITLE
[metricbeat][panw] fix concurrent map write error caused by reusing a mapstr.M

### DIFF
--- a/x-pack/metricbeat/module/panw/interfaces/ha_interfaces.go
+++ b/x-pack/metricbeat/module/panw/interfaces/ha_interfaces.go
@@ -57,7 +57,6 @@ func makeGroupEvent(m *MetricSet, input HAResult) *mb.Event {
 
 	group := input.Group
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	linkMonitoringEnabled, err := panw.StringToBool(group.LinkMonitoring.Enabled)
 	if err != nil {
@@ -130,7 +129,7 @@ func makeGroupEvent(m *MetricSet, input HAResult) *mb.Event {
 			"ha.peer_info.conn_ha1_backup.description": group.PeerInfo.ConnHA1Backup.Desc,
 			"ha.link_monitoring.enabled":               linkMonitoringEnabled,
 		},
-		RootFields: rootFields,
+		RootFields: panw.MakeRootFields(m.config.HostIp),
 	}
 
 	return &event
@@ -143,7 +142,6 @@ func makeLinkMonitoringEvents(m *MetricSet, links HALinkMonitoring) []mb.Event {
 
 	events := make([]mb.Event, 0, len(links.Groups))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	var event mb.Event
 	for _, group := range links.Groups {
@@ -172,7 +170,7 @@ func makeLinkMonitoringEvents(m *MetricSet, links HALinkMonitoring) []mb.Event {
 					"ha.link_monitoring.group.interface.name":    interface_entry.Name,
 					"ha.link_monitoring.group.interface.status":  interface_entry.Status,
 				},
-				RootFields: rootFields,
+				RootFields: panw.MakeRootFields(m.config.HostIp),
 			}
 		}
 

--- a/x-pack/metricbeat/module/panw/interfaces/ifnet_interfaces.go
+++ b/x-pack/metricbeat/module/panw/interfaces/ifnet_interfaces.go
@@ -51,7 +51,6 @@ func getIFNetInterfaceEvents(m *MetricSet) ([]mb.Event, error) {
 func formatIFInterfaceEvents(m *MetricSet, input InterfaceResult) []mb.Event {
 	events := make([]mb.Event, 0, len(input.HW.Entries)+len(input.Ifnet.Entries))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	// First process the phyiscal interfaces
 	for _, entry := range input.HW.Entries {
@@ -82,7 +81,7 @@ func formatIFInterfaceEvents(m *MetricSet, input InterfaceResult) []mb.Event {
 				"physical.full_state": entry.ST,
 				"physical.ae_member":  members,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)
@@ -104,7 +103,7 @@ func formatIFInterfaceEvents(m *MetricSet, input InterfaceResult) []mb.Event {
 				"logical.dyn_addr": entry.DynAddr,
 				"logical.addr6":    entry.Addr6,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)

--- a/x-pack/metricbeat/module/panw/interfaces/tunnels.go
+++ b/x-pack/metricbeat/module/panw/interfaces/tunnels.go
@@ -45,7 +45,6 @@ func formatIPSecTunnelEvents(m *MetricSet, entries []TunnelsEntry) []mb.Event {
 
 	events := make([]mb.Event, 0, len(entries))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	for _, entry := range entries {
 		event := mb.Event{
@@ -70,7 +69,7 @@ func formatIPSecTunnelEvents(m *MetricSet, entries []TunnelsEntry) []mb.Event {
 				"ipsec_tunnel.life.sec":   entry.Life,
 				"ipsec_tunnel.kb":         entry.KB,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)

--- a/x-pack/metricbeat/module/panw/routing/bgp_peers.go
+++ b/x-pack/metricbeat/module/panw/routing/bgp_peers.go
@@ -73,7 +73,6 @@ func convertEntryBooleanFields(entry BGPEntry) map[string]bool {
 func formatBGPEvents(m *MetricSet, entries []BGPEntry) []mb.Event {
 	events := make([]mb.Event, 0, len(entries))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	for _, entry := range entries {
 		booleanFields := convertEntryBooleanFields(entry)
@@ -130,7 +129,7 @@ func formatBGPEvents(m *MetricSet, entries []BGPEntry) []mb.Event {
 				"bgp.nexthop_thirdparty":     booleanFields["bgp.nexthop_thirdparty"],
 				"bgp.nexthop_peer":           booleanFields["bgp.nexthop_peer"],
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)

--- a/x-pack/metricbeat/module/panw/system/certificates.go
+++ b/x-pack/metricbeat/module/panw/system/certificates.go
@@ -47,7 +47,6 @@ func getCertificateEvents(m *MetricSet) ([]mb.Event, error) {
 
 func formatCertificateEvents(m *MetricSet, input string) ([]mb.Event, error) {
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	certificates, err := parseCertificates(input)
 	if err != nil {
@@ -72,7 +71,7 @@ func formatCertificateEvents(m *MetricSet, input string) ([]mb.Event, error) {
 				"certificate.db_name":             certificate.DBName,
 				"certificate.db_status":           certificate.DBStatus,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)

--- a/x-pack/metricbeat/module/panw/system/fans.go
+++ b/x-pack/metricbeat/module/panw/system/fans.go
@@ -40,7 +40,6 @@ func formatFanEvents(m *MetricSet, response *FanResponse) []mb.Event {
 
 	events := make([]mb.Event, 0)
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	for _, slot := range response.Result.Fan.Slots {
 		for _, entry := range slot.Entries {
@@ -58,7 +57,7 @@ func formatFanEvents(m *MetricSet, response *FanResponse) []mb.Event {
 					"fan.rpm":         entry.RPMs,
 					"fan.min_rpm":     entry.Min,
 				},
-				RootFields: rootFields,
+				RootFields: panw.MakeRootFields(m.config.HostIp),
 			}
 			events = append(events, event)
 		}

--- a/x-pack/metricbeat/module/panw/system/filesystem.go
+++ b/x-pack/metricbeat/module/panw/system/filesystem.go
@@ -128,7 +128,6 @@ func formatFilesystemEvents(m *MetricSet, filesystems []Filesystem) []mb.Event {
 
 	events := make([]mb.Event, 0, len(filesystems))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	for _, filesystem := range filesystems {
 		used, err := strconv.ParseInt(filesystem.UsePerc[:len(filesystem.UsePerc)-1], 10, 64)
@@ -146,7 +145,7 @@ func formatFilesystemEvents(m *MetricSet, filesystems []Filesystem) []mb.Event {
 				"filesystem.use_percent": used,
 				"filesystem.mounted":     filesystem.Mounted,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)

--- a/x-pack/metricbeat/module/panw/system/license.go
+++ b/x-pack/metricbeat/module/panw/system/license.go
@@ -49,7 +49,6 @@ func getLicenseEvents(m *MetricSet) ([]mb.Event, error) {
 func formatLicenseEvents(m *MetricSet, licenses []License) []mb.Event {
 	events := make([]mb.Event, 0, len(licenses))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	for _, license := range licenses {
 		expired, err := panw.StringToBool(license.Expired)
@@ -87,7 +86,7 @@ func formatLicenseEvents(m *MetricSet, licenses []License) []mb.Event {
 				"license.expired":       expired,
 				"license.auth_code":     license.AuthCode,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 		// only set the expires field if the license expires
 		if !neverExpires {

--- a/x-pack/metricbeat/module/panw/system/power.go
+++ b/x-pack/metricbeat/module/panw/system/power.go
@@ -44,7 +44,6 @@ func getPowerEvents(m *MetricSet) ([]mb.Event, error) {
 func formatPowerEvents(m *MetricSet, response *PowerResponse) []mb.Event {
 	events := make([]mb.Event, 0)
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	for _, slot := range response.Result.Power.Slots {
 		for _, entry := range slot.Entries {
@@ -59,7 +58,7 @@ func formatPowerEvents(m *MetricSet, response *PowerResponse) []mb.Event {
 					"power.minimum_volts": entry.MinimumVolts,
 					"power.maximum_volts": entry.MaximumVolts,
 				},
-				RootFields: rootFields,
+				RootFields: panw.MakeRootFields(m.config.HostIp),
 			}
 			events = append(events, event)
 		}

--- a/x-pack/metricbeat/module/panw/system/resources.go
+++ b/x-pack/metricbeat/module/panw/system/resources.go
@@ -69,7 +69,7 @@ MiB Swap:   5961.0 total,   4403.5 free,   1557.6 used.   1530.0 avail Mem
 */
 func formatResourceEvents(m *MetricSet, input string) []mb.Event {
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
+
 	events := make([]mb.Event, 0)
 
 	// We only need the top 5 lines
@@ -126,7 +126,7 @@ func formatResourceEvents(m *MetricSet, input string) []mb.Event {
 				"available": swapInfo.Available,
 			},
 		},
-		RootFields: rootFields,
+		RootFields: panw.MakeRootFields(m.config.HostIp),
 	}
 
 	events = append(events, event)

--- a/x-pack/metricbeat/module/panw/system/thermal.go
+++ b/x-pack/metricbeat/module/panw/system/thermal.go
@@ -43,7 +43,6 @@ func formatThermalEvents(m *MetricSet, response *ThermalResponse) []mb.Event {
 
 	events := make([]mb.Event, 0, len(response.Result.Thermal.Slots))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	var event mb.Event
 
@@ -64,7 +63,7 @@ func formatThermalEvents(m *MetricSet, response *ThermalResponse) []mb.Event {
 					"thermal.minimum_temp":    entry.MinimumTemp,
 					"thermal.maximum_temp":    entry.MaximumTemp,
 				},
-				RootFields: rootFields,
+				RootFields: panw.MakeRootFields(m.config.HostIp),
 			}
 
 			events = append(events, event)

--- a/x-pack/metricbeat/module/panw/vpn/gp_sessions.go
+++ b/x-pack/metricbeat/module/panw/vpn/gp_sessions.go
@@ -44,7 +44,6 @@ func formatGPSessionEvents(m *MetricSet, sessions []GPSession) []mb.Event {
 
 	events := make([]mb.Event, 0, len(sessions))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	for _, session := range sessions {
 		isLocal, err := panw.StringToBool(session.IsLocal)
@@ -79,7 +78,7 @@ func formatGPSessionEvents(m *MetricSet, sessions []GPSession) []mb.Event {
 				"globalprotect.session.request_get_config":     session.RequestGetConfig,
 				"globalprotect.session.request_sslvpn_connect": session.RequestSSLVPNConnect,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)

--- a/x-pack/metricbeat/module/panw/vpn/gp_stats.go
+++ b/x-pack/metricbeat/module/panw/vpn/gp_stats.go
@@ -46,7 +46,6 @@ func formatGPStatsEvents(m *MetricSet, response GPStatsResponse) []mb.Event {
 
 	events := make([]mb.Event, 0, len(response.Result.Gateways))
 	timestamp := time.Now().UTC()
-	rootFields := panw.MakeRootFields(m.config.HostIp)
 
 	totalCurrent := response.Result.TotalCurrentUsers
 	totalPrevious := response.Result.TotalPreviousUsers
@@ -61,7 +60,7 @@ func formatGPStatsEvents(m *MetricSet, response GPStatsResponse) []mb.Event {
 				"globalprotect.total_current_users":    totalCurrent,
 				"globalprotect.total_previous_users":   totalPrevious,
 			},
-			RootFields: rootFields,
+			RootFields: panw.MakeRootFields(m.config.HostIp),
 		}
 
 		events = append(events, event)


### PR DESCRIPTION
In the existing code, we create a mapstr.M containing attributes to set in the `RootFields` of metric events, which is reused several times in a loop. In the publisher code, the root fields are modified, e.g. https://github.com/elastic/beats/blob/main/metricbeat/mb/event.go#L79, which causes a panic due to `fatal error: concurrent map iteration and map write`, as the same mapstr.M object is still being used in later iterations of the loop.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
