### PR TITLE
otelconsumer: handle entity too large errors

### DIFF
--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -47,6 +47,8 @@ func TestPublish(t *testing.T) {
 	makeOtelConsumer := func(t *testing.T, consumeFn func(ctx context.Context, ld plog.Logs) error) *otelConsumer {
 		t.Helper()
 
+		assert.NoError(t, logp.TestingSetup(logp.WithSelectors("otelconsumer")))
+
 		logConsumer, err := consumer.NewLogs(consumeFn)
 		assert.NoError(t, err)
 		consumer := &otelConsumer{


### PR DESCRIPTION
## Proposed commit message

The elasticsearchexporter does not handle a 413 Request Entity too Large from Elasticsearch, only forwarding the error back to the client.

When using the batcher config in the ES exporter, it runs synchronously, any error reported can be intercepted in the otelconsumer. When using the batch processor this happens asynchronously and there is no way to handle the error. If we can intercept an entity too large error, split the batch and retry.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36163

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## Related issues

- Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36163.
- For https://github.com/elastic/ingest-dev/issues/3677