### PR TITLE
[metricbeat] Refactor kubernetes bearer token authentication

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -477,6 +477,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Collect more fields from ES node/stats metrics and only those that are necessary {pull}42421[42421]
 - Add new metricset wmi for the windows module. {pull}42017[42017]
 - Update beat module with apm-server tail sampling monitoring metrics fields {pull}42569[42569]
+- Log every 401 response from Kubernetes API Server {pull}42714[42714]
 
 *Metricbeat*
 - Add benchmark module {pull}41801[41801]

--- a/metricbeat/module/kubernetes/apiserver/metricset.go
+++ b/metricbeat/module/kubernetes/apiserver/metricset.go
@@ -19,11 +19,7 @@ package apiserver
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
-	"time"
 
-	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
@@ -34,7 +30,6 @@ import (
 // Metricset for apiserver is a prometheus based metricset
 type Metricset struct {
 	mb.BaseMetricSet
-	http               *helper.HTTP
 	prometheusClient   prometheus.Prometheus
 	prometheusMappings *prometheus.MetricsMapping
 	clusterMeta        mapstr.M
@@ -54,13 +49,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, fmt.Errorf("must be child of kubernetes module")
 	}
 
-	http, err := pc.GetHttp()
-	if err != nil {
-		return nil, fmt.Errorf("the http connection is not valid")
-	}
 	ms := &Metricset{
 		BaseMetricSet:      base,
-		http:               http,
 		prometheusClient:   pc,
 		prometheusMappings: mapping,
 		clusterMeta:        util.AddClusterECSMeta(base),
@@ -73,36 +63,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch gathers information from the apiserver and reports events with this information.
 func (m *Metricset) Fetch(reporter mb.ReporterV2) error {
 	events, err := m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
-	errorString := fmt.Sprintf("%s", err)
-	errorUnauthorisedMsg := fmt.Sprintf("unexpected status code %d", http.StatusUnauthorized)
-	if err != nil && strings.Contains(errorString, errorUnauthorisedMsg) {
-		count := 2 // We retry twice to refresh the Authorisation token in case of http.StatusUnauthorize = 401 Error
-		for count > 0 {
-			if _, errAuth := m.http.RefreshAuthorizationHeader(); errAuth == nil {
-				events, err = m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
-			}
-			if err != nil {
-				time.Sleep(m.mod.Config().Period)
-				count--
-			} else {
-				break
-			}
-		}
-	}
 	// We need to check for err again in case error is not 401 or RefreshAuthorizationHeader has failed
 	if err != nil {
 		return fmt.Errorf("error getting metrics: %w", err)
-	} else {
-		for _, e := range events {
-			event := mb.TransformMapStrToEvent("kubernetes", e, nil)
-			if len(m.clusterMeta) != 0 {
-				event.RootFields.DeepUpdate(m.clusterMeta)
-			}
-			isOpen := reporter.Event(event)
-			if !isOpen {
-				return nil
-			}
-		}
-		return nil
 	}
+	for _, e := range events {
+		event := mb.TransformMapStrToEvent("kubernetes", e, nil)
+		if len(m.clusterMeta) != 0 {
+			event.RootFields.DeepUpdate(m.clusterMeta)
+		}
+		isOpen := reporter.Event(event)
+		if !isOpen {
+			return nil
+		}
+	}
+	return nil
 }

--- a/metricbeat/module/kubernetes/controllermanager/controllermanager.go
+++ b/metricbeat/module/kubernetes/controllermanager/controllermanager.go
@@ -19,11 +19,7 @@ package controllermanager
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
-	"time"
 
-	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
@@ -79,7 +75,6 @@ func init() {
 // MetricSet implements the mb.PushMetricSet interface, and therefore does not rely on polling.
 type MetricSet struct {
 	mb.BaseMetricSet
-	http               *helper.HTTP
 	prometheusClient   prometheus.Prometheus
 	prometheusMappings *prometheus.MetricsMapping
 	clusterMeta        mapstr.M
@@ -100,13 +95,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, fmt.Errorf("must be child of kubernetes module")
 	}
 
-	http, err := pc.GetHttp()
-	if err != nil {
-		return nil, fmt.Errorf("the http connection is not valid")
-	}
 	ms := &MetricSet{
 		BaseMetricSet:      base,
-		http:               http,
 		prometheusClient:   pc,
 		prometheusMappings: mapping,
 		clusterMeta:        util.AddClusterECSMeta(base),
@@ -118,37 +108,20 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch gathers information from the apiserver and reports events with this information.
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	events, err := m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
-	errorString := fmt.Sprintf("%s", err)
-	errorUnauthorisedMsg := fmt.Sprintf("unexpected status code %d", http.StatusUnauthorized)
-	if err != nil && strings.Contains(errorString, errorUnauthorisedMsg) {
-		count := 2 // We retry twice to refresh the Authorisation token in case of http.StatusUnauthorize = 401 Error
-		for count > 0 {
-			if _, errAuth := m.http.RefreshAuthorizationHeader(); errAuth == nil {
-				events, err = m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
-			}
-			if err != nil {
-				time.Sleep(m.mod.Config().Period)
-				count--
-			} else {
-				break
-			}
-		}
-	}
-	// We need to check for err again in case error is not 401 or RefreshAuthorizationHeader has failed
 	if err != nil {
 		return fmt.Errorf("error getting metrics: %w", err)
-	} else {
-		for _, e := range events {
-			event := mb.TransformMapStrToEvent("kubernetes", e, nil)
-			if len(m.clusterMeta) != 0 {
-				event.RootFields.DeepUpdate(m.clusterMeta)
-			}
-			isOpen := reporter.Event(event)
-			if !isOpen {
-				return nil
-			}
+	}
+
+	for _, e := range events {
+		event := mb.TransformMapStrToEvent("kubernetes", e, nil)
+		if len(m.clusterMeta) != 0 {
+			event.RootFields.DeepUpdate(m.clusterMeta)
+		}
+		isOpen := reporter.Event(event)
+		if !isOpen {
+			return nil
 		}
 
-		return nil
 	}
+	return nil
 }

--- a/metricbeat/module/kubernetes/kubernetes.go
+++ b/metricbeat/module/kubernetes/kubernetes.go
@@ -19,8 +19,6 @@ package kubernetes
 
 import (
 	"fmt"
-	httpnet "net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -149,26 +147,10 @@ func (m *module) GetKubeletStats(http *helper.HTTP) ([]byte, error) {
 	// (https://github.com/elastic/beats/pull/25640#discussion_r633395213)
 	statsCache := m.kubeletStatsCache.getCacheMapEntry(m.cacheHash)
 
-	// Check if the last time we tried to make a request to the Kubelet API ended in a 401 Unauthorized error.
-	// If this is the case, we should not keep making requests.
-	errorUnauthorisedMsg := fmt.Sprintf("HTTP error %d", httpnet.StatusUnauthorized)
-	if statsCache.lastFetchErr != nil && strings.Contains(statsCache.lastFetchErr.Error(), errorUnauthorisedMsg) {
-		return statsCache.sharedStats, statsCache.lastFetchErr
-	}
-
 	// If this is the first request, or it has passed more time than config.period, we should
 	// make a request to the Kubelet API again to get the last metrics' values.
 	if statsCache.lastFetchTimestamp.IsZero() || now.Sub(statsCache.lastFetchTimestamp) > m.Config().Period {
 		statsCache.sharedStats, statsCache.lastFetchErr = http.FetchContent()
-
-		// If we got an unauthorized error from our HTTP request, it is possible the token has expired.
-		// We should update the Authorization header in that case. We only try this for the first time
-		// we get HTTP 401 to avoid getting in a loop in case the cause of the error is something different.
-		if statsCache.lastFetchErr != nil && strings.Contains(statsCache.lastFetchErr.Error(), errorUnauthorisedMsg) {
-			if _, err := http.RefreshAuthorizationHeader(); err == nil {
-				statsCache.sharedStats, statsCache.lastFetchErr = http.FetchContent()
-			}
-		}
 
 		statsCache.lastFetchTimestamp = now
 	}

--- a/metricbeat/module/kubernetes/scheduler/scheduler.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler.go
@@ -19,11 +19,7 @@ package scheduler
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
-	"time"
 
-	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
@@ -83,7 +79,6 @@ func init() {
 // MetricSet implements the mb.PushMetricSet interface, and therefore does not rely on polling.
 type MetricSet struct {
 	mb.BaseMetricSet
-	http               *helper.HTTP
 	prometheusClient   prometheus.Prometheus
 	prometheusMappings *prometheus.MetricsMapping
 	clusterMeta        mapstr.M
@@ -104,13 +99,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, fmt.Errorf("must be child of kubernetes module")
 	}
 
-	http, err := pc.GetHttp()
-	if err != nil {
-		return nil, fmt.Errorf("the http connection is not valid")
-	}
 	ms := &MetricSet{
 		BaseMetricSet:      base,
-		http:               http,
 		prometheusClient:   pc,
 		prometheusMappings: mapping,
 		clusterMeta:        util.AddClusterECSMeta(base),
@@ -122,37 +112,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch gathers information from the apiserver and reports events with this information.
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	events, err := m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
-	errorString := fmt.Sprintf("%s", err)
-	errorUnauthorisedMsg := fmt.Sprintf("unexpected status code %d", http.StatusUnauthorized)
-	if err != nil && strings.Contains(errorString, errorUnauthorisedMsg) {
-		count := 2 // We retry twice to refresh the Authorisation token in case of http.StatusUnauthorize = 401 Error
-		for count > 0 {
-			if _, errAuth := m.http.RefreshAuthorizationHeader(); errAuth == nil {
-				events, err = m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
-			}
-			if err != nil {
-				time.Sleep(m.mod.Config().Period)
-				count--
-			} else {
-				break
-			}
-		}
-	}
-	// We need to check for err again in case error is not 401 or RefreshAuthorizationHeader has failed
 	if err != nil {
 		return fmt.Errorf("error getting metrics: %w", err)
-	} else {
-		for _, e := range events {
-			event := mb.TransformMapStrToEvent("kubernetes", e, nil)
-			if len(m.clusterMeta) != 0 {
-				event.RootFields.DeepUpdate(m.clusterMeta)
-			}
-			isOpen := reporter.Event(event)
-			if !isOpen {
-				return nil
-			}
-		}
-
-		return nil
 	}
+	for _, e := range events {
+		event := mb.TransformMapStrToEvent("kubernetes", e, nil)
+		if len(m.clusterMeta) != 0 {
+			event.RootFields.DeepUpdate(m.clusterMeta)
+		}
+		isOpen := reporter.Event(event)
+		if !isOpen {
+			return nil
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

[metricbeat] Refactor kubernetes bearer token authentication

Instead of doing retries on 401 errors, use a mechanism from client-go which simply reloads the token periodically in the background.

Also, don't stop logging errors after the first 401. These errors, if present, need to be addressed by the cluster operator, so we should make them more prominent.

We have a report of the current mechanism running into race conditions in some OpenShift clusters. The exact root cause is unknown, but this change should address it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

After this change, we will continue logging errors when we get a 401 from the API Server of kubelet, whereas up until now we'd only log the first one.

## How to test this PR locally

1. Build a local metricbeat docker image using `mage package`.
2. Start a kind cluster.
3. Upload the docker image to the kind cluster.
4. Install metricbeat in the cluster using the [official manifests](https://github.com/elastic/beats/tree/main/deploy/kubernetes/metricbeat). 
5. Wait for an hour until the auth token gets rotated.
6. Look at records coming from the kubernetes module for the non-state metricsets in Kibana:

![Screenshot_20250217_120534](https://github.com/user-attachments/assets/6cd168bf-8490-4c2f-896b-72bf11674563)


## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/5612

