### PR TITLE
Correct the default filename of events-data

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1573,7 +1573,7 @@ logging.files:
   #path: /var/log/auditbeat
 
   # The name of the files where the logs are written to.
-  #name: auditbeat-event-data
+  #name: auditbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2687,7 +2687,7 @@ logging.files:
   #path: /var/log/filebeat
 
   # The name of the files where the logs are written to.
-  #name: filebeat-event-data
+  #name: filebeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1660,7 +1660,7 @@ logging.files:
   #path: /var/log/heartbeat
 
   # The name of the files where the logs are written to.
-  #name: heartbeat-event-data
+  #name: heartbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -92,7 +92,7 @@ logging.files:
   #path: /var/log/{{.BeatName}}
 
   # The name of the files where the logs are written to.
-  #name: {{.BeatName}}-event-data
+  #name: {{.BeatName}}-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -320,7 +320,7 @@ the <<directory-layout>> section for details.
 [float]
 ==== `logging.event_data.files.name`
 
-The name of the file that logs are written to. The default is '{beatname_lc}'-event-data.
+The name of the file that logs are written to. The default is '{beatname_lc}'-events-data.
 
 [float]
 ==== `logging.event_data.files.rotateeverybytes`

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2479,7 +2479,7 @@ logging.files:
   #path: /var/log/metricbeat
 
   # The name of the files where the logs are written to.
-  #name: metricbeat-event-data
+  #name: metricbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2039,7 +2039,7 @@ logging.files:
   #path: /var/log/packetbeat
 
   # The name of the files where the logs are written to.
-  #name: packetbeat-event-data
+  #name: packetbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1450,7 +1450,7 @@ logging.files:
   #path: /var/log/winlogbeat
 
   # The name of the files where the logs are written to.
-  #name: winlogbeat-event-data
+  #name: winlogbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1637,7 +1637,7 @@ logging.files:
   #path: /var/log/auditbeat
 
   # The name of the files where the logs are written to.
-  #name: auditbeat-event-data
+  #name: auditbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -4606,7 +4606,7 @@ logging.files:
   #path: /var/log/filebeat
 
   # The name of the files where the logs are written to.
-  #name: filebeat-event-data
+  #name: filebeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1288,7 +1288,7 @@ logging.files:
   #path: /var/log/functionbeat
 
   # The name of the files where the logs are written to.
-  #name: functionbeat-event-data
+  #name: functionbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1660,7 +1660,7 @@ logging.files:
   #path: /var/log/heartbeat
 
   # The name of the files where the logs are written to.
-  #name: heartbeat-event-data
+  #name: heartbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -3065,7 +3065,7 @@ logging.files:
   #path: /var/log/metricbeat
 
   # The name of the files where the logs are written to.
-  #name: metricbeat-event-data
+  #name: metricbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -1007,7 +1007,7 @@ logging.files:
   #path: /var/log/osquerybeat
 
   # The name of the files where the logs are written to.
-  #name: osquerybeat-event-data
+  #name: osquerybeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2039,7 +2039,7 @@ logging.files:
   #path: /var/log/packetbeat
 
   # The name of the files where the logs are written to.
-  #name: packetbeat-event-data
+  #name: packetbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1452,7 +1452,7 @@ logging.files:
   #path: /var/log/winlogbeat
 
   # The name of the files where the logs are written to.
-  #name: winlogbeat-event-data
+  #name: winlogbeat-events-data
 
   # Configure log file size limit. If the limit is reached, log file will be
   # automatically rotated.


### PR DESCRIPTION
Change 'event-data' to 'events-data' in the document.

## Reference:
https://github.com/elastic/beats/blob/1bd39c5cf55eed1715a41133ef64c324fc83adca/libbeat/tests/system/beat/beat.py#L535
https://github.com/elastic/beats/blob/1bd39c5cf55eed1715a41133ef64c324fc83adca/libbeat/tests/integration/framework.go#L626