### PR TITLE
[Heartbeat] Add managed status reporter at monitor factory level

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -323,6 +323,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Added status to monitor run log report.
 - Upgrade node to latest LTS v18.20.3. {pull}40038[40038]
 - Add journey duration to synthetics browser events. {pull}40230[40230]
+- Add monitor status reporter under managed mode. {pull}41077[41077]
 
 *Metricbeat*
 

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 )
 
 // ErrMonitorDisabled is returned when the monitor plugin is marked as disabled.
@@ -71,6 +72,12 @@ type Monitor struct {
 	stats plugin.RegistryRecorder
 
 	monitorStateTracker *monitorstate.Tracker
+	statusReporter      status.StatusReporter
+}
+
+// SetStatusReporter
+func (m *Monitor) SetStatusReporter(statusReporter status.StatusReporter) {
+	m.statusReporter = statusReporter
 }
 
 // String prints a description of the monitor in a threadsafe way. It is important that this use threadsafe
@@ -175,6 +182,9 @@ func newMonitorUnsafe(
 
 		logp.L().Error(fullErr)
 		p.Jobs = []jobs.Job{func(event *beat.Event) ([]jobs.Job, error) {
+			// if statusReporter is set, as it is for running managed-mode, update the input status
+			// to failed, specifying the error
+			m.updateStatus(status.Failed, fmt.Sprintf("monitor could not be started: %s, err: %s", m.stdFields.ID, fullErr))
 			return nil, fullErr
 		}}
 
@@ -237,6 +247,7 @@ func (m *Monitor) Start() {
 
 	m.stats.StartMonitor(int64(m.endpoints))
 	m.state = MON_STARTED
+	m.updateStatus(status.Running, "")
 }
 
 // Stop stops the monitor without freeing it in global dedup
@@ -262,4 +273,11 @@ func (m *Monitor) Stop() {
 
 	m.stats.StopMonitor(int64(m.endpoints))
 	m.state = MON_STOPPED
+	m.updateStatus(status.Stopped, "")
+}
+
+func (m *Monitor) updateStatus(status status.Status, msg string) {
+	if m.statusReporter != nil {
+		m.statusReporter.UpdateStatus(status, msg)
+	}
 }

--- a/heartbeat/monitors/monitor_test.go
+++ b/heartbeat/monitors/monitor_test.go
@@ -18,12 +18,14 @@
 package monitors
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent-libs/config"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
@@ -32,7 +34,9 @@ import (
 	"github.com/elastic/go-lookslike/testslike"
 	"github.com/elastic/go-lookslike/validator"
 
+	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/heartbeat/scheduler"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 )
 
 // TestMonitorBasic tests a basic config
@@ -130,4 +134,61 @@ func TestCheckInvalidConfig(t *testing.T) {
 	require.Equal(t, 0, closed.Load())
 
 	require.Error(t, checkMonitorConfig(serverMonConf, reg))
+}
+
+type MockStatusReporter struct {
+	us func(status status.Status, msg string)
+}
+
+func (sr *MockStatusReporter) UpdateStatus(status status.Status, msg string) {
+	sr.us(status, msg)
+}
+
+func TestStatusReporter(t *testing.T) {
+	confMap := map[string]interface{}{
+		"type":     "fail",
+		"urls":     []string{"http://example.net"},
+		"schedule": "@every 1ms",
+		"name":     "myName",
+		"id":       "myId",
+	}
+	conf, err := config.NewConfigFrom(confMap)
+	require.NoError(t, err)
+
+	reg, _, _ := mockPluginsReg()
+	pipel := &MockPipeline{}
+	monReg := monitoring.NewRegistry()
+
+	mockDegradedPluginFactory := plugin.PluginFactory{
+		Name:    "fail",
+		Aliases: []string{"failAlias"},
+		Make: func(s string, config *config.C) (plugin.Plugin, error) {
+			return plugin.Plugin{}, fmt.Errorf("error plugin")
+		},
+		Stats: plugin.NewPluginCountersRecorder("fail", monReg),
+	}
+	reg.Add(mockDegradedPluginFactory)
+
+	sched := scheduler.Create(1, monitoring.NewRegistry(), time.Local, nil, true)
+	defer sched.Stop()
+
+	c, err := pipel.Connect()
+	require.NoError(t, err)
+	m, err := newMonitor(conf, reg, c, sched.Add, nil, nil)
+	require.NoError(t, err)
+
+	// Track status marked as failed during run_once execution
+	var failed bool = false
+	m.SetStatusReporter(&MockStatusReporter{
+		us: func(s status.Status, msg string) {
+			if s == status.Failed {
+				failed = true
+			}
+		},
+	})
+	m.Start()
+
+	sched.WaitForRunOnce()
+
+	require.True(t, failed)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Add status reporting for monitors when running under elastic-agent, this will allow the Fleet UI to reflect theres an issue with one or more heartbeat integrations.
![image](https://github.com/user-attachments/assets/214be728-59e1-4fa8-9473-e7e64201f70f)


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build agentbeat locally with:
```sh
 DEV=true SNAPSHOT=true  PLATFORMS=linux/amd64 mage package
```
2. Build elastic-agent locally with:
```sh
DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=docker mage package
```
3. Enroll a non-complete elastic-agent into a private location policy with a browser monitor assigned.
4. Check agent status is eventually reported as degraded and the integration marked as failed.