### PR TITLE
.../input/entityanalytics/provider/okta: Handle 429s, concurrent limits

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -373,6 +373,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - The environment variable `BEATS_AZURE_EVENTHUB_INPUT_TRACING_ENABLED: true` enables internal logs tracer for the azure-eventhub input. {issue}41931[41931] {pull}41932[41932]
 - Rate limiting operability improvements in the Okta provider of the Entity Analytics input. {issue}40106[40106] {pull}41977[41977]
 - Added default values in the streaming input for websocket retries and put a cap on retry wait time to be lesser than equal to the maximum defined wait time. {pull}42012[42012]
+- Rate limiting fault tolerance improvements in the Okta provider of the Entity Analytics input. {issue}40106[40106] {pull}42094[42094]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta.go
@@ -374,55 +374,73 @@ type devUser struct {
 // See GetUserDetails for details of the query and rate limit parameters.
 func getDetails[E entity](ctx context.Context, cli *http.Client, u *url.URL, endpoint string, key string, all bool, omit Response, lim *RateLimiter, log *logp.Logger) ([]E, http.Header, error) {
 	url := u.String()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	contentType := "application/json"
-	if omit != OmitNone {
-		contentType += "; " + omit.String()
-	}
-	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Authorization", fmt.Sprintf("SSWS %s", key))
+	retryCount := 0
+	const maxRetries = 5
 
-	err = lim.Wait(ctx, endpoint, u, log)
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := cli.Do(req)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer resp.Body.Close()
-	err = lim.Update(endpoint, resp.Header, log)
-	if err != nil {
-		io.Copy(io.Discard, resp.Body)
-		return nil, nil, err
-	}
+	for {
+		if retryCount > maxRetries {
+			return nil, nil, fmt.Errorf("maximum retries (%d) finished without success", maxRetries)
+		}
+		if retryCount > 0 {
+			log.Warnf("retrying... (%d/%d)", retryCount, maxRetries)
+		}
 
-	var body bytes.Buffer
-	n, err := io.Copy(&body, resp.Body)
-	if n == 0 || err != nil {
-		return nil, nil, err
-	}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		contentType := "application/json"
+		if omit != OmitNone {
+			contentType += "; " + omit.String()
+		}
+		req.Header.Set("Content-Type", contentType)
+		req.Header.Set("Authorization", fmt.Sprintf("SSWS %s", key))
 
-	if all {
-		// List all entities.
-		var e []E
-		err = json.Unmarshal(body.Bytes(), &e)
+		err = lim.Wait(ctx, endpoint, u, log)
+		if err != nil {
+			return nil, nil, err
+		}
+		resp, err := cli.Do(req)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer resp.Body.Close()
+		err = lim.Update(endpoint, resp.Header, log)
+		if err != nil {
+			io.Copy(io.Discard, resp.Body)
+			return nil, nil, err
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			log.Warnf("received 429 Too Many Requests")
+			retryCount++
+			continue
+		}
+
+		var body bytes.Buffer
+		n, err := io.Copy(&body, resp.Body)
+		if n == 0 || err != nil {
+			return nil, nil, err
+		}
+
+		if all {
+			// List all entities.
+			var e []E
+			err = json.Unmarshal(body.Bytes(), &e)
+			if err != nil {
+				err = recoverError(body.Bytes())
+			}
+			return e, resp.Header, err
+		}
+		// Get single entity's details.
+		var e [1]E
+		err = json.Unmarshal(body.Bytes(), &e[0])
 		if err != nil {
 			err = recoverError(body.Bytes())
 		}
-		return e, resp.Header, err
+		return e[:], resp.Header, err
 	}
-	// Get single entity's details.
-	var e [1]E
-	err = json.Unmarshal(body.Bytes(), &e[0])
-	if err != nil {
-		err = recoverError(body.Bytes())
-	}
-	return e[:], resp.Header, err
 }
 
 // recoverError returns an error based on the returned Okta API error. Error

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta.go
@@ -382,7 +382,7 @@ func getDetails[E entity](ctx context.Context, cli *http.Client, u *url.URL, end
 			return nil, nil, fmt.Errorf("maximum retries (%d) finished without success", maxRetries)
 		}
 		if retryCount > 0 {
-			log.Warnf("retrying... (%d/%d)", retryCount, maxRetries)
+			log.Warnw("retrying...", "retry", retryCount, "max", maxRetries)
 		}
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -413,7 +413,7 @@ func getDetails[E entity](ctx context.Context, cli *http.Client, u *url.URL, end
 		}
 
 		if resp.StatusCode == http.StatusTooManyRequests {
-			log.Warnf("received 429 Too Many Requests")
+			log.Warnw("received 429 Too Many Requests")
 			retryCount++
 			continue
 		}

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/ratelimiter_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/ratelimiter_test.go
@@ -179,7 +179,6 @@ func TestRateLimiter(t *testing.T) {
 		}
 		ctx := context.Background()
 		log := logp.L()
-		e := r.endpoint(endpoint)
 
 		// update to 30 requests remaining, reset in 30s
 		headers := http.Header{
@@ -209,7 +208,7 @@ func TestRateLimiter(t *testing.T) {
 			t.Errorf("unexpected error from Wait(): %v", err)
 		}
 
-		e = r.endpoint(endpoint)
+		e := r.endpoint(endpoint)
 
 		newLimit := e.limiter.Limit()
 		expectedNewLimit := rate.Limit(1)

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/ratelimiter_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/ratelimiter_test.go
@@ -12,8 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"golang.org/x/time/rate"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestRateLimiter(t *testing.T) {


### PR DESCRIPTION
## Proposed commit message

```
.../input/entityanalytics/provider/okta: Handle 429s, concurrent limits

- Retry requests that get a 429 response, up to a maximum number of
  retries.
- If the concurrent rate limit[1] is exceeded, reset to the default
  initial rate, rather than to zero.

[1] https://developer.okta.com/docs/reference/rl-best-practices/#example-rate-limit-header-with-concurrent-rate-limit
```

## Discussion

Hiding whitespace changes will greatly improve the readability of the diff for `x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/okta.go`. It's mostly indentation changes.

For the concurrent rate limit, the previous behavior was to reset to a rate of zero, which would cause an error because the next wait would exceed the maximum wait time.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #40106