### PR TITLE
[libbeat] Do not modify slice while iterating over it

### DIFF
--- a/libbeat/processors/actions/drop_fields.go
+++ b/libbeat/processors/actions/drop_fields.go
@@ -74,10 +74,10 @@ func newDropFields(c *conf.C) (beat.Processor, error) {
 
 	// Parse regexp containing fields and removes them from initial config
 	regexpFields := make([]match.Matcher, 0)
-	for i := len(config.Fields) - 1; i >= 0; i-- {
-		field := config.Fields[i]
+	for i := len(configFields) - 1; i >= 0; i-- {
+		field := configFields[i]
 		if strings.HasPrefix(field, "/") && strings.HasSuffix(field, "/") && len(field) > 2 {
-			config.Fields = append(config.Fields[:i], config.Fields[i+1:]...)
+			configFields = append(configFields[:i], configFields[i+1:]...)
 
 			matcher, err := match.Compile(field[1 : len(field)-1])
 			if err != nil {

--- a/libbeat/processors/actions/drop_fields.go
+++ b/libbeat/processors/actions/drop_fields.go
@@ -61,13 +61,14 @@ func newDropFields(c *conf.C) (beat.Processor, error) {
 		return nil, fmt.Errorf("fail to unpack the drop_fields configuration: %w", err)
 	}
 
-	/* remove read only fields */
-	// TODO: Is this implementation used? If so, there's a fix needed in removal of exported fields
+	// Do not drop manadatory fields
+	var configFields []string
 	for _, readOnly := range processors.MandatoryExportedFields {
-		for i, field := range config.Fields {
-			if readOnly == field {
-				config.Fields = append(config.Fields[:i], config.Fields[i+1:]...)
+		for _, field := range config.Fields {
+			if readOnly == field || strings.HasPrefix(field, readOnly+".") {
+				continue
 			}
+			configFields = append(configFields, field)
 		}
 	}
 
@@ -87,7 +88,7 @@ func newDropFields(c *conf.C) (beat.Processor, error) {
 		}
 	}
 
-	f := &dropFields{Fields: config.Fields, IgnoreMissing: config.IgnoreMissing, RegexpFields: regexpFields}
+	f := &dropFields{Fields: configFields, IgnoreMissing: config.IgnoreMissing, RegexpFields: regexpFields}
 	return f, nil
 }
 

--- a/libbeat/processors/actions/drop_fields_test.go
+++ b/libbeat/processors/actions/drop_fields_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/common/match"
+	conf "github.com/elastic/elastic-agent-libs/config"
 	config2 "github.com/elastic/elastic-agent-libs/config"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,20 @@ func TestDropFieldRun(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, mapstr.M{}, newEvent.Fields)
 		assert.Equal(t, event.Meta, newEvent.Meta)
+	})
+
+	t.Run("Do not drop mandatory fields", func(t *testing.T) {
+		c := conf.MustNewConfigFrom(
+			mapstr.M{
+				"fields":         []string{"field1", "type", "type.value.key", "typeKey"},
+				"ignore_missing": true,
+			},
+		)
+
+		p, err := newDropFields(c)
+		process := p.(*dropFields)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"field1", "typeKey"}, process.Fields)
 	})
 
 	t.Run("supports a metadata field", func(t *testing.T) {

--- a/libbeat/processors/actions/drop_fields_test.go
+++ b/libbeat/processors/actions/drop_fields_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/common/match"
-	conf "github.com/elastic/elastic-agent-libs/config"
 	config2 "github.com/elastic/elastic-agent-libs/config"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -52,7 +52,7 @@ func TestDropFieldRun(t *testing.T) {
 	})
 
 	t.Run("Do not drop mandatory fields", func(t *testing.T) {
-		c := conf.MustNewConfigFrom(
+		c := config2.MustNewConfigFrom(
 			mapstr.M{
 				"fields":         []string{"field1", "type", "type.value.key", "typeKey"},
 				"ignore_missing": true,
@@ -60,7 +60,9 @@ func TestDropFieldRun(t *testing.T) {
 		)
 
 		p, err := newDropFields(c)
-		process := p.(*dropFields)
+		require.NoError(t, err)
+		process, ok := p.(*dropFields)
+		assert.True(t, ok)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"field1", "typeKey"}, process.Fields)
 	})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

We were modifying `config.Fields` while iterating over it (in `drop_fields` processor) - which can lead to unexpected behavior, such as skipping elements or accessing out-of-bounds indices.

This PR now makes sure not to drop mandatory fields.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


Does this require changelog entry?
