### PR TITLE
Lower logging levels in add_session_metadata processor

### DIFF
--- a/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
+++ b/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
@@ -166,7 +166,7 @@ func (p *addSessionMetadata) enrich(ev *beat.Event) (*beat.Event, error) {
 		proc, err := p.provider.GetProcess(pid)
 		if err != nil {
 			e := fmt.Errorf("pid %v not found in db: %w", pid, err)
-			p.logger.Warnw("PID not found in provider", "pid", pid, "error", err)
+			p.logger.Debugw("PID not found in provider", "pid", pid, "error", err)
 			return nil, e
 		}
 		fullProcess = *proc
@@ -174,7 +174,7 @@ func (p *addSessionMetadata) enrich(ev *beat.Event) (*beat.Event, error) {
 		fullProcess, err = p.db.GetProcess(pid)
 		if err != nil {
 			e := fmt.Errorf("pid %v not found in db: %w", pid, err)
-			p.logger.Warnw("PID not found in provider", "pid", pid, "error", err)
+			p.logger.Debugw("PID not found in provider", "pid", pid, "error", err)
 			return nil, e
 		}
 	}

--- a/x-pack/auditbeat/processors/sessionmd/processdb/db.go
+++ b/x-pack/auditbeat/processors/sessionmd/processdb/db.go
@@ -421,7 +421,7 @@ func (db *DB) InsertExit(exit types.ProcessExitEvent) {
 	pid := exit.PIDs.Tgid
 	process, ok := db.processes[pid]
 	if !ok {
-		db.logger.Errorf("could not insert exit, pid %v not found in db", pid)
+		db.logger.Debugf("could not insert exit, pid %v not found in db", pid)
 		return
 	}
 	process.ExitCode = exit.ExitCode

--- a/x-pack/auditbeat/processors/sessionmd/procfs/procfs.go
+++ b/x-pack/auditbeat/processors/sessionmd/procfs/procfs.go
@@ -196,7 +196,7 @@ func (r ProcfsReader) GetAllProcesses() ([]ProcessInfo, error) {
 	for _, proc := range procs {
 		process_info, err := r.getProcessInfo(proc)
 		if err != nil {
-			r.logger.Warnf("failed to read process info for %v", proc.PID)
+			r.logger.Debugf("failed to read process info for %v", proc.PID)
 		}
 		ret = append(ret, process_info)
 	}

--- a/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
@@ -211,7 +211,7 @@ func (p *prvdr) Sync(_ *beat.Event, pid uint32) error {
 func (p *prvdr) handleBackoff(now time.Time) {
 	if p.inBackoff {
 		if now.Sub(p.backoffStart) > backoffDuration {
-			p.logger.Warnw("ended backoff, skipped processes", "backoffSkipped", p.backoffSkipped)
+			p.logger.Infow("ended backoff, skipped processes", "backoffSkipped", p.backoffSkipped)
 			p.inBackoff = false
 			p.combinedWait = 0 * time.Millisecond
 		} else {
@@ -220,7 +220,7 @@ func (p *prvdr) handleBackoff(now time.Time) {
 		}
 	} else {
 		if p.combinedWait > combinedWaitLimit {
-			p.logger.Warn("starting backoff")
+			p.logger.Info("starting backoff")
 			p.inBackoff = true
 			p.backoffStart = now
 			p.backoffSkipped = 0

--- a/x-pack/auditbeat/processors/sessionmd/provider/procfsprovider/procfsprovider.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/procfsprovider/procfsprovider.go
@@ -68,7 +68,7 @@ func (p prvdr) Sync(ev *beat.Event, pid uint32) error {
 			pe.Env = procInfo.Env
 			pe.Filename = procInfo.Filename
 		} else {
-			p.logger.Warnw("couldn't get process info from proc for pid", "pid", pid, "error", err)
+			p.logger.Debugw("couldn't get process info from proc for pid", "pid", pid, "error", err)
 			// If process info couldn't be taken from procfs, populate with as much info as
 			// possible from the event
 			pe.PIDs.Tgid = pid


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Reduce logging levels for some log messages in the add_session_metadata processor.

If something goes wrong with the process cache where all, or most, processes are missed, many of these logs would be called for every process event, resulting in a lot of logging spam. These logs have been changed to `Debug`, which is below the default log level and will not cause log spam.

The logs that have been reduce to `Info` are in a timer, so they will not cause a lot of spam, but they should be Informational messages

There are better ways to detect if enrichment has failed, so changing the log levels shouldn't negatively affect anything. For example, an Elasticsearch query or alert on missing fields that only this processor will populate will show processes that weren't properly enriched  (i.e. `process.entry_leader` fields).
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

None