### PR TITLE
Cleanup states from registrar when the files are removed

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -182,6 +182,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix the "No such input type exist: 'salesforce'" error on the Windows/AIX platform. {pull}41664[41664]
 - Fix missing key in streaming input logging. {pull}41600[41600]
 - Improve S3 object size metric calculation to support situations where Content-Length is not available. {pull}41755[41755]
+- Effectively clean states from removed files when clean_removed is set to True {pull}41747[41747]
 
 *Heartbeat*
 

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -39,6 +39,7 @@ type State struct {
 	Meta           map[string]string `json:"meta" struct:"meta,omitempty"`
 	FileStateOS    file.StateOS      `json:"FileStateOS" struct:"FileStateOS"`
 	IdentifierName string            `json:"identifier_name" struct:"identifier_name"`
+	CleanRemoved   bool              `json:"clean_removed" struct:"clean_removed"`
 }
 
 // NewState creates a new file state

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -449,7 +449,10 @@ func (h *Harvester) onMessage(
 	// Check if json fields exist
 	var jsonFields mapstr.M
 	if f, ok := fields["json"]; ok {
-		jsonFields = f.(mapstr.M)
+		jsonFields, ok = f.(mapstr.M)
+		if !ok {
+			h.logger.Debugf("Error converting jsonFields from state %v", state.IdentifierName)
+		}
 	}
 
 	var meta mapstr.M

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -166,6 +166,11 @@ func NewHarvester(
 		h.state.TTL = h.config.CleanInactive
 	}
 
+	// Enable/disable cleaning removed files from the registrar
+	if h.config.CleanRemoved {
+		h.state.CleanRemoved = h.config.CleanRemoved
+	}
+
 	// Add outlet signal so harvester can also stop itself
 	return h, nil
 }


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
-->

## Proposed commit message

Cleanup states from registrar when the files are removed and no longer related to any input
Fixes unbounded registry file growth and increased memory usage on long running machines with a lot of input churn

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues


- Fixes #13140
 
## Use cases

Ensures registry file doesn't keep growing forever which causes additional disk space usage, as well increased mem/cpu usage. The fact that the registry never gets cleaned up in a number of scenarios like running on a Kubernetes cluster, constitues a slow memory leak (memory usage increases over time with long running nodes, especially when there is a lot of pod/input churn)

## Screenshots

![image](https://github.com/user-attachments/assets/74a59849-5e03-42ff-b0ce-52ec4d40f2b7)

