### PR TITLE
Remove `DEV=true` for snapshot packaging

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -88,7 +88,8 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
-          DEV: false # packaging with `DEV=true` may cause linker issues while crosscompiling
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
+          DEV: false
         command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
         agents:
           provider: gcp
@@ -122,7 +123,8 @@ steps:
           PLATFORMS: "${PLATFORMS_ARM}"
           PACKAGES: "docker"
           SNAPSHOT: true
-          DEV: false # packaging with `DEV=true` may cause linker issues while crosscompiling
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
+          DEV: false
         command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
         agents:
           provider: "aws"
@@ -152,7 +154,8 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
-          DEV: false # packaging with `DEV=true` may cause linker issues while crosscompiling
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
+          DEV: false
         command: ".buildkite/scripts/packaging/package-dra.sh x-pack/agentbeat"
         agents:
           provider: gcp

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -88,7 +88,7 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
-          DEV: true
+          DEV: false # packaging with `DEV=true` may cause linker issues while crosscompiling
         command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
         agents:
           provider: gcp
@@ -122,7 +122,7 @@ steps:
           PLATFORMS: "${PLATFORMS_ARM}"
           PACKAGES: "docker"
           SNAPSHOT: true
-          DEV: true
+          DEV: false # packaging with `DEV=true` may cause linker issues while crosscompiling
         command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
         agents:
           provider: "aws"
@@ -152,7 +152,7 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
-          DEV: true
+          DEV: false # packaging with `DEV=true` may cause linker issues while crosscompiling
         command: ".buildkite/scripts/packaging/package-dra.sh x-pack/agentbeat"
         agents:
           provider: gcp


### PR DESCRIPTION
Packaging with `DEV=true` adds additional Go flags that sometimes lead to linker failures using the old versions of `ld.gold`.

Closes https://github.com/elastic/beats/issues/41270