### PR TITLE
[Filebeat] Documentation update 

### DIFF
--- a/filebeat/docs/reload-configuration.asciidoc
+++ b/filebeat/docs/reload-configuration.asciidoc
@@ -29,13 +29,15 @@ example:
 
 
 Each file found by the `path` Glob must contain a list of one or more input
-definitions. 
+definitions. All referenced inputs will be enabled, regardless of configuration 
+settings in the external configuration file.
  
 TIP: The first line of each external configuration file must be an input
 definition that starts with `- type`. Make sure you omit the line
 +{beatname_lc}.config.inputs+ from this file. All <<filebeat-input-types,`input type configuration options`>> 
 must be specified within each external configuration file.  Specifying these
 configuration options at the global `filebeat.config.inputs` level is not supported.
+ 
 
 Example external configuration file:
 
@@ -91,10 +93,11 @@ For example:
 ------------------------------------------------------------------------------
 - module: apache
   access:
-    enabled: true
     var.paths: [/var/log/apache2/access.log*]
   error:
-    enabled: true
+    # Enable settings are ignored within external configuration files
+    enabled: false
+    # error logs will still be enabled despite the local setting
     var.paths: [/var/log/apache2/error.log*]
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Add information regarding automatic enablement of inputs in external configuration files and correct examples. https://github.com/elastic/beats/issues/17638

<!-- Type of change-->
Docs

## Proposed commit message
Add information regarding automatic enablement of inputs in external configuration files and correct examples. https://github.com/elastic/beats/issues/17638

## Details
Responding to recent concerns about external configuration enablement behavior. Correcting documentation for now, until we can prioritize the work to change the behavior and support enablement within external configurations.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact
None


## How to test this PR locally
N/A


## Related issues

- Closes #17638 
