### PR TITLE
Handle authorization errors in Kafka output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -126,6 +126,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Allow network condition to handle field values that are arrays of IP addresses. {pull}41918[41918]
 - Fix a bug where log files are rotated on startup when interval is configured and rotateonstartup is disabled {issue}41894[41894] {pull}41895[41895]
 - Fix setting unique registry for non beat receivers {issue}42288[42288] {pull}42292[42292]
+- The Kafka output now drops events when there is an authorisation error {issue}42343[42343] {pull}42401[42401]
 
 *Auditbeat*
 

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -72,9 +72,9 @@ type msgRef struct {
 var (
 	errNoTopicsSelected = errors.New("no topic could be selected")
 
-	// authErros are authentication/authorisation errors that will cause
+	// authErrors are authentication/authorisation errors that will cause
 	// the event to be dropped
-	authErros = []error{
+	authErrors = []error{
 		sarama.ErrTopicAuthorizationFailed,
 		sarama.ErrGroupAuthorizationFailed,
 		sarama.ErrClusterAuthorizationFailed,
@@ -454,7 +454,7 @@ func (c *client) Test(d testing.Driver) {
 }
 
 func isAuthError(err error) bool {
-	for _, e := range authErros {
+	for _, e := range authErrors {
 		if errors.Is(err, e) {
 			return true
 		}

--- a/libbeat/tests/integration/kafka_test.go
+++ b/libbeat/tests/integration/kafka_test.go
@@ -98,7 +98,7 @@ func TestAuthorisationErrors(t *testing.T) {
 	metadataResponse.AddTopicPartition(kafkaTopic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
 	leader.Returns(metadataResponse)
 
-	authErros := []sarama.KError{
+	authErrors := []sarama.KError{
 		sarama.ErrTopicAuthorizationFailed,
 		sarama.ErrGroupAuthorizationFailed,
 		sarama.ErrClusterAuthorizationFailed,
@@ -106,7 +106,7 @@ func TestAuthorisationErrors(t *testing.T) {
 
 	// The mock broker must return one produce response per error we want
 	// to test. If less calls are made, the test will fail
-	for _, err := range authErros {
+	for _, err := range authErrors {
 		producerResponse := new(sarama.ProduceResponse)
 		producerResponse.AddTopicPartition(kafkaTopic, 0, err)
 		leader.Returns(producerResponse)
@@ -118,7 +118,7 @@ func TestAuthorisationErrors(t *testing.T) {
 	mockbeat.Start()
 
 	// Wait for mockbeat to log each of the errors.
-	for _, err := range authErros {
+	for _, err := range authErrors {
 		t.Log("waiting for:", err)
 		mockbeat.WaitForLogs(
 			fmt.Sprintf("Kafka (topic=test_topic): authorisation error: %s", err),

--- a/libbeat/tests/integration/kafka_test.go
+++ b/libbeat/tests/integration/kafka_test.go
@@ -87,3 +87,42 @@ func TestKafkaOutputCanConnectAndPublish(t *testing.T) {
 		10*time.Second,
 		"did not find finished batch log")
 }
+
+func TestAuthorisationErrors(t *testing.T) {
+	leader := sarama.NewMockBroker(t, 1)
+	defer leader.Close()
+
+	// The mock broker must respond to a single metadata request.
+	metadataResponse := new(sarama.MetadataResponse)
+	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+	metadataResponse.AddTopicPartition(kafkaTopic, 0, leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
+	leader.Returns(metadataResponse)
+
+	authErros := []sarama.KError{
+		sarama.ErrTopicAuthorizationFailed,
+		sarama.ErrGroupAuthorizationFailed,
+		sarama.ErrClusterAuthorizationFailed,
+	}
+
+	// The mock broker must return one produce response per error we want
+	// to test. If less calls are made, the test will fail
+	for _, err := range authErros {
+		producerResponse := new(sarama.ProduceResponse)
+		producerResponse.AddTopicPartition(kafkaTopic, 0, err)
+		leader.Returns(producerResponse)
+	}
+
+	// Start mockbeat with the appropriate configuration.
+	mockbeat := NewBeat(t, "mockbeat", "../../libbeat.test")
+	mockbeat.WriteConfigFile(fmt.Sprintf(kafkaCfg, kafkaTopic, kafkaVersion, leader.Addr()))
+	mockbeat.Start()
+
+	// Wait for mockbeat to log each of the errors.
+	for _, err := range authErros {
+		t.Log("waiting for:", err)
+		mockbeat.WaitForLogs(
+			fmt.Sprintf("Kafka (topic=test_topic): authorisation error: %s", err),
+			10*time.Second,
+			"did not find error log: %s", err)
+	}
+}


### PR DESCRIPTION
## Proposed commit message

When there is an authorisation error in the Kafka output, the events are dropped and an error message is logged.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

Run the tests added by this PR:
```
mage buildSystemTestBinary
go test -tags integration -run=TestAuthorisationErrors -v ./tests/integration
```

If you want to run any Beat yourself, you can modify the test so it only starts the mock and waits, then configure a Beat to connect to it.

## Related issues
- Closes #42343

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~