### PR TITLE
move metricbeat command setup out of init

### DIFF
--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -43,9 +43,6 @@ const (
 	Name = "metricbeat"
 )
 
-// RootCmd to handle beats cli
-var RootCmd *cmd.BeatsRootCmd
-
 // withECSVersion is a modifier that adds ecs.version to events.
 var withECSVersion = processing.WithFields(mapstr.M{
 	"ecs": mapstr.M{
@@ -60,7 +57,7 @@ func MetricbeatSettings(moduleNameSpace string) instance.Settings {
 	if moduleNameSpace == "" {
 		moduleNameSpace = "module"
 	}
-	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
+	runFlags := pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
 	cfgfile.AddAllowedBackwardsCompatibleFlag("system.hostfs")
 	return instance.Settings{
@@ -81,8 +78,4 @@ func Initialize(settings instance.Settings) *cmd.BeatsRootCmd {
 	rootCmd.AddCommand(cmd.GenModulesCmd(Name, "", BuildModulesManager))
 	rootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, "", beater.DefaultTestModulesCreator()))
 	return rootCmd
-}
-
-func init() {
-	RootCmd = Initialize(MetricbeatSettings(""))
 }

--- a/metricbeat/main.go
+++ b/metricbeat/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 func main() {
-	if err := cmd.RootCmd.Execute(); err != nil {
+	if err := cmd.Initialize(cmd.MetricbeatSettings("")).Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/x-pack/agentbeat/main.go
+++ b/x-pack/agentbeat/main.go
@@ -42,7 +42,7 @@ into a single agentbeat binary.`,
 		prepareCommand(auditbeat.RootCmd),
 		prepareCommand(filebeat.Filebeat()),
 		prepareCommand(heartbeat.RootCmd),
-		prepareCommand(metricbeat.RootCmd),
+		prepareCommand(metricbeat.Initialize()),
 		prepareCommand(osquerybeat.RootCmd),
 		prepareCommand(packetbeat.RootCmd),
 	)

--- a/x-pack/libbeat/management/tests/mbtest/metricbeat_v2_test.go
+++ b/x-pack/libbeat/management/tests/mbtest/metricbeat_v2_test.go
@@ -34,8 +34,9 @@ var expectedMBStreams = &proto.UnitExpectedConfig{
 }
 
 func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
-	tests.InitBeatsForTest(t, cmd.RootCmd)
-	var mbStreams = []*proto.Stream{
+	mbCmd := cmd.Initialize()
+	tests.InitBeatsForTest(t, mbCmd)
+	mbStreams := []*proto.Stream{
 		{
 			Id: "system/metrics-system.cpu-default-system",
 			DataStream: &proto.DataStream{
@@ -79,7 +80,7 @@ func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
 
 	go func() {
 		t.Logf("Running beats...")
-		err := cmd.RootCmd.Execute()
+		err := mbCmd.Execute()
 		require.NoError(t, err)
 	}()
 

--- a/x-pack/libbeat/management/tests/mbtest/system/process_integration_test.go
+++ b/x-pack/libbeat/management/tests/mbtest/system/process_integration_test.go
@@ -37,7 +37,8 @@ func TestProcessStatusReporter(t *testing.T) {
 	unitOutID := mock.NewID()
 	token := mock.NewID()
 
-	tests.InitBeatsForTest(t, cmd.RootCmd)
+	mbCmd := cmd.Initialize()
+	tests.InitBeatsForTest(t, mbCmd)
 
 	filename := fmt.Sprintf("test-%d", time.Now().Unix())
 	outPath := filepath.Join(t.TempDir(), filename)
@@ -122,7 +123,7 @@ func TestProcessStatusReporter(t *testing.T) {
 
 	go func() {
 		t.Logf("Running beats...")
-		err := cmd.RootCmd.Execute()
+		err := mbCmd.Execute()
 		require.NoError(t, err)
 	}()
 

--- a/x-pack/metricbeat/cmd/root.go
+++ b/x-pack/metricbeat/cmd/root.go
@@ -33,9 +33,6 @@ const (
 	Name = "metricbeat"
 )
 
-// RootCmd to handle beats cli
-var RootCmd *cmd.BeatsRootCmd
-
 // withECSVersion is a modifier that adds ecs.version to events.
 var withECSVersion = processing.WithFields(mapstr.M{
 	"ecs": mapstr.M{
@@ -43,7 +40,7 @@ var withECSVersion = processing.WithFields(mapstr.M{
 	},
 })
 
-func init() {
+func Initialize() *cmd.BeatsRootCmd {
 	globalProcs, err := processors.NewPluginConfigFromList(defaultProcessors())
 	if err != nil { // these are hard-coded, shouldn't fail
 		panic(fmt.Errorf("error creating global processors: %w", err))
@@ -51,12 +48,13 @@ func init() {
 	settings := mbcmd.MetricbeatSettings("")
 	settings.ElasticLicensed = true
 	settings.Processing = processing.MakeDefaultSupport(true, globalProcs, withECSVersion, processing.WithHost, processing.WithAgentMeta())
-	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), settings)
-	RootCmd.AddCommand(cmd.GenModulesCmd(Name, "", mbcmd.BuildModulesManager))
-	RootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, "", beater.DefaultTestModulesCreator()))
-	RootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+	rootCmd := cmd.GenRootCmdWithSettings(beater.DefaultCreator(), settings)
+	rootCmd.AddCommand(cmd.GenModulesCmd(Name, "", mbcmd.BuildModulesManager))
+	rootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, "", beater.DefaultTestModulesCreator()))
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		management.ConfigTransform.SetTransform(metricbeatCfg)
 	}
+	return rootCmd
 }
 
 func defaultProcessors() []mapstr.M {

--- a/x-pack/metricbeat/main.go
+++ b/x-pack/metricbeat/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-	if err := cmd.RootCmd.Execute(); err != nil {
+	if err := cmd.Initialize().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/x-pack/metricbeat/main_test.go
+++ b/x-pack/metricbeat/main_test.go
@@ -6,21 +6,27 @@ package main
 // This file is mandatory as otherwise the metricbeat.test binary is not generated correctly.
 import (
 	"flag"
+	"os"
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
-	"github.com/elastic/beats/v7/x-pack/metricbeat/cmd"
+	mbcmd "github.com/elastic/beats/v7/x-pack/metricbeat/cmd"
 )
 
-var systemTest *bool
+var (
+	systemTest *bool
+	mbCommand  *cmd.BeatsRootCmd
+)
 
 func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
-	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	mbCommand = mbcmd.Initialize()
+	mbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
 	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
-	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+	mbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
 	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
@@ -28,10 +34,12 @@ func init() {
 func TestSystem(t *testing.T) {
 	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
-		main()
+		if err := mbCommand.Execute(); err != nil {
+			os.Exit(1)
+		}
 	}
 }
 
 func TestTemplate(t *testing.T) {
-	template.TestTemplate(t, cmd.Name, true)
+	template.TestTemplate(t, mbCommand.Name(), true)
 }


### PR DESCRIPTION
## Proposed commit message

Move metricbeat command setup outside of `init` function.  Having the setup inside the `init` function causes problems when you import metricbeat into other code bases.  A specific use case is when you use metricbeat as an otel receiver.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run unit tests

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates elastic/elastic-agent#6138
- Relates #41738

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
