### PR TITLE
[otelconsumer] Add log record attributes as flattened keys

### DIFF
--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -20,6 +20,7 @@ package otelconsumer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -113,7 +114,7 @@ func TestPublish(t *testing.T) {
 		var subFields = []string{"dataset", "namespace", "type"}
 		for _, subField := range subFields {
 			gotValue, ok := attributes.Get("data_stream." + subField)
-			require.True(t, ok)
+			require.True(t, ok, fmt.Sprintf("data_stream.%s not found on log record attribute", subField))
 			assert.EqualValues(t, dataStreamField[subField], gotValue.AsRaw())
 		}
 

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -31,7 +31,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/otelbeat/otelmap"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -110,12 +109,14 @@ func TestPublish(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, batch.Signals, 1)
 		assert.Equal(t, outest.BatchACK, batch.Signals[0].Tag)
-		pcommonFields := otelmap.FromMapstr(event1.Fields)
-		want, ok := pcommonFields.Get("data_stream")
-		require.True(t, ok)
-		got, ok := attributes.Get("data_stream")
-		require.True(t, ok)
-		assert.EqualValues(t, want.AsRaw(), got.AsRaw())
+
+		var subFields = []string{"dataset", "namespace", "type"}
+		for _, subField := range subFields {
+			gotValue, ok := attributes.Get("data_stream." + subField)
+			require.True(t, ok)
+			assert.EqualValues(t, dataStreamField[subField], gotValue.AsRaw())
+		}
+
 	})
 
 	t.Run("retries the batch on non-permanent consumer error", func(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
The log record attributes added on otelconsumer should be flattened keys (and not nested map structure) for dynamic indexing on ES exporter to work correctly. This is a fix for it

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes https://github.com/elastic/beats/issues/42623

