### PR TITLE
[Filebeat] [AWS] add support to source logs from AWS linked source accounts when using log_group_name_prefix

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -328,6 +328,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add support to source AWS cloudwatch logs from linked accounts. {pull}41188[41188]
 - Jounrald input now supports filtering by facilities {pull}41061[41061]
 - System module now supports reading from jounrald. {pull}41061[41061]
+- Add support to include AWS cloudwatch linked accounts when using log_group_name_prefix to define log group names. {pull}41206[41206]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -144,14 +144,14 @@
   #log_group_name: test
 
   # The prefix for a group of log group names.
-  # You can include linked source accounts by using the property `linked_accounts_for_prefix_mode`.
+  # You can include linked source accounts by using the property `include_linked_accounts_for_prefix_mode`.
   # Note: `region_name` is required when `log_group_name_prefix` is given.
   # `log_group_name` and `log_group_name_prefix` cannot be given at the same time.
   #log_group_name_prefix: /aws/
 
   # State whether to include linked source accounts when obtaining log groups matching the prefix provided through `log_group_name_prefix`
   # This property works together with `log_group_name_prefix` and default value (if unset) is false
-  #linked_accounts_for_prefix_mode: true
+  #include_linked_accounts_for_prefix_mode: true
 
   # Region that the specified log group or log group prefix belongs to.
   #region_name: us-east-1

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -144,9 +144,14 @@
   #log_group_name: test
 
   # The prefix for a group of log group names.
+  # You can include linked source accounts by using the property `linked_accounts_for_prefix_mode`.
   # Note: `region_name` is required when `log_group_name_prefix` is given.
   # `log_group_name` and `log_group_name_prefix` cannot be given at the same time.
   #log_group_name_prefix: /aws/
+
+  # State whether to include linked source accounts when obtaining log groups matching the prefix provided through `log_group_name_prefix`
+  # This property works together with `log_group_name_prefix` and default value (if unset) is false
+  #linked_accounts_for_prefix_mode: true
 
   # Region that the specified log group or log group prefix belongs to.
   #region_name: us-east-1

--- a/x-pack/filebeat/docs/inputs/input-aws-cloudwatch.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-cloudwatch.asciidoc
@@ -56,7 +56,7 @@ Note: `region_name` is required when log_group_name is given.
 
 [float]
 ==== `log_group_name_prefix`
-The prefix for a group of log group names. See `linked_accounts_for_prefix_mode` option for linked source accounts behavior.
+The prefix for a group of log group names. See `include_linked_accounts_for_prefix_mode` option for linked source accounts behavior.
 
 Note: `region_name` is required when
 `log_group_name_prefix` is given. `log_group_name` and `log_group_name_prefix`
@@ -64,7 +64,7 @@ cannot be given at the same time. The number of workers that will process the
 log groups under this prefix is set through the `number_of_workers` config.
 
 [float]
-==== `linked_accounts_for_prefix_mode`
+==== `include_linked_accounts_for_prefix_mode`
 Configure whether to include linked source accounts that contains the prefix value defined through `log_group_name_prefix`.
 Accepts a boolean and this is by default disabled.
 

--- a/x-pack/filebeat/docs/inputs/input-aws-cloudwatch.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-cloudwatch.asciidoc
@@ -56,12 +56,20 @@ Note: `region_name` is required when log_group_name is given.
 
 [float]
 ==== `log_group_name_prefix`
-The prefix for a group of log group names.
+The prefix for a group of log group names. See `linked_accounts_for_prefix_mode` option for linked source accounts behavior.
 
 Note: `region_name` is required when
 `log_group_name_prefix` is given. `log_group_name` and `log_group_name_prefix`
 cannot be given at the same time. The number of workers that will process the
 log groups under this prefix is set through the `number_of_workers` config.
+
+[float]
+==== `linked_accounts_for_prefix_mode`
+Configure whether to include linked source accounts that contains the prefix value defined through `log_group_name_prefix`.
+Accepts a boolean and this is by default disabled.
+
+Note: Utilize `log_group_arn` if you desire to obtain logs from a known log group (including linked source accounts)
+You can read more about AWS account linking and cross account observability from the https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html[official documentation].
 
 [float]
 ==== `region_name`

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3078,14 +3078,14 @@ filebeat.inputs:
   #log_group_name: test
 
   # The prefix for a group of log group names.
-  # You can include linked source accounts by using the property `linked_accounts_for_prefix_mode`.
+  # You can include linked source accounts by using the property `include_linked_accounts_for_prefix_mode`.
   # Note: `region_name` is required when `log_group_name_prefix` is given.
   # `log_group_name` and `log_group_name_prefix` cannot be given at the same time.
   #log_group_name_prefix: /aws/
 
   # State whether to include linked source accounts when obtaining log groups matching the prefix provided through `log_group_name_prefix`
   # This property works together with `log_group_name_prefix` and default value (if unset) is false
-  #linked_accounts_for_prefix_mode: true
+  #include_linked_accounts_for_prefix_mode: true
 
   # Region that the specified log group or log group prefix belongs to.
   #region_name: us-east-1

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3078,9 +3078,14 @@ filebeat.inputs:
   #log_group_name: test
 
   # The prefix for a group of log group names.
+  # You can include linked source accounts by using the property `linked_accounts_for_prefix_mode`.
   # Note: `region_name` is required when `log_group_name_prefix` is given.
   # `log_group_name` and `log_group_name_prefix` cannot be given at the same time.
   #log_group_name_prefix: /aws/
+
+  # State whether to include linked source accounts when obtaining log groups matching the prefix provided through `log_group_name_prefix`
+  # This property works together with `log_group_name_prefix` and default value (if unset) is false
+  #linked_accounts_for_prefix_mode: true
 
   # Region that the specified log group or log group prefix belongs to.
   #region_name: us-east-1

--- a/x-pack/filebeat/input/awscloudwatch/config.go
+++ b/x-pack/filebeat/input/awscloudwatch/config.go
@@ -13,21 +13,21 @@ import (
 )
 
 type config struct {
-	harvester.ForwarderConfig   `config:",inline"`
-	LogGroupARN                 string              `config:"log_group_arn"`
-	LogGroupName                string              `config:"log_group_name"`
-	LogGroupNamePrefix          string              `config:"log_group_name_prefix"`
-	LinkedAccountsForPrefixMode *bool               `config:"linked_accounts_for_prefix_mode"`
-	RegionName                  string              `config:"region_name"`
-	LogStreams                  []*string           `config:"log_streams"`
-	LogStreamPrefix             string              `config:"log_stream_prefix"`
-	StartPosition               string              `config:"start_position" default:"beginning"`
-	ScanFrequency               time.Duration       `config:"scan_frequency" validate:"min=0,nonzero"`
-	APITimeout                  time.Duration       `config:"api_timeout" validate:"min=0,nonzero"`
-	APISleep                    time.Duration       `config:"api_sleep" validate:"min=0,nonzero"`
-	Latency                     time.Duration       `config:"latency"`
-	NumberOfWorkers             int                 `config:"number_of_workers"`
-	AWSConfig                   awscommon.ConfigAWS `config:",inline"`
+	harvester.ForwarderConfig          `config:",inline"`
+	LogGroupARN                        string              `config:"log_group_arn"`
+	LogGroupName                       string              `config:"log_group_name"`
+	LogGroupNamePrefix                 string              `config:"log_group_name_prefix"`
+	IncludeLinkedAccountsForPrefixMode *bool               `config:"include_linked_accounts_for_prefix_mode"`
+	RegionName                         string              `config:"region_name"`
+	LogStreams                         []*string           `config:"log_streams"`
+	LogStreamPrefix                    string              `config:"log_stream_prefix"`
+	StartPosition                      string              `config:"start_position" default:"beginning"`
+	ScanFrequency                      time.Duration       `config:"scan_frequency" validate:"min=0,nonzero"`
+	APITimeout                         time.Duration       `config:"api_timeout" validate:"min=0,nonzero"`
+	APISleep                           time.Duration       `config:"api_sleep" validate:"min=0,nonzero"`
+	Latency                            time.Duration       `config:"latency"`
+	NumberOfWorkers                    int                 `config:"number_of_workers"`
+	AWSConfig                          awscommon.ConfigAWS `config:",inline"`
 }
 
 func defaultConfig() config {

--- a/x-pack/filebeat/input/awscloudwatch/config.go
+++ b/x-pack/filebeat/input/awscloudwatch/config.go
@@ -17,7 +17,7 @@ type config struct {
 	LogGroupARN                        string              `config:"log_group_arn"`
 	LogGroupName                       string              `config:"log_group_name"`
 	LogGroupNamePrefix                 string              `config:"log_group_name_prefix"`
-	IncludeLinkedAccountsForPrefixMode *bool               `config:"include_linked_accounts_for_prefix_mode"`
+	IncludeLinkedAccountsForPrefixMode bool                `config:"include_linked_accounts_for_prefix_mode"`
 	RegionName                         string              `config:"region_name"`
 	LogStreams                         []*string           `config:"log_streams"`
 	LogStreamPrefix                    string              `config:"log_stream_prefix"`

--- a/x-pack/filebeat/input/awscloudwatch/config.go
+++ b/x-pack/filebeat/input/awscloudwatch/config.go
@@ -13,20 +13,21 @@ import (
 )
 
 type config struct {
-	harvester.ForwarderConfig `config:",inline"`
-	LogGroupARN               string              `config:"log_group_arn"`
-	LogGroupName              string              `config:"log_group_name"`
-	LogGroupNamePrefix        string              `config:"log_group_name_prefix"`
-	RegionName                string              `config:"region_name"`
-	LogStreams                []*string           `config:"log_streams"`
-	LogStreamPrefix           string              `config:"log_stream_prefix"`
-	StartPosition             string              `config:"start_position" default:"beginning"`
-	ScanFrequency             time.Duration       `config:"scan_frequency" validate:"min=0,nonzero"`
-	APITimeout                time.Duration       `config:"api_timeout" validate:"min=0,nonzero"`
-	APISleep                  time.Duration       `config:"api_sleep" validate:"min=0,nonzero"`
-	Latency                   time.Duration       `config:"latency"`
-	NumberOfWorkers           int                 `config:"number_of_workers"`
-	AWSConfig                 awscommon.ConfigAWS `config:",inline"`
+	harvester.ForwarderConfig   `config:",inline"`
+	LogGroupARN                 string              `config:"log_group_arn"`
+	LogGroupName                string              `config:"log_group_name"`
+	LogGroupNamePrefix          string              `config:"log_group_name_prefix"`
+	LinkedAccountsForPrefixMode *bool               `config:"linked_accounts_for_prefix_mode"`
+	RegionName                  string              `config:"region_name"`
+	LogStreams                  []*string           `config:"log_streams"`
+	LogStreamPrefix             string              `config:"log_stream_prefix"`
+	StartPosition               string              `config:"start_position" default:"beginning"`
+	ScanFrequency               time.Duration       `config:"scan_frequency" validate:"min=0,nonzero"`
+	APITimeout                  time.Duration       `config:"api_timeout" validate:"min=0,nonzero"`
+	APISleep                    time.Duration       `config:"api_sleep" validate:"min=0,nonzero"`
+	Latency                     time.Duration       `config:"latency"`
+	NumberOfWorkers             int                 `config:"number_of_workers"`
+	AWSConfig                   awscommon.ConfigAWS `config:",inline"`
 }
 
 func defaultConfig() config {

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -105,8 +105,9 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	})
 
 	if len(logGroupIDs) == 0 {
-		// fallback to LogGroupNamePrefix to derive group IDs
-		logGroupIDs, err = getLogGroupNames(svc, in.config.LogGroupNamePrefix)
+		// We haven't extracted group identifiers directly from the input configurations,
+		// now fallback to provided LogGroupNamePrefix and use derived service client to derive logGroupIDs
+		logGroupIDs, err = getLogGroupNames(svc, in.config.LogGroupNamePrefix, in.config.LinkedAccountsForPrefixMode)
 		if err != nil {
 			return fmt.Errorf("failed to get log group names from LogGroupNamePrefix: %w", err)
 		}
@@ -164,15 +165,21 @@ func fromConfig(cfg config, awsCfg awssdk.Config) (logGroupIDs []string, region 
 	return logGroupIDs, region, nil
 }
 
-// getLogGroupNames uses DescribeLogGroups API to retrieve all log group names
-func getLogGroupNames(svc *cloudwatchlogs.Client, logGroupNamePrefix string) ([]string, error) {
+// getLogGroupNames uses DescribeLogGroups API to retrieve LogGroupArn entries that matches the provided logGroupNamePrefix
+func getLogGroupNames(svc *cloudwatchlogs.Client, logGroupNamePrefix string, withLinkedAccount *bool) ([]string, error) {
+	var linkedAccounts bool
+	if withLinkedAccount != nil {
+		linkedAccounts = *withLinkedAccount
+	}
+
 	// construct DescribeLogGroupsInput
 	describeLogGroupsInput := &cloudwatchlogs.DescribeLogGroupsInput{
-		LogGroupNamePrefix: awssdk.String(logGroupNamePrefix),
+		LogGroupNamePrefix:    awssdk.String(logGroupNamePrefix),
+		IncludeLinkedAccounts: awssdk.Bool(linkedAccounts),
 	}
 
 	// make API request
-	var logGroupNames []string
+	var logGroupIDs []string
 	paginator := cloudwatchlogs.NewDescribeLogGroupsPaginator(svc, describeLogGroupsInput)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.TODO())
@@ -181,8 +188,8 @@ func getLogGroupNames(svc *cloudwatchlogs.Client, logGroupNamePrefix string) ([]
 		}
 
 		for _, lg := range page.LogGroups {
-			logGroupNames = append(logGroupNames, *lg.LogGroupName)
+			logGroupIDs = append(logGroupIDs, *lg.LogGroupArn)
 		}
 	}
-	return logGroupNames, nil
+	return logGroupIDs, nil
 }

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -130,7 +130,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 // fromConfig is a helper to parse input configurations and derive logGroupIDs & aws region
 // Returned logGroupIDs could be empty, which require other fallback mechanisms to derive them.
 // See getLogGroupNames for example.
-func fromConfig(cfg config, awsCfg awssdk.Config) (logGroupIDs []string, region string, err error) {
+func fromConfig(cfg config, awsCfg awssdk.Config) (logGrouIDs []string, region string, err error) {
 	// LogGroupARN has precedence over LogGroupName & RegionName
 	if cfg.LogGroupARN != "" {
 		parsedArn, err := arn.Parse(cfg.LogGroupARN)
@@ -144,14 +144,14 @@ func fromConfig(cfg config, awsCfg awssdk.Config) (logGroupIDs []string, region 
 
 		// refine to match AWS API parameter regex of logGroupIdentifier
 		groupId := strings.TrimSuffix(cfg.LogGroupARN, ":*")
-		logGroupIDs = append(logGroupIDs, groupId)
+		logGrouIDs = append(logGrouIDs, groupId)
 
-		return logGroupIDs, parsedArn.Region, nil
+		return logGrouIDs, parsedArn.Region, nil
 	}
 
 	// then fallback to LogrGroupName
 	if cfg.LogGroupName != "" {
-		logGroupIDs = append(logGroupIDs, cfg.LogGroupName)
+		logGrouIDs = append(logGrouIDs, cfg.LogGroupName)
 	}
 
 	// finally derive region
@@ -161,7 +161,7 @@ func fromConfig(cfg config, awsCfg awssdk.Config) (logGroupIDs []string, region 
 		region = awsCfg.Region
 	}
 
-	return logGroupIDs, region, nil
+	return logGrouIDs, region, nil
 }
 
 // getLogGroupNames uses DescribeLogGroups API to retrieve all log group names

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -107,7 +107,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	if len(logGroupIDs) == 0 {
 		// We haven't extracted group identifiers directly from the input configurations,
 		// now fallback to provided LogGroupNamePrefix and use derived service client to derive logGroupIDs
-		logGroupIDs, err = getLogGroupNames(svc, in.config.LogGroupNamePrefix, in.config.LinkedAccountsForPrefixMode)
+		logGroupIDs, err = getLogGroupNames(svc, in.config.LogGroupNamePrefix, in.config.IncludeLinkedAccountsForPrefixMode)
 		if err != nil {
 			return fmt.Errorf("failed to get log group names from LogGroupNamePrefix: %w", err)
 		}

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -166,16 +166,11 @@ func fromConfig(cfg config, awsCfg awssdk.Config) (logGroupIDs []string, region 
 }
 
 // getLogGroupNames uses DescribeLogGroups API to retrieve LogGroupArn entries that matches the provided logGroupNamePrefix
-func getLogGroupNames(svc *cloudwatchlogs.Client, logGroupNamePrefix string, withLinkedAccount *bool) ([]string, error) {
-	var linkedAccounts bool
-	if withLinkedAccount != nil {
-		linkedAccounts = *withLinkedAccount
-	}
-
+func getLogGroupNames(svc *cloudwatchlogs.Client, logGroupNamePrefix string, withLinkedAccount bool) ([]string, error) {
 	// construct DescribeLogGroupsInput
 	describeLogGroupsInput := &cloudwatchlogs.DescribeLogGroupsInput{
 		LogGroupNamePrefix:    awssdk.String(logGroupNamePrefix),
-		IncludeLinkedAccounts: awssdk.Bool(linkedAccounts),
+		IncludeLinkedAccounts: awssdk.Bool(withLinkedAccount),
 	}
 
 	// make API request

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -130,7 +130,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 // fromConfig is a helper to parse input configurations and derive logGroupIDs & aws region
 // Returned logGroupIDs could be empty, which require other fallback mechanisms to derive them.
 // See getLogGroupNames for example.
-func fromConfig(cfg config, awsCfg awssdk.Config) (logGrouIDs []string, region string, err error) {
+func fromConfig(cfg config, awsCfg awssdk.Config) (logGroupIDs []string, region string, err error) {
 	// LogGroupARN has precedence over LogGroupName & RegionName
 	if cfg.LogGroupARN != "" {
 		parsedArn, err := arn.Parse(cfg.LogGroupARN)
@@ -144,14 +144,14 @@ func fromConfig(cfg config, awsCfg awssdk.Config) (logGrouIDs []string, region s
 
 		// refine to match AWS API parameter regex of logGroupIdentifier
 		groupId := strings.TrimSuffix(cfg.LogGroupARN, ":*")
-		logGrouIDs = append(logGrouIDs, groupId)
+		logGroupIDs = append(logGroupIDs, groupId)
 
-		return logGrouIDs, parsedArn.Region, nil
+		return logGroupIDs, parsedArn.Region, nil
 	}
 
 	// then fallback to LogrGroupName
 	if cfg.LogGroupName != "" {
-		logGrouIDs = append(logGrouIDs, cfg.LogGroupName)
+		logGroupIDs = append(logGroupIDs, cfg.LogGroupName)
 	}
 
 	// finally derive region
@@ -161,7 +161,7 @@ func fromConfig(cfg config, awsCfg awssdk.Config) (logGrouIDs []string, region s
 		region = awsCfg.Region
 	}
 
-	return logGrouIDs, region, nil
+	return logGroupIDs, region, nil
 }
 
 // getLogGroupNames uses DescribeLogGroups API to retrieve all log group names


### PR DESCRIPTION
## Proposed commit message

This is a follow-up to https://github.com/elastic/beats/pull/41188 where I am adding support to source linked accounts when using `log_group_name_prefix` to derive log groups.

PR introduce `include_inked_accounts_for_prefix_mode` boolean property, which is disabled by default. If enabled (`include_inked_accounts_for_prefix_mode : true`), then we set `includeLinkedAccounts` property of the DescribeLogGroups API [1] to obtain log groups matching prefix and included in linked accounts of the monitoring account. 

ex:- 

```yaml
- type: aws-cloudwatch
  ...
  log_group_name_prefix : /development/AppA/
  include_inked_accounts_for_prefix_mode: true
  ... 
```


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

This require a linked cloudwatch account. If already has one, then,

- Push logs to a newly created log group OR use an already existing log group in a source account
  - Note - you may use data-gen Go program to generate and push logs to your log group (using  output `CLOUDWATCH_LOG`) [2] 
- Configure filebeat cloudwatch input with `log_group_name_prefix` with desired prefix & set `include_inked_accounts_for_prefix_mode` to value `true` (enabled)
- Run filebeat and observe logs in Kibana discover which include logs from log groups (that match provided prefix) 

## Related issues

- Closes https://github.com/elastic/beats/issues/36642

[1] - https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html
[2] - https://github.com/Kavindu-Dodan/data-gen 