### PR TITLE
Document that `pipeline` needs to be lowercase

### DIFF
--- a/filebeat/docs/inputs/input-common-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-options.asciidoc
@@ -84,6 +84,9 @@ this option usually results in simpler configuration files. If the pipeline is
 configured both in the input and output, the option from the
 input is used.
 
+IMPORTANT: The `pipeline` is always lowercased. If `pipeline: Foo-Bar`, then
+the pipeline name in {es} needs to be defined as `foo-bar`.
+
 [float]
 ===== `keep_null`
 

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -467,6 +467,9 @@ output.elasticsearch:
   pipeline: my_pipeline_id
 ------------------------------------------------------------------------------
 
+IMPORTANT: The `pipeline` is always lowercased. If `pipeline: Foo-Bar`, then
+the pipeline name in {es} needs to be defined as `foo-bar`.
+
 For more information, see <<configuring-ingest-node>>.
 
 ifndef::apm-server[]


### PR DESCRIPTION
## Proposed commit message

Document that the ingest pipeline ID from Elasticsearch defined in the input or output configuration is always lowercased, thus the ingest pipeline in Elasticsearch can only use lowercase names.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~


## How to test this PR locally

1. Clone the [docs](https://github.com/elastic/docs) repository
2. Make sure `beats` and `docs` have the same parent folder
3. Define `$GIT_HOME` as the parent folder from `beats` and `docs`
4. Build the docs, a browser window will open with the rendered docs
```
$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/filebeat/docs --chunk 1 --open
```
5. Validate the changes in http://localhost:8000/guide/elasticsearch-output.html and some inputs like http://localhost:8000/guide/filebeat-input-filestream.html#_pipeline_9

## Related issues

- Closes https://github.com/elastic/beats/issues/41224


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
