### PR TITLE
Change codeowners from ent-search-application to app-search-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,7 +194,7 @@ CHANGELOG*
 /x-pack/metricbeat/module/cockroachdb @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/containerd/ @elastic/obs-cloudnative-monitoring
 /x-pack/metricbeat/module/coredns @elastic/obs-infraobs-integrations
-/x-pack/metricbeat/module/enterprisesearch @elastic/ent-search-application
+/x-pack/metricbeat/module/enterprisesearch @elastic/app-search-team
 /x-pack/metricbeat/module/gcp @elastic/obs-ds-hosted-services @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/billing @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/gcp/cloudrun_metrics @elastic/obs-infraobs-integrations


### PR DESCRIPTION
### Description
As part of the global teams renaming, it's required to change this team to be an @elastic/app-search-team.

@elastic/ingest-eng-prod , can you please add this team to the repo, so the CODEOWNERS is valid again?