### PR TITLE
x-pack/filebeat/input/awss3: support for Access Point ARN

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -175,6 +175,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix aws region in aws-s3 input s3 polling mode.  {pull}41572[41572]
 - Fix errors in SQS host resolution in the `aws-s3` input when using custom (non-AWS) endpoints. {pull}41504[41504]
 - The azure-eventhub input now correctly reports its status to the Elastic Agent on fatal errors {pull}41469[41469]
+- Add support for Access Points in the `aws-s3` input. {pull}41495[41495]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -102,6 +102,9 @@
   # Bucket ARN used for polling AWS S3 buckets
   #bucket_arn: arn:aws:s3:::test-s3-bucket
 
+  # Access Point ARN used for polling AWS S3 buckets
+  #access_point_arn: arn:aws:s3:us-east-1:123456789:accesspoint/my-accesspoint
+
   # Bucket Name used for polling non-AWS S3 buckets
   #non_aws_bucket_name: test-s3-bucket
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -348,7 +348,7 @@ configuring multiline options.
 [float]
 ==== `queue_url`
 
-URL of the AWS SQS queue that messages will be received from. (Required when `bucket_arn` and `non_aws_bucket_name` are not set).
+URL of the AWS SQS queue that messages will be received from. (Required when `bucket_arn`, `access_point_arn`, and `non_aws_bucket_name` are not set).
 
 [float]
 ==== `region`
@@ -472,7 +472,12 @@ value is `20s`.
 [float]
 ==== `bucket_arn`
 
-ARN of the AWS S3 bucket that will be polled for list operation. (Required when `queue_url` and `non_aws_bucket_name` are not set).
+ARN of the AWS S3 bucket that will be polled for list operation. (Required when `queue_url`, `access_point_arn, and `non_aws_bucket_name` are not set).
+
+[float]
+==== `access_point_arn`
+
+ARN of the AWS S3 Access Point that will be polled for list operation. (Required when `queue_url`, `bucket_arn`, and `non_aws_bucket_name` are not set).
 
 [float]
 ==== `non_aws_bucket_name`
@@ -492,7 +497,7 @@ Prefix to apply for the list request to the S3 bucket. Default empty.
 [float]
 ==== `number_of_workers`
 
-Number of workers that will process the S3 or SQS objects listed. Required when `bucket_arn` is set, otherwise (in the SQS case) defaults to 5.
+Number of workers that will process the S3 or SQS objects listed. Required when `bucket_arn` or `access_point_arn` is set, otherwise (in the SQS case) defaults to 5.
 
 
 [float]

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2990,6 +2990,9 @@ filebeat.inputs:
   # Bucket ARN used for polling AWS S3 buckets
   #bucket_arn: arn:aws:s3:::test-s3-bucket
 
+  # Access Point ARN used for polling AWS S3 buckets
+  #access_point_arn: arn:aws:s3:us-east-1:123456789:accesspoint/my-accesspoint
+
   # Bucket Name used for polling non-AWS S3 buckets
   #non_aws_bucket_name: test-s3-bucket
 

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -33,6 +34,7 @@ type config struct {
 	QueueURL           string               `config:"queue_url"`
 	RegionName         string               `config:"region"`
 	BucketARN          string               `config:"bucket_arn"`
+	AccessPointARN     string               `config:"access_point_arn"`
 	NonAWSBucketName   string               `config:"non_aws_bucket_name"`
 	BucketListInterval time.Duration        `config:"bucket_list_interval"`
 	BucketListPrefix   string               `config:"bucket_list_prefix"`
@@ -61,7 +63,7 @@ func defaultConfig() config {
 }
 
 func (c *config) Validate() error {
-	configs := []bool{c.QueueURL != "", c.BucketARN != "", c.NonAWSBucketName != ""}
+	configs := []bool{c.QueueURL != "", c.BucketARN != "", c.AccessPointARN != "", c.NonAWSBucketName != ""}
 	enabled := []bool{}
 	for i := range configs {
 		if configs[i] {
@@ -69,18 +71,22 @@ func (c *config) Validate() error {
 		}
 	}
 	if len(enabled) == 0 {
-		return errors.New("neither queue_url, bucket_arn nor non_aws_bucket_name were provided")
+		return errors.New("neither queue_url, bucket_arn, access_point_arn, nor non_aws_bucket_name were provided")
 	} else if len(enabled) > 1 {
-		return fmt.Errorf("queue_url <%v>, bucket_arn <%v>, non_aws_bucket_name <%v> "+
-			"cannot be set at the same time", c.QueueURL, c.BucketARN, c.NonAWSBucketName)
+		return fmt.Errorf("queue_url <%v>, bucket_arn <%v>, access_point_arn <%v>, non_aws_bucket_name <%v> "+
+			"cannot be set at the same time", c.QueueURL, c.BucketARN, c.AccessPointARN, c.NonAWSBucketName)
 	}
 
-	if (c.BucketARN != "" || c.NonAWSBucketName != "") && c.BucketListInterval <= 0 {
+	if (c.BucketARN != "" || c.AccessPointARN != "" || c.NonAWSBucketName != "") && c.BucketListInterval <= 0 {
 		return fmt.Errorf("bucket_list_interval <%v> must be greater than 0", c.BucketListInterval)
 	}
 
-	if (c.BucketARN != "" || c.NonAWSBucketName != "") && c.NumberOfWorkers <= 0 {
+	if (c.BucketARN != "" || c.AccessPointARN != "" || c.NonAWSBucketName != "") && c.NumberOfWorkers <= 0 {
 		return fmt.Errorf("number_of_workers <%v> must be greater than 0", c.NumberOfWorkers)
+	}
+
+	if c.AccessPointARN != "" && !isValidAccessPointARN(c.AccessPointARN) {
+		return fmt.Errorf("invalid format for access_point_arn <%v>", c.AccessPointARN)
 	}
 
 	if c.QueueURL != "" && (c.VisibilityTimeout <= 0 || c.VisibilityTimeout.Hours() > 12) {
@@ -117,14 +123,15 @@ func (c *config) Validate() error {
 	if c.BackupConfig.NonAWSBackupToBucketName != "" && c.NonAWSBucketName == "" {
 		return errors.New("backup to non-AWS bucket can only be used for non-AWS sources")
 	}
-	if c.BackupConfig.BackupToBucketArn != "" && c.BucketARN == "" {
+	if c.BackupConfig.BackupToBucketArn != "" && c.BucketARN == "" && c.AccessPointARN == "" {
 		return errors.New("backup to AWS bucket can only be used for AWS sources")
 	}
 	if c.BackupConfig.BackupToBucketArn != "" && c.BackupConfig.NonAWSBackupToBucketName != "" {
 		return errors.New("backup_to_bucket_arn and non_aws_backup_to_bucket_name cannot be used together")
 	}
 	if c.BackupConfig.GetBucketName() != "" && c.QueueURL == "" {
-		if (c.BackupConfig.BackupToBucketArn != "" && c.BackupConfig.BackupToBucketArn == c.BucketARN) ||
+		if (c.BackupConfig.BackupToBucketArn != "" &&
+			(c.BackupConfig.BackupToBucketArn == c.BucketARN || c.BackupConfig.BackupToBucketArn == c.AccessPointARN)) ||
 			(c.BackupConfig.NonAWSBackupToBucketName != "" && c.BackupConfig.NonAWSBackupToBucketName == c.NonAWSBucketName) {
 			if c.BackupConfig.BackupToBucketPrefix == "" {
 				return errors.New("backup_to_bucket_prefix is a required property when source and backup bucket are the same")
@@ -233,6 +240,9 @@ func (c config) getBucketName() string {
 	if c.NonAWSBucketName != "" {
 		return c.NonAWSBucketName
 	}
+	if c.AccessPointARN != "" {
+		return c.AccessPointARN
+	}
 	if c.BucketARN != "" {
 		return getBucketNameFromARN(c.BucketARN)
 	}
@@ -245,6 +255,9 @@ func (c config) getBucketARN() string {
 	}
 	if c.BucketARN != "" {
 		return c.BucketARN
+	}
+	if c.AccessPointARN != "" {
+		return c.AccessPointARN
 	}
 	return ""
 }
@@ -291,4 +304,13 @@ func (c config) getFileSelectors() []fileSelectorConfig {
 		return c.FileSelectors
 	}
 	return []fileSelectorConfig{{ReaderConfig: c.ReaderConfig}}
+}
+
+// Helper function to detect if an ARN is an Access Point
+func isValidAccessPointARN(arn string) bool {
+	arnParts := strings.Split(arn, ":")
+	if len(arnParts) < 6 {
+		return false
+	}
+	return strings.Contains(arn, ":accesspoint/")
 }

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -308,5 +308,8 @@ func (c config) getFileSelectors() []fileSelectorConfig {
 
 // Helper function to detect if an ARN is an Access Point
 func isValidAccessPointARN(arn string) bool {
-	return strings.Count(arn, ":") >= 5 && strings.Contains(arn, ":accesspoint/")
+	parts := strings.Split(arn, ":")
+	return len(parts) >= 6 &&
+		strings.HasPrefix(parts[5], "accesspoint/") &&
+		len(strings.TrimPrefix(parts[5], "accesspoint/")) > 0
 }

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -308,9 +308,5 @@ func (c config) getFileSelectors() []fileSelectorConfig {
 
 // Helper function to detect if an ARN is an Access Point
 func isValidAccessPointARN(arn string) bool {
-	arnParts := strings.Split(arn, ":")
-	if len(arnParts) < 6 {
-		return false
-	}
-	return strings.Contains(arn, ":accesspoint/")
+	return strings.Count(arn, ":") >= 5 && strings.Contains(arn, ":accesspoint/")
 }

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -23,8 +23,9 @@ import (
 func TestConfig(t *testing.T) {
 	const queueURL = "https://example.com"
 	const s3Bucket = "arn:aws:s3:::aBucket"
+	const s3AccessPoint = "arn:aws:s3:us-east-2:123456789:accesspoint/test-accesspoint"
 	const nonAWSS3Bucket = "minio-bucket"
-	makeConfig := func(quequeURL, s3Bucket string, nonAWSS3Bucket string) config {
+	makeConfig := func(quequeURL, s3Bucket string, s3AccessPoint string, nonAWSS3Bucket string) config {
 		// Have a separate copy of defaults in the test to make it clear when
 		// anyone changes the defaults.
 		parserConf := parser.Config{}
@@ -32,6 +33,7 @@ func TestConfig(t *testing.T) {
 		return config{
 			QueueURL:           quequeURL,
 			BucketARN:          s3Bucket,
+			AccessPointARN:     s3AccessPoint,
 			NonAWSBucketName:   nonAWSS3Bucket,
 			APITimeout:         120 * time.Second,
 			VisibilityTimeout:  300 * time.Second,
@@ -54,15 +56,17 @@ func TestConfig(t *testing.T) {
 		name           string
 		queueURL       string
 		s3Bucket       string
+		s3AccessPoint  string
 		nonAWSS3Bucket string
 		config         mapstr.M
 		expectedErr    string
-		expectedCfg    func(queueURL, s3Bucket, nonAWSS3Bucket string) config
+		expectedCfg    func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config
 	}{
 		{
 			name:           "input with defaults for queueURL",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url": queueURL,
@@ -74,14 +78,15 @@ func TestConfig(t *testing.T) {
 			name:           "input with defaults for s3Bucket",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
 				"number_of_workers": 5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig("", s3Bucket, "")
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig("", s3Bucket, "", "")
 				c.NumberOfWorkers = 5
 				return c
 			},
@@ -90,6 +95,7 @@ func TestConfig(t *testing.T) {
 			name:           "input with file_selectors",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url": queueURL,
@@ -100,8 +106,8 @@ func TestConfig(t *testing.T) {
 				},
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig(queueURL, "", "")
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "", "")
 				regex := match.MustCompile("/CloudTrail/")
 				c.FileSelectors = []fileSelectorConfig{
 					{
@@ -116,6 +122,7 @@ func TestConfig(t *testing.T) {
 			name:           "non-AWS_endpoint_with_explicit_region",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url": queueURL,
@@ -123,8 +130,8 @@ func TestConfig(t *testing.T) {
 				"endpoint":  "ep",
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig(queueURL, "", "")
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "", "")
 				c.RegionName = "region"
 				c.AWSConfig.Endpoint = "ep"
 				return c
@@ -134,6 +141,7 @@ func TestConfig(t *testing.T) {
 			name:           "explicit_AWS_endpoint_with_explicit_region",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url": "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
@@ -141,8 +149,8 @@ func TestConfig(t *testing.T) {
 				"endpoint":  "amazonaws.com",
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig(queueURL, "", "")
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "", "")
 				c.QueueURL = "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs"
 				c.AWSConfig.Endpoint = "amazonaws.com"
 				c.RegionName = "region"
@@ -153,14 +161,15 @@ func TestConfig(t *testing.T) {
 			name:           "inferred_AWS_endpoint_with_explicit_region",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url": "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
 				"region":    "region",
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig(queueURL, "", "")
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "", "")
 				c.QueueURL = "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs"
 				c.RegionName = "region"
 				return c
@@ -170,84 +179,105 @@ func TestConfig(t *testing.T) {
 			name:           "localstack_with_region_name",
 			queueURL:       "http://localhost:4566/000000000000/sample-queue",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url": "http://localhost:4566/000000000000/sample-queue",
 				"region":    "myregion",
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig(queueURL, "", "")
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "", "")
 				c.RegionName = "myregion"
 				return c
 			},
 		},
 		{
-			name:           "error on no queueURL and s3Bucket and nonAWSS3Bucket",
+			name:           "error on no queueURL, s3Bucket, s3AccessPoint, and nonAWSS3Bucket",
 			queueURL:       "",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":           "",
 				"bucket_arn":          "",
+				"access_point_arn":    "",
 				"non_aws_bucket_name": "",
 			},
-			expectedErr: "neither queue_url, bucket_arn nor non_aws_bucket_name were provided",
+			expectedErr: "neither queue_url, bucket_arn, access_point_arn, nor non_aws_bucket_name were provided",
 			expectedCfg: nil,
 		},
 		{
 			name:           "error on both queueURL and s3Bucket",
 			queueURL:       queueURL,
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":  queueURL,
 				"bucket_arn": s3Bucket,
 			},
-			expectedErr: "queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <> cannot be set at the same time",
+			expectedErr: "queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, access_point_arn <>, non_aws_bucket_name <> cannot be set at the same time",
 			expectedCfg: nil,
 		},
 		{
 			name:           "error on both queueURL and NonAWSS3Bucket",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"queue_url":           queueURL,
 				"non_aws_bucket_name": nonAWSS3Bucket,
 			},
-			expectedErr: "queue_url <https://example.com>, bucket_arn <>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
+			expectedErr: "queue_url <https://example.com>, bucket_arn <>, access_point_arn <>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
 			expectedCfg: nil,
 		},
 		{
 			name:           "error on both s3Bucket and NonAWSS3Bucket",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"bucket_arn":          s3Bucket,
 				"non_aws_bucket_name": nonAWSS3Bucket,
 			},
-			expectedErr: "queue_url <>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
+			expectedErr: "queue_url <>, bucket_arn <arn:aws:s3:::aBucket>, access_point_arn <>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
 			expectedCfg: nil,
 		},
 		{
 			name:           "error on queueURL, s3Bucket, and NonAWSS3Bucket",
 			queueURL:       queueURL,
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"queue_url":           queueURL,
 				"bucket_arn":          s3Bucket,
 				"non_aws_bucket_name": nonAWSS3Bucket,
 			},
-			expectedErr: "queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
+			expectedErr: "queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, access_point_arn <>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
+			expectedCfg: nil,
+		},
+		{
+			name:           "error on both s3Bucket and s3AccessPoint",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			s3AccessPoint:  s3AccessPoint,
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
+				"bucket_arn":       s3Bucket,
+				"access_point_arn": s3AccessPoint,
+			},
+			expectedErr: "queue_url <>, bucket_arn <arn:aws:s3:::aBucket>, access_point_arn <arn:aws:s3:us-east-2:123456789:accesspoint/test-accesspoint>, non_aws_bucket_name <> cannot be set at the same time",
 			expectedCfg: nil,
 		},
 		{
 			name:           "error on api_timeout == 0",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":   queueURL,
@@ -260,6 +290,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on visibility_timeout == 0",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":          queueURL,
@@ -272,6 +303,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on visibility_timeout > 12h",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":          queueURL,
@@ -284,6 +316,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on bucket_list_interval == 0",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":           s3Bucket,
@@ -296,6 +329,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on number_of_workers == 0",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
@@ -308,6 +342,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on buffer_size == 0 ",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":   queueURL,
@@ -320,6 +355,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on max_bytes == 0 ",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url": queueURL,
@@ -332,6 +368,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on expand_event_list_from_field and content_type != application/json ",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":                    queueURL,
@@ -345,6 +382,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on expand_event_list_from_field and content_type != application/json ",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":                   s3Bucket,
@@ -358,14 +396,15 @@ func TestConfig(t *testing.T) {
 			name:           "input with defaults for non-AWS S3 Bucket",
 			queueURL:       "",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"non_aws_bucket_name": nonAWSS3Bucket,
 				"number_of_workers":   5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig("", "", nonAWSS3Bucket)
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig("", "", "", nonAWSS3Bucket)
 				c.NumberOfWorkers = 5
 				return c
 			},
@@ -374,6 +413,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on FIPS with non-AWS S3 Bucket",
 			queueURL:       "",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"non_aws_bucket_name": nonAWSS3Bucket,
@@ -387,6 +427,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on path_style with AWS native S3 Bucket",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
@@ -400,6 +441,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on provider with AWS native S3 Bucket",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
@@ -413,6 +455,7 @@ func TestConfig(t *testing.T) {
 			name:           "error on provider with AWS SQS Queue",
 			queueURL:       queueURL,
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"queue_url":         queueURL,
@@ -426,6 +469,7 @@ func TestConfig(t *testing.T) {
 			name:           "backup_to_bucket with AWS",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":              s3Bucket,
@@ -434,8 +478,8 @@ func TestConfig(t *testing.T) {
 				"number_of_workers":       5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig("", s3Bucket, "")
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig("", s3Bucket, "", "")
 				c.BackupConfig.BackupToBucketArn = "arn:aws:s3:::bBucket"
 				c.BackupConfig.BackupToBucketPrefix = "backup"
 				c.NumberOfWorkers = 5
@@ -446,6 +490,7 @@ func TestConfig(t *testing.T) {
 			name:           "backup_to_bucket with non-AWS",
 			queueURL:       "",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"non_aws_bucket_name":           nonAWSS3Bucket,
@@ -454,8 +499,8 @@ func TestConfig(t *testing.T) {
 				"number_of_workers":             5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
-				c := makeConfig("", "", nonAWSS3Bucket)
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig("", "", "", nonAWSS3Bucket)
 				c.NonAWSBucketName = nonAWSS3Bucket
 				c.BackupConfig.NonAWSBackupToBucketName = "bBucket"
 				c.BackupConfig.BackupToBucketPrefix = "backup"
@@ -467,6 +512,7 @@ func TestConfig(t *testing.T) {
 			name:           "error with non-AWS backup and AWS source",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":                    s3Bucket,
@@ -480,6 +526,7 @@ func TestConfig(t *testing.T) {
 			name:           "error with AWS backup and non-AWS source",
 			queueURL:       "",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"non_aws_bucket_name":  nonAWSS3Bucket,
@@ -493,6 +540,7 @@ func TestConfig(t *testing.T) {
 			name:           "error with same bucket backup and empty backup prefix",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":           s3Bucket,
@@ -506,6 +554,7 @@ func TestConfig(t *testing.T) {
 			name:           "error with same bucket backup (non-AWS) and empty backup prefix",
 			queueURL:       "",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"non_aws_bucket_name":           nonAWSS3Bucket,
@@ -519,6 +568,7 @@ func TestConfig(t *testing.T) {
 			name:           "error with same bucket backup and backup prefix equal to list prefix",
 			queueURL:       "",
 			s3Bucket:       s3Bucket,
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
 				"bucket_arn":              s3Bucket,
@@ -534,6 +584,7 @@ func TestConfig(t *testing.T) {
 			name:           "error with same bucket backup (non-AWS) and backup prefix equal to list prefix",
 			queueURL:       "",
 			s3Bucket:       "",
+			s3AccessPoint:  "",
 			nonAWSS3Bucket: nonAWSS3Bucket,
 			config: mapstr.M{
 				"non_aws_bucket_name":           nonAWSS3Bucket,
@@ -563,7 +614,62 @@ func TestConfig(t *testing.T) {
 			if tc.expectedCfg == nil {
 				t.Fatal("missing expected config in test case")
 			}
-			assert.EqualValues(t, tc.expectedCfg(tc.queueURL, tc.s3Bucket, tc.nonAWSS3Bucket), c)
+			assert.EqualValues(t, tc.expectedCfg(tc.queueURL, tc.s3Bucket, tc.s3AccessPoint, tc.nonAWSS3Bucket), c)
+		})
+	}
+}
+
+// TestIsValidAccessPointARN tests the isValidAccessPointARN function
+func TestIsValidAccessPointARN(t *testing.T) {
+	testCases := []struct {
+		name     string
+		arn      string
+		expected bool
+	}{
+		{
+			name:     "Valid Access Point ARN",
+			arn:      "arn:aws:s3:us-east-1:123456789:accesspoint/my-access-point",
+			expected: true,
+		},
+		{
+			name:     "Valid Access Point ARN with another region",
+			arn:      "arn:aws:s3:us-west-2:123456789:accesspoint/my-access-point",
+			expected: true,
+		},
+		{
+			name:     "Invalid ARN with missing parts",
+			arn:      "arn:aws:s3:123456789:accesspoint",
+			expected: false,
+		},
+		{
+			name:     "Invalid ARN without accesspoint keyword",
+			arn:      "arn:aws:s3:us-east-1:123456789:bucket/my-bucket",
+			expected: false,
+		},
+		{
+			name:     "Invalid ARN with wrong format",
+			arn:      "arn:aws:s3:us-east-1:123456789:my-access-point",
+			expected: false,
+		},
+		{
+			name:     "Empty ARN",
+			arn:      "",
+			expected: false,
+		},
+		{
+			name:     "ARN with extra parts but valid access point format",
+			arn:      "arn:aws:s3:us-east-1:123456789:accesspoint/my-access-point/extra",
+			expected: true,
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isValidAccessPointARN(tc.arn)
+			if result != tc.expected {
+				t.Errorf("expected %v, got %v for ARN: %s", tc.expected, result, tc.arn)
+			}
 		})
 	}
 }

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -661,6 +661,11 @@ func TestIsValidAccessPointARN(t *testing.T) {
 			arn:      "arn:aws:s3:us-east-1:123456789:accesspoint/my-access-point/extra",
 			expected: true,
 		},
+		{
+			name:     "ARN with empty name",
+			arn:      "arn:aws:s3:us-east-1:123456789:accesspoint/",
+			expected: false,
+		},
 	}
 
 	// Run test cases

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -46,11 +46,7 @@ func (im *s3InputManager) Create(cfg *conf.C) (v2.Input, error) {
 		return nil, fmt.Errorf("initializing AWS config: %w", err)
 	}
 
-	if config.AccessPointARN != "" {
-		configureAccessPointEndpoint(&awsConfig, config.AccessPointARN)
-	}
-
-	if config.AccessPointARN == "" && config.RegionName != "" {
+	if config.RegionName != "" {
 		// The awsConfig now contains the region from the credential profile or default region
 		// if the region is explicitly set in the config, then it wins
 		awsConfig.Region = config.RegionName

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/elastic/beats/v7/filebeat/beater"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/feature"

--- a/x-pack/filebeat/input/awss3/s3.go
+++ b/x-pack/filebeat/input/awss3/s3.go
@@ -128,29 +128,3 @@ func getProviderFromDomain(endpoint string, ProviderOverride string) string {
 	}
 	return "unknown"
 }
-
-func configureAccessPointEndpoint(awsConfig *awssdk.Config, accessPointARN string) error {
-	// When using the access point ARN, requests must be directed to the
-	// access point hostname. The access point hostname takes the form
-	// AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com
-	parts := strings.Split(accessPointARN, ":")
-	region := parts[3]
-	accountID := parts[4]
-	accessPointName := strings.Split(parts[5], "/")[1]
-
-	// Construct the endpoint for the Access Point
-	endpoint := fmt.Sprintf("%s-%s.s3-accesspoint.%s.amazonaws.com", accessPointName, accountID, region)
-
-	// Set up a custom endpoint resolver for Access Points
-	//nolint:staticcheck // haven't migrated to the new interface yet
-	awsConfig.EndpointResolverWithOptions = awssdk.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (awssdk.Endpoint, error) {
-		return awssdk.Endpoint{
-			URL:               fmt.Sprintf("https://%s", endpoint),
-			SigningRegion:     region,
-			HostnameImmutable: true,
-		}, nil
-	})
-	awsConfig.Region = region
-
-	return nil
-}

--- a/x-pack/filebeat/input/awss3/s3.go
+++ b/x-pack/filebeat/input/awss3/s3.go
@@ -128,3 +128,29 @@ func getProviderFromDomain(endpoint string, ProviderOverride string) string {
 	}
 	return "unknown"
 }
+
+func configureAccessPointEndpoint(awsConfig *awssdk.Config, accessPointARN string) error {
+	// When using the access point ARN, requests must be directed to the
+	// access point hostname. The access point hostname takes the form
+	// AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com
+	parts := strings.Split(accessPointARN, ":")
+	region := parts[3]
+	accountID := parts[4]
+	accessPointName := strings.Split(parts[5], "/")[1]
+
+	// Construct the endpoint for the Access Point
+	endpoint := fmt.Sprintf("%s-%s.s3-accesspoint.%s.amazonaws.com", accessPointName, accountID, region)
+
+	// Set up a custom endpoint resolver for Access Points
+	//nolint:staticcheck // haven't migrated to the new interface yet
+	awsConfig.EndpointResolverWithOptions = awssdk.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (awssdk.Endpoint, error) {
+		return awssdk.Endpoint{
+			URL:               fmt.Sprintf("https://%s", endpoint),
+			SigningRegion:     region,
+			HostnameImmutable: true,
+		}, nil
+	})
+	awsConfig.Region = region
+
+	return nil
+}

--- a/x-pack/filebeat/input/awss3/s3_test.go
+++ b/x-pack/filebeat/input/awss3/s3_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -294,50 +293,4 @@ func TestS3ReaderLoop(t *testing.T) {
 
 func TestS3WorkerLoop(t *testing.T) {
 
-}
-
-// TestConfigureAccessPointEndpoint tests the configureAccessPointEndpoint function
-func TestConfigureAccessPointEndpoint(t *testing.T) {
-	testCases := []struct {
-		name             string
-		accessPointARN   string
-		expectedRegion   string
-		expectedEndpoint string
-	}{
-		{
-			name:             "Valid Access Point ARN in us-east-1",
-			accessPointARN:   "arn:aws:s3:us-east-1:123456789:accesspoint/my-access-point",
-			expectedRegion:   "us-east-1",
-			expectedEndpoint: "https://my-access-point-123456789.s3-accesspoint.us-east-1.amazonaws.com",
-		},
-		{
-			name:             "Valid Access Point ARN in eu-west-1",
-			accessPointARN:   "arn:aws:s3:eu-west-1:123456789:accesspoint/my-other-access-point",
-			expectedRegion:   "eu-west-1",
-			expectedEndpoint: "https://my-other-access-point-123456789.s3-accesspoint.eu-west-1.amazonaws.com",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Create a new aws.Config
-			awsConfig := aws.Config{}
-
-			// Call the function under test
-			configureAccessPointEndpoint(&awsConfig, tc.accessPointARN)
-
-			// Assert the region was set correctly
-			assert.Equal(t, tc.expectedRegion, awsConfig.Region)
-
-			// Assert the custom endpoint resolver was configured correctly
-			//nolint:staticcheck // haven't migrated to the new interface yet
-			if resolver, ok := awsConfig.EndpointResolverWithOptions.(aws.EndpointResolverWithOptionsFunc); ok {
-				endpoint, err := resolver("s3", tc.expectedRegion)
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedEndpoint, endpoint.URL)
-			} else {
-				t.Fatalf("EndpointResolverWithOptions is not properly configured")
-			}
-		})
-	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Added a new option `access_point_arn` to the AWS S3 input as an alternative to the bucket ARN to access S3 buckets.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/41494
