### PR TITLE
[system] - Add a flag to the system module to control whether metrics failures mark agent as degraded

### DIFF
--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -45,9 +45,10 @@ func init() {
 // MetricSet that fetches process metrics.
 type MetricSet struct {
 	mb.BaseMetricSet
-	stats  *process.Stats
-	perCPU bool
-	setpid int
+	stats            *process.Stats
+	perCPU           bool
+	setpid           int
+	degradeOnPartial bool
 }
 
 // New creates and returns a new MetricSet.
@@ -72,7 +73,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if config.Pid != 0 && config.Procs[0] != ".*" {
 		logp.L().Warnf("`process.pid` set to %d, but `processes` is set to a non-default value. Metricset will only report metrics for pid %d", config.Pid, config.Pid)
 	}
-
+	degradedConf := struct {
+		DegradeOnPartial bool `config:"degrade_on_partial"`
+	}{}
+	if err := base.Module().UnpackConfig(&degradedConf); err != nil {
+		logp.L().Warnf("Failed to unpack config; degraded mode will be disabled for partial metrics: %v", err)
+	}
 	m := &MetricSet{
 		BaseMetricSet: base,
 		stats: &process.Stats{
@@ -88,7 +94,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 				IgnoreRootCgroups: true,
 			},
 		},
-		perCPU: config.IncludePerCPU,
+		perCPU:           config.IncludePerCPU,
+		degradeOnPartial: degradedConf.DegradeOnPartial,
 	}
 
 	m.setpid = config.Pid
@@ -118,7 +125,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		if err != nil && !errors.Is(err, process.NonFatalErr{}) {
 			// return only if the error is fatal in nature
 			return fmt.Errorf("process stats: %w", err)
-		} else if (err != nil && errors.Is(err, process.NonFatalErr{})) {
+		} else if (err != nil && errors.Is(err, process.NonFatalErr{}) && !m.degradeOnPartial) {
 			err = mb.PartialMetricsError{Err: err}
 		}
 
@@ -137,7 +144,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		if err != nil && !errors.Is(err, process.NonFatalErr{}) {
 			// return only if the error is fatal in nature
 			return fmt.Errorf("error fetching pid %d: %w", m.setpid, err)
-		} else if (err != nil && errors.Is(err, process.NonFatalErr{})) {
+		} else if (err != nil && errors.Is(err, process.NonFatalErr{}) && !m.degradeOnPartial) {
 			err = mb.PartialMetricsError{Err: err}
 		}
 		// if error is non-fatal, emit partial metrics.


### PR DESCRIPTION
TODO..

Relates https://github.com/elastic/beats/issues/40543