### PR TITLE
Changed CreationDate to string to prevent scientific notation conversion

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -229,6 +229,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Do not report non-existant 0 values for RSS metrics in docker/memory {pull}41449[41449]
 - Log Cisco Meraki `getDevicePerformanceScores` errors without stopping metrics collection. {pull}41622[41622]
 - Don't skip first bucket value in GCP metrics metricset for distribution type metrics {pull}41822[41822]
+- Fixed `creation_date` scientific notation output in the `elasticsearch.index` metricset. {pull}42053[42053]
 
 
 *Osquerybeat*

--- a/metricbeat/include/list_init.go
+++ b/metricbeat/include/list_init.go
@@ -21,10 +21,9 @@ package include
 
 import (
 	// Import packages to perform 'func InitializeModule()' when in-use.
-	m0 "github.com/elastic/beats/v7/metricbeat/autodiscover/builder/hints"
 	m1 "github.com/elastic/beats/v7/metricbeat/autodiscover/appender/kubernetes/token"
+	m0 "github.com/elastic/beats/v7/metricbeat/autodiscover/builder/hints"
 	m2 "github.com/elastic/beats/v7/metricbeat/processor/add_kubernetes_metadata"
-
 	// Import packages that perform 'func init()'.
 )
 

--- a/metricbeat/include/list_init.go
+++ b/metricbeat/include/list_init.go
@@ -21,9 +21,10 @@ package include
 
 import (
 	// Import packages to perform 'func InitializeModule()' when in-use.
-	m1 "github.com/elastic/beats/v7/metricbeat/autodiscover/appender/kubernetes/token"
 	m0 "github.com/elastic/beats/v7/metricbeat/autodiscover/builder/hints"
+	m1 "github.com/elastic/beats/v7/metricbeat/autodiscover/appender/kubernetes/token"
 	m2 "github.com/elastic/beats/v7/metricbeat/processor/add_kubernetes_metadata"
+
 	// Import packages that perform 'func init()'.
 )
 

--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -20,7 +20,6 @@ package index
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/joeshaw/multierror"
 
@@ -44,7 +43,7 @@ type Index struct {
 	Index          string     `json:"index"`
 	Status         string     `json:"status"`
 	TierPreference string     `json:"tier_preference"`
-	CreationDate   int        `json:"creation_date"`
+	CreationDate   string     `json:"creation_date"`
 	Version        string     `json:"version"`
 	Shards         shardStats `json:"shards"`
 }
@@ -307,10 +306,7 @@ func addIndexSettings(idx *Index, indicesSettings mapstr.M) error {
 		return fmt.Errorf("failed to get index creation date: %w", err)
 	}
 
-	idx.CreationDate, err = strconv.Atoi(indexCreationDate)
-	if err != nil {
-		return fmt.Errorf("failed to convert index creation date to int: %w", err)
-	}
+	idx.CreationDate = indexCreationDate
 
 	indexTierPreference, err := getIndexSettingForIndex(indexSettings, idx.Index, "index.routing.allocation.require._tier_preference")
 	if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Changed `CreationDate` field internally from `int` to `string` - the marshalling of the string leads to scientific notation on some versions. Keeping it as string makes sure the value is passed as-is.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
