### PR TITLE
Additional stats fields for Elasticsearch

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -304,6 +304,19 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string) (maps
 	return clusterState, err
 }
 
+func GetIndexSettings(http *helper.HTTP, resetURI string, indexPattern string) (mapstr.M, error) {
+	indicesSettingsURI := indexPattern + "/_settings"
+
+	content, err := fetchPath(http, resetURI, indicesSettingsURI, "local=true&expand_wildcards=hidden,all")
+	if err != nil {
+		return nil, err
+	}
+
+	var indicesSettings map[string]interface{}
+	err = json.Unmarshal(content, &indicesSettings)
+	return indicesSettings, err
+}
+
 // GetClusterSettingsWithDefaults returns cluster settings.
 func GetClusterSettingsWithDefaults(http *helper.HTTP, resetURI string, filterPaths []string) (mapstr.M, error) {
 	return GetClusterSettings(http, resetURI, true, filterPaths)


### PR DESCRIPTION
This aims to replace https://github.com/elastic/beats/pull/41652

## Proposed commit message

Adds `creation_date` and `tier_preference` fields for `elasticsearch.index` dataset.
This will be necessary for further development through https://github.com/elastic/integrations/pull/11656

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation.
- [x] ~I have made corresponding change to the default configuration files~ N/A
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Regarding the [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-metricset-elasticsearch-index.html), the example document is copied from the `data.json` file, accurately modified in this PR.

Another modification in the `integrations` repo will be required (for [this file](https://github.com/elastic/integrations/tree/main/packages/elasticsearch/docs))

## Disruptive User Impact

This "shouldn't" have an impact on end-users, this doesn't alter existing behavior but only adds 2 new fields that will be exposed in the gathered Elasticsearch monitoring stats.

## Author's Checklist

- [ ] Modify the integrations repository so that the documentation is accurate there: https://github.com/elastic/integrations/pull/11942
- [ ] Modify the Elasticsearch code for the built-in index template: https://github.com/elastic/elasticsearch/pull/117851

## How to test this PR locally

You can run the integration against any cluster (with `xpack` or otherwise) and check that the generated index stats documents have the two new fields:

- `creation_date`
- `tier_preference`

## Screenshots

<img width="715" alt="image" src="https://github.com/user-attachments/assets/f5fc3cce-596e-4e28-8411-6924058e5ac6">


