### PR TITLE
Known issue 8.15.x field limit reached on Metricbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,10 @@ https://github.com/elastic/beats/compare/v8.15.2\...v8.15.3[View commits]
 
 - Memory usage is not correctly limited by the number of events actively in the memory queue, but rather the maximum size of the memory queue regardless of usage. {issue}41355[41355]
 
+*Affecting Metricbeat*
+
+- Metrics can be lost when using Metricbeat due to the total fields limit of the Metricbeat index template. We recommend increasing the `index.mapping.total_fields.limit` setting of the Metricbeat index template to 11000 and perform a rollover of the Metricbeat data stream. If you've customized the name of the index associated to Metricbeat, apply the same change accordingly.
+
 ==== Breaking changes
 
 *Filebeat*


### PR DESCRIPTION
Docs change

## Proposed commit message

Metricbeat 8.15.0 or more recent can drop documents/metrics just enabling the System module (others might also be affected).

Metricbeat index templates reached a quite high number of fields and the indexing of few dynamic fields can make it trip the field limit of 10000.

## Workaround

#### Option I

1.  Update **metricbeat.yml**:
    ```
        setup.template.settings:
            index.mapping.total_fields.limit: 11000
    ```
2.  Force the installation of the index template following [this](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-template.html#load-template-manually) steps and adding the extra **-E setup.template.overwrite=true**
3.  Rollover (in case you already started Metricbeat) using **POST metricbeat-8.15.<VERSION>/_rollover**

#### Option 2

Note: if you're using **setup.template.overwrite**, this solution is likely not applicable - you have to go with **Option I**.

1.  Update the Index Template setting **index.mapping.total_fields.limit** of Metricbeat raising it to 11000.
2.  Rollover (in case you already started Metricbeat) using **POST metricbeat-8.15.<VERSION>/_rollover**


## Author's Checklist

- [ ] Needs backport to 8.15.x and 8.16.x

## Logs

Logs when this is happening

```
{"log.level":"warn","@timestamp":"2024-11-06T18:12:56.490Z","log.logger":"elasticsearch","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch.(*Client).applyItemStatus","file.name":"elasticsearch/client.go","file.line":488},"message":"Cannot index event (status=400): dropping event! Look at the event log to view the event and cause.","service.name":"metricbeat","ecs.version":"1.6.0"}

(status=400): {\"type\":\"document_parsing_exception\",\"reason\":\"[1:3999] failed to parse: Limit of total fields [10000] has been exceeded while adding new fields [19]\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Limit of total fields [10000] has been exceeded while adding new fields [19]\"}}
```
