### PR TITLE
Skip flaky test TestFilebeat/Filebeat_crashes_due_to_incorrect_config

### DIFF
--- a/filebeat/testing/integration/sample_test.go
+++ b/filebeat/testing/integration/sample_test.go
@@ -113,6 +113,8 @@ output.console:
 	})
 
 	t.Run("Filebeat crashes due to incorrect config", func(t *testing.T) {
+		t.Skip("Flaky test: https://github.com/elastic/beats/issues/42778")
+
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 


### PR DESCRIPTION
skip flaky test: TestFilebeat/Filebeat_crashes_due_to_incorrect_config

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs

## Proposed commit message
```
skip flaky test

skip flaky test: TestFilebeat/Filebeat_crashes_due_to_incorrect_config
```
Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

N/A


## How to test this PR locally

run the test `TestFilebeat/Filebeat_crashes_due_to_incorrect_config`. It should be skipped

```
❯ cd filebeat
❯ go test -v -tags integration -run TestFilebeat/Filebeat_crashes_due_to_incorrect_config ./testing/integration/
=== RUN   TestFilebeat
    run_beat.go:238: ensuring the filebeat binary is available...
    run_beat.go:315: searching for the filebeat directory, starting with /home/ainsoph/devel/github.com/elastic/beats/filebeat/testing/integration...
    run_beat.go:330: found filebeat directory at /home/ainsoph/devel/github.com/elastic/beats/filebeat
    run_beat.go:255: found outdated filebeat binary at /home/ainsoph/devel/github.com/elastic/beats/filebeat/filebeat, removing...
    run_beat.go:270: building /home/ainsoph/devel/github.com/elastic/beats/filebeat/filebeat binary with "mage build"... 
    run_beat.go:281: /home/ainsoph/devel/github.com/elastic/beats/filebeat/filebeat binary has been successfully built 
=== RUN   TestFilebeat/Filebeat_crashes_due_to_incorrect_config
    sample_test.go:116: Flaky test: https://github.com/elastic/beats/issues/42778
--- PASS: TestFilebeat (11.36s)
    --- SKIP: TestFilebeat/Filebeat_crashes_due_to_incorrect_config (0.00s)
PASS
ok  	github.com/elastic/beats/v7/filebeat/testing/integration	11.415s

```

## Related issues

- Relates #42778
