### PR TITLE
[azure-eventhub] Make the azure-eventhub input v1 tracer opt-in

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -356,6 +356,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add evaluation state dump debugging option to CEL input. {pull}41335[41335]
 - Added support for retry configuration in GCS input. {issue}11580[11580] {pull}41862[41862]
 - Improve S3 polling mode states registry when using list prefix option. {pull}41869[41869]
+- The environment variable `BEATS_AZURE_EVENTHUB_INPUT_TRACING_ENABLED: true` enables internal logs tracer for the azure-eventhub input. {issue}41931[41931] {pull}41932[41932]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-azure-eventhub.asciidoc
@@ -13,7 +13,10 @@ Users can make use of the `azure-eventhub` input in order to read messages from 
 The azure-eventhub input implementation is based on the the event processor host (EPH is intended to be run across multiple processes and machines while load balancing message consumers more on this here https://github.com/Azure/azure-event-hubs-go#event-processor-host, https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-event-processor-host).
 State such as leases on partitions and checkpoints in the event stream are shared between receivers using an Azure Storage container. For this reason, as a prerequisite to using this input, users will have to create or use an existing storage account.
 
-
+Users can enable internal logs tracing for this input by setting the environment
+variable `BEATS_AZURE_EVENTHUB_INPUT_TRACING_ENABLED: true`. When enabled,
+this input will log additional information to the logs. Additional information
+includes partition ownership, blob lease information, and other internal state.
 
 
 Example configuration:

--- a/x-pack/filebeat/input/azureeventhub/tracer.go
+++ b/x-pack/filebeat/input/azureeventhub/tracer.go
@@ -8,6 +8,7 @@ package azureeventhub
 
 import (
 	"context"
+	"os"
 
 	"github.com/devigned/tab"
 
@@ -15,7 +16,12 @@ import (
 )
 
 func init() {
-	tab.Register(new(logsOnlyTracer))
+	// Register the logs tracer only if the environment variable is
+	// set to avoid the overhead of the tracer in environments where
+	// it's not needed.
+	if os.Getenv("BEATS_AZURE_EVENTHUB_INPUT_TRACING_ENABLED") == "true" {
+		tab.Register(new(logsOnlyTracer))
+	}
 }
 
 // logsOnlyTracer manages the creation of the required


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Make the `azure-eventhub` input v1 internal logs tracer opt-in. To enable internal (legacy) Event Hub SDK logs, now you need to set the following environment variable:

```sh
BEATS_AZURE_EVENTHUB_INPUT_TRACING_ENABLED: true
```

Before this change, the tracer was enabled by default.

A few customers reported higher than anticipated error logs in edge cases. These error logs are an essential signal to troubleshoot the root cause of several issues. However, we should give the option to completely opt out from the internal logs tracing when needed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Write a KB article that describes how to enable and what you get 
- [ ] Add the environment variable to the input docs

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/41931


<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
