### PR TITLE
[Stack Monitoring] Only fetch cluster-level index stats summary

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -268,6 +268,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Continue collecting metrics even if the Cisco Meraki `getDeviceLicenses` operation fails. {pull}42397[42397]
 - Fixed errors in the `elasticsearch.index` metricset when index settings are missing. {issue}42424[42424] {pull}42426[42426]
 - Fixed panic caused by uninitialized meraki device wifi0 and wifi1 struct pointers in the device WiFi data fetching. {issue}42745[42745] {pull}42746[42746]
+- Only fetch cluster-level index stats summary {issue}36019[36019] {pull}42901[42901]
 
 *Osquerybeat*
 

--- a/metricbeat/module/elasticsearch/_meta/README.md
+++ b/metricbeat/module/elasticsearch/_meta/README.md
@@ -33,7 +33,7 @@ Metricbeat will call the following Elasticsearch API endpoints corresponding to 
 - [mb exported fields](https://www.elastic.co/guide/en/beats/metricbeat/current/exported-fields-elasticsearch.html#_index_recovery)
 
 ### index_summary
-- `/_stats`
+- `/_stats?level=cluster`
 - [api reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html)
 - [mb exported fields](https://www.elastic.co/guide/en/beats/metricbeat/current/exported-fields-elasticsearch.html#_index_summary)
 
@@ -48,7 +48,7 @@ Metricbeat will call the following Elasticsearch API endpoints corresponding to 
 - [mb exported fields](https://www.elastic.co/guide/en/beats/metricbeat/current/exported-fields-elasticsearch.html#_node_2)
 
 ### node_stats
-- `/_nodes/{_local|_all}/stats`
+- `/_nodes/{_local|_all}/stats/jvm,indices,fs,os,process,transport,thread_pool,indexing_pressure,ingest/bulk,docs,get,merge,translog,fielddata,indexing,query_cache,request_cache,search,shard_stats,store,segments,refresh,flush`
 - `_local` | `_all` from [`scope`](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-metricbeat.html#CO490-2) setting
 - [api reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html)
 - [mb exported fields](https://www.elastic.co/guide/en/beats/metricbeat/current/exported-fields-elasticsearch.html#_node_stats)

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -41,7 +41,7 @@ const (
 	statsPath = "/_stats"
 
 	onlyClusterLevel   = "level=cluster"
-	allowClosedIndices = "forbid_closed_indices=false"
+	allowClosedIndices = "&forbid_closed_indices=false"
 )
 
 var (

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 const (
-	statsPath = "/_stats"
+	statsPath = "/_stats?level=cluster"
 
 	allowClosedIndices = "forbid_closed_indices=false"
 )

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -38,8 +38,9 @@ func init() {
 }
 
 const (
-	statsPath = "/_stats?level=cluster"
+	statsPath = "/_stats"
 
+	onlyClusterLevel   = "level=cluster"
 	allowClosedIndices = "forbid_closed_indices=false"
 )
 
@@ -109,6 +110,7 @@ func getServicePath(esVersion version.V) (string, error) {
 		return "", err
 	}
 
+	u.RawQuery += onlyClusterLevel
 	if !esVersion.LessThan(elasticsearch.BulkStatsAvailableVersion) {
 		u.RawQuery += allowClosedIndices
 	}


### PR DESCRIPTION
## Proposed commit message

This PR fixes the `index_summary` metric set of the `elasticsearch` module and makes sure to only request cluster-level indexing stats (i.e. primaries and total) and not index-level stats. Since the latter are not needed, the module should not request them as that creates unnecessary load on the master node and consumes CPU and network resources for nothing.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

There won't be any disruption as currently the `index_summary` metric set requests more info than needed. This PR is simply restricts the API call to only what is needed.

## How to test this PR locally

1. Run Metricbeat with the `elasticsearch` module and the `index_summary` metric set enabled
2. 

## Related issues

Fixes https://github.com/elastic/beats/issues/36019