### PR TITLE
[7.17] Use MongoDB 5.0 in metricbeat integration tests

### DIFF
--- a/metricbeat/docs/modules/mongodb.asciidoc
+++ b/metricbeat/docs/modules/mongodb.asciidoc
@@ -58,8 +58,7 @@ The default metricsets are `collstats`, `dbstats` and `status`.
 [float]
 === Compatibility
 
-The MongoDB metricsets were tested with MongoDB 3.4 and 3.0 and are expected to
-work with all versions >= 2.8.
+The MongoDB metricsets were tested with MongoDB 5.0 and are expected to work with all versions >= 5.0.
 
 [float]
 === MongoDB Privileges

--- a/metricbeat/module/mongodb/_meta/docs.asciidoc
+++ b/metricbeat/module/mongodb/_meta/docs.asciidoc
@@ -49,8 +49,7 @@ The default metricsets are `collstats`, `dbstats` and `status`.
 [float]
 === Compatibility
 
-The MongoDB metricsets were tested with MongoDB 3.4 and 3.0 and are expected to
-work with all versions >= 2.8.
+The MongoDB metricsets were tested with MongoDB 5.0 and are expected to work with all versions >= 5.0.
 
 [float]
 === MongoDB Privileges

--- a/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
@@ -51,22 +51,24 @@ func TestFetch(t *testing.T) {
 		assert.True(t, collections > 0)
 
 		objects := metricsetFields["objects"].(int64)
-		assert.True(t, objects > 0)
+		assert.True(t, objects >= 0)
 
 		avgObjSize, err := metricsetFields.GetValue("avg_obj_size.bytes")
 		assert.NoError(t, err)
-		assert.True(t, avgObjSize.(int64) > 0)
+		assert.True(t, avgObjSize.(int64) >= 0)
 
 		dataSize, err := metricsetFields.GetValue("data_size.bytes")
 		assert.NoError(t, err)
-		assert.True(t, dataSize.(int64) > 0)
+		assert.True(t, dataSize.(int64) >= 0)
 
 		storageSize, err := metricsetFields.GetValue("storage_size.bytes")
 		assert.NoError(t, err)
 		assert.True(t, storageSize.(int64) > 0)
 
-		numExtents := metricsetFields["num_extents"].(int64)
-		assert.True(t, numExtents >= 0)
+		if metricsetFields["num_extents"] != nil {
+			numExtents := metricsetFields["num_extents"].(int32)
+			assert.True(t, numExtents >= 0)
+		}
 
 		indexes := metricsetFields["indexes"].(int64)
 		assert.True(t, indexes >= 0)

--- a/metricbeat/module/mongodb/docker-compose.yml
+++ b/metricbeat/module/mongodb/docker-compose.yml
@@ -2,11 +2,10 @@ version: "2.3"
 
 services:
   mongodb:
-    image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-3.4}-1
+    image: docker.elastic.co/integrations-ci/beats-mongodb:${MONGODB_VERSION:-5.0}-1
     build:
       context: ./_meta
       args:
-        MONGODB_VERSION: "${MONGODB_VERSION:-3.4}"
-    command: mongod --replSet beats
+        MONGODB_VERSION: "${MONGODB_VERSION:-5.0}"
     ports:
-      - 27017
+      - "27017:27017"


### PR DESCRIPTION
## Proposed commit message

Use MongoDB 5.0 in metricbeat integration tests.

We're currently using 3.4, which is old enough that GPG signatures have expired for packages in the underlying Ubuntu base image.

This PR is essentially a selective backport of https://github.com/elastic/beats/pull/34624. I've only included the changes necessary to make the tests pass and documentation updates.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

```bash
cd metricbeat
MODULE=mongodb make integration-tests
```

## Related issues

Fixes CI failures in https://github.com/elastic/beats/pull/42073.

