### PR TITLE
[aws] Change log.file.path field in awscloudwatch input to nested object

### DIFF
--- a/x-pack/filebeat/input/awscloudwatch/input_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/input_test.go
@@ -29,7 +29,11 @@ func TestCreateEvent(t *testing.T) {
 		"event": mapstr.M{
 			"id": *logEvent.EventId,
 		},
-		"log.file.path": "logGroup1" + "/" + *logEvent.LogStreamName,
+		"log": mapstr.M{
+			"file": mapstr.M{
+				"path": "logGroup1" + "/" + *logEvent.LogStreamName,
+			},
+		},
 		"awscloudwatch": mapstr.M{
 			"log_group":      "logGroup1",
 			"log_stream":     *logEvent.LogStreamName,

--- a/x-pack/filebeat/input/awscloudwatch/processor.go
+++ b/x-pack/filebeat/input/awscloudwatch/processor.go
@@ -44,8 +44,12 @@ func createEvent(logEvent types.FilteredLogEvent, logGroup string, regionName st
 	event := beat.Event{
 		Timestamp: time.Unix(*logEvent.Timestamp/1000, 0).UTC(),
 		Fields: mapstr.M{
-			"message":       *logEvent.Message,
-			"log.file.path": logGroup + "/" + *logEvent.LogStreamName,
+			"message": *logEvent.Message,
+			"log": mapstr.M{
+				"file": mapstr.M{
+					"path": logGroup + "/" + *logEvent.LogStreamName,
+				},
+			},
 			"event": mapstr.M{
 				"id":       *logEvent.EventId,
 				"ingested": time.Now(),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR changes `log.file.path` field in awscloudwatch input from dotted field to nested object.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

The concern we have with this PR is when users have ingest pipelines or logstash filters configured down the line, this might break what they have. For example in ingest pipeline, ctx[‘log.file.path’] needs to be changed to `ctx.log?.file?.path`.