### PR TITLE
Adjust Beats container user to be numeric.

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -205,7 +205,7 @@ RUN cd /usr/share/heartbeat/.node \
     && curl ${NODE_DOWNLOAD_URL} | tar -xJ --strip 1 -C node \
     && chmod ug+rwX -R $NODE_PATH
 
-# Install synthetics as a regular user, installing npm deps as root odesn't work
+# Install synthetics as a regular user, installing npm deps as root doesn't work
 RUN chown -R {{ .user }} $NODE_PATH
 USER {{ .user }}
 # If this fails dump the NPM logs
@@ -227,7 +227,11 @@ done; \
 (exit $exit_code)
 {{- end }}
 
-USER {{ .user }}
+{{- if eq .user "root" }}
+USER 0
+{{- else }}
+USER 1000
+{{- end }}
 
 {{- range $i, $port := .ExposePorts }}
 EXPOSE {{ $port }}


### PR DESCRIPTION
## Adjust Beats container user to be numeric.

"Recently" the user in the dockerfile was adjusted to be `1000` instead of `metricbeat`: https://github.com/elastic/beats/pull/35272/files#r1184217000

I believe this was recently changed [here](https://github.com/elastic/beats/pull/40524)

See https://github.com/elastic/cloud-on-k8s/pull/8086#issuecomment-2401624589
This is causing issues when running the container as `runAsNonRoot: true`:

```
container has runAsNonRoot and image has non-numeric user (metricbeat)
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

This should only allow the container to run when `runAsNonRoot: true` is set.

## Author's Checklist

- [ ] Ensure the container builds in CI
- [ ] Ensure e2e tests pass

## How to test this PR locally

`mage package` I believe

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Relates #40524

