### PR TITLE
[FlakyTest] TestFileWatcher/does_not_emit_events_for_empty_files/emits_a_create_event_once_something_is_written_to_the_empty_file

### DIFF
--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestFileWatcher(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/41209")
 	dir := t.TempDir()
 	paths := []string{filepath.Join(dir, "*.log")}
 	cfgStr := `
@@ -306,7 +305,11 @@ scanner:
 					Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 5}), // +5 bytes appended
 				},
 			}
-			requireEqualEvents(t, expEvent, e)
+			require.Eventually(t, func() bool {
+				return expEvent.NewPath == e.NewPath
+			}, 100*time.Millisecond, 10*time.Millisecond, "NewPath")
+			require.Equal(t, expEvent.Op, e.Op, "Op")
+			requireEqualDescriptors(t, expEvent.Descriptor, e.Descriptor)
 		})
 	})
 

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
@@ -261,10 +260,10 @@ scanner:
 		paths := []string{filepath.Join(dir, "*.log")}
 		cfgStr := `
 scanner:
-  check_interval: 10ms
+  check_interval: 50ms
 `
 
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
 		defer cancel()
 
 		logp.DevelopmentSetup(logp.ToObserverOutput())
@@ -306,13 +305,7 @@ scanner:
 					Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 5}), // +5 bytes appended
 				},
 			}
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, expEvent.NewPath, e.NewPath)
-			}, 100*time.Millisecond, 10*time.Millisecond, "NewPath")
-
-			require.Equal(t, expEvent.Op, e.Op, "Op")
-			requireEqualDescriptors(t, expEvent.Descriptor, e.Descriptor)
+			requireEqualEvents(t, expEvent, e)
 		})
 	})
 

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -309,7 +309,7 @@ scanner:
 
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				assert.Equal(c, expEvent.NewPath, e.NewPath)
-			}, 100*time.Millisecond, 10*time.Millisecond, "NewPath")
+			}, 1000*time.Millisecond, 100*time.Millisecond, "NewPath")
 
 			require.Equal(t, expEvent.Op, e.Op, "Op")
 			requireEqualDescriptors(t, expEvent.Descriptor, e.Descriptor)

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
@@ -305,9 +306,11 @@ scanner:
 					Info:     file.ExtendFileInfo(&testFileInfo{name: basename, size: 5}), // +5 bytes appended
 				},
 			}
-			require.Eventually(t, func() bool {
-				return expEvent.NewPath == e.NewPath
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, expEvent.NewPath, e.NewPath)
 			}, 100*time.Millisecond, 10*time.Millisecond, "NewPath")
+
 			require.Equal(t, expEvent.Op, e.Op, "Op")
 			requireEqualDescriptors(t, expEvent.Descriptor, e.Descriptor)
 		})

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -309,7 +309,7 @@ scanner:
 
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				assert.Equal(c, expEvent.NewPath, e.NewPath)
-			}, 1000*time.Millisecond, 100*time.Millisecond, "NewPath")
+			}, 100*time.Millisecond, 10*time.Millisecond, "NewPath")
 
 			require.Equal(t, expEvent.Op, e.Op, "Op")
 			requireEqualDescriptors(t, expEvent.Descriptor, e.Descriptor)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This test fails due to timing in file creation and subsequent testing for file existence. This test case is especially hard to manifest if your file system caches file creation operation. The provided changes were tested multiple times in an isolated GCP environment and was not reproducible. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.




## Related issues

Closes https://github.com/elastic/beats/issues/41209




