### PR TITLE
libbeat: increase total_fields.limit to 12500

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/beats/compare/v8.15.3\...v8.15.4[View commits]
 *Affecting all Beats*
 
 - Fix issue where old data could be saved in the memory queue after acknowledgment, increasing memory use. {pull}41356[41356]
+- Fix metrics not being ingested, due to "Limit of total fields [10000] has been exceeded while adding new fields [...]". The total fields limit has been increased to 12500. No significant performance impact on Elasticsearch is anticipated. {pull}41640[41640]
 
 *Filebeat*
 
@@ -132,7 +133,7 @@ https://github.com/elastic/beats/compare/v8.15.0\...v8.15.1[View commits]
 
 *Affecting all Beats*
 
-- Beats Docker images do not log to stderr by default. The workaround is to pass the CLI flag `-e` or to set `logging.to_stderr: true` in the configuration file. 
+- Beats Docker images do not log to stderr by default. The workaround is to pass the CLI flag `-e` or to set `logging.to_stderr: true` in the configuration file.
 - Beats stop publishing data after a network error unless restarted. Avoid upgrading to 8.15.1. Affected Beats log `Get \"https://${ELASTICSEARCH_HOST}:443\": context canceled` repeatedly. {issue}40705{40705}
 - Memory usage is not correctly limited by the number of events actively in the memory queue, but rather the maximum size of the memory queue regardless of usage. {issue}41355[41355]
 

--- a/libbeat/template/load_test.go
+++ b/libbeat/template/load_test.go
@@ -170,7 +170,7 @@ func TestFileLoader_Load(t *testing.T) {
 							"refresh_interval": "5s",
 							"mapping": mapstr.M{
 								"total_fields": mapstr.M{
-									"limit": 10000,
+									"limit": defaultTotalFieldsLimit,
 								},
 							},
 							"query": mapstr.M{

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -35,7 +35,7 @@ import (
 var (
 	// Defaults used in the template
 	defaultDateDetection           = false
-	defaultTotalFieldsLimit        = 10000
+	defaultTotalFieldsLimit        = 12500
 	defaultMaxDocvalueFieldsSearch = 200
 
 	defaultFields []string


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

libbeat: increase index template total_fields.limit to 12500

It increased the `index.mapping.total_fields.limit` from `10000` to `12500` in order to avoid ingestion failures caused by too many field in the index. Since 8.15.0 the limit started to be hit.
The field count being exceeded is on the index, counting all mapped fields and the dynamic fields. That's why a small event might trigger the error, the event contains new fields to be mapped which would exceed the total field limit if mapped.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

Whereas the `index.mapping.total_fields.limit` might impact Elasticsearch's performance, [see here](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-settings-limit.html), we do not anticipate any significant impact.

## How to test this PR locally

### check for errors
Follow the tutorial for system metrics integration: https://YOUR_CLUSTER/app/home#/tutorial/systemMetrics

 - configure the elasticsearch output 
 - the run the following
```
./metricbeat modules enable system
./metricbeat setup
./metricbeat -e | grep -e 'has been exceeded while adding new fields'
```
 - you should not see any log

### check the new index settings

```
GET /metricbeat-9.0.0/_settings
```

you should get an answer like:
```json
{
  ".ds-metricbeat-9.0.0-2024.11.14-000001": {
    "settings": {
      "index": {
        "mapping": {
          "total_fields": {
            "limit": "12500"
          }
        },
```

without the fix, it'd be `10000`.

## Related issues

- Relates https://github.com/elastic/beats/pull/41614

## Logs

error log before the fix:

```
# failed to parse: Limit of total fields [10000] has been exceeded while adding new fields [1]\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Limit of total fields [10000] has been exceeded while adding new fields [1]\"

{"log.level":"warn","@timestamp":"2024-08-13T14:04:46.708Z","log.logger":"elasticsearch","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch.(*Client).applyItemStatus","file.name":"elasticsearch/client.go","file.line":489},"message":"Cannot index event publisher.Event{Content:beat.Event{Timestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Meta:null, Fields:null, Private:interface {}(nil), TimeSeries:false}, Flags:0x0, Cache:publisher.EventCache{m:mapstr.M(nil)}, EncodedEvent:(*elasticsearch.encodedEvent)(0xc003933700)} (status=400): {\"type\":\"document_parsing_exception\",\"reason\":\"[1:2756] failed to parse: Limit of total fields [10000] has been exceeded while adding new fields [1]\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Limit of total fields [10000] has been exceeded while adding new fields [1]\"}}, dropping event!","service.name":"metricbeat","log.type":"event","ecs.version":"1.6.0"}
```
