### PR TITLE
Fix some golangci-lint errors

### DIFF
--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -113,7 +113,7 @@ func (r *Registrar) Start() error {
 	// Load the previous log file locations now, for use in input
 	err := r.loadStates()
 	if err != nil {
-		return fmt.Errorf("error loading state: %v", err)
+		return fmt.Errorf("error loading state: %w", err)
 	}
 
 	r.wg.Add(1)

--- a/libbeat/common/cleanup/cleanup.go
+++ b/libbeat/common/cleanup/cleanup.go
@@ -19,7 +19,7 @@
 //
 // Use the helpers with `defer`. For example use IfNot with `defer`, such that
 // cleanup functions will be executed if `check` is false, no matter if an
-// error has been returned or an panic has occured.
+// error has been returned or an panic has occurred.
 //
 //	initOK := false
 //	defer cleanup.IfNot(&initOK, func() {
@@ -59,7 +59,7 @@ func IfNotPred(pred func() bool, cleanup func()) {
 	}
 }
 
-// WithError returns a cleanup function calling a custom handler if an error occured.
+// WithError returns a cleanup function calling a custom handler if an error occurred.
 func WithError(fn func(error), cleanup func() error) func() {
 	return func() {
 		if err := cleanup(); err != nil {

--- a/libbeat/common/schema/schema_test.go
+++ b/libbeat/common/schema/schema_test.go
@@ -160,7 +160,7 @@ func TestSchemaCases(t *testing.T) {
 			if errs != nil {
 				errorMessage := errs.Error()
 				if tc.expectedErrorMessage == "" {
-					t.Errorf("unexpected error ocurred: %s", errorMessage)
+					t.Errorf("unexpected error occurred: %s", errorMessage)
 				}
 				assert.Contains(t, errorMessage, tc.expectedErrorMessage)
 			} else if tc.expectedErrorMessage != "" {

--- a/libbeat/statestore/error.go
+++ b/libbeat/statestore/error.go
@@ -84,8 +84,5 @@ func (e *ErrorOperation) Error() string {
 // IsClosed returns true if the cause for an Error is ErrorClosed.
 func IsClosed(err error) bool {
 	var tmp *ErrorClosed
-	if errors.As(err, &tmp) {
-		return true
-	}
-	return false
+	return errors.As(err, &tmp)
 }

--- a/libbeat/statestore/error.go
+++ b/libbeat/statestore/error.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 )
 
-// ErrorAccess indicates that an error occured when trying to open a Store.
+// ErrorAccess indicates that an error occurred when trying to open a Store.
 type ErrorAccess struct {
 	name  string
 	cause error

--- a/libbeat/statestore/internal/storecompliance/reg.go
+++ b/libbeat/statestore/internal/storecompliance/reg.go
@@ -25,7 +25,7 @@ import (
 
 // Registry helper for writing tests.
 // The registry uses a testing.T and provides some MustX methods that fail if
-// an error occured.
+// an error occurred.
 type Registry struct {
 	T testing.TB
 	backend.Registry
@@ -34,7 +34,7 @@ type Registry struct {
 // Store helper for writing tests.
 // The store needs a reference to the Registry with the current test context.
 // The Store provides additional helpers for reopening the store, MustX methods
-// that will fail the test if an error has occured.
+// that will fail the test if an error has occurred.
 type Store struct {
 	backend.Store
 
@@ -51,7 +51,7 @@ func (r *Registry) Access(name string) (*Store, error) {
 	return &Store{Store: s, Registry: r, name: name}, nil
 }
 
-// MustAccess opens a Store. It fails the test if an error has occured.
+// MustAccess opens a Store. It fails the test if an error has occurred.
 func (r *Registry) MustAccess(name string) *Store {
 	store, err := r.Access(name)
 	must(r.T, err, "open store")
@@ -87,26 +87,26 @@ func (s *Store) Reopen() {
 	s.Store = store
 }
 
-// MustHave fails the test if an error occured in a call to Has.
+// MustHave fails the test if an error occurred in a call to Has.
 func (s *Store) MustHave(key string) bool {
 	b, err := s.Has(key)
 	must(s.Registry.T, err, "unexpected error on store/has call")
 	return b
 }
 
-// MustGet fails the test if an error occured in a call to Get.
+// MustGet fails the test if an error occurred in a call to Get.
 func (s *Store) MustGet(key string, into interface{}) {
 	err := s.Get(key, into)
 	must(s.Registry.T, err, "unexpected error on store/get call")
 }
 
-// MustSet fails the test if an error occured in a call to Set.
+// MustSet fails the test if an error occurred in a call to Set.
 func (s *Store) MustSet(key string, from interface{}) {
 	err := s.Set(key, from)
 	must(s.Registry.T, err, "unexpected error on store/set call")
 }
 
-// MustRemove fails the test if an error occured in a call to Remove.
+// MustRemove fails the test if an error occurred in a call to Remove.
 func (s *Store) MustRemove(key string) {
 	err := s.Store.Remove(key)
 	must(s.Registry.T, err, "unexpected error remove key")

--- a/libbeat/statestore/mock_test.go
+++ b/libbeat/statestore/mock_test.go
@@ -18,6 +18,8 @@
 package statestore
 
 import (
+	"fmt"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/beats/v7/libbeat/statestore/backend"
@@ -39,7 +41,11 @@ func (m *mockRegistry) Access(name string) (backend.Store, error) {
 
 	var store backend.Store
 	if ifc := args.Get(0); ifc != nil {
-		store = ifc.(backend.Store)
+		var ok bool
+		store, ok = ifc.(backend.Store)
+		if !ok {
+			return store, fmt.Errorf("unexpected type: %T", store)
+		}
 	}
 
 	return store, args.Error(1)

--- a/libbeat/statestore/storetest/storetest.go
+++ b/libbeat/statestore/storetest/storetest.go
@@ -141,7 +141,7 @@ func (s *MapStore) Has(key string) (bool, error) {
 }
 
 // Get returns a key value pair from the store. An error is returned if the
-// store has been closed, the key is unknown, or an decoding error occured.
+// store has been closed, the key is unknown, or an decoding error occurred.
 func (s *MapStore) Get(key string, into interface{}) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
## Proposed commit message

In https://github.com/elastic/beats/pull/41446, we are getting some unrelated golangci-lint errors from files that are touched by the PR but in different places. Instead of ignoring the failing CI, it's equally easy to fix them here.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~