### PR TITLE
refactor beats argument parsing

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -25582,6 +25582,43 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------
+Dependency : golang.org/x/term
+Version: v0.24.0
+Licence type (autodetected): BSD-3-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/golang.org/x/term@v0.24.0/LICENSE:
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Dependency : golang.org/x/text
 Version: v0.18.0
 Licence type (autodetected): BSD-3-Clause
@@ -57036,43 +57073,6 @@ copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
---------------------------------------------------------------------------------
-Dependency : golang.org/x/term
-Version: v0.24.0
-Licence type (autodetected): BSD-3-Clause
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/golang.org/x/term@v0.24.0/LICENSE:
-
-Copyright 2009 The Go Authors.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/auditbeat/main_test.go
+++ b/auditbeat/main_test.go
@@ -35,7 +35,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/auditbeat/main_test.go
+++ b/auditbeat/main_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/auditbeat/cmd"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -39,6 +40,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/filebeat/cmd/generate.go
+++ b/filebeat/cmd/generate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/generator/fields"
 	"github.com/elastic/beats/v7/filebeat/generator/fileset"
 	"github.com/elastic/beats/v7/filebeat/generator/module"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common/cli"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -63,7 +64,9 @@ func genGenerateModuleCmd() *cobra.Command {
 	}
 
 	genModuleCmd.Flags().String("modules-path", defaultHomePath, "Path to modules directory")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("modules-path")
 	genModuleCmd.Flags().String("es-beats", defaultHomePath, "Path to Elastic Beats")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("es-beats")
 
 	return genModuleCmd
 }
@@ -88,7 +91,9 @@ func genGenerateFilesetCmd() *cobra.Command {
 	}
 
 	genFilesetCmd.Flags().String("modules-path", defaultHomePath, "Path to modules directory")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("modules-path")
 	genFilesetCmd.Flags().String("es-beats", defaultHomePath, "Path to Elastic Beats")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("es-beats")
 
 	return genFilesetCmd
 }
@@ -113,7 +118,9 @@ func genGenerateFieldsCmd() *cobra.Command {
 	}
 
 	genFieldsCmd.Flags().String("es-beats", defaultHomePath, "Path to Elastic Beats")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("es-beats")
 	genFieldsCmd.Flags().Bool("without-documentation", false, "Do not add description fields")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("without-documentation")
 
 	return genFieldsCmd
 }

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/fileset"
 	"github.com/elastic/beats/v7/filebeat/include"
 	"github.com/elastic/beats/v7/filebeat/input"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 
@@ -49,7 +50,9 @@ func FilebeatSettings(moduleNameSpace string) instance.Settings {
 	}
 	runFlags := pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("once"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("once")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("modules"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("modules")
 	return instance.Settings{
 		RunFlags:      runFlags,
 		Name:          Name,
@@ -66,8 +69,10 @@ func FilebeatSettings(moduleNameSpace string) instance.Settings {
 func Filebeat(inputs beater.PluginFactory, settings instance.Settings) *cmd.BeatsRootCmd {
 	command := cmd.GenRootCmdWithSettings(beater.New(inputs), settings)
 	command.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("M")
 	command.TestCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
 	command.SetupCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("modules")
 	command.AddCommand(cmd.GenModulesCmd(Name, "", buildModulesManager))
 	command.AddCommand(genGenerateCmd())
 	return command

--- a/filebeat/main_test.go
+++ b/filebeat/main_test.go
@@ -26,6 +26,7 @@ import (
 
 	fbcmd "github.com/elastic/beats/v7/filebeat/cmd"
 	inputs "github.com/elastic/beats/v7/filebeat/input/default-inputs"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
@@ -45,6 +46,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := fbCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/filebeat/main_test.go
+++ b/filebeat/main_test.go
@@ -41,7 +41,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	fbCommand = fbcmd.Filebeat(inputs.Init, fbcmd.FilebeatSettings(""))
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/go.mod
+++ b/go.mod
@@ -224,6 +224,7 @@ require (
 	go.opentelemetry.io/collector/consumer v0.109.0
 	go.opentelemetry.io/collector/pdata v1.15.0
 	go.opentelemetry.io/collector/receiver v0.109.0
+	golang.org/x/term v0.24.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240725223205-93522f1f2a9f
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
@@ -382,7 +383,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 // indirect
-	golang.org/x/term v0.24.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/elastic/beats/v7/heartbeat/beater"
 	"github.com/elastic/beats/v7/heartbeat/include"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/ecs"
@@ -81,6 +82,7 @@ func Initialize(settings instance.Settings) *cmd.BeatsRootCmd {
 `
 	setup.ResetFlags()
 	setup.Flags().Bool(cmd.IndexManagementKey, false, "Setup all components related to Elasticsearch index management, including template, ilm policy and rollover alias")
+	cfgfile.AddAllowedBackwardsCompatibleFlag(cmd.IndexManagementKey)
 
 	return rootCmd
 }

--- a/heartbeat/main_test.go
+++ b/heartbeat/main_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/heartbeat/cmd"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -38,6 +39,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(_ *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/heartbeat/main_test.go
+++ b/heartbeat/main_test.go
@@ -34,7 +34,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -18,9 +18,12 @@
 package cfgfile
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/fleetmode"
@@ -28,39 +31,48 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-// Command line flags.
+// Evil package level globals
 var (
-	// The default config cannot include the beat name as it is not initialized
-	// when this variable is created. See ChangeDefaultCfgfileFlag which should
-	// be called prior to flags.Parse().
-	configfiles = config.StringArrFlag(nil, "c", "beat.yml", "Configuration file, relative to path.config")
-	overwrites  = config.SettingFlag(nil, "E", "Configuration overwrite")
-
-	// Additional default settings, that must be available for variable expansion
-	defaults = config.MustNewConfigFrom(map[string]interface{}{
-		"path": map[string]interface{}{
-			"home":   ".", // to be initialized by beat
-			"config": "${path.home}",
-			"data":   fmt.Sprint("${path.home}", string(os.PathSeparator), "data"),
-			"logs":   fmt.Sprint("${path.home}", string(os.PathSeparator), "logs"),
-		},
-	})
-
-	// home-path CLI flag (initialized in init)
-	homePath   *string
-	configPath *string
+	once        sync.Once
+	configfiles *config.StringsFlag
+	overwrites  *config.C
+	defaults    *config.C
+	homePath    *string
+	configPath  *string
+	dataPath    *string
+	logsPath    *string
 )
 
-func init() {
-	// add '-path.x' options overwriting paths in 'overwrites' config
-	makePathFlag := func(name, usage string) *string {
-		return config.ConfigOverwriteFlag(nil, overwrites, name, name, "", usage)
-	}
+func Initialize() {
+	once.Do(func() {
+		// The default config cannot include the beat name as
+		// it is not initialized when this variable is
+		// created. See ChangeDefaultCfgfileFlag which should
+		// be called prior to flags.Parse().
+		configfiles = config.StringArrFlag(nil, "c", "beat.yml", "Configuration file, relative to path.config")
+		overwrites = config.SettingFlag(nil, "E", "Configuration overwrite")
+		defaults = config.MustNewConfigFrom(map[string]interface{}{
+			"path": map[string]interface{}{
+				"home":   ".", // to be initialized by beat
+				"config": "${path.home}",
+				"data":   fmt.Sprint("${path.home}", string(os.PathSeparator), "data"),
+				"logs":   fmt.Sprint("${path.home}", string(os.PathSeparator), "logs"),
+			},
+		})
+		homePath = config.ConfigOverwriteFlag(nil, overwrites, "path.home", "path.home", "", "Home path")
+		configPath = config.ConfigOverwriteFlag(nil, overwrites, "path.config", "path.config", "", "Configuration path")
+		dataPath = config.ConfigOverwriteFlag(nil, overwrites, "path.data", "path.data", "", "Data path")
+		logsPath = config.ConfigOverwriteFlag(nil, overwrites, "path.logs", "path.logs", "", "Logs path")
+	})
+}
 
-	homePath = makePathFlag("path.home", "Home path")
-	configPath = makePathFlag("path.config", "Configuration path")
-	makePathFlag("path.data", "Data path")
-	makePathFlag("path.logs", "Logs path")
+func ConvertFlagsForBackwardsCompatibility() {
+	// backwards compatibility workaround, convert -flags to --flags:
+	for i, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") && len(arg) > 2 {
+			os.Args[1+i] = "-" + arg
+		}
+	}
 }
 
 // OverrideChecker checks if a config should be overwritten.
@@ -76,6 +88,7 @@ type ConditionalOverride struct {
 // ChangeDefaultCfgfileFlag replaces the value and default value for the `-c`
 // flag so that it reflects the beat name.
 func ChangeDefaultCfgfileFlag(beatName string) error {
+	Initialize()
 	configfiles.SetDefault(beatName + ".yml")
 	return nil
 }
@@ -97,7 +110,10 @@ func GetDefaultCfgfile() string {
 }
 
 // HandleFlags adapts default config settings based on command line flags.
+// This also stores if -E management.enabled=true was set on command line
+// to determine if running the Beat under agent.
 func HandleFlags() error {
+	Initialize()
 	// default for the home path is the binary location
 	home, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
@@ -114,6 +130,27 @@ func HandleFlags() error {
 		common.PrintConfigDebugf(overwrites, "CLI setting overwrites (-E flag):")
 	}
 
+	// Enable check to see if beat is running under Agent
+	// This is stored in a package so the modules which don't have
+	// access to the config can check this value.
+	type management struct {
+		Enabled bool `config:"management.enabled"`
+	}
+	var managementSettings management
+	cfgFlag := flag.Lookup("E")
+	if cfgFlag == nil {
+		fleetmode.SetAgentMode(false)
+		return nil
+	}
+	cfgObject, _ := cfgFlag.Value.(*config.SettingsFlag)
+	cliCfg := cfgObject.Config()
+
+	err = cliCfg.Unpack(&managementSettings)
+	if err != nil {
+		fleetmode.SetAgentMode(false)
+		return nil //nolint:nilerr // unpacking failing isn't an error for this case
+	}
+	fleetmode.SetAgentMode(managementSettings.Enabled)
 	return nil
 }
 
@@ -222,6 +259,7 @@ func SetConfigPath(path string) {
 
 // GetPathConfig returns ${path.config}. If ${path.config} is not set, ${path.home} is returned.
 func GetPathConfig() string {
+	Initialize()
 	if *configPath != "" {
 		return *configPath
 	} else if *homePath != "" {

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -39,8 +39,6 @@ var (
 	defaults                        *config.C
 	homePath                        *string
 	configPath                      *string
-	dataPath                        *string
-	logsPath                        *string
 	allowedBackwardsCompatibleFlags []string
 )
 
@@ -66,9 +64,9 @@ func Initialize() {
 		AddAllowedBackwardsCompatibleFlag("path.home")
 		configPath = config.ConfigOverwriteFlag(nil, overwrites, "path.config", "path.config", "", "Configuration path")
 		AddAllowedBackwardsCompatibleFlag("path.config")
-		dataPath = config.ConfigOverwriteFlag(nil, overwrites, "path.data", "path.data", "", "Data path")
+		_ = config.ConfigOverwriteFlag(nil, overwrites, "path.data", "path.data", "", "Data path")
 		AddAllowedBackwardsCompatibleFlag("path.data")
-		logsPath = config.ConfigOverwriteFlag(nil, overwrites, "path.logs", "path.logs", "", "Logs path")
+		_ = config.ConfigOverwriteFlag(nil, overwrites, "path.logs", "path.logs", "", "Logs path")
 		AddAllowedBackwardsCompatibleFlag("path.logs")
 	})
 }
@@ -92,8 +90,11 @@ func AddAllowedBackwardsCompatibleFlag(f string) {
 func ConvertFlagsForBackwardsCompatibility() {
 	// backwards compatibility workaround, convert -flags to --flags:
 	for i, arg := range os.Args[1:] {
-		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") && isAllowedBackwardsCompatibleFlag(strings.TrimPrefix(arg, "-")) {
-			os.Args[1+i] = "-" + arg
+		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			candidate, _, _ := strings.Cut(strings.TrimPrefix(arg, "-"), "=")
+			if isAllowedBackwardsCompatibleFlag(candidate) {
+				os.Args[1+i] = "-" + arg
+			}
 		}
 	}
 }

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -109,8 +109,9 @@ type ConditionalOverride struct {
 	Config *config.C
 }
 
-// ChangeDefaultCfgfileFlag replaces the value and default value for the `-c`
-// flag so that it reflects the beat name.
+// ChangeDefaultCfgfileFlag replaces the value and default value for
+// the `-c` flag so that it reflects the beat name.  It will call
+// Initialize() to register the `-c` flags
 func ChangeDefaultCfgfileFlag(beatName string) error {
 	Initialize()
 	configfiles.SetDefault(beatName + ".yml")
@@ -133,9 +134,10 @@ func GetDefaultCfgfile() string {
 	return cfg
 }
 
-// HandleFlags adapts default config settings based on command line flags.
-// This also stores if -E management.enabled=true was set on command line
-// to determine if running the Beat under agent.
+// HandleFlags adapts default config settings based on command line
+// flags.  This also stores if -E management.enabled=true was set on
+// command line to determine if running the Beat under agent.  It will
+// call Initialize() to register the flags like `-E`.
 func HandleFlags() error {
 	Initialize()
 	// default for the home path is the binary location
@@ -281,7 +283,9 @@ func SetConfigPath(path string) {
 	*configPath = path
 }
 
-// GetPathConfig returns ${path.config}. If ${path.config} is not set, ${path.home} is returned.
+// GetPathConfig returns ${path.config}. If ${path.config} is not set,
+// ${path.home} is returned.  It will call Initialize to ensure that
+// `path.config` and `path.home` are set.
 func GetPathConfig() string {
 	Initialize()
 	if *configPath != "" {

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -56,8 +56,8 @@ func Initialize() {
 			"path": map[string]interface{}{
 				"home":   ".", // to be initialized by beat
 				"config": "${path.home}",
-				"data":   fmt.Sprint("${path.home}", string(os.PathSeparator), "data"),
-				"logs":   fmt.Sprint("${path.home}", string(os.PathSeparator), "logs"),
+				"data":   filepath.Join("${path.home}", "data"),
+				"logs":   filepath.Join("${path.home}", "logs"),
 			},
 		})
 		homePath = config.ConfigOverwriteFlag(nil, overwrites, "path.home", "path.home", "", "Home path")

--- a/libbeat/cmd/export/dashboard.go
+++ b/libbeat/cmd/export/dashboard.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/dashboards"
 	"github.com/elastic/beats/v7/libbeat/version"
@@ -101,8 +102,11 @@ func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("id", "", "Dashboard id")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("id")
 	genTemplateConfigCmd.Flags().String("yml", "", "Yaml file containing list of dashboard ID and filename pairs")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("yml")
 	genTemplateConfigCmd.Flags().String("folder", "", "Target folder to save exported assets")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("folder")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/export/ilm_policy.go
+++ b/libbeat/cmd/export/ilm_policy.go
@@ -20,6 +20,7 @@ package export
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle"
@@ -57,7 +58,9 @@ func GenGetILMPolicyCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 	genTemplateConfigCmd.Flags().String("dir", "", "Specify directory for printing policy files. By default policies are printed to stdout.")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("dir")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/export/index_pattern.go
+++ b/libbeat/cmd/export/index_pattern.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/kibana"
 	libversion "github.com/elastic/elastic-agent-libs/version"
@@ -67,6 +68,7 @@ func GenIndexPatternConfigCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -20,6 +20,7 @@ package export
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle"
@@ -59,8 +60,11 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 	genTemplateConfigCmd.Flags().Bool("noilm", false, "Generate template with ILM disabled")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("noilm")
 	genTemplateConfigCmd.Flags().String("dir", "", "Specify directory for printing template files. By default templates are printed to stdout.")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("dir")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -974,9 +974,11 @@ func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) er
 	}())
 }
 
-// handleFlags parses the command line flags. It invokes the HandleFlags
-// callback if implemented by the Beat.
+// handleFlags converts -flag to --flags, parses the command line
+// flags, and it invokes the HandleFlags callback if implemented by
+// the Beat.
 func (b *Beat) handleFlags() error {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	flag.Parse()
 	return cfgfile.HandleFlags()
 }

--- a/libbeat/cmd/instance/beat_integration_test.go
+++ b/libbeat/cmd/instance/beat_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/mock"
 	"github.com/elastic/elastic-agent-libs/config"
@@ -92,7 +93,9 @@ func TestMonitoringNameFromConfig(t *testing.T) {
 		defer wg.Done()
 
 		// Set the configuration file path flag so the beat can read it
+		cfgfile.Initialize()
 		_ = flag.Set("c", "testdata/mockbeat.yml")
+		cfgfile.AddAllowedBackwardsCompatibleFlag("c")
 		_ = instance.Run(mock.Settings, func(_ *beat.Beat, _ *config.C) (beat.Beater, error) {
 			return &mockBeat, nil
 		})

--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	tml "golang.org/x/crypto/ssh/terminal"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/common/cli"
 	"github.com/elastic/beats/v7/libbeat/common/terminal"
@@ -74,6 +75,7 @@ func genCreateKeystoreCmd(settings instance.Settings) *cobra.Command {
 		}),
 	}
 	command.Flags().BoolVar(&flagForce, "force", false, "override the existing keystore")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("force")
 	return command
 }
 
@@ -92,7 +94,9 @@ func genAddKeystoreCmd(settings instance.Settings) *cobra.Command {
 		}),
 	}
 	command.Flags().BoolVar(&flagStdin, "stdin", false, "Use the stdin as the source of the secret")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("stdin")
 	command.Flags().BoolVar(&flagForce, "force", false, "Override the existing key")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("force")
 	return command
 }
 

--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -21,13 +21,13 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
-	tml "golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
@@ -39,7 +39,7 @@ import (
 func getKeystore(settings instance.Settings) (keystore.Keystore, error) {
 	b, err := instance.NewInitializedBeat(settings)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing beat: %s", err)
+		return nil, fmt.Errorf("error initializing beat: %w", err)
 	}
 
 	return b.Keystore(), nil
@@ -136,27 +136,27 @@ func createKeystore(settings instance.Settings, force bool) error {
 
 	writableKeystore, err := keystore.AsWritableKeystore(store)
 	if err != nil {
-		return fmt.Errorf("error creating the keystore: %s", err)
+		return fmt.Errorf("error creating the keystore: %w", err)
 	}
 
-	if store.IsPersisted() == true && force == false {
+	if store.IsPersisted() && !force {
 		response := terminal.PromptYesNo("A keystore already exists, Overwrite?", false)
-		if response == true {
+		if response {
 			err := writableKeystore.Create(true)
 			if err != nil {
-				return fmt.Errorf("error creating the keystore: %s", err)
+				return fmt.Errorf("error creating the keystore: %w", err)
 			}
 		} else {
-			fmt.Println("Exiting without creating keystore.")
+			fmt.Printf("Exiting without creating %s keystore.", settings.Name) //nolint:forbidigo //needs refactor
 			return nil
 		}
 	} else {
 		err := writableKeystore.Create(true)
 		if err != nil {
-			return fmt.Errorf("Error creating the keystore: %s", err)
+			return fmt.Errorf("Error creating the keystore: %w", err)
 		}
 	}
-	fmt.Printf("Created %s keystore\n", settings.Name)
+	fmt.Printf("Created %s keystore\n", settings.Name) //nolint:forbidigo //needs refactor
 	return nil
 }
 
@@ -171,32 +171,32 @@ func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
 
 	writableKeystore, err := keystore.AsWritableKeystore(store)
 	if err != nil {
-		return fmt.Errorf("error creating the keystore: %s", err)
+		return fmt.Errorf("error creating the keystore: %w", err)
 	}
 
-	if store.IsPersisted() == false {
-		if force == false {
+	if !store.IsPersisted() {
+		if !force {
 			answer := terminal.PromptYesNo("The keystore does not exist. Do you want to create it?", false)
-			if answer == false {
+			if !answer {
 				return errors.New("exiting without creating keystore")
 			}
 		}
 		err := writableKeystore.Create(true)
 		if err != nil {
-			return fmt.Errorf("could not create keystore, error: %s", err)
+			return fmt.Errorf("could not create keystore, error: %w", err)
 		}
-		fmt.Println("Created keystore")
+		fmt.Println("Created keystore") //nolint:forbidigo //needs refactor
 	}
 
 	key := strings.TrimSpace(keys[0])
-	value, err := store.Retrieve(key)
-	if value != nil && force == false {
-		if stdin == true {
+	value, _ := store.Retrieve(key)
+	if value != nil && !force {
+		if stdin {
 			return fmt.Errorf("the settings %s already exist in the keystore use `--force` to replace it", key)
 		}
 		answer := terminal.PromptYesNo(fmt.Sprintf("Setting %s already exists, Overwrite?", key), false)
-		if answer == false {
-			fmt.Println("Exiting without modifying keystore.")
+		if !answer {
+			fmt.Println("Exiting without modifying keystore.") //nolint:forbidigo //needs refactor
 			return nil
 		}
 	}
@@ -204,25 +204,25 @@ func addKey(store keystore.Keystore, keys []string, force, stdin bool) error {
 	var keyValue []byte
 	if stdin {
 		reader := bufio.NewReader(os.Stdin)
-		keyValue, err = ioutil.ReadAll(reader)
+		keyValue, err = io.ReadAll(reader)
 		if err != nil {
 			return fmt.Errorf("could not read input from stdin")
 		}
 	} else {
-		fmt.Printf("Enter value for %s: ", key)
-		keyValue, err = tml.ReadPassword(int(syscall.Stdin))
-		fmt.Println()
+		fmt.Printf("Enter value for %s: ", key)               //nolint:forbidigo //needs refactor
+		keyValue, err = term.ReadPassword(int(syscall.Stdin)) //nolint:unconvert,nolintlint //necessary on Windows
+		fmt.Println()                                         //nolint:forbidigo //needs refactor
 		if err != nil {
-			return fmt.Errorf("could not read value from the input, error: %s", err)
+			return fmt.Errorf("could not read value from the input, error: %w", err)
 		}
 	}
 	if err = writableKeystore.Store(key, keyValue); err != nil {
-		return fmt.Errorf("could not add the key in the keystore, error: %s", err)
+		return fmt.Errorf("could not add the key in the keystore, error: %w", err)
 	}
 	if err = writableKeystore.Save(); err != nil {
-		return fmt.Errorf("fail to save the keystore: %s", err)
+		return fmt.Errorf("fail to save the keystore: %w", err)
 	} else {
-		fmt.Println("Successfully updated the keystore")
+		fmt.Println("Successfully updated the keystore") //nolint:forbidigo //needs refactor
 	}
 	return nil
 }
@@ -234,10 +234,10 @@ func removeKey(store keystore.Keystore, keys []string) error {
 
 	writableKeystore, err := keystore.AsWritableKeystore(store)
 	if err != nil {
-		return fmt.Errorf("error deleting the keystore: %s", err)
+		return fmt.Errorf("error deleting the keystore: %w", err)
 	}
 
-	if store.IsPersisted() == false {
+	if !store.IsPersisted() {
 		return errors.New("the keystore doesn't exist. Use the 'create' command to create one")
 	}
 
@@ -248,12 +248,12 @@ func removeKey(store keystore.Keystore, keys []string) error {
 			return fmt.Errorf("could not find key '%v' in the keystore", key)
 		}
 
-		writableKeystore.Delete(key)
+		_ = writableKeystore.Delete(key)
 		err = writableKeystore.Save()
 		if err != nil {
-			return fmt.Errorf("could not update the keystore with the changes, key: %s, error: %v", key, err)
+			return fmt.Errorf("could not update the keystore with the changes, key: %s, error: %w", key, err)
 		}
-		fmt.Printf("successfully removed key: %s\n", key)
+		fmt.Printf("successfully removed key: %s\n", key) //nolint:forbidigo //needs refactor
 	}
 	return nil
 }
@@ -261,14 +261,14 @@ func removeKey(store keystore.Keystore, keys []string) error {
 func list(store keystore.Keystore) error {
 	listingKeystore, err := keystore.AsListingKeystore(store)
 	if err != nil {
-		return fmt.Errorf("error listing the keystore: %s", err)
+		return fmt.Errorf("error listing the keystore: %w", err)
 	}
 	keys, err := listingKeystore.List()
 	if err != nil {
-		return fmt.Errorf("could not read values from the keystore, error: %s", err)
+		return fmt.Errorf("could not read values from the keystore, error: %w", err)
 	}
 	for _, key := range keys {
-		fmt.Println(key)
+		fmt.Println(key) //nolint:forbidigo //needs refactor
 	}
 	return nil
 }

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -32,15 +31,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/licenser"
 	"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 )
-
-func init() {
-	// backwards compatibility workaround, convert -flags to --flags:
-	for i, arg := range os.Args[1:] {
-		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") && len(arg) > 2 {
-			os.Args[1+i] = "-" + arg
-		}
-	}
-}
 
 // BeatsRootCmd handles all application command line interface, parses user
 // flags and runs subcommands
@@ -76,6 +66,7 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 	rootCmd.Use = settings.Name
 
 	// Due to a dependence upon the beat name, the default config file path
+	cfgfile.Initialize()
 	err := cfgfile.ChangeDefaultCfgfileFlag(settings.Name)
 	if err != nil {
 		panic(fmt.Errorf("failed to set default config file path: %w", err))

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -87,18 +87,30 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 
 	// Persistent flags, common across all subcommands
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("E"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("E")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("c"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("c")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("d"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("d")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("v"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("v")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("e"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("e")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("environment"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("environment")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.config"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("path.config")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.data"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("path.data")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.logs"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("path.logs")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.home"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("path.home")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("strict.perms"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("strict.perms")
 	if f := flag.CommandLine.Lookup("plugin"); f != nil {
 		rootCmd.PersistentFlags().AddGoFlag(f)
+		cfgfile.AddAllowedBackwardsCompatibleFlag("plugin")
 	}
 
 	// Inherit root flags from run command

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 )
 
@@ -42,9 +43,13 @@ func genRunCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Comm
 
 	// Run subcommand flags, only available to *beat run
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("N"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("N")
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("httpprof"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("httpprof")
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("cpuprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("cpuprofile")
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("memprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("memprofile")
 
 	if settings.RunFlags != nil {
 		runCmd.Flags().AddFlagSet(settings.RunFlags)

--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 )
 
@@ -111,11 +112,16 @@ func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Co
 	}
 
 	setup.Flags().Bool(DashboardKey, false, "Setup dashboards")
+	cfgfile.AddAllowedBackwardsCompatibleFlag(DashboardKey)
 	setup.Flags().Bool(PipelineKey, false, "Setup Ingest pipelines")
+	cfgfile.AddAllowedBackwardsCompatibleFlag(PipelineKey)
 	setup.Flags().Bool(IndexManagementKey, false,
 		"Setup all components related to Elasticsearch index management, including template, ilm policy and rollover alias")
+	cfgfile.AddAllowedBackwardsCompatibleFlag(IndexManagementKey)
 	setup.Flags().Bool("enable-all-filesets", false, "Behave as if all modules and filesets had been enabled")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("enable-all-filesets")
 	setup.Flags().Bool("force-enable-module-filesets", false, "Behave as if all filesets, within enabled modules, are enabled")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("force-enable-module-filesets")
 
 	return &setup
 }

--- a/libbeat/common/fleetmode/fleet_mode.go
+++ b/libbeat/common/fleetmode/fleet_mode.go
@@ -17,33 +17,18 @@
 
 package fleetmode
 
-import (
-	"flag"
+var managementEnabled bool
 
-	"github.com/elastic/elastic-agent-libs/config"
-)
+// SetAgentMode stores if the Beat is running under Elastic Agent.
+// Normally this is called when the command line flags are parsed.
+// This is stored as a package level variable because some components
+// (like filebeat/metricbeat modules) don't have access to the
+// configuration information to determine this on their own.
+func SetAgentMode(enabled bool) {
+	managementEnabled = enabled
+}
 
-// Enabled checks to see if filebeat/metricbeat is running under Agent
-// The management setting is stored in the main Beat runtime object, but we can't see that from a module
-// So instead we check the CLI flags, since Agent starts filebeat/metricbeat with "-E", "management.enabled=true"
+// Enabled returns true if the Beat is running under Elastic Agent.
 func Enabled() bool {
-	type management struct {
-		Enabled bool `config:"management.enabled"`
-	}
-	var managementSettings management
-
-	cfgFlag := flag.Lookup("E")
-	if cfgFlag == nil {
-		return false
-	}
-
-	cfgObject, _ := cfgFlag.Value.(*config.SettingsFlag)
-	cliCfg := cfgObject.Config()
-
-	err := cliCfg.Unpack(&managementSettings)
-	if err != nil {
-		return false
-	}
-
-	return managementSettings.Enabled
+	return managementEnabled
 }

--- a/libbeat/libbeat_test.go
+++ b/libbeat/libbeat_test.go
@@ -32,7 +32,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started

--- a/libbeat/libbeat_test.go
+++ b/libbeat/libbeat_test.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -36,6 +37,7 @@ func init() {
 
 // Test started when the test binary is started
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/ecs"
@@ -61,6 +62,7 @@ func MetricbeatSettings(moduleNameSpace string) instance.Settings {
 	}
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("system.hostfs")
 	return instance.Settings{
 		RunFlags:      runFlags,
 		Name:          Name,

--- a/metricbeat/main_test.go
+++ b/metricbeat/main_test.go
@@ -34,7 +34,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/metricbeat/main_test.go
+++ b/metricbeat/main_test.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/metricbeat/cmd"
 )
@@ -38,6 +39,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/packetbeat/cmd/root.go
+++ b/packetbeat/cmd/root.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/ecs"
@@ -51,10 +52,15 @@ var RootCmd *cmd.BeatsRootCmd
 func PacketbeatSettings(globals processors.PluginConfig) instance.Settings {
 	runFlags := pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("I")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("t"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("t")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("O"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("O")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("l"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("l")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("dump")
 
 	return instance.Settings{
 		RunFlags:       runFlags,

--- a/packetbeat/main_test.go
+++ b/packetbeat/main_test.go
@@ -34,7 +34,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/packetbeat/main_test.go
+++ b/packetbeat/main_test.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/packetbeat/cmd"
 )
@@ -38,6 +39,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/winlogbeat/main_test.go
+++ b/winlogbeat/main_test.go
@@ -33,7 +33,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // TestSystem is the function called when the test binary is started.

--- a/winlogbeat/main_test.go
+++ b/winlogbeat/main_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/winlogbeat/cmd"
 )
@@ -38,6 +39,7 @@ func init() {
 // TestSystem is the function called when the test binary is started.
 // Only calls main.
 func TestSystem(*testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/agentbeat/main_test.go
+++ b/x-pack/agentbeat/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +28,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := abCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/x-pack/agentbeat/main_test.go
+++ b/x-pack/agentbeat/main_test.go
@@ -23,7 +23,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	abCommand = AgentBeat()
 	abCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	abCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/agentbeat/main_test.go
+++ b/x-pack/agentbeat/main_test.go
@@ -9,8 +9,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 )
 
 var (

--- a/x-pack/auditbeat/main_test.go
+++ b/x-pack/auditbeat/main_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/auditbeat/cmd"
 )
@@ -26,6 +27,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/auditbeat/main_test.go
+++ b/x-pack/auditbeat/main_test.go
@@ -22,7 +22,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/filebeat/main_test.go
+++ b/x-pack/filebeat/main_test.go
@@ -25,7 +25,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	fbCommand = fbcmd.Filebeat()
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/filebeat/main_test.go
+++ b/x-pack/filebeat/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	fbcmd "github.com/elastic/beats/v7/x-pack/filebeat/cmd"
@@ -29,6 +30,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := fbCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/x-pack/functionbeat/main_test.go
+++ b/x-pack/functionbeat/main_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/functionbeat/manager/cmd"
 )
@@ -26,6 +27,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/functionbeat/main_test.go
+++ b/x-pack/functionbeat/main_test.go
@@ -22,7 +22,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/functionbeat/provider/aws/cmd/root.go
+++ b/x-pack/functionbeat/provider/aws/cmd/root.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"flag"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/x-pack/functionbeat/function/beater"
 	funcmd "github.com/elastic/beats/v7/x-pack/functionbeat/function/cmd"
 )
@@ -20,6 +21,9 @@ var RootCmd *funcmd.FunctionCmd
 func init() {
 	RootCmd = funcmd.NewFunctionCmd(Name, beater.New)
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("d"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("d")
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("v"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("v")
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("e"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("e")
 }

--- a/x-pack/functionbeat/provider/aws/main_test.go
+++ b/x-pack/functionbeat/provider/aws/main_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/x-pack/functionbeat/provider/aws/cmd"
 )
 
@@ -25,7 +26,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/functionbeat/provider/aws/main_test.go
+++ b/x-pack/functionbeat/provider/aws/main_test.go
@@ -21,7 +21,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/functionbeat/provider/local/main_test.go
+++ b/x-pack/functionbeat/provider/local/main_test.go
@@ -21,7 +21,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/functionbeat/provider/local/main_test.go
+++ b/x-pack/functionbeat/provider/local/main_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/x-pack/functionbeat/provider/local/cmd"
 )
 
@@ -25,6 +26,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/heartbeat/main_test.go
+++ b/x-pack/heartbeat/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/heartbeat/cmd"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -24,6 +25,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(_ *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/heartbeat/main_test.go
+++ b/x-pack/heartbeat/main_test.go
@@ -20,7 +20,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/libbeat/libbeat_test.go
+++ b/x-pack/libbeat/libbeat_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -18,11 +19,14 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/metricbeat/main_test.go
+++ b/x-pack/metricbeat/main_test.go
@@ -19,7 +19,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/metricbeat/main_test.go
+++ b/x-pack/metricbeat/main_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/cmd"
 )
@@ -23,6 +24,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/osquerybeat/main_test.go
+++ b/x-pack/osquerybeat/main_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/cmd"
 )
 
@@ -25,6 +26,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(_ *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/osquerybeat/main_test.go
+++ b/x-pack/osquerybeat/main_test.go
@@ -21,7 +21,9 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/packetbeat/main_test.go
+++ b/x-pack/packetbeat/main_test.go
@@ -19,7 +19,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/packetbeat/main_test.go
+++ b/x-pack/packetbeat/main_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/packetbeat/cmd"
 )
@@ -23,6 +24,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/winlogbeat/cmd/export.go
+++ b/x-pack/winlogbeat/cmd/export.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/winlogbeat/module"
 	libversion "github.com/elastic/elastic-agent-libs/version"
@@ -48,7 +49,9 @@ func GenExportPipelineCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genExportPipelineCmd.Flags().String("es.version", settings.Version, "Elasticsearch version (required)")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 	genExportPipelineCmd.Flags().String("dir", "", "Specify directory for exporting pipelines. Default is current directory.")
+	cfgfile.AddAllowedBackwardsCompatibleFlag("dir")
 
 	return genExportPipelineCmd
 }

--- a/x-pack/winlogbeat/main_test.go
+++ b/x-pack/winlogbeat/main_test.go
@@ -19,7 +19,9 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.

--- a/x-pack/winlogbeat/main_test.go
+++ b/x-pack/winlogbeat/main_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/winlogbeat/cmd"
 )
@@ -23,6 +24,7 @@ func init() {
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
+	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}


### PR DESCRIPTION
## Proposed commit message

Change beats argument parsing behavior.

Beats currently sets some command line flags in an init function, this means that any other project that imports beats will have conflicts if it uses the same options.  This change moves this out of init.

Beats currently modifies the Argument list to offer backwards compatibility for flags in an init function. This would convert flags like `-e` to `--e`.  This means if any other project imports beats, it's argument parsing would be changed.  This change adds an allowed list of arguments that can be changed and moves it out of init.

Beats currently detects if it is `fleet managed` by looking at the command line flags.  This change keeps that behavior, but adds the ability to set this directly.  This allows setting the flag without the command line option.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

The goal is none, however if any flags are missed, then the user would have to call them as `--flag` instead of `-flag`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Must be tested with these changes running under `elastic-agent` (main elastic agent, beats built from this PR, policy had auditd and system metrics)
- [x] Must be tested with beats imported into `elastic-agent` (main elastic-agent, importing beats and implementing filebeat receiver, beats builts from this PR, policy had auditd and system metrics). Verified filebeatreceiver worked, normal agentbeat worked and that `-1s` could be passed as an argument to `--fleet-server-timeout`
- [x] Must be tested with `apm-server`.  Built apm-server using this PR, had to make changes to `internal/beatcmd/beat.go` and `internal/beatcmd/reloader.go`. This was expected for change to uuidv5 and storage of the reload registry.  Also had to upgrade to badgerv4, also expected, but may be a breaking change.  Tested that `apm-server -E management.enabled=true  -E logging.to_stderr=true` still worked as expected.  No changes were required to apm-server argument parsing.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #41153

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
