### PR TITLE
[system/cpu,core]: throw warning and switch to default

### DIFF
--- a/metricbeat/module/system/core/core.go
+++ b/metricbeat/module/system/core/core.go
@@ -70,7 +70,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 	cpu, err := metrics.New(sys, cpuOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing system.cpu metricset: %w", err)
+		if config.UserPerformanceCounters {
+			base.Logger().Warnf("Error using performance counters, possibly due to being disabled or insufficient permissions: %v", err)
+			// switch to default method i.e without any options
+			cpu, err = metrics.New(sys)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error initializing system.cpu metricset: %w", err)
+		}
 	}
 
 	return &MetricSet{

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -72,10 +72,17 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		cpuOpts = append(cpuOpts, metrics.WithWindowsPerformanceCounter())
 	}
 	cpu, err := metrics.New(sys, cpuOpts...)
-
 	if err != nil {
-		return nil, fmt.Errorf("error initializing system.cpu metricset: %w", err)
+		if config.UserPerformanceCounters {
+			base.Logger().Warnf("Error using performance counters, possibly due to being disabled or insufficient permissions: %v", err)
+			// switch to default method i.e without any options
+			cpu, err = metrics.New(sys)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error initializing system.cpu metricset: %w", err)
+		}
 	}
+
 	return &MetricSet{
 		BaseMetricSet: base,
 		opts:          opts,


### PR DESCRIPTION
This is an alternative to https://github.com/elastic/beats/pull/42041.

If we face any errors while reading performance counter (can happen if using `unprivileged` mode and not having enough permissions or if the performance counters are just disabled on the system), we can log a warning and default to existing implementations i.e. not using performance counters.