### PR TITLE
Don't package arm64 on amd64 workers

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -8,8 +8,8 @@ env:
   GCP_DEFAULT_MACHINE_TYPE: "c2d-standard-8"
   IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
 
-  PLATFORMS: "+all linux/amd64 linux/arm64 windows/amd64 darwin/amd64 darwin/arm64"
-  PLATFORMS_ARM: "linux/arm64"
+  PLATFORMS: "+all linux/amd64 windows/amd64 darwin/amd64 darwin/arm64"
+  PLATFORMS_ARM: "+all linux/arm64"
 
 steps:
   # we use concurrency gates (https://buildkite.com/blog/concurrency-gates)
@@ -124,7 +124,6 @@ steps:
       - label: "SNAPSHOT: {{matrix}} docker Linux/arm64"
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
-          PACKAGES: "docker"
           SNAPSHOT: true
           # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
@@ -151,6 +150,7 @@ steps:
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat
+          - x-pack/osquerybeat
 
       ## Agentbeat needs more CPUs because it builds many other beats
       - label: "SNAPSHOT: x-pack/agentbeat"
@@ -242,6 +242,7 @@ steps:
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat
+          - x-pack/osquerybeat
 
         ## Agentbeat needs more CPUs because it builds many other beats
       - label: "STAGING: x-pack/agentbeat"

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -263,9 +263,8 @@ steps:
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat
-          - x-pack/osquerybeat
 
-      - label: "STAGING: {{matrix} all artifacts for Linux/arm64"
+      - label: "STAGING: {{matrix}} all artifacts for Linux/arm64"
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
           SNAPSHOT: false

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -121,10 +121,9 @@ steps:
           - x-pack/packetbeat
           - x-pack/winlogbeat
 
-      - label: "SNAPSHOT: {{matrix}} docker Linux/arm64"
+      - label: "SNAPSHOT: {{matrix}} Linux/arm64"
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
-          PACKAGES: "docker"
           SNAPSHOT: true
           # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
@@ -151,30 +150,11 @@ steps:
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat
-
-      - label: "SNAPSHOT: {{matrix}} all artifacts for Linux/arm64"
-        env:
-          PLATFORMS: "${PLATFORMS_ARM}"
-          SNAPSHOT: true
-          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
-          DEV: false
-        command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
-        agents:
-          provider: "aws"
-          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
-          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
-        timeout_in_minutes: 40
-        retry:
-          automatic:
-            - limit: 1
-        artifact_paths:
-          - build/distributions/**/*
-        matrix:
-          - x-pack/agentbeat
           - x-pack/osquerybeat
+          - x-pack/agentbeat
 
       ## Agentbeat needs more CPUs because it builds many other beats
-      - label: "SNAPSHOT: x-pack/agentbeat"
+      - label: "SNAPSHOT: x-pack/agentbeat all artifacts apart from linux/arm64"
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: true
@@ -232,10 +212,9 @@ steps:
           - x-pack/packetbeat
           - x-pack/winlogbeat
 
-      - label: "STAGING: {{matrix}} docker Linux/arm64"
+      - label: "STAGING: {{matrix}} Linux/arm64"
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
-          PACKAGES: "docker"
           SNAPSHOT: false
           DEV: false
         command: |
@@ -263,31 +242,11 @@ steps:
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat
-
-      - label: "STAGING: {{matrix}} all artifacts for Linux/arm64"
-        env:
-          PLATFORMS: "${PLATFORMS_ARM}"
-          SNAPSHOT: false
-          DEV: false
-        command: |
-          source .buildkite/scripts/version_qualifier.sh
-          .buildkite/scripts/packaging/package-dra.sh {{matrix}}
-        agents:
-          provider: "aws"
-          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
-          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
-        timeout_in_minutes: 40
-        retry:
-          automatic:
-            - limit: 1
-        artifact_paths:
-          - build/distributions/**/*
-        matrix:
-          - x-pack/agentbeat
           - x-pack/osquerybeat
+          - x-pack/agentbeat
 
         ## Agentbeat needs more CPUs because it builds many other beats
-      - label: "STAGING: x-pack/agentbeat"
+      - label: "STAGING: x-pack/agentbeat all artifacts apart from linux/arm64"
         env:
           PLATFORMS: "${PLATFORMS}"
           SNAPSHOT: false

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -272,7 +272,7 @@ steps:
           DEV: false
         command: |
           source .buildkite/scripts/version_qualifier.sh
-          .buildkite/scripts/packaging/package-dra.sh x-pack/osquerybeat
+          .buildkite/scripts/packaging/package-dra.sh {{matrix}}
         agents:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
@@ -285,6 +285,7 @@ steps:
           - build/distributions/**/*
         matrix:
           - x-pack/agentbeat
+          - x-pack/osquerybeat
 
         ## Agentbeat needs more CPUs because it builds many other beats
       - label: "STAGING: x-pack/agentbeat"

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -124,6 +124,7 @@ steps:
       - label: "SNAPSHOT: {{matrix}} docker Linux/arm64"
         env:
           PLATFORMS: "${PLATFORMS_ARM}"
+          PACKAGES: "docker"
           SNAPSHOT: true
           # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
           DEV: false
@@ -150,6 +151,26 @@ steps:
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat
+
+      - label: "SNAPSHOT: {{matrix}} all artifacts for Linux/arm64"
+        env:
+          PLATFORMS: "${PLATFORMS_ARM}"
+          SNAPSHOT: true
+          # packaging with `DEV=true` may cause linker issues while crosscompiling https://github.com/elastic/beats/issues/41270
+          DEV: false
+        command: ".buildkite/scripts/packaging/package-dra.sh {{matrix}}"
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+        matrix:
+          - x-pack/agentbeat
           - x-pack/osquerybeat
 
       ## Agentbeat needs more CPUs because it builds many other beats
@@ -243,6 +264,27 @@ steps:
           - x-pack/metricbeat
           - x-pack/packetbeat
           - x-pack/osquerybeat
+
+      - label: "STAGING: {{matrix} all artifacts for Linux/arm64"
+        env:
+          PLATFORMS: "${PLATFORMS_ARM}"
+          SNAPSHOT: false
+          DEV: false
+        command: |
+          source .buildkite/scripts/version_qualifier.sh
+          .buildkite/scripts/packaging/package-dra.sh x-pack/osquerybeat
+        agents:
+          provider: "aws"
+          imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
+        matrix:
+          - x-pack/agentbeat
 
         ## Agentbeat needs more CPUs because it builds many other beats
       - label: "STAGING: x-pack/agentbeat"

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -41,7 +41,7 @@ const (
 	fpmVersion = "1.13.1"
 
 	// Docker images. See https://github.com/elastic/golang-crossbuild.
-	beatsFPMImage = "docker.elastic.co/observability-ci/fpm"
+	beatsFPMImage = "docker.elastic.co/beats-dev/fpm"
 	// BeatsCrossBuildImage is the image used for crossbuilding Beats.
 	BeatsCrossBuildImage = "docker.elastic.co/beats-dev/golang-crossbuild"
 

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -41,7 +41,7 @@ const (
 	fpmVersion = "1.13.1"
 
 	// Docker images. See https://github.com/elastic/golang-crossbuild.
-	beatsFPMImage = "docker.elastic.co/beats-dev/fpm"
+	beatsFPMImage = "docker.elastic.co/observability-ci/fpm"
 	// BeatsCrossBuildImage is the image used for crossbuilding Beats.
 	BeatsCrossBuildImage = "docker.elastic.co/beats-dev/golang-crossbuild"
 


### PR DESCRIPTION
## Proposed commit message

This commit is the counterpart of
https://github.com/elastic/beats/pull/43019 for the DRA packaging pipeline.

It ensures that arm64 packages get built without qemu emulation on dedicated arm64 workers.

## How to test this PR locally

Successful BK link:

https://buildkite.com/elastic/beats-packaging-pipeline/builds/2656#01956655-e341-4ec5-a3a2-859c4fac28a8

and another one using the latest commit: https://buildkite.com/elastic/beats-packaging-pipeline/builds/2664

where both staging + snapshot got triggered using `DRA_DRY_RUN=false`


Additionally, I compared the DRA job output for snapshot artifacts from the above triggered job , against the latest successful [DRA build on main](https://buildkite.com/elastic/beats-packaging-pipeline/builds/2626#01956241-0b5f-4a9f-b6da-1516f27f0d19) and the results were identical.

## Related issues

Closes https://github.com/elastic/beats/issues/43042

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

