### PR TITLE
Switch K8s tests to Wolfi by default and make it configurable

### DIFF
--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -1,4 +1,5 @@
 ALL=filebeat metricbeat auditbeat heartbeat
+IMAGE_MODIFIER?="-wolfi"
 BEAT_VERSION=$(shell head -n 1 ../../libbeat/docs/version.asciidoc | cut -c 17- )
 
 .PHONY: all $(ALL)
@@ -6,9 +7,15 @@ BEAT_VERSION=$(shell head -n 1 ../../libbeat/docs/version.asciidoc | cut -c 17- 
 all: $(ALL)
 
 test: all
-	for FILE in $(shell ls *-kubernetes.yaml); do \
-		BEAT=$$(echo $$FILE | cut -d \- -f 1); \
+	@for BEAT in $(ALL); do \
+		echo; \
+		echo "$$BEAT"; \
+		FILE="$$BEAT-kubernetes.yaml"; \
 		kubectl create -f $$FILE; \
+		echo "Testing $$BEAT container for readiness..."; \
+		kubectl wait pods -n kube-system -l k8s-app=$$BEAT --for=condition=Ready --timeout=90s; \
+		echo "Deleting $$BEAT..."; \
+		kubectl delete -f $$FILE; \
 	done
 
 clean:
@@ -20,7 +27,7 @@ $(ALL):
 	@for f in service-account role role-binding configmap deployment daemonset ; do \
 		if [ -f "$@/$@-$$f.yaml" ]; then \
 			echo "file: $@/$@-$$f.yaml"; \
-			sed "s/%VERSION%/${BEAT_VERSION}/g" $@/$@-$$f.yaml >> $@-kubernetes.yaml; \
+			cat $@/$@-$$f.yaml | sed "s/%VERSION%/${BEAT_VERSION}/g" | sed "s/%IMAGE_MODIFIER%/${IMAGE_MODIFIER}/g" >> $@-kubernetes.yaml; \
 			echo --- >> $@-kubernetes.yaml; \
 		fi \
 	done

--- a/deploy/kubernetes/Makefile
+++ b/deploy/kubernetes/Makefile
@@ -22,7 +22,7 @@ clean:
 	@for f in $(ALL); do rm -f "$$f-kubernetes.yaml"; done
 
 $(ALL):
-	@echo "Generating $@-kubernetes.yaml"
+	@echo "Generating $@-kubernetes.yaml for version ${BEAT_VERSION} and image modifier '${IMAGE_MODIFIER}'"
 	@rm -f $@-kubernetes.yaml
 	@for f in service-account role role-binding configmap deployment daemonset ; do \
 		if [ -f "$@/$@-$$f.yaml" ]; then \

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -209,7 +209,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:9.0.0
+        image: docker.elastic.co/beats/auditbeat-wolfi:9.0.0
         args: [
           "-c", "/etc/auditbeat.yml",
           "-e",

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:%VERSION%
+        image: docker.elastic.co/beats/auditbeat%IMAGE_MODIFIER%:%VERSION%
         args: [
           "-c", "/etc/auditbeat.yml",
           "-e",

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -183,7 +183,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:9.0.0
+        image: docker.elastic.co/beats/filebeat-wolfi:9.0.0
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:%VERSION%
+        image: docker.elastic.co/beats/filebeat%IMAGE_MODIFIER%:%VERSION%
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/heartbeat-kubernetes.yaml
+++ b/deploy/kubernetes/heartbeat-kubernetes.yaml
@@ -171,7 +171,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: heartbeat
-        image: docker.elastic.co/beats/heartbeat:9.0.0
+        image: docker.elastic.co/beats/heartbeat-wolfi:9.0.0
         args: [
           "-c", "/etc/heartbeat.yml",
           "-e",

--- a/deploy/kubernetes/heartbeat/heartbeat-deployment.yaml
+++ b/deploy/kubernetes/heartbeat/heartbeat-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: heartbeat
-        image: docker.elastic.co/beats/heartbeat:%VERSION%
+        image: docker.elastic.co/beats/heartbeat%IMAGE_MODIFIER%:%VERSION%
         args: [
           "-c", "/etc/heartbeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -291,7 +291,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:9.0.0
+        image: docker.elastic.co/beats/metricbeat-wolfi:9.0.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:%VERSION%
+        image: docker.elastic.co/beats/metricbeat%IMAGE_MODIFIER%:%VERSION%
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",


### PR DESCRIPTION
## Proposed commit message

By default we test Wolfi-based images but there is now an environment variable `IMAGE_MODIFIER` that can be used for specifying different image prefixes when calling the make target.

Also, now the test verifies the actual container readiness and deletes resources after itself.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->



<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run the packaging command in the following folders:

* x-pack/filebeat
* x-pack/metricbeat
* x-pack/auditbeat
* x-pack/heartbeat

(put your architecture instead)

```sh
PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

Then you need a running K8s cluster with the pre-configured `kubectl`. I used Docker Desktop.

then go to `./deploy/kubernetes` and run

```
make test
```

by default we test against the Wolfi-based images but it can be switched by:

```
IMAGE_MODIFIER="-ubi" mage test
```

or test the main image instead:

```
IMAGE_MODIFIER="" mage test
```

The output should be something like this:

```
Generating filebeat-kubernetes.yaml for version 9.0.0 and image modifier '-wolfi'
file: filebeat/filebeat-service-account.yaml
file: filebeat/filebeat-role.yaml
file: filebeat/filebeat-role-binding.yaml
file: filebeat/filebeat-configmap.yaml
file: filebeat/filebeat-daemonset.yaml
Generating metricbeat-kubernetes.yaml for version 9.0.0 and image modifier '-wolfi'
file: metricbeat/metricbeat-service-account.yaml
file: metricbeat/metricbeat-role.yaml
file: metricbeat/metricbeat-role-binding.yaml
file: metricbeat/metricbeat-configmap.yaml
file: metricbeat/metricbeat-daemonset.yaml
Generating auditbeat-kubernetes.yaml for version 9.0.0 and image modifier '-wolfi'
file: auditbeat/auditbeat-service-account.yaml
file: auditbeat/auditbeat-role.yaml
file: auditbeat/auditbeat-role-binding.yaml
file: auditbeat/auditbeat-configmap.yaml
file: auditbeat/auditbeat-daemonset.yaml
Generating heartbeat-kubernetes.yaml for version 9.0.0 and image modifier '-wolfi'
file: heartbeat/heartbeat-service-account.yaml
file: heartbeat/heartbeat-role.yaml
file: heartbeat/heartbeat-role-binding.yaml
file: heartbeat/heartbeat-configmap.yaml
file: heartbeat/heartbeat-deployment.yaml

filebeat
serviceaccount/filebeat created
clusterrole.rbac.authorization.k8s.io/filebeat created
role.rbac.authorization.k8s.io/filebeat created
role.rbac.authorization.k8s.io/filebeat-kubeadm-config created
clusterrolebinding.rbac.authorization.k8s.io/filebeat created
rolebinding.rbac.authorization.k8s.io/filebeat created
rolebinding.rbac.authorization.k8s.io/filebeat-kubeadm-config created
configmap/filebeat-config created
daemonset.apps/filebeat created
Testing filebeat container for readiness...
pod/filebeat-wsn22 condition met
Deleting filebeat...
serviceaccount "filebeat" deleted
clusterrole.rbac.authorization.k8s.io "filebeat" deleted
role.rbac.authorization.k8s.io "filebeat" deleted
role.rbac.authorization.k8s.io "filebeat-kubeadm-config" deleted
clusterrolebinding.rbac.authorization.k8s.io "filebeat" deleted
rolebinding.rbac.authorization.k8s.io "filebeat" deleted
rolebinding.rbac.authorization.k8s.io "filebeat-kubeadm-config" deleted
configmap "filebeat-config" deleted
daemonset.apps "filebeat" deleted

metricbeat
serviceaccount/metricbeat created
clusterrole.rbac.authorization.k8s.io/metricbeat created
role.rbac.authorization.k8s.io/metricbeat created
role.rbac.authorization.k8s.io/metricbeat-kubeadm-config created
clusterrolebinding.rbac.authorization.k8s.io/metricbeat created
rolebinding.rbac.authorization.k8s.io/metricbeat created
rolebinding.rbac.authorization.k8s.io/metricbeat-kubeadm-config created
configmap/metricbeat-daemonset-config created
configmap/metricbeat-daemonset-modules created
daemonset.apps/metricbeat created
Testing metricbeat container for readiness...
pod/metricbeat-lfrqq condition met
Deleting metricbeat...
serviceaccount "metricbeat" deleted
clusterrole.rbac.authorization.k8s.io "metricbeat" deleted
role.rbac.authorization.k8s.io "metricbeat" deleted
role.rbac.authorization.k8s.io "metricbeat-kubeadm-config" deleted
clusterrolebinding.rbac.authorization.k8s.io "metricbeat" deleted
rolebinding.rbac.authorization.k8s.io "metricbeat" deleted
rolebinding.rbac.authorization.k8s.io "metricbeat-kubeadm-config" deleted
configmap "metricbeat-daemonset-config" deleted
configmap "metricbeat-daemonset-modules" deleted
daemonset.apps "metricbeat" deleted

auditbeat
serviceaccount/auditbeat created
clusterrole.rbac.authorization.k8s.io/auditbeat created
role.rbac.authorization.k8s.io/auditbeat created
role.rbac.authorization.k8s.io/auditbeat-kubeadm-config created
clusterrolebinding.rbac.authorization.k8s.io/auditbeat created
rolebinding.rbac.authorization.k8s.io/auditbeat created
rolebinding.rbac.authorization.k8s.io/auditbeat-kubeadm-config created
configmap/auditbeat-config created
configmap/auditbeat-daemonset-modules created
daemonset.apps/auditbeat created
Testing auditbeat container for readiness...
pod/auditbeat-jv9l5 condition met
Deleting auditbeat...
serviceaccount "auditbeat" deleted
clusterrole.rbac.authorization.k8s.io "auditbeat" deleted
role.rbac.authorization.k8s.io "auditbeat" deleted
role.rbac.authorization.k8s.io "auditbeat-kubeadm-config" deleted
clusterrolebinding.rbac.authorization.k8s.io "auditbeat" deleted
rolebinding.rbac.authorization.k8s.io "auditbeat" deleted
rolebinding.rbac.authorization.k8s.io "auditbeat-kubeadm-config" deleted
configmap "auditbeat-config" deleted
configmap "auditbeat-daemonset-modules" deleted
daemonset.apps "auditbeat" deleted

heartbeat
serviceaccount/heartbeat created
clusterrole.rbac.authorization.k8s.io/heartbeat created
role.rbac.authorization.k8s.io/heartbeat created
role.rbac.authorization.k8s.io/heartbeat-kubeadm-config created
clusterrolebinding.rbac.authorization.k8s.io/heartbeat created
rolebinding.rbac.authorization.k8s.io/heartbeat created
rolebinding.rbac.authorization.k8s.io/heartbeat-kubeadm-config created
configmap/heartbeat-deployment-config created
deployment.apps/heartbeat created
Testing heartbeat container for readiness...
pod/heartbeat-77f95d9b7-6rb9n condition met
Deleting heartbeat...
serviceaccount "heartbeat" deleted
clusterrole.rbac.authorization.k8s.io "heartbeat" deleted
role.rbac.authorization.k8s.io "heartbeat" deleted
role.rbac.authorization.k8s.io "heartbeat-kubeadm-config" deleted
clusterrolebinding.rbac.authorization.k8s.io "heartbeat" deleted
rolebinding.rbac.authorization.k8s.io "heartbeat" deleted
rolebinding.rbac.authorization.k8s.io "heartbeat-kubeadm-config" deleted
configmap "heartbeat-deployment-config" deleted
deployment.apps "heartbeat" deleted
```

This means K8s manifests were successfully generated, applied and the containers were running successfully.

Check the generated manifests for the images to have `-wolfi` suffix:

```
-rw-r--r--  1 rdner  staff   7.9K Oct 14 16:00 auditbeat-kubernetes.yaml
-rw-r--r--  1 rdner  staff   5.8K Oct 14 16:00 filebeat-kubernetes.yaml
-rw-r--r--  1 rdner  staff   5.3K Oct 14 16:00 heartbeat-kubernetes.yaml
-rw-r--r--  1 rdner  staff   9.3K Oct 14 16:00 metricbeat-kubernetes.yaml
``` 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related to https://github.com/elastic/beats/pull/40524
