### PR TITLE
Fix read-only instructions for running Beats on Docker

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -150,7 +150,7 @@ For example:
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
-  --mount type=source=$(pwd}/data,destination=/usr/share/{beatname_lc}/data
+  --mount type=source=$(pwd)/data,destination=/usr/share/{beatname_lc}/data
   --read-only
   {dockerimage}
 --------------------------------------------

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -149,9 +149,9 @@ For example:
 
 ["source", "sh", subs="attributes"]
 --------------------------------------------
-docker run \
-  --mount type=source=$(pwd)/data,destination=/usr/share/{beatname_lc}/data
-  --read-only
+docker run --rm \
+  --mount type=bind,source=$(pwd)/data,destination=/usr/share/{beatname_lc}/data \
+  --read-only \
   {dockerimage}
 --------------------------------------------
 


### PR DESCRIPTION
@blakerouse, Bill noticed a couple of issues with the [Run (beat) on a read-only file system](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html#_run_filebeat_on_a_read_only_file_system) instructions:

---

```
docker run \
  --mount type=source=$(pwd}/data,destination=/usr/share/{beatname_lc}/data
  --read-only
  {dockerimage}
```

I believe:
 - the `$(pwd}` should be `$(pwd)`
 - the type is missing should be something like `type=....,source=`

---

This PR fixes up the first issue, but can you please help with the second? I'm not sure what the change should be, if any. I just copied that command from your comment [here](https://github.com/elastic/beats/pull/40092#discussion_r1669388125).
