### PR TITLE
Increase Osquery max timeout limit to 24 hours

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -19,7 +19,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Set default kafka version to 2.1.0 in kafka output and filebeat. {pull}41662[41662]
 - Replace default Ubuntu-based images with UBI-minimal-based ones {pull}42150[42150]
 - Fix templates and docs to use correct `--` version of command line arguments. {issue}42038[42038] {pull}42060[42060]
-- removed support for a single `-` to precede multi-letter command line arguments.  Use `--` instead. {issue}42117[42117] {pull}42209[42209] 
+- removed support for a single `-` to precede multi-letter command line arguments.  Use `--` instead. {issue}42117[42117] {pull}42209[42209]
 
 *Auditbeat*
 
@@ -79,8 +79,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Disable allow_unsafe osquery configuration. {pull}40130[40130]
 - Upgrade to osquery 5.12.1. {pull}40368[40368]
 - Upgrade to osquery 5.13.1. {pull}40849[40849]
-
-*Osquerybeat*
 
 
 *Packetbeat*
@@ -206,7 +204,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix awss3 document ID construction when using the CSV decoder. {pull}42019[42019]
 - The `_id` generation process for S3 events has been updated to incorporate the LastModified field. This enhancement ensures that the `_id` is unique. {pull}42078[42078]
 - Fix Netflow Template Sharing configuration handling. {pull}42080[42080]
-- Updated websocket retry error code list to allow more scenarios to be retried which could have been missed previously. {pull}42218[42218] 
+- Updated websocket retry error code list to allow more scenarios to be retried which could have been missed previously. {pull}42218[42218]
 - In the `streaming` input, prevent panics on shutdown with a null check and apply a consistent namespace to contextual data in debug logs. {pull}42315[42315]
 
 *Heartbeat*
@@ -456,6 +454,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Osquerybeat*
 
+- Increase maximum query timeout to 24 hours {pull}42356[42356]
 
 *Packetbeat*
 

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -46,7 +46,7 @@ const (
 	configurationRefreshIntervalSecs = 60
 
 	osqueryTimeout    = 1 * time.Minute
-	osqueryMaxTimeout = 15 * time.Minute
+	osqueryMaxTimeout = 24 * time.Hour
 )
 
 const (

--- a/x-pack/osquerybeat/internal/osqdcli/client.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client.go
@@ -25,7 +25,7 @@ const (
 	defaultTimeout = 1 * time.Minute
 
 	// The longest the query is allowed to run. Since queries are run one at a time, this will block all other queries until this query completes.
-	defaultMaxTimeout     = 15 * time.Minute
+	defaultMaxTimeout     = 24 * time.Hour
 	defaultConnectRetries = 10
 )
 


### PR DESCRIPTION

## Proposed commit message

Increasing the osquery max query timeout will allow users to run longer running queries that can be done with osquery.

Although osquery only supports running one query at a time, and this may block others from running, it will allow users to decide for themselves if they want to run long-running queries, and opens new use-cases.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Relates https://github.com/elastic/kibana/pull/207276
- Relates https://github.com/elastic/beats/issues/42352
