### PR TITLE
[Draft] [aws] [s3] Introduce ignore_older & start_timestamp for s3 input

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -115,6 +115,7 @@ filebeat.inputs:
 - Add support to source AWS cloudwatch logs from linked accounts. {pull}41188[41188]
 - Jounrald input now supports filtering by facilities. {pull}41061[41061]
 - Add support to include AWS cloudwatch linked accounts when using log_group_name_prefix to define log group names. {pull}41206[41206]
+- AWS S3 input registry cleanup for untracked s3 objects. {pull}41694[41694]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -346,6 +346,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add ability to remove request trace logs from http_endpoint input. {pull}40005[40005]
 - Add ability to remove request trace logs from entityanalytics input. {pull}40004[40004]
 - Update CEL mito extensions to v1.16.0. {pull}41727[41727]
+- Introduce ignore older and start timestamp filters for AWS S3 input. {pull}41804[41804]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -124,6 +124,16 @@
   # Controls deletion of objects after backing them up
   #delete_after_backup: false
 
+  # Ignore bucket entries older than the given timespan.
+  # Timespan is calculated from current time to processing object's last modified timestamp.
+  # This is disabled by default(value 0) and can be configured to a time duration like "48h" or "2h30m".
+  #ignore_older: 0
+
+  # Accept bucket entries with last modified timestamp newer than the given timestamp.
+  # Accepts a timestamp in YYYY-MM-DDTHH:MM:SSZ format and default is empty.
+  # For example, "2024-11-20T20:00:00Z" (UTC) or "2024-11-20T22:30:00+02:30" (with zone offset).
+  #start_timestamp:
+
 #------------------------------ AWS CloudWatch input --------------------------------
 # Beta: Config options for AWS CloudWatch input
 #- type: aws-cloudwatch

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -85,6 +85,8 @@ Please see <<aws-credentials-config,Configuration parameters>> for alternate AWS
 The `aws-s3` input supports the following configuration options plus the
 <<{beatname_lc}-input-{type}-common-options>> described later.
 
+NOTE: For time durations, valid time units are - "ns", "us" (or "µs"), "ms", "s", "m", "h". For example, "2h"
+
 [float]
 ==== `api_timeout`
 
@@ -568,6 +570,27 @@ Naming of the backed up files can be controlled with `backup_to_bucket_prefix`.
 Controls whether fully processed files will be deleted from the bucket.
 
 Can only be used together with the backup functionality.
+
+[float]
+==== `ignore_older`
+
+Parameter accepts a time duration in which bucket entries are accepted for processing.
+This is disabled by default allowing any entry in the bucket to be accepted.
+It is recommended to define a suitable duration so that the input processing can avoid tracking older bucket entries, which reduces the memory usage.
+
+If defined, bucket entries are processed only if their last modified timestamp falls within the time duration specified, relative to the current time.
+However, when `start_timestamp` is defined, the initial processing will include all bucket entries upto the defined timestamp.
+
+[float]
+==== `start_timestamp`
+
+Accepts a timestamp in `YYYY-MM-DDTHH:MM:SSZ` format from which bucket inputs are accepted for processing.
+This is disabled by default allowing any entry in the bucket to be accepted.
+
+This parameter is useful when configuring the input for the first time and wants to ingest logs from a desired time onwards.
+Timestamp can be configured to be in the future, providing flexibility.
+
+NOTE: It is recommended to update this value when updating or restarting filebeat
 
 [float]
 === AWS Permissions

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -747,7 +747,7 @@ filebeat.modules:
 #------------------------------- Coredns Module -------------------------------
 - module: coredns
   # Fileset for native deployment
-  log:
+  log: 
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -756,7 +756,7 @@ filebeat.modules:
 
 #----------------------------- Crowdstrike Module -----------------------------
 - module: crowdstrike
-
+  
   falcon:
     enabled: false
 
@@ -827,7 +827,7 @@ filebeat.modules:
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy
   # Fileset for native deployment
-  log:
+  log: 
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -4238,7 +4238,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-
+  
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 
@@ -4415,7 +4415,7 @@ setup.template.settings:
 
 # ======================== Data Stream Lifecycle (DSL) =========================
 
-# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch.
+# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch. 
 # These settings are mutually exclusive with ILM settings which are not supported in Serverless projects.
 
 # Enable DSL support. Valid values are true, or false.
@@ -4423,7 +4423,7 @@ setup.template.settings:
 
 # Set the lifecycle policy name or pattern. For DSL, this name must match the data stream that the lifecycle is for.
 # The default data stream pattern is filebeat-%{[agent.version]}"
-# The template string `%{[agent.version]}` will resolve to the current stack version.
+# The template string `%{[agent.version]}` will resolve to the current stack version. 
 # The other possible template value is `%{[beat.name]}`.
 #setup.dsl.data_stream_pattern: "filebeat-%{[agent.version]}"
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -747,7 +747,7 @@ filebeat.modules:
 #------------------------------- Coredns Module -------------------------------
 - module: coredns
   # Fileset for native deployment
-  log: 
+  log:
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -756,7 +756,7 @@ filebeat.modules:
 
 #----------------------------- Crowdstrike Module -----------------------------
 - module: crowdstrike
-  
+
   falcon:
     enabled: false
 
@@ -827,7 +827,7 @@ filebeat.modules:
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy
   # Fileset for native deployment
-  log: 
+  log:
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -3018,6 +3018,16 @@ filebeat.inputs:
   # Controls deletion of objects after backing them up
   #delete_after_backup: false
 
+  # Ignore bucket entries older than the given timespan.
+  # Timespan is calculated from current time to processing object's last modified timestamp.
+  # This is disabled by default(value 0) and can be configured to a time duration like "48h" or "2h30m".
+  #ignore_older: 0
+
+  # Accept bucket entries with last modified timestamp newer than the given timestamp.
+  # Accepts a timestamp in YYYY-MM-DDTHH:MM:SSZ format and default is empty.
+  # For example, "2024-11-20T20:00:00Z" (UTC) or "2024-11-20T22:30:00+02:30" (with zone offset).
+  #start_timestamp:
+
 #------------------------------ AWS CloudWatch input --------------------------------
 # Beta: Config options for AWS CloudWatch input
 #- type: aws-cloudwatch
@@ -4228,7 +4238,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-  
+
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 
@@ -4405,7 +4415,7 @@ setup.template.settings:
 
 # ======================== Data Stream Lifecycle (DSL) =========================
 
-# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch. 
+# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch.
 # These settings are mutually exclusive with ILM settings which are not supported in Serverless projects.
 
 # Enable DSL support. Valid values are true, or false.
@@ -4413,7 +4423,7 @@ setup.template.settings:
 
 # Set the lifecycle policy name or pattern. For DSL, this name must match the data stream that the lifecycle is for.
 # The default data stream pattern is filebeat-%{[agent.version]}"
-# The template string `%{[agent.version]}` will resolve to the current stack version. 
+# The template string `%{[agent.version]}` will resolve to the current stack version.
 # The other possible template value is `%{[beat.name]}`.
 #setup.dsl.data_stream_pattern: "filebeat-%{[agent.version]}"
 

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -25,26 +25,33 @@ import (
 	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 )
 
+// todo
+// add ignore_older & start_timestamp
+// must be disabled by default
+// but if start_timestamp is empty, then be cautious as
+// - Fresh startup need a full read
+// - But if registry is non-empty, we can assume we have read some data
+
 type config struct {
 	APITimeout         time.Duration        `config:"api_timeout"`
-	VisibilityTimeout  time.Duration        `config:"visibility_timeout"`
-	SQSWaitTime        time.Duration        `config:"sqs.wait_time"`         // The max duration for which the SQS ReceiveMessage call waits for a message to arrive in the queue before returning.
-	SQSMaxReceiveCount int                  `config:"sqs.max_receive_count"` // The max number of times a message should be received (retried) before deleting it.
-	SQSScript          *scriptConfig        `config:"sqs.notification_parsing_script"`
-	QueueURL           string               `config:"queue_url"`
-	RegionName         string               `config:"region"`
-	BucketARN          string               `config:"bucket_arn"`
+	AWSConfig          awscommon.ConfigAWS  `config:",inline"`
 	AccessPointARN     string               `config:"access_point_arn"`
-	NonAWSBucketName   string               `config:"non_aws_bucket_name"`
+	BackupConfig       backupConfig         `config:",inline"`
+	BucketARN          string               `config:"bucket_arn"`
 	BucketListInterval time.Duration        `config:"bucket_list_interval"`
 	BucketListPrefix   string               `config:"bucket_list_prefix"`
-	NumberOfWorkers    int                  `config:"number_of_workers"`
-	AWSConfig          awscommon.ConfigAWS  `config:",inline"`
 	FileSelectors      []fileSelectorConfig `config:"file_selectors"`
-	ReaderConfig       readerConfig         `config:",inline"` // Reader options to apply when no file_selectors are used.
+	NonAWSBucketName   string               `config:"non_aws_bucket_name"`
+	NumberOfWorkers    int                  `config:"number_of_workers"`
 	PathStyle          bool                 `config:"path_style"`
 	ProviderOverride   string               `config:"provider"`
-	BackupConfig       backupConfig         `config:",inline"`
+	QueueURL           string               `config:"queue_url"`
+	ReaderConfig       readerConfig         `config:",inline"` // Reader options to apply when no file_selectors are used.
+	RegionName         string               `config:"region"`
+	SQSMaxReceiveCount int                  `config:"sqs.max_receive_count"` // The max number of times a message should be received (retried) before deleting it.
+	SQSScript          *scriptConfig        `config:"sqs.notification_parsing_script"`
+	SQSWaitTime        time.Duration        `config:"sqs.wait_time"` // The max duration for which the SQS ReceiveMessage call waits for a message to arrive in the queue before returning.
+	VisibilityTimeout  time.Duration        `config:"visibility_timeout"`
 }
 
 func defaultConfig() config {

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -147,7 +147,7 @@ func (c *config) Validate() error {
 	if c.StartTimestamp != "" {
 		_, err := time.Parse(time.RFC3339, c.StartTimestamp)
 		if err != nil {
-			return fmt.Errorf("invalid input for start_timestamp: %v", err)
+			return fmt.Errorf("invalid input for start_timestamp: %w", err)
 		}
 	}
 
@@ -304,6 +304,7 @@ func (c config) sqsConfigModifier(o *sqs.Options) {
 		o.EndpointOptions.UseFIPSEndpoint = awssdk.FIPSEndpointStateEnabled
 	}
 	if c.AWSConfig.Endpoint != "" {
+		//nolint:staticcheck // not changing through this PR
 		o.EndpointResolver = sqs.EndpointResolverFromURL(c.AWSConfig.Endpoint)
 	}
 }

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -596,6 +596,39 @@ func TestConfig(t *testing.T) {
 			expectedErr: "backup_to_bucket_prefix cannot be the same as bucket_list_prefix, this will create an infinite loop",
 			expectedCfg: nil,
 		},
+		{
+			name:     "validate ignore_older and start_timestamp configurations",
+			s3Bucket: s3Bucket,
+			config: mapstr.M{
+				"bucket_arn":      s3Bucket,
+				"ignore_older":    "24h",
+				"start_timestamp": "2024-11-20T20:00:00Z",
+			},
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket)
+				c.IgnoreOlder = 24 * time.Hour
+				c.StartTimestamp = "2024-11-20T20:00:00Z"
+				return c
+			},
+		},
+		{
+			name:     "ignore_older only accepts valid duration - unit valid with ParseDuration",
+			s3Bucket: s3Bucket,
+			config: mapstr.M{
+				"bucket_arn":   s3Bucket,
+				"ignore_older": "24D",
+			},
+			expectedErr: "time: unknown unit \"D\" in duration \"24D\" accessing 'ignore_older'",
+		},
+		{
+			name:     "start_timestamp accepts a valid timestamp of format - YYYY-MM-DDTHH:MM:SSZ",
+			s3Bucket: s3Bucket,
+			config: mapstr.M{
+				"bucket_arn":      s3Bucket,
+				"start_timestamp": "2024-11-20 20:20:00",
+			},
+			expectedErr: "invalid input for start_timestamp: parsing time \"2024-11-20 20:20:00\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \" 20:20:00\" as \"T\" accessing config",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x-pack/filebeat/input/awss3/s3_filters.go
+++ b/x-pack/filebeat/input/awss3/s3_filters.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package awss3
 
 import (

--- a/x-pack/filebeat/input/awss3/s3_filters.go
+++ b/x-pack/filebeat/input/awss3/s3_filters.go
@@ -94,11 +94,7 @@ func newStartTimestampFilter(start time.Time) *startTimestampFilter {
 }
 
 func (s startTimestampFilter) isValid(objState state) bool {
-	if s.timeStart.Before(objState.LastModified) {
-		return true
-	}
-
-	return false
+	return s.timeStart.Before(objState.LastModified)
 }
 
 func (s startTimestampFilter) getID() string {
@@ -120,11 +116,7 @@ func newOldestTimeFilter(timespan time.Duration) *oldestTimeFilter {
 }
 
 func (s oldestTimeFilter) isValid(objState state) bool {
-	if s.timeOldest.Before(objState.LastModified) {
-		return true
-	}
-
-	return false
+	return s.timeOldest.Before(objState.LastModified)
 }
 
 func (s oldestTimeFilter) getID() string {

--- a/x-pack/filebeat/input/awss3/s3_filters.go
+++ b/x-pack/filebeat/input/awss3/s3_filters.go
@@ -1,0 +1,128 @@
+package awss3
+
+import (
+	"sync"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+const (
+	filterOldestTime = "oldestTimeFilter"
+	filterStartTime  = "startTimeFilter"
+)
+
+// filterProvider provides exposes filters that needs to be applied on derived state.
+// Once configured, retrieve filter applier using getApplierFunc.
+type filterProvider struct {
+	cfg *config
+
+	staticFilters []filter
+	once          sync.Once
+}
+
+func newFilterProvider(cfg *config) *filterProvider {
+	fp := &filterProvider{
+		cfg: cfg,
+	}
+
+	// derive static filters
+	if cfg.StartTimestamp != "" {
+		// note - errors should not occur as this has validated prior reaching here
+		parse, _ := time.Parse(time.RFC3339, cfg.StartTimestamp)
+		fp.staticFilters = append(fp.staticFilters, newStartTimestampFilter(parse))
+	}
+
+	return fp
+}
+
+// getApplierFunc returns aggregated filters valid for the time of retrival.
+// Applier return true if state is valid for processing according to the underlying filter collection.
+func (f *filterProvider) getApplierFunc() func(log *logp.Logger, s state) bool {
+	filters := map[string]filter{}
+
+	if f.cfg.IgnoreOlder != 0 {
+		timeFilter := newOldestTimeFilter(f.cfg.IgnoreOlder)
+		filters[timeFilter.getID()] = timeFilter
+	}
+
+	for _, f := range f.staticFilters {
+		filters[f.getID()] = f
+	}
+
+	f.once.Do(func() {
+		// Ignore the oldest time filter once for initial startup only if start timestamp filter is defined
+		// This allows users to ingest desired data from start time onwards.
+		if filters[filterStartTime] != nil {
+			delete(filters, filterOldestTime)
+		}
+	})
+
+	return func(log *logp.Logger, s state) bool {
+		for _, f := range filters {
+			if !f.isValid(s) {
+				log.Debugf("skipping processing of object '%s' by filter '%s'", s.Key, f.getID())
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+// filter defines the fileter implementation contract
+type filter interface {
+	getID() string
+	isValid(objState state) (valid bool)
+}
+
+// startTimestampFilter - filter out entries based on start time.
+type startTimestampFilter struct {
+	id        string
+	timeStart time.Time
+}
+
+func newStartTimestampFilter(start time.Time) *startTimestampFilter {
+	return &startTimestampFilter{
+		id:        filterStartTime,
+		timeStart: start,
+	}
+}
+
+func (s startTimestampFilter) isValid(objState state) bool {
+	if s.timeStart.Before(objState.LastModified) {
+		return true
+	}
+
+	return false
+}
+
+func (s startTimestampFilter) getID() string {
+	return s.id
+}
+
+// oldestTimeFilter - filter out entries based on acceptable oldest modified time
+type oldestTimeFilter struct {
+	id         string
+	timeOldest time.Time
+}
+
+func newOldestTimeFilter(timespan time.Duration) *oldestTimeFilter {
+	oldest := time.Now().Add(-1 * timespan)
+	return &oldestTimeFilter{
+		id:         filterOldestTime,
+		timeOldest: oldest,
+	}
+}
+
+func (s oldestTimeFilter) isValid(objState state) bool {
+	if s.timeOldest.Before(objState.LastModified) {
+		return true
+	}
+
+	return false
+}
+
+func (s oldestTimeFilter) getID() string {
+	return s.id
+}

--- a/x-pack/filebeat/input/awss3/s3_filters_test.go
+++ b/x-pack/filebeat/input/awss3/s3_filters_test.go
@@ -1,0 +1,178 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awss3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterProvider(t *testing.T) {
+	t.Run("Configuration check", func(t *testing.T) {
+		cfg := config{
+			StartTimestamp: "2024-11-26T21:00:00Z",
+			IgnoreOlder:    10 * time.Minute,
+		}
+
+		fProvider := newFilterProvider(&cfg)
+
+		assert.Equal(t, 1, len(fProvider.staticFilters))
+		assert.Equal(t, filterStartTime, fProvider.staticFilters[0].getID())
+	})
+
+	logger := logp.NewLogger("test-logger")
+
+	tests := []struct {
+		name                string
+		cfg                 config
+		inputState          state
+		runFilterForCount   int
+		expectFilterResults []bool
+	}{
+		{
+			name: "Simple run - all valid result",
+			cfg: config{
+				StartTimestamp: "2024-11-26T21:00:00Z",
+				IgnoreOlder:    10 * time.Minute,
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Now()),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{true},
+		},
+		{
+			name: "Simple run - all invalid result",
+			cfg: config{
+				StartTimestamp: "2024-11-26T21:00:00Z",
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Unix(0, 0)),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{false},
+		},
+		{
+			name:                "Simple run - no filters hence valid result",
+			cfg:                 config{},
+			inputState:          newState("bucket", "key", "eTag", time.Now()),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{true},
+		},
+		{
+			name: "Single filter - ignore old invalid result",
+			cfg: config{
+				IgnoreOlder: 1 * time.Minute,
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Unix(time.Now().Add(-2*time.Minute).Unix(), 0)),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{false},
+		},
+		{
+			name: "Combined filters - ignore old won't affect first run if timestamp is given but will affect thereafter",
+			cfg: config{
+				StartTimestamp: "2024-11-26T21:00:00Z",
+				IgnoreOlder:    10 * time.Minute,
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Unix(1732654860, 0)), // 2024-11-26T21:01:00Z in epoch
+			runFilterForCount:   3,
+			expectFilterResults: []bool{true, false, false},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := newFilterProvider(&test.cfg)
+			results := make([]bool, 0, test.runFilterForCount)
+
+			for i := 0; i < test.runFilterForCount; i++ {
+				applierFunc := provider.getApplierFunc()
+				results = append(results, applierFunc(logger, test.inputState))
+			}
+
+			assert.Equal(t, test.expectFilterResults, results)
+		})
+	}
+}
+
+func Test_startTimestampFilter(t *testing.T) {
+	t.Run("Configuration check", func(t *testing.T) {
+		entry := newState("bucket", "key", "eTag", time.Now())
+
+		oldTimeFilter := newStartTimestampFilter(time.Now().Add(-2 * time.Minute))
+
+		assert.Equal(t, filterStartTime, oldTimeFilter.getID())
+		assert.True(t, oldTimeFilter.isValid(entry))
+	})
+
+	tests := []struct {
+		name      string
+		timeStamp time.Time
+		input     state
+		result    bool
+	}{
+		{
+			name:      "State valid",
+			timeStamp: time.Now().Add(-10 * time.Minute),
+			input:     newState("bucket", "key", "eTag", time.Now()),
+			result:    true,
+		},
+
+		{
+			name:      "State invalid",
+			timeStamp: time.Now(),
+			input:     newState("bucket", "key", "eTag", time.Now().Add(-10*time.Minute)),
+			result:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			timeFilter := newStartTimestampFilter(test.timeStamp)
+			assert.Equal(t, test.result, timeFilter.isValid(test.input))
+		})
+	}
+
+}
+
+func Test_oldestTimeFilter(t *testing.T) {
+	t.Run("configuration check", func(t *testing.T) {
+		duration := time.Duration(1) * time.Second
+		entry := newState("bucket", "key", "eTag", time.Now())
+
+		oldTimeFilter := newOldestTimeFilter(duration)
+
+		assert.Equal(t, filterOldestTime, oldTimeFilter.getID())
+		assert.True(t, oldTimeFilter.isValid(entry))
+	})
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+		input    state
+		result   bool
+	}{
+		{
+			name:     "State valid",
+			duration: time.Duration(1) * time.Minute,
+			input:    newState("bucket", "key", "eTag", time.Now()),
+			result:   true,
+		},
+
+		{
+			name:     "State invalid",
+			duration: time.Duration(1) * time.Minute,
+			input:    newState("bucket", "key", "eTag", time.Now().Add(-10*time.Minute)),
+			result:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			timeFilter := newOldestTimeFilter(test.duration)
+			assert.Equal(t, test.result, timeFilter.isValid(test.input))
+		})
+	}
+
+}

--- a/x-pack/filebeat/input/awss3/s3_filters_test.go
+++ b/x-pack/filebeat/input/awss3/s3_filters_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,14 +30,14 @@ func Test_filterProvider(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		cfg                 config
+		cfg                 *config
 		inputState          state
 		runFilterForCount   int
 		expectFilterResults []bool
 	}{
 		{
 			name: "Simple run - all valid result",
-			cfg: config{
+			cfg: &config{
 				StartTimestamp: "2024-11-26T21:00:00Z",
 				IgnoreOlder:    10 * time.Minute,
 			},
@@ -46,7 +47,7 @@ func Test_filterProvider(t *testing.T) {
 		},
 		{
 			name: "Simple run - all invalid result",
-			cfg: config{
+			cfg: &config{
 				StartTimestamp: "2024-11-26T21:00:00Z",
 			},
 			inputState:          newState("bucket", "key", "eTag", time.Unix(0, 0)),
@@ -55,14 +56,14 @@ func Test_filterProvider(t *testing.T) {
 		},
 		{
 			name:                "Simple run - no filters hence valid result",
-			cfg:                 config{},
+			cfg:                 &config{},
 			inputState:          newState("bucket", "key", "eTag", time.Now()),
 			runFilterForCount:   1,
 			expectFilterResults: []bool{true},
 		},
 		{
 			name: "Single filter - ignore old invalid result",
-			cfg: config{
+			cfg: &config{
 				IgnoreOlder: 1 * time.Minute,
 			},
 			inputState:          newState("bucket", "key", "eTag", time.Unix(time.Now().Add(-2*time.Minute).Unix(), 0)),
@@ -71,7 +72,7 @@ func Test_filterProvider(t *testing.T) {
 		},
 		{
 			name: "Combined filters - ignore old won't affect first run if timestamp is given but will affect thereafter",
-			cfg: config{
+			cfg: &config{
 				StartTimestamp: "2024-11-26T21:00:00Z",
 				IgnoreOlder:    10 * time.Minute,
 			},
@@ -83,7 +84,7 @@ func Test_filterProvider(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			provider := newFilterProvider(&test.cfg)
+			provider := newFilterProvider(test.cfg)
 			results := make([]bool, 0, test.runFilterForCount)
 
 			for i := 0; i < test.runFilterForCount; i++ {

--- a/x-pack/filebeat/input/awss3/s3_input.go
+++ b/x-pack/filebeat/input/awss3/s3_input.go
@@ -8,9 +8,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
-	"sync"
 
 	"github.com/elastic/beats/v7/filebeat/beater"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"

--- a/x-pack/filebeat/input/awss3/s3_input.go
+++ b/x-pack/filebeat/input/awss3/s3_input.go
@@ -115,8 +115,19 @@ func (in *s3PollerInput) runPoll(ctx context.Context) {
 	}
 
 	// Start reading data and wait for its processing to be done
-	in.readerLoop(ctx, workChan)
+	ids, ok := in.readerLoop(ctx, workChan)
 	workerWg.Wait()
+
+	if !ok {
+		in.log.Warn("skipping state registry cleanup as object reading ended with a non-ok return")
+		return
+	}
+
+	// Perform state cleanup operation
+	err := in.states.CleanUp(ids)
+	if err != nil {
+		in.log.Errorf("failed to cleanup states: %v", err.Error())
+	}
 }
 
 func (in *s3PollerInput) workerLoop(ctx context.Context, workChan <-chan state) {
@@ -183,7 +194,10 @@ func (in *s3PollerInput) workerLoop(ctx context.Context, workChan <-chan state) 
 	}
 }
 
-func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) {
+// readerLoop performs the S3 object listing and emit state to work listeners if objet needs to be processed.
+// Returns all tracked state IDs correlates to all tracked S3 objects iff listing is successful.
+// These IDs are intended to be used for state clean-up.
+func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) (knownStateIDSlice []string, ok bool) {
 	defer close(workChan)
 
 	bucketName := getBucketNameFromARN(in.config.getBucketARN())
@@ -202,7 +216,7 @@ func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) 
 				circuitBreaker++
 				if circuitBreaker >= readerLoopMaxCircuitBreaker {
 					in.log.Warnw(fmt.Sprintf("%d consecutive error when paginating listing, breaking the circuit.", circuitBreaker), "error", err)
-					break
+					return nil, false
 				}
 			}
 			// add a backoff delay and try again
@@ -219,6 +233,8 @@ func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) 
 		in.metrics.s3ObjectsListedTotal.Add(uint64(totListedObjects))
 		for _, object := range page.Contents {
 			state := newState(bucketName, *object.Key, *object.ETag, *object.LastModified)
+			knownStateIDSlice = append(knownStateIDSlice, state.ID())
+
 			if in.states.IsProcessed(state) {
 				in.log.Debugw("skipping state.", "state", state)
 				continue
@@ -229,6 +245,8 @@ func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) 
 			in.metrics.s3ObjectsProcessedTotal.Inc()
 		}
 	}
+
+	return knownStateIDSlice, true
 }
 
 func (in *s3PollerInput) s3EventForState(state state) s3EventV2 {

--- a/x-pack/filebeat/input/awss3/s3_test.go
+++ b/x-pack/filebeat/input/awss3/s3_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/logp"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestS3Poller(t *testing.T) {
@@ -129,21 +130,24 @@ func TestS3Poller(t *testing.T) {
 		s3ObjProc := newS3ObjectProcessorFactory(nil, mockAPI, nil, backupConfig{})
 		states, err := newStates(nil, store)
 		require.NoError(t, err, "states creation must succeed")
+
+		cfg := config{
+			NumberOfWorkers:    numberOfWorkers,
+			BucketListInterval: pollInterval,
+			BucketARN:          bucket,
+			BucketListPrefix:   "key",
+			RegionName:         "region",
+		}
 		poller := &s3PollerInput{
-			log: logp.NewLogger(inputName),
-			config: config{
-				NumberOfWorkers:    numberOfWorkers,
-				BucketListInterval: pollInterval,
-				BucketARN:          bucket,
-				BucketListPrefix:   "key",
-				RegionName:         "region",
-			},
+			log:             logp.NewLogger(inputName),
+			config:          cfg,
 			s3:              mockAPI,
 			pipeline:        pipeline,
 			s3ObjectHandler: s3ObjProc,
 			states:          states,
 			provider:        "provider",
 			metrics:         newInputMetrics("", nil, 0),
+			filterProvider:  newFilterProvider(&cfg),
 		}
 		poller.runPoll(ctx)
 	})
@@ -267,6 +271,14 @@ func TestS3Poller(t *testing.T) {
 		s3ObjProc := newS3ObjectProcessorFactory(nil, mockS3, nil, backupConfig{})
 		states, err := newStates(nil, store)
 		require.NoError(t, err, "states creation must succeed")
+
+		cfg := config{
+			NumberOfWorkers:    numberOfWorkers,
+			BucketListInterval: pollInterval,
+			BucketARN:          bucket,
+			BucketListPrefix:   "key",
+			RegionName:         "region",
+		}
 		poller := &s3PollerInput{
 			log: logp.NewLogger(inputName),
 			config: config{
@@ -282,15 +294,233 @@ func TestS3Poller(t *testing.T) {
 			states:          states,
 			provider:        "provider",
 			metrics:         newInputMetrics("", nil, 0),
+			filterProvider:  newFilterProvider(&cfg),
 		}
 		poller.run(ctx)
 	})
 }
 
-func TestS3ReaderLoop(t *testing.T) {
+func Test_S3StateHandling(t *testing.T) {
+	bucket := "bucket"
+	logger := logp.NewLogger(inputName)
+	fixedTimeNow := time.Now()
 
-}
+	tests := []struct {
+		name           string
+		s3Objects      []types.Object
+		config         *config
+		initStates     []state
+		runPollFor     int
+		expectStateIDs []string
+	}{
+		{
+			name: "State unchanged - registry backed state",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+			},
+			initStates:     []state{newState(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+		},
+		{
+			name: "State cleanup - remove existing registry entry based on ignore older filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				IgnoreOlder:        1 * time.Second,
+			},
+			initStates:     []state{newState(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+			runPollFor:     1,
+			expectStateIDs: []string{},
+		},
+		{
+			name: "State cleanup - remove existing registry entry based on timestamp filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				StartTimestamp:     "2024-11-27T12:00:00Z",
+			},
+			initStates:     []state{newState(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+			runPollFor:     1,
+			expectStateIDs: []string{},
+		},
+		{
+			name: "State updated - no filters",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+			},
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+		},
+		{
+			name: "State updated - ignore old filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(fixedTimeNow),
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				IgnoreOlder:        1 * time.Hour,
+			},
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", fixedTimeNow)},
+		},
+		{
+			name: "State updated - timestamp filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(fixedTimeNow),
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				StartTimestamp:     "2024-11-26T12:00:00Z",
+			},
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", fixedTimeNow)},
+		},
+		{
+			name: "State updated - combined filters of ignore old and timestamp",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				IgnoreOlder:        1 * time.Hour,
+				StartTimestamp:     "2024-11-20T12:00:00Z",
+			},
+			runPollFor:     2,
+			expectStateIDs: []string{},
+		},
+	}
 
-func TestS3WorkerLoop(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// given - setup and mocks
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
 
+			ctrl, ctx := gomock.WithContext(ctx, t)
+			defer ctrl.Finish()
+
+			mockS3API := NewMockS3API(ctrl)
+			mockS3Pager := NewMockS3Pager(ctrl)
+			mockObjHandler := NewMockS3ObjectHandlerFactory(ctrl)
+			mockS3ObjectHandler := NewMockS3ObjectHandler(ctrl)
+
+			gomock.InOrder(
+				mockS3API.EXPECT().
+					ListObjectsPaginator(gomock.Eq(bucket), "").
+					AnyTimes().
+					DoAndReturn(func(_, _ string) s3Pager {
+						return mockS3Pager
+					}),
+			)
+
+			for i := 0; i < test.runPollFor; i++ {
+				mockS3Pager.EXPECT().HasMorePages().Times(1).DoAndReturn(func() bool { return true })
+				mockS3Pager.EXPECT().HasMorePages().Times(1).DoAndReturn(func() bool { return false })
+			}
+
+			mockS3Pager.EXPECT().
+				NextPage(gomock.Any()).
+				Times(test.runPollFor).
+				DoAndReturn(func(_ context.Context, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+					return &s3.ListObjectsV2Output{Contents: test.s3Objects}, nil
+				})
+
+			mockObjHandler.EXPECT().Create(gomock.Any(), gomock.Any()).AnyTimes().Return(mockS3ObjectHandler)
+			mockS3ObjectHandler.EXPECT().ProcessS3Object(gomock.Any(), gomock.Any()).AnyTimes().
+				DoAndReturn(func(log *logp.Logger, eventCallback func(e beat.Event)) error {
+					eventCallback(beat.Event{})
+					return nil
+				})
+
+			store := openTestStatestore()
+			s3States, err := newStates(logger, store)
+			require.NoError(t, err, "States creation must succeed")
+
+			// Note - add init states as if we are deriving them from registry
+			for _, st := range test.initStates {
+				err := s3States.AddState(st)
+				require.NoError(t, err, "State add should not error")
+			}
+
+			poller := &s3PollerInput{
+				log:             logger,
+				config:          *test.config,
+				s3:              mockS3API,
+				pipeline:        newFakePipeline(),
+				s3ObjectHandler: mockObjHandler,
+				states:          s3States,
+				metrics:         newInputMetrics("state-test: "+test.name, nil, 0),
+				filterProvider:  newFilterProvider(test.config),
+			}
+
+			// when - run polling for desired time
+			for i := 0; i < test.runPollFor; i++ {
+				poller.runPoll(ctx)
+				<-time.After(500 * time.Millisecond)
+			}
+
+			// then - desired state entries
+
+			// state must only contain expected state IDs
+			require.Equal(t, len(test.expectStateIDs), len(s3States.states))
+			for _, id := range test.expectStateIDs {
+				if s3States.states[id] == nil {
+					t.Errorf("state with ID %s should exist", id)
+				}
+			}
+		})
+	}
 }

--- a/x-pack/filebeat/input/awss3/states.go
+++ b/x-pack/filebeat/input/awss3/states.go
@@ -21,7 +21,7 @@ const awsS3ObjectStatePrefix = "filebeat::aws-s3::state::"
 type states struct {
 	// Completed S3 object states, indexed by state ID.
 	// statesLock must be held to access states.
-	states     map[string]state
+	states     map[string]*state
 	statesLock sync.Mutex
 
 	// The store used to persist state changes to the registry.
@@ -60,16 +60,43 @@ func (s *states) AddState(state state) error {
 	id := state.ID()
 	// Update in-memory copy
 	s.statesLock.Lock()
-	s.states[id] = state
+	s.states[id] = &state
 	s.statesLock.Unlock()
 
 	// Persist to the registry
 	s.storeLock.Lock()
 	defer s.storeLock.Unlock()
-	key := awsS3ObjectStatePrefix + id
-	if err := s.store.Set(key, state); err != nil {
+	if err := s.store.Set(getStoreKey(id), state); err != nil {
 		return err
 	}
+	return nil
+}
+
+// CleanUp performs state and store cleanup based on provided knownIDs.
+// knownIDs must contain valid currently tracked state IDs that must be known by this state registry.
+// State and underlying storage will be cleaned if ID is no longer present in knownIDs set.
+func (s *states) CleanUp(knownIDs []string) error {
+	knownIDHashSet := map[string]struct{}{}
+	for _, id := range knownIDs {
+		knownIDHashSet[id] = struct{}{}
+	}
+
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
+	s.statesLock.Lock()
+	defer s.statesLock.Unlock()
+
+	for id := range s.states {
+		if _, contains := knownIDHashSet[id]; !contains {
+			// remove from sate & store as ID is no longer seen in known ID set
+			delete(s.states, id)
+			err := s.store.Remove(getStoreKey(id))
+			if err != nil {
+				return fmt.Errorf("error while removing the state for ID %s: %w", id, err)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -79,8 +106,13 @@ func (s *states) Close() {
 	s.storeLock.Unlock()
 }
 
-func loadS3StatesFromRegistry(log *logp.Logger, store *statestore.Store) (map[string]state, error) {
-	stateTable := map[string]state{}
+// getStoreKey is a helper to generate the key used by underlying persistent storage
+func getStoreKey(stateID string) string {
+	return awsS3ObjectStatePrefix + stateID
+}
+
+func loadS3StatesFromRegistry(log *logp.Logger, store *statestore.Store) (map[string]*state, error) {
+	stateTable := map[string]*state{}
 	err := store.Each(func(key string, dec statestore.ValueDecoder) (bool, error) {
 		if !strings.HasPrefix(key, awsS3ObjectStatePrefix) {
 			return true, nil
@@ -103,7 +135,7 @@ func loadS3StatesFromRegistry(log *logp.Logger, store *statestore.Store) (map[st
 			return true, nil
 		}
 
-		stateTable[st.ID()] = st
+		stateTable[st.ID()] = &st
 		return true, nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Proposed commit message

Follow-up for [start_timestamp](https://github.com/elastic/beats/pull/41694) , hence in draft till complete

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Todo - fill up

## Related issues

Fixes #https://github.com/elastic/beats/issues/39116

## Use cases

Todo - fill up
