### PR TITLE
Enable response compression for Elasticsearch Requests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Replace default Ubuntu-based images with UBI-minimal-based ones {pull}42150[42150]
 - Fix templates and docs to use correct `--` version of command line arguments. {issue}42038[42038] {pull}42060[42060]
 - removed support for a single `-` to precede multi-letter command line arguments.  Use `--` instead. {issue}42117[42117] {pull}42209[42209]
+- Beats will request response compression when sending requests to Elasticsearch 
 
 *Auditbeat*
 


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/42644

## Proposed commit message

When Compression is enabled, let Elasticsearch know we accept gzipped responses, and if Elasticsearch complies by compressing the response, we decompress the response.
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Use cases

Customers with collectors in different regions from their target Elasticsearch clusters will experience lower egress fees for traffic leaving their Elasticsearch cluster (which is typically egress traffic).
