### PR TITLE
metricbeat: add integration TestIndexTotalFieldsLimitNotReached

### DIFF
--- a/x-pack/metricbeat/tests/integration/setup_integration_test.go
+++ b/x-pack/metricbeat/tests/integration/setup_integration_test.go
@@ -68,7 +68,7 @@ metricbeat.config.modules:
 		"-E", "output.file.enabled=false")
 	procState, err := metricbeat.Process.Wait()
 	require.NoError(t, err, "metricbeat setup failed")
-	require.Equal(t, 0, procState.ExitCode(), "metircbeat setup failed: incorrect exit code")
+	require.Equal(t, 0, procState.ExitCode(), "metricbeat setup failed: incorrect exit code")
 
 	// generate an event with dynamically mapped fields
 	fields := map[string]string{}
@@ -95,7 +95,7 @@ metricbeat.config.modules:
 	require.NoError(t, err, "could not send request to send event to ES")
 	defer resp.Body.Close()
 
-	failuremsg := fmt.Sprintf("filed to ingest events with %d new fields. If this test fails it likely means the current `index.mapping.total_fields.limit` for metricbeat index (%s) is close to be reached. Check the logs to see why the envent was not ingested", totalFields, index)
+	failuremsg := fmt.Sprintf("failed to ingest events with %d new fields. If this test fails it likely means the current `index.mapping.total_fields.limit` for metricbeat index (%s) is close to be reached. Check the logs to see why the event was not ingested", totalFields, index)
 	if !assert.Equal(t, http.StatusCreated, resp.StatusCode, failuremsg) {
 		t.Logf("event sent: %s", string(event))
 

--- a/x-pack/metricbeat/tests/integration/setup_integration_test.go
+++ b/x-pack/metricbeat/tests/integration/setup_integration_test.go
@@ -1,0 +1,88 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+	"github.com/elastic/beats/v7/libbeat/version"
+)
+
+func TestIndexTotalFieldsLimitNotReached(t *testing.T) {
+	cfg := `
+metricbeat:
+logging:
+  level: debug
+metricbeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: false
+`
+	metricbeat := integration.NewBeat(t, "metricbeat", "../../metricbeat.test")
+	metricbeat.WriteConfigFile(cfg)
+	esURL := integration.GetESURL(t, "http")
+	kURL, _ := integration.GetKibana(t)
+
+	metricbeat.Start("setup",
+		"--index-management",
+		"-E", "setup.kibana.protocol=http",
+		"-E", "setup.kibana.host="+kURL.Hostname(),
+		"-E", "setup.kibana.port="+kURL.Port(),
+		"-E", "output.elasticsearch.protocol=http",
+		"-E", "output.elasticsearch.hosts=['"+esURL.String()+"']",
+		"-E", "output.file.enabled=false")
+	procState, err := metricbeat.Process.Wait()
+	require.NoError(t, err, "metricbeat setup failed")
+	require.Equal(t, 0, procState.ExitCode(), "metircbeat setup failed: incorrect exit code")
+
+	// generate an event with dynamically mapped fields
+	fields := map[string]string{}
+	totalFields := 500
+	for i := range totalFields {
+		fields[fmt.Sprintf("a-label-%d", i)] = fmt.Sprintf("some-value-%d", i)
+	}
+	event, err := json.Marshal(map[string]any{
+		"@timestamp":        time.Now().Format(time.RFC3339),
+		"kubernetes.labels": fields,
+	})
+	require.NoError(t, err, "could not marshal event to send to ES")
+
+	ver, _, _ := strings.Cut(version.GetDefaultVersion(), "-")
+	index := "metricbeat-" + ver
+	endpoint := fmt.Sprintf("%s/%s/_doc", esURL.String(), index)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(event))
+	require.NoError(t, err, "could not create request to send event to ES")
+	r.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(r)
+	require.NoError(t, err, "could not send request to send event to ES")
+	defer resp.Body.Close()
+
+	failuremsg := fmt.Sprintf("filed to ingest events with %d new fields. If this test fails it likely means the current `index.mapping.total_fields.limit` for metricbeat index (%s) is close to be reached. Check the logs to see why the envent was not ingested", totalFields, index)
+	if !assert.Equal(t, http.StatusCreated, resp.StatusCode, failuremsg) {
+		t.Logf("event sent: %s", string(event))
+
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "could not read response body")
+		t.Logf("ES ingest event reponse: %s", string(respBody))
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
metricbeat: add integration TestIndexTotalFieldsLimitNotReached

The new integration test TestIndexTotalFieldsLimitNotReached ensures events with at least 500 new dynamically mapped fields can be ingested.
```

This new test will start failing when the metricbeat mapping has increased to the point it isn't possible to add a new event with 500 dynamically mapped fields. It should act as a safe guard to prevent us from releasing a version where the static mapping is too close to the total fields limit.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

- N/A

## How to test this PR locally

 - build `x-pack/metricbeat`
   - `cd x-pack/metricbeat`
   - `go build .`
 - adjust `metricbeat.yml` to point to your stack and make sure to include `setup.kibana.host`
 - run `./metricbeat setup`
 - generate an event with 500 dynamic fields. Just use the same for loop the test uses
 - ingest the event:
```
POST metricbeat-9.0.0/_doc
{ 
   ...
}
```
 - it should succeed
 - change the [`index.mapping.total_fields.limit`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-settings-limit.html) for the metricbeat index template:
   - go to `your-kibna/app/management/data/index_management/templates/metricbeat-9.0.0`
   - `metricbeat-9.0.0` > Manage > Edit > 3 Index settings
   - change `index.mapping.total_fields.limit` to 10000:
```json
"mapping": {
      "total_fields": {
        "limit": "10000"
      }
```
 - rollover the index
```
POST metricbeat-9.0.0/_rollover
```
 - try to ingest the same event again, you should get an error like:
```
{
  "error": {
    "root_cause": [
      {
        "type": "document_parsing_exception",
        "reason": "[1:378] failed to parse: Limit of total fields [10000] has been exceeded while adding new fields [11]"
      }
    ],
    "type": "document_parsing_exception",
    "reason": "[1:378] failed to parse: Limit of total fields [10000] has been exceeded while adding new fields [11]",
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "Limit of total fields [10000] has been exceeded while adding new fields [11]"
    },
    "failure_store": "not_enabled"
  },
  "status": 400
}
```


## Related issues

- Relates https://github.com/elastic/beats/pull/41614
