### PR TITLE
add metricbeat receiver

### DIFF
--- a/x-pack/filebeat/fbreceiver/factory.go
+++ b/x-pack/filebeat/fbreceiver/factory.go
@@ -31,7 +31,10 @@ func createDefaultConfig() component.Config {
 }
 
 func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.Config, consumer consumer.Logs) (receiver.Logs, error) {
-	cfg := baseCfg.(*Config)
+	cfg, ok := baseCfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("could not convert otel config to filebeat config")
+	}
 
 	settings := cmd.FilebeatSettings(Name)
 	globalProcs, err := processors.NewPluginConfigFromList(defaultProcessors())
@@ -59,7 +62,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("error getting %s creator:%w", Name, err)
 	}
 
-	return &filebeatReceiver{beat: &b.Beat, beater: fbBeater}, nil
+	return &filebeatReceiver{beat: &b.Beat, beater: fbBeater, logger: set.Logger}, nil
 }
 
 func defaultProcessors() []mapstr.M {

--- a/x-pack/filebeat/fbreceiver/receiver.go
+++ b/x-pack/filebeat/fbreceiver/receiver.go
@@ -10,21 +10,28 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
 )
 
 type filebeatReceiver struct {
 	beat   *beat.Beat
 	beater beat.Beater
+	logger *zap.Logger
 }
 
 func (fb *filebeatReceiver) Start(ctx context.Context, host component.Host) error {
 	go func() {
-		_ = fb.beater.Run(fb.beat)
+		fb.logger.Info("starting filebeat receiver")
+		err := fb.beater.Run(fb.beat)
+		if err != nil {
+			fb.logger.Error("filebeat receiver run error", zap.Error(err))
+		}
 	}()
 	return nil
 }
 
 func (fb *filebeatReceiver) Shutdown(ctx context.Context) error {
+	fb.logger.Info("stopping filebeat receiver")
 	fb.beater.Stop()
 	return nil
 }

--- a/x-pack/metricbeat/mbreceiver/config.go
+++ b/x-pack/metricbeat/mbreceiver/config.go
@@ -1,0 +1,25 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mbreceiver
+
+import "fmt"
+
+// Config is config settings for filebeat receiver.  The structure of
+// which is the same as the filebeat.yml configuration file.
+type Config struct {
+	Beatconfig map[string]interface{} `mapstructure:",remain"`
+}
+
+// Validate checks if the configuration in valid
+func (cfg *Config) Validate() error {
+	if len(cfg.Beatconfig) == 0 {
+		return fmt.Errorf("Configuration is required")
+	}
+	_, prs := cfg.Beatconfig["metricbeat"]
+	if !prs {
+		return fmt.Errorf("Configuration key 'metricbeat' is required")
+	}
+	return nil
+}

--- a/x-pack/metricbeat/mbreceiver/config.go
+++ b/x-pack/metricbeat/mbreceiver/config.go
@@ -6,8 +6,8 @@ package mbreceiver
 
 import "fmt"
 
-// Config is config settings for filebeat receiver.  The structure of
-// which is the same as the filebeat.yml configuration file.
+// Config is config settings for metricbeat receiver.  The structure of
+// which is the same as the metricbeat.yml configuration file.
 type Config struct {
 	Beatconfig map[string]interface{} `mapstructure:",remain"`
 }

--- a/x-pack/metricbeat/mbreceiver/config_test.go
+++ b/x-pack/metricbeat/mbreceiver/config_test.go
@@ -21,7 +21,7 @@ func TestValidate(t *testing.T) {
 			hasError:    true,
 			errorString: "Configuration is required",
 		},
-		"No filebeat section": {
+		"No metricbeat section": {
 			c:           &Config{Beatconfig: map[string]interface{}{"other": map[string]interface{}{}}},
 			hasError:    true,
 			errorString: "Configuration key 'metricbeat' is required",
@@ -35,11 +35,10 @@ func TestValidate(t *testing.T) {
 	for name, tc := range tests {
 		err := tc.c.Validate()
 		if tc.hasError {
-			assert.NotNil(t, err, name)
-			assert.Equal(t, err.Error(), tc.errorString, name)
-		}
-		if !tc.hasError {
-			assert.Nil(t, err, name)
+			assert.NotNilf(t, err, "%s failed, should have had error", name)
+			assert.Equalf(t, err.Error(), tc.errorString, "%s failed, error not equal", name)
+		} else {
+			assert.Nilf(t, err, "%s failed, should not have error", name)
 		}
 	}
 }

--- a/x-pack/metricbeat/mbreceiver/config_test.go
+++ b/x-pack/metricbeat/mbreceiver/config_test.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mbreceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		c           *Config
+		hasError    bool
+		errorString string
+	}{
+		"Empty config": {
+			c:           &Config{Beatconfig: map[string]interface{}{}},
+			hasError:    true,
+			errorString: "Configuration is required",
+		},
+		"No filebeat section": {
+			c:           &Config{Beatconfig: map[string]interface{}{"other": map[string]interface{}{}}},
+			hasError:    true,
+			errorString: "Configuration key 'metricbeat' is required",
+		},
+		"Valid config": {
+			c:           &Config{Beatconfig: map[string]interface{}{"metricbeat": map[string]interface{}{}}},
+			hasError:    false,
+			errorString: "",
+		},
+	}
+	for name, tc := range tests {
+		err := tc.c.Validate()
+		if tc.hasError {
+			assert.NotNil(t, err, name)
+			assert.Equal(t, err.Error(), tc.errorString, name)
+		}
+		if !tc.hasError {
+			assert.Nil(t, err, name)
+		}
+	}
+}

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -26,7 +26,10 @@ func createDefaultConfig() component.Config {
 }
 
 func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.Config, consumer consumer.Logs) (receiver.Logs, error) {
-	cfg := baseCfg.(*Config)
+	cfg, ok := baseCfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("could not convert otel config to metricbeat config")
+	}
 	settings := cmd.MetricbeatSettings(Name)
 	settings.ElasticLicensed = true
 

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -1,0 +1,58 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mbreceiver
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/metricbeat/beater"
+	"github.com/elastic/beats/v7/metricbeat/cmd"
+)
+
+const (
+	Name = "metricbeatreceiver"
+)
+
+func createDefaultConfig() component.Config {
+	return &Config{}
+}
+
+func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.Config, consumer consumer.Logs) (receiver.Logs, error) {
+	cfg := baseCfg.(*Config)
+	settings := cmd.MetricbeatSettings(Name)
+	settings.ElasticLicensed = true
+
+	b, err := instance.NewBeatReceiver(settings, cfg.Beatconfig, consumer, set.Logger.Core())
+	if err != nil {
+		return nil, fmt.Errorf("error creating %s: %w", Name, err)
+	}
+
+	beatCreator := beater.DefaultCreator()
+
+	beatConfig, err := b.BeatConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error getting beat config: %w", err)
+	}
+
+	mbBeater, err := beatCreator(&b.Beat, beatConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error getting %s creator:%w", Name, err)
+	}
+
+	return &metricbeatReceiver{beat: &b.Beat, beater: mbBeater}, nil
+}
+
+func NewFactory() receiver.Factory {
+	return receiver.NewFactory(
+		component.MustNewType(Name),
+		createDefaultConfig,
+		receiver.WithLogs(createReceiver, component.StabilityLevelAlpha))
+}

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -50,7 +50,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("error getting %s creator:%w", Name, err)
 	}
 
-	return &metricbeatReceiver{beat: &b.Beat, beater: mbBeater}, nil
+	return &metricbeatReceiver{beat: &b.Beat, beater: mbBeater, logger: set.Logger}, nil
 }
 
 func NewFactory() receiver.Factory {

--- a/x-pack/metricbeat/mbreceiver/receiver.go
+++ b/x-pack/metricbeat/mbreceiver/receiver.go
@@ -1,0 +1,30 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mbreceiver
+
+import (
+	"context"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+type metricbeatReceiver struct {
+	beat   *beat.Beat
+	beater beat.Beater
+}
+
+func (mb *metricbeatReceiver) Start(ctx context.Context, host component.Host) error {
+	go func() {
+		_ = mb.beater.Run(mb.beat)
+	}()
+	return nil
+}
+
+func (mb *metricbeatReceiver) Shutdown(ctx context.Context) error {
+	mb.beater.Stop()
+	return nil
+}

--- a/x-pack/metricbeat/mbreceiver/receiver.go
+++ b/x-pack/metricbeat/mbreceiver/receiver.go
@@ -10,21 +10,28 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
 )
 
 type metricbeatReceiver struct {
 	beat   *beat.Beat
 	beater beat.Beater
+	logger *zap.Logger
 }
 
 func (mb *metricbeatReceiver) Start(ctx context.Context, host component.Host) error {
 	go func() {
-		_ = mb.beater.Run(mb.beat)
+		mb.logger.Info("starting metricbeat receiver")
+		err := mb.beater.Run(mb.beat)
+		if err != nil {
+			mb.logger.Error("metricbeat receiver run error", zap.Error(err))
+		}
 	}()
 	return nil
 }
 
 func (mb *metricbeatReceiver) Shutdown(ctx context.Context) error {
+	mb.logger.Info("stopping metricbeat receiver")
 	mb.beater.Stop()
 	return nil
 }

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
@@ -59,12 +59,12 @@ func TestNewReceiver(t *testing.T) {
 		countLogs = countLogs + ld.LogRecordCount()
 		return nil
 	})
-	assert.NoError(t, err, "Error creating log consumer")
+	require.NoError(t, err, "Error creating log consumer")
 
 	r, err := createReceiver(context.Background(), receiverSettings, &config, logConsumer)
-	assert.NoErrorf(t, err, "Error creating receiver. Logs:\n %s", zapLogs.String())
+	require.NoErrorf(t, err, "Error creating receiver. Logs:\n %s", zapLogs.String())
 	err = r.Start(context.Background(), nil)
-	assert.NoError(t, err, "Error starting metricbeatreceiver")
+	require.NoError(t, err, "Error starting metricbeatreceiver")
 
 	ch := make(chan bool, 1)
 	timer := time.NewTimer(120 * time.Second)
@@ -88,5 +88,5 @@ func TestNewReceiver(t *testing.T) {
 	}
 found:
 	err = r.Shutdown(context.Background())
-	assert.NoError(t, err, "Error shutting down metricbeatreceiver")
+	require.NoError(t, err, "Error shutting down metricbeatreceiver")
 }

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mbreceiver
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestNewReceiver(t *testing.T) {
+	config := Config{
+		Beatconfig: map[string]interface{}{
+			"metricbeat": map[string]interface{}{
+				"modules": []map[string]interface{}{
+					{
+						"module":     "system",
+						"enabled":    true,
+						"period":     "1s",
+						"processes":  []string{".*"},
+						"metricsets": []string{"cpu"},
+					},
+				},
+			},
+			"output": map[string]interface{}{
+				"otelconsumer": map[string]interface{}{},
+			},
+			"logging": map[string]interface{}{
+				"level": "debug",
+				"selectors": []string{
+					"*",
+				},
+			},
+			"path.home": t.TempDir(),
+		},
+	}
+
+	var zapLogs bytes.Buffer
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(&zapLogs),
+		zapcore.DebugLevel)
+
+	receiverSettings := receiver.Settings{}
+	receiverSettings.Logger = zap.New(core)
+
+	var countLogs int
+	logConsumer, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
+		countLogs = countLogs + ld.LogRecordCount()
+		return nil
+	})
+	assert.NoError(t, err, "Error creating log consumer")
+
+	r, err := createReceiver(context.Background(), receiverSettings, &config, logConsumer)
+	assert.NoErrorf(t, err, "Error creating receiver. Logs:\n %s", zapLogs.String())
+	err = r.Start(context.Background(), nil)
+	assert.NoError(t, err, "Error starting metricbeatreceiver")
+
+	ch := make(chan bool, 1)
+	timer := time.NewTimer(120 * time.Second)
+	defer timer.Stop()
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for tick := ticker.C; ; {
+		select {
+		case <-timer.C:
+			t.Fatalf("consumed logs didn't increase\nCount: %d\nLogs: %s\n", countLogs, zapLogs.String())
+		case <-tick:
+			tick = nil
+			go func() { ch <- countLogs > 0 }()
+		case v := <-ch:
+			if v {
+				goto found
+			}
+			tick = ticker.C
+		}
+	}
+found:
+	err = r.Shutdown(context.Background())
+	assert.NoError(t, err, "Error shutting down metricbeatreceiver")
+}


### PR DESCRIPTION
## Proposed commit message

This adds a metricbeat OTel receiver.  This is necessary to run beats as OTel receivers.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None.  You have to import beats into your OTel project and instantiate a

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```shell
cd x-pack/metricbeat/mbreceiver
go test -v .
```

## Related issues

- Closes #41691

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
