### PR TITLE
metricbeat: handle nf_conntrack module not loaded in linux integration

### DIFF
--- a/metricbeat/module/linux/conntrack/conntrack.go
+++ b/metricbeat/module/linux/conntrack/conntrack.go
@@ -19,6 +19,7 @@ package conntrack
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/prometheus/procfs"
 
@@ -68,6 +69,9 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	}
 	conntrackStats, err := newFS.ConntrackStat()
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = mb.PartialMetricsError{Err: fmt.Errorf("nf_conntrack kernel module not loaded: %w", err)}
+		}
 		return fmt.Errorf("error fetching conntrack stats: %w", err)
 	}
 

--- a/metricbeat/module/linux/conntrack/conntrack_test.go
+++ b/metricbeat/module/linux/conntrack/conntrack_test.go
@@ -18,10 +18,16 @@
 package conntrack
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/metricbeat/mb"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/linux"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -58,6 +64,23 @@ func TestFetch(t *testing.T) {
 	rawEvent := events[0].BeatEvent("linux", "conntrack").Fields["linux"].(mapstr.M)["conntrack"].(mapstr.M)["summary"]
 
 	assert.Equal(t, testConn, rawEvent)
+}
+
+func TestFetchConntrackModuleNotLoaded(t *testing.T) {
+	// Create a temporary directory to simulate a missing /proc/net/stat/nf_conntrack file
+	tmpDir := t.TempDir()
+	assert.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "proc/net/stat"), 0755))
+	c := getConfig()
+	c["hostfs"] = tmpDir
+
+	f := mbtest.NewReportingMetricSetV2Error(t, c)
+	events, errs := mbtest.ReportingFetchV2Error(f)
+
+	require.Len(t, errs, 1)
+	err := errors.Join(errs...)
+	assert.ErrorAs(t, err, &mb.PartialMetricsError{})
+	assert.Regexp(t, regexp.MustCompile(`error fetching conntrack stats: nf_conntrack kernel module not loaded: open .*\/proc\/net\/stat\/nf_conntrack: no such file or directory`), err.Error())
+	require.Empty(t, events)
 }
 
 func getConfig() map[string]interface{} {


### PR DESCRIPTION
## Proposed commit message

When the Linux Metrics integration (beta) is installed with the conntrack metrics option enabled it causes an error and subsequent degraded state in Elastic Agent if the host does not have the nf_conntrack kernel module loaded.

For this case, report a partial metrics error.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #6155