### PR TITLE
fix(x-pack/filebeat/input/http_endpoint): hmac header validation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -224,6 +224,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fix truncation of bodies in request tracing by limiting bodies to 10% of the maximum file size. {pull}42327[42327]
 - [Journald] Fixes handling of `journalctl` restart. A known symptom was broken multiline messages when there was a restart of journalctl while aggregating the lines. {issue}41331[41331] {pull}42595[42595]
 - Fix entityanalytics activedirectory provider full sync use before initialization bug. {pull}42682[42682]
+- In the `http_endpoint` input, fix the check for a missing HMAC HTTP header. {pull}42756[42756]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/http_endpoint/handler_test.go
+++ b/x-pack/filebeat/input/http_endpoint/handler_test.go
@@ -331,6 +331,81 @@ func Test_apiResponse(t *testing.T) {
 			wantResponse: `{"message": "success"}`,
 		},
 		{
+			name: "hmac_header_not_present",
+			conf: func() config {
+				c := defaultConfig()
+				c.HMACHeader = "Authorization"
+				c.HMACKey = "mysecretkey"
+				c.HMACType = "sha256"
+				c.HMACPrefix = "HMAC-SHA256 "
+				return c
+			}(),
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"id":0}`))
+				req.Header.Set("Content-Type", "application/json")
+				return req
+			}(),
+			wantStatus:   http.StatusUnauthorized,
+			wantResponse: `{"message":"missing HMAC header"}`,
+		},
+		{
+			name: "hmac_header_value_is_empty",
+			conf: func() config {
+				c := defaultConfig()
+				c.HMACHeader = "Authorization"
+				c.HMACKey = "mysecretkey"
+				c.HMACType = "sha256"
+				c.HMACPrefix = "HMAC-SHA256 "
+				return c
+			}(),
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"id":0}`))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "")
+				return req
+			}(),
+			wantStatus:   http.StatusUnauthorized,
+			wantResponse: `{"message":"invalid HMAC signature encoding: unexpected empty header value"}`,
+		},
+		{
+			name: "hmac_header_value_only_contains_prefix",
+			conf: func() config {
+				c := defaultConfig()
+				c.HMACHeader = "Authorization"
+				c.HMACKey = "mysecretkey"
+				c.HMACType = "sha256"
+				c.HMACPrefix = "HMAC-SHA256 "
+				return c
+			}(),
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"id":0}`))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "HMAC-SHA256 ")
+				return req
+			}(),
+			wantStatus:   http.StatusUnauthorized,
+			wantResponse: `{"message":"invalid HMAC signature encoding: unexpected empty header value"}`,
+		},
+		{
+			name: "hmac_header_value_bad_encoding",
+			conf: func() config {
+				c := defaultConfig()
+				c.HMACHeader = "Authorization"
+				c.HMACKey = "mysecretkey"
+				c.HMACType = "sha256"
+				c.HMACPrefix = "HMAC-SHA256 "
+				return c
+			}(),
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"id":0}`))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "HMAC-SHA256 not-hex-or-base64")
+				return req
+			}(),
+			wantStatus:   http.StatusUnauthorized,
+			wantResponse: `{"message":"invalid HMAC signature encoding: encoding/hex: invalid byte: U+006E 'n'\nillegal base64 data at input byte 3\nillegal base64 data at input byte 3"}`,
+		},
+		{
 			name: "single_event_gzip",
 			conf: defaultConfig(),
 			request: func() *http.Request {


### PR DESCRIPTION
## Proposed commit message

```
The HMAC signature validation code had an optimization intended to
return early when the configured HMAC header was not present in the 
request. However, it was checking the wrong variable for emptiness,
which effectively skipped this check. If a request included an empty
HMAC header, the HMAC signature check would still proceed and fail due 
to the missing or incorrect signature.

This issue has been corrected by this commit. The code now returns
`errMissingHMACHeader` only when the header is truly absent (not present
rather than having an empty value). Additionally, before decoding the 
signature, a check for an empty value is added to return a helpful error.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author notes

The problematic code is this section where on L67 it checks the value of `v.hmacHeader` which is from config instead of `hmacHeaderValue` which is from the request.

https://github.com/elastic/beats/blob/26fecc126fe80b648471e401a7b175cf2165ab1b/x-pack/filebeat/input/http_endpoint/validate.go#L65-L68
