### PR TITLE
Fix handling of custom endpoints in AWS input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -171,6 +171,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Improve modification time handling for entities and entity deletion logic in the Active Directory entityanalytics input. {pull}41179[41179]
 - Journald input now can read events from all boots {issue}41083[41083] {pull}41244[41244]
 - Fix double encoding of client_secret in the Entity Analytics input's Azure Active Directory provider {pull}41393[41393]
+- Fix errors in SQS host resolution in the `aws-s3` input when using custom (non-AWS) endpoints. {pull}41504[41504]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -248,7 +248,11 @@ func (c config) s3ConfigModifier(o *s3.Options) {
 	if c.AWSConfig.FIPSEnabled {
 		o.EndpointOptions.UseFIPSEndpoint = awssdk.FIPSEndpointStateEnabled
 	}
-	if c.AWSConfig.Endpoint != "" {
+	// Apply slightly different endpoint resolvers depending on whether we're in S3 or SQS mode.
+	if c.NonAWSBucketName != "" {
+		//nolint:staticcheck // haven't migrated to the new interface yet
+		o.EndpointResolver = nonAWSBucketResolver{endpoint: c.AWSConfig.Endpoint}
+	} else if c.QueueURL != "" && c.AWSConfig.Endpoint != "" {
 		//nolint:staticcheck // haven't migrated to the new interface yet
 		o.EndpointResolver = s3.EndpointResolverFromURL(c.AWSConfig.Endpoint)
 	}

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -245,13 +245,12 @@ func (c config) getBucketARN() string {
 // options struct.
 // Should be provided as a parameter to s3.NewFromConfig.
 func (c config) s3ConfigModifier(o *s3.Options) {
-	if c.NonAWSBucketName != "" {
-		//nolint:staticcheck // haven't migrated to the new interface yet
-		o.EndpointResolver = nonAWSBucketResolver{endpoint: c.AWSConfig.Endpoint}
-	}
-
 	if c.AWSConfig.FIPSEnabled {
 		o.EndpointOptions.UseFIPSEndpoint = awssdk.FIPSEndpointStateEnabled
+	}
+	if c.AWSConfig.Endpoint != "" {
+		//nolint:staticcheck // haven't migrated to the new interface yet
+		o.EndpointResolver = s3.EndpointResolverFromURL(c.AWSConfig.Endpoint)
 	}
 	o.UsePathStyle = c.PathStyle
 
@@ -268,6 +267,9 @@ func (c config) s3ConfigModifier(o *s3.Options) {
 func (c config) sqsConfigModifier(o *sqs.Options) {
 	if c.AWSConfig.FIPSEnabled {
 		o.EndpointOptions.UseFIPSEndpoint = awssdk.FIPSEndpointStateEnabled
+	}
+	if c.AWSConfig.Endpoint != "" {
+		o.EndpointResolver = sqs.EndpointResolverFromURL(c.AWSConfig.Endpoint)
 	}
 }
 

--- a/x-pack/filebeat/input/awss3/input_integration_test.go
+++ b/x-pack/filebeat/input/awss3/input_integration_test.go
@@ -269,6 +269,174 @@ func TestInputRunSQSOnLocalstack(t *testing.T) {
 	assert.EqualValues(t, 0.0, s3Input.metrics.sqsWorkerUtilization.Get()) // Workers are reset after processing and hence utilization should be 0 at the end
 }
 
+func TestInputRunSQSWithConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		queue_url      string
+		endpoint       string
+		region         string
+		default_region string
+		want           string
+		wantErr        error
+	}{
+		{
+			name:      "no region",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			want:      "us-east-1",
+		},
+		{
+			name:      "no region but with long endpoint",
+			queue_url: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint:  "https://s3.us-east-1.abc.xyz",
+			want:      "us-east-1",
+		},
+		{
+			name:      "no region but with short endpoint",
+			queue_url: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint:  "https://abc.xyz",
+			want:      "us-east-1",
+		},
+		{
+			name:      "no region custom queue domain",
+			queue_url: "https://sqs.us-east-1.xyz.abc/627959692251/test-s3-logs",
+			wantErr:   errBadQueueURL,
+		},
+		{
+			name:      "region",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:    "us-west-2",
+			want:      "us-west-2",
+		},
+		{
+			name:           "default_region",
+			queue_url:      "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			default_region: "us-west-2",
+			want:           "us-west-2",
+		},
+		{
+			name:           "region and default_region",
+			queue_url:      "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:         "us-east-2",
+			default_region: "us-east-3",
+			want:           "us-east-2",
+		},
+		{
+			name:      "short_endpoint",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			endpoint:  "https://amazonaws.com",
+			want:      "us-east-1",
+		},
+		{
+			name:      "long_endpoint",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			endpoint:  "https://s3.us-east-1.amazonaws.com",
+			want:      "us-east-1",
+		},
+		{
+			name:      "region and custom short_endpoint",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:    "us-west-2",
+			endpoint:  "https://.elastic.co",
+			want:      "us-west-2",
+		},
+		{
+			name:      "region and custom long_endpoint",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:    "us-west-2",
+			endpoint:  "https://s3.us-east-1.elastic.co",
+			want:      "us-west-2",
+		},
+		{
+			name:      "region and short_endpoint",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:    "us-west-2",
+			endpoint:  "https://amazonaws.com",
+			want:      "us-west-2",
+		},
+		{
+			name:      "region and long_endpoint",
+			queue_url: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:    "us-west-2",
+			endpoint:  "https://s3.us-east-1.amazonaws.com",
+			want:      "us-west-2",
+		},
+		{
+			name:           "region and default region and short_endpoint",
+			queue_url:      "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:         "us-west-2",
+			default_region: "us-east-1",
+			endpoint:       "https://amazonaws.com",
+			want:           "us-west-2",
+		},
+		{
+			name:           "region and default region and long_endpoint",
+			queue_url:      "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			region:         "us-west-2",
+			default_region: "us-east-1",
+			endpoint:       "https://s3.us-east-1.amazonaws.com",
+			want:           "us-west-2",
+		},
+	}
+
+	for _, test := range tests {
+		logp.TestingSetup()
+
+		// Create a filebeat config using the provided test parameters
+		config := ""
+		if test.queue_url != "" {
+			config += fmt.Sprintf("queue_url: %s \n", test.queue_url)
+		}
+		if test.region != "" {
+			config += fmt.Sprintf("region: %s \n", test.region)
+		}
+		if test.default_region != "" {
+			config += fmt.Sprintf("default_region: %s \n", test.default_region)
+		}
+		if test.endpoint != "" {
+			config += fmt.Sprintf("endpoint: %s \n", test.endpoint)
+		}
+
+		s3Input := createInput(t, conf.MustNewConfigFrom(config))
+
+		inputCtx, cancel := newV2Context()
+		t.Cleanup(cancel)
+		time.AfterFunc(5*time.Second, func() {
+			cancel()
+		})
+
+		var errGroup errgroup.Group
+		errGroup.Go(func() error {
+			return s3Input.Run(inputCtx, &fakePipeline{})
+		})
+
+		if err := errGroup.Wait(); err != nil {
+			// assert that err == test.wantErr
+			if test.wantErr != nil {
+				continue
+			}
+			// Print the test name to help identify the failing test
+			t.Fatal(test.name, err)
+		}
+
+		// If the endpoint starts with s3, the endpoint resolver should be null at this point
+		// If the endpoint does not start with s3, the endpointresolverwithoptions should be set
+		// If the endpoint is not set, the endpoint resolver should be null
+		if test.endpoint == "" {
+			assert.Nil(t, s3Input.awsConfig.EndpointResolver, test.name)
+			assert.Nil(t, s3Input.awsConfig.EndpointResolverWithOptions, test.name)
+		} else if strings.HasPrefix(test.endpoint, "https://s3") {
+			// S3 resolvers are added later in the code than this integration test covers
+			assert.Nil(t, s3Input.awsConfig.EndpointResolver, test.name)
+			assert.Nil(t, s3Input.awsConfig.EndpointResolverWithOptions, test.name)
+		} else { // If the endpoint is specified but is not s3
+			assert.Nil(t, s3Input.awsConfig.EndpointResolver, test.name)
+			assert.NotNil(t, s3Input.awsConfig.EndpointResolverWithOptions, test.name)
+		}
+
+		assert.EqualValues(t, test.want, s3Input.awsConfig.Region, test.name)
+	}
+}
+
 func TestInputRunSQS(t *testing.T) {
 	logp.TestingSetup()
 

--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -100,8 +100,8 @@ func TestRegionSelection(t *testing.T) {
 			want:     "us-east-1",
 		},
 		{
-			name:     "abc.xyz_and_domain_with_blank_endpoint",
-			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			name:     "abc.xyz_and_no_region_term",
+			queueURL: "https://sqs.abc.xyz/627959692251/test-s3-logs",
 			wantErr:  errBadQueueURL,
 		},
 		{
@@ -130,7 +130,7 @@ func TestRegionSelection(t *testing.T) {
 		{
 			name:     "non_aws_vpce_without_endpoint",
 			queueURL: "https://vpce-test.sqs.us-east-1.vpce.abc.xyz/12345678912/sqs-queue",
-			wantErr:  errBadQueueURL,
+			want:     "us-east-1",
 		},
 		{
 			name:       "non_aws_vpce_with_region_override",

--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -88,6 +88,18 @@ func TestRegionSelection(t *testing.T) {
 			want:       "us-west-3",
 		},
 		{
+			name:     "abc.xyz_and_domain_with_matching_endpoint_and_scheme",
+			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint: "https://abc.xyz",
+			want:     "us-east-1",
+		},
+		{
+			name:     "abc.xyz_and_domain_with_matching_url_endpoint",
+			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint: "https://s3.us-east-1.abc.xyz",
+			want:     "us-east-1",
+		},
+		{
 			name:     "abc.xyz_and_domain_with_blank_endpoint",
 			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
 			wantErr:  errBadQueueURL,

--- a/x-pack/filebeat/input/awss3/s3.go
+++ b/x-pack/filebeat/input/awss3/s3.go
@@ -110,12 +110,3 @@ func getProviderFromDomain(endpoint string, ProviderOverride string) string {
 	}
 	return "unknown"
 }
-
-type nonAWSBucketResolver struct {
-	endpoint string
-}
-
-func (n nonAWSBucketResolver) ResolveEndpoint(region string, options s3.EndpointResolverOptions) (awssdk.Endpoint, error) {
-	//nolint:staticcheck // haven't migrated to the new interface yet
-	return awssdk.Endpoint{URL: n.endpoint, SigningRegion: region, HostnameImmutable: true, Source: awssdk.EndpointSourceCustom}, nil
-}

--- a/x-pack/filebeat/input/awss3/sqs_input.go
+++ b/x-pack/filebeat/input/awss3/sqs_input.go
@@ -89,17 +89,18 @@ func (in *sqsReaderInput) setup(
 	in.pipeline = pipeline
 
 	in.detectedRegion = getRegionFromQueueURL(in.config.QueueURL)
-	if in.config.RegionName == "" {
-		if in.detectedRegion != "" {
-			// Only use detected region if there is no explicit region configured.
-			in.awsConfig.Region = in.detectedRegion
-		} else if in.config.AWSConfig.DefaultRegion != "" {
-			// If we can't find anything else, fall back on the default.
-			in.awsConfig.Region = in.config.AWSConfig.DefaultRegion
-		} else {
-			// If we can't find a usable region, return an error
-			return fmt.Errorf("region not specified and failed to get AWS region from queue_url: %w", errBadQueueURL)
-		}
+	if in.config.RegionName != "" {
+		// Configured region always takes precedence
+		in.awsConfig.Region = in.config.RegionName
+	} else if in.detectedRegion != "" {
+		// Only use detected region if there is no explicit region configured.
+		in.awsConfig.Region = in.detectedRegion
+	} else if in.config.AWSConfig.DefaultRegion != "" {
+		// If we can't find anything else, fall back on the default.
+		in.awsConfig.Region = in.config.AWSConfig.DefaultRegion
+	} else {
+		// If we can't find a usable region, return an error
+		return fmt.Errorf("region not specified and failed to get AWS region from queue_url: %w", errBadQueueURL)
 	}
 
 	in.sqs = &awsSQSAPI{


### PR DESCRIPTION
Fix custom endpoint selection in the S3/SQS input (https://github.com/elastic/beats/issues/39718) by porting @strawgate's 8.14 fix (https://github.com/elastic/beats/pull/39709) to main.

In addition to the previous fixes, this simplifies the logic for detecting queue region, since the 8.14 version still had some broken cases caused by requiring over-strict endpoint matching, and it was concluded (talking to @strawgate) that there's no advantage to rejecting standard region format from queue URLs just because the endpoint URL is different (if there is a genuine mismatch in the queue and endpoint we'll learn it from the connection attempt, not from `getRegionFromQueueURL`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes https://github.com/elastic/beats/issues/39718
- Fixes https://github.com/elastic/beats/issues/40792
