### PR TITLE
[Filebeat] Add Initial Interval for Microsoft Filesets

### DIFF
--- a/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/config/atp.yml
@@ -25,7 +25,7 @@ request.transforms:
   - set:
       target: "url.params.$filter"
       value: 'lastUpdateTime gt [[formatDate .cursor.lastUpdateTime "2006-01-02T15:04:05.9999999Z"]]'
-      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-5m")) "2006-01-02T15:04:05.9999999Z"]]'
+      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-{{.initial_interval}}")) "2006-01-02T15:04:05.9999999Z"]]'
 
 response.split:
   target: body.value

--- a/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
@@ -10,7 +10,7 @@ var:
   - name: oauth2
   - name: proxy_url
   - name: initial_interval
-    default: 24h
+    default: 5m
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/atp.yml

--- a/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/defender_atp/manifest.yml
@@ -9,6 +9,8 @@ var:
     default: [defender-atp, forwarded]
   - name: oauth2
   - name: proxy_url
+  - name: initial_interval
+    default: 24h
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/atp.yml

--- a/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
+++ b/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
@@ -20,7 +20,7 @@ request.transforms:
   - set:
       target: "url.params.$filter"
       value: 'lastUpdateTime gt [[.cursor.lastUpdateTime]]'
-      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-55m")) "2006-01-02T15:04:05.9999999Z"]]'
+      default: 'lastUpdateTime gt [[formatDate (now (parseDuration "-{{.initial_interval}}")) "2006-01-02T15:04:05.9999999Z"]]'
 response.split:
   target: body.value
   ignore_empty_value: true

--- a/x-pack/filebeat/module/microsoft/m365_defender/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/m365_defender/manifest.yml
@@ -9,6 +9,8 @@ var:
     default: [m365-defender, forwarded]
   - name: oauth2
   - name: proxy_url
+  - name: initial_interval
+    default: 24h
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/defender.yml

--- a/x-pack/filebeat/module/microsoft/m365_defender/manifest.yml
+++ b/x-pack/filebeat/module/microsoft/m365_defender/manifest.yml
@@ -10,7 +10,7 @@ var:
   - name: oauth2
   - name: proxy_url
   - name: initial_interval
-    default: 24h
+    default: 55m
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/defender.yml


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->



## Proposed commit message

The initial intervals for microsoft filesets are currently hard coded. Adding initial interval variable.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Will need to test this with varying initial intervals.
