### PR TITLE
otelconsumer: remove metadata and adjust timestamp format

### DIFF
--- a/libbeat/outputs/otelconsumer/otelconsumer.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer.go
@@ -259,7 +259,7 @@ func mapstrToPcommonMap(m mapstr.M) pcommon.Map {
 			dest := out.PutEmptySlice(k)
 			for _, i := range v.([]time.Time) {
 				newVal := dest.AppendEmpty()
-				newVal.SetInt(i.UnixMilli())
+				newVal.SetStr(i.Format("2006-01-02T15:04:05.000Z"))
 			}
 		default:
 			out.PutStr(k, fmt.Sprintf("unknown type: %T", x))

--- a/libbeat/outputs/otelconsumer/otelconsumer.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer.go
@@ -87,14 +87,8 @@ func (out *otelConsumer) logsPublish(ctx context.Context, batch publisher.Batch)
 	events := batch.Events()
 	for _, event := range events {
 		logRecord := logRecords.AppendEmpty()
-		meta := event.Content.Meta.Clone()
-		meta["beat"] = out.beatInfo.Beat
-		meta["version"] = out.beatInfo.Version
-		meta["type"] = "_doc"
-
 		beatEvent := event.Content.Fields.Clone()
 		beatEvent["@timestamp"] = event.Content.Timestamp
-		beatEvent["@metadata"] = meta
 		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(event.Content.Timestamp))
 		pcommonEvent := mapstrToPcommonMap(beatEvent)
 		pcommonEvent.CopyTo(logRecord.Body().SetEmptyMap())
@@ -260,7 +254,7 @@ func mapstrToPcommonMap(m mapstr.M) pcommon.Map {
 				newMap.CopyTo(newVal.SetEmptyMap())
 			}
 		case time.Time:
-			out.PutInt(k, x.UnixMilli())
+			out.PutStr(k, x.Format("2006-01-02T15:04:05.000Z"))
 		case []time.Time:
 			dest := out.PutEmptySlice(k)
 			for _, i := range v.([]time.Time) {

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -140,6 +140,25 @@ func TestPublish(t *testing.T) {
 	})
 }
 
+func TestMapstrToPcommonMapTime(t *testing.T) {
+	tests := []struct {
+		mapstr_val  string
+		pcommon_val string
+	}{
+		{mapstr_val: "2006-01-02T15:04:05+07:00", pcommon_val: "2006-01-02T15:04:05.000Z"},
+		{mapstr_val: "1970-01-01T00:00:00+00:00", pcommon_val: "1970-01-01T00:00:00.000Z"},
+	}
+	for _, tc := range tests {
+		origTime, err := time.Parse(time.RFC3339, tc.mapstr_val)
+		assert.NoError(t, err, "Error parsing time")
+		a := mapstr.M{"test": origTime}
+		want := pcommon.NewMap()
+		want.PutStr("test", tc.pcommon_val)
+		got := mapstrToPcommonMap(a)
+		assert.Equal(t, want, got)
+	}
+}
+
 func TestMapstrToPcommonMapString(t *testing.T) {
 	tests := map[string]struct {
 		mapstr_val  interface{}
@@ -323,10 +342,10 @@ func TestMapstrToPcommonMapSliceMapstr(t *testing.T) {
 func TestMapstrToPcommonMapSliceTime(t *testing.T) {
 	times := []struct {
 		mapstr_val  string
-		pcommon_val int64
+		pcommon_val string
 	}{
-		{mapstr_val: "2006-01-02T15:04:05+07:00", pcommon_val: 1136189045000},
-		{mapstr_val: "1970-01-01T00:00:00+00:00", pcommon_val: 0},
+		{mapstr_val: "2006-01-02T15:04:05+07:00", pcommon_val: "2006-01-02T15:04:05.000Z"},
+		{mapstr_val: "1970-01-01T00:00:00+00:00", pcommon_val: "1970-01-01T00:00:00.000Z"},
 	}
 	var sliceTimes []time.Time
 	pcommonSlice := pcommon.NewSlice()
@@ -335,7 +354,7 @@ func TestMapstrToPcommonMapSliceTime(t *testing.T) {
 		assert.NoError(t, err, "Error parsing time")
 		sliceTimes = append(sliceTimes, targetTime)
 		pVal := pcommonSlice.AppendEmpty()
-		pVal.SetInt(tc.pcommon_val)
+		pVal.SetStr(tc.pcommon_val)
 	}
 	inputMap := mapstr.M{
 		"slice": sliceTimes,

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -117,6 +117,27 @@ func TestPublish(t *testing.T) {
 		assert.Len(t, batch.Signals, 1)
 		assert.Equal(t, outest.BatchRetry, batch.Signals[0].Tag)
 	})
+
+	t.Run("sets the @timestamp field with the correct format", func(t *testing.T) {
+		batch := outest.NewBatch(event3)
+		batch.Events()[0].Content.Timestamp = time.Date(2025, time.January, 29, 9, 2, 39, 0, time.UTC)
+
+		var timestamp string
+		otelConsumer := makeOtelConsumer(t, func(ctx context.Context, ld plog.Logs) error {
+			record := ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+			field, ok := record.Body().Map().Get("@timestamp")
+			assert.True(t, ok, "timestamp field not found")
+			timestamp = field.AsString()
+
+			return nil
+		})
+
+		err := otelConsumer.Publish(ctx, batch)
+		assert.NoError(t, err)
+		assert.Len(t, batch.Signals, 1)
+		assert.Equal(t, outest.BatchACK, batch.Signals[0].Tag)
+		assert.Equal(t, "2025-01-29T09:02:39.000Z", timestamp)
+	})
 }
 
 func TestMapstrToPcommonMapString(t *testing.T) {


### PR DESCRIPTION

## Proposed commit message

This PR removes the `@metadata` field from plog.Logs. This is an internal field part of the beats event and should not be exposed. While at it, adjust the `@timestamp` field to have the same format as an event ingested by filebeat.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/4736
