### PR TITLE
Docs: update Docker setup commands to remove container when done

### DIFF
--- a/libbeat/docs/howto/load-index-templates.asciidoc
+++ b/libbeat/docs/howto/load-index-templates.asciidoc
@@ -150,7 +150,7 @@ ifdef::docker_platform[]
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-docker run {dockerimage} setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+docker run --rm {dockerimage} setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
 endif::docker_platform[]
 
@@ -354,4 +354,3 @@ endif::win_only[]
 PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/{beatname_lc}-{version}
 ----
 endif::win_os[]
-

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -73,7 +73,7 @@ and machine learning jobs.  Run this command:
 ifeval::["{beatname_lc}"=="filebeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
@@ -83,7 +83,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="metricbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
@@ -93,7 +93,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="heartbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 --cap-add=NET_RAW \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
@@ -104,7 +104,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="packetbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
 --cap-add=NET_ADMIN \
 {dockerimage} \
 setup -E setup.kibana.host=kibana:5601 \
@@ -115,7 +115,7 @@ endif::[]
 ifeval::["{beatname_lc}"=="auditbeat"]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
+docker run --rm \
   --cap-add="AUDIT_CONTROL" \
   --cap-add="AUDIT_READ" \
   {dockerimage} \
@@ -139,7 +139,7 @@ endif::apm-server[]
 
 ==== Run {beatname_uc} on a read-only file system
 
-If you'd like to run {beatname_uc} in a Docker container on a read-only file 
+If you'd like to run {beatname_uc} in a Docker container on a read-only file
 system, you can do so by specifying the `--read-only` option.
 {beatname_uc} requires a stateful directory to store application data, so
 with the `--read-only` option you also need to use the `--mount` option to
@@ -185,7 +185,7 @@ docker run -d \
   --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
-  --volume="registry:/usr/share/{beatname_lc}/data:rw" \  
+  --volume="registry:/usr/share/{beatname_lc}/data:rw" \
   {dockerimage} {beatname_lc} -e --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------

--- a/libbeat/docs/tab-widgets/load-dashboards-logstash.asciidoc
+++ b/libbeat/docs/tab-widgets/load-dashboards-logstash.asciidoc
@@ -49,7 +49,7 @@
 // tag::docker[]
 ["source","sh",subs="attributes"]
 ----
-docker run --net="host" {dockerimage} setup -e \
+docker run --rm --net="host" {dockerimage} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username={beat_default_index_prefix}_internal \

--- a/libbeat/docs/tab-widgets/load-dashboards.asciidoc
+++ b/libbeat/docs/tab-widgets/load-dashboards.asciidoc
@@ -29,7 +29,7 @@
 // tag::docker[]
 ["source","sh",subs="attributes"]
 ----
-docker run --net="host" {dockerimage} setup --dashboards
+docker run --rm --net="host" {dockerimage} setup --dashboards
 ----
 // end::docker[]
 

--- a/libbeat/docs/tab-widgets/load-index-template.asciidoc
+++ b/libbeat/docs/tab-widgets/load-index-template.asciidoc
@@ -29,7 +29,7 @@
 // tag::docker[]
 ["source","sh",subs="attributes"]
 ----
-docker run --net="host" {dockerimage} setup --index-management
+docker run --rm --net="host" {dockerimage} setup --index-management
 ----
 // end::docker[]
 


### PR DESCRIPTION
## Proposed commit message

Add --rm to the setup command to automatically remove the container used to setup. This prevents leaving behind a single-use container instance.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

No, docs only