### PR TITLE
[filebeat] Compare documents ingested by fb in normal vs otel mode

### DIFF
--- a/libbeat/otelbeat/beatconverter/beatconverter_test.go
+++ b/libbeat/otelbeat/beatconverter/beatconverter_test.go
@@ -47,6 +47,8 @@ exporters:
     batcher:
       enabled: true
       max_size_items: 1600
+    mapping:
+      mode: bodymap       
 `
 
 func TestConverter(t *testing.T) {
@@ -187,6 +189,8 @@ exporters:
     batcher:
       enabled: true
       max_size_items: 1600
+    mapping:
+      mode: bodymap       
 receivers:
   filebeatreceiver:
     filebeat:

--- a/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
+++ b/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
@@ -150,6 +150,10 @@ func ToOTelConfig(output *config.C) (map[string]any, error) {
 			"enabled":        true,
 			"max_size_items": escfg.BulkMaxSize, // bulk_max_size
 		},
+
+		"mapping": map[string]any{
+			"mode": "bodymap",
+		},
 	}
 
 	setIfNotNil(otelYAMLCfg, "headers", escfg.Headers)    // headers

--- a/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel_test.go
+++ b/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel_test.go
@@ -76,6 +76,8 @@ headers:
 batcher:
   enabled: true
   max_size_items: 1600
+mapping:
+  mode: bodymap  
  `
 		input := newFromYamlString(t, beatCfg)
 		cfg := config.MustNewConfigFrom(input.ToStringMap())
@@ -111,6 +113,8 @@ logs_index: some-index
 password: changeme
 user: elastic
 timeout: 1m30s
+mapping:
+  mode: bodymap 
 `
 
 		tests := []struct {
@@ -157,6 +161,8 @@ num_workers: 1
 batcher:
   enabled: true
   max_size_items: 1600
+mapping:
+  mode: bodymap    
  `,
 			},
 			{

--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -16,9 +16,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/tests/integration"
+	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/testing/estools"
 	"github.com/elastic/go-elasticsearch/v8"
 )
@@ -29,7 +32,7 @@ filebeat.inputs:
     id: filestream-input-id
     enabled: true
     file_identity.native: ~
-    prospector.scanner.fingerprint.enabled: false	
+    prospector.scanner.fingerprint.enabled: false
     paths:
       - %s
 output:
@@ -41,11 +44,18 @@ output:
     password: testing
     index: %s
 queue.mem.flush.timeout: 0s
+processors:
+    - add_host_metadata: ~
+    - add_cloud_metadata: ~
+    - add_docker_metadata: ~
+    - add_kubernetes_metadata: ~
 `
 
 func TestFilebeatOTelE2E(t *testing.T) {
 	integration.EnsureESIsRunning(t)
+	numEvents := 1
 
+	// start filebeat in otel mode
 	filebeatOTel := integration.NewBeat(
 		t,
 		"filebeat-otel",
@@ -55,29 +65,25 @@ func TestFilebeatOTelE2E(t *testing.T) {
 
 	logFilePath := filepath.Join(filebeatOTel.TempDir(), "log.log")
 	filebeatOTel.WriteConfigFile(fmt.Sprintf(beatsCfgFile, logFilePath, "logs-integration-default"))
-
-	logFile, err := os.Create(logFilePath)
-	if err != nil {
-		t.Fatalf("could not create file '%s': %s", logFilePath, err)
-	}
-
-	numEvents := 5
-
-	// write events to log file
-	for i := 0; i < numEvents; i++ {
-		msg := fmt.Sprintf("Line %d", i)
-		_, err = logFile.Write([]byte(msg + "\n"))
-		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
-	}
-
-	if err := logFile.Sync(); err != nil {
-		t.Fatalf("could not sync log file '%s': %s", logFilePath, err)
-	}
-	if err := logFile.Close(); err != nil {
-		t.Fatalf("could not close log file '%s': %s", logFilePath, err)
-	}
-
+	writeEventsToLogFile(t, logFilePath, numEvents)
 	filebeatOTel.Start()
+
+	// start filebeat
+	filebeat := integration.NewBeat(
+		t,
+		"filebeat",
+		"../../filebeat.test",
+	)
+	logFilePath = filepath.Join(filebeat.TempDir(), "log.log")
+	writeEventsToLogFile(t, logFilePath, numEvents)
+	s := fmt.Sprintf(beatsCfgFile, logFilePath, "logs-filebeat-default")
+	s = s + `
+setup.template.name: logs-filebeat-default
+setup.template.pattern: logs-filebeat-default
+`
+
+	filebeat.WriteConfigFile(s)
+	filebeat.Start()
 
 	// prepare to query ES
 	esCfg := elasticsearch.Config{
@@ -93,19 +99,84 @@ func TestFilebeatOTelE2E(t *testing.T) {
 	es, err := elasticsearch.NewClient(esCfg)
 	require.NoError(t, err)
 
-	actualHits := &struct{ Hits int }{}
+	var filebeatDocs estools.Documents
+	var otelDocs estools.Documents
 	// wait for logs to be published
 	require.Eventually(t,
 		func() bool {
 			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer findCancel()
 
-			OTelDocs, err := estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-integration-default*")
+			otelDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-integration-default*")
 			require.NoError(t, err)
 
-			actualHits.Hits = OTelDocs.Hits.Total.Value
-			return actualHits.Hits == numEvents
-		},
-		2*time.Minute, 1*time.Second, numEvents, actualHits.Hits)
+			filebeatDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-filebeat-default*")
+			require.NoError(t, err)
 
+			return otelDocs.Hits.Total.Value >= numEvents && filebeatDocs.Hits.Total.Value >= numEvents
+		},
+		2*time.Minute, 1*time.Second, fmt.Sprintf("Number of hits %d not equal to number of events for %d", filebeatDocs.Hits.Total.Value, numEvents))
+
+	filebeatDoc := filebeatDocs.Hits.Hits[0].Source
+	otelDoc := otelDocs.Hits.Hits[0].Source
+	ignoredFields := []string{
+		// Expected to change between agentDocs and OtelDocs
+		"@timestamp",
+		"agent.ephemeral_id",
+		"agent.id",
+		"log.file.indoe",
+		"log.file.path",
+		"log.offset",
+	}
+
+	assertMapsEqual(t, filebeatDoc, otelDoc, ignoredFields, "expected documents to be equal")
+}
+
+func writeEventsToLogFile(t *testing.T, filename string, numEvents int) {
+
+	logFile, err := os.Create(filename)
+	if err != nil {
+		t.Fatalf("could not create file '%s': %s", filename, err)
+	}
+	// write events to log file
+	for i := 0; i < numEvents; i++ {
+		msg := fmt.Sprintf("Line %d", i)
+		_, err = logFile.Write([]byte(msg + "\n"))
+		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
+	}
+
+	if err := logFile.Sync(); err != nil {
+		t.Fatalf("could not sync log file '%s': %s", filename, err)
+	}
+	if err := logFile.Close(); err != nil {
+		t.Fatalf("could not close log file '%s': %s", filename, err)
+	}
+}
+
+func assertMapsEqual(t *testing.T, m1, m2 mapstr.M, ignoredFields []string, msg string) {
+	t.Helper()
+
+	flatM1 := m1.Flatten()
+	flatM2 := m2.Flatten()
+	for _, f := range ignoredFields {
+		hasKeyM1, _ := flatM1.HasKey(f)
+		hasKeyM2, _ := flatM2.HasKey(f)
+
+		if !hasKeyM1 && !hasKeyM2 {
+			assert.Failf(t, msg, "ignored field %q does not exist in either map, please remove it from the ignored fields", f)
+		}
+
+		// If the ignored field exists and is equal in both maps then it shouldn't be ignored
+		if hasKeyM1 && hasKeyM2 {
+			valM1, _ := flatM1.GetValue(f)
+			valM2, _ := flatM2.GetValue(f)
+			if valM1 == valM2 {
+				assert.Failf(t, msg, "ignored field %q is equal in both maps, please remove it from the ignored fields", f)
+			}
+		}
+
+		flatM1.Delete(f)
+		flatM2.Delete(f)
+	}
+	require.Equal(t, "", cmp.Diff(flatM1, flatM2), "expected maps to be equal")
 }

--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -124,16 +124,15 @@ setup.template.pattern: logs-filebeat-default
 		"@timestamp",
 		"agent.ephemeral_id",
 		"agent.id",
-		"log.file.indoe",
+		"log.file.inode",
 		"log.file.path",
-		"log.offset",
 	}
 
 	assertMapsEqual(t, filebeatDoc, otelDoc, ignoredFields, "expected documents to be equal")
 }
 
 func writeEventsToLogFile(t *testing.T, filename string, numEvents int) {
-
+	t.Helper()
 	logFile, err := os.Create(filename)
 	if err != nil {
 		t.Fatalf("could not create file '%s': %s", filename, err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This adds tests to compare document ingested  by filebeat in normal vs otel mode.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

```
cd x-pack/filebeat
mage docker:composeUp
go test -run TestFilebeatOTelE2E -tags integration ./tests/integration -v
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/ingest-dev/issues/4595

