### PR TITLE
Put full version of Go in go.mod while updating

### DIFF
--- a/.github/workflows/updatecli.d/bump-golang.yml
+++ b/.github/workflows/updatecli.d/bump-golang.yml
@@ -87,7 +87,7 @@ targets:
     scmid: githubConfig
     kind: file
     spec:
-      content: 'go {{ source "gomod" }}'
+      content: 'go {{ source "latestGoVersion" }}'
       file: go.mod
       matchpattern: 'go \d+.\d+.\d+'
   update-go-version:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/beats/v7
 
-go 1.22.0
+go 1.22.8
 
 require (
 	cloud.google.com/go/bigquery v1.62.0


### PR DESCRIPTION
The previous configuration was always replacing the full version of Go with a minor version: 1.22.8 -> 1.22.

Newer versions of Go now put the full version value in `go.mod`. This leads to our CI failing because `go mod tidy` causes a change in `go.mod`.

This is to fix those failures.