### PR TITLE
x-pack/filebeat/input/internal/private: add field redaction package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,6 +123,7 @@ CHANGELOG*
 /x-pack/filebeat/input/httpjson/ @elastic/security-service-integrations
 /x-pack/filebeat/input/internal/httplog @elastic/security-service-integrations
 /x-pack/filebeat/input/internal/httpmon @elastic/security-service-integrations
+/x-pack/filebeat/input/internal/private @elastic/security-service-integrations
 /x-pack/filebeat/input/lumberjack/ @elastic/security-service-integrations
 /x-pack/filebeat/input/netflow/ @elastic/sec-deployment-and-devices
 /x-pack/filebeat/input/o365audit/ @elastic/security-service-integrations

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -206,6 +206,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Added debug logging to parquet reader in x-pack/libbeat/reader. {pull}40651[40651]
 - Added filebeat debug histograms for s3 object size and events per processed s3 object. {pull}40775[40775]
 - Simplified Azure Blob Storage input state checkpoint calculation logic. {issue}40674[40674] {pull}40936[40936]
+- Add field redaction package. {pull}40997[40997]
 
 ==== Deprecated
 

--- a/x-pack/filebeat/input/internal/private/private.go
+++ b/x-pack/filebeat/input/internal/private/private.go
@@ -1,0 +1,234 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package private implements field redaction in maps and structs.
+package private
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"unsafe"
+)
+
+const tooDeep = 100
+
+var privateKey = reflect.ValueOf("private")
+
+// Redact returns a copy of val with any fields or map elements that have been
+// marked as private removed. Fields can be marked as private by including a
+// sibling string- or []string-valued field or element with the name of the
+// private field. The names of fields are interpreted through the tag parameter
+// if present. For example if tag is "json", the `json:"<name>"` name would be
+// used, falling back to the field name if not present. The tag parameter is
+// ignored for map values.
+//
+// If a field has a `private:...` tag, its tag value will also be used to
+// determine the list of private fields. If the private tag is empty,
+// `private:""`, the fields with the tag will be marked as private. Otherwise
+// the comma-separated list of names with be used. The list may refer to its
+// own field.
+func Redact[T any](val T, tag string) (redacted T, err error) {
+	defer func() {
+		switch r := recover().(type) {
+		case nil:
+			return
+		case cycle:
+			// Make the returned type informative in all cases.
+			// If Redact[any](v) is called and we use the zero
+			// value, we would return a nil any, which is less
+			// informative.
+			redacted = reflect.New(reflect.TypeOf(val)).Elem().Interface().(T)
+			err = r
+		default:
+			panic(r)
+		}
+	}()
+	rv := reflect.ValueOf(val)
+	switch rv.Kind() {
+	case reflect.Map, reflect.Pointer, reflect.Struct:
+		return redact(rv, tag, 0, make(map[any]int)).Interface().(T), nil
+	default:
+		return val, nil
+	}
+}
+
+func redact(v reflect.Value, tag string, depth int, seen map[any]int) reflect.Value {
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			return v
+		}
+		if depth > tooDeep {
+			ident := v.Interface()
+			if last, ok := seen[ident]; ok && last < depth {
+				panic(cycle{v.Type()})
+			}
+			seen[ident] = depth
+			defer delete(seen, ident)
+		}
+		return redact(v.Elem(), tag, depth+1, seen).Addr()
+	case reflect.Interface:
+		if v.IsNil() {
+			return v
+		}
+		return redact(v.Elem(), tag, depth+1, seen)
+	case reflect.Array:
+		if v.Len() == 0 {
+			return v
+		}
+		r := reflect.New(v.Type()).Elem()
+		for i := 0; i < v.Len(); i++ {
+			r.Index(i).Set(redact(v.Index(i), tag, depth+1, seen))
+		}
+		return r
+	case reflect.Slice:
+		if v.Len() == 0 {
+			return v
+		}
+		if depth > tooDeep {
+			ident := struct {
+				data unsafe.Pointer
+				len  int
+			}{
+				v.UnsafePointer(),
+				v.Len(),
+			}
+			if last, ok := seen[ident]; ok && last < depth {
+				panic(cycle{v.Type()})
+			}
+			seen[ident] = depth
+			defer delete(seen, ident)
+		}
+		r := reflect.MakeSlice(v.Type(), v.Len(), v.Cap())
+		for i := 0; i < v.Len(); i++ {
+			r.Index(i).Set(redact(v.Index(i), tag, depth+1, seen))
+		}
+		return r
+	case reflect.Map:
+		if v.IsNil() {
+			return v
+		}
+		if depth > tooDeep {
+			ident := v.UnsafePointer()
+			if last, ok := seen[ident]; ok && last < depth {
+				panic(cycle{v.Type()})
+			}
+			seen[ident] = depth
+			defer delete(seen, ident)
+		}
+		var private []string
+		if privateKey.CanConvert(v.Type().Key()) {
+			p := v.MapIndex(privateKey.Convert(v.Type().Key()))
+			if p.IsValid() && p.CanInterface() {
+				switch p := p.Interface().(type) {
+				case string:
+					private = []string{p}
+				case []string:
+					private = p
+				case []any:
+					private = make([]string, len(p))
+					for i, s := range p {
+						private[i] = fmt.Sprint(s)
+					}
+				}
+			}
+		}
+		r := reflect.MakeMap(v.Type())
+		it := v.MapRange()
+		for it.Next() {
+			if slices.Contains(private, it.Key().String()) {
+				continue
+			}
+			r.SetMapIndex(it.Key(), redact(it.Value(), tag, depth+1, seen))
+		}
+		return r
+	case reflect.Struct:
+		var private []string
+		rt := v.Type()
+		names := make([]string, rt.NumField())
+		for i := range names {
+			f := rt.Field(i)
+
+			// Look for `private:` tags.
+			p, ok := f.Tag.Lookup("private")
+			if ok {
+				if p != "" {
+					private = append(private, strings.Split(p, ",")...)
+				} else {
+					if tag == "" {
+						names[i] = f.Name
+						private = append(private, f.Name)
+					} else {
+						p = f.Tag.Get(tag)
+						if p != "" {
+							name, _, _ := strings.Cut(p, ",")
+							names[i] = name
+							private = append(private, name)
+						}
+					}
+				}
+			}
+
+			// Look after Private fields if we are not using a tag.
+			if tag == "" {
+				names[i] = f.Name
+				if f.Name == "Private" {
+					switch p := v.Field(i).Interface().(type) {
+					case string:
+						private = append(private, p)
+					case []string:
+						private = append(private, p...)
+					}
+				}
+				continue
+			}
+
+			// If we are using a tag, look for `tag:"<private>"`
+			// falling back to fields named Private if no tag is
+			// present.
+			p = f.Tag.Get(tag)
+			var name string
+			if p == "" {
+				name = f.Name
+			} else {
+				name, _, _ = strings.Cut(p, ",")
+			}
+			names[i] = name
+			if name == "private" {
+				switch p := v.Field(i).Interface().(type) {
+				case string:
+					private = append(private, p)
+				case []string:
+					private = append(private, p...)
+				}
+			}
+		}
+
+		r := reflect.New(v.Type()).Elem()
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if f.IsZero() || !rt.Field(i).IsExported() {
+				continue
+			}
+			if slices.Contains(private, names[i]) {
+				continue
+			}
+			if r.Field(i).CanSet() {
+				r.Field(i).Set(redact(f, tag, depth+1, seen))
+			}
+		}
+		return r
+	}
+	return v
+}
+
+type cycle struct {
+	typ reflect.Type
+}
+
+func (e cycle) Error() string {
+	return fmt.Sprintf("cycle including %s", e.typ)
+}

--- a/x-pack/filebeat/input/internal/private/private_test.go
+++ b/x-pack/filebeat/input/internal/private/private_test.go
@@ -1,0 +1,291 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package private
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type redactTest struct {
+	name    string
+	in      any
+	tag     string
+	want    any
+	wantErr error
+}
+
+var redactTests = []redactTest{
+	{
+		name: "map_string",
+		in: map[string]any{
+			"private":    "secret",
+			"secret":     "1",
+			"not_secret": "2",
+		},
+		want: map[string]any{
+			"private":    "secret",
+			"not_secret": "2",
+		},
+	},
+	{
+		name: "map_string_inner",
+		in: map[string]any{
+			"inner": map[string]any{
+				"private":    "secret",
+				"secret":     "1",
+				"not_secret": "2",
+			}},
+		want: map[string]any{
+			"inner": map[string]any{
+				"private":    "secret",
+				"not_secret": "2",
+			}},
+	},
+	{
+		name: "map_slice",
+		in: map[string]any{
+			"private":    []string{"secret"},
+			"secret":     "1",
+			"not_secret": "2",
+		},
+		want: map[string]any{
+			"private":    []string{"secret"},
+			"not_secret": "2",
+		},
+	},
+	{
+		name: "map_cycle",
+		in: func() any {
+			m := map[string]any{
+				"private":    "secret",
+				"secret":     "1",
+				"not_secret": "2",
+			}
+			m["loop"] = m
+			return m
+		}(),
+		want:    map[string]any(nil),
+		wantErr: cycle{reflect.TypeOf(map[string]any(nil))},
+	},
+	func() redactTest {
+		type s struct {
+			Private   string
+			Secret    string
+			NotSecret string
+		}
+		return redactTest{
+			name: "struct_string",
+			in: s{
+				Private:   "Secret",
+				Secret:    "1",
+				NotSecret: "2",
+			},
+			tag: "",
+			want: s{
+				Private:   "Secret",
+				NotSecret: "2",
+			},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   []string
+			Secret    string
+			NotSecret string
+		}
+		return redactTest{
+			name: "struct_slice",
+			in: s{
+				Private:   []string{"Secret"},
+				Secret:    "1",
+				NotSecret: "2",
+			},
+			tag: "",
+			want: s{
+				Private:   []string{"Secret"},
+				NotSecret: "2",
+			},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   string
+			Secret    string
+			NotSecret string
+			Loop      *s
+		}
+		v := s{
+			Private:   "Secret",
+			Secret:    "1",
+			NotSecret: "2",
+		}
+		v.Loop = &v
+		return redactTest{
+			name:    "struct_loop",
+			in:      v,
+			tag:     "",
+			want:    s{},
+			wantErr: cycle{reflect.TypeOf(&s{})},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   string `json:"private"`
+			Secret    string `json:"secret"`
+			NotSecret string `json:"not_secret"`
+		}
+		return redactTest{
+			name: "struct_string_json",
+			in: s{
+				Private:   "secret",
+				Secret:    "1",
+				NotSecret: "2",
+			},
+			tag: "json",
+			want: s{
+				Private:   "secret",
+				NotSecret: "2",
+			},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   struct{} `private:"secret"`
+			Secret    string   `json:"secret"`
+			NotSecret string   `json:"not_secret"`
+		}
+		return redactTest{
+			name: "struct_string_on_tag_json",
+			in: s{
+				Secret:    "1",
+				NotSecret: "2",
+			},
+			tag: "json",
+			want: s{
+				NotSecret: "2",
+			},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   struct{} `private:"secret1,secret2"`
+			Secret1   string   `json:"secret1"`
+			Secret2   string   `json:"secret2"`
+			NotSecret string   `json:"not_secret"`
+		}
+		return redactTest{
+			name: "struct_string_list_on_tag_json",
+			in: s{
+				Secret1:   "1",
+				Secret2:   "1",
+				NotSecret: "2",
+			},
+			tag: "json",
+			want: s{
+				NotSecret: "2",
+			},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   string `json:"private"`
+			Secret    string
+			NotSecret string `json:"not_secret"`
+		}
+		return redactTest{
+			name: "struct_string_json_missing_tag",
+			in: s{
+				Private:   "Secret",
+				Secret:    "1",
+				NotSecret: "2",
+			},
+			tag: "json",
+			want: s{
+				Private:   "Secret",
+				NotSecret: "2",
+			},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   []string `json:"private"`
+			Secret    string   `json:"secret"`
+			NotSecret string   `json:"not_secret"`
+		}
+		return redactTest{
+			name: "struct_slice_json",
+			in: s{
+				Private:   []string{"secret"},
+				Secret:    "1",
+				NotSecret: "2",
+			},
+			tag: "json",
+			want: s{
+				Private:   []string{"secret"},
+				NotSecret: "2",
+			},
+		}
+	}(),
+	func() redactTest {
+		type s struct {
+			Private   string `json:"private"`
+			Secret    string `json:"secret"`
+			NotSecret string `json:"not_secret"`
+			Loop      *s     `json:"loop"`
+		}
+		v := s{
+			Private:   "secret",
+			Secret:    "1",
+			NotSecret: "2",
+		}
+		v.Loop = &v
+		return redactTest{
+			name:    "struct_loop_json",
+			in:      v,
+			tag:     "json",
+			want:    s{},
+			wantErr: cycle{reflect.TypeOf(&s{})},
+		}
+	}(),
+}
+
+func TestRedact(t *testing.T) {
+	allow := cmp.AllowUnexported()
+
+	for _, test := range redactTests {
+		t.Run(test.name, func(t *testing.T) {
+			var before []byte
+			_, isCycle := test.wantErr.(cycle)
+			if !isCycle {
+				var err error
+				before, err = json.Marshal(test.in)
+				if err != nil {
+					t.Fatalf("failed to get before state: %v", err)
+				}
+			}
+			got, err := Redact(test.in, test.tag)
+			if err != test.wantErr {
+				t.Fatalf("unexpected error from Redact: %v", err)
+			}
+			if !isCycle {
+				after, err := json.Marshal(test.in)
+				if err != nil {
+					t.Fatalf("failed to get after state: %v", err)
+				}
+				if !bytes.Equal(before, after) {
+					t.Errorf("unexpected change in input:\n---:\n+++:\n%s", cmp.Diff(before, after))
+				}
+			}
+			if !cmp.Equal(test.want, got, allow) {
+				t.Errorf("unexpected paths:\n--- want:\n+++ got:\n%s", cmp.Diff(test.want, got, allow))
+			}
+		})
+	}
+}

--- a/x-pack/filebeat/input/internal/private/private_test.go
+++ b/x-pack/filebeat/input/internal/private/private_test.go
@@ -124,6 +124,76 @@ var redactTests = []redactTest{
 			}},
 	},
 	{
+		name: "map_string_inner_next_inner_params_global_internal_slice",
+		in: map[string]any{
+			"inner": map[string]any{
+				"next_inner": []map[string]any{
+					{
+						"headers": url.Values{
+							"secret":     []string{"1"},
+							"not_secret": []string{"2"},
+						},
+						"not_secret": "2",
+					},
+					{
+						"headers": url.Values{
+							"secret":     []string{"3"},
+							"not_secret": []string{"4"},
+						},
+						"not_secret": "4",
+					},
+				},
+			}},
+		global: []string{"inner.next_inner.headers"},
+		want: map[string]any{
+			"inner": map[string]any{
+				"next_inner": []map[string]any{
+					{"not_secret": "2"},
+					{"not_secret": "4"},
+				},
+			}},
+	},
+	{
+		name: "map_string_inner_next_inner_params_global_internal_slice_precise",
+		in: map[string]any{
+			"inner": map[string]any{
+				"next_inner": []map[string]any{
+					{
+						"headers": url.Values{
+							"secret":     []string{"1"},
+							"not_secret": []string{"2"},
+						},
+						"not_secret": "2",
+					},
+					{
+						"headers": url.Values{
+							"secret":     []string{"3"},
+							"not_secret": []string{"4"},
+						},
+						"not_secret": "4",
+					},
+				},
+			}},
+		global: []string{"inner.next_inner.headers.secret"},
+		want: map[string]any{
+			"inner": map[string]any{
+				"next_inner": []map[string]any{
+					{
+						"headers": url.Values{
+							"not_secret": []string{"2"},
+						},
+						"not_secret": "2",
+					},
+					{
+						"headers": url.Values{
+							"not_secret": []string{"4"},
+						},
+						"not_secret": "4",
+					},
+				},
+			}},
+	},
+	{
 		name: "map_slice",
 		in: map[string]any{
 			"private":    []string{"secret"},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Initial donation of code from github.com/kortschak/dex/internal/private.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

```diff
diff --git a/x-pack/filebeat/input/httpjson/input.go b/x-pack/filebeat/input/httpjson/input.go
index 67daa7ef84..41b46c1878 100644
--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -33,6 +33,7 @@ import (
        "github.com/elastic/beats/v7/libbeat/version"
        "github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
        "github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httpmon"
+       "github.com/elastic/beats/v7/x-pack/filebeat/input/internal/private"
        "github.com/elastic/elastic-agent-libs/logp"
        "github.com/elastic/elastic-agent-libs/mapstr"
        "github.com/elastic/elastic-agent-libs/monitoring"
@@ -82,6 +83,19 @@ func (log *retryLogger) Warn(msg string, keysAndValues ...interface{}) {
        log.log.Warnw(msg, keysAndValues...)
 }
 
+type redact struct {
+       value  mapstr.M
+       fields []string
+}
+
+func (r redact) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+       v, err := private.Redact(r.value, "", r.fields)
+       if err != nil {
+               return fmt.Errorf("could not redact value: %v", err)
+       }
+       return v.MarshalLogObject(enc)
+}
+
 func Plugin(log *logp.Logger, store inputcursor.StateStore) v2.Plugin {
        return v2.Plugin{
                Name:       inputName,
diff --git a/x-pack/filebeat/input/httpjson/request.go b/x-pack/filebeat/input/httpjson/request.go
index 6cc46b27f2..5dfb91dbdb 100644
--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -465,7 +465,7 @@ func (rf *requestFactory) newRequest(ctx *transformContext) (transformable, erro
                }
        }
 
-       rf.log.Debugf("new request: %#v", req)
+       rf.log.Debugw("new request", "req", redact{value: mapstr.M(req), fields: []string{"header.Authorization"}})
 
        return req, nil
 }
```

Could also be used in place of the current redactor in CEL, though that has a non-deletion redaction that this does not have. Adding that requires thought since this will redact non-string values.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
