### PR TITLE
[AWS] [S3] fix: improve object size metric calculation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -181,6 +181,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add support for Access Points in the `aws-s3` input. {pull}41495[41495]
 - Fix the "No such input type exist: 'salesforce'" error on the Windows/AIX platform. {pull}41664[41664]
 - Fix missing key in streaming input logging. {pull}41600[41600]
+- Improve S3 object size metric calculation to support situations where Content-Length is not available. {pull}41755[41755]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/awss3/metrics.go
+++ b/x-pack/filebeat/input/awss3/metrics.go
@@ -210,6 +210,8 @@ func newInputMetrics(id string, optionalParent *monitoring.Registry, maxWorkers 
 type monitoredReader struct {
 	reader         io.Reader
 	totalBytesRead *monitoring.Uint
+
+	trackBytes int64
 }
 
 func newMonitoredReader(r io.Reader, metric *monitoring.Uint) *monitoredReader {
@@ -219,5 +221,10 @@ func newMonitoredReader(r io.Reader, metric *monitoring.Uint) *monitoredReader {
 func (m *monitoredReader) Read(p []byte) (int, error) {
 	n, err := m.reader.Read(p)
 	m.totalBytesRead.Add(uint64(n))
+	m.trackBytes += int64(n)
 	return n, err
+}
+
+func (m *monitoredReader) GetTrackedBytes() int64 {
+	return m.trackBytes
 }

--- a/x-pack/filebeat/input/awss3/metrics.go
+++ b/x-pack/filebeat/input/awss3/metrics.go
@@ -36,7 +36,7 @@ func init() {
 // currentTime returns the current time. This exists to allow unit tests
 // simulate the passage of time.
 func currentTime() time.Time {
-	clock := clockValue.Load().(clock)
+	clock, _ := clockValue.Load().(clock)
 	return clock.Now()
 }
 

--- a/x-pack/filebeat/input/awss3/s3_objects.go
+++ b/x-pack/filebeat/input/awss3/s3_objects.go
@@ -213,7 +213,7 @@ func (p *s3ObjectProcessor) ProcessS3Object(log *logp.Logger, eventCallback func
 	}
 
 	// finally obtain total bytes of the object through metered reader
-	p.metrics.s3ObjectSizeInBytes.Update(mReader.GetTrackedBytes())
+	p.metrics.s3ObjectSizeInBytes.Update(mReader.totalBytesReadCurrent)
 
 	return nil
 }

--- a/x-pack/filebeat/input/awss3/s3_objects.go
+++ b/x-pack/filebeat/input/awss3/s3_objects.go
@@ -51,7 +51,6 @@ type s3ObjectProcessor struct {
 
 type s3DownloadedObject struct {
 	body        io.ReadCloser
-	length      int64
 	contentType string
 	metadata    map[string]interface{}
 }
@@ -142,9 +141,9 @@ func (p *s3ObjectProcessor) ProcessS3Object(log *logp.Logger, eventCallback func
 	defer s3Obj.body.Close()
 
 	p.s3Metadata = s3Obj.metadata
-	p.metrics.s3ObjectSizeInBytes.Update(s3Obj.length)
 
-	reader, err := p.addGzipDecoderIfNeeded(newMonitoredReader(s3Obj.body, p.metrics.s3BytesProcessedTotal))
+	mReader := newMonitoredReader(s3Obj.body, p.metrics.s3BytesProcessedTotal)
+	reader, err := p.addGzipDecoderIfNeeded(mReader)
 	if err != nil {
 		return fmt.Errorf("failed checking for gzip content: %w", err)
 	}
@@ -213,6 +212,9 @@ func (p *s3ObjectProcessor) ProcessS3Object(log *logp.Logger, eventCallback func
 			time.Since(start).Nanoseconds(), err)
 	}
 
+	// finally obtain total bytes of the object through metered reader
+	p.metrics.s3ObjectSizeInBytes.Update(mReader.GetTrackedBytes())
+
 	return nil
 }
 
@@ -241,7 +243,6 @@ func (p *s3ObjectProcessor) download() (obj *s3DownloadedObject, err error) {
 
 	s := &s3DownloadedObject{
 		body:        getObjectOutput.Body,
-		length:      *getObjectOutput.ContentLength,
 		contentType: ctType,
 		metadata:    meta,
 	}

--- a/x-pack/filebeat/input/awss3/s3_objects_test.go
+++ b/x-pack/filebeat/input/awss3/s3_objects_test.go
@@ -289,6 +289,76 @@ func TestS3ObjectProcessor(t *testing.T) {
 	})
 }
 
+func TestProcessObjectMetricCollection(t *testing.T) {
+	logger := logp.NewLogger("testing-s3-processor-metrics")
+
+	tests := []struct {
+		name        string
+		filename    string
+		contentType string
+		objectSize  int64
+	}{
+		{
+			name:        "simple text - octet-stream",
+			filename:    "testdata/log.txt",
+			contentType: "application/octet-stream",
+			objectSize:  18,
+		},
+		{
+			name:        "json text",
+			filename:    "testdata/log.json",
+			contentType: "application/json",
+			objectSize:  199,
+		},
+		{
+			name:        "gzip with json text",
+			filename:    "testdata/multiline.json.gz",
+			contentType: "application/x-gzip",
+			objectSize:  175,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// given
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
+
+			ctrl, ctx := gomock.WithContext(ctx, t)
+			defer ctrl.Finish()
+
+			s3Event, s3Resp := newS3Object(t, test.filename, test.contentType)
+			mockS3API := NewMockS3API(ctrl)
+			gomock.InOrder(
+				mockS3API.EXPECT().
+					GetObject(gomock.Any(), gomock.Eq("us-east-1"), gomock.Eq(s3Event.S3.Bucket.Name), gomock.Eq(s3Event.S3.Object.Key)).
+					Return(s3Resp, nil),
+			)
+
+			// metric recorder with zero workers
+			metricRecorder := newInputMetrics(test.name, nil, 0)
+			objFactory := newS3ObjectProcessorFactory(metricRecorder, mockS3API, nil, backupConfig{})
+			objHandler := objFactory.Create(ctx, s3Event)
+
+			// when
+			err := objHandler.ProcessS3Object(logger, func(_ beat.Event) {})
+
+			// then
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(1), metricRecorder.s3ObjectsRequestedTotal.Get())
+			require.Equal(t, uint64(0), metricRecorder.s3ObjectsInflight.Get())
+
+			values := metricRecorder.s3ObjectSizeInBytes.Values()
+			require.Equal(t, 1, len(values))
+
+			// since we processed a single object, total and current process size is same
+			require.Equal(t, test.objectSize, values[0])
+			require.Equal(t, uint64(test.objectSize), metricRecorder.s3BytesProcessedTotal.Get())
+		})
+	}
+}
+
 func testProcessS3Object(t testing.TB, file, contentType string, numEvents int, selectors ...fileSelectorConfig) []beat.Event {
 	return _testProcessS3Object(t, file, contentType, numEvents, false, selectors)
 }


### PR DESCRIPTION
## Proposed commit message

This fixes a bug with Cloudflare logpush integration, which uses the S3 input. 

https://github.com/elastic/beats/pull/40775 introduced a feature introducing s3_object_size_in_bytes histogram. Internally it utilized S3 SDK's GetObjectOutput instances' ContentLength property [^1].  In code level (SDK internally), this is derived using Content-Length header [^2].

It seems that Cloudflare R2 (API compatible with S3) could omit Content-Length header [^3]. Hence, I have improved how we derive the `s3_object_size_in_bytes` metric by avoiding using Content-Length backed method. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Build filebeat from this branch
- Enable monitoring endpoints
- Configure buckets with data and observe metrics in monitoring endpoint

## Screenshots

See metric comparison with proposed collection method (before removing content length usage). Tracked total bytes are same as content length. 

Handling validated for gzip

![image](https://github.com/user-attachments/assets/2b5ec1c2-8431-4447-b517-27bf7d60714f)

Handling validated for plain text

![image](https://github.com/user-attachments/assets/6325d481-22e4-4952-bb11-c9987bc896a5)


---

[^1]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_ResponseSyntax
[^2]: https://github.com/aws/aws-sdk-go-v2/blob/service/s3/v1.60.1/service/s3/deserializers.go#L5477-L5484
[^3]: https://community.cloudflare.com/t/no-content-length-header-when-serving-plaintext-from-r2/565521 
