### PR TITLE
Revert the Ubuntu version update

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -12,6 +12,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 - Fix FQDN being lowercased when used as `host.hostname` {issue}39993[39993]
 - Beats won't log start up information when running under the Elastic Agent {40390}40390[40390]
+- Default Docker base image was reverted to Ubuntu 20.04 due to incompatability issues with glibc {pull}42144[42144]
 
 *Auditbeat*
 

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -159,7 +159,7 @@ shared:
   - &docker_spec
     <<: *binary_spec
     extra_vars:
-      from: '--platform=linux/amd64 ubuntu:24.04'
+      from: '--platform=linux/amd64 ubuntu:20.04'
       buildFrom: '--platform=linux/amd64 cgr.dev/chainguard/wolfi-base'
       user: '{{ .BeatName }}'
       linux_capabilities: ''
@@ -172,7 +172,7 @@ shared:
   - &docker_arm_spec
     <<: *docker_spec
     extra_vars:
-      from: '--platform=linux/arm64 ubuntu:24.04'
+      from: '--platform=linux/arm64 ubuntu:20.04'
       buildFrom: '--platform=linux/arm64 cgr.dev/chainguard/wolfi-base'
 
   - &docker_ubi_spec

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -57,7 +57,6 @@ RUN for iter in {1..10}; do \
 {{- end }}
 
 {{- if contains .from "ubuntu" }}
-RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
 
 RUN for iter in {1..10}; do \
         apt-get update -y && \


### PR DESCRIPTION
Due to ECE compatibility issues we have to switch back to 20.04.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
PLATFORMS=linux/arm64 PACKAGES=docker mage package
```

### Before the change

```
docker.elastic.co/beats/filebeat 8.17.1 19e23b0fa142 356MB
```

<details>

<summary>docker history</summary>

```
IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
19e23b0fa142   About a minute ago   CMD ["-environment" "container"]                0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENTRYPOINT ["/usr/bin/tini" "--" "/usr/local…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   WORKDIR /usr/share/filebeat                     0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVE…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   USER 1000                                       0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c useradd -M --uid 1000 --gid 1…   4.42kB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c groupadd --gid 1000 filebeat …   1.63kB    buildkit.dockerfile.v0
<missing>      About a minute ago   COPY /usr/share/filebeat/NOTICE.txt /license…   3.28MB    buildkit.dockerfile.v0
<missing>      About a minute ago   COPY /usr/share/filebeat/LICENSE.txt /licens…   13.7kB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c mkdir /licenses # buildkit       0B        buildkit.dockerfile.v0
<missing>      About a minute ago   COPY /usr/share/filebeat /usr/share/filebeat…   196MB     buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c chmod 755 /usr/local/bin/dock…   716B      buildkit.dockerfile.v0
<missing>      About a minute ago   COPY docker-entrypoint /usr/local/bin/docker…   716B      buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c set -e ;   TINI_BIN="";   TIN…   23.9kB    buildkit.dockerfile.v0
<missing>      About a minute ago   ENV GODEBUG=madvdontneed=1                      0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENV PATH=/usr/share/filebeat:/usr/local/sbin…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENV ELASTIC_CONTAINER=true                      0B        buildkit.dockerfile.v0
<missing>      About a minute ago   LABEL org.label-schema.build-date=2024-12-22…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c for iter in {1..10}; do      …   56.6MB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c touch /var/mail/ubuntu && cho…   4.47kB    buildkit.dockerfile.v0
<missing>      4 weeks ago          /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B        
<missing>      4 weeks ago          /bin/sh -c #(nop) ADD file:765dfd09ec2ac4870…   101MB     
<missing>      4 weeks ago          /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B        
<missing>      4 weeks ago          /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B        
<missing>      4 weeks ago          /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B        
<missing>      4 weeks ago          /bin/sh -c #(nop)  ARG RELEASE                  0B        
```

</details>

### After the change

```
docker.elastic.co/beats/filebeat 8.17.1 5931ccc2e70c 319MB
```

<details>

<summary>docker history</summary>

```
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
5931ccc2e70c   52 seconds ago   CMD ["-environment" "container"]                0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   ENTRYPOINT ["/usr/bin/tini" "--" "/usr/local…   0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   WORKDIR /usr/share/filebeat                     0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVE…   0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   USER 1000                                       0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   RUN /bin/sh -c useradd -M --uid 1000 --gid 1…   333kB     buildkit.dockerfile.v0
<missing>      52 seconds ago   RUN /bin/sh -c groupadd --gid 1000 filebeat …   1.67kB    buildkit.dockerfile.v0
<missing>      52 seconds ago   COPY /usr/share/filebeat/NOTICE.txt /license…   3.28MB    buildkit.dockerfile.v0
<missing>      52 seconds ago   COPY /usr/share/filebeat/LICENSE.txt /licens…   13.7kB    buildkit.dockerfile.v0
<missing>      52 seconds ago   RUN /bin/sh -c mkdir /licenses # buildkit       0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   COPY /usr/share/filebeat /usr/share/filebeat…   196MB     buildkit.dockerfile.v0
<missing>      52 seconds ago   RUN /bin/sh -c chmod 755 /usr/local/bin/dock…   716B      buildkit.dockerfile.v0
<missing>      52 seconds ago   COPY docker-entrypoint /usr/local/bin/docker…   716B      buildkit.dockerfile.v0
<missing>      52 seconds ago   RUN /bin/sh -c set -e ;   TINI_BIN="";   TIN…   23.9kB    buildkit.dockerfile.v0
<missing>      52 seconds ago   ENV GODEBUG=madvdontneed=1                      0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   ENV PATH=/usr/share/filebeat:/usr/local/sbin…   0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   ENV ELASTIC_CONTAINER=true                      0B        buildkit.dockerfile.v0
<missing>      52 seconds ago   LABEL org.label-schema.build-date=2024-12-22…   0B        buildkit.dockerfile.v0
<missing>      53 seconds ago   RUN /bin/sh -c for iter in {1..10}; do      …   53.6MB    buildkit.dockerfile.v0
<missing>      2 months ago     /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B        
<missing>      2 months ago     /bin/sh -c #(nop) ADD file:8537b4db344382b39…   65.7MB    
<missing>      2 months ago     /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B        
<missing>      2 months ago     /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B        
<missing>      2 months ago     /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B        
<missing>      2 months ago     /bin/sh -c #(nop)  ARG RELEASE                  0B        
```

</details>