### PR TITLE
[AWS] [EC2] enrich events with EC2 tags with add_cloud_metadata processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -337,6 +337,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Libbeat*
 
+- enrich events with EC2 tags in add_cloud_metadata processor {pull}41477[41477]
 
 
 *Heartbeat*

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -83,6 +83,8 @@ examples for each of the supported providers.
 
 _AWS_
 
+Metadata given below are extracted from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html[instance identity document],
+
 [source,json]
 -------------------------------------------------------------------------------
 {
@@ -97,6 +99,22 @@ _AWS_
   }
 }
 -------------------------------------------------------------------------------
+
+If the EC2 instance has IMDS enabled and if tags are allowed through IMDS endpoint, the processor will further append tags in metadata.
+Please refer official documentation on https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[IMDS endpoint] for further details.
+
+[source,json]
+-------------------------------------------------------------------------------
+{
+  "ec2": {
+    "tag": {
+      "org" : "myOrg",
+      "owner": "userID"
+    }
+  }
+}
+-------------------------------------------------------------------------------
+
 
 _Digital Ocean_
 

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -106,8 +106,8 @@ Please refer official documentation on https://docs.aws.amazon.com/AWSEC2/latest
 [source,json]
 -------------------------------------------------------------------------------
 {
-  "ec2": {
-    "tag": {
+  "aws": {
+    "tags": {
       "org" : "myOrg",
       "owner": "userID"
     }

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -41,7 +41,7 @@ import (
 const (
 	eksClusterNameTagKey = "eks:cluster-name"
 	tagsCategory         = "tags/instance"
-	tagPrefix            = "ec2.tag"
+	tagPrefix            = "aws.tags"
 )
 
 type IMDSClient interface {

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -20,12 +20,15 @@ package add_cloud_metadata
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -35,7 +38,14 @@ import (
 	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
+const (
+	eksClusterNameTagKey = "eks:cluster-name"
+	tagsCategory         = "tags/instance"
+	tagPrefix            = "ec2.tag"
+)
+
 type IMDSClient interface {
+	ec2rolecreds.GetMetadataAPIClient
 	GetInstanceIdentityDocument(ctx context.Context, params *imds.GetInstanceIdentityDocumentInput, optFns ...func(*imds.Options)) (*imds.GetInstanceIdentityDocumentOutput, error)
 }
 
@@ -90,30 +100,17 @@ func fetchRawProviderMetadata(
 		result.err = fmt.Errorf("failed loading AWS default configuration: %w", err)
 		return
 	}
-	awsClient := NewIMDSClient(awsConfig)
 
-	instanceIdentity, err := awsClient.GetInstanceIdentityDocument(context.TODO(), &imds.GetInstanceIdentityDocumentInput{})
+	imdsClient := NewIMDSClient(awsConfig)
+	instanceIdentity, err := imdsClient.GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
 	if err != nil {
 		result.err = fmt.Errorf("failed fetching EC2 Identity Document: %w", err)
 		return
 	}
 
-	// AWS Region must be set to be able to get EC2 Tags
 	awsRegion := instanceIdentity.InstanceIdentityDocument.Region
-	awsConfig.Region = awsRegion
 	accountID := instanceIdentity.InstanceIdentityDocument.AccountID
-
-	clusterName, err := fetchEC2ClusterNameTag(awsConfig, instanceIdentity.InstanceIdentityDocument.InstanceID)
-	if err != nil {
-		logger.Warnf("error fetching cluster name metadata: %s.", err)
-	} else if clusterName != "" {
-		// for AWS cluster ID is used cluster ARN: arn:partition:service:region:account-id:resource-type/resource-id, example:
-		// arn:aws:eks:us-east-2:627286350134:cluster/cluster-name
-		clusterARN := fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%v", awsRegion, accountID, clusterName)
-
-		_, _ = result.metadata.Put("orchestrator.cluster.id", clusterARN)
-		_, _ = result.metadata.Put("orchestrator.cluster.name", clusterName)
-	}
+	instanceID := instanceIdentity.InstanceIdentityDocument.InstanceID
 
 	_, _ = result.metadata.Put("cloud.instance.id", instanceIdentity.InstanceIdentityDocument.InstanceID)
 	_, _ = result.metadata.Put("cloud.machine.type", instanceIdentity.InstanceIdentityDocument.InstanceType)
@@ -122,10 +119,90 @@ func fetchRawProviderMetadata(
 	_, _ = result.metadata.Put("cloud.account.id", accountID)
 	_, _ = result.metadata.Put("cloud.image.id", instanceIdentity.InstanceIdentityDocument.ImageID)
 
+	// AWS Region must be set to be able to get EC2 Tags
+	awsConfig.Region = awsRegion
+	tags := getTags(ctx, imdsClient, NewEC2Client(awsConfig), instanceID, logger)
+
+	if tags[eksClusterNameTagKey] != "" {
+		// for AWS cluster ID is used cluster ARN: arn:partition:service:region:account-id:resource-type/resource-id, example:
+		// arn:aws:eks:us-east-2:627286350134:cluster/cluster-name
+		clusterARN := fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%v", awsRegion, accountID, tags[eksClusterNameTagKey])
+
+		_, _ = result.metadata.Put("orchestrator.cluster.id", clusterARN)
+		_, _ = result.metadata.Put("orchestrator.cluster.name", tags[eksClusterNameTagKey])
+	}
+
+	if len(tags) == 0 {
+		return
+	}
+
+	logger.Infof("Adding retrieved tags with key: %s", tagPrefix)
+	for k, v := range tags {
+		_, _ = result.metadata.Put(fmt.Sprintf("%s.%s", tagPrefix, k), v)
+	}
 }
 
-func fetchEC2ClusterNameTag(awsConfig awssdk.Config, instanceID string) (string, error) {
-	svc := NewEC2Client(awsConfig)
+// getTags is a helper to extract EC2 tags. Internally it utilize multiple extraction methods.
+func getTags(ctx context.Context, imdsClient IMDSClient, ec2Client EC2Client, instanceId string, logger *logp.Logger) map[string]string {
+	logger.Info("Extracting EC2 tags from IMDS endpoint")
+	tags, ok := getTagsFromIMDS(ctx, imdsClient, logger)
+	if ok {
+		return tags
+	}
+
+	logger.Info("Tag extraction from IMDS failed, fallback to DescribeTags API to obtain EKS cluster name.")
+	clusterName, err := clusterNameFromDescribeTag(ctx, ec2Client, instanceId)
+	if err != nil {
+		logger.Warnf("error obtaining cluster name: %s.", err)
+		return tags
+	}
+
+	if clusterName != "" {
+		tags[eksClusterNameTagKey] = clusterName
+	}
+	return tags
+}
+
+// getTagsFromIMDS is a helper to extract EC2 tags using instance metadata service.
+// Note that this call could get throttled and currently does not implement a retry mechanism.
+// See - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instancedata-throttling
+func getTagsFromIMDS(ctx context.Context, client IMDSClient, logger *logp.Logger) (tags map[string]string, ok bool) {
+	tags = make(map[string]string)
+
+	metadata, err := client.GetMetadata(ctx, &imds.GetMetadataInput{Path: tagsCategory})
+	if err != nil {
+		logger.Warnf("error from IMDS tags category request: %s", err)
+		return tags, false
+	}
+
+	b, err := io.ReadAll(metadata.Content)
+	if err != nil {
+		logger.Warnf("error extracting tags category payload: %s", err)
+		return tags, false
+	}
+
+	for _, tag := range strings.Split(string(b), "\n") {
+		tagPath := fmt.Sprintf("%s/%s", tagsCategory, tag)
+		metadata, err := client.GetMetadata(ctx, &imds.GetMetadataInput{Path: tagPath})
+		if err != nil {
+			logger.Warnf("error from IMDS tag request: %s", err)
+			return tags, false
+		}
+
+		b, err := io.ReadAll(metadata.Content)
+		if err != nil {
+			logger.Warnf("error extracting tag value payload: %s", err)
+			return tags, false
+		}
+
+		tags[tag] = string(b)
+	}
+
+	return tags, true
+}
+
+// clusterNameFromDescribeTag is a helper to extract EKS cluster name using DescribeTag.
+func clusterNameFromDescribeTag(ctx context.Context, ec2Client EC2Client, instanceID string) (string, error) {
 	input := &ec2.DescribeTagsInput{
 		Filters: []types.Filter{
 			{
@@ -135,15 +212,13 @@ func fetchEC2ClusterNameTag(awsConfig awssdk.Config, instanceID string) (string,
 				},
 			},
 			{
-				Name: awssdk.String("key"),
-				Values: []string{
-					"eks:cluster-name",
-				},
+				Name:   awssdk.String("key"),
+				Values: []string{eksClusterNameTagKey},
 			},
 		},
 	}
 
-	tagsResult, err := svc.DescribeTags(context.TODO(), input)
+	tagsResult, err := ec2Client.DescribeTags(ctx, input)
 	if err != nil {
 		return "", fmt.Errorf("error fetching EC2 Tags: %w", err)
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -208,8 +208,8 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 						"id":   fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", regionDoc1, accountIDDoc1, clusterNameValue),
 					},
 				},
-				"ec2": mapstr.M{
-					"tag": mapstr.M{
+				"aws": mapstr.M{
+					"tags": mapstr.M{
 						eksClusterNameTagKey: clusterNameValue,
 					},
 				},
@@ -247,8 +247,8 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 						"id":   fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", regionDoc1, accountIDDoc1, clusterNameValue),
 					},
 				},
-				"ec2": mapstr.M{
-					"tag": mapstr.M{
+				"aws": mapstr.M{
+					"tags": mapstr.M{
 						eksClusterNameTagKey: clusterNameValue,
 					},
 				},
@@ -295,8 +295,8 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 						"id":   fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", regionDoc1, accountIDDoc1, clusterNameValue),
 					},
 				},
-				"ec2": mapstr.M{
-					"tag": mapstr.M{
+				"aws": mapstr.M{
+					"tags": mapstr.M{
 						eksClusterNameTagKey: clusterNameValue,
 					},
 				},
@@ -379,8 +379,8 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 						"id":   fmt.Sprintf("arn:aws:eks:%s:%s:cluster/%s", regionDoc1, accountIDDoc1, clusterNameValue),
 					},
 				},
-				"ec2": mapstr.M{
-					"tag": mapstr.M{
+				"aws": mapstr.M{
+					"tags": mapstr.M{
 						eksClusterNameTagKey: clusterNameValue,
 						customTagKey:         customTagValue,
 					},

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -187,7 +187,7 @@ func (p *addCloudMetadata) fetchMetadata() *result {
 			if result.err == nil && result.metadata != nil {
 				return &result
 			} else if result.err != nil {
-				p.logger.Errorf("add_cloud_metadata: received error %v", result.err)
+				p.logger.Errorf("add_cloud_metadata: received error for provider %s: %v", result.provider, result.err)
 			}
 		case <-ctx.Done():
 			p.logger.Debugf("add_cloud_metadata: timed-out waiting for all responses")


### PR DESCRIPTION
## Proposed commit message

This PR adds support to enrich events with EC2 tags iff,

- IMDS endpoint is enabled [^1]
- Tag access is enabled through IMDS endpoint. [^2]

Tags are added to event payload with key `aws.tags.<KEY>`, 

```json
{
  "aws" : {
   "tags" : {
      "org" : "acme",
      "owner" : "userA"
    }
   }
}
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

The best way to validate this is through a beats deployment (ex:- metricbeat) in an EC2 instance.

- Create an EC2 instance
  - Enable IMDS endpoint
  - Enable tags access through IMDS endpoint 
  - Assign instance with a role with adequate permissions
  - Add few tags to the instance
- Build metricbeat from this branch
- Deploy custom build into EC2
- Enable `add_cloud_metadata` processor
- Run and observe metrics containing tags 

## Related issues

Closes #31899

## Screenshots

![image](https://github.com/user-attachments/assets/4ec69ef3-1620-4927-b985-96c9d723d9e8)

[^1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html
[^2]:  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-tags-in-IMDS.html#allow-access-to-tags-in-IMDS