### PR TITLE
Update metricbeat-kubernetes.yaml

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -295,7 +295,7 @@ spec:
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
-          "-system.hostfs=/hostfs",
+          "--system.hostfs=/hostfs",
         ]
         env:
         - name: ELASTICSEARCH_HOST


### PR DESCRIPTION
fix `--system.hostfs=/hostfs` argument

The original argument missing a dash '-'