### PR TITLE
Revert "[8.x](backport #40909) [filebeat] Fix long filepaths in diagnostics exceeding max path limits on Windows"

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -169,8 +169,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix publication of group data from the Okta entity analytics provider. {pull}40681[40681]
 - Ensure netflow custom field configuration is applied. {issue}40735[40735] {pull}40730[40730]
 - Fix replace processor handling of zero string replacement validation. {pull}40751[40751]
-- Fix long filepaths in diagnostics exceeding max path limits on Windows. {pull}40909[40909]
-
 
 *Heartbeat*
 

--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -128,7 +128,6 @@ func (r *runner) Start() {
 		err := r.input.Run(
 			v2.Context{
 				ID:             r.id,
-				IDWithoutName:  r.id,
 				Agent:          *r.agent,
 				Logger:         log,
 				Cancelation:    r.sig,

--- a/filebeat/input/v2/input-cursor/input.go
+++ b/filebeat/input/v2/input-cursor/input.go
@@ -115,8 +115,6 @@ func (inp *managedInput) Run(
 		grp.Go(func() (err error) {
 			// refine per worker context
 			inpCtx := ctx
-			// Preserve IDWithoutName, in case the context was constructed who knows how
-			inpCtx.IDWithoutName = ctx.ID
 			inpCtx.ID = ctx.ID + "::" + source.Name()
 			inpCtx.Logger = ctx.Logger.With("input_source", source.Name())
 

--- a/filebeat/input/v2/input.go
+++ b/filebeat/input/v2/input.go
@@ -79,10 +79,6 @@ type Context struct {
 	// The input ID.
 	ID string
 
-	// The input ID without name. Some inputs append sourcename, we need the id to be untouched
-	// https://github.com/elastic/beats/blob/43d80af2aea60b0c45711475d114e118d90c4581/filebeat/input/v2/input-cursor/input.go#L118
-	IDWithoutName string
-
 	// Agent provides additional Beat info like instance ID or beat name.
 	Agent beat.Info
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -142,7 +142,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	ctx := ctxtool.FromCanceller(env.Cancelation)
 
 	if cfg.Resource.Tracer != nil {
-		id := sanitizeFileName(env.IDWithoutName)
+		id := sanitizeFileName(env.ID)
 		cfg.Resource.Tracer.Filename = strings.ReplaceAll(cfg.Resource.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -1690,12 +1690,10 @@ func TestInput(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			id := "test_id:" + test.name
 			v2Ctx := v2.Context{
-				Logger:        logp.NewLogger("cel_test"),
-				ID:            id,
-				IDWithoutName: id,
-				Cancelation:   ctx,
+				Logger:      logp.NewLogger("cel_test"),
+				ID:          "test_id:" + test.name,
+				Cancelation: ctx,
 			}
 			var client publisher
 			client.done = func() {

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
@@ -109,7 +109,7 @@ func (p *jamfInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	updateTimer := time.NewTimer(updateWaitTime)
 
 	if p.cfg.Tracer != nil {
-		id := sanitizeFileName(inputCtx.IDWithoutName)
+		id := sanitizeFileName(inputCtx.ID)
 		p.cfg.Tracer.Filename = strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -113,7 +113,7 @@ func (p *oktaInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	p.lim = rate.NewLimiter(1, 1)
 
 	if p.cfg.Tracer != nil {
-		id := sanitizeFileName(inputCtx.IDWithoutName)
+		id := sanitizeFileName(inputCtx.ID)
 		p.cfg.Tracer.Filename = strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -108,7 +108,7 @@ func (e *httpEndpoint) Run(ctx v2.Context, pipeline beat.Pipeline) error {
 	defer metrics.Close()
 
 	if e.config.Tracer != nil {
-		id := sanitizeFileName(ctx.IDWithoutName)
+		id := sanitizeFileName(ctx.ID)
 		e.config.Tracer.Filename = strings.ReplaceAll(e.config.Tracer.Filename, "*", id)
 	}
 

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -123,7 +123,7 @@ func run(ctx v2.Context, cfg config, pub inputcursor.Publisher, crsr *inputcurso
 	stdCtx := ctxtool.FromCanceller(ctx.Cancelation)
 
 	if cfg.Request.Tracer != nil {
-		id := sanitizeFileName(ctx.IDWithoutName)
+		id := sanitizeFileName(ctx.ID)
 		cfg.Request.Tracer.Filename = strings.ReplaceAll(cfg.Request.Tracer.Filename, "*", id)
 
 		// Propagate tracer behaviour to all chain children.

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -1660,10 +1660,9 @@ func newChainPaginationTestServer(
 func newV2Context(id string) (v2.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	return v2.Context{
-		Logger:        logp.NewLogger("httpjson_test"),
-		ID:            id,
-		IDWithoutName: id,
-		Cancelation:   ctx,
+		Logger:      logp.NewLogger("httpjson_test"),
+		ID:          id,
+		Cancelation: ctx,
 	}, cancel
 }
 


### PR DESCRIPTION
Reverts elastic/beats#40923

@aleksmaus I am sorry I have to revert this but it introduced a problem with Elastic Agent where lock file on Windows remain and diagnostic are not being generated at all.

cc @ycombinator @cmacknz 