### PR TITLE
Metricbeat: add configurable failure threshold before reporting streams as degraded

### DIFF
--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -38,9 +38,10 @@ import (
 
 const (
 	// Expvar metric names.
-	successesKey = "success"
-	failuresKey  = "failures"
-	eventsKey    = "events"
+	successesKey           = "success"
+	failuresKey            = "failures"
+	eventsKey              = "events"
+	consecutiveFailuresKey = "consecutive_failures"
 
 	// Failure threshold config key
 	failureThresholdKey = "failure_threshold"
@@ -75,17 +76,16 @@ type metricSetWrapper struct {
 
 	periodic         bool // Set to true if this metricset is a periodic fetcher
 	failureThreshold uint // threshold of consecutive errors needed to set the stream as degraded
-
-	consecutiveErrors uint // consecutive errors counter
 }
 
 // stats bundles common metricset stats.
 type stats struct {
-	key      string          // full stats key
-	ref      uint32          // number of modules/metricsets reusing stats instance
-	success  *monitoring.Int // Total success events.
-	failures *monitoring.Int // Total error events.
-	events   *monitoring.Int // Total events published.
+	key                 string           // full stats key
+	ref                 uint32           // number of modules/metricsets reusing stats instance
+	success             *monitoring.Int  // Total success events.
+	failures            *monitoring.Int  // Total error events.
+	events              *monitoring.Int  // Total events published.
+	consecutiveFailures *monitoring.Uint // Consecutive failures fetching this metricset
 }
 
 // NewWrapper creates a new module and its associated metricsets based on the given configuration.
@@ -313,20 +313,20 @@ func (msw *metricSetWrapper) Test(d testing.Driver) {
 func (msw *metricSetWrapper) handleFetchError(err error, reporter mb.PushReporterV2) {
 	switch {
 	case err == nil:
-		msw.consecutiveErrors = 0
+		msw.stats.consecutiveFailures.Set(0)
 		msw.module.UpdateStatus(status.Running, "")
 
 	case errors.As(err, &mb.PartialMetricsError{}):
 		reporter.Error(err)
-		msw.consecutiveErrors = 0
+		msw.stats.consecutiveFailures.Set(0)
 		// mark module as running if metrics are partially available and display the error message
 		msw.module.UpdateStatus(status.Running, fmt.Sprintf("Error fetching data for metricset %s.%s: %v", msw.module.Name(), msw.MetricSet.Name(), err))
 		logp.Err("Error fetching data for metricset %s.%s: %s", msw.module.Name(), msw.Name(), err)
 
 	default:
 		reporter.Error(err)
-		msw.consecutiveErrors++
-		if msw.failureThreshold > 0 && msw.consecutiveErrors >= msw.failureThreshold {
+		msw.stats.consecutiveFailures.Inc()
+		if msw.failureThreshold > 0 && msw.stats.consecutiveFailures != nil && uint(msw.stats.consecutiveFailures.Get()) >= msw.failureThreshold {
 			// mark it as degraded for any other issue encountered
 			msw.module.UpdateStatus(status.Degraded, fmt.Sprintf("Error fetching data for metricset %s.%s: %v", msw.module.Name(), msw.MetricSet.Name(), err))
 		}
@@ -461,11 +461,12 @@ func getMetricSetStats(module, name string) *stats {
 
 	reg := monitoring.Default.NewRegistry(key)
 	s := &stats{
-		key:      key,
-		ref:      1,
-		success:  monitoring.NewInt(reg, successesKey),
-		failures: monitoring.NewInt(reg, failuresKey),
-		events:   monitoring.NewInt(reg, eventsKey),
+		key:                 key,
+		ref:                 1,
+		success:             monitoring.NewInt(reg, successesKey),
+		failures:            monitoring.NewInt(reg, failuresKey),
+		events:              monitoring.NewInt(reg, eventsKey),
+		consecutiveFailures: monitoring.NewUint(reg, consecutiveFailuresKey),
 	}
 
 	fetches[key] = s

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -36,11 +36,14 @@ import (
 	"github.com/elastic/elastic-agent-libs/testing"
 )
 
-// Expvar metric names.
 const (
+	// Expvar metric names.
 	successesKey = "success"
 	failuresKey  = "failures"
 	eventsKey    = "events"
+
+	// Failure threshold config key
+	failureThresholdKey = "failure_threshold"
 )
 
 var (
@@ -112,7 +115,7 @@ func createWrapper(module mb.Module, metricSets []mb.MetricSet, options ...Optio
 	failureThreshold := uint(1)
 
 	var streamHealthSettings struct {
-		FailureThreshold *uint `config:"failureThreshold"`
+		FailureThreshold *uint `config:"failure_threshold"`
 	}
 
 	err := module.UnpackConfig(&streamHealthSettings)

--- a/metricbeat/mb/module/wrapper_internal_test.go
+++ b/metricbeat/mb/module/wrapper_internal_test.go
@@ -1,0 +1,419 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package module
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const mockModuleName = "MockModule"
+const mockMetricSetName = "MockMetricSet"
+const mockMetricSetWithContextName = "MockMetricSetWithContext"
+
+// mockReportingFetcher
+type mockReportingFetcher struct {
+	mb.BaseMetricSet
+	mock.Mock
+}
+
+func (mrf *mockReportingFetcher) Fetch(r mb.ReporterV2) error {
+	args := mrf.Called(r)
+	return args.Error(0)
+}
+
+// mockReportingFetcherWithContext
+type mockReportingFetcherWithContext struct {
+	mb.BaseMetricSet
+	mock.Mock
+}
+
+func (mrf *mockReportingFetcherWithContext) Fetch(ctx context.Context, r mb.ReporterV2) error {
+	args := mrf.Called(ctx, r)
+	return args.Error(0)
+}
+
+// mockReporter
+type mockReporter struct {
+	mock.Mock
+}
+
+func (mr *mockReporter) StartFetchTimer() {
+	mr.Called()
+}
+
+func (mr *mockReporter) V1() mb.PushReporter { //nolint:staticcheck // PushReporter is deprecated but not removed
+	args := mr.Called()
+	return args.Get(0).(mb.PushReporter)
+}
+
+func (mr *mockReporter) V2() mb.PushReporterV2 {
+	args := mr.Called()
+	return args.Get(0).(mb.PushReporterV2)
+}
+
+// mockPushReporterV2
+type mockPushReporterV2 struct {
+	mock.Mock
+}
+
+func (mpr *mockPushReporterV2) Event(event mb.Event) bool {
+	args := mpr.Called(event)
+	return args.Bool(0)
+}
+
+func (mpr *mockPushReporterV2) Error(err error) bool {
+	args := mpr.Called(err)
+	return args.Bool(0)
+}
+
+func (mpr *mockPushReporterV2) Done() <-chan struct{} {
+	args := mpr.Called()
+	return args.Get(0).(<-chan struct{})
+}
+
+// mockStatusReporterV2
+type mockStatusReporter struct {
+	mock.Mock
+}
+
+func (m *mockStatusReporter) UpdateStatus(status status.Status, msg string) {
+	m.Called(status, msg)
+}
+
+func TestWrapperHandleFetchErrorSync(t *testing.T) {
+
+	fetchError := errors.New("fetch has gone all wrong")
+
+	type setupFunc func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
+	type postIterationAssertFunc func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
+
+	testcases := []struct {
+		name            string
+		config          *conf.C
+		setup           setupFunc
+		iterations      int
+		assertIteration postIterationAssertFunc
+	}{
+		{
+			name: "no failureThreshold: status DEGRADED after first error",
+			config: newConfig(t, map[string]interface{}{
+				"module":     mockModuleName,
+				"metricsets": []string{mockMetricSetName},
+				"period":     "100ms",
+				"hosts":      []string{"testhost"},
+			}),
+			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				// fetcher will immediately error out
+				fetcher.On("Fetch", pushReporter).Return(fetchError).Once()
+				// expect the error to be propagated via the pushReporter
+				pushReporter.On("Error", fetchError).Return(true).Once()
+				// expect the status degraded to be set
+				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+			},
+			iterations:      1,
+			assertIteration: nil,
+		},
+		{
+			name: "no failureThreshold: status DEGRADED after first error, reset to Running after first successful fetch",
+			config: newConfig(t, map[string]interface{}{
+				"module":     mockModuleName,
+				"metricsets": []string{mockMetricSetName},
+				"period":     "100ms",
+				"hosts":      []string{"testhost"},
+			}),
+			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				// fetcher will immediately error out 3 times
+				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
+				// fetcher will never error again afterwards
+				fetcher.On("Fetch", pushReporter).Return(nil)
+				// expect the error to be propagated via the pushReporter
+				pushReporter.On("Error", fetchError).Return(true).Times(3)
+				// expect the status degraded to be set 3 times
+				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Times(3)
+				// expect the status Running to be set once fetch recovers
+				statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Twice()
+			},
+			iterations: 5,
+			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				t.Logf("Assertion after iteration %d", i)
+				switch {
+				case i < 3:
+					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+				case i >= 3:
+					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream set to running at iteration %d", i)
+				}
+			},
+		},
+		{
+			name: "failureThreshold = 2: status DEGRADED at the 3rd error",
+			config: newConfig(t, map[string]interface{}{
+				"module":           mockModuleName,
+				"metricsets":       []string{mockMetricSetName},
+				"period":           "100ms",
+				"hosts":            []string{"testhost"},
+				"failureThreshold": 2,
+			}),
+			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				// fetcher will immediately error out 3 times in a row
+				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
+				// expect the error to be propagated via the pushReporter at every iteration
+				pushReporter.On("Error", fetchError).Return(true).Times(3)
+				// expect the status degraded to be set
+				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+			},
+			iterations: 3,
+			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				t.Logf("Assertion after iteration %d", i)
+				switch {
+				case i < 2:
+					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+				case i == 2:
+					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
+				}
+			},
+		},
+		{
+			name: "failureThreshold = 2: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
+			config: newConfig(t, map[string]interface{}{
+				"module":           mockModuleName,
+				"metricsets":       []string{mockMetricSetName},
+				"period":           "100ms",
+				"hosts":            []string{"testhost"},
+				"failureThreshold": 2,
+			}),
+			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				// fetcher will error out 2 times in a row
+				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(2)
+				// fetcher will then succeed once
+				fetcher.On("Fetch", pushReporter).Return(nil).Once()
+				// fetcher will error out 3 more times in a row
+				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
+
+				// expect the error to be propagated via the pushReporter at every failing iteration
+				pushReporter.On("Error", fetchError).Return(true).Times(5)
+				// expect the status running to be set when there's no error returned by the fetcher at the 3rd iteration
+				statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
+				// expect the status degraded to be set only once
+				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+			},
+			iterations: 6,
+			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				t.Logf("Assertion after iteration %d", i)
+				switch {
+				case i < 2:
+					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+				case i >= 2 && i < 5:
+					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+				case i == 5:
+					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
+				}
+			},
+		},
+		{
+			name: "failureThreshold = -1: stream status update never become DEGRADED",
+			config: newConfig(t, map[string]interface{}{
+				"module":           mockModuleName,
+				"metricsets":       []string{mockMetricSetName},
+				"period":           "100ms",
+				"hosts":            []string{"testhost"},
+				"failureThreshold": -1,
+			}),
+			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				// fetcher will error out 9 times in a row
+				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(9)
+				// fetcher will then succeed once
+				fetcher.On("Fetch", pushReporter).Return(nil).Once()
+
+				// expect the error to be propagated via the pushReporter at every failing iteration
+				pushReporter.On("Error", fetchError).Return(true).Times(9)
+				// expect the status running to be set when there's no error returned by the fetcher at the 10th iteration
+				statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
+			},
+			iterations: 10,
+			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+				t.Logf("Assertion after iteration %d", i)
+				switch {
+				case i < 9:
+					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+				case i == 9:
+					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup mock push reporter
+			mpr := new(mockPushReporterV2)
+
+			// Setup mock fetcher
+			mrf := new(mockReportingFetcher)
+
+			// Setup mock StatusReporter
+			msr := new(mockStatusReporter)
+
+			//Setup mock reporter (ensure proper handling of intermediate calls, no functional value here)
+			mr := new(mockReporter)
+			mr.On("StartFetchTimer").Return()
+			mr.On("V2").Return(mpr)
+
+			// assert mocks expectations
+			t.Cleanup(func() {
+				mock.AssertExpectationsForObjects(t, mrf, mr, mpr, msr)
+			})
+
+			// setup mocks before starting the test
+			if tc.setup != nil {
+				tc.setup(t, mrf, mpr, msr)
+			}
+
+			// add metricset in registry
+			r := mb.NewRegister()
+			err := r.AddMetricSet(mockModuleName, mockMetricSetName, func(base mb.BaseMetricSet) (mb.MetricSet, error) {
+				mrf.BaseMetricSet = base
+				return mrf, nil
+			})
+			require.NoError(t, err)
+
+			aModule, metricSets, err := mb.NewModule(tc.config, r)
+			require.NoError(t, err)
+
+			// Set the mock status reporter
+			aModule.SetStatusReporter(msr)
+
+			moduleWrapper, err := NewWrapperForMetricSet(aModule, metricSets[0], WithMetricSetInfo())
+			require.NoError(t, err)
+
+			// run metricset synchronously
+			wrappedMetricSet := moduleWrapper.MetricSets()[0]
+			for i := 0; i < tc.iterations; i++ {
+				wrappedMetricSet.fetch(context.TODO(), mr)
+				if tc.assertIteration != nil {
+					tc.assertIteration(t, i, wrappedMetricSet, mrf, mpr, msr)
+				}
+			}
+		})
+	}
+}
+
+func TestWrapperHandleFetchErrorAsync(t *testing.T) {
+
+	t.Skip("This test runs a mock wrapped metricset asynchronously. Preferring the synchronous test for now")
+
+	// Setup mock push reporter
+	mpr := new(mockPushReporterV2)
+
+	// Setup mock fetcher
+	mrf := new(mockReportingFetcher)
+	//mrf.On("Fetch", mpr).Return(nil)
+
+	//Setup mock reporter
+	mr := new(mockReporter)
+	//mr.On("StartFetchTimer").Return()
+	//mr.On("V2").Return(mpr)
+
+	// assert mocks expectations
+	t.Cleanup(func() {
+		mock.AssertExpectationsForObjects(t, mrf, mr, mpr)
+	})
+
+	// add metricset in registry
+	r := mb.NewRegister()
+	err := r.AddMetricSet(mockModuleName, mockMetricSetName, func(base mb.BaseMetricSet) (mb.MetricSet, error) {
+		mrf.BaseMetricSet = base
+		return mrf, nil
+	})
+	require.NoError(t, err)
+
+	hosts := []string{"testhost"}
+	c := newConfig(t, map[string]interface{}{
+		"module":     mockModuleName,
+		"metricsets": []string{mockMetricSetName},
+		"period":     "100ms",
+		"hosts":      hosts,
+		"health": map[string]interface{}{
+			"enabled":          true,
+			"failureThreshold": 2,
+		},
+	})
+
+	aModule, metricSets, err := mb.NewModule(c, r)
+	require.NoError(t, err)
+
+	mWrapper, err := NewWrapperForMetricSet(aModule, metricSets[0], WithMetricSetInfo())
+	require.NoError(t, err)
+
+	require.Len(t, mWrapper.MetricSets(), 1)
+
+	// run the metricset asynchronously
+	done := make(chan struct{})
+	output := mWrapper.Start(done)
+
+	wg := new(sync.WaitGroup)
+	outputConsumeLoop(t, wg, output, done, func(event beat.Event) {
+		t.Logf("received event: %v", event)
+	})
+	time.Sleep(1 * time.Second)
+
+	close(done)
+	wg.Wait()
+}
+
+func outputConsumeLoop(t *testing.T, wg *sync.WaitGroup, output <-chan beat.Event, done chan struct{}, ehf eventHandlingTestFunc) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case e := <-output:
+				ehf(e)
+			case <-done:
+				// finish consuming and return
+				t.Log("test done, consuming remaining events")
+				for e := range output {
+					ehf(e)
+				}
+				t.Log("done consuming events")
+				return
+			}
+		}
+	}()
+}
+
+type eventHandlingTestFunc func(beat.Event)
+
+func newConfig(t testing.TB, moduleConfig interface{}) *conf.C {
+	config, err := conf.NewConfigFrom(moduleConfig)
+	require.NoError(t, err)
+	return config
+}

--- a/metricbeat/mb/module/wrapper_internal_test.go
+++ b/metricbeat/mb/module/wrapper_internal_test.go
@@ -22,12 +22,13 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/management/status"
-	"github.com/elastic/beats/v7/metricbeat/mb"
-	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
 const mockModuleName = "MockModule"

--- a/metricbeat/mb/module/wrapper_internal_test.go
+++ b/metricbeat/mb/module/wrapper_internal_test.go
@@ -120,7 +120,7 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 			assertIteration postIterationAssertFunc
 		}{
 			{
-				name: "no failureThreshold: status DEGRADED after first error",
+				name: "no failure_threshold: status DEGRADED after first error",
 				config: newConfig(t, map[string]interface{}{
 					"module":     mockModuleName,
 					"metricsets": []string{mockMetricSetName},
@@ -140,7 +140,7 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				assertIteration: nil,
 			},
 			{
-				name: "no failureThreshold: status DEGRADED after first error, reset to Running after first successful fetch",
+				name: "no failure_threshold: status DEGRADED after first error, reset to Running after first successful fetch",
 				config: newConfig(t, map[string]interface{}{
 					"module":     mockModuleName,
 					"metricsets": []string{mockMetricSetName},
@@ -171,13 +171,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				},
 			},
 			{
-				name: "failureThreshold = 3: status DEGRADED at the 3rd error",
+				name: "failure_threshold = 3: status DEGRADED at the 3rd error",
 				config: newConfig(t, map[string]interface{}{
-					"module":           mockModuleName,
-					"metricsets":       []string{mockMetricSetName},
-					"period":           "100ms",
-					"hosts":            []string{"testhost"},
-					"failureThreshold": 3,
+					"module":            mockModuleName,
+					"metricsets":        []string{mockMetricSetName},
+					"period":            "100ms",
+					"hosts":             []string{"testhost"},
+					failureThresholdKey: 3,
 				}),
 				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 					// fetcher will immediately error out 3 times in a row
@@ -199,13 +199,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				},
 			},
 			{
-				name: "failureThreshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
+				name: "failure_threshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
 				config: newConfig(t, map[string]interface{}{
-					"module":           mockModuleName,
-					"metricsets":       []string{mockMetricSetName},
-					"period":           "100ms",
-					"hosts":            []string{"testhost"},
-					"failureThreshold": 3,
+					"module":            mockModuleName,
+					"metricsets":        []string{mockMetricSetName},
+					"period":            "100ms",
+					"hosts":             []string{"testhost"},
+					failureThresholdKey: 3,
 				}),
 				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 					// fetcher will error out 2 times in a row
@@ -237,13 +237,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				},
 			},
 			{
-				name: "failureThreshold = 0: stream status update never become DEGRADED",
+				name: "failure_threshold = 0: stream status update never become DEGRADED",
 				config: newConfig(t, map[string]interface{}{
-					"module":           mockModuleName,
-					"metricsets":       []string{mockMetricSetName},
-					"period":           "100ms",
-					"hosts":            []string{"testhost"},
-					"failureThreshold": 0,
+					"module":            mockModuleName,
+					"metricsets":        []string{mockMetricSetName},
+					"period":            "100ms",
+					"hosts":             []string{"testhost"},
+					failureThresholdKey: 0,
 				}),
 				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 					// fetcher will error out 9 times in a row
@@ -342,7 +342,7 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 			assertIteration postIterationAssertFunc
 		}{
 			{
-				name: "no failureThreshold: status DEGRADED after first error",
+				name: "no failure_threshold: status DEGRADED after first error",
 				config: newConfig(t, map[string]interface{}{
 					"module":     mockModuleName,
 					"metricsets": []string{mockMetricSetName},
@@ -362,7 +362,7 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				assertIteration: nil,
 			},
 			{
-				name: "no failureThreshold: status DEGRADED after first error, reset to Running after first successful fetch",
+				name: "no failure_threshold: status DEGRADED after first error, reset to Running after first successful fetch",
 				config: newConfig(t, map[string]interface{}{
 					"module":     mockModuleName,
 					"metricsets": []string{mockMetricSetName},
@@ -393,13 +393,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				},
 			},
 			{
-				name: "failureThreshold = 3: status DEGRADED at the 3rd error",
+				name: "failure_threshold = 3: status DEGRADED at the 3rd error",
 				config: newConfig(t, map[string]interface{}{
-					"module":           mockModuleName,
-					"metricsets":       []string{mockMetricSetName},
-					"period":           "100ms",
-					"hosts":            []string{"testhost"},
-					"failureThreshold": 3,
+					"module":            mockModuleName,
+					"metricsets":        []string{mockMetricSetName},
+					"period":            "100ms",
+					"hosts":             []string{"testhost"},
+					failureThresholdKey: 3,
 				}),
 				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 					// fetcher will immediately error out 3 times in a row
@@ -421,13 +421,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				},
 			},
 			{
-				name: "failureThreshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
+				name: "failure_threshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
 				config: newConfig(t, map[string]interface{}{
-					"module":           mockModuleName,
-					"metricsets":       []string{mockMetricSetName},
-					"period":           "100ms",
-					"hosts":            []string{"testhost"},
-					"failureThreshold": 3,
+					"module":            mockModuleName,
+					"metricsets":        []string{mockMetricSetName},
+					"period":            "100ms",
+					"hosts":             []string{"testhost"},
+					failureThresholdKey: 3,
 				}),
 				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 					// fetcher will error out 2 times in a row
@@ -459,13 +459,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 				},
 			},
 			{
-				name: "failureThreshold = 0: stream status update never become DEGRADED",
+				name: "failure_threshold = 0: stream status update never become DEGRADED",
 				config: newConfig(t, map[string]interface{}{
-					"module":           mockModuleName,
-					"metricsets":       []string{mockMetricSetName},
-					"period":           "100ms",
-					"hosts":            []string{"testhost"},
-					"failureThreshold": 0,
+					"module":            mockModuleName,
+					"metricsets":        []string{mockMetricSetName},
+					"period":            "100ms",
+					"hosts":             []string{"testhost"},
+					failureThresholdKey: 0,
 				}),
 				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 					// fetcher will error out 9 times in a row

--- a/metricbeat/mb/module/wrapper_internal_test.go
+++ b/metricbeat/mb/module/wrapper_internal_test.go
@@ -169,13 +169,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 			},
 		},
 		{
-			name: "failureThreshold = 2: status DEGRADED at the 3rd error",
+			name: "failureThreshold = 3: status DEGRADED at the 3rd error",
 			config: newConfig(t, map[string]interface{}{
 				"module":           mockModuleName,
 				"metricsets":       []string{mockMetricSetName},
 				"period":           "100ms",
 				"hosts":            []string{"testhost"},
-				"failureThreshold": 2,
+				"failureThreshold": 3,
 			}),
 			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 				// fetcher will immediately error out 3 times in a row
@@ -197,13 +197,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 			},
 		},
 		{
-			name: "failureThreshold = 2: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
+			name: "failureThreshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
 			config: newConfig(t, map[string]interface{}{
 				"module":           mockModuleName,
 				"metricsets":       []string{mockMetricSetName},
 				"period":           "100ms",
 				"hosts":            []string{"testhost"},
-				"failureThreshold": 2,
+				"failureThreshold": 3,
 			}),
 			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 				// fetcher will error out 2 times in a row
@@ -235,13 +235,13 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 			},
 		},
 		{
-			name: "failureThreshold = -1: stream status update never become DEGRADED",
+			name: "failureThreshold = 0: stream status update never become DEGRADED",
 			config: newConfig(t, map[string]interface{}{
 				"module":           mockModuleName,
 				"metricsets":       []string{mockMetricSetName},
 				"period":           "100ms",
 				"hosts":            []string{"testhost"},
-				"failureThreshold": -1,
+				"failureThreshold": 0,
 			}),
 			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
 				// fetcher will error out 9 times in a row

--- a/metricbeat/mb/module/wrapper_internal_test.go
+++ b/metricbeat/mb/module/wrapper_internal_test.go
@@ -32,7 +32,6 @@ import (
 
 const mockModuleName = "MockModule"
 const mockMetricSetName = "MockMetricSet"
-const mockMetricSetWithContextName = "MockMetricSetWithContext"
 
 // mockReportingFetcher
 type mockReportingFetcher struct {
@@ -67,7 +66,7 @@ func (mr *mockReporter) StartFetchTimer() {
 
 func (mr *mockReporter) V1() mb.PushReporter { //nolint:staticcheck // PushReporter is deprecated but not removed
 	args := mr.Called()
-	return args.Get(0).(mb.PushReporter)
+	return args.Get(0).(mb.PushReporter) //nolint:staticcheck // PushReporter is deprecated but not removed
 }
 
 func (mr *mockReporter) V2() mb.PushReporterV2 {

--- a/metricbeat/mb/module/wrapper_internal_test.go
+++ b/metricbeat/mb/module/wrapper_internal_test.go
@@ -108,219 +108,444 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 
 	fetchError := errors.New("fetch has gone all wrong")
 
-	type setupFunc func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
-	type postIterationAssertFunc func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
+	t.Run("ReportingMetricSetV2Error", func(t *testing.T) {
+		type setupFunc func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
+		type postIterationAssertFunc func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
 
-	testcases := []struct {
-		name            string
-		config          *conf.C
-		setup           setupFunc
-		iterations      int
-		assertIteration postIterationAssertFunc
-	}{
-		{
-			name: "no failureThreshold: status DEGRADED after first error",
-			config: newConfig(t, map[string]interface{}{
-				"module":     mockModuleName,
-				"metricsets": []string{mockMetricSetName},
-				"period":     "100ms",
-				"hosts":      []string{"testhost"},
-			}),
-			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				// fetcher will immediately error out
-				fetcher.On("Fetch", pushReporter).Return(fetchError).Once()
-				// expect the error to be propagated via the pushReporter
-				pushReporter.On("Error", fetchError).Return(true).Once()
-				// expect the status degraded to be set
-				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+		testcases := []struct {
+			name            string
+			config          *conf.C
+			setup           setupFunc
+			iterations      int
+			assertIteration postIterationAssertFunc
+		}{
+			{
+				name: "no failureThreshold: status DEGRADED after first error",
+				config: newConfig(t, map[string]interface{}{
+					"module":     mockModuleName,
+					"metricsets": []string{mockMetricSetName},
+					"period":     "100ms",
+					"hosts":      []string{"testhost"},
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will immediately error out
+					fetcher.On("Fetch", pushReporter).Return(fetchError).Once()
+
+					// expect the error to be propagated via the pushReporter
+					pushReporter.On("Error", fetchError).Return(true).Once()
+					// expect the status degraded to be set
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+				},
+				iterations:      1,
+				assertIteration: nil,
 			},
-			iterations:      1,
-			assertIteration: nil,
-		},
-		{
-			name: "no failureThreshold: status DEGRADED after first error, reset to Running after first successful fetch",
-			config: newConfig(t, map[string]interface{}{
-				"module":     mockModuleName,
-				"metricsets": []string{mockMetricSetName},
-				"period":     "100ms",
-				"hosts":      []string{"testhost"},
-			}),
-			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				// fetcher will immediately error out 3 times
-				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
-				// fetcher will never error again afterwards
-				fetcher.On("Fetch", pushReporter).Return(nil)
-				// expect the error to be propagated via the pushReporter
-				pushReporter.On("Error", fetchError).Return(true).Times(3)
-				// expect the status degraded to be set 3 times
-				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Times(3)
-				// expect the status Running to be set once fetch recovers
-				statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Twice()
+			{
+				name: "no failureThreshold: status DEGRADED after first error, reset to Running after first successful fetch",
+				config: newConfig(t, map[string]interface{}{
+					"module":     mockModuleName,
+					"metricsets": []string{mockMetricSetName},
+					"period":     "100ms",
+					"hosts":      []string{"testhost"},
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will immediately error out 3 times
+					fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
+					// fetcher will never error again afterwards
+					fetcher.On("Fetch", pushReporter).Return(nil)
+					// expect the error to be propagated via the pushReporter
+					pushReporter.On("Error", fetchError).Return(true).Times(3)
+					// expect the status degraded to be set 3 times
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Times(3)
+					// expect the status Running to be set once fetch recovers
+					statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Twice()
+				},
+				iterations: 5,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 3:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i >= 3:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream set to running at iteration %d", i)
+					}
+				},
 			},
-			iterations: 5,
-			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				t.Logf("Assertion after iteration %d", i)
-				switch {
-				case i < 3:
-					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-				case i >= 3:
-					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream set to running at iteration %d", i)
+			{
+				name: "failureThreshold = 3: status DEGRADED at the 3rd error",
+				config: newConfig(t, map[string]interface{}{
+					"module":           mockModuleName,
+					"metricsets":       []string{mockMetricSetName},
+					"period":           "100ms",
+					"hosts":            []string{"testhost"},
+					"failureThreshold": 3,
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will immediately error out 3 times in a row
+					fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
+					// expect the error to be propagated via the pushReporter at every iteration
+					pushReporter.On("Error", fetchError).Return(true).Times(3)
+					// expect the status degraded to be set
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+				},
+				iterations: 3,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 2:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i == 2:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
+					}
+				},
+			},
+			{
+				name: "failureThreshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
+				config: newConfig(t, map[string]interface{}{
+					"module":           mockModuleName,
+					"metricsets":       []string{mockMetricSetName},
+					"period":           "100ms",
+					"hosts":            []string{"testhost"},
+					"failureThreshold": 3,
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will error out 2 times in a row
+					fetcher.On("Fetch", pushReporter).Return(fetchError).Times(2)
+					// fetcher will then succeed once
+					fetcher.On("Fetch", pushReporter).Return(nil).Once()
+					// fetcher will error out 3 more times in a row
+					fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
+
+					// expect the error to be propagated via the pushReporter at every failing iteration
+					pushReporter.On("Error", fetchError).Return(true).Times(5)
+					// expect the status running to be set when there's no error returned by the fetcher at the 3rd iteration
+					statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
+					// expect the status degraded to be set only once
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+				},
+				iterations: 6,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 2:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i >= 2 && i < 5:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i == 5:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
+					}
+				},
+			},
+			{
+				name: "failureThreshold = 0: stream status update never become DEGRADED",
+				config: newConfig(t, map[string]interface{}{
+					"module":           mockModuleName,
+					"metricsets":       []string{mockMetricSetName},
+					"period":           "100ms",
+					"hosts":            []string{"testhost"},
+					"failureThreshold": 0,
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will error out 9 times in a row
+					fetcher.On("Fetch", pushReporter).Return(fetchError).Times(9)
+					// fetcher will then succeed once
+					fetcher.On("Fetch", pushReporter).Return(nil).Once()
+
+					// expect the error to be propagated via the pushReporter at every failing iteration
+					pushReporter.On("Error", fetchError).Return(true).Times(9)
+					// expect the status running to be set when there's no error returned by the fetcher at the 10th iteration
+					statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
+				},
+				iterations: 10,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 9:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i == 9:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					}
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Setup mock push reporter
+				mpr := new(mockPushReporterV2)
+
+				// Setup mock fetcher
+				mrf := new(mockReportingFetcher)
+
+				// Setup mock StatusReporter
+				msr := new(mockStatusReporter)
+
+				//Setup mock reporter (ensure proper handling of intermediate calls, no functional value here)
+				mr := new(mockReporter)
+				mr.On("StartFetchTimer").Return()
+				mr.On("V2").Return(mpr)
+
+				// assert mocks expectations
+				t.Cleanup(func() {
+					mock.AssertExpectationsForObjects(t, mrf, mr, mpr, msr)
+				})
+
+				// setup mocks before starting the test
+				if tc.setup != nil {
+					tc.setup(t, mrf, mpr, msr)
 				}
-			},
-		},
-		{
-			name: "failureThreshold = 3: status DEGRADED at the 3rd error",
-			config: newConfig(t, map[string]interface{}{
-				"module":           mockModuleName,
-				"metricsets":       []string{mockMetricSetName},
-				"period":           "100ms",
-				"hosts":            []string{"testhost"},
-				"failureThreshold": 3,
-			}),
-			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				// fetcher will immediately error out 3 times in a row
-				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
-				// expect the error to be propagated via the pushReporter at every iteration
-				pushReporter.On("Error", fetchError).Return(true).Times(3)
-				// expect the status degraded to be set
-				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
-			},
-			iterations: 3,
-			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				t.Logf("Assertion after iteration %d", i)
-				switch {
-				case i < 2:
-					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-				case i == 2:
-					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
+
+				// add metricset in registry
+				r := mb.NewRegister()
+				err := r.AddMetricSet(mockModuleName, mockMetricSetName, func(base mb.BaseMetricSet) (mb.MetricSet, error) {
+					mrf.BaseMetricSet = base
+					return mrf, nil
+				})
+				require.NoError(t, err)
+
+				aModule, metricSets, err := mb.NewModule(tc.config, r)
+				require.NoError(t, err)
+
+				// Set the mock status reporter
+				aModule.SetStatusReporter(msr)
+
+				moduleWrapper, err := NewWrapperForMetricSet(aModule, metricSets[0], WithMetricSetInfo())
+				require.NoError(t, err)
+
+				// run metricset synchronously
+				wrappedMetricSet := moduleWrapper.MetricSets()[0]
+				for i := 0; i < tc.iterations; i++ {
+					wrappedMetricSet.fetch(context.TODO(), mr)
+					if tc.assertIteration != nil {
+						tc.assertIteration(t, i, wrappedMetricSet, mrf, mpr, msr)
+					}
 				}
-			},
-		},
-		{
-			name: "failureThreshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
-			config: newConfig(t, map[string]interface{}{
-				"module":           mockModuleName,
-				"metricsets":       []string{mockMetricSetName},
-				"period":           "100ms",
-				"hosts":            []string{"testhost"},
-				"failureThreshold": 3,
-			}),
-			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				// fetcher will error out 2 times in a row
-				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(2)
-				// fetcher will then succeed once
-				fetcher.On("Fetch", pushReporter).Return(nil).Once()
-				// fetcher will error out 3 more times in a row
-				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(3)
-
-				// expect the error to be propagated via the pushReporter at every failing iteration
-				pushReporter.On("Error", fetchError).Return(true).Times(5)
-				// expect the status running to be set when there's no error returned by the fetcher at the 3rd iteration
-				statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
-				// expect the status degraded to be set only once
-				statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
-			},
-			iterations: 6,
-			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				t.Logf("Assertion after iteration %d", i)
-				switch {
-				case i < 2:
-					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-				case i >= 2 && i < 5:
-					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-				case i == 5:
-					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
-				}
-			},
-		},
-		{
-			name: "failureThreshold = 0: stream status update never become DEGRADED",
-			config: newConfig(t, map[string]interface{}{
-				"module":           mockModuleName,
-				"metricsets":       []string{mockMetricSetName},
-				"period":           "100ms",
-				"hosts":            []string{"testhost"},
-				"failureThreshold": 0,
-			}),
-			setup: func(t *testing.T, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				// fetcher will error out 9 times in a row
-				fetcher.On("Fetch", pushReporter).Return(fetchError).Times(9)
-				// fetcher will then succeed once
-				fetcher.On("Fetch", pushReporter).Return(nil).Once()
-
-				// expect the error to be propagated via the pushReporter at every failing iteration
-				pushReporter.On("Error", fetchError).Return(true).Times(9)
-				// expect the status running to be set when there's no error returned by the fetcher at the 10th iteration
-				statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
-			},
-			iterations: 10,
-			assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcher, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
-				t.Logf("Assertion after iteration %d", i)
-				switch {
-				case i < 9:
-					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-				case i == 9:
-					assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-					assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
-				}
-			},
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup mock push reporter
-			mpr := new(mockPushReporterV2)
-
-			// Setup mock fetcher
-			mrf := new(mockReportingFetcher)
-
-			// Setup mock StatusReporter
-			msr := new(mockStatusReporter)
-
-			//Setup mock reporter (ensure proper handling of intermediate calls, no functional value here)
-			mr := new(mockReporter)
-			mr.On("StartFetchTimer").Return()
-			mr.On("V2").Return(mpr)
-
-			// assert mocks expectations
-			t.Cleanup(func() {
-				mock.AssertExpectationsForObjects(t, mrf, mr, mpr, msr)
 			})
+		}
+	})
 
-			// setup mocks before starting the test
-			if tc.setup != nil {
-				tc.setup(t, mrf, mpr, msr)
-			}
+	t.Run("ReportingMetricSetV2WithContext", func(t *testing.T) {
+		// These tests are the same as ReportingMetricSetV2Error, duplicated here because the generic solution to specify
+		// testcases only once is awkward and not very readable
 
-			// add metricset in registry
-			r := mb.NewRegister()
-			err := r.AddMetricSet(mockModuleName, mockMetricSetName, func(base mb.BaseMetricSet) (mb.MetricSet, error) {
-				mrf.BaseMetricSet = base
-				return mrf, nil
-			})
-			require.NoError(t, err)
+		type setupFunc func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
+		type postIterationAssertFunc func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter)
 
-			aModule, metricSets, err := mb.NewModule(tc.config, r)
-			require.NoError(t, err)
+		fetchCtx := context.TODO()
 
-			// Set the mock status reporter
-			aModule.SetStatusReporter(msr)
+		testcases := []struct {
+			name            string
+			config          *conf.C
+			setup           setupFunc
+			iterations      int
+			assertIteration postIterationAssertFunc
+		}{
+			{
+				name: "no failureThreshold: status DEGRADED after first error",
+				config: newConfig(t, map[string]interface{}{
+					"module":     mockModuleName,
+					"metricsets": []string{mockMetricSetName},
+					"period":     "100ms",
+					"hosts":      []string{"testhost"},
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will immediately error out
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(fetchError).Once()
 
-			moduleWrapper, err := NewWrapperForMetricSet(aModule, metricSets[0], WithMetricSetInfo())
-			require.NoError(t, err)
+					// expect the error to be propagated via the pushReporter
+					pushReporter.On("Error", fetchError).Return(true).Once()
+					// expect the status degraded to be set
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+				},
+				iterations:      1,
+				assertIteration: nil,
+			},
+			{
+				name: "no failureThreshold: status DEGRADED after first error, reset to Running after first successful fetch",
+				config: newConfig(t, map[string]interface{}{
+					"module":     mockModuleName,
+					"metricsets": []string{mockMetricSetName},
+					"period":     "100ms",
+					"hosts":      []string{"testhost"},
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will immediately error out 3 times
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(fetchError).Times(3)
+					// fetcher will never error again afterwards
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(nil)
+					// expect the error to be propagated via the pushReporter
+					pushReporter.On("Error", fetchError).Return(true).Times(3)
+					// expect the status degraded to be set 3 times
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Times(3)
+					// expect the status Running to be set once fetch recovers
+					statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Twice()
+				},
+				iterations: 5,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 3:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i >= 3:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream set to running at iteration %d", i)
+					}
+				},
+			},
+			{
+				name: "failureThreshold = 3: status DEGRADED at the 3rd error",
+				config: newConfig(t, map[string]interface{}{
+					"module":           mockModuleName,
+					"metricsets":       []string{mockMetricSetName},
+					"period":           "100ms",
+					"hosts":            []string{"testhost"},
+					"failureThreshold": 3,
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will immediately error out 3 times in a row
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(fetchError).Times(3)
+					// expect the error to be propagated via the pushReporter at every iteration
+					pushReporter.On("Error", fetchError).Return(true).Times(3)
+					// expect the status degraded to be set
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+				},
+				iterations: 3,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 2:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i == 2:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
+					}
+				},
+			},
+			{
+				name: "failureThreshold = 3: status HEALTHY after 2 errors, 1 success and 2 more errors, DEGRADED at the 3rd consecutive error",
+				config: newConfig(t, map[string]interface{}{
+					"module":           mockModuleName,
+					"metricsets":       []string{mockMetricSetName},
+					"period":           "100ms",
+					"hosts":            []string{"testhost"},
+					"failureThreshold": 3,
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will error out 2 times in a row
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(fetchError).Times(2)
+					// fetcher will then succeed once
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(nil).Once()
+					// fetcher will error out 3 more times in a row
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(fetchError).Times(3)
 
-			// run metricset synchronously
-			wrappedMetricSet := moduleWrapper.MetricSets()[0]
-			for i := 0; i < tc.iterations; i++ {
-				wrappedMetricSet.fetch(context.TODO(), mr)
-				if tc.assertIteration != nil {
-					tc.assertIteration(t, i, wrappedMetricSet, mrf, mpr, msr)
+					// expect the error to be propagated via the pushReporter at every failing iteration
+					pushReporter.On("Error", fetchError).Return(true).Times(5)
+					// expect the status running to be set when there's no error returned by the fetcher at the 3rd iteration
+					statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
+					// expect the status degraded to be set only once
+					statusReporter.On("UpdateStatus", status.Degraded, mock.AnythingOfType("string")).Once()
+				},
+				iterations: 6,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 2:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i >= 2 && i < 5:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i == 5:
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream not yet degraded at iteration %d", i)
+					}
+				},
+			},
+			{
+				name: "failureThreshold = 0: stream status update never become DEGRADED",
+				config: newConfig(t, map[string]interface{}{
+					"module":           mockModuleName,
+					"metricsets":       []string{mockMetricSetName},
+					"period":           "100ms",
+					"hosts":            []string{"testhost"},
+					"failureThreshold": 0,
+				}),
+				setup: func(t *testing.T, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					// fetcher will error out 9 times in a row
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(fetchError).Times(9)
+					// fetcher will then succeed once
+					fetcher.On("Fetch", fetchCtx, pushReporter).Return(nil).Once()
+
+					// expect the error to be propagated via the pushReporter at every failing iteration
+					pushReporter.On("Error", fetchError).Return(true).Times(9)
+					// expect the status running to be set when there's no error returned by the fetcher at the 10th iteration
+					statusReporter.On("UpdateStatus", status.Running, mock.AnythingOfType("string")).Once()
+				},
+				iterations: 10,
+				assertIteration: func(t *testing.T, i int, msWrapper *metricSetWrapper, fetcher *mockReportingFetcherWithContext, pushReporter *mockPushReporterV2, statusReporter *mockStatusReporter) {
+					t.Logf("Assertion after iteration %d", i)
+					switch {
+					case i < 9:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					case i == 9:
+						assert.Truef(t, statusReporter.AssertNotCalled(t, "UpdateStatus", status.Degraded, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+						assert.Truef(t, statusReporter.AssertCalled(t, "UpdateStatus", status.Running, mock.AnythingOfType("string")), "stream degraded at iteration %d", i)
+					}
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Setup mock push reporter
+				mpr := new(mockPushReporterV2)
+
+				// Setup mock fetcher
+				mrf := new(mockReportingFetcherWithContext)
+
+				// Setup mock StatusReporter
+				msr := new(mockStatusReporter)
+
+				//Setup mock reporter (ensure proper handling of intermediate calls, no functional value here)
+				mr := new(mockReporter)
+				mr.On("StartFetchTimer").Return()
+				mr.On("V2").Return(mpr)
+
+				// assert mocks expectations
+				t.Cleanup(func() {
+					mock.AssertExpectationsForObjects(t, mrf, mr, mpr, msr)
+				})
+
+				// setup mocks before starting the test
+				if tc.setup != nil {
+					tc.setup(t, mrf, mpr, msr)
 				}
-			}
-		})
-	}
+
+				// add metricset in registry
+				r := mb.NewRegister()
+				err := r.AddMetricSet(mockModuleName, mockMetricSetName, func(base mb.BaseMetricSet) (mb.MetricSet, error) {
+					mrf.BaseMetricSet = base
+					return mrf, nil
+				})
+				require.NoError(t, err)
+
+				aModule, metricSets, err := mb.NewModule(tc.config, r)
+				require.NoError(t, err)
+
+				// Set the mock status reporter
+				aModule.SetStatusReporter(msr)
+
+				moduleWrapper, err := NewWrapperForMetricSet(aModule, metricSets[0], WithMetricSetInfo())
+				require.NoError(t, err)
+
+				// run metricset synchronously
+				wrappedMetricSet := moduleWrapper.MetricSets()[0]
+				for i := 0; i < tc.iterations; i++ {
+					wrappedMetricSet.fetch(context.TODO(), mr)
+					if tc.assertIteration != nil {
+						tc.assertIteration(t, i, wrappedMetricSet, mrf, mpr, msr)
+					}
+				}
+			})
+		}
+	})
 }
 
 func newConfig(t testing.TB, moduleConfig interface{}) *conf.C {

--- a/metricbeat/mb/module/wrapper_internal_test.go
+++ b/metricbeat/mb/module/wrapper_internal_test.go
@@ -315,6 +315,12 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 
 				// run metricset synchronously
 				wrappedMetricSet := moduleWrapper.MetricSets()[0]
+
+				t.Cleanup(func() {
+					// release stats structure across testcases
+					releaseStats(wrappedMetricSet.stats)
+				})
+
 				for i := 0; i < tc.iterations; i++ {
 					wrappedMetricSet.fetch(context.TODO(), mr)
 					if tc.assertIteration != nil {
@@ -537,6 +543,12 @@ func TestWrapperHandleFetchErrorSync(t *testing.T) {
 
 				// run metricset synchronously
 				wrappedMetricSet := moduleWrapper.MetricSets()[0]
+
+				t.Cleanup(func() {
+					// release stats structure across testcases
+					releaseStats(wrappedMetricSet.stats)
+				})
+
 				for i := 0; i < tc.iterations; i++ {
 					wrappedMetricSet.fetch(context.TODO(), mr)
 					if tc.assertIteration != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
Add configurable failure threshold before reporting streams as degraded

With this change it is possible to configure a threshold for the number of consecutive errors that may happen while fetching metrics for a given stream before the stream gets marked as DEGRADED.
To configure such threshold, add a `"failure_threshold": <n>` to a module configuration block.
Depending on the value of `<n>` the threshold will be configured in different ways:
- n == 0: status reporting for the stream has been disabled, the stream will never become DEGRADED no matter how many errors are encountered while fetching metrics
- n==1 or `failure_threshold` not specified: backward compatible behavior, the stream will become DEGRADED at the first error encountered
- n > 1: stream will become DEGRADED after at least `n` consecutive errors have been encountered

When a `fetch` operation completes without errors the consecutive errors counter is reset and the stream is set to HEALTHY.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

No disruptive user impact since not specifying the new configuration key maintains the previous behavior

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/issues/5332

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
