### PR TITLE
[libbeat]: Add support for `values` in lowercase processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -236,6 +236,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Update to Go 1.22.7. {pull}41018[41018]
 - Replace Ubuntu 20.04 with 24.04 for Docker base images {issue}40743[40743] {pull}40942[40942]
 - Reduce memory consumption of k8s autodiscovery and the add_kubernetes_metadata processor when Deployment metadata is enabled
+- Add `lowercase` processor. {issue}22254[22254] {pull}41424[41424]
 
 *Auditbeat*
 
@@ -245,7 +246,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add process.entity_id, process.group.name and process.group.id in add_process_metadata processor. Make fim module with kprobes backend to always add an appropriately configured add_process_metadata processor to enrich file events {pull}38776[38776]
 
 *Auditbeat*
-- Add `lowercase` processor. {issue}22254[22254] {pull}41424[41424]
 
 *Auditbeat*
 

--- a/libbeat/processors/actions/docs/lowercase.asciidoc
+++ b/libbeat/processors/actions/docs/lowercase.asciidoc
@@ -107,7 +107,7 @@ processors:
 The `lowercase` processor has the following configuration settings:
 
 `fields`:: The field names to lowercase. The match is case-insensitive, e.g. `a.b.c.d` would match `A.b.C.d` or `A.B.C.D`.
-`values`:: (Optional) Specifies the exact values to be converted to lowercase. Each entry should include the full path to the value. Key matching is case-sensitive.
+`values`:: (Optional) Specifies the exact values to be converted to lowercase. Each entry should include the full path to the value. Key matching is case-sensitive. If the target value is not a string, an error is triggered (`fail_on_error: true`) or the value is skipped (`fail_on_error: false`).
 `ignore_missing`:: (Optional) Indicates whether to ignore events that lack the source field.
                     The default is `false`, which will fail processing of an event if a field is missing.
 `fail_on_error`:: (Optional) If set to `true` and an error occurs, the changes are reverted and the original event is returned.

--- a/libbeat/processors/actions/docs/lowercase.asciidoc
+++ b/libbeat/processors/actions/docs/lowercase.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>lowercase</titleabbrev>
 ++++
 
-The `lowercase` processor specifies a list of fields that should be converted to lowercase. This transformation applies to keys that match the specified fields. Matching is performed case-insensitively. 
+The `lowercase` processor specifies a list of `fields` and `values` to be converted to lowercase. Keys listed in `fields` will be matched case-insensitively and converted to lowercase. For `values`, only exact, case-sensitive matches are transformed to lowercase. This way, keys and values can be selectively converted based on the specified criteria.
 
 
 ==== Examples: 
@@ -18,28 +18,32 @@ processors:
   - rename:
       fields:
         - "ab.cd"
+      values:
+        - "testKey"          
       ignore_missing: false
       fail_on_error: true
-      full_path: true
+      alter_full_field: true
 ----
 [source,json]
 ----
 // Input
 {
   "AB": {"CD":"data"},
-  "CD": {"ef":"data"} 
+  "CD": {"ef":"data"},
+  "testKey": {"TESTVALUE"}   
 }
 
 
 // output
 {
   "ab": {"cd":"data"},  // `AB.CD` -> `ab.cd`
-  "CD": {"ef":"data"}  
+  "CD": {"ef":"data"},
+  "testKey": {"testvalue"} // `TESTVALUE` -> `testvalue` is lowercased 
 }
 ----
 
 [start=2]
-2. When `full_path` is false
+2. When `alter_full_field` is false (applicable only for fields)
 
 [source,yaml]
 ----
@@ -57,14 +61,14 @@ processors:
 // Input
 {
   "AB": {"CD":"data"},
-  "CD": {"ef":"data"} 
+  "CD": {"ef":"data"}, 
 }
 
 
 // output
 {
   "AB": {"cd":"data"},  // `AB.CD` -> `AB.cd` (only `cd` is lowercased)
-  "CD": {"ef":"data"}  
+  "CD": {"ef":"data"}, 
 }
 ----
 
@@ -103,6 +107,7 @@ processors:
 The `lowercase` processor has the following configuration settings:
 
 `fields`:: The field names to lowercase. The match is case-insensitive, e.g. `a.b.c.d` would match `A.b.C.d` or `A.B.C.D`.
+`values`:: (Optional) Specifies the exact values to be converted to lowercase. Each entry should include the full path to the value. Key matching is case-sensitive.
 `ignore_missing`:: (Optional) Indicates whether to ignore events that lack the source field.
                     The default is `false`, which will fail processing of an event if a field is missing.
 `fail_on_error`:: (Optional) If set to `true` and an error occurs, the changes are reverted and the original event is returned.

--- a/libbeat/processors/actions/lowercase.go
+++ b/libbeat/processors/actions/lowercase.go
@@ -32,7 +32,7 @@ func init() {
 		checks.ConfigChecked(
 			NewLowerCaseProcessor,
 			checks.RequireFields("fields"),
-			checks.AllowedFields("fields", "when", "ignore_missing", "fail_on_error", "alter_full_field"),
+			checks.AllowedFields("fields", "ignore_missing", "fail_on_error", "alter_full_field", "values"),
 		),
 	)
 }

--- a/libbeat/processors/actions/lowercase_test.go
+++ b/libbeat/processors/actions/lowercase_test.go
@@ -248,6 +248,115 @@ func TestLowerCaseProcessorRun(t *testing.T) {
 	})
 }
 
+func TestLowerCaseProcessorValues(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Values        []string
+		IgnoreMissing bool
+		FailOnError   bool
+		FullPath      bool
+		Input         mapstr.M
+		Output        mapstr.M
+		Error         bool
+	}{
+		{
+			Name:          "Lowercase Values",
+			Values:        []string{"a.b.c"},
+			IgnoreMissing: false,
+			FailOnError:   true,
+			FullPath:      true,
+			Input: mapstr.M{
+				"a": mapstr.M{
+					"b": mapstr.M{
+						"c": "D",
+					},
+				},
+			},
+			Output: mapstr.M{
+				"a": mapstr.M{
+					"b": mapstr.M{
+						"c": "d", // d is lowercased
+					},
+				},
+			},
+			Error: false,
+		},
+		{
+			Name:          "Fail if given path to value is not a string",
+			Values:        []string{"a.B"},
+			IgnoreMissing: false,
+			FailOnError:   true,
+			FullPath:      true,
+			Input: mapstr.M{
+				"Field3": "Value",
+				"a": mapstr.M{
+					"B": mapstr.M{
+						"C": "D",
+					},
+				},
+			},
+			Output: mapstr.M{
+				"Field3": "Value",
+				"a": mapstr.M{
+					"B": mapstr.M{
+						"C": "D",
+					},
+				},
+				"error": mapstr.M{"message": "error visiting key \"B\" of the path \"a.B\": value of key \"a.B\" is not a string"},
+			},
+
+			Error: true,
+		},
+		{
+			Name:          "Fail On Missing Key Error",
+			Values:        []string{"a.B.c"},
+			IgnoreMissing: false,
+			FailOnError:   true,
+			FullPath:      true,
+			Input: mapstr.M{
+				"Field3": "Value",
+				"a": mapstr.M{
+					"B": mapstr.M{
+						"C": "D",
+					},
+				},
+			},
+			Output: mapstr.M{
+				"Field3": "Value",
+				"a": mapstr.M{
+					"B": mapstr.M{
+						"C": "D",
+					},
+				},
+				"error": mapstr.M{"message": "could not fetch value for key: a.B.c, Error: key not found"},
+			},
+
+			Error: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			p := &alterFieldProcessor{
+				Values:         test.Values,
+				IgnoreMissing:  test.IgnoreMissing,
+				FailOnError:    test.FailOnError,
+				AlterFullField: test.FullPath,
+				alterFunc:      lowerCase,
+			}
+
+			event, err := p.Run(&beat.Event{Fields: test.Input})
+
+			if !test.Error {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+
+			assert.Equal(t, test.Output, event.Fields)
+		})
+	}
+}
 func BenchmarkLowerCaseProcessorRun(b *testing.B) {
 	tests := []struct {
 		Name   string

--- a/libbeat/processors/actions/lowercase_test.go
+++ b/libbeat/processors/actions/lowercase_test.go
@@ -302,7 +302,7 @@ func TestLowerCaseProcessorValues(t *testing.T) {
 						"C": "D",
 					},
 				},
-				"error": mapstr.M{"message": "error visiting key \"B\" of the path \"a.B\": value of key \"a.B\" is not a string"},
+				"error": mapstr.M{"message": "value of key \"a.B\" is not a string"},
 			},
 
 			Error: true,


### PR DESCRIPTION
## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
This adds support to lowercase values. The user is expected to provide a full path (case sensitive here) of the key. With this addition, the user can now selectively convert the keys and values.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Part of https://github.com/elastic/beats/issues/22254



