### PR TITLE
fix(tests): ensure TestFilebeatOTelE2E does not fail if timestamps are equal

### DIFF
--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -165,15 +165,6 @@ func assertMapsEqual(t *testing.T, m1, m2 mapstr.M, ignoredFields []string, msg 
 			assert.Failf(t, msg, "ignored field %q does not exist in either map, please remove it from the ignored fields", f)
 		}
 
-		// If the ignored field exists and is equal in both maps then it shouldn't be ignored
-		if hasKeyM1 && hasKeyM2 {
-			valM1, _ := flatM1.GetValue(f)
-			valM2, _ := flatM2.GetValue(f)
-			if valM1 == valM2 {
-				assert.Failf(t, msg, "ignored field %q is equal in both maps, please remove it from the ignored fields", f)
-			}
-		}
-
 		flatM1.Delete(f)
 		flatM2.Delete(f)
 	}


### PR DESCRIPTION
## Proposed commit message

The TestFilebeatOTelE2E test sometimes fails in CI. This test is designed to ensure that a document ingested by Filebeat and fbreceiver does not have any meaningful differences. Some fields are expected to change, such as agent.id, log.file.path, and at timestamp.

The test explicitly fails if any of the ignored fields match in both documents, as it assumes these fields should not be ignored. In the case of at timestamp, depending on how fast indexing works, it may sometimes match and sometimes differ, introducing flakiness to the test.

This check seems to do more harm than good and I have already removed it from a similar Elastic Agent test in https://github.com/elastic/elastic-agent/pull/6819.

Example of a build failure caused by this: https://buildkite.com/elastic/beats-xpack-filebeat/builds/11240#01953eac-0d88-4ab5-aa5a-a1dcc909ecd4/179-688.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/pull/42777
- Relates https://github.com/elastic/elastic-agent/pull/6819