### PR TITLE
perf(add_docker_metadata): always try to lookup the cache before retrieving the cid from cgroup

### DIFF
--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -64,7 +64,7 @@ type addDockerMetadata struct {
 	sourceProcessor beat.Processor
 
 	pidFields       []string      // Field names that contain PIDs.
-	cgroups         *common.Cache // Cache of PID (int) to cgropus (map[string]string).
+	cgroups         *common.Cache // Cache of PID (int) to container ids (string).
 	dedot           bool          // If set to true, replace dots in labels with `_`.
 	dockerAvailable bool          // If Docker exists in env, then it is set to true
 	cgreader        processors.CGReader
@@ -247,7 +247,8 @@ func (d *addDockerMetadata) String() string {
 // lookupContainerIDByPID finds the container ID based on PID fields contained
 // in the event.
 func (d *addDockerMetadata) lookupContainerIDByPID(event *beat.Event) (string, error) {
-	var cgroups cgroup.PathList
+	pids := make([]int, 0, len(d.pidFields))
+
 	for _, field := range d.pidFields {
 		v, err := event.GetValue(field)
 		if err != nil {
@@ -260,7 +261,18 @@ func (d *addDockerMetadata) lookupContainerIDByPID(event *beat.Event) (string, e
 			continue
 		}
 
-		cgroups, err = d.getProcessCgroups(pid)
+		if d.cgroups != nil {
+			if cid := d.cgroups.Get(pid); cid != nil {
+				d.log.Debugf("Using cached cgroups for pid=%v", pid)
+				return cid.(string), nil
+			}
+		}
+
+		pids = append(pids, pid)
+	}
+
+	for _, pid := range pids {
+		cgroups, err := d.getProcessCgroups(pid)
 		if err != nil && errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
@@ -268,24 +280,21 @@ func (d *addDockerMetadata) lookupContainerIDByPID(event *beat.Event) (string, e
 			d.log.Debugf("failed to get cgroups for pid=%v: %v", pid, err)
 		}
 
-		break
+		// Initialize at time of first use.
+		lazyCgroupCacheInit(d)
+
+		cid, err := getContainerIDFromCgroups(cgroups)
+		d.cgroups.Put(pid, cid)
+
+		return cid, err
 	}
 
-	return getContainerIDFromCgroups(cgroups)
+	return "", nil
 }
 
 // getProcessCgroups returns a mapping of cgroup subsystem name to path. It
 // returns an error if it failed to retrieve the cgroup info.
 func (d *addDockerMetadata) getProcessCgroups(pid int) (cgroup.PathList, error) {
-	// Initialize at time of first use.
-	lazyCgroupCacheInit(d)
-
-	cgroups, ok := d.cgroups.Get(pid).(cgroup.PathList)
-	if ok {
-		d.log.Debugf("Using cached cgroups for pid=%v", pid)
-		return cgroups, nil
-	}
-
 	cgroups, err := d.cgreader.ProcessCgroupPaths(pid)
 	if err != nil {
 		return cgroups, fmt.Errorf("failed to read cgroups for pid=%v: %w", pid, err)
@@ -293,7 +302,6 @@ func (d *addDockerMetadata) getProcessCgroups(pid int) (cgroup.PathList, error) 
 	if len(cgroups.Flatten()) == 0 {
 		return cgroup.PathList{}, fs.ErrNotExist
 	}
-	d.cgroups.Put(pid, cgroups)
 	return cgroups, nil
 }
 


### PR DESCRIPTION
## Proposed commit message

profiling data in the last 24h shows add_docker_metadata being responsible for ~25% of auditbeat cpu time.

Try to improve cpu time with better and more aggressive caching:

- Cache container id instead of cgroup to avoid reparsing/matching the same cgroup list on each cached pid
- Always lookup the cache for each pidFields before falling back to cgroup

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
