### PR TITLE
Upgrade dbadger-io to v4.4.0

### DIFF
--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -108,8 +108,7 @@ steps:
             - limit: 1
         agents:
           provider: "gcp"
-          image: "platform-ingest-beats-ubuntu-2204-1738063532"
-          imageProject: "elastic-images-qa"
+          image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
         artifact_paths:
           - "x-pack/metricbeat/build/*.xml"
@@ -130,8 +129,7 @@ steps:
             - limit: 1
         agents:
           provider: "gcp"
-          image: "platform-ingest-beats-ubuntu-2204-1738063532"
-          imageProject: "elastic-images-qa"
+          image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
         artifact_paths:
           - "x-pack/metricbeat/build/*.xml"

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -108,7 +108,7 @@ steps:
             - limit: 1
         agents:
           provider: "gcp"
-          image: "platform-ingest-beats-ubuntu-2204-1737995800"
+          image: "platform-ingest-beats-ubuntu-2204-1738063532"
           imageProject: "elastic-images-qa"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
         artifact_paths:
@@ -130,7 +130,7 @@ steps:
             - limit: 1
         agents:
           provider: "gcp"
-          image: "platform-ingest-beats-ubuntu-2204-1737995800"
+          image: "platform-ingest-beats-ubuntu-2204-1738063532"
           imageProject: "elastic-images-qa"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
         artifact_paths:

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -108,7 +108,8 @@ steps:
             - limit: 1
         agents:
           provider: "gcp"
-          image: "${IMAGE_UBUNTU_X86_64}"
+          image: "platform-ingest-beats-ubuntu-2204-1737995800"
+          imageProject: "elastic-images-qa"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
         artifact_paths:
           - "x-pack/metricbeat/build/*.xml"
@@ -129,7 +130,8 @@ steps:
             - limit: 1
         agents:
           provider: "gcp"
-          image: "${IMAGE_UBUNTU_X86_64}"
+          image: "platform-ingest-beats-ubuntu-2204-1737995800"
+          imageProject: "elastic-images-qa"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
         artifact_paths:
           - "x-pack/metricbeat/build/*.xml"

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11383,11 +11383,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/dgraph-io/badger/v4
-Version: v4.2.1-0.20240828131336-2725dc8ed5c2
+Version: v4.4.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/dgraph-io/badger/v4@v4.2.1-0.20240828131336-2725dc8ed5c2/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/dgraph-io/badger/v4@v4.4.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004
@@ -18915,11 +18915,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/google/flatbuffers
-Version: v23.5.26+incompatible
+Version: v24.3.25+incompatible
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/google/flatbuffers@v23.5.26+incompatible/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/google/flatbuffers@v24.3.25+incompatible/LICENSE:
 
 
                                  Apache License
@@ -21072,11 +21072,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/klauspost/compress
-Version: v1.17.9
+Version: v1.17.11
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/klauspost/compress@v1.17.9/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/klauspost/compress@v1.17.11/LICENSE:
 
 Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright (c) 2019 Klaus Post. All rights reserved.
@@ -38533,12 +38533,12 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/dgraph-io/ristretto
-Version: v0.1.2-0.20240116140435-c67e07994f91
+Dependency : github.com/dgraph-io/ristretto/v2
+Version: v2.0.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/dgraph-io/ristretto@v0.1.2-0.20240116140435-c67e07994f91/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/dgraph-io/ristretto/v2@v2.0.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4
 	github.com/gomodule/redigo v1.8.3
-	github.com/google/flatbuffers v23.5.26+incompatible
+	github.com/google/flatbuffers v24.3.25+incompatible
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0 // indirect
@@ -187,7 +187,7 @@ require (
 	github.com/aws/smithy-go v1.20.4
 	github.com/awslabs/goformation/v7 v7.14.9
 	github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5
-	github.com/dgraph-io/badger/v4 v4.2.1-0.20240828131336-2725dc8ed5c2
+	github.com/dgraph-io/badger/v4 v4.4.0
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.6.0
 	github.com/elastic/elastic-agent-autodiscover v0.9.0
@@ -210,7 +210,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/icholy/digest v0.1.22
-	github.com/klauspost/compress v1.17.9
+	github.com/klauspost/compress v1.17.11
 	github.com/meraki/dashboard-api-go/v3 v3.0.9
 	github.com/otiai10/copy v1.12.0
 	github.com/pierrec/lz4/v4 v4.1.18
@@ -278,7 +278,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dgraph-io/ristretto v0.1.2-0.20240116140435-c67e07994f91 // indirect
+	github.com/dgraph-io/ristretto/v2 v2.0.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,10 +287,10 @@ github.com/denisenkom/go-mssqldb v0.12.3 h1:pBSGx9Tq67pBOTLmxNuirNTeB8Vjmf886Kx+
 github.com/denisenkom/go-mssqldb v0.12.3/go.mod h1:k0mtMFOnU+AihqFxPMiF05rtiDrorD1Vrm1KEz5hxDo=
 github.com/devigned/tab v0.1.2-0.20190607222403-0c15cf42f9a2 h1:6+hM8KeYKV0Z9EIINNqIEDyyIRAcNc2FW+/TUYNmWyw=
 github.com/devigned/tab v0.1.2-0.20190607222403-0c15cf42f9a2/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
-github.com/dgraph-io/badger/v4 v4.2.1-0.20240828131336-2725dc8ed5c2 h1:1JGAkmP07Stzb04z4nQYkqtXglMlU0F3Jx5ROqGMLtQ=
-github.com/dgraph-io/badger/v4 v4.2.1-0.20240828131336-2725dc8ed5c2/go.mod h1:Sc0T595g8zqAQRDf44n+z3wG4BOqLwceaFntt8KPxUM=
-github.com/dgraph-io/ristretto v0.1.2-0.20240116140435-c67e07994f91 h1:Pux6+xANi0I7RRo5E1gflI4EZ2yx3BGZ75JkAIvGEOA=
-github.com/dgraph-io/ristretto v0.1.2-0.20240116140435-c67e07994f91/go.mod h1:swkazRqnUf1N62d0Nutz7KIj2UKqsm/H8tD0nBJAXqM=
+github.com/dgraph-io/badger/v4 v4.4.0 h1:rA48XiDynZLyMdlaJl67p9+lqfqwxlgKtCpYLAio7Zk=
+github.com/dgraph-io/badger/v4 v4.4.0/go.mod h1:sONMmPPfbnj9FPwS/etCqky/ULth6CQJuAZSuWCmixE=
+github.com/dgraph-io/ristretto/v2 v2.0.0 h1:l0yiSOtlJvc0otkqyMaDNysg8E9/F/TYZwMbxscNOAQ=
+github.com/dgraph-io/ristretto/v2 v2.0.0/go.mod h1:FVFokF2dRqXyPyeMnK1YDy8Fc6aTe0IKgbcd03CYeEk=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/digitalocean/go-libvirt v0.0.0-20240709142323-d8406205c752 h1:NI7XEcHzWVvBfVjSVK6Qk4wmrUfoyQxCNpBjrHelZFk=
@@ -524,8 +524,8 @@ github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc
 github.com/gomodule/redigo v1.8.3/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/cel-go v0.19.0 h1:vVgaZoHPBDd1lXCYGQOh5A06L4EtuIfmqQ/qnSXSKiU=
 github.com/google/cel-go v0.19.0/go.mod h1:kWcIzTsPX0zmQ+H3TirHstLLf9ep5QTsZBN9u4dOYLg=
-github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
-github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v24.3.25+incompatible h1:CX395cjN9Kke9mmalRoL3d81AtFUxJM+yDthflgJGkI=
+github.com/google/flatbuffers v24.3.25+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -666,8 +666,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Relates https://github.com/elastic/beats/pull/42358

## Proposed commit message

Update dbadger-io to v4.4.0 in branch 8.17 to match `main` and `8.x`.

## How to test this PR locally

To test this PR, due the problem described in https://github.com/elastic/beats/issues/42446, a prerequisite is VM images bundled with the [module pre-downloaded](https://github.com/elastic/ci-agent-images/pull/1187). Example successful run: https://buildkite.com/elastic/beats/builds/18167 (particularly the [x-pack/metricbeat Go IntegTests](https://buildkite.com/elastic/beats-xpack-metricbeat/builds/10972#0194ad3d-b09f-43e3-bd63-eb2e05cd9264/149-618))

## Related issues

- https://github.com/elastic/beats/issues/42446

## Logs

```
>> go test: Integration-cloudfoundry Test Passed
go: downloading gotest.tools/gotestsum v1.7.0
go: downloading github.com/fatih/color v1.16.0
go: downloading github.com/dnephin/pflag v1.0.7
go: downloading github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: downloading github.com/pkg/errors v0.9.1
go: downloading golang.org/x/tools v0.25.0
go: downloading github.com/elastic/fsnotify v1.6.1-0.20240920222514-49f82bdbc9e3
go: downloading golang.org/x/sys v0.28.0
go: downloading github.com/jonboulle/clockwork v0.2.2
go: downloading golang.org/x/sync v0.10.0
go: downloading golang.org/x/term v0.27.0
go: downloading github.com/mattn/go-colorable v0.1.13
go: downloading github.com/mattn/go-isatty v0.0.20
go: downloading golang.org/x/mod v0.21.0
>> go test: Integration-cockroachdb Testing
exec: gotestsum --no-color -f standard-quiet --junitfile build/TEST-go-integration-cockroachdb.xml --jsonfile build/TEST-go-integration-cockroachdb.out.json -- -tags oracle integration -covermode=atomic -coverprofile=build/TEST-go-integration-cockroachdb.cov ./module/cockroachdb/...
go: downloading github.com/elastic/elastic-agent-libs v0.17.4
go: downloading github.com/stretchr/testify v1.9.0
go: downloading github.com/elastic/go-concert v0.3.0
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/mitchellh/hashstructure v1.1.0
go: downloading github.com/gofrs/uuid/v5 v5.2.0
go: downloading github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
go: downloading github.com/docker/docker v27.3.1+incompatible
go: downloading github.com/elastic/elastic-agent-autodiscover v0.9.0
go: downloading github.com/prometheus/common v0.57.0
go: downloading github.com/prometheus/prometheus v0.54.1
go: downloading github.com/elastic/go-ucfg v0.8.8
go: downloading github.com/elastic/elastic-agent-client/v7 v7.15.0
go: downloading go.opentelemetry.io/collector/consumer v0.109.0
go: downloading github.com/elastic/elastic-agent-system-metrics v0.11.6
go: downloading go.uber.org/zap v1.27.0
go: downloading go.elastic.co/ecszap v1.0.2
go: downloading github.com/cespare/xxhash/v2 v2.3.0
go: downloading github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
go: downloading github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/gorilla/mux v1.8.0
go: downloading go.uber.org/multierr v1.11.0
go: downloading go.elastic.co/apm/v2 v2.6.0
go: downloading google.golang.org/grpc v1.66.0
go: downloading google.golang.org/protobuf v1.34.2
go: downloading golang.org/x/crypto v0.31.0
go: downloading go.opentelemetry.io/collector/pdata v1.15.0
go: downloading golang.org/x/net v0.33.0
go: downloading github.com/docker/go-connections v0.4.0
go: downloading github.com/prometheus/client_model v0.6.1
go: downloading github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
go: downloading golang.org/x/text v0.21.0
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading github.com/elastic/go-sysinfo v1.15.0
go: downloading go.elastic.co/fastjson v1.1.0
go: downloading github.com/golang/protobuf v1.5.4
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd
go: downloading google.golang.org/genproto v0.0.0-20240730163845-b1a4ccb954bf
go: downloading github.com/json-iterator/go v1.1.12
go: downloading github.com/elastic/go-structform v0.0.10
go: downloading github.com/elastic/gosigar v0.14.3
go: downloading github.com/elastic/pkcs8 v1.0.0
go: downloading go.elastic.co/apm/module/apmhttp/v2 v2.6.0
go: downloading github.com/armon/go-radix v1.0.0
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/modern-go/reflect2 v1.0.2
go: downloading howett.net/plist v1.0.1
go: downloading github.com/prometheus/procfs v0.15.1
go: downloading github.com/opencontainers/image-spec v1.1.0
go: downloading github.com/docker/go-units v0.5.0
go: downloading github.com/moby/docker-image-spec v1.3.1
go: downloading github.com/opencontainers/go-digest v1.0.0
go: downloading github.com/distribution/reference v0.6.0
go: downloading go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
go: downloading go.opentelemetry.io/otel/trace v1.29.0
go: downloading go.opentelemetry.io/otel v1.29.0
go: downloading go.opentelemetry.io/otel/metric v1.29.0
go: downloading github.com/felixge/httpsnoop v1.0.4
go: downloading github.com/go-logr/logr v1.4.2
go: downloading github.com/go-logr/stdr v1.2.2
	github.com/elastic/beats/v7/x-pack/metricbeat/module/cockroachdb		coverage: 0.0% of statements
coverage: [no statements]
ok  	github.com/elastic/beats/v7/x-pack/metricbeat/module/cockroachdb/status	11.413s	coverage: [no statements]
DONE 1 tests in 38.099s
```