### PR TITLE
metricbeat: suppress error when RAID metrics are enabled on non-RAID system

### DIFF
--- a/metricbeat/module/system/raid/blockinfo/getdev.go
+++ b/metricbeat/module/system/raid/blockinfo/getdev.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
 // ListAll lists all the multi-disk devices in a RAID array
@@ -43,7 +45,7 @@ func ListAll(path string) ([]MDDevice, error) {
 	}
 
 	if len(mds) == 0 {
-		return nil, nil
+		return nil, mb.PartialMetricsError{Err: fmt.Errorf("no RAID devices found. You have probably enabled the RAID metrics on a non-RAID system.")}
 	}
 
 	return mds, nil

--- a/metricbeat/module/system/raid/blockinfo/getdev.go
+++ b/metricbeat/module/system/raid/blockinfo/getdev.go
@@ -19,14 +19,13 @@ package blockinfo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
 // ListAll lists all the multi-disk devices in a RAID array
 func ListAll(path string) ([]MDDevice, error) {
-	dir, err := ioutil.ReadDir(path)
+	dir, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not read directory: %w", err)
 	}
@@ -44,7 +43,7 @@ func ListAll(path string) ([]MDDevice, error) {
 	}
 
 	if len(mds) == 0 {
-		return nil, fmt.Errorf("no matches from path %s", path)
+		return nil, nil
 	}
 
 	return mds, nil
@@ -69,8 +68,5 @@ func getMDDevice(path string) (MDDevice, error) {
 // Right now, we're doing this by looking for an `md` directory in the device dir.
 func isMD(path string) bool {
 	_, err := os.Stat(filepath.Join(path, "md"))
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }

--- a/metricbeat/module/system/raid/raid.go
+++ b/metricbeat/module/system/raid/raid.go
@@ -62,7 +62,7 @@ func blockto1024(b int64) int64 {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	devices, err := blockinfo.ListAll(m.mod.ResolveHostFS("/sys/block"))
 	if err != nil {
-		return fmt.Errorf("failed to parse sysfs: %w", err)
+		return fmt.Errorf("failed to list RAID devices: %w", err)
 	}
 
 	for _, blockDev := range devices {

--- a/metricbeat/module/system/raid/raid.go
+++ b/metricbeat/module/system/raid/raid.go
@@ -41,8 +41,11 @@ type MetricSet struct {
 
 // New creates a new instance of the raid metricset.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	sys, ok := base.Module().(resolve.Resolver)
+	if !ok {
+		return nil, fmt.Errorf("unexpected module type: %T", base.Module())
+	}
 
-	sys := base.Module().(resolve.Resolver)
 	return &MetricSet{
 		BaseMetricSet: base,
 

--- a/metricbeat/module/system/raid/raid_test.go
+++ b/metricbeat/module/system/raid/raid_test.go
@@ -18,6 +18,8 @@
 package raid
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,6 +46,20 @@ func TestFetch(t *testing.T) {
 	}
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
 		events[0].BeatEvent("system", "raid").Fields.StringToPrint())
+}
+
+func TestFetchNoRAID(t *testing.T) {
+	// Ensure that we don't error out when no RAID devices are present
+	tmpDir := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "sys/block"), 0755))
+	c := getConfig()
+	c["hostfs"] = tmpDir
+
+	f := mbtest.NewReportingMetricSetV2Error(t, c)
+	events, errs := mbtest.ReportingFetchV2Error(f)
+
+	assert.Empty(t, errs)
+	assert.Empty(t, events)
 }
 
 func getConfig() map[string]interface{} {


### PR DESCRIPTION
## Proposed commit message

When the Linux Metrics integration (beta) is installed with the raid metrics option enabled it causes an error if the host does not have a RAID configuration. This error causes the Agent to go into a degraded state.

This happens because we report not having `/sys/block/md*` devices  as an error, this only means that no RAID configuration is in place.

Instead, do not report this case as an error.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/6155
