### PR TITLE
Add status reporting for Journald input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -397,6 +397,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Added OAuth2 support with auto token refresh for websocket streaming input. {issue}41989[41989] {pull}42212[42212]
 - Added infinite & blanket retry options to websockets and improved logging and retry logic. {pull}42225[42225]
 - Introduce ignore older and start timestamp filters for AWS S3 input. {pull}41804[41804]
+- Journald input now can report its status to Elastic-Agent {issue}39791[39791] {pull}42462[42462]
 
 *Auditbeat*
 

--- a/filebeat/input/journald/environment_test.go
+++ b/filebeat/input/journald/environment_test.go
@@ -128,6 +128,25 @@ func (e *inputTestingEnvironment) waitUntilEventCount(count int) {
 	}, 5*time.Second, 10*time.Millisecond, &msg)
 }
 
+func (e *inputTestingEnvironment) RequireStatuses(expected []statusUpdate) {
+	t := e.t
+	t.Helper()
+	got := e.statusReporter.GetUpdates()
+	if len(got) != len(expected) {
+		t.Fatalf("expecting %d updates, got %d", len(expected), len(got))
+	}
+
+	for i := range expected {
+		g, e := got[i], expected[i]
+		if g != e {
+			t.Errorf(
+				"expecting [%d] status update to be {state:%s, msg:%s}, got  {state:%s, msg:%s}",
+				i, e.state.String(), e.msg, g.state.String(), g.msg,
+			)
+		}
+	}
+}
+
 type testInputStore struct {
 	registry *statestore.Registry
 }
@@ -275,23 +294,4 @@ func (m *mockStatusReporter) GetUpdates() []statusUpdate {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	return append([]statusUpdate{}, m.updates...)
-}
-
-func (env *inputTestingEnvironment) RequireStatuses(expected []statusUpdate) {
-	t := env.t
-	t.Helper()
-	got := env.statusReporter.GetUpdates()
-	if len(got) != len(expected) {
-		t.Fatalf("expecting %d updates, got %d", len(expected), len(got))
-	}
-
-	for i := range expected {
-		g, e := got[i], expected[i]
-		if g != e {
-			t.Errorf(
-				"expecting [%d] status update to be {state:%s, msg:%s}, got  {state:%s, msg:%s}",
-				i, e.state.String(), e.msg, g.state.String(), g.msg,
-			)
-		}
-	}
 }

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -29,6 +29,7 @@ import (
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	cursor "github.com/elastic/beats/v7/filebeat/input/v2/input-cursor"
 	"github.com/elastic/beats/v7/libbeat/feature"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/reader"
 	"github.com/elastic/beats/v7/libbeat/reader/parser"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -154,6 +155,8 @@ func (inp *journald) Run(
 	logger := ctx.Logger.
 		With("path", src.Name()).
 		With("input_id", inp.ID)
+
+	ctx.UpdateStatus(status.Starting, "Starting")
 	currentCheckpoint := initCheckpoint(logger, cursor)
 
 	mode := inp.Seek
@@ -173,7 +176,9 @@ func (inp *journald) Run(
 		journalctl.Factory,
 	)
 	if err != nil {
-		return fmt.Errorf("could not start journal reader: %w", err)
+		wrappedErr := fmt.Errorf("could not start journal reader: %w", err)
+		ctx.UpdateStatus(status.Failed, wrappedErr.Error())
+		return wrappedErr
 	}
 
 	defer reader.Close()
@@ -186,6 +191,7 @@ func (inp *journald) Run(
 			saveRemoteHostname: inp.SaveRemoteHostname,
 		})
 
+	ctx.UpdateStatus(status.Running, "Running")
 	for {
 		entry, err := parser.Next()
 		if err != nil {
@@ -197,14 +203,18 @@ func (inp *journald) Run(
 			case errors.Is(err, journalctl.ErrRestarting):
 				continue
 			default:
-				logger.Errorf("could not read event: %s", err)
+				msg := fmt.Sprintf("could not read event: %s", err)
+				ctx.UpdateStatus(status.Failed, msg)
+				logger.Error(msg)
 				return err
 			}
 		}
 
 		event := entry.ToEvent()
 		if err := publisher.Publish(event, event.Private); err != nil {
-			logger.Errorf("could not publish event: %s", err)
+			msg := fmt.Sprintf("could not publish event: %s", err)
+			ctx.UpdateStatus(status.Failed, msg)
+			logger.Errorf(msg)
 			return err
 		}
 	}

--- a/filebeat/input/journald/input_test.go
+++ b/filebeat/input/journald/input_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalfield"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -328,6 +329,33 @@ func TestReaderAdapterCanHandleNonStringFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInputCanReportStatus(t *testing.T) {
+	out := decompress(t, filepath.Join("testdata", "multiple-boots.journal.gz"))
+
+	env := newInputTestingEnvironment(t)
+	cfg := mapstr.M{
+		"paths": []string{out},
+	}
+	inp := env.mustCreateInput(cfg)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	t.Cleanup(cancelInput)
+
+	env.startInput(ctx, inp)
+	env.waitUntilEventCount(6)
+
+	env.RequireStatuses([]statusUpdate{
+		{
+			state: status.Starting,
+			msg:   "Starting",
+		},
+		{
+			state: status.Running,
+			msg:   "Running",
+		},
+	})
 }
 
 func decompress(t *testing.T, namegz string) string {

--- a/filebeat/input/v2/input.go
+++ b/filebeat/input/v2/input.go
@@ -97,6 +97,7 @@ type Context struct {
 
 func (c Context) UpdateStatus(status status.Status, msg string) {
 	if c.StatusReporter != nil {
+		c.Logger.Debugf("updating status, status: '%s', message: '%s'", status.String(), msg)
 		c.StatusReporter.UpdateStatus(status, msg)
 	}
 }


### PR DESCRIPTION
## Proposed commit message

This commit adds the status reporting for the Journald input. It also adds a debug log to the `UpdateStatus` function from `v2.Context`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

1. Build the Elastic-Agent with Beats from this PR or build Agent beat and replace its binary in a existing Elastic-Agent installation
2. Create a policy with "Custom Journald logs" or add the integration to an existing policy
3. Set the log level to debug
2. Deploy/Restart the Elastic-Agent
3. Look for the debug messages from the logger `input.journald`:
     - `updating status, status: 'Starting', message: 'Starting'`
     - `updating status, status: 'Running', message: 'Running'`
4. Ensure the Journald integration for your Elastic-Agent shows the status `Healthy`


## Related issues
- Closes #39791


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
