### PR TITLE
[winlogbeat] Several improvements to winlogbeat raw api

### DIFF
--- a/winlogbeat/sys/wineventlog/publisher_metadata.go
+++ b/winlogbeat/sys/wineventlog/publisher_metadata.go
@@ -231,7 +231,8 @@ func NewMetadataKeyword(publisherMetadataHandle EvtHandle, arrayHandle EvtObject
 
 type MetadataOpcode struct {
 	Name      string
-	Mask      uint32
+	Opcode    uint16
+	Task      uint16
 	MessageID uint32
 	Message   string
 }
@@ -292,11 +293,15 @@ func NewMetadataOpcode(publisherMetadataHandle EvtHandle, arrayHandle EvtObjectA
 	if err != nil {
 		return nil, err
 	}
+	// Mask high word contains the opcode value and the low word contains the task to which it belongs.
+	// If the low word is zero, the opcode is defined globally; otherwise, the opcode is task specific.
+	// Use the low word value to determine the task that defines the opcode.
 	valueMask := v.(uint32)
 
 	return &MetadataOpcode{
 		Name:      name,
-		Mask:      valueMask,
+		Opcode:    uint16((valueMask >> 16) & 0xFFFF),
+		Task:      uint16(valueMask & 0xFFFF),
 		MessageID: messageID,
 		Message:   message,
 	}, nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Several improvements to winlogbeat raw api:
 - Fingerprint templates by eventID+version
 - Properly parse opcodes
 - Improve handling of user data

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [] I have made corresponding changes to the documentation~
~- [] I have made corresponding change to the default configuration files~
~- [] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


