### PR TITLE
docs: fix table formatting in Filebeat metrics descriptions

### DIFF
--- a/libbeat/docs/metrics-in-logs.asciidoc
+++ b/libbeat/docs/metrics-in-logs.asciidoc
@@ -188,9 +188,9 @@ endif::[]
 | `.output.events.total` | Integer | Number of events currently being processed by the output. | If this number grows over time, it may indicate that the output destination (e.g. {ls} pipeline or {es} cluster) is not able to accept events at the same or faster rate than what {beatname_uc} is sending to it.
 | `.output.events.acked` | Integer | Number of events acknowledged by the output destination. | Generally, we want this number to be the same as `.output.events.total` as this indicates that the output destination has reliably received all the events sent to it.
 | `.output.events.failed` | Integer | Number of events that {beatname_uc} tried to send to the output destination, but the destination failed to receive them. | Generally, we want this field to be absent or its value to be zero. When the value is greater than zero, it's useful to check {beatname_uc}'s logs right before this log entry's `@timestamp` to see if there are any connectivity issues with the output destination. Note that failed events are not lost or dropped; they will be sent back to the publisher pipeline for retrying later.
-| `.output.events.dropped` | Integer | Number of events that {beatname_uc} gave up sending to the output destination because of a permanent (non-retryable) error.
-| `.output.events.dead_letter` | Integer | Number of events that {beatname_uc} successfully sent to a configured dead letter index after they failed to ingest in the primary index.
-| `.output.write.latency` | Object | Reports statistics on the time to send an event to the connected output, in milliseconds. This can be used to diagnose delays and performance issues caused by I/O or output configuration. This metric is available for the Elasticsearch, file, redis, and logstash outputs.
+| `.output.events.dropped` | Integer | Number of events that {beatname_uc} gave up sending to the output destination because of a permanent (non-retryable) error. |
+| `.output.events.dead_letter` | Integer | Number of events that {beatname_uc} successfully sent to a configured dead letter index after they failed to ingest in the primary index. |
+| `.output.write.latency` | Object | Reports statistics on the time to send an event to the connected output, in milliseconds. This can be used to diagnose delays and performance issues caused by I/O or output configuration. This metric is available for the Elasticsearch, file, redis, and logstash outputs. |
 |===
 
 [cols="1,1,2,2"]
@@ -199,7 +199,7 @@ endif::[]
 
 | `.queue.max_events` | Integer (gauge) | The queue's maximum event count if it has one, otherwise zero.
 | `.queue.max_bytes` | Integer (gauge) | The queue's maximum byte count if it has one, otherwise zero.
-| `.queue.filled.events` | Integer (gauge) | Number of events currently stored by the queue. | 
+| `.queue.filled.events` | Integer (gauge) | Number of events currently stored by the queue. |
 | `.queue.filled.bytes` | Integer (gauge) | Number of bytes currently stored by the queue. |
 | `.queue.filled.pct` | Float (gauge) | How full the queue is relative to its maximum size, as a fraction from 0 to 1. | Low throughput while `queue.filled.pct` is low means congestion in the input. Low throughput while `queue.filled.pct` is high means congestion in the output.
 | `.queue.added.events` | Integer | Number of events added to the queue by input workers. |

--- a/libbeat/docs/metrics-in-logs.asciidoc
+++ b/libbeat/docs/metrics-in-logs.asciidoc
@@ -197,8 +197,8 @@ endif::[]
 |===
 | Field path (relative to `.monitoring.metrics.libbeat.pipeline`) | Type    | Meaning                              | Troubleshooting hints
 
-| `.queue.max_events` | Integer (gauge) | The queue's maximum event count if it has one, otherwise zero.
-| `.queue.max_bytes` | Integer (gauge) | The queue's maximum byte count if it has one, otherwise zero.
+| `.queue.max_events` | Integer (gauge) | The queue's maximum event count if it has one, otherwise zero. |
+| `.queue.max_bytes` | Integer (gauge) | The queue's maximum byte count if it has one, otherwise zero. |
 | `.queue.filled.events` | Integer (gauge) | Number of events currently stored by the queue. |
 | `.queue.filled.bytes` | Integer (gauge) | Number of bytes currently stored by the queue. |
 | `.queue.filled.pct` | Float (gauge) | How full the queue is relative to its maximum size, as a fraction from 0 to 1. | Low throughput while `queue.filled.pct` is low means congestion in the input. Low throughput while `queue.filled.pct` is high means congestion in the output.


### PR DESCRIPTION
## Proposed commit message

Fixes a table column formatting glitch in the metric descriptions table in [Understand metrics in Filebeat logs](https://www.elastic.co/guide/en/beats/filebeat/current/understand-filebeat-logs.html). See screenshot for what it looked like before.

Also uncovers the description of the `.output.write.latency` metric, which was previously hidden due to the formatting glitch.

![image](https://github.com/user-attachments/assets/efe9aa06-0eb2-424d-bf4b-c951178ac01a)

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~