### PR TITLE
Use npcap 1.80

### DIFF
--- a/x-pack/packetbeat/magefile.go
+++ b/x-pack/packetbeat/magefile.go
@@ -36,7 +36,7 @@ import (
 // the packetbeat executable. It is used to specify which npcap builder crossbuild
 // image to use and the installer to obtain from the cloud store for testing.
 const (
-	NpcapVersion = "1.79"
+	NpcapVersion = "1.80"
 	installer    = "npcap-" + NpcapVersion + "-oem.exe"
 )
 


### PR DESCRIPTION
So, turns out I was wrong, we _do_ need to tell packetbeat to use a specific version of npcap, and you can't just set the version flag in the crossbuild scripts. This updates the npcap version to 1.80