### PR TITLE
Add missing changelog for ES fix.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -9,6 +9,10 @@ https://github.com/elastic/beats/compare/v8.15.1\...v8.15.2[View commits]
 
 ==== Bugfixes
 
+*Affecting all Beats*
+
+- Fix bug that prevented the Elasticsearch output from recovering from an interrupted connection. {issue}40705[40705] {pull}40769[40796]
+
 *Filebeat*
 
 - Fix publication of group data from the Okta entity analytics provider. {pull}40681[40681]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -68,7 +68,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Support Elastic Agent control protocol chunking support {pull}37343[37343]
 - Lower logging level to debug when attempting to configure beats with unknown fields from autodiscovered events/environments {pull}[37816][37816]
 - Set timeout of 1 minute for FQDN requests {pull}37756[37756]
-- Fix bug that prevented the Elasticsearch output from recovering from an interrupted connection. {issue}40705[40705] {pull}40769[40796]
 
 *Auditbeat*
 


### PR DESCRIPTION
The changelog for the 8.15.1 bug that causes data ingestion to stop when connections have a transient error was omitted from the 8.15.2 changelog. Add it back.

It was added in https://github.com/elastic/beats/commit/a09bd5160f191b725bd0ea46e3efc69c71b7c36a#diff-867eb8a32d99eda9bb244b7b86d7abd0031618bae71d0276fe139fe697c3063dR71 but we didn't merge 8.15 into https://github.com/elastic/beats/pull/40982 before merging it to pick it up.

 