### PR TITLE
.../input/entityanalytics/provider/okta: Publish events progressively

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -410,6 +410,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Added infinite & blanket retry options to websockets and improved logging and retry logic. {pull}42225[42225]
 - Introduce ignore older and start timestamp filters for AWS S3 input. {pull}41804[41804]
 - Journald input now can report its status to Elastic-Agent {issue}39791[39791] {pull}42462[42462]
+- Publish events progressively in the Okta provider of the Entity Analytics input. {issue}40106[40106] {pull}42567[42567]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -318,9 +318,14 @@ func (p *oktaInput) runFullSync(inputCtx v2.Context, store *kvstore.Store, clien
 	wantUsers := p.cfg.wantUsers()
 	wantDevices := p.cfg.wantDevices()
 	if wantUsers || wantDevices {
-
 		ctx := ctxtool.FromCanceller(inputCtx.Cancelation)
 		p.logger.Debugf("Starting fetch...")
+
+		tracker := kvstore.NewTxTracker(ctx)
+
+		start := time.Now()
+		p.publishMarker(start, start, inputCtx.ID, true, client, tracker)
+
 		_, err = p.doFetchUsers(ctx, state, true)
 		if err != nil {
 			return err
@@ -330,10 +335,6 @@ func (p *oktaInput) runFullSync(inputCtx v2.Context, store *kvstore.Store, clien
 			return err
 		}
 
-		tracker := kvstore.NewTxTracker(ctx)
-
-		start := time.Now()
-		p.publishMarker(start, start, inputCtx.ID, true, client, tracker)
 		if wantUsers {
 			for _, u := range state.users {
 				p.publishUser(u, state, inputCtx.ID, client, tracker)

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
@@ -211,14 +211,18 @@ func TestOktaDoFetch(t *testing.T) {
 
 			t.Run("users", func(t *testing.T) {
 				n = 0
+				published := make(map[string]struct{})
 
-				got, err := a.doFetchUsers(ctx, ss, false)
+				got, err := a.doFetchUsers(ctx, ss, false, func(u *User) { published[u.ID] = struct{}{} })
 				if err != nil {
 					t.Fatalf("unexpected error from doFetch: %v", err)
 				}
 
 				if len(got) != wantCount(repeats, test.wantUsers) {
 					t.Errorf("unexpected number of results: got:%d want:%d", len(got), wantCount(repeats, test.wantUsers))
+				}
+				if len(published) != len(got) {
+					t.Errorf("unexpected number of distinct users published: got:%d want:%d", len(published), len(got))
 				}
 				for i, g := range got {
 					wantID := fmt.Sprintf("userid%d", i+1)
@@ -244,14 +248,18 @@ func TestOktaDoFetch(t *testing.T) {
 
 			t.Run("devices", func(t *testing.T) {
 				n = 0
+				published := make(map[string]struct{})
 
-				got, err := a.doFetchDevices(ctx, ss, false)
+				got, err := a.doFetchDevices(ctx, ss, false, func(d *Device) { published[d.ID] = struct{}{} })
 				if err != nil {
 					t.Fatalf("unexpected error from doFetch: %v", err)
 				}
 
 				if len(got) != wantCount(repeats, test.wantDevices) {
 					t.Errorf("unexpected number of results: got:%d want:%d", len(got), wantCount(repeats, test.wantDevices))
+				}
+				if len(published) != len(got) {
+					t.Errorf("unexpected number of distinct devices published: got:%d want:%d", len(published), len(got))
 				}
 				for i, g := range got {
 					if wantID := fmt.Sprintf("deviceid%d", i+1); g.ID != wantID {

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
@@ -211,9 +211,13 @@ func TestOktaDoFetch(t *testing.T) {
 
 			t.Run("users", func(t *testing.T) {
 				n = 0
+				var got []*User
 				published := make(map[string]struct{})
 
-				got, err := a.doFetchUsers(ctx, ss, false, func(u *User) { published[u.ID] = struct{}{} })
+				err := a.doFetchUsers(ctx, ss, false, func(u *User) {
+					got = append(got, u)
+					published[u.ID] = struct{}{}
+				})
 				if err != nil {
 					t.Fatalf("unexpected error from doFetch: %v", err)
 				}
@@ -248,9 +252,13 @@ func TestOktaDoFetch(t *testing.T) {
 
 			t.Run("devices", func(t *testing.T) {
 				n = 0
+				var got []*Device
 				published := make(map[string]struct{})
 
-				got, err := a.doFetchDevices(ctx, ss, false, func(d *Device) { published[d.ID] = struct{}{} })
+				err := a.doFetchDevices(ctx, ss, false, func(d *Device) {
+					got = append(got, d)
+					published[d.ID] = struct{}{}
+				})
 				if err != nil {
 					t.Fatalf("unexpected error from doFetch: %v", err)
 				}


### PR DESCRIPTION
## Proposed commit message

```
.../input/entityanalytics/provider/okta: Publish events progressively

Instead of waiting for a full sync (which may take hours) to finish
before publishing anything, we now publish data as it is received, so
that users have immediate feedback.

Incremental updates are also published more frequently: page by page
instead of at the end of the pagination sequence.

For the full sync, the previous behavior of adding everything to the
store and publishing it at the end would theoretically de-duplicate
repeated items. However, within a pagination sequence we use opaque
cursors from the API that should avoid overlap between pages. Whether an
item modified after an earlier page in a sequence can appear again in a
later page of the same sequence depends on the API's implementation.
Incremental updates begin with a previously seen timestamp value, so
there is overlap between updates there, but that is unaffected by this
change.

For the full sync, markers for the start and end were only published if
data is retrieved, but now the markers are published regardless of how
much data is received.

Some extra checks of configuration are done to decide whether to fetch
and publish items of a given type (user or device).

---------

Co-authored-by: Dan Kortschak <dan.kortschak@elastic.co>
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #40106