### PR TITLE
[aws] [s3] Introduce ignore_older & start_timestamp for S3 input allowing better registry cleanups

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -200,6 +200,7 @@ filebeat.inputs:
 - Add support to source AWS cloudwatch logs from linked accounts. {pull}41188[41188]
 - Jounrald input now supports filtering by facilities. {pull}41061[41061]
 - Add support to include AWS cloudwatch linked accounts when using log_group_name_prefix to define log group names. {pull}41206[41206]
+- AWS S3 input registry cleanup for untracked s3 objects. {pull}41694[41694]
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -200,7 +200,6 @@ filebeat.inputs:
 - Add support to source AWS cloudwatch logs from linked accounts. {pull}41188[41188]
 - Jounrald input now supports filtering by facilities. {pull}41061[41061]
 - Add support to include AWS cloudwatch linked accounts when using log_group_name_prefix to define log group names. {pull}41206[41206]
-- AWS S3 input registry cleanup for untracked s3 objects. {pull}41694[41694]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -384,6 +384,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Added default values in the streaming input for websocket retries and put a cap on retry wait time to be lesser than equal to the maximum defined wait time. {pull}42012[42012]
 - Rate limiting fault tolerance improvements in the Okta provider of the Entity Analytics input. {issue}40106[40106] {pull}42094[42094]
 - Added infinite & blanket retry options to websockets and improved logging and retry logic. {pull}42225[42225]
+- Introduce ignore older and start timestamp filters for AWS S3 input. {pull}41804[41804]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -124,6 +124,16 @@
   # Controls deletion of objects after backing them up
   #delete_after_backup: false
 
+  # Ignore bucket entries older than the given timespan.
+  # Timespan is calculated from current time to processing object's last modified timestamp.
+  # This is disabled by default(value 0) and can be configured to a time duration like "48h" or "2h30m".
+  #ignore_older: 0
+
+  # Accept bucket entries with last modified timestamp newer than the given timestamp.
+  # Accepts a timestamp in YYYY-MM-DDTHH:MM:SSZ format and default is empty.
+  # For example, "2024-11-20T20:00:00Z" (UTC) or "2024-11-20T22:30:00+02:30" (with zone offset).
+  #start_timestamp:
+
 #------------------------------ AWS CloudWatch input --------------------------------
 # Beta: Config options for AWS CloudWatch input
 #- type: aws-cloudwatch

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -695,7 +695,7 @@ include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 [float]
 ==== `ignore_older`
 
-The parameter specifies the time duration during which bucket entries are accepted for processing.
+The parameter specifies the time duration (ex:- 30m, 2h or 48h) during which bucket entries are accepted for processing.
 By default, this feature is disabled, allowing any entry in the bucket to be processed.
 It is recommended to set a suitable duration to prevent older bucket entries from being tracked, which helps to reduce the memory usage.
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -697,12 +697,13 @@ include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 
 The parameter specifies the time duration during which bucket entries are accepted for processing.
 By default, this feature is disabled, allowing any entry in the bucket to be processed.
-It is recommended to set a suitable duration to prevent older bucket entries from being tracked, which can help reduce memory usage.
+It is recommended to set a suitable duration to prevent older bucket entries from being tracked, which helps to reduce the memory usage.
 
-If defined, bucket entries are processed only if their last modified timestamp falls within the specified time duration, relative to the current time.
+When defined, bucket entries are processed only if their last modified timestamp falls within the specified time duration, relative to the current time.
 However, when the start_timestamp is set, the initial processing will include all bucket entries up to that timestamp.
 
-NOTE: It is recommended to configure a sufficiently long duration based on your use case and current settings to avoid conflicts with bucket_list_interval.
+NOTE: Bucket entries that are older than the defined duration and have failed processing will not be re-processed.
+It is recommended to configure a sufficiently long duration based on your use case and current settings to avoid conflicts with the bucket_list_interval property.
 Additionally, this ensures that subsequent runs can include and re-process objects that failed due to unavoidable errors.
 
 [float]
@@ -713,6 +714,7 @@ By default, this is disabled, allowing all entries in the bucket to be processed
 
 This parameter is useful when configuring input for the first time, especially if you want to ingest logs starting from a specific time.
 The timestamp can also be set to a future time, offering greater flexibility.
+You can combine this property with ignore_older duration to improve memory usage by reducing tracked bucket entries.
 
 NOTE: It is recommended to update this value when updating or restarting filebeat
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -178,6 +178,8 @@ Node pipeline.
 The `aws-s3` input supports the following configuration options plus the
 <<{beatname_lc}-input-{type}-common-options>> described later.
 
+NOTE: For time durations, valid time units are - "ns", "us" (or "µs"), "ms", "s", "m", "h". For example, "2h"
+
 [float]
 ==== `api_timeout`
 
@@ -689,6 +691,30 @@ This option can only be used together with the backup functionality.
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
+
+[float]
+==== `ignore_older`
+
+The parameter specifies the time duration during which bucket entries are accepted for processing.
+By default, this feature is disabled, allowing any entry in the bucket to be processed.
+It is recommended to set a suitable duration to prevent older bucket entries from being tracked, which can help reduce memory usage.
+
+If defined, bucket entries are processed only if their last modified timestamp falls within the specified time duration, relative to the current time.
+However, when the start_timestamp is set, the initial processing will include all bucket entries up to that timestamp.
+
+NOTE: It is recommended to configure a sufficiently long duration based on your use case and current settings to avoid conflicts with bucket_list_interval.
+Additionally, this ensures that subsequent runs can include and re-process objects that failed due to unavoidable errors.
+
+[float]
+==== `start_timestamp`
+
+Accepts a timestamp in the YYYY-MM-DDTHH:MM:SSZ format, which defines the point from which bucket entries are accepted for processing.
+By default, this is disabled, allowing all entries in the bucket to be processed.
+
+This parameter is useful when configuring input for the first time, especially if you want to ingest logs starting from a specific time.
+The timestamp can also be set to a future time, offering greater flexibility.
+
+NOTE: It is recommended to update this value when updating or restarting filebeat
 
 [float]
 === AWS Permissions

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -747,7 +747,7 @@ filebeat.modules:
 #------------------------------- Coredns Module -------------------------------
 - module: coredns
   # Fileset for native deployment
-  log:
+  log: 
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -756,7 +756,7 @@ filebeat.modules:
 
 #----------------------------- Crowdstrike Module -----------------------------
 - module: crowdstrike
-
+  
   falcon:
     enabled: false
 
@@ -827,7 +827,7 @@ filebeat.modules:
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy
   # Fileset for native deployment
-  log:
+  log: 
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -4273,7 +4273,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-
+  
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 
@@ -4450,7 +4450,7 @@ setup.template.settings:
 
 # ======================== Data Stream Lifecycle (DSL) =========================
 
-# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch.
+# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch. 
 # These settings are mutually exclusive with ILM settings which are not supported in Serverless projects.
 
 # Enable DSL support. Valid values are true, or false.
@@ -4458,7 +4458,7 @@ setup.template.settings:
 
 # Set the lifecycle policy name or pattern. For DSL, this name must match the data stream that the lifecycle is for.
 # The default data stream pattern is filebeat-%{[agent.version]}"
-# The template string `%{[agent.version]}` will resolve to the current stack version.
+# The template string `%{[agent.version]}` will resolve to the current stack version. 
 # The other possible template value is `%{[beat.name]}`.
 #setup.dsl.data_stream_pattern: "filebeat-%{[agent.version]}"
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -747,7 +747,7 @@ filebeat.modules:
 #------------------------------- Coredns Module -------------------------------
 - module: coredns
   # Fileset for native deployment
-  log: 
+  log:
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -756,7 +756,7 @@ filebeat.modules:
 
 #----------------------------- Crowdstrike Module -----------------------------
 - module: crowdstrike
-  
+
   falcon:
     enabled: false
 
@@ -827,7 +827,7 @@ filebeat.modules:
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy
   # Fileset for native deployment
-  log: 
+  log:
     enabled: false
 
     # Set custom paths for the log files. If left empty,
@@ -3051,6 +3051,16 @@ filebeat.inputs:
   # Controls deletion of objects after backing them up
   #delete_after_backup: false
 
+  # Ignore bucket entries older than the given timespan.
+  # Timespan is calculated from current time to processing object's last modified timestamp.
+  # This is disabled by default(value 0) and can be configured to a time duration like "48h" or "2h30m".
+  #ignore_older: 0
+
+  # Accept bucket entries with last modified timestamp newer than the given timestamp.
+  # Accepts a timestamp in YYYY-MM-DDTHH:MM:SSZ format and default is empty.
+  # For example, "2024-11-20T20:00:00Z" (UTC) or "2024-11-20T22:30:00+02:30" (with zone offset).
+  #start_timestamp:
+
 #------------------------------ AWS CloudWatch input --------------------------------
 # Beta: Config options for AWS CloudWatch input
 #- type: aws-cloudwatch
@@ -4263,7 +4273,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-  
+
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 
@@ -4440,7 +4450,7 @@ setup.template.settings:
 
 # ======================== Data Stream Lifecycle (DSL) =========================
 
-# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch. 
+# Configure Data Stream Lifecycle to manage data streams while connected to Serverless elasticsearch.
 # These settings are mutually exclusive with ILM settings which are not supported in Serverless projects.
 
 # Enable DSL support. Valid values are true, or false.
@@ -4448,7 +4458,7 @@ setup.template.settings:
 
 # Set the lifecycle policy name or pattern. For DSL, this name must match the data stream that the lifecycle is for.
 # The default data stream pattern is filebeat-%{[agent.version]}"
-# The template string `%{[agent.version]}` will resolve to the current stack version. 
+# The template string `%{[agent.version]}` will resolve to the current stack version.
 # The other possible template value is `%{[beat.name]}`.
 #setup.dsl.data_stream_pattern: "filebeat-%{[agent.version]}"
 

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -25,26 +25,33 @@ import (
 	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 )
 
+// todo
+// add ignore_older & start_timestamp
+// must be disabled by default
+// but if start_timestamp is empty, then be cautious as
+// - Fresh startup need a full read
+// - But if registry is non-empty, we can assume we have read some data
+
 type config struct {
 	APITimeout         time.Duration        `config:"api_timeout"`
-	VisibilityTimeout  time.Duration        `config:"visibility_timeout"`
-	SQSWaitTime        time.Duration        `config:"sqs.wait_time"`         // The max duration for which the SQS ReceiveMessage call waits for a message to arrive in the queue before returning.
-	SQSMaxReceiveCount int                  `config:"sqs.max_receive_count"` // The max number of times a message should be received (retried) before deleting it.
-	SQSScript          *scriptConfig        `config:"sqs.notification_parsing_script"`
-	QueueURL           string               `config:"queue_url"`
-	RegionName         string               `config:"region"`
-	BucketARN          string               `config:"bucket_arn"`
+	AWSConfig          awscommon.ConfigAWS  `config:",inline"`
 	AccessPointARN     string               `config:"access_point_arn"`
-	NonAWSBucketName   string               `config:"non_aws_bucket_name"`
+	BackupConfig       backupConfig         `config:",inline"`
+	BucketARN          string               `config:"bucket_arn"`
 	BucketListInterval time.Duration        `config:"bucket_list_interval"`
 	BucketListPrefix   string               `config:"bucket_list_prefix"`
-	NumberOfWorkers    int                  `config:"number_of_workers"`
-	AWSConfig          awscommon.ConfigAWS  `config:",inline"`
 	FileSelectors      []fileSelectorConfig `config:"file_selectors"`
-	ReaderConfig       readerConfig         `config:",inline"` // Reader options to apply when no file_selectors are used.
+	NonAWSBucketName   string               `config:"non_aws_bucket_name"`
+	NumberOfWorkers    int                  `config:"number_of_workers"`
 	PathStyle          bool                 `config:"path_style"`
 	ProviderOverride   string               `config:"provider"`
-	BackupConfig       backupConfig         `config:",inline"`
+	QueueURL           string               `config:"queue_url"`
+	ReaderConfig       readerConfig         `config:",inline"` // Reader options to apply when no file_selectors are used.
+	RegionName         string               `config:"region"`
+	SQSMaxReceiveCount int                  `config:"sqs.max_receive_count"` // The max number of times a message should be received (retried) before deleting it.
+	SQSScript          *scriptConfig        `config:"sqs.notification_parsing_script"`
+	SQSWaitTime        time.Duration        `config:"sqs.wait_time"` // The max duration for which the SQS ReceiveMessage call waits for a message to arrive in the queue before returning.
+	VisibilityTimeout  time.Duration        `config:"visibility_timeout"`
 }
 
 func defaultConfig() config {

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -147,7 +147,7 @@ func (c *config) Validate() error {
 	if c.StartTimestamp != "" {
 		_, err := time.Parse(time.RFC3339, c.StartTimestamp)
 		if err != nil {
-			return fmt.Errorf("invalid input for start_timestamp: %v", err)
+			return fmt.Errorf("invalid input for start_timestamp: %w", err)
 		}
 	}
 
@@ -304,6 +304,7 @@ func (c config) sqsConfigModifier(o *sqs.Options) {
 		o.EndpointOptions.UseFIPSEndpoint = awssdk.FIPSEndpointStateEnabled
 	}
 	if c.AWSConfig.Endpoint != "" {
+		//nolint:staticcheck // not changing through this PR
 		o.EndpointResolver = sqs.EndpointResolverFromURL(c.AWSConfig.Endpoint)
 	}
 }

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -596,6 +596,39 @@ func TestConfig(t *testing.T) {
 			expectedErr: "backup_to_bucket_prefix cannot be the same as bucket_list_prefix, this will create an infinite loop",
 			expectedCfg: nil,
 		},
+		{
+			name:     "validate ignore_older and start_timestamp configurations",
+			s3Bucket: s3Bucket,
+			config: mapstr.M{
+				"bucket_arn":      s3Bucket,
+				"ignore_older":    "24h",
+				"start_timestamp": "2024-11-20T20:00:00Z",
+			},
+			expectedCfg: func(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, s3Bucket, s3AccessPoint, nonAWSS3Bucket)
+				c.IgnoreOlder = 24 * time.Hour
+				c.StartTimestamp = "2024-11-20T20:00:00Z"
+				return c
+			},
+		},
+		{
+			name:     "ignore_older only accepts valid duration - unit valid with ParseDuration",
+			s3Bucket: s3Bucket,
+			config: mapstr.M{
+				"bucket_arn":   s3Bucket,
+				"ignore_older": "24D",
+			},
+			expectedErr: "time: unknown unit \"D\" in duration \"24D\" accessing 'ignore_older'",
+		},
+		{
+			name:     "start_timestamp accepts a valid timestamp of format - YYYY-MM-DDTHH:MM:SSZ",
+			s3Bucket: s3Bucket,
+			config: mapstr.M{
+				"bucket_arn":      s3Bucket,
+				"start_timestamp": "2024-11-20 20:20:00",
+			},
+			expectedErr: "invalid input for start_timestamp: parsing time \"2024-11-20 20:20:00\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \" 20:20:00\" as \"T\" accessing config",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x-pack/filebeat/input/awss3/input_benchmark_test.go
+++ b/x-pack/filebeat/input/awss3/input_benchmark_test.go
@@ -352,6 +352,7 @@ func benchmarkInputS3(t *testing.T, numberOfWorkers int) testing.BenchmarkResult
 					s3ObjectHandler: s3EventHandlerFactory,
 					states:          states,
 					provider:        "provider",
+					filterProvider:  newFilterProvider(&config),
 				}
 
 				s3Poller.run(ctx)

--- a/x-pack/filebeat/input/awss3/s3_filters.go
+++ b/x-pack/filebeat/input/awss3/s3_filters.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package awss3
 
 import (

--- a/x-pack/filebeat/input/awss3/s3_filters.go
+++ b/x-pack/filebeat/input/awss3/s3_filters.go
@@ -94,11 +94,7 @@ func newStartTimestampFilter(start time.Time) *startTimestampFilter {
 }
 
 func (s startTimestampFilter) isValid(objState state) bool {
-	if s.timeStart.Before(objState.LastModified) {
-		return true
-	}
-
-	return false
+	return s.timeStart.Before(objState.LastModified)
 }
 
 func (s startTimestampFilter) getID() string {
@@ -120,11 +116,7 @@ func newOldestTimeFilter(timespan time.Duration) *oldestTimeFilter {
 }
 
 func (s oldestTimeFilter) isValid(objState state) bool {
-	if s.timeOldest.Before(objState.LastModified) {
-		return true
-	}
-
-	return false
+	return s.timeOldest.Before(objState.LastModified)
 }
 
 func (s oldestTimeFilter) getID() string {

--- a/x-pack/filebeat/input/awss3/s3_filters.go
+++ b/x-pack/filebeat/input/awss3/s3_filters.go
@@ -1,0 +1,128 @@
+package awss3
+
+import (
+	"sync"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+const (
+	filterOldestTime = "oldestTimeFilter"
+	filterStartTime  = "startTimeFilter"
+)
+
+// filterProvider exposes filters that needs to be applied on derived state.
+// Once configured, retrieve filter applier using getApplierFunc.
+type filterProvider struct {
+	cfg *config
+
+	staticFilters []filter
+	once          sync.Once
+}
+
+func newFilterProvider(cfg *config) *filterProvider {
+	fp := &filterProvider{
+		cfg: cfg,
+	}
+
+	// derive static filters
+	if cfg.StartTimestamp != "" {
+		// note - errors should not occur as this has validated prior reaching here
+		parse, _ := time.Parse(time.RFC3339, cfg.StartTimestamp)
+		fp.staticFilters = append(fp.staticFilters, newStartTimestampFilter(parse))
+	}
+
+	return fp
+}
+
+// getApplierFunc returns aggregated filters valid at the time of retrival.
+// Applier return true if state is valid for processing according to the underlying filter collection.
+func (f *filterProvider) getApplierFunc() func(log *logp.Logger, s state) bool {
+	filters := map[string]filter{}
+
+	if f.cfg.IgnoreOlder != 0 {
+		timeFilter := newOldestTimeFilter(f.cfg.IgnoreOlder)
+		filters[timeFilter.getID()] = timeFilter
+	}
+
+	for _, f := range f.staticFilters {
+		filters[f.getID()] = f
+	}
+
+	f.once.Do(func() {
+		// Ignore the oldest time filter once for initial startup only if start timestamp filter is defined
+		// This allows users to ingest desired data from start time onwards.
+		if filters[filterStartTime] != nil {
+			delete(filters, filterOldestTime)
+		}
+	})
+
+	return func(log *logp.Logger, s state) bool {
+		for _, f := range filters {
+			if !f.isValid(s) {
+				log.Debugf("skipping processing of object '%s' by filter '%s'", s.Key, f.getID())
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+// filter defines the fileter implementation contract
+type filter interface {
+	getID() string
+	isValid(objState state) (valid bool)
+}
+
+// startTimestampFilter - filter out entries based on provided start time stamp, compared to filtering object's last modified times stamp.
+type startTimestampFilter struct {
+	id        string
+	timeStart time.Time
+}
+
+func newStartTimestampFilter(start time.Time) *startTimestampFilter {
+	return &startTimestampFilter{
+		id:        filterStartTime,
+		timeStart: start,
+	}
+}
+
+func (s startTimestampFilter) isValid(objState state) bool {
+	if s.timeStart.Before(objState.LastModified) {
+		return true
+	}
+
+	return false
+}
+
+func (s startTimestampFilter) getID() string {
+	return s.id
+}
+
+// oldestTimeFilter - filter out entries based on calculated oldest modified time, compared to filtering object's last modified times stamp.
+type oldestTimeFilter struct {
+	id         string
+	timeOldest time.Time
+}
+
+func newOldestTimeFilter(timespan time.Duration) *oldestTimeFilter {
+	oldest := time.Now().Add(-1 * timespan)
+	return &oldestTimeFilter{
+		id:         filterOldestTime,
+		timeOldest: oldest,
+	}
+}
+
+func (s oldestTimeFilter) isValid(objState state) bool {
+	if s.timeOldest.Before(objState.LastModified) {
+		return true
+	}
+
+	return false
+}
+
+func (s oldestTimeFilter) getID() string {
+	return s.id
+}

--- a/x-pack/filebeat/input/awss3/s3_filters.go
+++ b/x-pack/filebeat/input/awss3/s3_filters.go
@@ -46,7 +46,7 @@ func (f *filterProvider) getApplierFunc() func(log *logp.Logger, s state) bool {
 	filters := map[string]filter{}
 
 	if f.cfg.IgnoreOlder != 0 {
-		timeFilter := newOldestTimeFilter(f.cfg.IgnoreOlder)
+		timeFilter := newOldestTimeFilter(f.cfg.IgnoreOlder, time.Now())
 		filters[timeFilter.getID()] = timeFilter
 	}
 
@@ -107,11 +107,10 @@ type oldestTimeFilter struct {
 	timeOldest time.Time
 }
 
-func newOldestTimeFilter(timespan time.Duration) *oldestTimeFilter {
-	oldest := time.Now().Add(-1 * timespan)
+func newOldestTimeFilter(timespan time.Duration, now time.Time) *oldestTimeFilter {
 	return &oldestTimeFilter{
 		id:         filterOldestTime,
-		timeOldest: oldest,
+		timeOldest: now.Add(-1 * timespan),
 	}
 }
 

--- a/x-pack/filebeat/input/awss3/s3_filters_test.go
+++ b/x-pack/filebeat/input/awss3/s3_filters_test.go
@@ -142,7 +142,7 @@ func Test_oldestTimeFilter(t *testing.T) {
 		duration := time.Duration(1) * time.Second
 		entry := newState("bucket", "key", "eTag", time.Now())
 
-		oldTimeFilter := newOldestTimeFilter(duration)
+		oldTimeFilter := newOldestTimeFilter(duration, time.Now())
 
 		assert.Equal(t, filterOldestTime, oldTimeFilter.getID())
 		assert.True(t, oldTimeFilter.isValid(entry))
@@ -171,7 +171,7 @@ func Test_oldestTimeFilter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			timeFilter := newOldestTimeFilter(test.duration)
+			timeFilter := newOldestTimeFilter(test.duration, time.Now())
 			assert.Equal(t, test.result, timeFilter.isValid(test.input))
 		})
 	}

--- a/x-pack/filebeat/input/awss3/s3_filters_test.go
+++ b/x-pack/filebeat/input/awss3/s3_filters_test.go
@@ -1,0 +1,178 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awss3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterProvider(t *testing.T) {
+	t.Run("Configuration check", func(t *testing.T) {
+		cfg := config{
+			StartTimestamp: "2024-11-26T21:00:00Z",
+			IgnoreOlder:    10 * time.Minute,
+		}
+
+		fProvider := newFilterProvider(&cfg)
+
+		assert.Equal(t, 1, len(fProvider.staticFilters))
+		assert.Equal(t, filterStartTime, fProvider.staticFilters[0].getID())
+	})
+
+	logger := logp.NewLogger("test-logger")
+
+	tests := []struct {
+		name                string
+		cfg                 config
+		inputState          state
+		runFilterForCount   int
+		expectFilterResults []bool
+	}{
+		{
+			name: "Simple run - all valid result",
+			cfg: config{
+				StartTimestamp: "2024-11-26T21:00:00Z",
+				IgnoreOlder:    10 * time.Minute,
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Now()),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{true},
+		},
+		{
+			name: "Simple run - all invalid result",
+			cfg: config{
+				StartTimestamp: "2024-11-26T21:00:00Z",
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Unix(0, 0)),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{false},
+		},
+		{
+			name:                "Simple run - no filters hence valid result",
+			cfg:                 config{},
+			inputState:          newState("bucket", "key", "eTag", time.Now()),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{true},
+		},
+		{
+			name: "Single filter - ignore old invalid result",
+			cfg: config{
+				IgnoreOlder: 1 * time.Minute,
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Unix(time.Now().Add(-2*time.Minute).Unix(), 0)),
+			runFilterForCount:   1,
+			expectFilterResults: []bool{false},
+		},
+		{
+			name: "Combined filters - ignore old won't affect first run if timestamp is given but will affect thereafter",
+			cfg: config{
+				StartTimestamp: "2024-11-26T21:00:00Z",
+				IgnoreOlder:    10 * time.Minute,
+			},
+			inputState:          newState("bucket", "key", "eTag", time.Unix(1732654860, 0)), // 2024-11-26T21:01:00Z in epoch
+			runFilterForCount:   3,
+			expectFilterResults: []bool{true, false, false},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := newFilterProvider(&test.cfg)
+			results := make([]bool, 0, test.runFilterForCount)
+
+			for i := 0; i < test.runFilterForCount; i++ {
+				applierFunc := provider.getApplierFunc()
+				results = append(results, applierFunc(logger, test.inputState))
+			}
+
+			assert.Equal(t, test.expectFilterResults, results)
+		})
+	}
+}
+
+func Test_startTimestampFilter(t *testing.T) {
+	t.Run("Configuration check", func(t *testing.T) {
+		entry := newState("bucket", "key", "eTag", time.Now())
+
+		oldTimeFilter := newStartTimestampFilter(time.Now().Add(-2 * time.Minute))
+
+		assert.Equal(t, filterStartTime, oldTimeFilter.getID())
+		assert.True(t, oldTimeFilter.isValid(entry))
+	})
+
+	tests := []struct {
+		name      string
+		timeStamp time.Time
+		input     state
+		result    bool
+	}{
+		{
+			name:      "State valid",
+			timeStamp: time.Now().Add(-10 * time.Minute),
+			input:     newState("bucket", "key", "eTag", time.Now()),
+			result:    true,
+		},
+
+		{
+			name:      "State invalid",
+			timeStamp: time.Now(),
+			input:     newState("bucket", "key", "eTag", time.Now().Add(-10*time.Minute)),
+			result:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			timeFilter := newStartTimestampFilter(test.timeStamp)
+			assert.Equal(t, test.result, timeFilter.isValid(test.input))
+		})
+	}
+
+}
+
+func Test_oldestTimeFilter(t *testing.T) {
+	t.Run("configuration check", func(t *testing.T) {
+		duration := time.Duration(1) * time.Second
+		entry := newState("bucket", "key", "eTag", time.Now())
+
+		oldTimeFilter := newOldestTimeFilter(duration)
+
+		assert.Equal(t, filterOldestTime, oldTimeFilter.getID())
+		assert.True(t, oldTimeFilter.isValid(entry))
+	})
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+		input    state
+		result   bool
+	}{
+		{
+			name:     "State valid",
+			duration: time.Duration(1) * time.Minute,
+			input:    newState("bucket", "key", "eTag", time.Now()),
+			result:   true,
+		},
+
+		{
+			name:     "State invalid",
+			duration: time.Duration(1) * time.Minute,
+			input:    newState("bucket", "key", "eTag", time.Now().Add(-10*time.Minute)),
+			result:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			timeFilter := newOldestTimeFilter(test.duration)
+			assert.Equal(t, test.result, timeFilter.isValid(test.input))
+		})
+	}
+
+}

--- a/x-pack/filebeat/input/awss3/s3_filters_test.go
+++ b/x-pack/filebeat/input/awss3/s3_filters_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,14 +30,14 @@ func Test_filterProvider(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		cfg                 config
+		cfg                 *config
 		inputState          state
 		runFilterForCount   int
 		expectFilterResults []bool
 	}{
 		{
 			name: "Simple run - all valid result",
-			cfg: config{
+			cfg: &config{
 				StartTimestamp: "2024-11-26T21:00:00Z",
 				IgnoreOlder:    10 * time.Minute,
 			},
@@ -46,7 +47,7 @@ func Test_filterProvider(t *testing.T) {
 		},
 		{
 			name: "Simple run - all invalid result",
-			cfg: config{
+			cfg: &config{
 				StartTimestamp: "2024-11-26T21:00:00Z",
 			},
 			inputState:          newState("bucket", "key", "eTag", time.Unix(0, 0)),
@@ -55,14 +56,14 @@ func Test_filterProvider(t *testing.T) {
 		},
 		{
 			name:                "Simple run - no filters hence valid result",
-			cfg:                 config{},
+			cfg:                 &config{},
 			inputState:          newState("bucket", "key", "eTag", time.Now()),
 			runFilterForCount:   1,
 			expectFilterResults: []bool{true},
 		},
 		{
 			name: "Single filter - ignore old invalid result",
-			cfg: config{
+			cfg: &config{
 				IgnoreOlder: 1 * time.Minute,
 			},
 			inputState:          newState("bucket", "key", "eTag", time.Unix(time.Now().Add(-2*time.Minute).Unix(), 0)),
@@ -71,7 +72,7 @@ func Test_filterProvider(t *testing.T) {
 		},
 		{
 			name: "Combined filters - ignore old won't affect first run if timestamp is given but will affect thereafter",
-			cfg: config{
+			cfg: &config{
 				StartTimestamp: "2024-11-26T21:00:00Z",
 				IgnoreOlder:    10 * time.Minute,
 			},
@@ -83,7 +84,7 @@ func Test_filterProvider(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			provider := newFilterProvider(&test.cfg)
+			provider := newFilterProvider(test.cfg)
 			results := make([]bool, 0, test.runFilterForCount)
 
 			for i := 0; i < test.runFilterForCount; i++ {

--- a/x-pack/filebeat/input/awss3/s3_input.go
+++ b/x-pack/filebeat/input/awss3/s3_input.go
@@ -8,9 +8,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
-	"sync"
 
 	"github.com/elastic/beats/v7/filebeat/beater"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"

--- a/x-pack/filebeat/input/awss3/s3_input.go
+++ b/x-pack/filebeat/input/awss3/s3_input.go
@@ -202,7 +202,7 @@ func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) 
 	defer close(workChan)
 	bucketName := getBucketNameFromARN(in.config.getBucketARN())
 
-	applyFilter := in.filterProvider.getApplierFunc()
+	isStateValid := in.filterProvider.getApplierFunc()
 
 	errorBackoff := backoff.NewEqualJitterBackoff(ctx.Done(), 1, 120)
 	circuitBreaker := 0
@@ -235,7 +235,7 @@ func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) 
 		in.metrics.s3ObjectsListedTotal.Add(uint64(totListedObjects))
 		for _, object := range page.Contents {
 			state := newState(bucketName, *object.Key, *object.ETag, *object.LastModified)
-			if !applyFilter(in.log, state) {
+			if !isStateValid(in.log, state) {
 				continue
 			}
 

--- a/x-pack/filebeat/input/awss3/s3_test.go
+++ b/x-pack/filebeat/input/awss3/s3_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/logp"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestS3Poller(t *testing.T) {
@@ -130,21 +131,24 @@ func TestS3Poller(t *testing.T) {
 		s3ObjProc := newS3ObjectProcessorFactory(nil, mockAPI, nil, backupConfig{})
 		states, err := newStates(nil, store, listPrefix)
 		require.NoError(t, err, "states creation must succeed")
+
+		cfg := config{
+			NumberOfWorkers:    numberOfWorkers,
+			BucketListInterval: pollInterval,
+			BucketARN:          bucket,
+			BucketListPrefix:   listPrefix,
+			RegionName:         "region",
+		}
 		poller := &s3PollerInput{
-			log: logp.NewLogger(inputName),
-			config: config{
-				NumberOfWorkers:    numberOfWorkers,
-				BucketListInterval: pollInterval,
-				BucketARN:          bucket,
-				BucketListPrefix:   listPrefix,
-				RegionName:         "region",
-			},
+			log:             logp.NewLogger(inputName),
+			config:          cfg,
 			s3:              mockAPI,
 			pipeline:        pipeline,
 			s3ObjectHandler: s3ObjProc,
 			states:          states,
 			provider:        "provider",
 			metrics:         newInputMetrics("", nil, 0),
+			filterProvider:  newFilterProvider(&cfg),
 		}
 		poller.runPoll(ctx)
 	})
@@ -268,6 +272,14 @@ func TestS3Poller(t *testing.T) {
 		s3ObjProc := newS3ObjectProcessorFactory(nil, mockS3, nil, backupConfig{})
 		states, err := newStates(nil, store, listPrefix)
 		require.NoError(t, err, "states creation must succeed")
+
+		cfg := config{
+			NumberOfWorkers:    numberOfWorkers,
+			BucketListInterval: pollInterval,
+			BucketARN:          bucket,
+			BucketListPrefix:   "key",
+			RegionName:         "region",
+		}
 		poller := &s3PollerInput{
 			log: logp.NewLogger(inputName),
 			config: config{
@@ -283,15 +295,254 @@ func TestS3Poller(t *testing.T) {
 			states:          states,
 			provider:        "provider",
 			metrics:         newInputMetrics("", nil, 0),
+			filterProvider:  newFilterProvider(&cfg),
 		}
 		poller.run(ctx)
 	})
 }
 
-func TestS3ReaderLoop(t *testing.T) {
+func Test_S3StateHandling(t *testing.T) {
+	bucket := "bucket"
+	logger := logp.NewLogger(inputName)
+	fixedTimeNow := time.Now()
 
-}
+	tests := []struct {
+		name           string
+		s3Objects      []types.Object
+		config         *config
+		initStates     []state
+		runPollFor     int
+		expectStateIDs []string
+	}{
+		{
+			name: "State unchanged - registry backed state",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+			},
+			initStates:     []state{newState(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+		},
+		{
+			name: "State cleanup - remove existing registry entry based on ignore older filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				IgnoreOlder:        1 * time.Second,
+			},
+			initStates:     []state{newState(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+			runPollFor:     1,
+			expectStateIDs: []string{},
+		},
+		{
+			name: "State cleanup - remove existing registry entry based on timestamp filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				StartTimestamp:     "2024-11-27T12:00:00Z",
+			},
+			initStates:     []state{newState(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+			runPollFor:     1,
+			expectStateIDs: []string{},
+		},
+		{
+			name: "State updated - no filters",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+			},
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+		},
+		{
+			name: "State updated - ignore old filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(fixedTimeNow),
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				IgnoreOlder:        1 * time.Hour,
+			},
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", fixedTimeNow)},
+		},
+		{
+			name: "State updated - timestamp filter",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(fixedTimeNow),
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				StartTimestamp:     "2024-11-26T12:00:00Z",
+			},
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", fixedTimeNow)},
+		},
+		{
+			name: "State updated - combined filters of ignore old and timestamp entry exist after first run",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				IgnoreOlder:        1 * time.Hour,
+				StartTimestamp:     "2024-11-20T12:00:00Z",
+			},
+			// run once to validate initial coverage of entries till start timestamp
+			runPollFor:     1,
+			expectStateIDs: []string{stateID(bucket, "obj-A", "etag-A", time.Unix(1732622400, 0))}, // 2024-11-26T12:00:00Z
+		},
+		{
+			name: "State updated - combined filters of ignore old and timestamp remove entry after second run",
+			s3Objects: []types.Object{
+				{
+					Key:          aws.String("obj-A"),
+					ETag:         aws.String("etag-A"),
+					LastModified: aws.Time(time.Unix(1732622400, 0)), // 2024-11-26T12:00:00Z
+				},
+			},
+			config: &config{
+				NumberOfWorkers:    1,
+				BucketListInterval: 1 * time.Second,
+				BucketARN:          bucket,
+				IgnoreOlder:        1 * time.Hour,
+				StartTimestamp:     "2024-11-20T12:00:00Z",
+			},
+			// run twice to validate removal by ignore old filter
+			runPollFor:     2,
+			expectStateIDs: []string{},
+		},
+	}
 
-func TestS3WorkerLoop(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// given - setup and mocks
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
 
+			ctrl, ctx := gomock.WithContext(ctx, t)
+			defer ctrl.Finish()
+
+			mockS3API := NewMockS3API(ctrl)
+			mockS3Pager := NewMockS3Pager(ctrl)
+			mockObjHandler := NewMockS3ObjectHandlerFactory(ctrl)
+			mockS3ObjectHandler := NewMockS3ObjectHandler(ctrl)
+
+			gomock.InOrder(
+				mockS3API.EXPECT().
+					ListObjectsPaginator(gomock.Eq(bucket), "").
+					AnyTimes().
+					DoAndReturn(func(_, _ string) s3Pager {
+						return mockS3Pager
+					}),
+			)
+
+			for i := 0; i < test.runPollFor; i++ {
+				mockS3Pager.EXPECT().HasMorePages().Times(1).DoAndReturn(func() bool { return true })
+				mockS3Pager.EXPECT().HasMorePages().Times(1).DoAndReturn(func() bool { return false })
+			}
+
+			mockS3Pager.EXPECT().
+				NextPage(gomock.Any()).
+				Times(test.runPollFor).
+				DoAndReturn(func(_ context.Context, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+					return &s3.ListObjectsV2Output{Contents: test.s3Objects}, nil
+				})
+
+			mockObjHandler.EXPECT().Create(gomock.Any(), gomock.Any()).AnyTimes().Return(mockS3ObjectHandler)
+			mockS3ObjectHandler.EXPECT().ProcessS3Object(gomock.Any(), gomock.Any()).AnyTimes().
+				DoAndReturn(func(log *logp.Logger, eventCallback func(e beat.Event)) error {
+					eventCallback(beat.Event{})
+					return nil
+				})
+
+			store := openTestStatestore()
+			s3States, err := newStates(logger, store, "")
+			require.NoError(t, err, "States creation must succeed")
+
+			// Note - add init states as if we are deriving them from registry
+			for _, st := range test.initStates {
+				err := s3States.AddState(st)
+				require.NoError(t, err, "State add should not error")
+			}
+
+			poller := &s3PollerInput{
+				log:             logger,
+				config:          *test.config,
+				s3:              mockS3API,
+				pipeline:        newFakePipeline(),
+				s3ObjectHandler: mockObjHandler,
+				states:          s3States,
+				metrics:         newInputMetrics("state-test: "+test.name, nil, 0),
+				filterProvider:  newFilterProvider(test.config),
+			}
+
+			// when - run polling for desired time
+			for i := 0; i < test.runPollFor; i++ {
+				poller.runPoll(ctx)
+				<-time.After(500 * time.Millisecond)
+			}
+
+			// then - desired state entries
+
+			// state must only contain expected state IDs
+			require.Equal(t, len(test.expectStateIDs), len(s3States.states))
+			for _, id := range test.expectStateIDs {
+				if s3States.states[id] == nil {
+					t.Errorf("state with ID %s should exist", id)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Proposed commit message

Introduce `ignore_older` and `start_timestamp` properties to AWS S3 input. This is a follow-up for [#41694](https://github.com/elastic/beats/pull/41694).

The configurations introduced here act as input object filters. If the object fails to match derived filters, the entries will be cleaned up from the registry, reducing filebeat memory consumption.

Introduced configurations are, 

- ignore_older : Accepts a time duration in which entries are accepted for processing
- start_timestamp: A timestamp from which objects are accepted for processing

For both inputs, the object's last modified timestamp is taken into comparison. See **Use cases** section for further explanation

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

##  Disruptive User Impact

None as defaults are disabled. However, when configurations introduced here are used, the following can have an impact on the user,

-  When`start_timestamp` is defined, then objects with the last modified timestamps prior to the timestamp are ignored from processing   (documented [^1])
- When `ignore_older` is defined, then objects that do not fall within the look-back period when processing starts (polling run) are ignored  (documented [^1])
- When both `start_timestamp` & `ignore_older` are defined, the initial run will process all entries up to `start_timestamp`. The subsequent runs will not include entries that do not fall within `ignore_older` even if processing failed for an object. (documented [^1])


## How to test this PR locally

- Build filebeat from the changest included in the PR 
- Source S3 bucket with objects (you may use this tool [^2] to create entries)
- Try configuring filebeat with alternative values for `ignore_older` & `start_timestamp` to see how data ingestion change with their values. See **Use cases** section for further explanation
 
## Related issues

- Depends on https://github.com/elastic/beats/pull/41694
- Fixes https://github.com/elastic/beats/issues/39116
- Fixes https://github.com/elastic/beats/issues/41232

## Use cases

Consider below diagrams where there're 3 objects Object A, Object B and Object C with their last modified timestamps of t1, t2 and t3.

And consider how filebeat processes and tracks registry entries based on the following scenarios

### Default behavior 

If none of the configurations are used, then filebeat will process and the internal registry will track all objects continuously unless they are removed from the bucket.

![image](https://github.com/user-attachments/assets/51cc00bd-9ab5-46bd-86cd-36a83a824aca)


### Use start_timestamp

If `start_timestamp` is used, objects newer than the timestamp are accepted for processing. The registry will grow unless objects are removed from the bucket by other means (ex:- lifecycle policy).

![image](https://github.com/user-attachments/assets/c363cd96-5a16-465a-86ec-468a1c3020d2)

### Use ignore_older

If `ignore_older` is defined, input will process objects within the provided duration, calculated from the current time. The registry will track objects within the current timeframe and others will get cleaned up eventually by subsequent runs.

![image](https://github.com/user-attachments/assets/65ea96b6-469c-47f7-b084-635080af5836)

### Use both ignore_older & start_timestamp

If both properties are defined, 

- The initial run will include entries within the start_timestamp (ignoring `ignore_older` duration). 
- Subsequent runs will only consider entries within the `ignore_older` duration. 

![image](https://github.com/user-attachments/assets/1e1f2046-765e-45dc-bc35-2be9b83ea5e4)


[^1]: https://github.com/elastic/beats/pull/41817/files#diff-422765b7341c5bbf6de7af38927e34e00a5073b188585a7af3c4fee1175b64a6
[^2]: https://github.com/Kavindu-Dodan/data-gen

 