### PR TITLE
[chore][metricbeat/test_diskio]: fix CI failure

### DIFF
--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -252,6 +252,7 @@ class Test(metricbeat.BaseTest):
             if 'error' not in evt:
                 if "system" in evt:
                     diskio = evt["system"]["diskio"]
+                    self.remove_fields(diskio, ["serial_number"])
                     self.assert_fields_for_platform(SYSTEM_DISKIO, diskio)
                 elif "host" in evt:
                     host_disk = evt["host"]["disk"]

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -141,6 +141,7 @@ class BaseTest(TestCase):
             if field in event:
                 del event[fields]
 
+
 def supported_versions(path):
     """
     Returns variants information as expected by parameterized_class,

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -139,7 +139,7 @@ class BaseTest(TestCase):
     def remove_fields(self, event: object, fields: list):
         for field in fields:
             if field in event:
-                del event[fields]
+                del event[field]
 
 
 def supported_versions(path):

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -136,6 +136,10 @@ class BaseTest(TestCase):
 
         self.assert_fields_are_documented(evt)
 
+    def remove_fields(self, event: object, fields: list):
+        for field in fields:
+            if field in event:
+                del event[fields]
 
 def supported_versions(path):
     """


### PR DESCRIPTION
For `diskio` metricset, https://github.com/elastic/beats/blob/bfaa70fa9ae857322d4deaf9e870ba8b84fbd8e3/metricbeat/module/system/diskio/diskio.go#L118-L120
`serial_number` field is set, conditionally. 

This error has likely originated by bumping [PR](https://github.com/elastic/elastic-agent-system-metrics/pull/178/) on https://github.com/elastic/elastic-agent-system-metrics. 

I think, for such conditional fields, our best case is to remove them from `event` or else they trigger a failure.

We cannot add such fields at https://github.com/elastic/beats/blob/bfaa70fa9ae857322d4deaf9e870ba8b84fbd8e3/metricbeat/module/system/test_system.py#L70-L76 
as that would also result in a failure, because the `serial_number` can be absent for some devices.

This is needed to unblock https://github.com/elastic/beats/pull/41524