### PR TITLE
Fix Metricbeat k8s metadata sometimes not being present at startup

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -206,6 +206,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add AWS OwningAccount support for cross account monitoring {issue}40570[40570] {pull}40691[40691]
 - Use namespace for GetListMetrics when exists in AWS {pull}41022[41022]
 - Fix http server helper SSL config. {pull}39405[39405]
+- Fix Kubernetes metadata sometimes not being present after startup {pull}41216[41216]
 
 *Osquerybeat*
 

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -1104,10 +1104,9 @@ func (e *enricher) Enrich(events []mapstr.M) {
 				}
 
 				// don't apply pod metadata to module level
-				k8sMeta = k8sMeta.Clone()
 				delete(k8sMeta, "pod")
 			}
-			ecsMeta := meta.Clone()
+			ecsMeta := meta
 			err = ecsMeta.Delete("kubernetes")
 			if err != nil {
 				logp.Debug("kubernetes", "Failed to delete field '%s': %s", "kubernetes", err)
@@ -1123,6 +1122,7 @@ func (e *enricher) Enrich(events []mapstr.M) {
 
 // getMetadata returns metadata for the given event. If the metadata doesn't exist in the cache, we try to get it
 // from the watcher store.
+// The returned map is copy to be owned by the caller.
 func (e *enricher) getMetadata(event mapstr.M) mapstr.M {
 	e.Lock()
 	defer e.Unlock()
@@ -1131,6 +1131,9 @@ func (e *enricher) getMetadata(event mapstr.M) mapstr.M {
 	if eventMeta == nil {
 		e.updateMetadataCacheFromWatcher(metaKey)
 		eventMeta = e.metadataCache[metaKey]
+	}
+	if eventMeta != nil {
+		eventMeta = eventMeta.Clone()
 	}
 	return eventMeta
 }


### PR DESCRIPTION
## Proposed commit message

Fix Metricbeat k8s metadata sometimes not being present at startup

In the metricbeat k8s module, each metricset has an enricher, which is used to add k8s metadata to events. Enrichers use watchers to watch k8s resource changes, and these watchers can be shared between enrichers. This is implemented by each enricher maintaining a writethrough cache of metadata - when a K8s event indicating a change to a resource is received, the metadata cache is updated.

The problem with this is that a watcher is only started once, so enrichers which are created after it was started, have to catch up on the resource change events. This is a great opportunity for race conditions, and is in general unnecessarily complicated.

Instead, we turn the writethrough cache into a readthrough cache. The change event handlers now only invalidate the cache, and the enricher computes the metadata when it is first requested. This completely sidesteps the catch up problem, as we only compute the metadata lazily.

I've also refactored the code a bit:

- Resource event handlers are now added to a watcher when it is created, as opposed to when an enricher is created. They're always the same, so there's no reason to do it multiple times.
- Removed `TestBuildMetadataEnricher_EventHandler_PastObjects`, as it doesn't seem to check anything not covered by other tests.
- Rearranged the `createWatcher` function, so actual watcher creation (as opposed to skipping because it's already there) happens on the main path.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Install elastic-agent in K8s using the standalone manifests and track the metadata.

## Related issues

- Closes #41213 


