### PR TITLE
Fix Kafka output panic at startup

### DIFF
--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -113,7 +113,7 @@ func newKafkaClient(
 	return c, nil
 }
 
-func (c *client) Connect() error {
+func (c *client) Connect(_ context.Context) error {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -280,7 +280,7 @@ func TestKafkaPublish(t *testing.T) {
 
 			output, ok := grp.Clients[0].(*client)
 			assert.True(t, ok, "grp.Clients[0] didn't contain a ptr to client")
-			if err := output.Connect(); err != nil {
+			if err := output.Connect(context.Background()); err != nil {
 				t.Fatal(err)
 			}
 			assert.Equal(t, output.index, "testbeat")

--- a/libbeat/outputs/redis/backoff.go
+++ b/libbeat/outputs/redis/backoff.go
@@ -61,7 +61,7 @@ func newBackoffClient(client *client, init, max time.Duration) *backoffClient {
 }
 
 func (b *backoffClient) Connect(ctx context.Context) error {
-	err := b.client.Connect()
+	err := b.client.Connect(ctx)
 	if err != nil {
 		// give the client a chance to promote an internal error to a network error.
 		b.updateFailReason(err)

--- a/libbeat/outputs/redis/backoff.go
+++ b/libbeat/outputs/redis/backoff.go
@@ -19,6 +19,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
@@ -102,7 +103,8 @@ func (b *backoffClient) updateFailReason(err error) {
 		return
 	}
 
-	if _, ok := err.(redis.Error); ok {
+	var redisErr *redis.Error
+	if errors.As(err, &redisErr) {
 		b.reason = failRedis
 	} else {
 		b.reason = failOther

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -90,7 +90,7 @@ func newClient(
 	}
 }
 
-func (c *client) Connect() error {
+func (c *client) Connect(_ context.Context) error {
 	c.log.Debug("connect")
 	err := c.Client.Connect()
 	if err != nil {

--- a/libbeat/tests/integration/kafka_test.go
+++ b/libbeat/tests/integration/kafka_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+)
+
+var kafkaCfg = `
+mockbeat:
+logging:
+  level: debug
+  selectors:
+    - publisher_pipeline_output
+    - kafka
+queue.mem:
+  events: 4096
+  flush.min_events: 8
+  flush.timeout: 0.1s
+output.kafka:
+  topic: test
+  hosts:
+    - "localhost:9092"
+  backoff:
+    init: 0.1s
+    max: 0.2s
+`
+
+// Regression test for https://github.com/elastic/beats/issues/41823
+// The Kafka output would panic on the first Publish because it's Connect method was no longer called.
+func TestKafkaOutputCanConnect(t *testing.T) {
+	mockbeat := NewBeat(t, "mockbeat", "../../libbeat.test")
+	mockbeat.WriteConfigFile(kafkaCfg)
+
+	mockbeat.Start()
+
+	// 3. Wait for connection error logs
+	mockbeat.WaitForLogs(
+		`Connection to kafka(localhost:9092) established`,
+		15*time.Second,
+		"did not find connection establishment log")
+
+	mockbeat.WaitForLogs(
+		"Kafka publish failed with: kafka: client has run out of available brokers to talk to (Is your cluster reachable?",
+		5*time.Second,
+		"did not find message from Kafka producer after connecting")
+}

--- a/libbeat/tests/integration/kafka_test.go
+++ b/libbeat/tests/integration/kafka_test.go
@@ -69,7 +69,7 @@ func TestKafkaOutputCanConnectAndPublish(t *testing.T) {
 	metadataResponse.AddTopicPartition(kafkaTopic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
 	leader.Returns(metadataResponse)
 
-	// The mock broker must return a single produce response. If no produce request is received, the test wil fail.
+	// The mock broker must return a single produce response. If no produce request is received, the test will fail.
 	// This guarantees that mockbeat successfully produced a message to Kafka and connectivity is established.
 	prodSuccess := new(sarama.ProduceResponse)
 	prodSuccess.AddTopicPartition(kafkaTopic, 0, sarama.ErrNoError)

--- a/libbeat/tests/integration/kafka_test.go
+++ b/libbeat/tests/integration/kafka_test.go
@@ -54,7 +54,7 @@ output.kafka:
 `
 )
 
-// TestKafkaOutputCanConnectAndPublish ensures the beat Kafka output can successfuly produce messages to Kafka.
+// TestKafkaOutputCanConnectAndPublish ensures the beat Kafka output can successfully produce messages to Kafka.
 // Regression test for https://github.com/elastic/beats/issues/41823 where the Kafka output would
 // panic on the first Publish because it's Connect method was no longer called.
 func TestKafkaOutputCanConnectAndPublish(t *testing.T) {


### PR DESCRIPTION
- Closes https://github.com/elastic/beats/issues/41823

In https://github.com/elastic/beats/pull/40794 the Connectable interface was changed to include a `context.Context` argument, causing all clients with a Connect() that weren't updated to have a `Context(context.Context)` method instead to fail the NetworkClient interface check in https://github.com/elastic/beats/blob/367d94e1dc40a82713d651735eac7921bb584474/libbeat/publisher/pipeline/client_worker.go#L64-L70

This made it so that the Kafka and Redis outputs no longer counted as NetworkClients, bypassing the initial call to `Connect()` that was there previously at https://github.com/elastic/beats/blob/367d94e1dc40a82713d651735eac7921bb584474/libbeat/publisher/pipeline/client_worker.go#L143


In the case of Kafka the Connect call never happening makes the output panic on the first call to `Publish` because there is no producer.

~Raising without tests to make sure nothing else was missed while I figure out the best test for this that isn't totally contrived, because the problem is in the publisher pipeline and the output specific tests don't hook in at that level. This is how the problem was originally missed.~

The PR has been updated with an integration test to reproduce the problem: https://github.com/elastic/beats/pull/41824#issuecomment-2506777622
