### PR TITLE
Add known issue for AWS S3 input (target 8.16)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,21 @@ https://github.com/elastic/beats/compare/v8.15.4\...v8.16.0[View commits]
 
 ==== Known issues
 
+*Filebeat*
+
+- The AWS S3 input polling mode is not working when the S3 bucket is not in the `us-east-1` default region. This also impacts all AWS integrations and any custom AWS log integration which uses the `aws-s3` input polling mode. When using Filebeat, please add a `default_region` configuration with the region of the S3 bucket. For example:
++
+["source","yaml"]
+----
+filebeat.inputs:
+- type: aws-s3
+  enabled: true
+  credential_profile_name: elastic-observability
+  default_region: us-east-2
+  number_of_workers: 5
+  bucket_arn: 'arn:aws:s3:::test1'
+----
+
 *Metricbeat*
 
 - Metrics can be lost when using Metricbeat due to the total fields limit of the Metricbeat index template. We recommend increasing the `index.mapping.total_fields.limit` setting of the Metricbeat index template to 12500 and perform a rollover of the Metricbeat data stream. If you've customized the name of the index associated to Metricbeat, apply the same change accordingly.
@@ -312,6 +327,19 @@ https://github.com/elastic/beats/compare/v8.14.3\...v8.15.0[View commits]
 *Filebeat*
 
 - The Azure EventHub input in Filebeat is not found when running on Windows. Please refrain from upgrading to 8.15. See {issue}40608[40608] for details.
+
+- The AWS S3 input polling mode is not working when the S3 bucket is not in the `us-east-1` default region. This also impacts all AWS integrations and any custom AWS log integration which uses the `aws-s3` input polling mode. When using Filebeat, please add a `default_region` configuration with the region of the S3 bucket. For example:
++
+["source","yaml"]
+----
+filebeat.inputs:
+- type: aws-s3
+  enabled: true
+  credential_profile_name: elastic-observability
+  default_region: us-east-2
+  number_of_workers: 5
+  bucket_arn: 'arn:aws:s3:::test1'
+----
 
 *Metricbeat*
 


### PR DESCRIPTION
Adds a known issue to the 8.16 and 8.15 [release notes](https://www.elastic.co/guide/en/beats/libbeat/master/release-notes-8.16.0.html) for the AWS S3 input.

---

![Screenshot 2024-11-21 at 9 49 59 AM](https://github.com/user-attachments/assets/e3ea6f62-456d-4b95-ba13-99f176430422)
