### PR TITLE
x-pack/metricbeat/module/gcp:  Override GCP API endpoint in metric client

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -59,7 +59,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Mark system process metricsets as running if metrics are partially available {pull}40565[40565]
 - Added back `elasticsearch.node.stats.jvm.mem.pools.*` to the `node_stats` metricset {pull}40571[40571]
 - Add GCP organization and project details to ECS cloud fields. {pull}40461[40461]
-- Add `endpoint` field to the GCP configuration in order to append it to the metric client. {issue}40848[40848] {pull}40918[40918]
+- Add support for specifying a custom endpoint for GCP service clients. {issue}40848[40848] {pull}40918[40918]
 
 *Osquerybeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -59,6 +59,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Mark system process metricsets as running if metrics are partially available {pull}40565[40565]
 - Added back `elasticsearch.node.stats.jvm.mem.pools.*` to the `node_stats` metricset {pull}40571[40571]
 - Add GCP organization and project details to ECS cloud fields. {pull}40461[40461]
+- Add `endpoint` field to the GCP configuration in order to append it to the metric client. {issue}40848[40848] {pull}40918[40918]
 
 *Osquerybeat*
 

--- a/metricbeat/docs/modules/gcp.asciidoc
+++ b/metricbeat/docs/modules/gcp.asciidoc
@@ -381,6 +381,16 @@ metricbeat.modules:
   credentials_file_path: "your JSON credentials file path"
   dataset_id: "dataset id"
   table_pattern: "table pattern"
+
+ - module: gcp
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
+  exclude_labels: false
+  period: 1m 
 ----
 
 [float]

--- a/metricbeat/docs/modules/gcp.asciidoc
+++ b/metricbeat/docs/modules/gcp.asciidoc
@@ -379,18 +379,9 @@ metricbeat.modules:
   period: 24h
   project_id: "your project id"
   credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
   dataset_id: "dataset id"
   table_pattern: "table pattern"
-
- - module: gcp
-  metricsets:
-    - compute
-  region: "us-"
-  project_id: "your project id"
-  credentials_file_path: "your JSON credentials file path"
-  endpoint: http://your-endpoint
-  exclude_labels: false
-  period: 1m 
 ----
 
 [float]

--- a/metricbeat/docs/modules/gcp.asciidoc
+++ b/metricbeat/docs/modules/gcp.asciidoc
@@ -52,6 +52,8 @@ and metadata information from metricsets and fetch metrics only. At the moment,
 
 * *period*: A single time duration specified for this module collection frequency.
 
+* *endpoint*: A custom endpoint to use for the GCP API calls. If not specified, the default endpoint will be used.
+
 [float]
 == Example configuration
 * `compute` metricset is enabled to collect metrics from `us-central1-a` zone

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -641,18 +641,9 @@ metricbeat.modules:
   period: 24h
   project_id: "your project id"
   credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
   dataset_id: "dataset id"
   table_pattern: "table pattern"
-
- - module: gcp
-  metricsets:
-    - compute
-  region: "us-"
-  project_id: "your project id"
-  credentials_file_path: "your JSON credentials file path"
-  endpoint: http://your-endpoint
-  exclude_labels: false
-  period: 1m 
 
 #-------------------------------- Golang Module --------------------------------
 - module: golang

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -644,6 +644,16 @@ metricbeat.modules:
   dataset_id: "dataset id"
   table_pattern: "table pattern"
 
+ - module: gcp
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
+  exclude_labels: false
+  period: 1m 
+
 #-------------------------------- Golang Module --------------------------------
 - module: golang
   #metricsets:

--- a/x-pack/metricbeat/module/gcp/_meta/config.yml
+++ b/x-pack/metricbeat/module/gcp/_meta/config.yml
@@ -67,15 +67,6 @@
   period: 24h
   project_id: "your project id"
   credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
   dataset_id: "dataset id"
   table_pattern: "table pattern"
-
- - module: gcp
-  metricsets:
-    - compute
-  region: "us-"
-  project_id: "your project id"
-  credentials_file_path: "your JSON credentials file path"
-  endpoint: http://your-endpoint
-  exclude_labels: false
-  period: 1m 

--- a/x-pack/metricbeat/module/gcp/_meta/config.yml
+++ b/x-pack/metricbeat/module/gcp/_meta/config.yml
@@ -69,3 +69,13 @@
   credentials_file_path: "your JSON credentials file path"
   dataset_id: "dataset id"
   table_pattern: "table pattern"
+
+ - module: gcp
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
+  exclude_labels: false
+  period: 1m 

--- a/x-pack/metricbeat/module/gcp/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/gcp/_meta/docs.asciidoc
@@ -40,6 +40,8 @@ and metadata information from metricsets and fetch metrics only. At the moment,
 
 * *period*: A single time duration specified for this module collection frequency.
 
+* *endpoint*: A custom endpoint to use for the GCP API calls. If not specified, the default endpoint will be used.
+
 [float]
 == Example configuration
 * `compute` metricset is enabled to collect metrics from `us-central1-a` zone

--- a/x-pack/metricbeat/module/gcp/metrics/metricset.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset.go
@@ -109,11 +109,11 @@ type config struct {
 	CredentialsJSON     string   `config:"credentials_json"`
 	Endpoint            string   `config:"endpoint"`
 
-	opt                 []option.ClientOption
-	period              *durationpb.Duration
-	organizationID      string
-	organizationName    string
-	projectName         string
+	opt              []option.ClientOption
+	period           *durationpb.Duration
+	organizationID   string
+	organizationName string
+	projectName      string
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -144,7 +144,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	} else {
 		return m, fmt.Errorf("no credentials_file_path or credentials_json specified")
 	}
-	
+
 	if m.config.Endpoint != "" {
 		m.Logger().Warnf("You are using a custom endpoint '%s' for the GCP API calls.", m.config.Endpoint)
 		m.config.opt = append(m.config.opt, option.WithEndpoint(m.config.Endpoint))

--- a/x-pack/metricbeat/module/gcp/metrics/metricset.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset.go
@@ -108,6 +108,7 @@ type config struct {
 	CredentialsFilePath string   `config:"credentials_file_path"`
 	CredentialsJSON     string   `config:"credentials_json"`
 	Endpoint            string   `config:"endpoint"`
+
 	opt                 []option.ClientOption
 	period              *durationpb.Duration
 	organizationID      string
@@ -143,6 +144,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	} else {
 		return m, fmt.Errorf("no credentials_file_path or credentials_json specified")
 	}
+	
 	if m.config.Endpoint != "" {
 		m.Logger().Warnf("You are using a custom endpoint '%s' for the GCP API calls.", m.config.Endpoint)
 		m.config.opt = append(m.config.opt, option.WithEndpoint(m.config.Endpoint))

--- a/x-pack/metricbeat/module/gcp/metrics/metricset.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset.go
@@ -107,12 +107,12 @@ type config struct {
 	ExcludeLabels       bool     `config:"exclude_labels"`
 	CredentialsFilePath string   `config:"credentials_file_path"`
 	CredentialsJSON     string   `config:"credentials_json"`
-
-	opt              []option.ClientOption
-	period           *durationpb.Duration
-	organizationID   string
-	organizationName string
-	projectName      string
+	Endpoint            string   `config:"endpoint"`
+	opt                 []option.ClientOption
+	period              *durationpb.Duration
+	organizationID      string
+	organizationName    string
+	projectName         string
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -142,6 +142,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		m.config.opt = []option.ClientOption{option.WithCredentialsJSON([]byte(m.config.CredentialsJSON))}
 	} else {
 		return m, fmt.Errorf("no credentials_file_path or credentials_json specified")
+	}
+	if m.config.Endpoint != "" {
+		m.Logger().Warnf("You are using a custom endpoint '%s' for the GCP API calls.", m.config.Endpoint)
+		m.config.opt = append(m.config.opt, option.WithEndpoint(m.config.Endpoint))
 	}
 
 	m.config.period = &durationpb.Duration{

--- a/x-pack/metricbeat/modules.d/gcp.yml.disabled
+++ b/x-pack/metricbeat/modules.d/gcp.yml.disabled
@@ -72,3 +72,13 @@
   credentials_file_path: "your JSON credentials file path"
   dataset_id: "dataset id"
   table_pattern: "table pattern"
+
+ - module: gcp
+  metricsets:
+    - compute
+  region: "us-"
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
+  exclude_labels: false
+  period: 1m 

--- a/x-pack/metricbeat/modules.d/gcp.yml.disabled
+++ b/x-pack/metricbeat/modules.d/gcp.yml.disabled
@@ -70,15 +70,6 @@
   period: 24h
   project_id: "your project id"
   credentials_file_path: "your JSON credentials file path"
+  endpoint: http://your-endpoint
   dataset_id: "dataset id"
   table_pattern: "table pattern"
-
- - module: gcp
-  metricsets:
-    - compute
-  region: "us-"
-  project_id: "your project id"
-  credentials_file_path: "your JSON credentials file path"
-  endpoint: http://your-endpoint
-  exclude_labels: false
-  period: 1m 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
The GCP metric client does not currently allow overriding with a custom endpoint, which is necessary for testing against a mock GCP API endpoint. 
Resolved this issue by implementing a check to determine if an endpoint is specified in the GCP configuration, and subsequently overriding the `ClientOption` with that endpoint.
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #40848 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
