### PR TITLE
[system/cpu,core] - Disable performance counter by default to unblock agent CI

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -269,7 +269,7 @@ metricbeat.modules:
   # This option enables the use of performance counters to collect data for cpu/core metricset.
   # Only effective for Windows.
   # You should use this option if running beats on machins with more than 64 cores.
-  #use_performance_counters: true
+  #use_performance_counters: false
 ----
 
 [float]

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -145,7 +145,7 @@ metricbeat.modules:
   # This option enables the use of performance counters to collect data for cpu/core metricset.
   # Only effective for Windows.
   # You should use this option if running beats on machins with more than 64 cores.
-  #use_performance_counters: true
+  #use_performance_counters: false
 
 #------------------------------ Aerospike Module ------------------------------
 - module: aerospike

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -85,4 +85,4 @@
   # This option enables the use of performance counters to collect data for cpu/core metricset.
   # Only effective for Windows.
   # You should use this option if running beats on machins with more than 64 cores.
-  #use_performance_counters: true
+  #use_performance_counters: false

--- a/metricbeat/module/system/core/_meta/docs.asciidoc
+++ b/metricbeat/module/system/core/_meta/docs.asciidoc
@@ -25,5 +25,5 @@ metricbeat.modules:
 - module: system
   metricsets: [core]
   core.metrics: [percentages, ticks]
-  #use_performance_counters: true
+  #use_performance_counters: false
 ----

--- a/metricbeat/module/system/core/config.go
+++ b/metricbeat/module/system/core/config.go
@@ -67,5 +67,5 @@ func (c Config) Validate() (metrics.MetricOpts, error) {
 
 var defaultConfig = Config{
 	Metrics:                 []string{percentages},
-	UserPerformanceCounters: true,
+	UserPerformanceCounters: false,
 }

--- a/metricbeat/module/system/cpu/_meta/docs.asciidoc
+++ b/metricbeat/module/system/cpu/_meta/docs.asciidoc
@@ -26,5 +26,5 @@ metricbeat.modules:
 - module: system
   metricsets: [cpu]
   cpu.metrics: [percentages, normalized_percentages, ticks]
-  #use_performance_counters: true
+  #use_performance_counters: false
 ----

--- a/metricbeat/module/system/cpu/config.go
+++ b/metricbeat/module/system/cpu/config.go
@@ -71,5 +71,5 @@ func (c Config) Validate() (metrics.MetricOpts, error) {
 
 var defaultConfig = Config{
 	Metrics:                 []string{percentages, normalizedPercentages},
-	UserPerformanceCounters: true,
+	UserPerformanceCounters: false,
 }

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -145,7 +145,7 @@ metricbeat.modules:
   # This option enables the use of performance counters to collect data for cpu/core metricset.
   # Only effective for Windows.
   # You should use this option if running beats on machins with more than 64 cores.
-  #use_performance_counters: true
+  #use_performance_counters: false
 
 #------------------------------- ActiveMQ Module -------------------------------
 - module: activemq


### PR DESCRIPTION
Alternative to https://github.com/elastic/beats/pull/42042.

This is a temporary fix as CI on elastic-agent's main is broken https://buildkite.com/elastic/elastic-agent-extended-testing/builds/5390#0193c17f-c655-422a-8dc9-ae5a7a40fdbd. 

This most likely happened because user not having enough permissions to read from performance counter. I'll do some more digging and fix the underlying issue.
