### PR TITLE
Revert "Don't register cfgfile flags on `flag.CommandLine` in `func init()`"

### DIFF
--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -18,7 +18,6 @@
 package cfgfile
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/libbeat/cmd/instance/beat_integration_test.go
+++ b/libbeat/cmd/instance/beat_integration_test.go
@@ -18,7 +18,6 @@
 package instance_test
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"net/http"
@@ -27,7 +26,6 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/mock"
 	"github.com/elastic/elastic-agent-libs/config"
@@ -79,7 +77,6 @@ func (mb mockbeat) Stop() {
 }
 
 func TestMonitoringNameFromConfig(t *testing.T) {
-
 	mockBeat := mockbeat{
 		done:     make(chan struct{}),
 		initDone: make(chan struct{}),
@@ -93,11 +90,9 @@ func TestMonitoringNameFromConfig(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		// Initialize cfgfile flags
-		cfgfile.InitFlags()
 		// Set the configuration file path flag so the beat can read it
-		_ = flag.Set("c", "testdata/mockbeat.yml")
-		_ = instance.Run(mock.Settings, func(_ *beat.Beat, _ *config.C) (beat.Beater, error) {
+		flag.Set("c", "testdata/mockbeat.yml")
+		instance.Run(mock.Settings, func(_ *beat.Beat, _ *config.C) (beat.Beater, error) {
 			return &mockBeat, nil
 		})
 	}()
@@ -114,13 +109,9 @@ func TestMonitoringNameFromConfig(t *testing.T) {
 	// the HTTP server goroutine
 	time.Sleep(10 * time.Millisecond)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost:5066/state", nil)
+	resp, err := http.Get("http://localhost:5066/state")
 	if err != nil {
-		t.Fatalf("error creating request: %v", err)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("calling state endpoint: %v", err)
+		t.Fatal("calling state endpoint: ", err.Error())
 	}
 	defer resp.Body.Close()
 

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -61,7 +61,7 @@ type BeatsRootCmd struct {
 func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings) *BeatsRootCmd {
 	// Add global Elasticsearch license endpoint check.
 	// Check we are actually talking with Elasticsearch, to ensure that used features actually exist.
-	elasticsearch.RegisterGlobalCallback(licenser.FetchAndVerify)
+	_, _ = elasticsearch.RegisterGlobalCallback(licenser.FetchAndVerify)
 
 	if err := platformcheck.CheckNativePlatformCompat(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize: %v\n", err)
@@ -78,7 +78,7 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 	// Due to a dependence upon the beat name, the default config file path
 	err := cfgfile.ChangeDefaultCfgfileFlag(settings.Name)
 	if err != nil {
-		panic(fmt.Errorf("failed to set default config file path: %v", err))
+		panic(fmt.Errorf("failed to set default config file path: %w", err))
 	}
 
 	// must be updated prior to CLI flag handling.

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -61,7 +61,7 @@ type BeatsRootCmd struct {
 func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings) *BeatsRootCmd {
 	// Add global Elasticsearch license endpoint check.
 	// Check we are actually talking with Elasticsearch, to ensure that used features actually exist.
-	_, _ = elasticsearch.RegisterGlobalCallback(licenser.FetchAndVerify)
+	elasticsearch.RegisterGlobalCallback(licenser.FetchAndVerify)
 
 	if err := platformcheck.CheckNativePlatformCompat(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize: %v\n", err)
@@ -78,11 +78,8 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 	// Due to a dependence upon the beat name, the default config file path
 	err := cfgfile.ChangeDefaultCfgfileFlag(settings.Name)
 	if err != nil {
-		panic(fmt.Errorf("failed to set default config file path: %w", err))
+		panic(fmt.Errorf("failed to set default config file path: %v", err))
 	}
-
-	// Initialize the configuration flags.
-	cfgfile.InitFlags()
 
 	// must be updated prior to CLI flag handling.
 


### PR DESCRIPTION
Reverts elastic/beats#40993

Due to https://github.com/elastic/apm-server/pull/14214 and https://github.com/elastic/apm-server/issues/14280