### PR TITLE
[x-pack][metricbeat][iis] improve error handling on pdh counters in application_pool data stream

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -109,6 +109,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Fix flaky test in cel and httpjson inputs of filebeat. {issue}40503[40503] {pull}41358[41358]
 - Fix documentation and implementation of raw message handling in Filebeat http_endpoint by removing it. {pull}41498[41498]
 - Fix flaky test in filebeat Okta entity analytics provider. {issue}42059[42059] {pull}42123[42123]
+- Fix IIS module logging errors in case application pool PDH counter is not found. {pull}42274[42274]
 
 ==== Added
 

--- a/x-pack/metricbeat/module/iis/application_pool/reader.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/windows/pdh"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -116,7 +117,7 @@ func (r *Reader) initAppPools() error {
 	for key, value := range appPoolCounters {
 		childQueries, err := r.query.GetCounterPaths(value)
 		if err != nil {
-			if errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTER) || errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTERNAME) || errors.Is(err, pdh.PDH_CSTATUS_NO_INSTANCE) || errors.Is(err, pdh.PDH_CSTATUS_NO_OBJECT) {
+			if err == pdh.PdhErrno(syscall.ERROR_NOT_FOUND) || errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTER) || errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTERNAME) || errors.Is(err, pdh.PDH_CSTATUS_NO_INSTANCE) || errors.Is(err, pdh.PDH_CSTATUS_NO_OBJECT) {
 				r.log.Infow("Ignoring non existent counter", "error", err,
 					logp.Namespace("application pool"), "query", value)
 			} else {

--- a/x-pack/metricbeat/module/iis/application_pool/reader.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader.go
@@ -117,7 +117,7 @@ func (r *Reader) initAppPools() error {
 	for key, value := range appPoolCounters {
 		childQueries, err := r.query.GetCounterPaths(value)
 		if err != nil {
-			if err == pdh.PdhErrno(syscall.ERROR_NOT_FOUND) || errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTER) || errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTERNAME) || errors.Is(err, pdh.PDH_CSTATUS_NO_INSTANCE) || errors.Is(err, pdh.PDH_CSTATUS_NO_OBJECT) {
+			if errors.Is(err, pdh.PdhErrno(syscall.ERROR_NOT_FOUND)) || errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTER) || errors.Is(err, pdh.PDH_CSTATUS_NO_COUNTERNAME) || errors.Is(err, pdh.PDH_CSTATUS_NO_INSTANCE) || errors.Is(err, pdh.PDH_CSTATUS_NO_OBJECT) {
 				r.log.Infow("Ignoring non existent counter", "error", err,
 					logp.Namespace("application pool"), "query", value)
 			} else {


### PR DESCRIPTION
## Proposed commit message

The error occurs [initAppPools](https://github.com/elastic/beats/blob/main/x-pack/metricbeat/module/iis/application_pool/reader.go#L104) > calls [GetCounterPaths](https://github.com/elastic/beats/blob/main/x-pack/metricbeat/module/iis/application_pool/reader.go#L117) > calls [ExpandWildCardPath](https://github.com/elastic/beats/blob/main/metricbeat/helper/windows/pdh/pdh_query_windows.go#L113) > calls [PdhExpandWildCardPath](https://github.com/elastic/beats/blob/main/metricbeat/helper/windows/pdh/pdh_query_windows.go#L227) which returns no data and no error > `PdhExpandWildCardPath`returns `PdhErrno(syscall.ERROR_NOT_FOUND)` error [here](https://github.com/elastic/beats/blob/main/metricbeat/helper/windows/pdh/pdh_query_windows.go#L249) > the error returns all the way back to `initAppPools` and since the error type isn't part of this [condition](https://github.com/elastic/beats/blob/main/x-pack/metricbeat/module/iis/application_pool/reader.go#L119) an error log appears (logged [here](https://github.com/elastic/beats/blob/main/x-pack/metricbeat/module/iis/application_pool/reader.go#L123)).

On why PDH's function returns no data and no error - I didn't find a coverage of this behavior in the [docs](https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhexpandwildcardpathw). My guess is that object/counter exists but has no data in it (for w3wp process).
The fix I suggest is simply adding a check for `PdhErrno(syscall.ERROR_NOT_FOUND)` error in this [condition](https://github.com/elastic/beats/blob/main/x-pack/metricbeat/module/iis/application_pool/reader.go#L119) which prevents those errors causing unnecessary error level log entries.



<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes #41596

## Screenshots

Before the change (`Element not found.failed to expand counter path` errors show up in the logs)
<img width="1161" alt="Screenshot 2025-01-09 at 2 14 55 PM" src="https://github.com/user-attachments/assets/43165886-ed29-458c-970c-42e4a33fadd0" />

After the change (NO `Element not found.failed to expand counter path` errors show up in the logs)
<img width="1153" alt="Screenshot 2025-01-09 at 2 03 47 PM" src="https://github.com/user-attachments/assets/98d3fead-dbd6-48d4-b41b-48011ecbfab0" />


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->