### PR TITLE
Add the missing process.name field to System module, Syslog fileset

### DIFF
--- a/filebeat/module/system/syslog/ingest/journald.yml
+++ b/filebeat/module/system/syslog/ingest/journald.yml
@@ -5,7 +5,11 @@ processors:
     copy_from: _ingest.timestamp
 - set:
     field: "process.pid"
-    value: '{{ journald.pid }}'
+    value: "{{ journald.pid }}"
+- set:
+    field: "process.name"
+    value: "{{ journald.process.name }}"
+    ignore_failure: true
 - set:
     field: event.kind
     value: event

--- a/filebeat/module/system/syslog/test/debian-12.journal-expected.json
+++ b/filebeat/module/system/syslog/test/debian-12.journal-expected.json
@@ -16,6 +16,7 @@
         ],
         "process.args_count": 1,
         "process.command_line": "/sbin/init",
+        "process.name": "systemd",
         "process.pid": "1",
         "related.hosts": [
             "vagrant-debian-12"
@@ -36,6 +37,7 @@
         "log.syslog.facility.code": 0,
         "log.syslog.priority": 6,
         "message": "Console: switching to colour frame buffer device 160x50",
+        "process.name": "",
         "process.pid": "",
         "related.hosts": [
             "vagrant-debian-12"
@@ -54,6 +56,7 @@
         "log.syslog.facility.code": 0,
         "log.syslog.priority": 6,
         "message": "thermal_sys: Registered thermal governor 'power_allocator'",
+        "process.name": "",
         "process.pid": "",
         "related.hosts": [
             "bookworm"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This PR adds the missing `process.name` field to System module, Syslog fileset

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~



~~## Author's Checklist~~

## How to test this PR locally
0. Make sure you're testing on a system where system logs are sent to Journald. The Debian 12 Vagrant VM from Beats is a good option.
1. Package Filebeat (adjust for your system/platform). If you don't package it, dashboards won't be loaded
   ```
   DEV=true SNAPSHOT=true EXTERNAL=true PACKAGES="tar.gz" PLATFORMS=linux/amd64 mage -v package
   ```
2. Extract it, enable the system module
   ```
   ./filebeat modules enable system
   ```
3. Edit `filebeat/modules.d/system.yml` to enable the syslog fileset and ensure Journald input will be used
   ```
   - module: system
     syslog:
       enabled: true
       var.use_journald: true
   ```
4. Edit `filebeat.yml` with your ES and Kibana credentials
   ```
   filebeat.config.modules:
     path: ${path.config}/modules.d/*.yml
     reload.enabled: false
     reload.period: 1s
   
   setup.template:
     settings:
       index.number_of_shards: 1
   
   setup.kibana:
     host: "http://kibana:5601"
     username: admin
     password: testing
     ssl.verification_mode: none
   
   output.elasticsearch:
     hosts: ["http://elasticsearch:9200"]
     preset: latency
     protocol: "http"
   
     username: admin
     password: testing
     ssl.verification_mode: none
   ```
5. Run the setup command
   ```
   ./filebeat setup --modules system
   ```
6. Start Filebeat
7. Ensure the events contain `process.name` and the [[Filebeat System] Syslog dashboard ECS](http://kibana:5601/app/dashboards#/view/Filebeat-syslog-dashboard-ecs?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-30d%2Fd,to:now))) contains data. You might have to adjust the time window

## Related issues

- Fixes https://github.com/elastic/beats/issues/41353

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

