### PR TITLE
libbeat/tests/system: bump python libs to fix issues with Python 3.13

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -10,7 +10,7 @@ backports.ssl-match-hostname==3.5.0.1
 bcrypt==4.1.2
 cached-property==1.4.2
 certifi==2024.7.4
-cffi==1.16.0
+cffi==1.17.1
 chardet==3.0.4
 charset-normalizer==3.3.2
 cryptography==43.0.1
@@ -24,7 +24,7 @@ elasticsearch==7.8.1
 enum34==1.1.6
 exceptiongroup==1.2.0
 googleapis-common-protos==1.56.4
-grpcio==1.60.0
+grpcio==1.68.1
 idna==3.7
 importlib-metadata==1.7.0
 iniconfig==1.0.1


### PR DESCRIPTION
## Proposed commit message

This commit fixes errors when installing libbeat python dependencies when running on Python 3.13. This was causing failures when running `make update` since the python deps installation is part of it.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

```bash
# Delete your existing python env
$ python -m venv ./build/python-env --clear
# Since venv is a python module, you need to be running python 3.13 (released Oct 7) in your system
$ python -V
Python 3.13.1
# Create a new python env on 3.13
$ python -m venv ./build/python-env
$ make update
```

## Related issues

- Fixes https://github.com/elastic/beats/issues/42181