### PR TITLE
Fix Auditd client goroutine leak

### DIFF
--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -175,7 +175,7 @@ func closeAuditClient(client *libaudit.AuditClient, log *logp.Logger) {
 	}
 	// If we don't wait for the socket to drain, the calling function can
 	// assign a new client instance to the same pointer while our goroutine is using it.
-	// This guarentees that nothing is depending on the *client pointer by the time we return.
+	// This guarantees that nothing is depending on the *client pointer by the time we return.
 	closeWaiter.Wait()
 }
 

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -172,6 +172,8 @@ func closeAuditClient(client *libaudit.AuditClient, log *logp.Logger) {
 	if err := client.Close(); err != nil {
 		log.Errorw("Error closing audit monitoring client", "error", err)
 	}
+	// If we don't wait for the socket to drain, the calling function may tinker with
+	// the AuditClient pointer while the goroutine is trying to drain it
 	closeWaiter.Wait()
 }
 
@@ -222,7 +224,7 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 			reporter.Error(err)
 			ms.log.Errorw("Failure creating audit monitoring client", "error", err)
 		}
-		ms.log.Infof("starting lost event monitor")
+
 		go func() {
 			defer func() { // Close the most recently allocated "client" instance.
 				if client != nil {

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -174,8 +174,8 @@ func closeAuditClient(client *libaudit.AuditClient, log *logp.Logger) {
 		log.Errorw("Error closing audit monitoring client", "error", err)
 	}
 	// If we don't wait for the socket to drain, the calling function can
-	// assign a new client instance to the same pointer while our goroutine is using it.
-	// This guarantees that nothing is depending on the *client pointer by the time we return.
+	// assign a new client instance to the same FD while our goroutine is using it.
+	// This guarantees that we're not trying to read from the file descriptor by the time we return.
 	closeWaiter.Wait()
 }
 


### PR DESCRIPTION
## Proposed commit message

This fixes a rather severe (and interesting) goroutine leak where a failure in `Run()` where if `client.GetStatus()` fails, we can assign a new client to the `client` pointer before the goroutine created by `closeAuditClient()` exits, thus causing that goroutine to just live forever and periodically read from the client socket.

I can't get `client.GetStatus()` to fail on its own, but I did some testing where I hard-coded an error return, and auditbeat will grow about 0-3 goroutines a minute. In the real world, I've seen this result in 30K or so goroutines after a few days of running.

This just adds a waitgroup, so `closeAuditClient()` blocks until it's actually done.

This currently doesn't add any tests, I'm debating on if we want to refactor `Run()` so we can better add some unit tests to this; ideally we would come up with something that can test both this and the original bug fixed by https://github.com/elastic/beats/pull/26032

We might also want to make `ms.kernelLost.enabled`, to enable workarounds for this in the future.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

