### PR TITLE
Package fips beats

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -338,6 +338,7 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: false
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
           FIPS: true
         command: |
@@ -362,6 +363,7 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
           SNAPSHOT: false
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
           FIPS: true
         command: |
@@ -388,6 +390,7 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: false
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
           FIPS: true
         command: |

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -10,6 +10,8 @@ env:
 
   PLATFORMS: "+all linux/amd64 windows/amd64 darwin/amd64"
   PLATFORMS_ARM: "+all linux/arm64 darwin/arm64"
+  PLATFORMS_FIPS: "+all linux/amd64"
+  PLATFORMS_ARM_FIPS: "+all linux/arm64"
 
 steps:
   # we use concurrency gates (https://buildkite.com/blog/concurrency-gates)
@@ -172,6 +174,73 @@ steps:
         artifact_paths:
           - build/distributions/**/*
 
+      - label: "SNAPSHOT: {{matrix}} FIPS"
+        env:
+          PLATFORMS: "${PLATFORMS_FIPS}"
+          SNAPSHOT: true
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
+          DEV: false
+          FIPS: true
+        command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
+        agents:
+          provider: gcp
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+        matrix:
+          - x-pack/auditbeat
+          - x-pack/filebeat
+          - x-pack/metricbeat
+
+      - label: "SNAPSHOT: {{matrix}} Linux/arm64 FIPS"
+        env:
+          PLATFORMS: "${PLATFORMS_ARM_FIPS}"
+          SNAPSHOT: true
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
+          DEV: false
+          FIPS: true
+        command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+        matrix:
+          - x-pack/auditbeat
+          - x-pack/filebeat
+          - x-pack/metricbeat
+          - x-pack/agentbeat
+
+      ## Agentbeat needs more CPUs because it builds many other beats
+      - label: "SNAPSHOT: x-pack/agentbeat all artifacts apart from linux/arm64 FIPS"
+        env:
+          PLATFORMS: "${PLATFORMS_FIPS}"
+          SNAPSHOT: true
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
+          DEV: false
+          FIPS: true
+        command: ".buildkite/scripts/packaging/package-dra.sh x-pack/agentbeat"
+        agents:
+          provider: gcp
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "c2-standard-16"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+
   - group: Packaging Staging
     key: packaging-staging
     depends_on: start-gate-staging
@@ -251,6 +320,76 @@ steps:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: false
           DEV: false
+        command: |
+          source .buildkite/scripts/version_qualifier.sh
+          .buildkite/scripts/packaging/package-dra.sh x-pack/agentbeat
+        agents:
+          provider: gcp
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "c2-standard-16"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+
+      - label: "STAGING: {{matrix}} FIPS"
+        env:
+          PLATFORMS: "${PLATFORMS_FIPS}"
+          SNAPSHOT: false
+          DEV: false
+          FIPS: true
+        command: |
+          source .buildkite/scripts/version_qualifier.sh
+          .buildkite/scripts/packaging/package-dra.sh {{matrix}}
+        agents:
+          provider: gcp
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+        matrix:
+          - x-pack/auditbeat
+          - x-pack/filebeat
+          - x-pack/metricbeat
+
+      - label: "STAGING: {{matrix}} Linux/arm64 FIPS"
+        env:
+          PLATFORMS: "${PLATFORMS_ARM_FIPS}"
+          SNAPSHOT: false
+          DEV: false
+          FIPS: true
+        command: |
+          source .buildkite/scripts/version_qualifier.sh
+          .buildkite/scripts/packaging/package-dra.sh {{matrix}}
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+        matrix:
+          - x-pack/auditbeat
+          - x-pack/filebeat
+          - x-pack/metricbeat
+          - x-pack/agentbeat
+
+        ## Agentbeat needs more CPUs because it builds many other beats
+      - label: "STAGING: x-pack/agentbeat all artifacts apart from linux/arm64 FIPS"
+        env:
+          PLATFORMS: "${PLATFORMS_FIPS}"
+          SNAPSHOT: false
+          DEV: false
+          FIPS: true
         command: |
           source .buildkite/scripts/version_qualifier.sh
           .buildkite/scripts/packaging/package-dra.sh x-pack/agentbeat

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -11,7 +11,7 @@ env:
   PLATFORMS: "+all linux/amd64 windows/amd64 darwin/amd64"
   PLATFORMS_ARM: "+all linux/arm64 darwin/arm64"
   PLATFORMS_AMD64_FIPS: "+all linux/amd64"
-  PLATFORMS_ARM_FIPS: "+all linux/arm64"
+  PLATFORMS_ARM64_FIPS: "+all linux/arm64"
 
 steps:
   # we use concurrency gates (https://buildkite.com/blog/concurrency-gates)
@@ -176,7 +176,7 @@ steps:
 
       - label: "SNAPSHOT: {{matrix}} Linux/amd64 FIPS"
         env:
-          PLATFORMS: "${PLATFORMS_FIPS}"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: true
           # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
@@ -199,7 +199,7 @@ steps:
 
       - label: "SNAPSHOT: {{matrix}} Linux/arm64 FIPS"
         env:
-          PLATFORMS: "${PLATFORMS_ARM_FIPS}"
+          PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
           SNAPSHOT: true
           # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
@@ -224,7 +224,7 @@ steps:
       ## Agentbeat needs more CPUs because it builds many other beats
       - label: "SNAPSHOT: x-pack/agentbeat Linux/amd64 FIPS"
         env:
-          PLATFORMS: "${PLATFORMS_FIPS}"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: true
           # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
@@ -334,9 +334,9 @@ steps:
         artifact_paths:
           - build/distributions/**/*
 
-      - label: "STAGING: {{matrix}} FIPS"
+      - label: "STAGING: {{matrix}} Linux/amd64 FIPS"
         env:
-          PLATFORMS: "${PLATFORMS_FIPS}"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: false
           DEV: false
           FIPS: true
@@ -360,7 +360,7 @@ steps:
 
       - label: "STAGING: {{matrix}} Linux/arm64 FIPS"
         env:
-          PLATFORMS: "${PLATFORMS_ARM_FIPS}"
+          PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
           SNAPSHOT: false
           DEV: false
           FIPS: true
@@ -384,9 +384,9 @@ steps:
           - x-pack/agentbeat
 
         ## Agentbeat needs more CPUs because it builds many other beats
-      - label: "STAGING: x-pack/agentbeat all artifacts apart from linux/arm64 FIPS"
+      - label: "STAGING: x-pack/agentbeat Linux/amd64 FIPS"
         env:
-          PLATFORMS: "${PLATFORMS_FIPS}"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: false
           DEV: false
           FIPS: true

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -10,7 +10,7 @@ env:
 
   PLATFORMS: "+all linux/amd64 windows/amd64 darwin/amd64"
   PLATFORMS_ARM: "+all linux/arm64 darwin/arm64"
-  PLATFORMS_FIPS: "+all linux/amd64"
+  PLATFORMS_AMD64_FIPS: "+all linux/amd64"
   PLATFORMS_ARM_FIPS: "+all linux/arm64"
 
 steps:
@@ -174,7 +174,7 @@ steps:
         artifact_paths:
           - build/distributions/**/*
 
-      - label: "SNAPSHOT: {{matrix}} FIPS"
+      - label: "SNAPSHOT: {{matrix}} Linux/amd64 FIPS"
         env:
           PLATFORMS: "${PLATFORMS_FIPS}"
           SNAPSHOT: true
@@ -222,7 +222,7 @@ steps:
           - x-pack/agentbeat
 
       ## Agentbeat needs more CPUs because it builds many other beats
-      - label: "SNAPSHOT: x-pack/agentbeat all artifacts apart from linux/arm64 FIPS"
+      - label: "SNAPSHOT: x-pack/agentbeat Linux/amd64 FIPS"
         env:
           PLATFORMS: "${PLATFORMS_FIPS}"
           SNAPSHOT: true

--- a/.buildkite/scripts/packaging/packaging.sh
+++ b/.buildkite/scripts/packaging/packaging.sh
@@ -12,3 +12,6 @@ source .buildkite/scripts/qemu.sh
 
 cd $BEAT_DIR
 mage package
+
+echo "Generated packages in ${BEAT_DIR}/build/distributions:"
+ls -lah "build/distributions"

--- a/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
@@ -10,6 +10,7 @@ env:
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
   IMAGE_WIN_2022: "family/platform-ingest-beats-windows-2022"
 
+  # Platforms to be used for FIPS packaging nodes
   PLATFORMS_AMD64_FIPS: "+all linux/amd64"
   PLATFORMS_ARM64_FIPS: "+all linux/arm64"
 

--- a/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
@@ -1,5 +1,7 @@
 env:
   ASDF_MAGE_VERSION: 1.15.0
+  AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
 
@@ -7,6 +9,9 @@ env:
 
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
   IMAGE_WIN_2022: "family/platform-ingest-beats-windows-2022"
+
+  PLATFORMS_AMD64_FIPS: "+all linux/amd64"
+  PLATFORMS_ARM64_FIPS: "+all linux/arm64"
 
 steps:
   - group: "Check/Update"
@@ -88,13 +93,12 @@ steps:
         notify:
           - github_commit_status:
               context: "agentbeat: Packaging"
-
-      - label: ":linux: Agentbeat packaging Linux FIPS"
-        key: "agentbeat-package-linux-fips"
+      - label: ":linux: Agentbeat packaging linux/amd64 FIPS"
+        key: "agentbeat-package-linux-x86-fips"
         depends_on:
           - mandatory-win-2022-system-tests
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: true
           FIPS: "true"
         command: |
@@ -115,7 +119,32 @@ steps:
           disk_type: "pd-ssd"
         notify:
           - github_commit_status:
-              context: "agentbeat: Packaging Linux FIPS"
+              context: "agentbeat: Packaging linux/amd64 FIPS"
+      - label: ":linux: Agentbeat packaging linux/arm FIPS"
+        key: "agentbeat-package-linux-arm-fips"
+        depends_on:
+          - mandatory-win-2022-system-tests
+        env:
+          PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
+          SNAPSHOT: true
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/agentbeat
+        artifact_paths:
+          - x-pack/agentbeat/build/distributions/**/*
+          - "x-pack/agentbeat/build/*.xml"
+          - "x-pack/agentbeat/build/*.json"
+        retry:
+          automatic:
+            - limit: 2
+        timeout_in_minutes: 60
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        notify:
+          - github_commit_status:
+              context: "agentbeat: Packaging linux/arm64 FIPS"
 
       - label: ":linux: Agentbeat/Integration tests Linux"
         key: "agentbeat-it-linux"

--- a/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
@@ -89,6 +89,34 @@ steps:
           - github_commit_status:
               context: "agentbeat: Packaging"
 
+      - label: ":linux: Agentbeat packaging Linux FIPS"
+        key: "agentbeat-package-linux-fips"
+        depends_on:
+          - mandatory-win-2022-system-tests
+        env:
+          PLATFORMS: "+all linux/amd64 linux/arm64"
+          SNAPSHOT: true
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/agentbeat
+        artifact_paths:
+          - x-pack/agentbeat/build/distributions/**/*
+          - "x-pack/agentbeat/build/*.xml"
+          - "x-pack/agentbeat/build/*.json"
+        retry:
+          automatic:
+            - limit: 2
+        timeout_in_minutes: 60
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          disk_size: 100
+          disk_type: "pd-ssd"
+        notify:
+          - github_commit_status:
+              context: "agentbeat: Packaging Linux FIPS"
+
       - label: ":linux: Agentbeat/Integration tests Linux"
         key: "agentbeat-it-linux"
         depends_on:

--- a/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
@@ -101,7 +101,7 @@ steps:
         env:
           PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           SNAPSHOT: true
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/agentbeat
         artifact_paths:
@@ -121,14 +121,14 @@ steps:
         notify:
           - github_commit_status:
               context: "agentbeat: Packaging linux/amd64 FIPS"
-      - label: ":linux: Agentbeat packaging linux/arm FIPS"
+      - label: ":linux: Agentbeat packaging linux/arm64 FIPS"
         key: "agentbeat-package-linux-arm-fips"
         depends_on:
           - mandatory-win-2022-system-tests
         env:
           PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
           SNAPSHOT: true
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/agentbeat
         artifact_paths:

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -406,3 +406,24 @@ steps:
         notify:
           - github_commit_status:
               context: "x-pack/auditbeat: Packaging Linux arm64"
+
+      - label: ":ubuntu: x-pack/auditbeat: Packaging Linux FIPS"
+        key: "packaging-linux-fips"
+        env:
+          PLATFORMS: "+all linux/amd64 linux/arm64"
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/auditbeat
+        retry:
+          automatic:
+            - limit: 1
+        timeout_in_minutes: 20
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          disk_size: 100
+          disk_type: "pd-ssd"
+        notify:
+          - github_commit_status:
+              context: "x-pack/auditbeat: Packaging Linux FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -36,6 +36,10 @@ env:
   CONCURRENCY_COUNT: 10
   CONCURRENCY_METHOD: eager
 
+  # Platforms to be used for FIPS packaging nodes
+  PLATFORMS_AMD64_FIPS: "+all linux/amd64"
+  PLATFORMS_ARM64_FIPS: "+all linux/arm64"
+
 steps:
   - group: "Check/Update"
     key: "x-pack-auditbeat-check-update"
@@ -407,10 +411,10 @@ steps:
           - github_commit_status:
               context: "x-pack/auditbeat: Packaging Linux arm64"
 
-      - label: ":ubuntu: x-pack/auditbeat: Packaging Linux FIPS"
+      - label: ":ubuntu: x-pack/auditbeat: Packaging Linux amd64 FIPS"
         key: "packaging-linux-fips"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           FIPS: "true"
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/auditbeat
@@ -426,4 +430,23 @@ steps:
           disk_type: "pd-ssd"
         notify:
           - github_commit_status:
-              context: "x-pack/auditbeat: Packaging Linux FIPS"
+              context: "x-pack/auditbeat: Packaging Linux amd64 FIPS"
+
+      - label: ":ubuntu: x-pack/auditbeat: Packaging Linux arm64 FIPS"
+        key: "packaging-arm-fips"
+        env:
+          PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/auditbeat
+        retry:
+          automatic:
+            - limit: 1
+        timeout_in_minutes: 20
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        notify:
+          - github_commit_status:
+              context: "x-pack/auditbeat: Packaging Linux arm64 FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -415,7 +415,7 @@ steps:
         key: "packaging-linux-fips"
         env:
           PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/auditbeat
         retry:
@@ -436,7 +436,7 @@ steps:
         key: "packaging-arm-fips"
         env:
           PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/auditbeat
         retry:

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -462,3 +462,24 @@ steps:
         notify:
           - github_commit_status:
               context: "x-pack/filebeat: Packaging Linux arm64"
+
+      - label: ":linux: x-pack/filebeat: Packaging Linux FIPS"
+        key: "packaging-linux-fips"
+        env:
+          PLATFORMS: "+all linux/amd64 linux/arm64"
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/filebeat
+        retry:
+          automatic:
+            - limit: 1
+        timeout_in_minutes: 20
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          disk_size: 100
+          disk_type: "pd-ssd"
+        notify:
+          - github_commit_status:
+              context: "x-pack/filebeat: Packaging Linux FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -32,6 +32,10 @@ env:
   CONCURRENCY_COUNT: 10
   CONCURRENCY_METHOD: eager
 
+  # Platforms to be used for FIPS packaging nodes
+  PLATFORMS_AMD64_FIPS: "+all linux/amd64"
+  PLATFORMS_ARM64_FIPS: "+all linux/arm64"
+
 steps:
   - group: "Check/Update"
     key: "x-pack-filebeat-check-update"
@@ -463,10 +467,10 @@ steps:
           - github_commit_status:
               context: "x-pack/filebeat: Packaging Linux arm64"
 
-      - label: ":linux: x-pack/filebeat: Packaging Linux FIPS"
+      - label: ":linux: x-pack/filebeat: Packaging Linux amd64 FIPS"
         key: "packaging-linux-fips"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           FIPS: "true"
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/filebeat
@@ -482,4 +486,23 @@ steps:
           disk_type: "pd-ssd"
         notify:
           - github_commit_status:
-              context: "x-pack/filebeat: Packaging Linux FIPS"
+              context: "x-pack/filebeat: Packaging Linux amd64 FIPS"
+
+      - label: ":linux: x-pack/filebeat: Packaging Linux arm64 FIPS"
+        key: "packaging-arm-fips"
+        env:
+          PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/filebeat
+        retry:
+          automatic:
+            - limit: 1
+        timeout_in_minutes: 20
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        notify:
+          - github_commit_status:
+              context: "x-pack/filebeat: Packaging Linux arm64 FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -471,7 +471,7 @@ steps:
         key: "packaging-linux-fips"
         env:
           PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/filebeat
         retry:
@@ -492,7 +492,7 @@ steps:
         key: "packaging-arm-fips"
         env:
           PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/filebeat
         retry:

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -35,6 +35,10 @@ env:
   CONCURRENCY_COUNT: 10
   CONCURRENCY_METHOD: eager
 
+  # Platforms to be used for FIPS packaging nodes
+  PLATFORMS_AMD64_FIPS: "+all linux/amd64"
+  PLATFORMS_ARM64_FIPS: "+all linux/arm64"
+
 steps:
   - group: "Check/Update"
     key: "x-pack-metricbeat-check-update"
@@ -441,10 +445,10 @@ steps:
           - github_commit_status:
               context: "x-pack/metricbeat: Packaging Linux arm64"
 
-      - label: ":ubuntu: x-pack/metricbeat: Packaging Linux FIPS"
+      - label: ":ubuntu: x-pack/metricbeat: Packaging Linux amd64 FIPS"
         key: "packaging-linux-fips"
         env:
-          PLATFORMS: "+all linux/amd64 linux/arm64"
+          PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
           FIPS: "true"
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/metricbeat
@@ -460,4 +464,23 @@ steps:
           disk_type: "pd-ssd"
         notify:
           - github_commit_status:
-              context: "x-pack/metricbeat: Packaging Linux FIPS"
+              context: "x-pack/metricbeat: Packaging Linux amd64 FIPS"
+
+      - label: ":ubuntu: x-pack/metricbeat: Packaging linux arm64"
+        key: "packaging-arm-fips"
+        env:
+          PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/metricbeat
+        retry:
+          automatic:
+            - limit: 1
+        timeout_in_minutes: 20
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        notify:
+          - github_commit_status:
+              context: "x-pack/metricbeat: Packaging Linux arm64 FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -440,3 +440,24 @@ steps:
         notify:
           - github_commit_status:
               context: "x-pack/metricbeat: Packaging Linux arm64"
+
+      - label: ":ubuntu: x-pack/metricbeat: Packaging Linux FIPS"
+        key: "packaging-linux-fips"
+        env:
+          PLATFORMS: "+all linux/amd64 linux/arm64"
+          FIPS: "true"
+        command: |
+          .buildkite/scripts/packaging/packaging.sh x-pack/metricbeat
+        retry:
+          automatic:
+            - limit: 1
+        timeout_in_minutes: 20
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          disk_size: 100
+          disk_type: "pd-ssd"
+        notify:
+          - github_commit_status:
+              context: "x-pack/metricbeat: Packaging Linux FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -449,7 +449,7 @@ steps:
         key: "packaging-linux-fips"
         env:
           PLATFORMS: "${PLATFORMS_AMD64_FIPS}"
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/metricbeat
         retry:
@@ -470,7 +470,7 @@ steps:
         key: "packaging-arm-fips"
         env:
           PLATFORMS: "${PLATFORMS_ARM64_FIPS}"
-          FIPS: "true"
+          FIPS: true
         command: |
           .buildkite/scripts/packaging/packaging.sh x-pack/metricbeat
         retry:

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -133,6 +133,7 @@ type crossBuildParams struct {
 func CrossBuild(options ...CrossBuildOption) error {
 	if FIPSBuild && !slices.Contains(FIPSConfig.Beats, BeatName) {
 		log.Printf("Skipping cross-build for beat %q because it's not included in the FIPS-enabled beat list %v", BeatName, FIPSConfig.Beats)
+		return nil
 	}
 
 	params := crossBuildParams{Platforms: Platforms, Target: defaultCrossBuildTarget, ImageSelector: CrossBuildImage}

--- a/dev-tools/mage/fips-settings.yaml
+++ b/dev-tools/mage/fips-settings.yaml
@@ -2,10 +2,13 @@
 beats:
   - agentbeat
   - auditbeat
-  - cloudbeat
   - filebeat
   - metricbeat
 compile:
-  # placeholder for compiler settings
+  cgo: true
+  env:
+    GOEXPERIMENT: systemcrypto
+  tags:
+    - requirefips
 package:
   # placeholder for global packaging settings

--- a/dev-tools/mage/fips-settings.yaml
+++ b/dev-tools/mage/fips-settings.yaml
@@ -11,6 +11,7 @@ compile:
   tags:
     - requirefips
   platforms:
+    # If the platform list changes, update the platforms for FIPS packaging in CI pipelines '.buildkite/**/pipeline.<beat>.yml' and '.buildkite/packaging-pipeline.yml'
     - linux/amd64
     - linux/arm64
 package:

--- a/dev-tools/mage/fips-settings.yaml
+++ b/dev-tools/mage/fips-settings.yaml
@@ -10,5 +10,8 @@ compile:
     GOEXPERIMENT: systemcrypto
   tags:
     - requirefips
+  platforms:
+    - linux/amd64
+    - linux/arm64
 package:
   # placeholder for global packaging settings

--- a/dev-tools/mage/fips-settings.yaml
+++ b/dev-tools/mage/fips-settings.yaml
@@ -14,5 +14,3 @@ compile:
     # If the platform list changes, update the platforms for FIPS packaging in CI pipelines '.buildkite/**/pipeline.<beat>.yml' and '.buildkite/packaging-pipeline.yml'
     - linux/amd64
     - linux/arm64
-package:
-  # placeholder for global packaging settings

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -367,10 +367,6 @@ func TestPackages(options ...TestPackagesOption) error {
 		args = append(args, "-root-owner")
 	}
 
-	if FIPSBuild {
-		args = append(args, "-fips")
-	}
-
 	args = append(args, "-files", MustExpand("{{.PWD}}/build/distributions/*"))
 
 	if out, err := goTest(args...); err != nil {

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -106,7 +106,6 @@ func Package() error {
 				spec.OS = target.GOOS()
 				spec.Arch = packageArch
 				spec.Snapshot = Snapshot
-				//spec.FIPS = FIPSBuild
 				spec.evalContext = map[string]interface{}{
 					"GOOS":          target.GOOS(),
 					"GOARCH":        target.GOARCH(),

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -50,6 +51,11 @@ func Package() error {
 	var tasks []interface{}
 	for _, target := range platforms {
 		for _, pkg := range Packages {
+
+			if mg.Verbose() {
+				log.Printf("Evaluating package %v for target %s", pkg.Spec, target)
+			}
+
 			if pkg.OS != target.GOOS() || pkg.Arch != "" && pkg.Arch != target.Arch() {
 				continue
 			}
@@ -82,13 +88,25 @@ func Package() error {
 					continue
 				}
 
+				// Filter out non fips-enabled beats
+				if FIPSBuild && !slices.Contains(FIPSConfig.Beats, BeatName) {
+					log.Printf("Skipping creation for beat %v package type %v because beat is not listed as FIPS compliant %v", BeatName, pkgType, FIPSConfig.Beats)
+					continue
+				}
+
+				// Filter out non fips specs
+				if pkg.Spec.FIPS != FIPSBuild {
+					log.Printf("Skipping creation for package type %v because spec.FIPS = %v and FIPSBuild = %v", pkgType, pkg.Spec.FIPS, FIPSBuild)
+					continue
+				}
+
 				agentPackageDrop, _ := os.LookupEnv("AGENT_DROP_PATH")
 
 				spec := pkg.Spec.Clone()
 				spec.OS = target.GOOS()
 				spec.Arch = packageArch
 				spec.Snapshot = Snapshot
-				spec.FIPS = FIPSBuild
+				//spec.FIPS = FIPSBuild
 				spec.evalContext = map[string]interface{}{
 					"GOOS":          target.GOOS(),
 					"GOARCH":        target.GOARCH(),
@@ -121,6 +139,11 @@ func Package() error {
 //
 // Use SNAPSHOT=true to build snapshots.
 func Ironbank() error {
+	if FIPSBuild {
+		fmt.Println(">> IronBank images are not supported for FIPS builds")
+		return nil
+	}
+
 	if runtime.GOARCH != "amd64" {
 		fmt.Printf(">> IronBank images are only supported for amd64 arch (%s is not supported)\n", runtime.GOARCH)
 		return nil

--- a/dev-tools/mage/pkgspecs.go
+++ b/dev-tools/mage/pkgspecs.go
@@ -42,7 +42,11 @@ func UseElasticBeatOSSPackaging() {
 // UseElasticBeatXPackPackaging configures the package target to build Elastic
 // licensed (X-Pack) packages.
 func UseElasticBeatXPackPackaging() {
-	MustUsePackaging("elastic_beat_xpack", packageSpecFile)
+	if FIPSBuild {
+		MustUsePackaging("elastic_beat_xpack_fips", packageSpecFile)
+	} else {
+		MustUsePackaging("elastic_beat_xpack", packageSpecFile)
+	}
 }
 
 // UseElasticBeatXPackReducedPackaging configures the package target to build Elastic

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -47,7 +47,7 @@ const (
 	packageStagingDir = "build/package"
 
 	// defaultBinaryName specifies the output file for zip and tar.gz.
-	defaultBinaryName = "{{.Name}}{{if .FIPS}}-fips{{end}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
+	defaultBinaryName = "{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
 )
 
 // PackageType defines the file format of the package (e.g. zip, rpm, etc).
@@ -529,7 +529,7 @@ func (s PackageSpec) rootDir() string {
 
 	// NOTE: This uses .BeatName instead of .Name because we wanted the internal
 	// directory to not include "-oss".
-	return s.MustExpand("{{.BeatName}}{{if .FIPS}}-fips{{end}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}")
+	return s.MustExpand("{{.BeatName}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}")
 }
 
 // PackageZip packages a zip file.
@@ -728,7 +728,7 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 	}
 	defer os.Remove(inputTar)
 
-	outputFile, err := spec.Expand("{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.Arch}}{{if .FIPS}}-fips{{end}}")
+	outputFile, err := spec.Expand("{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.Arch}}")
 	if err != nil {
 		return err
 	}

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -91,9 +91,10 @@ var (
 	FIPSConfig struct {
 		Beats   []string `yaml:"beats"`
 		Compile struct {
-			CGO  bool              `yaml:"cgo"`
-			Env  map[string]string `yaml:"env"`
-			Tags []string          `yaml:"tags"`
+			CGO       bool              `yaml:"cgo"`
+			Env       map[string]string `yaml:"env"`
+			Tags      []string          `yaml:"tags"`
+			Platforms []string          `yaml:"platforms"`
 		} `yaml:"compile"`
 	}
 

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -89,7 +89,12 @@ var (
 	fipsConfigRaw []byte
 
 	FIPSConfig struct {
-		Beats []string
+		Beats   []string `yaml:"beats"`
+		Compile struct {
+			CGO  bool              `yaml:"cgo"`
+			Env  map[string]string `yaml:"env"`
+			Tags []string          `yaml:"tags"`
+		} `yaml:"compile"`
 	}
 
 	versionQualified bool
@@ -143,11 +148,9 @@ func init() {
 		panic(fmt.Errorf("failed to parse FIPS env value: %w", err))
 	}
 
-	if FIPSBuild {
-		err := yaml.Unmarshal(fipsConfigRaw, &FIPSConfig)
-		if err != nil {
-			panic(fmt.Errorf("failed to parse FIPS config: %w", err))
-		}
+	err = yaml.Unmarshal(fipsConfigRaw, &FIPSConfig)
+	if err != nil {
+		panic(fmt.Errorf("failed to parse FIPS config: %w", err))
 	}
 
 	versionQualifier, versionQualified = os.LookupEnv("VERSION_QUALIFIER")

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -651,10 +651,3 @@ specs:
       spec:
         <<: *deb_rpm_spec_fips
         <<: *elastic_license_for_deb_rpm
-
-    - os: darwin
-      arch: arm64
-      types: [ tgz ]
-      spec:
-        <<: *fips_binary_spec
-        <<: *elastic_license_for_binaries

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -147,7 +147,7 @@ shared:
     files:
       <<: *binary_files
 
-  - &fips_binary_spec
+  - &binary_spec_fips
     <<: *common_fips
     files:
       <<: *binary_files
@@ -643,7 +643,7 @@ specs:
     - os: linux
       types: [tgz]
       spec:
-        <<: *fips_binary_spec
+        <<: *binary_spec_fips
         <<: *elastic_license_for_binaries
 
     - os: linux

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -15,6 +15,11 @@ shared:
     url: '{{.BeatURL}}'
     description: '{{.BeatDescription}}'
 
+  - &common_fips
+    <<: *common
+    name: '{{.BeatName}}-fips'
+    fips: true
+
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec
     <<: *common
@@ -55,6 +60,10 @@ shared:
       /lib/systemd/system/{{.BeatServiceName}}.service:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/systemd.unit.tmpl'
         mode: 0644
+
+  - &deb_rpm_spec_fips
+    <<: *deb_rpm_spec
+    <<: *common_fips
 
   # MacOS pkg spec for community beats.
   - &macos_beat_pkg_spec
@@ -139,9 +148,7 @@ shared:
       <<: *binary_files
 
   - &fips_binary_spec
-    <<: *common
-    name: '{{.BeatName}}-fips'
-    fips: true
+    <<: *common_fips
     files:
       <<: *binary_files
       '{{.BeatName}}{{.BinaryExt}}':
@@ -638,67 +645,16 @@ specs:
       spec:
         <<: *fips_binary_spec
         <<: *elastic_license_for_binaries
-#
-#    - os: linux
-#      types: [deb, rpm]
-#      spec:
-#        <<: *deb_rpm_spec
-#        <<: *elastic_license_for_deb_rpm
-#
-#    - os: linux
-#      arch: amd64
-#      types: [docker]
-#      spec:
-#        <<: *docker_spec
-#        <<: *elastic_docker_spec
-#        <<: *elastic_license_for_binaries
-#
-#    - os: linux
-#      arch: amd64
-#      types: [docker]
-#      spec:
-#        <<: *docker_spec
-#        <<: *docker_ubi_spec
-#        <<: *elastic_docker_spec
-#        <<: *elastic_license_for_binaries
-#
-#    - os: linux
-#      arch: amd64
-#      types: [docker]
-#      spec:
-#        <<: *docker_spec
-#        <<: *docker_wolfi_spec
-#        <<: *elastic_docker_spec
-#        <<: *elastic_license_for_binaries
-#
-#    - os: linux
-#      arch: arm64
-#      types: [docker]
-#      spec:
-#        <<: *docker_arm_spec
-#        <<: *elastic_docker_spec
-#        <<: *elastic_license_for_binaries
-#
-#    - os: linux
-#      arch: arm64
-#      types: [docker]
-#      spec:
-#        <<: *docker_arm_spec
-#        <<: *docker_arm_ubi_spec
-#        <<: *elastic_docker_spec
-#        <<: *elastic_license_for_binaries
-#
-#    - os: linux
-#      arch: arm64
-#      types: [docker]
-#      spec:
-#        <<: *docker_arm_spec
-#        <<: *docker_arm_wolfi_spec
-#        <<: *elastic_docker_spec
-#        <<: *elastic_license_for_binaries
-#
-#    - os: aix
-#      types: [tgz]
-#      spec:
-#        <<: *binary_spec
-#        <<: *elastic_license_for_binaries
+
+    - os: linux
+      types: [deb]
+      spec:
+        <<: *deb_rpm_spec_fips
+        <<: *elastic_license_for_deb_rpm
+
+    - os: darwin
+      arch: arm64
+      types: [ tgz ]
+      spec:
+        <<: *fips_binary_spec
+        <<: *elastic_license_for_binaries

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -138,6 +138,16 @@ shared:
     files:
       <<: *binary_files
 
+  - &fips_binary_spec
+    <<: *common
+    name: '{{.BeatName}}-fips'
+    fips: true
+    files:
+      <<: *binary_files
+      '{{.BeatName}}{{.BinaryExt}}':
+        source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+        mode: 0755
+
   # Binary package spec (zip for windows) for community beats.
   - &windows_binary_spec
     <<: *common
@@ -617,3 +627,78 @@ specs:
             source: data/{{.BeatName}}-{{ commit_short }}/{{.BeatName}}{{.BinaryExt}}
             symlink: true
             mode: 0755
+
+  # Elastic Beat with Elastic License and binary taken the current directory.
+  elastic_beat_xpack_fips:
+    ###
+    # Elastic Licensed Packages
+    ###
+    - os: linux
+      types: [tgz]
+      spec:
+        <<: *fips_binary_spec
+        <<: *elastic_license_for_binaries
+#
+#    - os: linux
+#      types: [deb, rpm]
+#      spec:
+#        <<: *deb_rpm_spec
+#        <<: *elastic_license_for_deb_rpm
+#
+#    - os: linux
+#      arch: amd64
+#      types: [docker]
+#      spec:
+#        <<: *docker_spec
+#        <<: *elastic_docker_spec
+#        <<: *elastic_license_for_binaries
+#
+#    - os: linux
+#      arch: amd64
+#      types: [docker]
+#      spec:
+#        <<: *docker_spec
+#        <<: *docker_ubi_spec
+#        <<: *elastic_docker_spec
+#        <<: *elastic_license_for_binaries
+#
+#    - os: linux
+#      arch: amd64
+#      types: [docker]
+#      spec:
+#        <<: *docker_spec
+#        <<: *docker_wolfi_spec
+#        <<: *elastic_docker_spec
+#        <<: *elastic_license_for_binaries
+#
+#    - os: linux
+#      arch: arm64
+#      types: [docker]
+#      spec:
+#        <<: *docker_arm_spec
+#        <<: *elastic_docker_spec
+#        <<: *elastic_license_for_binaries
+#
+#    - os: linux
+#      arch: arm64
+#      types: [docker]
+#      spec:
+#        <<: *docker_arm_spec
+#        <<: *docker_arm_ubi_spec
+#        <<: *elastic_docker_spec
+#        <<: *elastic_license_for_binaries
+#
+#    - os: linux
+#      arch: arm64
+#      types: [docker]
+#      spec:
+#        <<: *docker_arm_spec
+#        <<: *docker_arm_wolfi_spec
+#        <<: *elastic_docker_spec
+#        <<: *elastic_license_for_binaries
+#
+#    - os: aix
+#      types: [tgz]
+#      spec:
+#        <<: *binary_spec
+#        <<: *elastic_license_for_binaries

--- a/x-pack/agentbeat/dev-tools/packaging/packages.yml
+++ b/x-pack/agentbeat/dev-tools/packaging/packages.yml
@@ -14,6 +14,11 @@ shared:
     url: '{{.BeatURL}}'
     description: '{{.BeatDescription}}'
 
+  - &common_fips
+    <<: *common
+    name: '{{.BeatName}}-fips'
+    fips: true
+
   - &binary_files
     '{{.BeatName}}{{.BinaryExt}}':
       source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
@@ -56,9 +61,7 @@ shared:
       <<: *windows_osquery_files
 
   - &fips_binary_spec
-    <<: *common
-    name: '{{.BeatName}}-fips'
-    fips: true
+    <<: *common_fips
     files:
       <<: *binary_files
       '{{.BeatName}}{{.BinaryExt}}':
@@ -122,10 +125,4 @@ specs:
       types: [tgz]
       spec:
         <<: *fips_binary_spec
-        <<: *elastic_license_for_binaries
-    - os: darwin
-      arch: arm64
-      types: [ tgz ]
-      spec:
-        <<: *unix_binary_spec
         <<: *elastic_license_for_binaries

--- a/x-pack/agentbeat/dev-tools/packaging/packages.yml
+++ b/x-pack/agentbeat/dev-tools/packaging/packages.yml
@@ -55,6 +55,16 @@ shared:
       <<: *binary_files
       <<: *windows_osquery_files
 
+  - &fips_binary_spec
+    <<: *common
+    name: '{{.BeatName}}-fips'
+    fips: true
+    files:
+      <<: *binary_files
+      '{{.BeatName}}{{.BinaryExt}}':
+        source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+        mode: 0755
+
   # License modifiers for the Elastic License
   - &elastic_license_for_binaries
     license: "Elastic License"
@@ -101,4 +111,15 @@ specs:
       types: [tgz]
       spec:
         <<: *unix_binary_spec
+        <<: *elastic_license_for_binaries
+
+  # Elastic Beat with Elastic License and binary taken the current directory.
+  agentbeat_fips:
+    ###
+    # Elastic Licensed Packages
+    ###
+    - os: linux
+      types: [tgz]
+      spec:
+        <<: *fips_binary_spec
         <<: *elastic_license_for_binaries

--- a/x-pack/agentbeat/dev-tools/packaging/packages.yml
+++ b/x-pack/agentbeat/dev-tools/packaging/packages.yml
@@ -60,7 +60,7 @@ shared:
       <<: *binary_files
       <<: *windows_osquery_files
 
-  - &fips_binary_spec
+  - &binary_spec_fips
     <<: *common_fips
     files:
       <<: *binary_files
@@ -124,5 +124,5 @@ specs:
     - os: linux
       types: [tgz]
       spec:
-        <<: *fips_binary_spec
+        <<: *binary_spec_fips
         <<: *elastic_license_for_binaries

--- a/x-pack/agentbeat/dev-tools/packaging/packages.yml
+++ b/x-pack/agentbeat/dev-tools/packaging/packages.yml
@@ -123,3 +123,9 @@ specs:
       spec:
         <<: *fips_binary_spec
         <<: *elastic_license_for_binaries
+    - os: darwin
+      arch: arm64
+      types: [ tgz ]
+      spec:
+        <<: *unix_binary_spec
+        <<: *elastic_license_for_binaries

--- a/x-pack/agentbeat/magefile.go
+++ b/x-pack/agentbeat/magefile.go
@@ -128,8 +128,14 @@ func Package() error {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 	fmt.Printf(">> Packaging agentbeat that includes %v\n", getIncludedBeats())
-	// specific packaging just for agentbeat
-	devtools.MustUsePackaging("agentbeat", "x-pack/agentbeat/dev-tools/packaging/packages.yml")
+
+	if devtools.FIPSBuild {
+		// FIPS specific packaging spec
+		devtools.MustUsePackaging("agentbeat_fips", "x-pack/agentbeat/dev-tools/packaging/packages.yml")
+	} else {
+		// specific packaging just for agentbeat
+		devtools.MustUsePackaging("agentbeat", "x-pack/agentbeat/dev-tools/packaging/packages.yml")
+	}
 
 	// Add metricbeat lightweight modules.
 	if err := metricbeat.CustomizeLightModulesPackaging(); err != nil {

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -374,6 +375,9 @@ func GolangCrossBuild() error {
 
 // Package builds a "release" tarball that can be used later with `docker plugin create`
 func Package() {
+	if devtools.FIPSBuild && !slices.Contains(devtools.FIPSConfig.Beats, "dockerlogbeat") {
+		return
+	}
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Implement packaging of FIPS compliant Beats.

With this change the following beats are compiled and packaged in a FIPS compliant fashion when specifying env var `FIPS=true`:
- agentbeat (for details see PR #42913)
- auditbeat
- filebeat
- metricbeat

The FIPS config parameters are controlled by `dev-tools/mage/fips-settings.yaml` config file which allows to:
- define the list of FIPS compliant beat names
- control some compile settings like environment variables and build tags.
The initial configuration of FIPS settings is:
```yaml
# beats contains the list of beats that are FIPS-enabled
beats:
  - agentbeat
  - auditbeat
  - filebeat
  - metricbeat
compile:
  cgo: true
  env:
    GOEXPERIMENT: systemcrypto
  tags:
    - requirefips
  platforms:
    # If the platform list changes, update the platforms for FIPS packaging in CI pipelines '.buildkite/**/pipeline.<beat>.yml' and '.buildkite/packaging-pipeline.yml'
    - linux/amd64
    - linux/arm64

```
This compile settings are global for all beats and **apply only when building/packaging with `FIPS=true`**


The packaging is based on the x-pack spec and includes only `.tar.gz` and `.deb` artifacts for `linux/amd64` and `linux/arm64` platforms.
A new spec has been added to `dev-tools/packaging/packages.yml` for FIPS-enabled beats: it is based on the `x-pack` spec  and includes only `.tar.gz` and `.deb` artifacts for `linux/amd64` and `linux/arm64` platforms.
A quick sample of the spec (extracted from `dev-tools/packaging/packages.yml`, omitting all non-relevant specs):
```yaml
shared:
  - &common
    name: '{{.BeatName}}'
    service_name: '{{.BeatServiceName}}'
    os: '{{.GOOS}}'
    arch: '{{.PackageArch}}'
    vendor: '{{.BeatVendor}}'
    version: '{{ beat_version }}'
    license: '{{.BeatLicense}}'
    url: '{{.BeatURL}}'
    description: '{{.BeatDescription}}'

  - &common_fips
    <<: *common
    name: '{{.BeatName}}-fips'
    fips: true

  - &deb_rpm_spec_fips
    <<: *deb_rpm_spec
    <<: *common_fips

  - &fips_binary_spec
    <<: *common_fips
    files:
      <<: *binary_files
      '{{.BeatName}}{{.BinaryExt}}':
        source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
        mode: 0755

# specs is a list of named packaging "flavors".
specs:

  # Elastic Beat with Elastic License and binary taken the current directory.
  elastic_beat_xpack_fips:
    ###
    # Elastic Licensed Packages
    ###
    - os: linux
      types: [tgz]
      spec:
        <<: *fips_binary_spec
        <<: *elastic_license_for_binaries

    - os: linux
      types: [deb]
      spec:
        <<: *deb_rpm_spec_fips
        <<: *elastic_license_for_deb_rpm

```

**Note: another spec `agentbeat_fips` had to be defined for `agentbeat` as it uses its own packaging specs file `x-pack/agentbeat/dev-tools/packaging/packages.yml`**

Modifications have been introduced in build/packaging code under `dev-tools/` to filter out non FIPS compliant beats or package specs.

Another set of changes impacts Buildkite pipeline definitions:
- For each FIPS-enabled beat a "test" packaging step has been introduced in the relevant `.buildkite/<beat name>/<beat name>-pipeline.yml` to ensure that we can still build and package with `FIPS=true` in PRs
- New packaging steps have been introduced in `.buildkite/packaging.pipeline.yml` to produce new `<beat name>-fips-*` DRAs for both snapshot and staging workflow.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

To test FIPS compiling and packaging, step into a beat directory and package, taking `agentbeat` for example:
```shell
cd x-pack/agentbeat
# cross-compiling in golang-crossbuild is currently disabled, make sure you choose the cpu arch corresponding to the docker host in PLATFORMS env var
PLATFORMS="linux/amd64" FIPS=true mage clean package
```
Sample output
```shell
➜  beats git:(package-fips-beats) ✗ cd x-pack/agentbeat
➜  agentbeat git:(package-fips-beats) ✗ PLATFORMS="linux/amd64" FIPS=true mage clean package
>> Packaging agentbeat that includes [auditbeat filebeat metricbeat]
>> Changing into auditbeat directory
>> Executing mage update for auditbeat
Generated fields.yml for auditbeat to /home/paolo/dev/beats/x-pack/auditbeat/fields.yml
>> Building auditbeat.yml for linux/amd64
>> Building auditbeat.reference.yml for linux/amd64
>> Building auditbeat.docker.yml for linux/amd64
>> Changing into filebeat directory
>> Executing mage update for filebeat
No fields files for module add_nomad_metadata
No fields files for module aws_vpcflow
No fields files for module azureblobstorage
No fields files for module azureeventhub
No fields files for module benchmark
No fields files for module cel
No fields files for module cloudfoundry
No fields files for module cometd
No fields files for module default-inputs
No fields files for module entityanalytics
No fields files for module gcppubsub
No fields files for module gcs
No fields files for module http_endpoint
No fields files for module httpjson
No fields files for module internal
No fields files for module o365audit
No fields files for module salesforce
No fields files for module streaming
No fields files for module unifiedlogs
Generated fields.yml for filebeat to /home/paolo/dev/beats/x-pack/filebeat/fields.yml
>> Building filebeat.yml for linux/amd64
>> Building filebeat.reference.yml for linux/amd64
>> Building filebeat.docker.yml for linux/amd64
>> Changing into metricbeat directory
>> Executing mage update for metricbeat
Generated fields.yml for metricbeat to /home/paolo/dev/beats/x-pack/metricbeat/fields.yml
>> Building metricbeat.yml for linux/amd64
>> Building metricbeat.reference.yml for linux/amd64
>> Building metricbeat.docker.yml for linux/amd64
>> golangCrossBuild: Building for linux/amd64
>> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=gcc, CXX=g++, GOARCH=amd64, GOARM=, GOOS=linux, PLATFORM_ID=linux-amd64]
>> package: Building agentbeat-fips type=tar.gz for platform=linux/amd64 fips=true
>> Testing package contents
package ran for 2m11.617967314s
➜  agentbeat git:(package-fips-beats) ✗ tree build/distributions
build/distributions
├── agentbeat-fips-9.1.0-linux-x86_64.tar.gz
└── agentbeat-fips-9.1.0-linux-x86_64.tar.gz.sha512

0 directories, 2 files
➜
```

There's also a best-effort to have FIPS artifacts built for all the enabled beats using `make` (although it's not the method used in the buildkite pipelines):
```shell
PLATFORMS="linux/amd64" FIPS=true make  release
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
