### PR TITLE
[filebeat] Fix long filepaths in diagnostics exceeding max path limits on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -166,6 +166,8 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix publication of group data from the Okta entity analytics provider. {pull}40681[40681]
 - Ensure netflow custom field configuration is applied. {issue}40735[40735] {pull}40730[40730]
 - Fix replace processor handling of zero string replacement validation. {pull}40751[40751]
+- Fix long filepaths in diagnostics exceeding max path limits on Windows. {pull}40909[40909]
+
 
 *Heartbeat*
 

--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -128,6 +128,7 @@ func (r *runner) Start() {
 		err := r.input.Run(
 			v2.Context{
 				ID:             r.id,
+				IDWithoutName:  r.id,
 				Agent:          *r.agent,
 				Logger:         log,
 				Cancelation:    r.sig,

--- a/filebeat/input/v2/input-cursor/input.go
+++ b/filebeat/input/v2/input-cursor/input.go
@@ -115,6 +115,8 @@ func (inp *managedInput) Run(
 		grp.Go(func() (err error) {
 			// refine per worker context
 			inpCtx := ctx
+			// Preserve IDWithoutName, in case the context was constructed who knows how
+			inpCtx.IDWithoutName = ctx.ID
 			inpCtx.ID = ctx.ID + "::" + source.Name()
 			inpCtx.Logger = ctx.Logger.With("input_source", source.Name())
 

--- a/filebeat/input/v2/input.go
+++ b/filebeat/input/v2/input.go
@@ -79,6 +79,10 @@ type Context struct {
 	// The input ID.
 	ID string
 
+	// The input ID without name. Some inputs append sourcename, we need the id to be untouched
+	// https://github.com/elastic/beats/blob/43d80af2aea60b0c45711475d114e118d90c4581/filebeat/input/v2/input-cursor/input.go#L118
+	IDWithoutName string
+
 	// Agent provides additional Beat info like instance ID or beat name.
 	Agent beat.Info
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1250,6 +1250,7 @@ func cloneMap(dst, src mapstr.M) {
 // walkMap walks to all ends of the provided path in m and applies fn to the
 // final element of each walk. Nested arrays are not handled.
 func walkMap(m mapstr.M, path string, fn func(parent mapstr.M, key string)) {
+	//nolint:typecheck // typecheck linter is buggy and thinks rest is not used.
 	key, rest, more := strings.Cut(path, ".")
 	v, ok := m[key]
 	if !ok {

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1250,7 +1250,6 @@ func cloneMap(dst, src mapstr.M) {
 // walkMap walks to all ends of the provided path in m and applies fn to the
 // final element of each walk. Nested arrays are not handled.
 func walkMap(m mapstr.M, path string, fn func(parent mapstr.M, key string)) {
-	//nolint:typecheck,nolintlint // typecheck linter is buggy and thinks rest is not used.
 	key, rest, more := strings.Cut(path, ".")
 	v, ok := m[key]
 	if !ok {

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -142,7 +142,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	ctx := ctxtool.FromCanceller(env.Cancelation)
 
 	if cfg.Resource.Tracer != nil {
-		id := sanitizeFileName(env.ID)
+		id := sanitizeFileName(env.IDWithoutName)
 		cfg.Resource.Tracer.Filename = strings.ReplaceAll(cfg.Resource.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1250,7 +1250,7 @@ func cloneMap(dst, src mapstr.M) {
 // walkMap walks to all ends of the provided path in m and applies fn to the
 // final element of each walk. Nested arrays are not handled.
 func walkMap(m mapstr.M, path string, fn func(parent mapstr.M, key string)) {
-	//nolint:typecheck // typecheck linter is buggy and thinks rest is not used.
+	//nolint:typecheck,nolintlint // typecheck linter is buggy and thinks rest is not used.
 	key, rest, more := strings.Cut(path, ".")
 	v, ok := m[key]
 	if !ok {

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -448,9 +448,9 @@ var inputTests = []struct {
   </item>
 </order>
 `
-				io.ReadAll(r.Body)
+				_, _ = io.ReadAll(r.Body)
 				r.Body.Close()
-				w.Write([]byte(text))
+				_, _ = w.Write([]byte(text))
 			})
 			server := httptest.NewServer(r)
 			config["resource.url"] = server.URL
@@ -582,7 +582,7 @@ var inputTests = []struct {
 				msg = fmt.Sprintf(`{"error":"expected method was %#q"}`, http.MethodGet)
 			}
 
-			w.Write([]byte(msg))
+			_, _ = w.Write([]byte(msg))
 		},
 		want: []map[string]interface{}{
 			{
@@ -630,7 +630,7 @@ var inputTests = []struct {
 				msg = fmt.Sprintf(`{"error":"expected method was %#q"}`, http.MethodGet)
 			}
 
-			w.Write([]byte(msg))
+			_, _ = w.Write([]byte(msg))
 		},
 		want: []map[string]interface{}{
 			{
@@ -676,7 +676,7 @@ var inputTests = []struct {
 				msg = fmt.Sprintf(`{"error":"expected method was %#q"}`, http.MethodGet)
 			}
 
-			w.Write([]byte(msg))
+			_, _ = w.Write([]byte(msg))
 		},
 		want: []map[string]interface{}{
 			{

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -448,9 +448,9 @@ var inputTests = []struct {
   </item>
 </order>
 `
-				_, _ = io.ReadAll(r.Body)
+				io.ReadAll(r.Body)
 				r.Body.Close()
-				_, _ = w.Write([]byte(text))
+				w.Write([]byte(text))
 			})
 			server := httptest.NewServer(r)
 			config["resource.url"] = server.URL
@@ -582,7 +582,7 @@ var inputTests = []struct {
 				msg = fmt.Sprintf(`{"error":"expected method was %#q"}`, http.MethodGet)
 			}
 
-			_, _ = w.Write([]byte(msg))
+			w.Write([]byte(msg))
 		},
 		want: []map[string]interface{}{
 			{
@@ -630,7 +630,7 @@ var inputTests = []struct {
 				msg = fmt.Sprintf(`{"error":"expected method was %#q"}`, http.MethodGet)
 			}
 
-			_, _ = w.Write([]byte(msg))
+			w.Write([]byte(msg))
 		},
 		want: []map[string]interface{}{
 			{
@@ -676,7 +676,7 @@ var inputTests = []struct {
 				msg = fmt.Sprintf(`{"error":"expected method was %#q"}`, http.MethodGet)
 			}
 
-			_, _ = w.Write([]byte(msg))
+			w.Write([]byte(msg))
 		},
 		want: []map[string]interface{}{
 			{

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -1690,10 +1690,12 @@ func TestInput(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
+			id := "test_id:" + test.name
 			v2Ctx := v2.Context{
-				Logger:      logp.NewLogger("cel_test"),
-				ID:          "test_id:" + test.name,
-				Cancelation: ctx,
+				Logger:        logp.NewLogger("cel_test"),
+				ID:            id,
+				IDWithoutName: id,
+				Cancelation:   ctx,
 			}
 			var client publisher
 			client.done = func() {

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
@@ -109,7 +109,7 @@ func (p *jamfInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	updateTimer := time.NewTimer(updateWaitTime)
 
 	if p.cfg.Tracer != nil {
-		id := sanitizeFileName(inputCtx.ID)
+		id := sanitizeFileName(inputCtx.IDWithoutName)
 		p.cfg.Tracer.Filename = strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -113,7 +113,7 @@ func (p *oktaInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	p.lim = rate.NewLimiter(1, 1)
 
 	if p.cfg.Tracer != nil {
-		id := sanitizeFileName(inputCtx.ID)
+		id := sanitizeFileName(inputCtx.IDWithoutName)
 		p.cfg.Tracer.Filename = strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -478,7 +478,7 @@ func (p *oktaInput) doFetchUsers(ctx context.Context, state *stateStore, fullSyn
 
 		next, err := okta.Next(h)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
+			if err == io.EOF {
 				break
 			}
 			p.logger.Debugf("received %d users from API", len(users))
@@ -588,7 +588,7 @@ func (p *oktaInput) doFetchDevices(ctx context.Context, state *stateStore, fullS
 
 				next, err := okta.Next(h)
 				if err != nil {
-					if errors.Is(err, io.EOF) {
+					if err == io.EOF {
 						break
 					}
 					p.logger.Debugf("received %d devices from API", len(devices))
@@ -617,7 +617,7 @@ func (p *oktaInput) doFetchDevices(ctx context.Context, state *stateStore, fullS
 
 		next, err := okta.Next(h)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
+			if err == io.EOF {
 				break
 			}
 			p.logger.Debugf("received %d devices from API", len(devices))

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -478,7 +478,7 @@ func (p *oktaInput) doFetchUsers(ctx context.Context, state *stateStore, fullSyn
 
 		next, err := okta.Next(h)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			p.logger.Debugf("received %d users from API", len(users))
@@ -588,7 +588,7 @@ func (p *oktaInput) doFetchDevices(ctx context.Context, state *stateStore, fullS
 
 				next, err := okta.Next(h)
 				if err != nil {
-					if err == io.EOF {
+					if errors.Is(err, io.EOF) {
 						break
 					}
 					p.logger.Debugf("received %d devices from API", len(devices))
@@ -617,7 +617,7 @@ func (p *oktaInput) doFetchDevices(ctx context.Context, state *stateStore, fullS
 
 		next, err := okta.Next(h)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			p.logger.Debugf("received %d devices from API", len(devices))

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -108,7 +108,7 @@ func (e *httpEndpoint) Run(ctx v2.Context, pipeline beat.Pipeline) error {
 	defer metrics.Close()
 
 	if e.config.Tracer != nil {
-		id := sanitizeFileName(ctx.ID)
+		id := sanitizeFileName(ctx.IDWithoutName)
 		e.config.Tracer.Filename = strings.ReplaceAll(e.config.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -123,7 +123,7 @@ func run(ctx v2.Context, cfg config, pub inputcursor.Publisher, crsr *inputcurso
 	stdCtx := ctxtool.FromCanceller(ctx.Cancelation)
 
 	if cfg.Request.Tracer != nil {
-		id := sanitizeFileName(ctx.ID)
+		id := sanitizeFileName(ctx.IDWithoutName)
 		cfg.Request.Tracer.Filename = strings.ReplaceAll(cfg.Request.Tracer.Filename, "*", id)
 
 		// Propagate tracer behaviour to all chain children.

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -1357,9 +1357,9 @@ var testCases = []struct {
   </item>
 </order>
 `
-				_, _ = io.ReadAll(r.Body)
+				io.ReadAll(r.Body)
 				r.Body.Close()
-				_, _ = w.Write([]byte(text))
+				w.Write([]byte(text))
 			})
 			server := httptest.NewServer(r)
 			config["request.url"] = server.URL
@@ -1695,7 +1695,7 @@ func defaultHandler(expectedMethod, expectedBody, msg string) http.HandlerFunc {
 			}
 		}
 
-		_, _ = w.Write([]byte(msg))
+		w.Write([]byte(msg))
 	}
 }
 

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -1357,9 +1357,9 @@ var testCases = []struct {
   </item>
 </order>
 `
-				io.ReadAll(r.Body)
+				_, _ = io.ReadAll(r.Body)
 				r.Body.Close()
-				w.Write([]byte(text))
+				_, _ = w.Write([]byte(text))
 			})
 			server := httptest.NewServer(r)
 			config["request.url"] = server.URL

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -1660,9 +1660,10 @@ func newChainPaginationTestServer(
 func newV2Context(id string) (v2.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	return v2.Context{
-		Logger:      logp.NewLogger("httpjson_test"),
-		ID:          id,
-		Cancelation: ctx,
+		Logger:        logp.NewLogger("httpjson_test"),
+		ID:            id,
+		IDWithoutName: id,
+		Cancelation:   ctx,
 	}, cancel
 }
 

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -1695,7 +1695,7 @@ func defaultHandler(expectedMethod, expectedBody, msg string) http.HandlerFunc {
 			}
 		}
 
-		w.Write([]byte(msg))
+		_, _ = w.Write([]byte(msg))
 	}
 }
 


### PR DESCRIPTION

## Proposed commit message

Fix long filepaths in diagnostics exceeding max path limits on Windows.

Following the first proposal here
https://github.com/elastic/elastic-agent/issues/3758#issuecomment-1830229924
Added ```IDWithoutName``` that doesn't include the source name and using that instead.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/3758

## Screenshots

The screenshot that shows the diagnostics collected before and after this change. The earlier diagnostics shows the long path that includes the sanitized okta log collection URL. The diagnostics after this change have shorter path that doesn't include the sanitized URL in the path.
<img width="1009" alt="Screenshot 2024-09-19 at 2 36 12 PM" src="https://github.com/user-attachments/assets/7efd7e51-ce24-4dbe-947e-34a520a441c4">

