### PR TITLE
Add support for region/zone for Vertex AI service in GCP module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -381,6 +381,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Restore docker.network.in.* and docker.network.out.* fields in docker module {pull}40968[40968]
 - Add `id` field to all the vSphere metricsets. {pull}41097[41097]
 - Only watch metadata for ReplicaSets in metricbeat k8s module {pull}41289[41289]
+- Add support for region/zone for Vertex AI service in GCP module {pull}41551[41551]
 
 *Metricbeat*
 

--- a/x-pack/metricbeat/module/gcp/constants.go
+++ b/x-pack/metricbeat/module/gcp/constants.go
@@ -27,6 +27,7 @@ const (
 	ServiceDataproc       = "dataproc"
 	ServiceCloudSQL       = "cloudsql"
 	ServiceRedis          = "redis"
+	ServiceAIPlatform     = "aiplatform"
 )
 
 // Paths within the GCP monitoring.TimeSeries response, if converted to JSON, where you can find each ECS field required for the output event
@@ -82,13 +83,14 @@ const (
 
 // NOTE: if you are adding labels make sure to update tests in metrics/metrics_requester_test.go.
 const (
-	DefaultResourceLabel  = "resource.label.zone"
-	ComputeResourceLabel  = "resource.labels.zone"
-	GKEResourceLabel      = "resource.label.location"
-	StorageResourceLabel  = "resource.label.location"
-	CloudSQLResourceLabel = "resource.labels.region"
-	DataprocResourceLabel = "resource.label.region"
-	RedisResourceLabel    = "resource.label.region"
+	DefaultResourceLabel    = "resource.label.zone"
+	ComputeResourceLabel    = "resource.labels.zone"
+	GKEResourceLabel        = "resource.label.location"
+	StorageResourceLabel    = "resource.label.location"
+	CloudSQLResourceLabel   = "resource.labels.region"
+	DataprocResourceLabel   = "resource.label.region"
+	RedisResourceLabel      = "resource.label.region"
+	AIPlatformResourceLabel = "resource.label.location"
 )
 
 // AlignersMapToGCP map contains available perSeriesAligner

--- a/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
@@ -196,6 +196,8 @@ func getServiceLabelFor(serviceName string) string {
 		return gcp.CloudSQLResourceLabel
 	case gcp.ServiceRedis:
 		return gcp.RedisResourceLabel
+	case gcp.ServiceAIPlatform:
+		return gcp.AIPlatformResourceLabel
 	default:
 		return gcp.DefaultResourceLabel
 	}

--- a/x-pack/metricbeat/module/gcp/metrics/metrics_requester_test.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metrics_requester_test.go
@@ -222,6 +222,7 @@ func TestIsAGlobalService(t *testing.T) {
 		{"Dataproc service", gcp.ServiceDataproc, false},
 		{"CloudSQL service", gcp.ServiceCloudSQL, false},
 		{"Redis service", gcp.ServiceRedis, false},
+		{"AIPlatform service", gcp.ServiceAIPlatform, false},
 	}
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
@@ -249,6 +250,7 @@ func TestGetServiceLabelFor(t *testing.T) {
 		{"Dataproc service", gcp.ServiceDataproc, "resource.label.region"},
 		{"CloudSQL service", gcp.ServiceCloudSQL, "resource.labels.region"},
 		{"Redis service", gcp.ServiceRedis, "resource.label.region"},
+		{"AIPlatform service", gcp.ServiceAIPlatform, "resource.label.location"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Checklist

- [ x ] My code follows the style guidelines of this project
- [  ] I have commented my code, particularly in hard-to-understand areas
- [  ] I have made corresponding changes to the documentation
- [  ] I have made corresponding change to the default configuration files
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/beats/issues/41360

## Screenshots

#### Data coming in from all the regions
<img width="1910" alt="Screenshot 2024-11-08 at 4 11 03 PM" src="https://github.com/user-attachments/assets/631077d7-7e9d-4789-a3cd-40c9ac75f98f">


#### The config of GCP for aiplatform service with region enabled as us-east4
<img width="670" alt="Screenshot 2024-11-08 at 4 07 36 PM" src="https://github.com/user-attachments/assets/d0f94108-46f4-4d9a-9485-d0c7442c85a1">

#### Data coming in after region filter is applied
<img width="1916" alt="Screenshot 2024-11-08 at 4 10 50 PM" src="https://github.com/user-attachments/assets/3d89bb5d-869c-4a37-a93d-e01b98c2fb4e">


#### Config with `regions` enabled


<img width="578" alt="Screenshot 2024-11-08 at 4 38 19 PM" src="https://github.com/user-attachments/assets/dc349297-f5c0-4c37-821a-42c7f34cb98b">


#### Data after the above Regions Filter
<img width="1916" alt="Screenshot 2024-11-08 at 4 31 16 PM" src="https://github.com/user-attachments/assets/56da9e9e-a76d-4707-9698-128f0fef6df9">



