### PR TITLE
Fix event deletion in the memqueue

### DIFF
--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -290,7 +290,7 @@ var batchPool = sync.Pool{
 }
 
 func newBatch(queue *broker, start, count int) *batch {
-	batch := batchPool.Get().(*batch)
+	batch := batchPool.Get().(*batch) //nolint: errcheck // we want this to panic if there's an error
 	batch.next = nil
 	batch.queue = queue
 	batch.start = start

--- a/libbeat/publisher/queue/memqueue/runloop.go
+++ b/libbeat/publisher/queue/memqueue/runloop.go
@@ -204,12 +204,14 @@ func (l *runLoop) handleGetReply(req *getRequest) {
 
 func (l *runLoop) handleDelete(count int) {
 	byteCount := 0
+	// remove entries from the queue
 	for i := 0; i < count; i++ {
-		entry := l.broker.buf[(l.bufPos+i)%len(l.broker.buf)]
-		byteCount += entry.eventSize
+		index := (l.bufPos + i) % len(l.broker.buf)
+		byteCount += l.broker.buf[index].eventSize
+		l.broker.buf[index].event = nil
 	}
-	// Advance position and counters. Event data was already cleared in
-	// batch.FreeEntries when the events were vended.
+
+	// advance the buffer position and update tracking fields
 	l.bufPos = (l.bufPos + count) % len(l.broker.buf)
 	l.eventCount -= count
 	l.consumedCount -= count


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Fix event deletion in the memqueue

https://github.com/elastic/beats/pull/39584 accidentally removed `Batch.FreeEntries`, which was responsible for actually deleting events from the queue. Since that change, events are never deleted from the queue, just overwritten. As a result, we consume noticably more memory wherever the event rate is significantly smaller than the queue size.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Related to https://github.com/elastic/elastic-agent/issues/4729, I believe it's the main culprit there.

