### PR TITLE
remove os.Args hack for backwards compatible arguments

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -18,7 +18,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix metrics not being ingested, due to "Limit of total fields [10000] has been exceeded while adding new fields [...]". The total fields limit has been increased to 12500. No significant performance impact on Elasticsearch is anticipated. {pull}41640[41640]
 - Set default kafka version to 2.1.0 in kafka output and filebeat. {pull}41662[41662]
 - Fix templates and docs to use correct `--` version of command line arguments. {issue}42038[42038] {pull}42060[42060]
-- removed support for a single `-` to precede multi-letter command line arguments.  Use `--` instead. {issue}42117[42117] {pull}99999[99999] 
+- removed support for a single `-` to precede multi-letter command line arguments.  Use `--` instead. {issue}42117[42117] {pull}42209[42209] 
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix metrics not being ingested, due to "Limit of total fields [10000] has been exceeded while adding new fields [...]". The total fields limit has been increased to 12500. No significant performance impact on Elasticsearch is anticipated. {pull}41640[41640]
 - Set default kafka version to 2.1.0 in kafka output and filebeat. {pull}41662[41662]
 - Fix templates and docs to use correct `--` version of command line arguments. {issue}42038[42038] {pull}42060[42060]
+- removed support for a single `-` to precede multi-letter command line arguments.  Use `--` instead. {issue}42117[42117] {pull}99999[99999] 
 
 *Auditbeat*
 

--- a/auditbeat/main_test.go
+++ b/auditbeat/main_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/auditbeat/cmd"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -35,14 +34,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/auditbeat/tests/system/test_show_command.py
+++ b/auditbeat/tests/system/test_show_command.py
@@ -57,7 +57,7 @@ class Test(BaseTest):
                 }
             }]
         )
-        proc = self.start_beat(extra_args=['-strict.perms=false'])
+        proc = self.start_beat(extra_args=['--strict.perms=false'])
         # auditbeat adds an extra rule to ignore itself
         self.wait_log_contains('Successfully added {0} of {0} audit rules.'.format(len(rules) + 1),
                                max_timeout=30)

--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -46,7 +46,7 @@ func main() {
 	insecure := flag.Bool("insecure", false, "Disable TLS verification.")
 	spaceID := flag.String("space-id", "", "Space ID")
 	dashboard := flag.String("dashboard", "", "Dashboard ID")
-	fileOutput := flag.String("output", "", "Output NDJSON file, when exporting dashboards for Beats, please use -folder instead")
+	fileOutput := flag.String("output", "", "Output NDJSON file, when exporting dashboards for Beats, please use --folder instead")
 	folderOutput := flag.String("folder", "", "Output folder to save all assets to more human friendly JSON format")
 	ymlFile := flag.String("yml", "", "Path to the module.yml file containing the dashboards")
 	flag.BoolVar(&indexPattern, "indexPattern", false, "include index-pattern in output")
@@ -56,7 +56,7 @@ func main() {
 	log.SetFlags(0)
 
 	if len(*fileOutput) > 0 {
-		log.Fatalf("-output is configured, please use -folder flag instead to get the expected formatting of assets")
+		log.Fatalf("-output is configured, please use --folder flag instead to get the expected formatting of assets")
 	}
 
 	u, err := url.Parse(*kibanaURL)
@@ -92,10 +92,10 @@ func main() {
 
 	if len(*ymlFile) == 0 && len(*dashboard) == 0 {
 		flag.Usage()
-		log.Fatalf("Please specify a dashboard ID (-dashboard) or a manifest file (-yml)")
+		log.Fatalf("Please specify a dashboard ID (--dashboard) or a manifest file (--yml)")
 	}
 	if len(*folderOutput) == 0 {
-		log.Fatalf("Please specify a target folder using -folder flag")
+		log.Fatalf("Please specify a target folder using --folder flag")
 	}
 
 	if len(*ymlFile) > 0 {

--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -56,7 +56,7 @@ func main() {
 	log.SetFlags(0)
 
 	if len(*fileOutput) > 0 {
-		log.Fatalf("-output is configured, please use --folder flag instead to get the expected formatting of assets")
+		log.Fatalf("--output is configured, please use --folder flag instead to get the expected formatting of assets")
 	}
 
 	u, err := url.Parse(*kibanaURL)

--- a/dev-tools/mage/dashboard.go
+++ b/dev-tools/mage/dashboard.go
@@ -49,8 +49,8 @@ func ExportDashboard() error {
 	folder := CWD("module", module)
 
 	args := []string{
-		"-folder", folder,
-		"-dashboard", id,
+		"--folder", folder,
+		"--dashboard", id,
 	}
 	if kibanaURL := EnvOr("KIBANA_URL", ""); kibanaURL != "" {
 		args = append(args, "-kibana", kibanaURL)

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -224,10 +224,6 @@ func runVGo(cmd string, args *Args) error {
 	}, cmd, args)
 }
 
-func runGo(cmd string, args *Args) error {
-	return execGoWith(sh.RunWith, cmd, args)
-}
-
 func execGoWith(
 	fn func(map[string]string, string, ...string) error,
 	cmd string, args *Args,

--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -163,7 +163,7 @@ func HasTests(pkg string) (bool, error) {
 }
 
 func (goTest) WithCoverage(to string) ArgOpt {
-	return combine(flagArg("-cover", ""), flagArgIf("-test.coverprofile", to))
+	return combine(flagArg("-cover", ""), flagArgIf("--test.coverprofile", to))
 }
 func (goTest) Short(b bool) ArgOpt        { return flagBoolIf("-test.short", b) }
 func (goTest) Use(bin string) ArgOpt      { return extraArgIf("use", bin) }

--- a/docs/devguide/migrate-dashboards.asciidoc
+++ b/docs/devguide/migrate-dashboards.asciidoc
@@ -93,6 +93,6 @@ Using the yml file, you can export all the dashboards for a single module or for
 [source,shell]
 ----
 cd metricbeat/module/system
-go run ../../../dev-tools/cmd/dashboards/export_dashboards.go -yml module.yml
+go run ../../../dev-tools/cmd/dashboards/export_dashboards.go --yml module.yml
 ----
 

--- a/docs/devguide/migrate-dashboards.asciidoc
+++ b/docs/devguide/migrate-dashboards.asciidoc
@@ -93,6 +93,6 @@ Using the yml file, you can export all the dashboards for a single module or for
 [source,shell]
 ----
 cd metricbeat/module/system
-go run ../../../dev-tools/cmd/dashboards/export_dashboards.go --yml module.yml
+go run ../../../dev-tools/cmd/dashboards/export_dashboards.go -yml module.yml
 ----
 

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -100,7 +100,7 @@ Then run `export_dashboards` like this:
 ----
 $ cd dev-tools/cmd/dashboards
 $ make # if export_dashboard is not built yet
-$ ./export_dashboards -yml '../../../filebeat/module/{module}/module.yml'
+$ ./export_dashboards --yml '../../../filebeat/module/{module}/module.yml'
 ----
 
 New Filebeat modules might not be compatible with Kibana 5.x. To export dashboards

--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -253,7 +253,7 @@ MODULE=redis ID=AV4REOpp5NkDleZmzKkE mage exportDashboard
 
 [source,shell]
 ---------------
-./filebeat export dashboard -id 7fea2930-478e-11e7-b1f0-cb29bac6bf8b -folder module/redis
+./filebeat export dashboard --id 7fea2930-478e-11e7-b1f0-cb29bac6bf8b --folder module/redis
 ---------------
 
 This generates an appropriate folder under module/redis for the dashboard, separating assets into dashboards, searches, vizualizations, etc.
@@ -289,12 +289,12 @@ By passing the yml file to the `export_dashboards.go` script or to the Beat, you
 
 [source,shell]
 -------------------
-go run dev-tools/cmd/dashboards/export_dashboards.go -yml filebeat/module/system/module.yml -folder dashboards
+go run dev-tools/cmd/dashboards/export_dashboards.go --yml filebeat/module/system/module.yml --folder dashboards
 -------------------
 
 [source,shell]
 -------------------
-./filebeat export dashboard -yml filebeat/module/system/module.yml
+./filebeat export dashboard --yml filebeat/module/system/module.yml
 -------------------
 
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -166,7 +166,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 	}
 
 	if *once && config.ConfigInput.Enabled() && config.ConfigModules.Enabled() {
-		return nil, fmt.Errorf("input configs and -once cannot be used together")
+		return nil, fmt.Errorf("input configs and --once cannot be used together")
 	}
 
 	if config.IsInputEnabled("stdin") && len(enabledInputs) > 1 {

--- a/filebeat/cmd/generate.go
+++ b/filebeat/cmd/generate.go
@@ -26,7 +26,6 @@ import (
 	"github.com/elastic/beats/v7/filebeat/generator/fields"
 	"github.com/elastic/beats/v7/filebeat/generator/fileset"
 	"github.com/elastic/beats/v7/filebeat/generator/module"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common/cli"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -64,9 +63,7 @@ func genGenerateModuleCmd() *cobra.Command {
 	}
 
 	genModuleCmd.Flags().String("modules-path", defaultHomePath, "Path to modules directory")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("modules-path")
 	genModuleCmd.Flags().String("es-beats", defaultHomePath, "Path to Elastic Beats")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("es-beats")
 
 	return genModuleCmd
 }
@@ -91,9 +88,7 @@ func genGenerateFilesetCmd() *cobra.Command {
 	}
 
 	genFilesetCmd.Flags().String("modules-path", defaultHomePath, "Path to modules directory")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("modules-path")
 	genFilesetCmd.Flags().String("es-beats", defaultHomePath, "Path to Elastic Beats")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("es-beats")
 
 	return genFilesetCmd
 }
@@ -118,9 +113,7 @@ func genGenerateFieldsCmd() *cobra.Command {
 	}
 
 	genFieldsCmd.Flags().String("es-beats", defaultHomePath, "Path to Elastic Beats")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("es-beats")
 	genFieldsCmd.Flags().Bool("without-documentation", false, "Do not add description fields")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("without-documentation")
 
 	return genFieldsCmd
 }

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -26,7 +26,6 @@ import (
 	"github.com/elastic/beats/v7/filebeat/fileset"
 	"github.com/elastic/beats/v7/filebeat/include"
 	"github.com/elastic/beats/v7/filebeat/input"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 
@@ -50,9 +49,7 @@ func FilebeatSettings(moduleNameSpace string) instance.Settings {
 	}
 	runFlags := pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("once"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("once")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("modules"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("modules")
 	return instance.Settings{
 		RunFlags:      runFlags,
 		Name:          Name,
@@ -69,10 +66,8 @@ func FilebeatSettings(moduleNameSpace string) instance.Settings {
 func Filebeat(inputs beater.PluginFactory, settings instance.Settings) *cmd.BeatsRootCmd {
 	command := cmd.GenRootCmdWithSettings(beater.New(inputs), settings)
 	command.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("M")
 	command.TestCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
 	command.SetupCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("modules")
 	command.AddCommand(cmd.GenModulesCmd(Name, "", buildModulesManager))
 	command.AddCommand(genGenerateCmd())
 	return command

--- a/filebeat/main_test.go
+++ b/filebeat/main_test.go
@@ -26,7 +26,6 @@ import (
 
 	fbcmd "github.com/elastic/beats/v7/filebeat/cmd"
 	inputs "github.com/elastic/beats/v7/filebeat/input/default-inputs"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
@@ -41,14 +40,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	fbCommand = fbcmd.Filebeat(inputs.Init, fbcmd.FilebeatSettings(""))
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := fbCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/filebeat/tests/system/test_generate.py
+++ b/filebeat/tests/system/test_generate.py
@@ -11,7 +11,7 @@ class Test(filebeat.BaseTest):
 
         self._create_clean_test_modules()
         exit_code = self.run_beat(
-            extra_args=["generate", "module", "my_module", "-modules-path", "test_modules", "-es-beats", self.beat_path])
+            extra_args=["generate", "module", "my_module", "--modules-path", "test_modules", "--es-beats", self.beat_path])
         assert exit_code == 0
 
         module_root = os.path.join("test_modules", "module", "my_module")
@@ -47,11 +47,11 @@ class Test(filebeat.BaseTest):
 
         self._create_clean_test_modules()
         exit_code = self.run_beat(
-            extra_args=["generate", "module", "my_module", "-modules-path", "test_modules", "-es-beats", self.beat_path])
+            extra_args=["generate", "module", "my_module", "--modules-path", "test_modules", "--es-beats", self.beat_path])
         assert exit_code == 0
 
         exit_code = self.run_beat(
-            extra_args=["generate", "fileset", "my_module", "my_fileset", "-modules-path", "test_modules", "-es-beats", self.beat_path])
+            extra_args=["generate", "fileset", "my_module", "my_fileset", "--modules-path", "test_modules", "--es-beats", self.beat_path])
         assert exit_code == 0
 
         fileset_root = os.path.join("test_modules", "module", "my_module", "my_fileset")
@@ -88,11 +88,11 @@ class Test(filebeat.BaseTest):
 
         self._create_clean_test_modules()
         exit_code = self.run_beat(
-            extra_args=["generate", "module", "my_module", "-modules-path", "test_modules", "-es-beats", self.beat_path])
+            extra_args=["generate", "module", "my_module", "--modules-path", "test_modules", "--es-beats", self.beat_path])
         assert exit_code == 0
 
         exit_code = self.run_beat(
-            extra_args=["generate", "fileset", "my_module", "my_fileset", "-modules-path", "test_modules", "-es-beats", self.beat_path])
+            extra_args=["generate", "fileset", "my_module", "my_fileset", "--modules-path", "test_modules", "--es-beats", self.beat_path])
         assert exit_code == 0
 
         test_pipeline_path = os.path.join(self.beat_path, "tests", "system", "input", "my-module-pipeline.json")
@@ -102,7 +102,7 @@ class Test(filebeat.BaseTest):
         shutil.copyfile(test_pipeline_path, fileset_pipeline)
 
         exit_code = self.run_beat(
-            extra_args=["generate", "fields", "my_module", "my_fileset", "-es-beats", "test_modules", "-without-documentation"])
+            extra_args=["generate", "fields", "my_module", "my_fileset", "--es-beats", "test_modules", "--without-documentation"])
         assert exit_code == 0
 
         fields_yml_path = os.path.join("test_modules", "module", "my_module", "my_fileset", "_meta", "fields.yml")

--- a/filebeat/tests/system/test_keystore.py
+++ b/filebeat/tests/system/test_keystore.py
@@ -55,7 +55,7 @@ class TestKeystore(BaseTest):
         Add new secret using the --stdin option
         """
         args = [self.test_binary,
-                "-systemTest",
+                "--systemTest",
                 "-c", os.path.join(self.working_dir, self.beat_name + ".yml"),
                 "-e", "-v", "-d", "*",
                 "keystore", "add", key, "--stdin",

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -168,11 +168,11 @@ class Test(BaseTest):
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 
         cmd = [
-            self.filebeat, "-systemTest",
-            "-d", "*", "-once",
+            self.filebeat, "--systemTest",
+            "-d", "*", "--once",
             "-c", cfgfile,
             "-E", "setup.ilm.enabled=false",
-            "-modules={}".format(module),
+            "--modules={}".format(module),
             "-M", "{module}.*.enabled=false".format(module=module),
             "-M", "{module}.{fileset}.enabled=true".format(
                 module=module, fileset=fileset),
@@ -191,7 +191,7 @@ class Test(BaseTest):
                 module=module, fileset=fileset))
 
         if ".journal" in test_file:
-            cmd.remove("-once")
+            cmd.remove("--once")
             cmd.append("-M")
             cmd.append("{module}.{fileset}.var.use_journald=true".format(
                 module=module, fileset=fileset))
@@ -224,7 +224,7 @@ class Test(BaseTest):
                                     stderr=subprocess.STDOUT,
                                     bufsize=0)
             # The journald input (used by some modules like 'system') does not
-            # support the -once flag, hence we run Filebeat for at most
+            # support the --once flag, hence we run Filebeat for at most
             # 15 seconds, if it does not finish, then kill the process.
             # If for any reason the Filebeat process gets stuck, only SIGKILL
             # will terminate it. We use SIGKILL to avoid leaking any running

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -141,7 +141,7 @@ class Test(BaseTest):
 
         file.close()
 
-        filebeat = self.start_beat(extra_args=["-once"])
+        filebeat = self.start_beat(extra_args=["--once"])
 
         # Make sure all lines are read
         self.wait_until(

--- a/filebeat/tests/system/test_stdin.py
+++ b/filebeat/tests/system/test_stdin.py
@@ -58,9 +58,9 @@ class Test(BaseTest):
             close_eof="true",
         )
 
-        args = [self.test_binary, "-systemTest"]
+        args = [self.test_binary, "--systemTest"]
         if os.getenv("TEST_COVERAGE") == "true":
-            args += ["-test.coverprofile",
+            args += ["--test.coverprofile",
                      os.path.join(self.working_dir, "coverage.cov")]
         args += ["-c", os.path.join(self.working_dir, "filebeat.yml"), "-e",
                  "-v", "-d", "*"]

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/elastic/beats/v7/heartbeat/beater"
 	"github.com/elastic/beats/v7/heartbeat/include"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/ecs"
@@ -82,7 +81,6 @@ func Initialize(settings instance.Settings) *cmd.BeatsRootCmd {
 `
 	setup.ResetFlags()
 	setup.Flags().Bool(cmd.IndexManagementKey, false, "Setup all components related to Elasticsearch index management, including template, ilm policy and rollover alias")
-	cfgfile.AddAllowedBackwardsCompatibleFlag(cmd.IndexManagementKey)
 
 	return rootCmd
 }

--- a/heartbeat/main_test.go
+++ b/heartbeat/main_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/heartbeat/cmd"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -34,14 +33,11 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(_ *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -32,13 +32,12 @@ import (
 
 // Evil package level globals
 var (
-	once                            sync.Once
-	configfiles                     *config.StringsFlag
-	overwrites                      *config.C
-	defaults                        *config.C
-	homePath                        *string
-	configPath                      *string
-	allowedBackwardsCompatibleFlags []string
+	once        sync.Once
+	configfiles *config.StringsFlag
+	overwrites  *config.C
+	defaults    *config.C
+	homePath    *string
+	configPath  *string
 )
 
 func Initialize() {

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -49,9 +48,7 @@ func Initialize() {
 		// created. See ChangeDefaultCfgfileFlag which should
 		// be called prior to flags.Parse().
 		configfiles = config.StringArrFlag(nil, "c", "beat.yml", "Configuration file, relative to path.config")
-		AddAllowedBackwardsCompatibleFlag("c")
 		overwrites = config.SettingFlag(nil, "E", "Configuration overwrite")
-		AddAllowedBackwardsCompatibleFlag("E")
 		defaults = config.MustNewConfigFrom(map[string]interface{}{
 			"path": map[string]interface{}{
 				"home":   ".", // to be initialized by beat
@@ -61,42 +58,10 @@ func Initialize() {
 			},
 		})
 		homePath = config.ConfigOverwriteFlag(nil, overwrites, "path.home", "path.home", "", "Home path")
-		AddAllowedBackwardsCompatibleFlag("path.home")
 		configPath = config.ConfigOverwriteFlag(nil, overwrites, "path.config", "path.config", "", "Configuration path")
-		AddAllowedBackwardsCompatibleFlag("path.config")
 		_ = config.ConfigOverwriteFlag(nil, overwrites, "path.data", "path.data", "", "Data path")
-		AddAllowedBackwardsCompatibleFlag("path.data")
 		_ = config.ConfigOverwriteFlag(nil, overwrites, "path.logs", "path.logs", "", "Logs path")
-		AddAllowedBackwardsCompatibleFlag("path.logs")
 	})
-}
-
-func isAllowedBackwardsCompatibleFlag(f string) bool {
-	for _, existing := range allowedBackwardsCompatibleFlags {
-		if existing == f {
-			return true
-		}
-	}
-	return false
-}
-
-func AddAllowedBackwardsCompatibleFlag(f string) {
-	if isAllowedBackwardsCompatibleFlag(f) {
-		return
-	}
-	allowedBackwardsCompatibleFlags = append(allowedBackwardsCompatibleFlags, f)
-}
-
-func ConvertFlagsForBackwardsCompatibility() {
-	// backwards compatibility workaround, convert -flags to --flags:
-	for i, arg := range os.Args[1:] {
-		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
-			candidate, _, _ := strings.Cut(strings.TrimPrefix(arg, "-"), "=")
-			if isAllowedBackwardsCompatibleFlag(candidate) {
-				os.Args[1+i] = "-" + arg
-			}
-		}
-	}
 }
 
 // OverrideChecker checks if a config should be overwritten.

--- a/libbeat/cmd/export/dashboard.go
+++ b/libbeat/cmd/export/dashboard.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/dashboards"
 	"github.com/elastic/beats/v7/libbeat/version"
@@ -41,7 +40,7 @@ func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 			folder, _ := cmd.Flags().GetString("folder")
 
 			if len(folder) == 0 {
-				fatalf("-folder must be specified")
+				fatalf("--folder must be specified")
 			}
 
 			b, err := instance.NewInitializedBeat(settings)
@@ -102,11 +101,8 @@ func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("id", "", "Dashboard id")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("id")
 	genTemplateConfigCmd.Flags().String("yml", "", "Yaml file containing list of dashboard ID and filename pairs")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("yml")
 	genTemplateConfigCmd.Flags().String("folder", "", "Target folder to save exported assets")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("folder")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/export/ilm_policy.go
+++ b/libbeat/cmd/export/ilm_policy.go
@@ -20,7 +20,6 @@ package export
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle"
@@ -58,9 +57,7 @@ func GenGetILMPolicyCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 	genTemplateConfigCmd.Flags().String("dir", "", "Specify directory for printing policy files. By default policies are printed to stdout.")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("dir")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/export/index_pattern.go
+++ b/libbeat/cmd/export/index_pattern.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/kibana"
 	libversion "github.com/elastic/elastic-agent-libs/version"
@@ -68,7 +67,6 @@ func GenIndexPatternConfigCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -20,7 +20,6 @@ package export
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle"
@@ -60,11 +59,8 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 	genTemplateConfigCmd.Flags().Bool("noilm", false, "Generate template with ILM disabled")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("noilm")
 	genTemplateConfigCmd.Flags().String("dir", "", "Specify directory for printing template files. By default templates are printed to stdout.")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("dir")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -998,7 +998,6 @@ func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) er
 // flags, and it invokes the HandleFlags callback if implemented by
 // the Beat.
 func (b *Beat) handleFlags() error {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	flag.Parse()
 	return cfgfile.HandleFlags()
 }

--- a/libbeat/cmd/instance/beat_integration_test.go
+++ b/libbeat/cmd/instance/beat_integration_test.go
@@ -95,7 +95,6 @@ func TestMonitoringNameFromConfig(t *testing.T) {
 		// Set the configuration file path flag so the beat can read it
 		cfgfile.Initialize()
 		_ = flag.Set("c", "testdata/mockbeat.yml")
-		cfgfile.AddAllowedBackwardsCompatibleFlag("c")
 		_ = instance.Run(mock.Settings, func(_ *beat.Beat, _ *config.C) (beat.Beater, error) {
 			return &mockBeat, nil
 		})

--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/common/cli"
 	"github.com/elastic/beats/v7/libbeat/common/terminal"
@@ -75,7 +74,6 @@ func genCreateKeystoreCmd(settings instance.Settings) *cobra.Command {
 		}),
 	}
 	command.Flags().BoolVar(&flagForce, "force", false, "override the existing keystore")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("force")
 	return command
 }
 
@@ -94,9 +92,7 @@ func genAddKeystoreCmd(settings instance.Settings) *cobra.Command {
 		}),
 	}
 	command.Flags().BoolVar(&flagStdin, "stdin", false, "Use the stdin as the source of the secret")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("stdin")
 	command.Flags().BoolVar(&flagForce, "force", false, "Override the existing key")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("force")
 	return command
 }
 

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -80,30 +80,18 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 
 	// Persistent flags, common across all subcommands
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("E"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("E")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("c"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("c")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("d"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("d")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("v"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("v")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("e"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("e")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("environment"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("environment")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.config"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("path.config")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.data"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("path.data")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.logs"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("path.logs")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.home"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("path.home")
 	rootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("strict.perms"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("strict.perms")
 	if f := flag.CommandLine.Lookup("plugin"); f != nil {
 		rootCmd.PersistentFlags().AddGoFlag(f)
-		cfgfile.AddAllowedBackwardsCompatibleFlag("plugin")
 	}
 
 	// Inherit root flags from run command

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 )
 
@@ -43,13 +42,9 @@ func genRunCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Comm
 
 	// Run subcommand flags, only available to *beat run
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("N"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("N")
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("httpprof"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("httpprof")
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("cpuprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("cpuprofile")
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("memprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("memprofile")
 
 	if settings.RunFlags != nil {
 		runCmd.Flags().AddFlagSet(settings.RunFlags)

--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 )
 
@@ -112,16 +111,11 @@ func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Co
 	}
 
 	setup.Flags().Bool(DashboardKey, false, "Setup dashboards")
-	cfgfile.AddAllowedBackwardsCompatibleFlag(DashboardKey)
 	setup.Flags().Bool(PipelineKey, false, "Setup Ingest pipelines")
-	cfgfile.AddAllowedBackwardsCompatibleFlag(PipelineKey)
 	setup.Flags().Bool(IndexManagementKey, false,
 		"Setup all components related to Elasticsearch index management, including template, ilm policy and rollover alias")
-	cfgfile.AddAllowedBackwardsCompatibleFlag(IndexManagementKey)
 	setup.Flags().Bool("enable-all-filesets", false, "Behave as if all modules and filesets had been enabled")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("enable-all-filesets")
 	setup.Flags().Bool("force-enable-module-filesets", false, "Behave as if all filesets, within enabled modules, are enabled")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("force-enable-module-filesets")
 
 	return &setup
 }

--- a/libbeat/common/seccomp/README.md
+++ b/libbeat/common/seccomp/README.md
@@ -71,7 +71,7 @@ Another profiling option is `strace -c`. This will record all system calls used
 by the Beat. Then this list can be used to steer the development of a policy.
 
 ```sh
-sudo strace -c ./metricbeat -strict.perms=false
+sudo strace -c ./metricbeat --strict.perms=false
 % time     seconds  usecs/call     calls    errors syscall
 ------ ----------- ----------- --------- --------- ----------------
  79.75    0.002521          97        26           futex

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -590,7 +590,7 @@ Prints the list of devices that are available for sniffing and then exits.
 endif::[]
 
 ifeval::["{beatname_lc}"=="packetbeat"]
-*`-dump FILE`*::
+*`--dump FILE`*::
 Writes all captured packets to the specified file. This option is useful for
 troubleshooting {beatname_uc}.
 endif::[]
@@ -907,7 +907,7 @@ ifeval::["{beatname_lc}"=="filebeat"]
 +
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-{beatname_lc} -modules=nginx -M "nginx.access.var.paths=['/var/log/nginx/access.log*']" -M "nginx.access.var.pipeline=no_plugins"
+{beatname_lc} --modules=nginx -M "nginx.access.var.paths=['/var/log/nginx/access.log*']" -M "nginx.access.var.pipeline=no_plugins"
 ----------------------------------------------------------------------
 endif::[]
 
@@ -948,7 +948,7 @@ details.
 Sets the path for log files. See the <<directory-layout>> section for details.
 
 *`--strict.perms`*::
-Sets strict permission checking on configuration files. The default is `-strict.perms=true`.
+Sets strict permission checking on configuration files. The default is `--strict.perms=true`.
 ifndef::apm-server[]
 See {beats-ref}/config-file-permissions.html[Config file ownership and permissions]
 for more information.

--- a/libbeat/docs/shared-systemd.asciidoc
+++ b/libbeat/docs/shared-systemd.asciidoc
@@ -67,7 +67,7 @@ override to change the default options.
 | Variable | Description | Default value
 | BEAT_LOG_OPTS | Log options |
 | BEAT_CONFIG_OPTS | Flags for configuration file path | +-c /etc/{beatname_lc}/{beatname_lc}.yml+
-| BEAT_PATH_OPTS | Other paths | +-path.home /usr/share/{beatname_lc} -path.config /etc/{beatname_lc} -path.data /var/lib/{beatname_lc} -path.logs /var/log/{beatname_lc}+
+| BEAT_PATH_OPTS | Other paths | +--path.home /usr/share/{beatname_lc} --path.config /etc/{beatname_lc} --path.data /var/lib/{beatname_lc} --path.logs /var/log/{beatname_lc}+
 |=======================================
 
 NOTE: You can use `BEAT_LOG_OPTS` to set debug selectors for logging. However,

--- a/libbeat/libbeat_test.go
+++ b/libbeat/libbeat_test.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -32,14 +31,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/libbeat/tests/integration/dashboard_test.go
+++ b/libbeat/tests/integration/dashboard_test.go
@@ -173,7 +173,7 @@ queue.mem:
 		"-E", "setup.kibana.username=beats",
 		"-E", "setup.kibana.password=testing",
 		"-id", "Metricbeat-system-overview",
-		"-folder", filepath.Join(mockbeat.TempDir(), "system-overview"))
+		"--folder", filepath.Join(mockbeat.TempDir(), "system-overview"))
 	procState, err = mockbeat.Process.Wait()
 	require.NoError(t, err)
 	require.Equal(t, 0, procState.ExitCode(), "incorrect exit code")
@@ -205,8 +205,8 @@ queue.mem:
 		"-E", "setup.kibana.port="+kURL.Port(),
 		"-E", "setup.kibana.username=beats",
 		"-E", "setup.kibana.password=testing",
-		"-id", "No-such-dashboard",
-		"-folder", filepath.Join(mockbeat.TempDir(), "system-overview"))
+		"--id", "No-such-dashboard",
+		"--folder", filepath.Join(mockbeat.TempDir(), "system-overview"))
 	procState, err := mockbeat.Process.Wait()
 	require.NoError(t, err)
 	require.Equal(t, 1, procState.ExitCode(), "incorrect exit code")

--- a/libbeat/tests/integration/dashboard_test.go
+++ b/libbeat/tests/integration/dashboard_test.go
@@ -172,7 +172,7 @@ queue.mem:
 		"-E", "setup.kibana.port="+kURL.Port(),
 		"-E", "setup.kibana.username=beats",
 		"-E", "setup.kibana.password=testing",
-		"-id", "Metricbeat-system-overview",
+		"--id", "Metricbeat-system-overview",
 		"--folder", filepath.Join(mockbeat.TempDir(), "system-overview"))
 	procState, err = mockbeat.Process.Wait()
 	require.NoError(t, err)

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -269,10 +269,10 @@ class TestCase(unittest.TestCase, ComposeMixin):
         if output is None:
             output = self.beat_name + "-" + self.today + ".ndjson"
 
-        args = [cmd, "-systemTest"]
+        args = [cmd, "--systemTest"]
         if os.getenv("TEST_COVERAGE") == "true":
             args += [
-                "-test.coverprofile",
+                "--test.coverprofile",
                 os.path.join(self.working_dir, "coverage.cov"),
             ]
 
@@ -281,7 +281,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             path_home = home
 
         args += [
-            "-path.home", path_home,
+            "--path.home", path_home,
             "-c", os.path.join(self.working_dir, config),
         ]
 

--- a/libbeat/tests/system/keystore.py
+++ b/libbeat/tests/system/keystore.py
@@ -12,10 +12,10 @@ class KeystoreBase(BaseTest):
         """
         Add new secret using the --stdin option
         """
-        args = [self.test_binary, "-systemTest"]
+        args = [self.test_binary, "--systemTest"]
         if os.getenv("TEST_COVERAGE") == "true":
             args += [
-                "-test.coverprofile",
+                "--test.coverprofile",
                 os.path.join(self.working_dir, "coverage.cov"),
             ]
         args += [

--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/ecs"
@@ -59,7 +58,6 @@ func MetricbeatSettings(moduleNameSpace string) instance.Settings {
 	}
 	runFlags := pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("system.hostfs")
 	return instance.Settings{
 		RunFlags:      runFlags,
 		Name:          Name,

--- a/metricbeat/main_test.go
+++ b/metricbeat/main_test.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	mbcmd "github.com/elastic/beats/v7/metricbeat/cmd"
@@ -40,14 +39,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	mbCommand = mbcmd.Initialize(mbcmd.MetricbeatSettings(""))
 	mbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	mbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := mbCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/metricbeat/module/golang/test_golang.py
+++ b/metricbeat/module/golang/test_golang.py
@@ -23,7 +23,7 @@ class Test(metricbeat.BaseTest):
             "period": "1s"
         }])
         proc = self.start_beat(
-            extra_args=["-httpprof", "localhost:6060"])
+            extra_args=["--httpprof", "localhost:6060"])
 
         self.wait_until(lambda: self.output_lines() > 0)
         proc.check_kill_and_wait()

--- a/metricbeat/module/openmetrics/collector/_meta/data.json
+++ b/metricbeat/module/openmetrics/collector/_meta/data.json
@@ -11,10 +11,12 @@
     },
     "openmetrics": {
         "labels": {
-            "job": "openmetrics"
+            "job": "openmetrics",
+            "listener_name": "http"
         },
         "metrics": {
-            "up": 1
+            "net_conntrack_listener_conn_accepted_total": 3,
+            "net_conntrack_listener_conn_closed_total": 0
         }
     },
     "service": {

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -563,9 +563,9 @@ class Test(metricbeat.BaseTest):
         output = self.read_output()[0]
 
         assert re.match("(?i)metricbeat.test(.exe)?", output["process.name"])
-        assert re.match("(?i).*metricbeat.test(.exe)? -systemTest",
+        assert re.match("(?i).*metricbeat.test(.exe)? --systemTest",
                         output["system.process.cmdline"])
-        assert re.match("(?i).*metricbeat.test(.exe)? -systemTest",
+        assert re.match("(?i).*metricbeat.test(.exe)? --systemTest",
                         output["process.command_line"])
         assert isinstance(output["system.process.state"], six.string_types)
         assert isinstance(

--- a/packetbeat/cmd/root.go
+++ b/packetbeat/cmd/root.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/ecs"
@@ -52,15 +51,10 @@ var RootCmd *cmd.BeatsRootCmd
 func PacketbeatSettings(globals processors.PluginConfig) instance.Settings {
 	runFlags := pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("I")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("t"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("t")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("O"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("O")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("l"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("l")
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("dump")
 
 	return instance.Settings{
 		RunFlags:       runFlags,

--- a/packetbeat/docs/troubleshooting.asciidoc
+++ b/packetbeat/docs/troubleshooting.asciidoc
@@ -52,7 +52,7 @@ of 10-20 seconds is usually enough. To record the trace, you can use the followi
 
 [source,shell]
 ------------------------------------------------------------
-packetbeat -e -dump trace.pcap
+packetbeat -e --dump trace.pcap
 ------------------------------------------------------------
 
 This command executes Packetbeat in normal mode (all processing happens as usual), but

--- a/packetbeat/main_test.go
+++ b/packetbeat/main_test.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/packetbeat/cmd"
 )
@@ -34,14 +33,11 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -59,11 +59,11 @@ class BaseTest(TestCase):
             "-e",
             "-I", os.path.join(self.beat_path + "/tests/system/pcaps", pcap),
             "-c", os.path.join(self.working_dir, config),
-            "-systemTest",
+            "--systemTest",
         ])
         if os.getenv("TEST_COVERAGE") == "true":
             args += [
-                "-test.coverprofile", os.path.join(self.working_dir, "coverage.cov"),
+                "--test.coverprofile", os.path.join(self.working_dir, "coverage.cov"),
             ]
 
         if extra_args:
@@ -107,11 +107,11 @@ class BaseTest(TestCase):
         args = [cmd,
                 "-e",
                 "-c", os.path.join(self.working_dir, config),
-                "-systemTest",
+                "--systemTest",
                 ]
         if os.getenv("TEST_COVERAGE") == "true":
             args += [
-                "-test.coverprofile", os.path.join(self.working_dir, "coverage.cov"),
+                "--test.coverprofile", os.path.join(self.working_dir, "coverage.cov"),
             ]
 
         if extra_args:

--- a/packetbeat/tests/system/test_0026_test_config.py
+++ b/packetbeat/tests/system/test_0026_test_config.py
@@ -42,13 +42,13 @@ class Test(BaseTest):
 
         cmd = os.path.join(self.beat_path, "packetbeat.test")
         args = [
-            cmd, "-systemTest",
+            cmd, "--systemTest",
             "-c", os.path.join(self.working_dir, config),
         ]
 
         if os.getenv("TEST_COVERAGE") == "true":
             args += [
-                "-test.coverprofile",
+                "--test.coverprofile",
                 os.path.join(self.working_dir, "coverage.cov"),
             ]
 

--- a/winlogbeat/main_test.go
+++ b/winlogbeat/main_test.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/winlogbeat/cmd"
 )
@@ -33,15 +32,12 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // TestSystem is the function called when the test binary is started.
 // Only calls main.
 func TestSystem(*testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/winlogbeat/tests/system/test_config.py
+++ b/winlogbeat/tests/system/test_config.py
@@ -70,13 +70,13 @@ class Test(BaseTest, common_tests.TestExportsMixin):
 
         cmd = os.path.join(self.beat_path, "winlogbeat.test")
         args = [
-            cmd, "-systemTest",
+            cmd, "--systemTest",
             "-c", os.path.join(self.working_dir, config),
         ]
 
         if os.getenv("TEST_COVERAGE") == "true":
             args += [
-                "-test.coverprofile",
+                "--test.coverprofile",
                 os.path.join(self.working_dir, "coverage.cov"),
             ]
 

--- a/x-pack/agentbeat/main_test.go
+++ b/x-pack/agentbeat/main_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 )
 
 var (
@@ -24,14 +22,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	abCommand = AgentBeat()
 	abCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	abCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := abCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/x-pack/auditbeat/main_test.go
+++ b/x-pack/auditbeat/main_test.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/auditbeat/cmd"
 )
@@ -22,14 +21,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/filebeat/main_test.go
+++ b/x-pack/filebeat/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	fbcmd "github.com/elastic/beats/v7/x-pack/filebeat/cmd"
@@ -25,14 +24,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	fbCommand = fbcmd.Filebeat()
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	fbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := fbCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/x-pack/heartbeat/main_test.go
+++ b/x-pack/heartbeat/main_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/heartbeat/cmd"
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -20,14 +19,11 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(_ *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/libbeat/libbeat_test.go
+++ b/x-pack/libbeat/libbeat_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 )
 
@@ -19,14 +18,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/metricbeat/main_test.go
+++ b/x-pack/metricbeat/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	mbcmd "github.com/elastic/beats/v7/x-pack/metricbeat/cmd"
@@ -25,14 +24,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	mbCommand = mbcmd.Initialize()
 	mbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	mbCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		if err := mbCommand.Execute(); err != nil {
 			os.Exit(1)

--- a/x-pack/osquerybeat/main_test.go
+++ b/x-pack/osquerybeat/main_test.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/cmd"
 )
 
@@ -21,14 +20,11 @@ func init() {
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(_ *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/packetbeat/main_test.go
+++ b/x-pack/packetbeat/main_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/packetbeat/cmd"
 )
@@ -19,14 +18,11 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(t *testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/packetbeat/tests/system/app_run_agentbeat_test.go
+++ b/x-pack/packetbeat/tests/system/app_run_agentbeat_test.go
@@ -37,7 +37,7 @@ func runPacketbeat(t testing.TB, args ...string) (stdout, stderr string, err err
 	if err != nil {
 		return "", "", err
 	}
-	cmd := exec.CommandContext(ctx, agentbeatPath, append([]string{"-systemTest", "packetbeat", "-c", conf}, args...)...)
+	cmd := exec.CommandContext(ctx, agentbeatPath, append([]string{"--systemTest", "packetbeat", "-c", conf}, args...)...)
 	cmd.Dir = t.TempDir()
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf

--- a/x-pack/packetbeat/tests/system/app_run_test.go
+++ b/x-pack/packetbeat/tests/system/app_run_test.go
@@ -37,7 +37,7 @@ func runPacketbeat(t testing.TB, args ...string) (stdout, stderr string, err err
 	if err != nil {
 		return "", "", err
 	}
-	cmd := exec.CommandContext(ctx, packetbeatPath, append([]string{"-systemTest", "-c", conf}, args...)...)
+	cmd := exec.CommandContext(ctx, packetbeatPath, append([]string{"--systemTest", "-c", conf}, args...)...)
 	cmd.Dir = t.TempDir()
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf

--- a/x-pack/winlogbeat/cmd/export.go
+++ b/x-pack/winlogbeat/cmd/export.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/winlogbeat/module"
 	libversion "github.com/elastic/elastic-agent-libs/version"
@@ -49,9 +48,7 @@ func GenExportPipelineCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genExportPipelineCmd.Flags().String("es.version", settings.Version, "Elasticsearch version (required)")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("es.version")
 	genExportPipelineCmd.Flags().String("dir", "", "Specify directory for exporting pipelines. Default is current directory.")
-	cfgfile.AddAllowedBackwardsCompatibleFlag("dir")
 
 	return genExportPipelineCmd
 }

--- a/x-pack/winlogbeat/main_test.go
+++ b/x-pack/winlogbeat/main_test.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/tests/system/template"
 	"github.com/elastic/beats/v7/x-pack/winlogbeat/cmd"
 )
@@ -19,14 +18,11 @@ func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("systemTest")
 	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
-	cfgfile.AddAllowedBackwardsCompatibleFlag("test.coverprofile")
 }
 
 // Test started when the test binary is started. Only calls main.
 func TestSystem(*testing.T) {
-	cfgfile.ConvertFlagsForBackwardsCompatibility()
 	if *systemTest {
 		main()
 	}

--- a/x-pack/winlogbeat/module/security/dashboards.yml
+++ b/x-pack/winlogbeat/module/security/dashboards.yml
@@ -1,5 +1,5 @@
 # To export all dashboards use:
-# go run ../../../../dev-tools/cmd/dashboards/export_dashboards.go -yml dashboards.yml
+# go run ../../../../dev-tools/cmd/dashboards/export_dashboards.go --yml dashboards.yml
 
 dashboards:
   - id: d401ef40-a7d5-11e9-a422-d144027429da


### PR DESCRIPTION
-------

*** Breaking Change ***




## Proposed commit message

This PR removes support for single `-` multi-character command line options.  You will need to use `--` instead.

For example `-environment` will no longer work, but `--environment` will.  The single charater options will continue to work, for example `-d` and `-c`.

This greatly simplifies our command line argument parsing and makes it much easier to import the beats module into other projects.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

If users have scripts that use the old single `-` arguments they will need to modify their scripts to use the double `--`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build a beat
2. make sure that `-environment container` fails but `--environment container` succeeds


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #42117

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->