### PR TITLE
Enable type assertion checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,7 +80,8 @@ linters-settings:
             desc: Apache 2.0 licensed code cannot depend on Elastic licensed code (x-pack/).
   errcheck:
     # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
-    check-type-assertions: false
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: true
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
     check-blank: false
     # List of functions to exclude from checking, where each entry is a single function to exclude.


### PR DESCRIPTION
This PR (re)enables the `errcheck.check-type-assertions` linter, in light of https://github.com/elastic/beats/pull/41009
