### PR TITLE
.../input/entityanalytics/provider/okta: Fix flaky tests

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -108,6 +108,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - AWS CloudWatch Metrics record previous endTime to use for next collection period and change log.logger from cloudwatch to aws.cloudwatch. {pull}40870[40870]
 - Fix flaky test in cel and httpjson inputs of filebeat. {issue}40503[40503] {pull}41358[41358]
 - Fix documentation and implementation of raw message handling in Filebeat http_endpoint by removing it. {pull}41498[41498]
+- Fix flaky test in cel and httpjson inputs of filebeat. {issue}42059[42059] {pull}42123[42123]
 
 ==== Added
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -108,7 +108,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - AWS CloudWatch Metrics record previous endTime to use for next collection period and change log.logger from cloudwatch to aws.cloudwatch. {pull}40870[40870]
 - Fix flaky test in cel and httpjson inputs of filebeat. {issue}40503[40503] {pull}41358[41358]
 - Fix documentation and implementation of raw message handling in Filebeat http_endpoint by removing it. {pull}41498[41498]
-- Fix flaky test in cel and httpjson inputs of filebeat. {issue}42059[42059] {pull}42123[42123]
+- Fix flaky test in filebeat Okta entity analytics provider. {issue}42059[42059] {pull}42123[42123]
 
 ==== Added
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/ratelimiter_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta/ratelimiter_test.go
@@ -89,7 +89,7 @@ func TestRateLimiter(t *testing.T) {
 		r.Wait(ctx, endpoint, url, log)
 		wait := time.Since(start)
 
-		if wait > 1010*time.Millisecond {
+		if wait > 1100*time.Millisecond {
 			t.Errorf("doesn't allow requests to resume after reset. had to wait %s", wait)
 		}
 		if e.limiter.Limit() != 1.0 {
@@ -102,7 +102,7 @@ func TestRateLimiter(t *testing.T) {
 		e.limiter.SetBurst(100) // increase bucket size to check token accumulation
 		tokens := e.limiter.TokensAt(time.Unix(0, time.Now().Add(30*time.Second).UnixNano()))
 		target := 30.0
-		buffer := 0.01
+		buffer := 0.1
 
 		if tokens < target-buffer || target+buffer < tokens {
 			t.Errorf("tokens don't accumulate at the expected rate over 30s: %f", tokens)


### PR DESCRIPTION
## Proposed commit message

```
.../input/entityanalytics/provider/okta: Fix flaky tests

In rate limiting tests by expanding the allowed ranges by 10x.

Earlier failures were double the allowed ranges:
  ratelimiter_test.go: doesn't allow requests to resume after reset. had to wait 1.0242622s
  ratelimiter_test.go: tokens don't accumulate at the expected rate over 30s: 30.024262
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None.

## Related issues

- Closes #42059