### PR TITLE
Add description of Wolfi container install image

### DIFF
--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -2,6 +2,7 @@
 :beats-ref-all: https://www.elastic.co/guide/en/beats/libbeat
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
+:dockerimage-wolfi: docker.elastic.co/beats/{beatname_lc}-wolfi:{version}
 :dockerconfig: https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/docker/{beatname_lc}.docker.yml
 :downloads: https://artifacts.elastic.co/downloads/beats
 :libbeat-processors-dir: {beats-root}/libbeat/processors

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -35,6 +35,16 @@ https://www.docker.elastic.co[www.docker.elastic.co].
 
 ifndef::apm-server[]
 
+As another option, you can use the hardened link:https://wolfi.dev/[Wolfi] image.
+Using Wolfi images requires Docker version 20.10.10 or higher.
+For details about why the Wolfi images have been introduced, refer to our article 
+link:https://www.elastic.co/blog/reducing-cves-in-elastic-container-images[Reducing CVEs in Elastic container images].
+
+[source,terminal,subs="attributes"]
+----
+docker pull {dockerimage-wolfi}
+----
+
 ==== Optional: Verify the image
 
 You can use the https://docs.sigstore.dev/cosign/installation/[Cosign application] to verify the {beatname_uc} Docker image signature.


### PR DESCRIPTION
This updates the [Run [Beatname] in Docker](http://localhost:8000/guide/running-on-docker.html) pages to mention the availability of the Wolfi images, with a link to the Blog article about why they were introduced.

**Note to reviewers:** Please confirm that the path is correct for the Wolfi image. I've just assumed based on what we have in the Elastic Agent docs.

Rel: https://github.com/elastic/ingest-docs/issues/1608#issuecomment-2577852013
Associated Elastic Agent PR: https://github.com/elastic/ingest-docs/pull/1610

---

<img width="1114" alt="beats" src="https://github.com/user-attachments/assets/958d4ec2-3911-495e-90a9-e5f34ebef12b" />
