### PR TITLE
Add warning about needing -e to start 8.17.0 Docker images

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -63,7 +63,7 @@ The following checks were performed on each of these signatures:
 
 ==== Run the {beatname_uc} setup
 
-IMPORTANT: Due to a link:https://github.com/elastic/beats/issues/42038[known issue] in version 8.17.0, in that release standalone Beats Docker images will not start if a `-e` option is not added. The `-e` option makes {beatname_uc} log to stderr, which is the correct behaviour when running on Docker.
+IMPORTANT: A link:https://github.com/elastic/beats/issues/42038[known issue] in version 8.17.0 prevents {beats} Docker images from starting when no options are provided. When running an image on that version, add an `--environment` parameter to avoid the problem. This is planned to be addressed in link:https://github.com/elastic/beats/pull/42060[issue #42060].
 
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -63,6 +63,8 @@ The following checks were performed on each of these signatures:
 
 ==== Run the {beatname_uc} setup
 
+IMPORTANT: Due to a link:https://github.com/elastic/beats/issues/42038[known issue] in version 8.17.0, in that release standalone Beats Docker images will not start if a `-e` option is not added. The `-e` option makes {beatname_uc} log to stderr, which is the correct behaviour when running on Docker.
+
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations
 ifndef::no_dashboards[]

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -63,7 +63,7 @@ The following checks were performed on each of these signatures:
 
 ==== Run the {beatname_uc} setup
 
-IMPORTANT: A link:https://github.com/elastic/beats/issues/42038[known issue] in version 8.17.0 prevents {beats} Docker images from starting when no options are provided. When running an image on that version, add an `--environment` parameter to avoid the problem. This is planned to be addressed in link:https://github.com/elastic/beats/pull/42060[issue #42060].
+IMPORTANT: A link:https://github.com/elastic/beats/issues/42038[known issue] in version 8.17.0 prevents {beats} Docker images from starting when no options are provided. When running an image on that version, add an `--environment` parameter to avoid the problem. This is planned to be addressed in issue link:https://github.com/elastic/beats/pull/42060[#42060].
 
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations


### PR DESCRIPTION
This updates the [Run the -Beatname- setup](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html#_run_the_filebeat_setup) step for all Beats to address a [known issue](https://github.com/elastic/beats/issues/42038).


---

![Screenshot 2024-12-16 at 12 21 40 PM](https://github.com/user-attachments/assets/0fc79a59-2e27-40ce-98d8-8a89d9d52c83)


