### PR TITLE
Remove TLSv1.0 from supported protocols

### DIFF
--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -66,7 +66,7 @@ heartbeat.monitors:
   ports: [80, 9200, 5044]
   ssl:
     certificate_authorities: ['/etc/ca.crt']
-    supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
+    supported_protocols: ["TLSv1.1", "TLSv1.2"]
 -------------------------------------------------------------------------------
 endif::[]
 
@@ -120,10 +120,9 @@ SSL settings are disabled if either `enabled` is set to `false` or the
 List of allowed SSL/TLS versions. If SSL/TLS server decides for protocol versions
 not configured, the connection will be dropped during or after the handshake. The
 setting is a list of allowed protocol versions:
-`TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, and
-`TLSv1.3`.
+`TLSv1.1`, `TLSv1.2`, and `TLSv1.3`.
 
-The default value is `[TLSv1.1, TLSv1.2, TLSv1.3]`.
+The default value is `[TLSv1.2, TLSv1.3]`.
 
 [float]
 [[cipher-suites]]
@@ -406,7 +405,7 @@ supports SSL.
 [[server-certificate-authorities]]
 ==== `certificate_authorities`
 
-The list of root certificates for client verifications is only required if 
+The list of root certificates for client verifications is only required if
 `client_authentication` is configured. If `certificate_authorities` is empty or not set, and
 `client_authentication` is configured, the system keystore is used.
 


### PR DESCRIPTION
## Proposed commit message

Remove TLSv1.0 from supported_protocols list and set defaults to TLSv1.2, TLSv1.3 for the 9.x release docs.

## Checklist

- ~~My code follows the style guidelines of this project~~
- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues


- #41595