### PR TITLE
[add_session_metadata] Always use correct code for backend in use.

### DIFF
--- a/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
+++ b/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
-	processorName = "add_session_metadata"
-	logName       = "processor." + processorName
+	processorName     = "add_session_metadata"
+	logName           = "processor." + processorName
+	procfsType        = "procfs"
+	kernelTracingType = "kernel_tracing"
 )
 
 // InitializeModule initializes this module.
@@ -36,13 +38,14 @@ func InitializeModule() {
 }
 
 type addSessionMetadata struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
-	config   config
-	logger   *logp.Logger
-	db       *processdb.DB
-	provider provider.Provider
-	backend  string
+	ctx          context.Context
+	cancel       context.CancelFunc
+	config       config
+	logger       *logp.Logger
+	db           *processdb.DB
+	provider     provider.Provider
+	backend      string
+	providerType string
 }
 
 func New(cfg *cfg.C) (beat.Processor, error) {
@@ -61,51 +64,56 @@ func New(cfg *cfg.C) (beat.Processor, error) {
 		return nil, fmt.Errorf("failed to create DB: %w", err)
 	}
 
-	if c.Backend != "kernel_tracing" {
-		backfilledPIDs := db.ScrapeProcfs()
-		logger.Infof("backfilled %d processes", len(backfilledPIDs))
-	}
-
 	var p provider.Provider
+	var pType string
 
 	switch c.Backend {
 	case "auto":
 		p, err = kerneltracingprovider.NewProvider(ctx, logger)
 		if err != nil {
 			// Most likely cause of error is not supporting ebpf or kprobes on system, try procfs
+			backfilledPIDs := db.ScrapeProcfs()
+			logger.Infof("backfilled %d processes", len(backfilledPIDs))
 			p, err = procfsprovider.NewProvider(ctx, logger, db, reader, c.PIDField)
 			if err != nil {
 				cancel()
 				return nil, fmt.Errorf("failed to create provider: %w", err)
 			}
 			logger.Info("backend=auto using procfs")
+			pType = procfsType
 		} else {
 			logger.Info("backend=auto using kernel_tracing")
+			pType = kernelTracingType
 		}
 	case "procfs":
+		backfilledPIDs := db.ScrapeProcfs()
+		logger.Infof("backfilled %d processes", len(backfilledPIDs))
 		p, err = procfsprovider.NewProvider(ctx, logger, db, reader, c.PIDField)
 		if err != nil {
 			cancel()
 			return nil, fmt.Errorf("failed to create procfs provider: %w", err)
 		}
+		pType = procfsType
 	case "kernel_tracing":
 		p, err = kerneltracingprovider.NewProvider(ctx, logger)
 		if err != nil {
 			cancel()
 			return nil, fmt.Errorf("failed to create kernel_tracing provider: %w", err)
 		}
+		pType = kernelTracingType
 	default:
 		cancel()
 		return nil, fmt.Errorf("unknown backend configuration")
 	}
 	return &addSessionMetadata{
-		ctx:      ctx,
-		cancel:   cancel,
-		config:   c,
-		logger:   logger,
-		db:       db,
-		provider: p,
-		backend:  c.Backend,
+		ctx:          ctx,
+		cancel:       cancel,
+		config:       c,
+		logger:       logger,
+		db:           db,
+		provider:     p,
+		backend:      c.Backend,
+		providerType: pType,
 	}, nil
 }
 
@@ -161,7 +169,7 @@ func (p *addSessionMetadata) enrich(ev *beat.Event) (*beat.Event, error) {
 	}
 
 	var fullProcess types.Process
-	if p.backend == "kernel_tracing" {
+	if p.providerType == kernelTracingType {
 		// kernel_tracing doesn't enrich with the processor DB;  process info is taken directly from quark cache
 		proc, err := p.provider.GetProcess(pid)
 		if err != nil {


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

With the add_session_metadata processor, the config backend option and actual backend in use doesn't always match; the 'auto' option doesn't match a real backend (kernel_tracing, procfs). This fixes some logic so that when the 'auto' option is used, the processor will always follow the code path intended for whatever the actual backend is use is.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->
None
## How to test this PR locally

In the auditbeat config, set each of the available backend options for add_session_metadata processor ("auto", "kernel_tracking", "procfs"), and ensure the processor is enriching data correctly for each.

e.g., use this config
```
- module: auditd
  # Load audit rules from separate files. Same format as audit.rules(7).
  processors:
    - add_session_metadata:
        backend: "auto"
```

