### PR TITLE
x-pack/filebeat/input/cel: add evaluation coverage collection support

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -213,6 +213,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Add field redaction package. {pull}40997[40997]
 - Add support for marked redaction to x-pack/filebeat/input/internal/private {pull}41212[41212]
 - Add support for collecting Okta role and factor data for users with filebeat entityanalytics input. {pull}41044[41044]
+- Add CEL input program evaluation coverage collection support. {pull}41884[41884]
 
 ==== Deprecated
 

--- a/x-pack/filebeat/docs/inputs/input-cel.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-cel.asciidoc
@@ -815,6 +815,13 @@ dump is configured, it is recommended that data input sizes be reduced to avoid 
 making dumps that are intractable to analysis. To delete existing failure dumps, set `failure_dump.enabled` to
 false without unsetting the filename option.
 
+[[cel-record-coverage]]
+[float]
+==== `record_coverage`
+
+This specifies that CEL code evaluation coverage should be recorded and logged in debug logs. This is a
+developer-only option.
+
 [float]
 === Metrics
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -168,7 +168,8 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 		}
 	}
 	wantDump := cfg.FailureDump.enabled() && cfg.FailureDump.Filename != ""
-	prg, ast, err := newProgram(ctx, cfg.Program, root, getEnv(cfg.AllowedEnvironment), client, limiter, auth, patterns, cfg.XSDs, log, trace, wantDump)
+	doCov := cfg.RecordCoverage && log.IsDebug()
+	prg, ast, cov, err := newProgram(ctx, cfg.Program, root, getEnv(cfg.AllowedEnvironment), client, limiter, auth, patterns, cfg.XSDs, log, trace, wantDump, doCov)
 	if err != nil {
 		return err
 	}
@@ -228,6 +229,14 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 		)
 		// Keep track of whether CEL is degraded for this periodic run.
 		var isDegraded bool
+		if doCov {
+			defer func() {
+				// If doCov is true, log the updated coverage details.
+				// Updates are a running aggregate for each call to run
+				// as cov is shared via the program compilation.
+				log.Debugw("coverage", "details", cov.Details())
+			}()
+		}
 		for {
 			if wait := time.Until(waitUntil); wait > 0 {
 				// We have a special-case wait for when we have a zero limit.
@@ -1039,10 +1048,10 @@ func getEnv(allowed []string) map[string]string {
 	return env
 }
 
-func newProgram(ctx context.Context, src, root string, vars map[string]string, client *http.Client, limiter *rate.Limiter, auth *lib.BasicAuth, patterns map[string]*regexp.Regexp, xsd map[string]string, log *logp.Logger, trace *httplog.LoggingRoundTripper, details bool) (cel.Program, *cel.Ast, error) {
+func newProgram(ctx context.Context, src, root string, vars map[string]string, client *http.Client, limiter *rate.Limiter, auth *lib.BasicAuth, patterns map[string]*regexp.Regexp, xsd map[string]string, log *logp.Logger, trace *httplog.LoggingRoundTripper, details, coverage bool) (cel.Program, *cel.Ast, *lib.Coverage, error) {
 	xml, err := lib.XML(nil, xsd)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to build xml type hints: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to build xml type hints: %w", err)
 	}
 	opts := []cel.EnvOption{
 		cel.Declarations(decls.NewVar(root, decls.Dyn)),
@@ -1070,23 +1079,30 @@ func newProgram(ctx context.Context, src, root string, vars map[string]string, c
 	}
 	env, err := cel.NewEnv(opts...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create env: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create env: %w", err)
 	}
 
 	ast, iss := env.Compile(src)
 	if iss.Err() != nil {
-		return nil, nil, fmt.Errorf("failed compilation: %w", iss.Err())
+		return nil, nil, nil, fmt.Errorf("failed compilation: %w", iss.Err())
 	}
 
-	var progOpts []cel.ProgramOption
+	var (
+		progOpts []cel.ProgramOption
+		cov      *lib.Coverage
+	)
+	if coverage {
+		cov = lib.NewCoverage(ast)
+		progOpts = []cel.ProgramOption{cov.ProgramOption()}
+	}
 	if details {
 		progOpts = []cel.ProgramOption{cel.EvalOptions(cel.OptTrackState)}
 	}
 	prg, err := env.Program(ast, progOpts...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed program instantiation: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed program instantiation: %w", err)
 	}
-	return prg, ast, nil
+	return prg, ast, cov, nil
 }
 
 func debug(log *logp.Logger, trace *httplog.LoggingRoundTripper) func(string, any) {

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -1769,6 +1769,49 @@ var inputTests = []struct {
 		},
 	},
 
+	// Coverage
+	{
+		name: "coverage",
+		config: map[string]interface{}{
+			"interval": 1,
+			"program": `int(state.n).as(n, {
+							"events": [{"n": n+1}],
+							"n":          n+1,
+							"want_more":  n+1 < 5,
+							"probe":      n < 2 ?
+								"little"
+							:
+								"big",
+							"fail_probe": n < 0 ?
+								"negative"
+							:
+								"non-negative",
+						})`,
+			"record_coverage": true,
+			"state":           map[string]any{"n": 0},
+			"resource": map[string]interface{}{
+				"url": "",
+			},
+		},
+		time: func() time.Time { return time.Date(2010, 2, 9, 0, 0, 0, 0, time.UTC) },
+		// The program will be evaluated five times in the first periodic
+		// run and then once for all subsequent runs. We depend here on
+		// the test construction that asks that we get at least as many
+		// results from the input as there are elements in the want slice
+		// and then stop.
+		want: []map[string]interface{}{
+			// First periodic run.
+			{"n": float64(1)},
+			{"n": float64(2)},
+			{"n": float64(3)},
+			{"n": float64(4)},
+			{"n": float64(5)},
+			// Second and subsequent periodic runs.
+			{"n": float64(6)},
+			{"n": float64(7)},
+		},
+	},
+
 	// not yet done from httpjson (some are redundant since they are compositional products).
 	//
 	// cursor/pagination (place above auth test block)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This allows collecting the execution coverage data from a running input. Coverage data is logged as JSON data at debug level when this option is enabled. Currently no tooling is available for rendering the data in a more human-friendly format, but the backing infrastructure for this exists in the mito repository.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `go test -v` in x-pack/filebeat/input/cel (maybe with `-run TestInput/coverage` to mimimise irrelevant verbosity, but season to taste).

You should see lines like (jq expanded):
```
{
    "log.level": "debug",
    "@timestamp": "2024-12-04T11:22:34.585+1030",
    "log.logger": "cel_test",
    "log.origin": {
        "function": "github.com/elastic/beats/v7/x-pack/filebeat/input/cel.input.run.func1.1",
        "file.name": "cel/input.go",
        "file.line": 237
    },
    "message": "coverage",
    "input_url": "",
    "details": [
        {
            "line": 1,
            "coverage": 0.625,
            "nodes": [
                1,
                2,
                3,
                6,
                44,
                45,
                46,
                47
            ],
            "covered": [
                1,
                3,
                6,
                44,
                47
            ],
            "missed": [
                2,
                45,
                46
            ],
            "annotation": " | int(state.n).as(n, {\n |     !          !"
        },
        {
            "line": 2,
            "coverage": 1,
            "nodes": [
                8,
                9,
                10,
                12,
                13,
                14,
                15
            ],
            "covered": [
                8,
                9,
                10,
                12,
                13,
                14,
                15
            ],
            "missed": null,
            "annotation": ""
        },
        {
            "line": 3,
            "coverage": 1,
            "nodes": [
                17,
                18,
                19,
                20
            ],
            "covered": [
                17,
                18,
                19,
                20
            ],
            "missed": null,
            "annotation": ""
        },
        {
            "line": 4,
            "coverage": 1,
            "nodes": [
                22,
                23,
                24,
                25,
                26,
                27
            ],
            "covered": [
                22,
                23,
                24,
                25,
                26,
                27
            ],
            "missed": null,
            "annotation": ""
        },
        {
            "line": 5,
            "coverage": 1,
            "nodes": [
                29,
                30,
                31,
                32,
                33
            ],
            "covered": [
                29,
                30,
                31,
                32,
                33
            ],
            "missed": null,
            "annotation": ""
        },
        {
            "line": 6,
            "coverage": 1,
            "nodes": [
                34
            ],
            "covered": [
                34
            ],
            "missed": null,
            "annotation": ""
        },
        {
            "line": 8,
            "coverage": 1,
            "nodes": [
                35
            ],
            "covered": [
                35
            ],
            "missed": null,
            "annotation": ""
        },
        {
            "line": 9,
            "coverage": 1,
            "nodes": [
                37,
                38,
                39,
                40,
                41
            ],
            "covered": [
                37,
                38,
                39,
                40,
                41
            ],
            "missed": null,
            "annotation": ""
        },
        {
            "line": 10,
            "coverage": 0,
            "nodes": [
                42
            ],
            "covered": null,
            "missed": [
                42
            ],
            "annotation": " |         \"negative\"\n |         !"
        },
        {
            "line": 12,
            "coverage": 1,
            "nodes": [
                43
            ],
            "covered": [
                43
            ],
            "missed": null,
            "annotation": ""
        }
    ],
    "ecs.version": "1.6.0"
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
