### PR TITLE
Add breaking change for Filebeat removed 'docker' input

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -2844,6 +2844,7 @@ https://github.com/elastic/beats/compare/v7.17.0\...v8.0.0[View commits]
 - Add `while_pattern` type to multiline reader. {pull}19662[19662]
 - auditd dataset: Use `process.args` to store program arguments instead of `auditd.log.aNNN` fields. {pull}29601[29601]
 - Remove deprecated old `awscloudwatch` input name. {pull}29844[29844]
+- Remove `docker` input. Please use `filestream` input with `container` parser or `container` input. {pull}28817[28817]
 
 *Metricbeat*
 


### PR DESCRIPTION
Adds the removed `docker` input for Filebeat to the [Beats 8.0 breaking changes list](https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-8.0.0.html). See the related issue for details.

Closes: https://github.com/elastic/beats/issues/41624

---

![creen2](https://github.com/user-attachments/assets/602d6d7f-cc50-473e-971b-fbefd158b716)

