### PR TITLE
Create nil cgroups reader for processor, improve error handling

### DIFF
--- a/libbeat/processors/add_process_metadata/add_process_metadata.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata.go
@@ -164,7 +164,9 @@ func newProcessMetadataProcessorWithProvider(config config, provider processMeta
 	}
 
 	reader, err := initCgroupPaths(resolve.NewTestResolver(config.HostPath), false)
-	if err != nil && !errors.Is(err, cgroup.ErrCgroupsMissing) {
+	if errors.Is(err, cgroup.ErrCgroupsMissing) {
+		reader = &processors.NilCGReader{}
+	} else if err != nil {
 		return nil, fmt.Errorf("error creating cgroup reader: %w", err)
 	}
 

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -54,6 +54,22 @@ func newCGHandlerBuilder(handler testCGRsolver) processors.InitCgroupHandler {
 	}
 }
 
+func TestNilProcessor(t *testing.T) {
+	initCgroupPaths = func(rootfsMountpoint resolve.Resolver, ignoreRootCgroups bool) (processors.CGReader, error) {
+		return &processors.NilCGReader{}, nil
+	}
+
+	proc, err := newProcessMetadataProcessorWithProvider(defaultConfig(), &procCache, false)
+	require.NoError(t, err)
+
+	// make sure a nil cgroup reader doesn't blow anything up
+	unwrapped, _ := proc.(*addProcessMetadata)
+	metadata, err := unwrapped.provider.GetProcessMetadata(os.Getpid())
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+
+}
+
 func TestDefaultProcessorStartup(t *testing.T) {
 	// set initCgroupPaths to system non-test defaults
 	initCgroupPaths = func(rootfsMountpoint resolve.Resolver, ignoreRootCgroups bool) (processors.CGReader, error) {
@@ -67,7 +83,7 @@ func TestDefaultProcessorStartup(t *testing.T) {
 	unwrapped, _ := proc.(*addProcessMetadata)
 	metadata, err := unwrapped.provider.GetProcessMetadata(os.Getpid())
 	require.NoError(t, err)
-	require.NotNil(t, metadata)
+	require.NotNil(t, metadata.fields)
 }
 
 func TestAddProcessMetadata(t *testing.T) {

--- a/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
+++ b/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
@@ -55,7 +55,7 @@ func (p gosigarCidProvider) GetCid(pid int) (result string, err error) {
 
 	cgroups, err := p.getProcessCgroups(pid)
 	if err != nil {
-		return "", fmt.Errorf("failed to get cgroups for pid=%v: %v", pid, err)
+		return "", fmt.Errorf("failed to get cgroups for pid=%v: %w", pid, err)
 	}
 
 	cid = p.getContainerID(cgroups)

--- a/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
+++ b/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
@@ -81,9 +81,6 @@ func newCidProvider(cgroupPrefixes []string, cgroupRegex *regexp.Regexp, process
 // returns an error if it failed to retrieve the cgroup info.
 func (p gosigarCidProvider) getProcessCgroups(pid int) (cgroup.PathList, error) {
 	//return nil if we aren't supporting cgroups
-	if p.processCgroupPaths == nil {
-		return cgroup.PathList{}, nil
-	}
 	pathList, err := p.processCgroupPaths.ProcessCgroupPaths(pid)
 	if err != nil {
 		return cgroup.PathList{}, fmt.Errorf("failed to read cgroups for pid=%v: %w", pid, err)

--- a/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
+++ b/libbeat/processors/add_process_metadata/gosigar_cid_provider.go
@@ -55,7 +55,7 @@ func (p gosigarCidProvider) GetCid(pid int) (result string, err error) {
 
 	cgroups, err := p.getProcessCgroups(pid)
 	if err != nil {
-		p.log.Debugf("failed to get cgroups for pid=%v: %v", pid, err)
+		return "", fmt.Errorf("failed to get cgroups for pid=%v: %v", pid, err)
 	}
 
 	cid = p.getContainerID(cgroups)

--- a/libbeat/processors/cgroups.go
+++ b/libbeat/processors/cgroups.go
@@ -18,6 +18,8 @@
 package processors
 
 import (
+	"io/fs"
+
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/cgroup"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
@@ -29,4 +31,13 @@ type InitCgroupHandler = func(rootfsMountpoint resolve.Resolver, ignoreRootCgrou
 // set different cgroups readers for testing.
 type CGReader interface {
 	ProcessCgroupPaths(pid int) (cgroup.PathList, error)
+}
+
+// NilCGReader does nothing
+type NilCGReader struct {
+}
+
+// ProcessCgroupPaths returns a blank pathLists and fs.ErrNotExist
+func (*NilCGReader) ProcessCgroupPaths(_ int) (cgroup.PathList, error) {
+	return cgroup.PathList{}, fs.ErrNotExist
 }


### PR DESCRIPTION
## Proposed commit message

Continuation of https://github.com/elastic/beats/pull/41189 . This adds a `NilCGReader` type that makes us a little less likely to hit a nil pointer deref if this code is changed in the future, and also cleans up some of the error handling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
