### PR TITLE
Update Stack Monitoring data stream to 9

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -165,7 +165,6 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, optionalXpa
 	if err == nil && cfgdMetricsets != nil {
 		// Type cast the metricsets to a slice of strings
 		cfgdMetricsetsSlice, ok := cfgdMetricsets.([]interface{})
-
 		if !ok {
 			return nil, fmt.Errorf("configured metricsets are not an array for module %v: %v", moduleName, cfgdMetricsets)
 		}

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -21,11 +21,12 @@ import (
 	"errors"
 	"fmt"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/version"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	conf "github.com/elastic/elastic-agent-libs/config"

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -84,7 +84,7 @@ func (p Product) String() string {
 // MakeXPackMonitoringIndexName method returns the name of the monitoring index for
 // a given product { elasticsearch, kibana, logstash, beats }
 func MakeXPackMonitoringIndexName(product Product) string {
-	const version = "8"
+	const version = "9"
 
 	return fmt.Sprintf(".monitoring-%v-%v-mb", product.xPackMonitoringIndexString(), version)
 }

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -166,7 +166,7 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, optionalXpa
 		// Type cast the metricsets to a slice of strings
 		cfgdMetricsetsSlice, ok := cfgdMetricsets.([]interface{})
 		if !ok {
-			return nil, fmt.Errorf("configured metricsets are not an array for module %v: %v", moduleName, cfgdMetricsets)
+			return nil, fmt.Errorf("configured metricsets are not an slice for module %s: %v", moduleName, cfgdMetricsets)
 		}
 
 		cfgdMetricsetsStrings := make([]string, 0, len(cfgdMetricsetsSlice))

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -18,12 +18,14 @@
 package elastic
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/version"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -100,7 +102,7 @@ func ReportErrorForMissingField(field string, product Product, r mb.ReporterV2) 
 // MakeErrorForMissingField returns an error message for the given field being missing in an API
 // response received from a given product
 func MakeErrorForMissingField(field string, product Product) error {
-	return fmt.Errorf("Could not find field '%v' in %v API response", field, strings.Title(product.String()))
+	return fmt.Errorf("could not find field '%v' in %v API response", field, cases.Title(language.English).String(product.String()))
 }
 
 // IsFeatureAvailable returns whether a feature is available in the current product version
@@ -120,7 +122,7 @@ func ReportAndLogError(err error, r mb.ReporterV2, l *logp.Logger) {
 // for it's date fields: https://github.com/elastic/elasticsearch/pull/36691
 func FixTimestampField(m mapstr.M, field string) error {
 	v, err := m.GetValue(field)
-	if err == mapstr.ErrKeyNotFound {
+	if errors.Is(err, mapstr.ErrKeyNotFound) {
 		return nil
 	}
 	if err != nil {
@@ -161,10 +163,19 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, optionalXpa
 	metricsets := xpackEnabledMetricsets
 	if err == nil && cfgdMetricsets != nil {
 		// Type cast the metricsets to a slice of strings
-		cfgdMetricsetsSlice := cfgdMetricsets.([]interface{})
-		cfgdMetricsetsStrings := make([]string, len(cfgdMetricsetsSlice))
+		cfgdMetricsetsSlice, ok := cfgdMetricsets.([]interface{})
+
+		if !ok {
+			return nil, fmt.Errorf("configured metricsets are not an array for module %v: %v", moduleName, cfgdMetricsets)
+		}
+
+		cfgdMetricsetsStrings := make([]string, 0, len(cfgdMetricsetsSlice))
 		for i := range cfgdMetricsetsSlice {
-			cfgdMetricsetsStrings[i] = cfgdMetricsetsSlice[i].(string)
+			asString, ok := cfgdMetricsetsSlice[i].(string)
+
+			if ok {
+				cfgdMetricsetsStrings[i] = asString
+			}
 		}
 
 		// Add any optional metricsets which are not already configured

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -172,7 +172,6 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, optionalXpa
 		cfgdMetricsetsStrings := make([]string, 0, len(cfgdMetricsetsSlice))
 		for i := range cfgdMetricsetsSlice {
 			asString, ok := cfgdMetricsetsSlice[i].(string)
-
 			if ok {
 				cfgdMetricsetsStrings = append(cfgdMetricsetsStrings, asString)
 			}

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -174,7 +174,7 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, optionalXpa
 			asString, ok := cfgdMetricsetsSlice[i].(string)
 
 			if ok {
-				cfgdMetricsetsStrings[i] = asString
+				cfgdMetricsetsStrings = append(cfgdMetricsetsStrings, asString)
 			}
 		}
 

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -86,7 +86,7 @@ func TestReportErrorForMissingField(t *testing.T) {
 	r := MockReporterV2{}
 	err := ReportErrorForMissingField(field, Elasticsearch, r)
 
-	expectedError := fmt.Errorf("Could not find field '%v' in Elasticsearch API response", field)
+	expectedError := fmt.Errorf("could not find field '%v' in Elasticsearch API response", field)
 	assert.Equal(t, expectedError, err)
 	assert.Equal(t, expectedError, currentErr)
 }

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -38,22 +38,22 @@ func TestMakeXPackMonitoringIndexName(t *testing.T) {
 		{
 			"Elasticsearch monitoring index",
 			Elasticsearch,
-			".monitoring-es-8-mb",
+			".monitoring-es-9-mb",
 		},
 		{
 			"Kibana monitoring index",
 			Kibana,
-			".monitoring-kibana-8-mb",
+			".monitoring-kibana-9-mb",
 		},
 		{
 			"Logstash monitoring index",
 			Logstash,
-			".monitoring-logstash-8-mb",
+			".monitoring-logstash-9-mb",
 		},
 		{
 			"Beats monitoring index",
 			Beats,
-			".monitoring-beats-8-mb",
+			".monitoring-beats-9-mb",
 		},
 	}
 


### PR DESCRIPTION
## Proposed commit message

This PR updates the Stack Monitoring data stream names to match the [new index patterns](https://github.com/elastic/elasticsearch/issues/123102) for release 9 similar to what was done between 7 and 8 (PR #29493)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

## Disruptive User Impact

If this change is not made, the monitoring data collected by Metricbeat will not end up in the right data streams.

## How to test this PR locally

1. Run the latest 9 version of any Elastic Stack components (Elasticsearch, Kibana, Logstash, Beats) and monitor them using the appropriate Metricbeat module (`elasticsearch`, `kibana`, `logstash`, `beats`) with `xpack.enabled: true` mode
2. Make sure that the monitoring data ends up in a data stream called `.monitoring-<product>-9-mb`

For monitoring Elasticsearch, the following configuration can be used.
```
- module: elasticsearch
  xpack.enabled: true
  period: 10s
  hosts: ["https://localhost:9200"]
  username: "elastic"
  password: "changeme"
  ssl.ca_trusted_fingerprint: "REDACTED"
```

## Related issues

Closes https://github.com/elastic/beats/issues/42822
Relates to https://github.com/elastic/elasticsearch/issues/123102