### PR TITLE
Add note about scaling Elastic Agent with Kafka input

### DIFF
--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -60,6 +60,9 @@ might work as well, but are not supported.
 The `kafka` input supports the following configuration options plus the
 <<{beatname_lc}-input-{type}-common-options>> described later.
 
+NOTE: If you're using {agent} with a Kafka input and need to scale out Kafka to increase throughput, we recommend adding additional {agents} to read from the Kafka topic.
+Note that a single Kafka consumer ID is used for each {agent}, and {agent} then assigns an individual thread to each partition in a topic.
+
 [float]
 [[kafka-hosts]]
 ===== `hosts`


### PR DESCRIPTION
As part of [this enhancement request](https://github.com/elastic/enhancements/issues/20183#issuecomment-2406433591), this PR adds a note to the Filebeat [Configuration options](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-kafka.html#filebeat-input-kafka-options) section with regard to scaling when using the Kafka input. I'm not sure that this is the best place for the note, but we don't describe inputs in the Elastic Agent docs. 

![screen](https://github.com/user-attachments/assets/3f1d9115-c72c-47be-90aa-c82b435be980)
