### PR TITLE
{filebeat,winlogbeat} Improve error handling when opening and reading event logs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -279,6 +279,8 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 
 - Fix message handling in the experimental api. {issue}19338[19338] {pull}41730[41730]
 - Sync missing changes in modules pipelines. {pull}42619[42619]
+- Reset EventLog if error EOF is encountered. {pull}42826[42826]
+- Implement backoff on error retrial. {pull}42826[42826]
 
 
 *Elastic Logging Plugin*

--- a/winlogbeat/eventlog/errors_unix.go
+++ b/winlogbeat/eventlog/errors_unix.go
@@ -22,11 +22,6 @@ package eventlog
 // IsRecoverable returns a boolean indicating whether the error represents
 // a condition where the Windows Event Log session can be recovered through a
 // reopening of the handle (Close, Open).
-func IsRecoverable(err error) bool {
-	return false
-}
-
-// IsChannelNotFound returns true if the error indicates the channel was not found.
-func IsChannelNotFound(err error) bool {
+func IsRecoverable(error, bool) bool {
 	return false
 }

--- a/winlogbeat/eventlog/errors_windows.go
+++ b/winlogbeat/eventlog/errors_windows.go
@@ -19,6 +19,7 @@ package eventlog
 
 import (
 	"errors"
+	"io"
 
 	win "github.com/elastic/beats/v7/winlogbeat/sys/wineventlog"
 )
@@ -28,13 +29,13 @@ import (
 // reopening of the handle (Close, Open).
 //
 //nolint:errorlint // These are never wrapped.
-func IsRecoverable(err error) bool {
-	return err == win.ERROR_INVALID_HANDLE || err == win.RPC_S_SERVER_UNAVAILABLE ||
-		err == win.RPC_S_CALL_CANCELLED || err == win.ERROR_EVT_QUERY_RESULT_STALE ||
-		err == win.ERROR_INVALID_PARAMETER || err == win.ERROR_EVT_PUBLISHER_DISABLED
-}
-
-// IsChannelNotFound returns true if the error indicates the channel was not found.
-func IsChannelNotFound(err error) bool {
-	return errors.Is(err, win.ERROR_EVT_CHANNEL_NOT_FOUND)
+func IsRecoverable(err error, isFile bool) bool {
+	return err == win.ERROR_INVALID_HANDLE ||
+		err == win.RPC_S_SERVER_UNAVAILABLE ||
+		err == win.RPC_S_CALL_CANCELLED ||
+		err == win.ERROR_EVT_QUERY_RESULT_STALE ||
+		err == win.ERROR_INVALID_PARAMETER ||
+		err == win.ERROR_EVT_PUBLISHER_DISABLED ||
+		(!isFile && errors.Is(err, io.EOF)) ||
+		(!isFile && errors.Is(err, win.ERROR_EVT_CHANNEL_NOT_FOUND))
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

- Retry if EOF errors are found during eventlog reads.
- Add exponential limited backoff retrials when handling recoverable errors.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #35662
- Closes #37238

