### PR TITLE
[DOCS] [7.12] Removes link to master

### DIFF
--- a/docs/devguide/create-module.asciidoc
+++ b/docs/devguide/create-module.asciidoc
@@ -134,7 +134,7 @@ This will enable the module and rename file `metricbeat/modules.d/mysql.yml.disa
 $ cat modules.d/mysql.yml
 
 # Module: mysql
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mysql.html
+# Docs: {metricbeat-ref}/metricbeat-module-mysql.html[MySQL module].
 
 - module: mysql
   metricsets:


### PR DESCRIPTION
## Proposed commit message

Relates to https://github.com/elastic/docs/pull/3160

This PR fixes the following broken link:

```
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/devguide/7.12/creating-metricbeat-module.html contains broken links to:
--
  | INFO:build_docs:   - en/beats/metricbeat/master/metricbeat-module-mysql.html
```