### PR TITLE
Fix nil pointer deref if the file output lacks a `path` setting.

### DIFF
--- a/libbeat/outputs/fileout/config.go
+++ b/libbeat/outputs/fileout/config.go
@@ -38,6 +38,7 @@ type fileOutConfig struct {
 
 func defaultConfig() fileOutConfig {
 	return fileOutConfig{
+		Path:            &PathFormatString{},
 		NumberOfFiles:   7,
 		RotateEveryKb:   10 * 1024,
 		Permissions:     0600,

--- a/libbeat/outputs/fileout/config_test.go
+++ b/libbeat/outputs/fileout/config_test.go
@@ -37,6 +37,7 @@ func TestConfig(t *testing.T) {
 			config: config.MustNewConfigFrom([]byte(`{ }`)),
 			assertion: func(t *testing.T, actual *fileOutConfig, err error) {
 				expectedConfig := &fileOutConfig{
+					Path:            &PathFormatString{},
 					NumberOfFiles:   7,
 					RotateEveryKb:   10 * 1024,
 					Permissions:     0600,

--- a/libbeat/outputs/fileout/pathformatstring.go
+++ b/libbeat/outputs/fileout/pathformatstring.go
@@ -18,6 +18,7 @@
 package fileout
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -43,6 +44,9 @@ type PathFormatString struct {
 func (fs *PathFormatString) Run(timestamp time.Time) (string, error) {
 	placeholderEvent := &beat.Event{
 		Timestamp: timestamp,
+	}
+	if fs.efs == nil {
+		return "", fmt.Errorf("path format string is nil; check if `path` option is configured correctly")
 	}
 	return fs.efs.Run(placeholderEvent)
 }

--- a/libbeat/outputs/fileout/pathformatstring_test.go
+++ b/libbeat/outputs/fileout/pathformatstring_test.go
@@ -21,8 +21,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCheckNilDoesntPanic(t *testing.T) {
+	newCfg := config.NewConfig()
+	handler, err := readConfig(newCfg)
+	require.NoError(t, err)
+	_, err = handler.Path.Run(time.Now())
+	require.Error(t, err)
+
+}
 
 func TestPathFormatString(t *testing.T) {
 	tests := []struct {

--- a/libbeat/outputs/fileout/pathformatstring_test.go
+++ b/libbeat/outputs/fileout/pathformatstring_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/config"
 )
 
 func TestCheckNilDoesntPanic(t *testing.T) {


### PR DESCRIPTION

## Proposed commit message

Fixes a small bug where if the `output.file` config is enabled but doesn't have a correctly set `path` setting, the `pathFormatString.Run()` method will be null, and explode. This sets the default config to have a non-null path format string, and also checks to make sure `EventFormatString` is non-null.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


