### PR TITLE
Add tests, fallback properly if we can't init the cgroups

### DIFF
--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -113,7 +113,7 @@ func buildDockerMetadataProcessor(log *logp.Logger, cfg *conf.C, watcherConstruc
 	}
 
 	reader, err := initCgroupPaths(resolve.NewTestResolver(config.HostFS), false)
-	if err != nil {
+	if err != nil && !errors.Is(err, cgroup.ErrCgroupsMissing) {
 		return nil, fmt.Errorf("error creating cgroup reader: %w", err)
 	}
 
@@ -284,6 +284,9 @@ func (d *addDockerMetadata) getProcessCgroups(pid int) (cgroup.PathList, error) 
 		return cgroups, nil
 	}
 
+	if d.cgreader == nil {
+		return cgroups, fs.ErrNotExist
+	}
 	cgroups, err := d.cgreader.ProcessCgroupPaths(pid)
 	if err != nil {
 		return cgroups, fmt.Errorf("failed to read cgroups for pid=%v: %w", pid, err)

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -84,7 +84,7 @@ func TestDefaultProcessorStartup(t *testing.T) {
 	proc, err := buildDockerMetadataProcessor(logp.L(), cfg, docker.NewWatcher)
 	require.NoError(t, err)
 
-	unwrapped := proc.(*addDockerMetadata)
+	unwrapped, _ := proc.(*addDockerMetadata)
 
 	// make sure pid readers have been initialized properly
 	_, err = unwrapped.getProcessCgroups(os.Getpid())

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -77,6 +77,12 @@ func TestDefaultProcessorStartup(t *testing.T) {
 		return cgroup.NewReader(rootfsMountpoint, ignoreRootCgroups)
 	}
 
+	defer func() {
+		initCgroupPaths = func(_ resolve.Resolver, _ bool) (processors.CGReader, error) {
+			return testCGReader{}, nil
+		}
+	}()
+
 	rawCfg := defaultConfig()
 	cfg, err := config.NewConfigFrom(rawCfg)
 	require.NoError(t, err)

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/processors"
@@ -68,6 +69,26 @@ func init() {
 	initCgroupPaths = func(_ resolve.Resolver, _ bool) (processors.CGReader, error) {
 		return testCGReader{}, nil
 	}
+}
+
+func TestDefaultProcessorStartup(t *testing.T) {
+	// set initCgroupPaths to system non-test defaults
+	initCgroupPaths = func(rootfsMountpoint resolve.Resolver, ignoreRootCgroups bool) (processors.CGReader, error) {
+		return cgroup.NewReader(rootfsMountpoint, ignoreRootCgroups)
+	}
+
+	rawCfg := defaultConfig()
+	cfg, err := config.NewConfigFrom(rawCfg)
+	require.NoError(t, err)
+
+	proc, err := buildDockerMetadataProcessor(logp.L(), cfg, docker.NewWatcher)
+	require.NoError(t, err)
+
+	unwrapped := proc.(*addDockerMetadata)
+
+	// make sure pid readers have been initialized properly
+	_, err = unwrapped.getProcessCgroups(os.Getpid())
+	require.NoError(t, err)
 }
 
 func TestInitializationNoDocker(t *testing.T) {

--- a/libbeat/processors/add_process_metadata/add_process_metadata.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata.go
@@ -164,7 +164,7 @@ func newProcessMetadataProcessorWithProvider(config config, provider processMeta
 	}
 
 	reader, err := initCgroupPaths(resolve.NewTestResolver(config.HostPath), false)
-	if err != nil {
+	if err != nil && !errors.Is(err, cgroup.ErrCgroupsMissing) {
 		return nil, fmt.Errorf("error creating cgroup reader: %w", err)
 	}
 

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -28,6 +28,7 @@ import (
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common/capabilities"
@@ -51,6 +52,22 @@ func newCGHandlerBuilder(handler testCGRsolver) processors.InitCgroupHandler {
 	return func(_ resolve.Resolver, _ bool) (processors.CGReader, error) {
 		return handler, nil
 	}
+}
+
+func TestDefaultProcessorStartup(t *testing.T) {
+	// set initCgroupPaths to system non-test defaults
+	initCgroupPaths = func(rootfsMountpoint resolve.Resolver, ignoreRootCgroups bool) (processors.CGReader, error) {
+		return cgroup.NewReader(rootfsMountpoint, ignoreRootCgroups)
+	}
+
+	proc, err := newProcessMetadataProcessorWithProvider(defaultConfig(), &procCache, false)
+	require.NoError(t, err)
+
+	// ensure the underlying provider has been initialized properly
+	unwrapped := proc.(*addProcessMetadata)
+	metadata, err := unwrapped.provider.GetProcessMetadata(os.Getpid())
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
 }
 
 func TestAddProcessMetadata(t *testing.T) {

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -64,7 +64,7 @@ func TestDefaultProcessorStartup(t *testing.T) {
 	require.NoError(t, err)
 
 	// ensure the underlying provider has been initialized properly
-	unwrapped := proc.(*addProcessMetadata)
+	unwrapped, _ := proc.(*addProcessMetadata)
 	metadata, err := unwrapped.provider.GetProcessMetadata(os.Getpid())
 	require.NoError(t, err)
 	require.NotNil(t, metadata)

--- a/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
+++ b/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
@@ -18,9 +18,7 @@
 package add_process_metadata
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -82,15 +80,12 @@ func newCidProvider(cgroupPrefixes []string, cgroupRegex *regexp.Regexp, process
 // getProcessCgroups returns a mapping of cgroup subsystem name to path. It
 // returns an error if it failed to retrieve the cgroup info.
 func (p gosigarCidProvider) getProcessCgroups(pid int) (cgroup.PathList, error) {
+	//return nil if we aren't supporting cgroups
+	if p.processCgroupPaths == nil {
+		return cgroup.PathList{}, nil
+	}
 	pathList, err := p.processCgroupPaths.ProcessCgroupPaths(pid)
 	if err != nil {
-		var pathError *fs.PathError
-		if errors.As(err, &pathError) {
-			// do no thing when err is nil or when os.PathError happens because the process don't exist,
-			// or not running in linux system
-			return cgroup.PathList{}, nil
-		}
-		// should never happen
 		return cgroup.PathList{}, fmt.Errorf("failed to read cgroups for pid=%v: %w", pid, err)
 	}
 


### PR DESCRIPTION
## Proposed commit message

Turns out that we don't have any tests that actually check to see if the default cgroups callback actually initializes properly, so https://github.com/elastic/beats/pull/41108 broke the processors on non-linux systems.

This re-adds support for systems that don't have cgroups support, and also adds tests that makes sure the processors can startup and run with the default cgroups provider.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

