### PR TITLE
Only watch metadata for ReplicaSets in metricbeat k8s module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -377,6 +377,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Added Cisco Meraki module {pull}40836[40836]
 - Added Palo Alto Networks module {pull}40686[40686]
 - Restore docker.network.in.* and docker.network.out.* fields in docker module {pull}40968[40968]
+- Only watch metadata for ReplicaSets in metricbeat k8s module {pull}41289[41289]
 
 *Metricbeat*
 


### PR DESCRIPTION
## Proposed commit message

Use metadata watchers for ReplicaSets in the metricbeats Kubernetes module. This is a similar change to #41100, with two major differences:

* State metrics for ReplicaSets may actually need all the metadata, so our transform function keeps it.
* Due to the way the update handler function switches over the resource type, our resource needs to have `TypeMeta` present. The informer doesn't set this, so we need to do it ourselves.

A decent chunk of the changes is just passing around a metadata-only k8s client.

For more details see https://github.com/elastic/elastic-agent/issues/5623.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

You need a full K8s cluster, unfortunately. I've tested it using the default elastic-agent standalone manifest, by building a custom container image and loading it into a local kind cluster.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/5623

