### PR TITLE
Add support for podman metrics in docker module

### DIFF
--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -62,6 +62,9 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Docker module supports metrics collection from podman's docker compatible API. In case of podman set to true.
+  # podman: false
+
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -268,6 +268,9 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Docker module supports metrics collection from podman's docker compatible API. In case of podman set to true.
+  # podman: false
+
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.

--- a/metricbeat/module/docker/_meta/config.reference.yml
+++ b/metricbeat/module/docker/_meta/config.reference.yml
@@ -17,6 +17,9 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Docker module supports metrics collection from podman's docker compatible API. In case of podman set to true.
+  # podman: false
+
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -15,6 +15,9 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Docker module supports metrics collection from podman's docker compatible API. In case of podman set to true.
+  # podman: false
+
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.

--- a/metricbeat/module/docker/config.go
+++ b/metricbeat/module/docker/config.go
@@ -19,14 +19,16 @@ package docker
 
 // Config contains the config needed for the docker
 type Config struct {
-	TLS   *TLSConfig `config:"ssl"`
-	DeDot bool       `config:"labels.dedot"`
+	TLS    *TLSConfig `config:"ssl"`
+	DeDot  bool       `config:"labels.dedot"`
+	Podman bool       `config:"podman"`
 }
 
 // DefaultConfig returns default module config
 func DefaultConfig() Config {
 	return Config{
-		DeDot: true,
+		DeDot:  true,
+		Podman: false,
 	}
 }
 

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -40,6 +40,7 @@ type MetricSet struct {
 	cpuService   *CPUService
 	dockerClient *client.Client
 	dedot        bool
+	podman       bool
 }
 
 // New creates a new instance of the docker cpu MetricSet.
@@ -68,12 +69,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		dockerClient:  client,
 		cpuService:    &CPUService{Cores: cpuConfig.Cores},
 		dedot:         config.DeDot,
+		podman:        config.Podman,
 	}, nil
 }
 
 // Fetch returns a list of docker CPU stats.
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout)
+	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout, m.podman)
 	if err != nil {
 		return fmt.Errorf("failed to get docker stats: %w", err)
 	}

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -89,7 +89,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch creates list of events with diskio stats for all containers.
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout)
+	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout, false)
 	if err != nil {
 		return fmt.Errorf("failed to get docker stats: %w", err)
 	}

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -43,6 +43,7 @@ type MetricSet struct {
 	memoryService *MemoryService
 	dockerClient  *client.Client
 	dedot         bool
+	podman        bool
 	logger        *logp.Logger
 }
 
@@ -64,13 +65,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		memoryService: &MemoryService{},
 		dockerClient:  dockerClient,
 		dedot:         config.DeDot,
+		podman:        config.Podman,
 		logger:        logger,
 	}, nil
 }
 
 // Fetch creates a list of memory events for each container.
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout)
+	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout, m.podman)
 	if err != nil {
 		return fmt.Errorf("failed to get docker stats: %w", err)
 	}

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -66,7 +66,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods creates a list of network events for each container.
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout)
+	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout, false)
 	if err != nil {
 		return fmt.Errorf("failed to get docker stats: %w", err)
 	}

--- a/metricbeat/module/docker/network_summary/network_summary.go
+++ b/metricbeat/module/docker/network_summary/network_summary.go
@@ -84,7 +84,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(ctx context.Context, report mb.ReporterV2) error {
 
-	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout)
+	stats, err := docker.FetchStats(m.dockerClient, m.Module().Config().Timeout, false)
 	if err != nil {
 		return fmt.Errorf("failed to get docker stats: %w", err)
 	}

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -18,6 +18,9 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Docker module supports metrics collection from podman's docker compatible API. In case of podman set to true.
+  # podman: false
+
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.


### PR DESCRIPTION
## Proposed commit message



- WHAT:  Enhance docker module so that podman metrics are collected and calculated correctly
- WHY:  support for podman metrics in docker module


## Details

Podman offers a docker compatible API for metrics collection. So using docker module to collect podman metrics should be working out of the box. 
In reality the memory metrics were not published at all and cpu usage percentage calculation was incorrect.
The reason is that the podman api returns zero values for `precpu_stats`. These stats refer to the latest's read cpu statistics, needed for cpu percentage calculation. Also due to these stats being zero, the memory metrics were not populated because of a sanity check in the code.https://github.com/elastic/beats/blob/3f51793e33da83d62bb9260d9957df62eaf69fb7/metricbeat/module/docker/memory/helper.go#L55

For docker, the `precpu_stats` are returned every time. 
The solution in the Podman's case is to [stream](https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerStats) the api response. By default we had set the stream option to false as there was no need in case of docker.

As part of this PR we introduce a new configuration parameter named `podman` (by default false). If set to true, indicating that podman is used, then the stream parameter is set to true, only for the collection of cpu and memory stats.
The reason is that for cpu and memory stats the `precpu_stats` are needed. 
From the streamed response, we get the second response as it was noticed during testing that the `precpu_stats` of the first response were incorrect and the cpu was miscalculated.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

There is no disruptive user impact.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. start podman machine (In macOS use podman desktop)
2. start an nginx test container `podman run -d -p 8080:80 --name mynginx nginx`
3. exec into mynginx pod and start a cpu intensive task:
a. `podman exec -ti mynginx bash `
b. `while true; do :; done &`
4. run metricbeat locally with docker module enabled and `podman` parameter set to true
5. watch the docker.* metrics being published to ES with correct values. Compare with `podman stats` command results.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/enhancements/issues/22801

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

Podman Stats command (check for mynginx container)
<img width="1336" alt="podman stats" src="https://github.com/user-attachments/assets/1765303a-2158-43f7-9fde-1f3f1fa6cec1">

![docker cpu percentage](https://github.com/user-attachments/assets/e47f3b37-d3bc-4f77-89bf-5a3c337b59c6)

![docker memory percentage](https://github.com/user-attachments/assets/63be7542-2446-460d-a878-8b68953e401d)

