### PR TITLE
Prevent 'thundering herd' issue with the scale preset

### DIFF
--- a/libbeat/outputs/elasticsearch/config_presets.go
+++ b/libbeat/outputs/elasticsearch/config_presets.go
@@ -63,6 +63,8 @@ var presetConfigs = map[string]*config.C{
 		"queue.mem.flush.timeout":    20 * time.Second,
 		"compression_level":          1,
 		"idle_connection_timeout":    1 * time.Second,
+		"backoff.init":               5 * time.Second,
+		"backoff.max":                300 * time.Second,
 	}),
 	presetLatency: config.MustNewConfigFrom(map[string]interface{}{
 		"bulk_max_size":              50,

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -680,6 +680,8 @@ Setting `bulk_max_size` to values less than or equal to 0 disables the
 splitting of batches. When splitting is disabled, the queue decides on the
 number of events to be contained in a batch.
 
+
+[[backoff-init-option]]
 ===== `backoff.init`
 
 The number of seconds to wait before trying to reconnect to Elasticsearch after
@@ -689,6 +691,7 @@ to `backoff.max`. After a successful connection, the backoff timer is reset. The
 default is `1s`.
 
 
+[[backoff-max-option]]
 ===== `backoff.max`
 
 The maximum number of seconds to wait before attempting to connect to
@@ -774,7 +777,7 @@ output.elasticsearch:
   preset: balanced
 ------------------------------------------------------------------------------
 
-Performance presets apply a set of configuration overrides based on a desired performance goal. If set, a performance preset will override other configuration flags to match the recommended settings for that preset. Valid options are:
+Performance presets apply a set of configuration overrides based on a desired performance goal. If set, a performance preset will override other configuration flags to match the recommended settings for that preset. If a preset doesn't set a value for a particular field, the user-specified value will be used if present, otherwise the default. Valid options are:
 * `balanced`: good starting point for general efficiency
 * `throughput`: good for high data volumes, may increase cpu and memory requirements
 * `scale`: reduces ambient resource use in large low-throughput deployments
@@ -830,6 +833,18 @@ Presets represent current recommendations based on the intended goal; their effe
 |`15s`
 |`1s`
 |`60s`
+
+|<<backoff-init-option,`backoff.init`>>
+|none
+|none
+|`5s`
+|none
+
+|<<backoff-max-option,`backoff.max`>>
+|none
+|none
+|`300s`
+|none
 |===
 
 [[es-apis]]


### PR DESCRIPTION
Add backoff settings to the `scale` performance preset, as described in https://github.com/elastic/elastic-agent/issues/4469, to reduce load on large deployments.

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

If users have already set an output backoff while using the scale preset, this will override it (and possibly reduce the effective backoff).

However, this reduces cluster overload in the more common case that users have default backoff settings.

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/4469
