### PR TITLE
github-actions: python 3.12 is the default when using ubuntu-latest

### DIFF
--- a/.github/workflows/check-default.yml
+++ b/.github/workflows/check-default.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Fix Code is not compatible with Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Run check-default
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-default.yml
+++ b/.github/workflows/check-default.yml
@@ -20,6 +20,11 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: .go-version
+    #  when using ubuntu-latest, python 3.10 is not the default version.
+    - name: Fix Code is not compatible with Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
     - name: Run check-default
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -28,6 +28,11 @@ jobs:
       run: sudo apt-get install -y libsystemd-dev
     - name: Install librpm-dev
       run: sudo apt-get install -y librpm-dev
+    #  when using ubuntu-latest, python 3.10 is not the default version.
+    - name: Fix Code is not compatible with Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
     - name: Run check
       run: |
         make check

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Fix Code is not compatible with Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Run check
       run: |
         make check


### PR DESCRIPTION
## Proposed commit message

The GitHub runners has been bumped from ubuntu-22 to ubuntu-24 and the default python version has changed from 3.10 to 3.12. See https://github.com/actions/runner-images/issues/10636

For the long run: `make check-default` should be updated to support `3.12`. 

This a workaround for:

```
ModuleNotFoundError: No module named 'lib2to3'
Traceback (most recent call last):
  File "/home/runner/work/beats/beats/build/python-env/bin/autopep8", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/autopep8.py", line 4474, in main
    results = fix_multiple_files(args.files, args, sys.stdout)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/autopep8.py", line 4369, in fix_multiple_files
    ret = _fix_file((name, options, output))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/autopep8.py", line 4345, in _fix_file
    return fix_file(*parameters)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/autopep8.py", line 3596, in fix_file
    original_source = readlines_from_file(filename)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/autopep8.py", line 188, in readlines_from_file
    with open_with_encoding(filename) as input_file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/autopep8.py", line 165, in open_with_encoding
    encoding = detect_encoding(filename, limit_byte_check=limit_byte_check)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/autopep8.py", line 175, in detect_encoding
    from lib2to3.pgen2 import tokenize as lib2to3_tokenize
ModuleNotFoundError: No module named 'lib2to3'
Traceback (most recent call last):
  File "/home/runner/work/beats/beats/build/python-env/bin/pylint", line 5, in <module>
    from pylint import run_pylint
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/pylint/__init__.py", line 13, in <module>
    from pylint.checkers.similar import Run as SimilarRun
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/pylint/checkers/__init__.py", line 42, in <module>
    from pylint.checkers.base_checker import BaseChecker, BaseTokenChecker
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/pylint/checkers/base_checker.py", line 17, in <module>
    from pylint.config import OptionsProviderMixIn
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/pylint/config.py", line 49, in <module>
    from pylint import utils
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/pylint/utils/__init__.py", line 44, in <module>
    from pylint.utils.ast_walker import ASTWalker
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/pylint/utils/ast_walker.py", line 8, in <module>
    from astroid import nodes
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/astroid/__init__.py", line 43, in <module>
    import wrapt
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/wrapt/__init__.py", line 10, in <module>
    from .decorators import (adapter_factory, AdapterFactory, decorator,
  File "/home/runner/work/beats/beats/build/python-env/lib/python3.12/site-packages/wrapt/decorators.py", line 34, in <module>
    from inspect import ismethod, isclass, formatargspec
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/lib/python3.12/inspect.py). Did you mean: 'formatargvalues'?
Code is not compatible with Python 3
```



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
