### PR TITLE
Adjust beats-packaging-pipeline to trigger on 8.x

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1063,7 +1063,7 @@ spec:
         build_pull_requests: false
         build_tags: false
         filter_condition: >-
-          build.branch =~ /^[0-9]+\.[0-9]+$$/ || build.branch == "main"
+          build.branch =~ /^[0-9]+\.[0-9x]+$$/ || build.branch == "main"
         filter_enabled: true
         trigger_mode: code
       env:


### PR DESCRIPTION
I noticed that the beats-packaging-pipeline wasn't triggering automatically on the 8.x branch. Looks like adjusting this regex should fix that.