### PR TITLE
backport: Add 8.16 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -355,6 +355,19 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.16 branch
+    conditions:
+      - merged
+      - label~=^(backport-v8.16.0|backport-8.16)$
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.x branch
     conditions:
       - merged


### PR DESCRIPTION
Merge as soon as 8.16 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821