### PR TITLE
Switch crossbuilding to Debian 11

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -14,6 +14,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Beats won't log start up information when running under the Elastic Agent {40390}40390[40390]
 - Filebeat now needs `dup3`, `faccessat2`, `prctl` and `setrlimit` syscalls to run the journald input. If this input is not being used, the syscalls are not needed. All Beats have those syscalls allowed now because the default seccomp policy is global to all Beats. {pull}40061[40061]
 - Beats will rate limit the logs about errors when indexing events on Elasticsearch, logging a summary every 10s. The logs sent to the event log is unchanged. {issue}40157[40157]
+- Drop support for Debian 10 and upgrade statically linked glibc from 2.28 to 2.31 {pull}41402[41402]
 
 *Auditbeat*
 

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -221,11 +221,11 @@ func CrossBuildImage(platform string) (string, error) {
 
 	switch {
 	case platform == "darwin/amd64":
-		tagSuffix = "darwin-debian10"
+		tagSuffix = "darwin-debian11"
 	case platform == "darwin/arm64":
-		tagSuffix = "darwin-arm64-debian10"
+		tagSuffix = "darwin-arm64-debian11"
 	case platform == "darwin/universal":
-		tagSuffix = "darwin-arm64-debian10"
+		tagSuffix = "darwin-arm64-debian11"
 	case platform == "linux/arm64":
 		tagSuffix = "arm"
 	case platform == "linux/armv5":
@@ -235,13 +235,13 @@ func CrossBuildImage(platform string) (string, error) {
 	case platform == "linux/armv7":
 		tagSuffix = "armhf"
 	case strings.HasPrefix(platform, "linux/mips"):
-		tagSuffix = "mips-debian10"
+		tagSuffix = "mips-debian11"
 	case strings.HasPrefix(platform, "linux/ppc"):
-		tagSuffix = "ppc-debian10"
+		tagSuffix = "ppc-debian11"
 	case platform == "linux/s390x":
-		tagSuffix = "s390x-debian10"
+		tagSuffix = "s390x-debian11"
 	case strings.HasPrefix(platform, "linux"):
-		tagSuffix = "main-debian10"
+		tagSuffix = "main-debian11"
 	}
 
 	goVersion, err := GoVersion()


### PR DESCRIPTION
We're dropping support for Debian 10, so no need to crossbuild using the outdated image anymore.

The old linker in Debian 10 caused a packaging issue with some Go dependency updates https://github.com/elastic/beats/issues/41270

So, this update should also help with that.

**This also updates the statically linked glibc from 2.28 to 2.31.**