### PR TITLE
[REVERT] Update Stack Monitoring data stream to 9

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -82,7 +82,7 @@ func (p Product) String() string {
 // MakeXPackMonitoringIndexName method returns the name of the monitoring index for
 // a given product { elasticsearch, kibana, logstash, beats }
 func MakeXPackMonitoringIndexName(product Product) string {
-	const version = "9"
+	const version = "8"
 
 	return fmt.Sprintf(".monitoring-%v-%v-mb", product.xPackMonitoringIndexString(), version)
 }

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -38,22 +38,22 @@ func TestMakeXPackMonitoringIndexName(t *testing.T) {
 		{
 			"Elasticsearch monitoring index",
 			Elasticsearch,
-			".monitoring-es-9-mb",
+			".monitoring-es-8-mb",
 		},
 		{
 			"Kibana monitoring index",
 			Kibana,
-			".monitoring-kibana-9-mb",
+			".monitoring-kibana-8-mb",
 		},
 		{
 			"Logstash monitoring index",
 			Logstash,
-			".monitoring-logstash-9-mb",
+			".monitoring-logstash-8-mb",
 		},
 		{
 			"Beats monitoring index",
 			Beats,
-			".monitoring-beats-9-mb",
+			".monitoring-beats-8-mb",
 		},
 	}
 


### PR DESCRIPTION
This PR reverts https://github.com/elastic/beats/pull/42823/

On an afterthought, there are (too) many things that can go wrong on the upgrade path from 8 to 9 (both in ECH and ESM). Given the days of the `.monitoring` indices are counted, we'll keep it low friction and stay on `-8-`.

Sorry for the noise