### PR TITLE
Add metrics for kernel_tracing provider, fix mutex issue

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -148,6 +148,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - hasher: Geneneral improvements and fixes. {pull}41863[41863]
 - hasher: Add a cached hasher for upcoming backend. {pull}41952[41952]
 - Split common tty definitions. {pull}42004[42004]
+- Fix potential data loss in add_session_metadata. {pull}42795[42795]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/processors/sessionmd/add_session_metadata_test.go
+++ b/x-pack/auditbeat/processors/sessionmd/add_session_metadata_test.go
@@ -8,6 +8,7 @@ package sessionmd
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -338,6 +339,21 @@ var (
 
 	logger = logp.NewLogger("add_session_metadata_test")
 )
+
+func TestMetricsSetup(t *testing.T) {
+	reg := monitoring.NewRegistry()
+	name := "test.metrics"
+	other := "other.metrics"
+	gen_registry(reg, name)
+	require.NotNil(t, reg.Get(name))
+
+	gen_registry(reg, name)
+	require.NotNil(t, reg.Get(fmt.Sprintf("%s.1", name)))
+
+	gen_registry(reg, other)
+	require.NotNil(t, reg.Get(other))
+	require.Nil(t, reg.Get(fmt.Sprintf("%s.1", other)))
+}
 
 func TestEnrich(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*15)

--- a/x-pack/auditbeat/processors/sessionmd/add_session_metadata_test.go
+++ b/x-pack/auditbeat/processors/sessionmd/add_session_metadata_test.go
@@ -341,18 +341,24 @@ var (
 )
 
 func TestMetricsSetup(t *testing.T) {
+	// init a metrics registry multiple times with the same name, ensure we don't panic, and the names are correct
 	reg := monitoring.NewRegistry()
-	name := "test.metrics"
-	other := "other.metrics"
-	gen_registry(reg, name)
-	require.NotNil(t, reg.Get(name))
+	firstName := "test.metrics"
+	secondName := "other.stuff"
+	genRegistry(reg, firstName)
+	require.NotNil(t, reg.Get(firstName))
 
-	gen_registry(reg, name)
-	require.NotNil(t, reg.Get(fmt.Sprintf("%s.1", name)))
+	genRegistry(reg, firstName)
+	require.NotNil(t, reg.Get(fmt.Sprintf("%s.1", firstName)))
 
-	gen_registry(reg, other)
-	require.NotNil(t, reg.Get(other))
-	require.Nil(t, reg.Get(fmt.Sprintf("%s.1", other)))
+	genRegistry(reg, secondName)
+	require.NotNil(t, reg.Get(secondName))
+	require.Nil(t, reg.Get(fmt.Sprintf("%s.1", secondName)))
+
+	genRegistry(reg, secondName)
+	require.NotNil(t, reg.Get(secondName))
+	require.NotNil(t, reg.Get(fmt.Sprintf("%s.1", secondName)))
+	require.Nil(t, reg.Get(fmt.Sprintf("%s.2", secondName)))
 }
 
 func TestEnrich(t *testing.T) {

--- a/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/auditbeat/processors/sessionmd/provider"
 	"github.com/elastic/beats/v7/x-pack/auditbeat/processors/sessionmd/types"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
 type prvdr struct {
@@ -82,13 +83,15 @@ func readPIDNsInode() (uint64, error) {
 }
 
 // NewProvider returns a new instance of kerneltracingprovider
-func NewProvider(ctx context.Context, logger *logp.Logger) (provider.Provider, error) {
+func NewProvider(ctx context.Context, logger *logp.Logger, reg *monitoring.Registry) (provider.Provider, error) {
 	attr := quark.DefaultQueueAttr()
 	attr.Flags = quark.QQ_ALL_BACKENDS | quark.QQ_ENTRY_LEADER | quark.QQ_NO_SNAPSHOT
 	qq, err := quark.OpenQueue(attr, 64)
 	if err != nil {
 		return nil, fmt.Errorf("open queue: %w", err)
 	}
+
+	procMetrics := NewStats(reg)
 
 	p := &prvdr{
 		ctx:            ctx,
@@ -102,7 +105,7 @@ func NewProvider(ctx context.Context, logger *logp.Logger) (provider.Provider, e
 		backoffSkipped: 0,
 	}
 
-	go func(ctx context.Context, qq *quark.Queue, logger *logp.Logger, p *prvdr) {
+	go func(ctx context.Context, qq *quark.Queue, logger *logp.Logger, p *prvdr, stats *Stats) {
 		defer qq.Close()
 		for ctx.Err() == nil {
 			p.qqMtx.Lock()
@@ -112,6 +115,17 @@ func NewProvider(ctx context.Context, logger *logp.Logger) (provider.Provider, e
 				logger.Errorw("get events from quark, no more process enrichment from this processor will be done", "error", err)
 				break
 			}
+
+			p.qqMtx.Lock()
+			metrics := qq.Stats()
+			p.qqMtx.Unlock()
+
+			stats.Aggregations.Set(metrics.Aggregations)
+			stats.Insertions.Set(metrics.Insertions)
+			stats.Lost.Set(metrics.Lost)
+			stats.NonAggregations.Set(metrics.NonAggregations)
+			stats.Removals.Set(metrics.Removals)
+
 			if len(events) == 0 {
 				err = qq.Block()
 				if err != nil {
@@ -120,7 +134,7 @@ func NewProvider(ctx context.Context, logger *logp.Logger) (provider.Provider, e
 				}
 			}
 		}
-	}(ctx, qq, logger, p)
+	}(ctx, qq, logger, p, procMetrics)
 
 	bootID, err = readBootID()
 	if err != nil {
@@ -150,11 +164,8 @@ const (
 // does not exceed a reasonable threshold that would delay all other events processed by auditbeat. When in the backoff state, enrichment
 // will proceed without waiting for the process data to exist in the cache, likely resulting in missing enrichment data.
 func (p *prvdr) Sync(_ *beat.Event, pid uint32) error {
-	p.qqMtx.Lock()
-	defer p.qqMtx.Unlock()
-
 	// If pid is already in qq, return immediately
-	if _, found := p.qq.Lookup(int(pid)); found {
+	if _, found := p.lookupLocked(pid); found {
 		return nil
 	}
 
@@ -169,7 +180,7 @@ func (p *prvdr) Sync(_ *beat.Event, pid uint32) error {
 	nextWait := 5 * time.Millisecond
 	for {
 		waited := time.Since(start)
-		if _, found := p.qq.Lookup(int(pid)); found {
+		if _, found := p.lookupLocked(pid); found {
 			p.logger.Debugw("got process that was missing ", "waited", waited)
 			p.combinedWait = p.combinedWait + waited
 			return nil

--- a/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/metrics.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/metrics.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build linux && (amd64 || arm64) && cgo
+
+package kerneltracingprovider
+
+import (
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+type Stats struct {
+	Insertions      *monitoring.Uint
+	Removals        *monitoring.Uint
+	Aggregations    *monitoring.Uint
+	NonAggregations *monitoring.Uint
+	Lost            *monitoring.Uint
+}
+
+func NewStats(reg *monitoring.Registry) *Stats {
+	return &Stats{
+		Insertions:      monitoring.NewUint(reg, "insertions"),
+		Removals:        monitoring.NewUint(reg, "removals"),
+		Aggregations:    monitoring.NewUint(reg, "aggregations"),
+		NonAggregations: monitoring.NewUint(reg, "nonaggregations"),
+		Lost:            monitoring.NewUint(reg, "lost"),
+	}
+}

--- a/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/metrics.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
+// / Stats tracks the quark internal stats, which are integrated into the beats monitoring runtime
 type Stats struct {
 	Insertions      *monitoring.Uint
 	Removals        *monitoring.Uint
@@ -18,6 +19,7 @@ type Stats struct {
 	Lost            *monitoring.Uint
 }
 
+// / NewStats creates a new stats object
 func NewStats(reg *monitoring.Registry) *Stats {
 	return &Stats{
 		Insertions:      monitoring.NewUint(reg, "insertions"),


### PR DESCRIPTION
## Proposed commit message

This does two things:

- Adds quark's stats objects to auditbeat's metrics reporter
- Fixes a bug where the kernel_tracing provider for add_session_metadata would hold a mutex for too long, leading to dropped events within quark

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
