### PR TITLE
[otelconsumer] Fix timestamp discrepancy for documents ingested in otel mode

### DIFF
--- a/libbeat/otelbeat/otelmap/otelmap.go
+++ b/libbeat/otelbeat/otelmap/otelmap.go
@@ -161,12 +161,12 @@ func FromMapstr(m mapstr.M) pcommon.Map {
 				newMap.CopyTo(newVal.SetEmptyMap())
 			}
 		case time.Time:
-			out.PutStr(k, x.Format("2006-01-02T15:04:05.000Z"))
+			out.PutStr(k, x.UTC().Format("2006-01-02T15:04:05.000Z"))
 		case []time.Time:
 			dest := out.PutEmptySlice(k)
 			for _, i := range v.([]time.Time) {
 				newVal := dest.AppendEmpty()
-				newVal.SetStr(i.Format("2006-01-02T15:04:05.000Z"))
+				newVal.SetStr(i.UTC().Format("2006-01-02T15:04:05.000Z"))
 			}
 		default:
 			out.PutStr(k, fmt.Sprintf("unknown type: %T", x))

--- a/libbeat/otelbeat/otelmap/otelmap_test.go
+++ b/libbeat/otelbeat/otelmap/otelmap_test.go
@@ -32,7 +32,7 @@ func TestFromMapstrTime(t *testing.T) {
 		mapstr_val  string
 		pcommon_val string
 	}{
-		{mapstr_val: "2006-01-02T15:04:05+07:00", pcommon_val: "2006-01-02T15:04:05.000Z"},
+		{mapstr_val: "2006-01-02T15:04:05+07:00", pcommon_val: "2006-01-02T08:04:05.000Z"},
 		{mapstr_val: "1970-01-01T00:00:00+00:00", pcommon_val: "1970-01-01T00:00:00.000Z"},
 	}
 	for _, tc := range tests {
@@ -231,7 +231,7 @@ func TestFromMapstrSliceTime(t *testing.T) {
 		mapstr_val  string
 		pcommon_val string
 	}{
-		{mapstr_val: "2006-01-02T15:04:05+07:00", pcommon_val: "2006-01-02T15:04:05.000Z"},
+		{mapstr_val: "2006-01-02T15:04:05+07:00", pcommon_val: "2006-01-02T08:04:05.000Z"},
 		{mapstr_val: "1970-01-01T00:00:00+00:00", pcommon_val: "1970-01-01T00:00:00.000Z"},
 	}
 	var sliceTimes []time.Time

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -186,12 +186,14 @@ func TestPublish(t *testing.T) {
 		batch := outest.NewBatch(event3)
 		batch.Events()[0].Content.Timestamp = time.Date(2025, time.January, 29, 9, 2, 39, 0, time.UTC)
 
-		var bodytimestamp string
+		var bodyTimestamp string
+		var recordTimestamp string
 		otelConsumer := makeOtelConsumer(t, func(ctx context.Context, ld plog.Logs) error {
 			record := ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 			field, ok := record.Body().Map().Get("@timestamp")
+			recordTimestamp = record.Timestamp().AsTime().UTC().Format("2006-01-02T15:04:05.000Z")
 			assert.True(t, ok, "timestamp field not found")
-			bodytimestamp = field.AsString()
+			bodyTimestamp = field.AsString()
 			return nil
 		})
 
@@ -199,6 +201,7 @@ func TestPublish(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, batch.Signals, 1)
 		assert.Equal(t, outest.BatchACK, batch.Signals[0].Tag)
-		assert.Equal(t, "2025-01-29T09:02:39.000Z", bodytimestamp, "body timestamp is incorrect")
+		assert.Equal(t, "2025-01-29T09:02:39.000Z", bodyTimestamp, "body timestamp is incorrect")
+		assert.Equal(t, "2025-01-29T09:02:39.000Z", recordTimestamp, "record timestamp is incorrect")
 	})
 }

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -201,7 +201,6 @@ func TestPublish(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, batch.Signals, 1)
 		assert.Equal(t, outest.BatchACK, batch.Signals[0].Tag)
-		assert.Equal(t, "2025-01-29T09:02:39.000Z", bodyTimestamp, "body timestamp is incorrect")
-		assert.Equal(t, "2025-01-29T09:02:39.000Z", recordTimestamp, "record timestamp is incorrect")
+		assert.Equal(t, bodyTimestamp, recordTimestamp, "log record timestamp should match body timestamp")
 	})
 }

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -184,15 +184,14 @@ func TestPublish(t *testing.T) {
 
 	t.Run("sets the @timestamp field with the correct format", func(t *testing.T) {
 		batch := outest.NewBatch(event3)
-		batch.Events()[0].Content.Timestamp = time.Date(2025, time.January, 29, 9, 2, 39, 0, time.UTC)
+		batch.Events()[0].Content.Timestamp = time.Date(2025, time.January, 29, 9, 2, 39, 0, time.Local)
 
-		var timestamp string
+		var bodyimestamp string
 		otelConsumer := makeOtelConsumer(t, func(ctx context.Context, ld plog.Logs) error {
 			record := ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 			field, ok := record.Body().Map().Get("@timestamp")
 			assert.True(t, ok, "timestamp field not found")
-			timestamp = field.AsString()
-
+			bodyimestamp = field.AsString()
 			return nil
 		})
 
@@ -200,6 +199,6 @@ func TestPublish(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, batch.Signals, 1)
 		assert.Equal(t, outest.BatchACK, batch.Signals[0].Tag)
-		assert.Equal(t, "2025-01-29T09:02:39.000Z", timestamp)
+		assert.Equal(t, "2025-01-29T09:02:39.000", bodyimestamp, "body timestamp is incorrect")
 	})
 }

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -184,14 +184,14 @@ func TestPublish(t *testing.T) {
 
 	t.Run("sets the @timestamp field with the correct format", func(t *testing.T) {
 		batch := outest.NewBatch(event3)
-		batch.Events()[0].Content.Timestamp = time.Date(2025, time.January, 29, 9, 2, 39, 0, time.Local)
+		batch.Events()[0].Content.Timestamp = time.Date(2025, time.January, 29, 9, 2, 39, 0, time.UTC)
 
-		var bodyimestamp string
+		var bodytimestamp string
 		otelConsumer := makeOtelConsumer(t, func(ctx context.Context, ld plog.Logs) error {
 			record := ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 			field, ok := record.Body().Map().Get("@timestamp")
 			assert.True(t, ok, "timestamp field not found")
-			bodyimestamp = field.AsString()
+			bodytimestamp = field.AsString()
 			return nil
 		})
 
@@ -199,6 +199,6 @@ func TestPublish(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, batch.Signals, 1)
 		assert.Equal(t, outest.BatchACK, batch.Signals[0].Tag)
-		assert.Equal(t, "2025-01-29T09:02:39.000", bodyimestamp, "body timestamp is incorrect")
+		assert.Equal(t, "2025-01-29T09:02:39.000Z", bodytimestamp, "body timestamp is incorrect")
 	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
Documents ingested in otel mode had discrepancy in `Body.timestamp` and `timestamp` fields. As can be seen here 
<img width="542" alt="image" src="https://github.com/user-attachments/assets/e29d9b02-42a9-4cf6-be79-b990f1616de7" />


This PR fixes this by converting timestamp to UTC format in otelconsumer before sending it to ES exporter.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

