### PR TITLE
Skip flaky tests TestFileWatcher and TestGroup_Go

### DIFF
--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestFileWatcher(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/41209")
 	dir := t.TempDir()
 	paths := []string{filepath.Join(dir, "*.log")}
 	cfgStr := `

--- a/filebeat/input/filestream/internal/task/group_test.go
+++ b/filebeat/input/filestream/internal/task/group_test.go
@@ -67,7 +67,7 @@ func TestNewGroup(t *testing.T) {
 }
 
 func TestGroup_Go(t *testing.T) {
-	t.Skip("Flaky tests: https://github.com/elastic/beats/issues/4121")
+	t.Skip("Flaky tests: https://github.com/elastic/beats/issues/41218")
 	t.Run("don't run more than limit goroutines", func(t *testing.T) {
 		done := make(chan struct{})
 		defer close(done)

--- a/filebeat/input/filestream/internal/task/group_test.go
+++ b/filebeat/input/filestream/internal/task/group_test.go
@@ -67,6 +67,7 @@ func TestNewGroup(t *testing.T) {
 }
 
 func TestGroup_Go(t *testing.T) {
+	t.Skip("Flaky tests: https://github.com/elastic/beats/issues/4121")
 	t.Run("don't run more than limit goroutines", func(t *testing.T) {
 		done := make(chan struct{})
 		defer close(done)


### PR DESCRIPTION

## Proposed commit message

This PR skips two flaky tests from the Filestream input, the tests are:
- TestFileWatcher (issue: https://github.com/elastic/beats/issues/41209)
- TestGroup_Go (issue: https://github.com/elastic/beats/issues/41218)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~
~~## How to test this PR locally~~


## Related issues
- Relates https://github.com/elastic/beats/issues/41209
- Relates https://github.com/elastic/beats/issues/41218

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~