### PR TITLE
Remove direct dependency on Azure/go-autorest/autorest/adal

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -111,6 +111,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Fix documentation and implementation of raw message handling in Filebeat http_endpoint by removing it. {pull}41498[41498]
 - Fix flaky test in filebeat Okta entity analytics provider. {issue}42059[42059] {pull}42123[42123]
 - Fix IIS module logging errors in case application pool PDH counter is not found. {pull}42274[42274]
+- Removed direct dependency on Azure/go-autorest/autorest/adal, which is deprecated. {issue}41463[41463] {pull}42959[42959]
 
 ==== Added
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2245,207 +2245,6 @@ Contents of probable licence file $GOMODCACHE/github.com/!azure/go-autorest/auto
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/Azure/go-autorest/autorest/adal
-Version: v0.9.24
-Licence type (autodetected): Apache-2.0
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/!azure/go-autorest/autorest/adal@v0.9.24/LICENSE:
-
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2015 Microsoft Corporation
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
---------------------------------------------------------------------------------
 Dependency : github.com/Azure/go-autorest/autorest/date
 Version: v0.3.0
 Licence type (autodetected): Apache-2.0
@@ -32930,6 +32729,207 @@ Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
 Contents of probable licence file $GOMODCACHE/github.com/!azure/go-autorest@v14.2.0+incompatible/LICENSE:
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 Microsoft Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--------------------------------------------------------------------------------
+Dependency : github.com/Azure/go-autorest/autorest/adal
+Version: v0.9.24
+Licence type (autodetected): Apache-2.0
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/!azure/go-autorest/autorest/adal@v0.9.24/LICENSE:
 
 
                                  Apache License

--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0
 	github.com/Azure/azure-storage-blob-go v0.15.0
-	github.com/Azure/go-autorest/autorest/adal v0.9.24
 	github.com/aerospike/aerospike-client-go/v7 v7.7.1
 	github.com/apache/arrow/go/v17 v17.0.0
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.22
@@ -248,6 +247,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/go-amqp v1.3.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.24 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect

--- a/x-pack/filebeat/input/o365audit/auth/auth.go
+++ b/x-pack/filebeat/input/o365audit/auth/auth.go
@@ -15,7 +15,7 @@ import (
 // allows to obtain tokens.
 type TokenProvider interface {
 	// Token returns a valid OAuth token, or an error.
-	Token() (string, error)
+	Token(ctx context.Context) (string, error)
 }
 
 // credentialTokenProvider extends azidentity.ClientSecretCredential with the
@@ -23,10 +23,10 @@ type TokenProvider interface {
 type credentialTokenProvider azidentity.ClientSecretCredential
 
 // Token returns an oauth token that can be used for bearer authorization.
-func (provider *credentialTokenProvider) Token() (string, error) {
+func (provider *credentialTokenProvider) Token(ctx context.Context) (string, error) {
 	inner := (*azidentity.ClientSecretCredential)(provider)
 	tk, err := inner.GetToken(
-		context.TODO(), policy.TokenRequestOptions{Scopes: []string{"https://manage.office.com/.default"}},
+		ctx, policy.TokenRequestOptions{Scopes: []string{"https://manage.office.com/.default"}},
 	)
 	if err != nil {
 		return "", err

--- a/x-pack/filebeat/input/o365audit/auth/auth.go
+++ b/x-pack/filebeat/input/o365audit/auth/auth.go
@@ -5,9 +5,10 @@
 package auth
 
 import (
-	"fmt"
+	"context"
 
-	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
 
 // TokenProvider is the interface that wraps an authentication mechanism and
@@ -15,28 +16,20 @@ import (
 type TokenProvider interface {
 	// Token returns a valid OAuth token, or an error.
 	Token() (string, error)
-
-	// Renew must be called to re-authenticate against the oauth2 endpoint if
-	// when the API returns an Authentication error.
-	Renew() error
 }
 
-// servicePrincipalToken extends adal.ServicePrincipalToken with the
+// credentialTokenProvider extends azidentity.ClientSecretCredential with the
 // the TokenProvider interface.
-type servicePrincipalToken adal.ServicePrincipalToken
+type credentialTokenProvider azidentity.ClientSecretCredential
 
 // Token returns an oauth token that can be used for bearer authorization.
-func (provider *servicePrincipalToken) Token() (string, error) {
-	inner := (*adal.ServicePrincipalToken)(provider)
-	if err := inner.EnsureFresh(); err != nil {
-		return "", fmt.Errorf("refreshing spt token: %w", err)
+func (provider *credentialTokenProvider) Token() (string, error) {
+	inner := (*azidentity.ClientSecretCredential)(provider)
+	tk, err := inner.GetToken(
+		context.TODO(), policy.TokenRequestOptions{Scopes: []string{"https://manage.office.com/.default"}},
+	)
+	if err != nil {
+		return "", err
 	}
-	token := inner.Token()
-	return token.OAuthToken(), nil
-}
-
-// Renew re-authenticates with the oauth2 endpoint to get a new Service Principal Token.
-func (provider *servicePrincipalToken) Renew() error {
-	inner := (*adal.ServicePrincipalToken)(provider)
-	return inner.Refresh()
+	return tk.Token, nil
 }

--- a/x-pack/filebeat/input/o365audit/auth/cert.go
+++ b/x-pack/filebeat/input/o365audit/auth/cert.go
@@ -5,7 +5,6 @@
 package auth
 
 import (
-	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
@@ -17,9 +16,7 @@ import (
 
 // NewProviderFromCertificate returns a TokenProvider that uses certificate-based
 // authentication.
-func NewProviderFromCertificate(
-	endpoint, resource, applicationID, tenantID string,
-	conf tlscommon.CertificateConfig) (sptp TokenProvider, err error) {
+func NewProviderFromCertificate(resource, applicationID, tenantID string, conf tlscommon.CertificateConfig) (sptp TokenProvider, err error) {
 	cert, privKey, err := loadConfigCerts(conf)
 	if err != nil {
 		return nil, fmt.Errorf("failed loading certificates: %w", err)
@@ -33,7 +30,7 @@ func NewProviderFromCertificate(
 	return (*credentialTokenProvider)(cred), nil
 }
 
-func loadConfigCerts(cfg tlscommon.CertificateConfig) (cert *x509.Certificate, key crypto.PrivateKey, err error) {
+func loadConfigCerts(cfg tlscommon.CertificateConfig) (cert *x509.Certificate, key *rsa.PrivateKey, err error) {
 	tlsCert, err := tlscommon.LoadCertificate(&cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error loading X509 certificate from '%s': %w", cfg.Certificate, err)
@@ -48,9 +45,9 @@ func loadConfigCerts(cfg tlscommon.CertificateConfig) (cert *x509.Certificate, k
 	if tlsCert.PrivateKey == nil {
 		return nil, nil, fmt.Errorf("failed loading private key from '%s'", cfg.Key)
 	}
-	_, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
+	key, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
 	if !ok {
 		return nil, nil, fmt.Errorf("private key at '%s' is not an RSA private key", cfg.Key)
 	}
-	return cert, tlsCert.PrivateKey, nil
+	return cert, key, nil
 }

--- a/x-pack/filebeat/input/o365audit/auth/cert.go
+++ b/x-pack/filebeat/input/o365audit/auth/cert.go
@@ -48,7 +48,7 @@ func loadConfigCerts(cfg tlscommon.CertificateConfig) (cert *x509.Certificate, k
 	if tlsCert.PrivateKey == nil {
 		return nil, nil, fmt.Errorf("failed loading private key from '%s'", cfg.Key)
 	}
-	key, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
+	_, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
 	if !ok {
 		return nil, nil, fmt.Errorf("private key at '%s' is not an RSA private key", cfg.Key)
 	}

--- a/x-pack/filebeat/input/o365audit/auth/secret.go
+++ b/x-pack/filebeat/input/o365audit/auth/secret.go
@@ -5,22 +5,22 @@
 package auth
 
 import (
-	"fmt"
-
-	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
 
 // NewProviderFromClientSecret returns a token provider that uses a secret
 // for authentication.
 func NewProviderFromClientSecret(endpoint, resource, applicationID, tenantID, secret string) (p TokenProvider, err error) {
-	oauth, err := adal.NewOAuthConfig(endpoint, tenantID)
-	if err != nil {
-		return nil, fmt.Errorf("error generating OAuthConfig: %w", err)
-	}
-	spt, err := adal.NewServicePrincipalToken(*oauth, applicationID, secret, resource)
+	clientOpts := azcore.ClientOptions{Cloud: cloud.Configuration{ActiveDirectoryAuthorityHost: endpoint}}
+
+	cred, err := azidentity.NewClientSecretCredential(
+		tenantID, applicationID, secret, &azidentity.ClientSecretCredentialOptions{ClientOptions: clientOpts},
+	)
 	if err != nil {
 		return nil, err
 	}
-	spt.SetAutoRefresh(true)
-	return (*servicePrincipalToken)(spt), nil
+
+	return (*credentialTokenProvider)(cred), nil
 }

--- a/x-pack/filebeat/input/o365audit/config.go
+++ b/x-pack/filebeat/input/o365audit/config.go
@@ -197,7 +197,6 @@ func (c *Config) NewTokenProvider(tenantID string) (auth.TokenProvider, error) {
 		)
 	}
 	return auth.NewProviderFromCertificate(
-		c.API.AuthenticationEndpoint,
 		c.API.Resource,
 		c.ApplicationID,
 		tenantID,

--- a/x-pack/filebeat/input/o365audit/contentblob.go
+++ b/x-pack/filebeat/input/o365audit/contentblob.go
@@ -107,7 +107,7 @@ func (c contentBlob) handleError(response *http.Response) (actions []poll.Action
 	}
 
 	switch response.StatusCode {
-	case 401: // Authentication error. Renew oauth token and repeat this op.
+	case 401: // Authentication error. Repeat this op.
 		return []poll.Action{
 			poll.Fetch(withDelay{contentBlob: c, delay: c.env.Config.PollInterval}),
 		}

--- a/x-pack/filebeat/input/o365audit/contentblob.go
+++ b/x-pack/filebeat/input/o365audit/contentblob.go
@@ -109,7 +109,6 @@ func (c contentBlob) handleError(response *http.Response) (actions []poll.Action
 	switch response.StatusCode {
 	case 401: // Authentication error. Renew oauth token and repeat this op.
 		return []poll.Action{
-			poll.RenewToken(),
 			poll.Fetch(withDelay{contentBlob: c, delay: c.env.Config.PollInterval}),
 		}
 	case 404:

--- a/x-pack/filebeat/input/o365audit/listblobs.go
+++ b/x-pack/filebeat/input/o365audit/listblobs.go
@@ -186,7 +186,6 @@ func (l listBlob) handleError(response *http.Response) (actions []poll.Action) {
 		// Authentication error. Renew oauth token and repeat this op.
 		l.delay = l.env.Config.PollInterval
 		return []poll.Action{
-			poll.RenewToken(),
 			poll.Fetch(l),
 		}
 	case 408, 503:

--- a/x-pack/filebeat/input/o365audit/listblobs.go
+++ b/x-pack/filebeat/input/o365audit/listblobs.go
@@ -183,7 +183,7 @@ func (l listBlob) handleError(response *http.Response) (actions []poll.Action) {
 
 	switch response.StatusCode {
 	case 401:
-		// Authentication error. Renew oauth token and repeat this op.
+		// Authentication error. Repeat this op.
 		l.delay = l.env.Config.PollInterval
 		return []poll.Action{
 			poll.Fetch(l),

--- a/x-pack/filebeat/input/o365audit/poll/poll.go
+++ b/x-pack/filebeat/input/o365audit/poll/poll.go
@@ -94,7 +94,7 @@ func (r *Poller) fetchWithDelay(item Transaction, minDelay time.Duration) error 
 		append([]autorest.PrepareDecorator{}, item.RequestDecorators()...),
 		r.decorators...)
 	if r.tp != nil {
-		token, err := r.tp.Token()
+		token, err := r.tp.Token(r.ctx)
 		if err != nil {
 			return fmt.Errorf("failed getting a token: %w", err)
 		}

--- a/x-pack/filebeat/input/o365audit/poll/poll.go
+++ b/x-pack/filebeat/input/o365audit/poll/poll.go
@@ -86,7 +86,7 @@ func (r *Poller) fetchWithDelay(item Transaction, minDelay time.Duration) error 
 	// Delay before getting the token, so it doesn't become stale.
 	delay := max(item.Delay(), minDelay)
 	r.log.Debugf(" -- wait %s for %s", delay, item)
-	time.After(delay)
+	time.Sleep(delay)
 
 	// The order here is important. item's decorators must come first as those
 	// set the URL, which is required by other decorators (WithQueryParameters).

--- a/x-pack/filebeat/input/o365audit/poll/poll.go
+++ b/x-pack/filebeat/input/o365audit/poll/poll.go
@@ -82,6 +82,12 @@ func (r *Poller) fetch(item Transaction) error {
 
 func (r *Poller) fetchWithDelay(item Transaction, minDelay time.Duration) error {
 	r.log.Debugf("* Fetch %s", item)
+
+	// Delay before getting the token, so it doesn't become stale.
+	delay := max(item.Delay(), minDelay)
+	r.log.Debugf(" -- wait %s for %s", delay, item)
+	time.After(delay)
+
 	// The order here is important. item's decorators must come first as those
 	// set the URL, which is required by other decorators (WithQueryParameters).
 	decorators := append(
@@ -99,12 +105,8 @@ func (r *Poller) fetchWithDelay(item Transaction, minDelay time.Duration) error 
 	if err != nil {
 		return fmt.Errorf("failed preparing request: %w", err)
 	}
-	delay := max(item.Delay(), minDelay)
-	r.log.Debugf(" -- wait %s for %s", delay, request.URL.String())
-
 	response, err := autorest.Send(request,
-		autorest.DoCloseIfError(),
-		autorest.AfterDelay(delay))
+		autorest.DoCloseIfError())
 	if err != nil {
 		r.log.Warnf("-- error sending request: %v", err)
 		return r.fetchWithDelay(item, max(time.Minute, r.interval))
@@ -215,7 +217,6 @@ func (p *transactionList) pop() Transaction {
 // Enqueuer is the interface provided to actions so they can act on a Poller.
 type Enqueuer interface {
 	Enqueue(item Transaction) error
-	RenewToken() error
 }
 
 // Action is an operation returned by a transaction.
@@ -225,15 +226,6 @@ type Action func(q Enqueuer) error
 func (r *Poller) Enqueue(item Transaction) error {
 	r.list.push(item)
 	return nil
-}
-
-// RenewToken renews the token provider's master token in the case of an
-// authorization error.
-func (r *Poller) RenewToken() error {
-	if r.tp == nil {
-		return errors.New("can't renew token: no token provider set")
-	}
-	return r.tp.Renew()
 }
 
 // Terminate action causes the poll loop to finish with the given error.
@@ -250,14 +242,6 @@ func Terminate(err error) Action {
 func Fetch(item Transaction) Action {
 	return func(q Enqueuer) error {
 		return q.Enqueue(item)
-	}
-}
-
-// RenewToken will renew the token provider's master token in the case of an
-// authorization error.
-func RenewToken() Action {
-	return func(q Enqueuer) error {
-		return q.RenewToken()
 	}
 }
 


### PR DESCRIPTION
## Proposed commit message

```
Remove direct dependency on Azure/go-autorest/autorest/adal

Remove direct use of the deprecated autorest/adal, replacing it with
azidentity, as described in the migration guide[1].

Indirect dependencies remain:

- github.com/elastic/beats/v7/x-pack/filebeat/input/o365audit
  - github.com/Azure/go-autorest/autorest
    - github.com/Azure/go-autorest/autorest/adal

- github.com/elastic/beats/v7/x-pack/filebeat/input/azureeventhub
  - github.com/Azure/azure-event-hubs-go/v3/storage
    - github.com/Azure/go-autorest/autorest/adal

- github.com/elastic/beats/v7/x-pack/metricbeat/module/azure/app_insights
  - github.com/Azure/go-autorest/autorest
    - github.com/Azure/go-autorest/autorest/adal

[1]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/MIGRATION.md
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #41463
