### PR TITLE
[auditbeat] Allow memfd_create(2) in seccomp for add_session_metadata…

### DIFF
--- a/x-pack/auditbeat/seccomp_linux.go
+++ b/x-pack/auditbeat/seccomp_linux.go
@@ -35,5 +35,13 @@ func init() {
 		); err != nil {
 			panic(err)
 		}
+
+		// The sessionmd processor kerneltracingprovider needs
+		// memfd_create to operate via EBPF
+		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall,
+			"memfd_create",
+		); err != nil {
+			panic(err)
+		}
 	}
 }


### PR DESCRIPTION
…@ebpf

Quark was falling back into kprobe since ebpf would fail with EPERM at memfd_create(2).

```
$ strace -f auditbeat ....
[pid  2917] memfd_create("libbpf-placeholder-fd", MFD_CLOEXEC) = -1 EPERM (Operation not permitted)
```

With this my test case where kprobe is disabled now uses ebpf when I select backend "auto", before it was falling back to procfsprovider.

## Proposed commit message

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Change QQ_ALL_BACKENDS to QQ_EBPF and kerneltracingprovider will fallback into procfs, with the fix it doesn't.

