### PR TITLE
Disable keystore for beats in FIPS mode

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -1687,13 +1687,6 @@ func obfuscateConfigOpts() []ucfg.Option {
 	}
 }
 
-// LoadKeystore returns the appropriate keystore based on the configuration.
-func LoadKeystore(cfg *config.C, name string) (keystore.Keystore, error) {
-	keystoreCfg, _ := cfg.Child("keystore", -1)
-	defaultPathConfig := paths.Resolve(paths.Data, fmt.Sprintf("%s.keystore", name))
-	return keystore.Factory(keystoreCfg, defaultPathConfig, common.IsStrictPerms())
-}
-
 func InitKibanaConfig(beatConfig beatConfig) *config.C {
 	var esConfig *config.C
 	if isElasticsearchOutput(beatConfig.Output.Name()) {

--- a/libbeat/cmd/instance/keystore_fips.go
+++ b/libbeat/cmd/instance/keystore_fips.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package instance
+
+import (
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/keystore"
+)
+
+// LoadKeystore returns nil in FIPS mode
+func LoadKeystore(cfg *config.C, name string) (keystore.Keystore, error) {
+	return nil, nil
+}

--- a/libbeat/cmd/instance/keystore_nofips.go
+++ b/libbeat/cmd/instance/keystore_nofips.go
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !requirefips
+
+package instance
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/keystore"
+	"github.com/elastic/elastic-agent-libs/paths"
+)
+
+// LoadKeystore returns the appropriate keystore based on the configuration.
+func LoadKeystore(cfg *config.C, name string) (keystore.Keystore, error) {
+	keystoreCfg, _ := cfg.Child("keystore", -1)
+	defaultPathConfig := paths.Resolve(paths.Data, fmt.Sprintf("%s.keystore", name))
+	return keystore.Factory(keystoreCfg, defaultPathConfig, common.IsStrictPerms())
+}

--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -44,26 +44,6 @@ func getKeystore(settings instance.Settings) (keystore.Keystore, error) {
 	return b.Keystore(), nil
 }
 
-// genKeystoreCmd initialize the Keystore command to manage the Keystore
-// with the following subcommands:
-//   - create
-//   - add
-//   - remove
-//   - list
-func genKeystoreCmd(settings instance.Settings) *cobra.Command {
-	keystoreCmd := cobra.Command{
-		Use:   "keystore",
-		Short: "Manage secrets keystore",
-	}
-
-	keystoreCmd.AddCommand(genCreateKeystoreCmd(settings))
-	keystoreCmd.AddCommand(genAddKeystoreCmd(settings))
-	keystoreCmd.AddCommand(genRemoveKeystoreCmd(settings))
-	keystoreCmd.AddCommand(genListKeystoreCmd(settings))
-
-	return &keystoreCmd
-}
-
 func genCreateKeystoreCmd(settings instance.Settings) *cobra.Command {
 	var flagForce bool
 	command := &cobra.Command{

--- a/libbeat/cmd/keystore_fips.go
+++ b/libbeat/cmd/keystore_fips.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+)
+
+// genKeystoreCmd returns nil in fips mode as the keystore is disabled.
+func genKeystoreCmd(_ instance.Settings) *cobra.Command {
+	return nil
+}

--- a/libbeat/cmd/keystore_nofips.go
+++ b/libbeat/cmd/keystore_nofips.go
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !requirefips
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+)
+
+// genKeystoreCmd initialize the Keystore command to manage the Keystore
+// with the following subcommands:
+//   - create
+//   - add
+//   - remove
+//   - list
+func genKeystoreCmd(settings instance.Settings) *cobra.Command {
+	keystoreCmd := cobra.Command{
+		Use:   "keystore",
+		Short: "Manage secrets keystore",
+	}
+
+	keystoreCmd.AddCommand(genCreateKeystoreCmd(settings))
+	keystoreCmd.AddCommand(genAddKeystoreCmd(settings))
+	keystoreCmd.AddCommand(genRemoveKeystoreCmd(settings))
+	keystoreCmd.AddCommand(genListKeystoreCmd(settings))
+
+	return &keystoreCmd
+}


### PR DESCRIPTION
## Proposed commit message

Disable keystore functionality when in FIPS mode.

Alternate approach to https://github.com/elastic/elastic-agent-libs/pull/279

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

Beats in FIPS mode will be unable to use the keystore

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

