### PR TITLE
[libbeat] fix: aws & openstack metadata conflict in add_cloud_metadata processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -115,9 +115,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Ensure Elasticsearch output can always recover from network errors {pull}40794[40794]
 - Add `translate_ldap_attribute` processor. {pull}41472[41472]
 - Remove unnecessary debug logs during idle connection teardown {issue}40824[40824]
-
-*Libbeat*
-
 - Fix incorrect cloud provider identification in add_cloud_metadata processor using provider priority mechanism {pull}41636[41636]
 
 *Auditbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -116,6 +116,10 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add `translate_ldap_attribute` processor. {pull}41472[41472]
 - Remove unnecessary debug logs during idle connection teardown {issue}40824[40824]
 
+*Libbeat*
+
+- Fix incorrect cloud provider identification in add_cloud_metadata processor using provider priority mechanism {pull}41636[41636]
+
 *Auditbeat*
 
 

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -21,7 +21,10 @@ The following cloud providers are supported:
 - Openstack Nova
 - Hetzner Cloud
 
-NOTE: `huawei` is an alias for `openstack`. Huawei cloud runs on OpenStack platform, and when
+[float]
+==== Special notes
+
+`huawei` is an alias for `openstack`. Huawei cloud runs on OpenStack platform, and when
 viewed from a metadata API standpoint, it is impossible to differentiate it from OpenStack. If you know that your
 deployments run on Huawei Cloud exclusively, and you wish to have `cloud.provider` value as `huawei`, you can achieve
 this by overwriting the value using an `add_fields` processor.
@@ -29,6 +32,15 @@ this by overwriting the value using an `add_fields` processor.
 The Alibaba Cloud and Tencent cloud providers are disabled by default, because
 they require to access a remote host. The `providers` setting allows users to
 select a list of default providers to query.
+
+Cloud providers tend to maintain metadata services compliant with other cloud providers.
+For example, Openstack supports https://docs.openstack.org/nova/latest/user/metadata.html#ec2-compatible-metadata[EC2 compliant metadat service].
+This makes it impossible to differentiate cloud provider (`cloud.provider` property) with auto discovery (when `providers` configuration is omitted).
+The processor implementation incorporates a priority mechanism where priority is given to some providers over others when there are multiple successful metadata results.
+Currently, `aws/ec2` and `azure` has priority over any other provider as their metadata retrival rely on SDKs.
+
+[float]
+==== Configurations
 
 The simple configuration below enables the processor.
 
@@ -71,12 +83,25 @@ List of names the `providers` setting supports:
 - "tencent", or "qcloud" for Tencent Cloud (disabled by default).
 - "hetzner" for Hetzner Cloud (enabled by default).
 
+For example, configuration below only utilize `aws` metadata retrival mechanism,
+
+[source,yaml]
+-------------------------------------------------------------------------------
+processors:
+  - add_cloud_metadata:
+      providers:
+        aws
+-------------------------------------------------------------------------------
+
 The third optional configuration setting is `overwrite`. When `overwrite` is
 `true`, `add_cloud_metadata` overwrites existing `cloud.*` fields (`false` by
 default).
 
 The `add_cloud_metadata` processor supports SSL options to configure the http
 client used to query cloud metadata. See <<configuration-ssl>> for more information.
+
+[float]
+==== Provided metadata
 
 The metadata that is added to events varies by hosting provider. Below are
 examples for each of the supported providers.

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -37,7 +37,8 @@ Cloud providers tend to maintain metadata services compliant with other cloud pr
 For example, Openstack supports https://docs.openstack.org/nova/latest/user/metadata.html#ec2-compatible-metadata[EC2 compliant metadat service].
 This makes it impossible to differentiate cloud provider (`cloud.provider` property) with auto discovery (when `providers` configuration is omitted).
 The processor implementation incorporates a priority mechanism where priority is given to some providers over others when there are multiple successful metadata results.
-Currently, `aws/ec2` and `azure` has priority over any other provider as their metadata retrival rely on SDKs.
+Currently, `aws/ec2` and `azure` have priority over any other provider as their metadata retrival rely on SDKs.
+The expectation here is that SDK methods should fail if run in an environment not configured accordingly (ex:- missing configurations or credentials).
 
 [float]
 ==== Configurations

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
@@ -27,7 +27,7 @@ import (
 var alibabaCloudMetadataFetcher = provider{
 	Name: "alibaba-ecs",
 
-	Local: false,
+	DefaultEnabled: false,
 
 	Create: func(_ string, c *conf.C) (metadataFetcher, error) {
 		ecsMetadataHost := "100.100.100.200"

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -65,7 +65,7 @@ var NewEC2Client func(cfg awssdk.Config) EC2Client = func(cfg awssdk.Config) EC2
 var ec2MetadataFetcher = provider{
 	Name: "aws-ec2",
 
-	Local: true,
+	DefaultEnabled: true,
 
 	Create: func(_ string, config *conf.C) (metadataFetcher, error) {
 		ec2Schema := func(m map[string]interface{}) mapstr.M {

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
@@ -62,7 +62,7 @@ var NewClusterClient func(clientFactory *armcontainerservice.ClientFactory) *arm
 var azureVMMetadataFetcher = provider{
 	Name: "azure-compute",
 
-	Local: true,
+	DefaultEnabled: true,
 
 	Create: func(_ string, config *conf.C) (metadataFetcher, error) {
 		azMetadataURI := "/metadata/instance/compute?api-version=2021-02-01"

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
@@ -28,7 +28,7 @@ import (
 var doMetadataFetcher = provider{
 	Name: "digitalocean",
 
-	Local: true,
+	DefaultEnabled: true,
 
 	Create: func(provider string, config *conf.C) (metadataFetcher, error) {
 		doSchema := func(m map[string]interface{}) mapstr.M {

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce.go
@@ -45,7 +45,7 @@ type Server struct {
 var gceMetadataFetcher = provider{
 	Name: "google-gce",
 
-	Local: true,
+	DefaultEnabled: true,
 
 	Create: func(provider string, config *conf.C) (metadataFetcher, error) {
 		gceMetadataURI := "/computeMetadata/v1/?recursive=true&alt=json"

--- a/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud.go
@@ -32,8 +32,8 @@ const (
 // Hetzner Cloud Metadata Service
 // Document https://docs.hetzner.cloud/#server-metadata
 var hetznerMetadataFetcher = provider{
-	Name:  "hetzner-cloud",
-	Local: true,
+	Name:           "hetzner-cloud",
+	DefaultEnabled: true,
 	Create: func(_ string, c *conf.C) (metadataFetcher, error) {
 		hetznerSchema := func(m map[string]interface{}) mapstr.M {
 			m["service"] = mapstr.M{

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
@@ -33,15 +33,15 @@ const (
 // OpenStack Nova Metadata Service
 // Document https://docs.openstack.org/nova/latest/user/metadata-service.html
 var openstackNovaMetadataFetcher = provider{
-	Name:   "openstack-nova",
-	Local:  true,
-	Create: buildOpenstackNovaCreate("http"),
+	Name:           "openstack-nova",
+	DefaultEnabled: true,
+	Create:         buildOpenstackNovaCreate("http"),
 }
 
 var openstackNovaSSLMetadataFetcher = provider{
-	Name:   "openstack-nova-ssl",
-	Local:  true,
-	Create: buildOpenstackNovaCreate("https"),
+	Name:           "openstack-nova-ssl",
+	DefaultEnabled: true,
+	Create:         buildOpenstackNovaCreate("https"),
 }
 
 func buildOpenstackNovaCreate(scheme string) func(provider string, c *conf.C) (metadataFetcher, error) {

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
@@ -27,7 +27,7 @@ import (
 var qcloudMetadataFetcher = provider{
 	Name: "tencent-qcloud",
 
-	Local: false,
+	DefaultEnabled: false,
 
 	Create: func(_ string, c *conf.C) (metadataFetcher, error) {
 		qcloudMetadataHost := "metadata.tencentyun.com"

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -208,6 +209,11 @@ func (p *addCloudMetadata) fetchMetadata() *result {
 		}
 	}
 
+	return priorityResult(responses, p.logger)
+}
+
+// priorityResult is a helper to extract correct result (if multiple exist) based on priorityProviders
+func priorityResult(responses []result, logger *logp.Logger) *result {
 	if len(responses) == 0 {
 		return nil
 	}
@@ -216,7 +222,7 @@ func (p *addCloudMetadata) fetchMetadata() *result {
 		return &responses[0]
 	}
 
-	p.logger.Debugf("add_cloud_metadata: multiple responses were received, filtering based on priority")
+	logger.Debugf("add_cloud_metadata: multiple responses were received, filtering based on priority")
 	var prioritizedResponses []result
 	for _, r := range responses {
 		if slices.Contains(priorityProviders, r.provider) {
@@ -227,7 +233,7 @@ func (p *addCloudMetadata) fetchMetadata() *result {
 	// simply send the first entry of prioritized response
 	if len(prioritizedResponses) != 0 {
 		pr := prioritizedResponses[0]
-		p.logger.Debugf("add_cloud_metadata: using provider %s metadata based on priority", pr.provider)
+		logger.Debugf("add_cloud_metadata: using provider %s metadata based on priority", pr.provider)
 		return &pr
 	}
 

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -75,7 +75,7 @@ var cloudMetaProviders = map[string]provider{
 
 // priorityProviders contains providers which has priority over others.
 // Metadata of these are derived using cloud provider SDKs, making them valid over metadata derived over well-known IP
-// or other common endpoints. For example, Openstack supports EC2 compliant metadata endpoint. Thus adding possiblity to
+// or other common endpoints. For example, Openstack supports EC2 compliant metadata endpoint. Thus adding possibility to
 // conflict metadata between EC2/AWS and Openstack.
 var priorityProviders = []string{
 	"aws", "ec2", "azure",

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -34,8 +34,9 @@ type provider struct {
 	// Name contains a long name of provider and service metadata is fetched from.
 	Name string
 
-	// Local Set to true if local IP is accessed only
-	Local bool
+	// DefaultEnabled allows to control whether metadata provider should be enabled by default
+	// Set to true if metadata access is enabled by default for the provider
+	DefaultEnabled bool
 
 	// Create returns an actual metadataFetcher
 	Create func(string, *conf.C) (metadataFetcher, error)
@@ -93,7 +94,7 @@ func providersFilter(configList providerList, allProviders map[string]provider) 
 	if len(configList) == 0 {
 		return func(name string) bool {
 			ff, ok := allProviders[name]
-			return ok && ff.Local
+			return ok && ff.DefaultEnabled
 		}
 	}
 	return func(name string) (ok bool) {

--- a/libbeat/processors/add_cloud_metadata/providers_test.go
+++ b/libbeat/processors/add_cloud_metadata/providers_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func init() {
@@ -116,6 +117,62 @@ func TestProvidersFilter(t *testing.T) {
 
 			sort.Strings(actual)
 			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func Test_priorityResult(t *testing.T) {
+	tLogger := logp.NewLogger("add_cloud_metadata testing")
+	awsRsp := result{
+		provider: "aws",
+		metadata: map[string]interface{}{
+			"id": "a-1",
+		},
+	}
+
+	openStackRsp := result{
+		provider: "openstack",
+		metadata: map[string]interface{}{
+			"id": "o-1",
+		},
+	}
+
+	digitaloceanRsp := result{
+		provider: "digitalocean",
+		metadata: map[string]interface{}{
+			"id": "d-1",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		collected []result
+		want      *result
+	}{
+		{
+			name:      "Empty results returns nil",
+			collected: []result{},
+			want:      nil,
+		},
+		{
+			name:      "Single result returns the same",
+			collected: []result{awsRsp},
+			want:      &awsRsp,
+		},
+		{
+			name:      "Priority result wins",
+			collected: []result{openStackRsp, awsRsp},
+			want:      &awsRsp,
+		},
+		{
+			name:      "For non-priority result, response order wins",
+			collected: []result{openStackRsp, digitaloceanRsp},
+			want:      &openStackRsp,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, priorityResult(tt.collected, tLogger))
 		})
 	}
 }

--- a/libbeat/processors/add_cloud_metadata/providers_test.go
+++ b/libbeat/processors/add_cloud_metadata/providers_test.go
@@ -34,7 +34,7 @@ func init() {
 func TestProvidersFilter(t *testing.T) {
 	var allLocal []string
 	for name, ff := range cloudMetaProviders {
-		if ff.Local {
+		if ff.DefaultEnabled {
 			allLocal = append(allLocal, name)
 		}
 	}


### PR DESCRIPTION
## Proposed commit message

This PR fixes incorrect recognition of EC2/AWS cloud provider as Openstack. The root cause was the common metadata endpoints used by both AWS SDK & Openstack logic. And this happened when IMDSv2 is disabled in AWS. 

I attempted to migrate Openstack logic to another metadata implementation. However, I did not manage to create a fully functioning setup to validate the implementation. Hence, this PR focuses on a priority-based solution where priority is given for SDK-backed metadata fetching over HTTP endpoints. 

Current priory providers are - aws/ec2 & azure 

Note - I have done a minor refactoring to rename `Local` struct property to `DefaultEnabled` to make intention clearer
 
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

You need a local copy and an EC2 instance to validate the fix.

- Enable metadata service in EC2 instance and make IMDSv2 optional 
- Build a beats (ex:- metricbeat) module based on this libbeat change
- Copy the beats module to EC2 instance and start the module with add_cloud_metadata processor enabled & logs set to debug for more in-depth logs & no provider enforced
- Observe logs and see data (ex:- system monitoring) through Kibana to validate cloud provider detection

## Related issues

- Closes #13816

## Screenshots

-IMDSv2 disabled 

![Screenshot 2024-11-13 at 11 45 38 AM](https://github.com/user-attachments/assets/9f24e48a-f3fa-423f-882b-96acfe3b53cf)

- Processor enabled but no provider enforced 

![Screenshot 2024-11-13 at 11 50 24 AM](https://github.com/user-attachments/assets/18f87d97-9c4f-4555-9aa0-a4767cb32b20)

- Debug logs on multi-result and priority based selection

![Screenshot 2024-11-13 at 11 44 47 AM](https://github.com/user-attachments/assets/d87cff12-d961-43ca-97ac-3948d19e7e29)


- Cloud provider detected correctly,

![Screenshot 2024-11-13 at 11 45 13 AM](https://github.com/user-attachments/assets/c101de63-31ad-4e7d-a3a5-6e6f7c7da63c)



