### PR TITLE
Execute Go integration tests sequentially within a beat module

### DIFF
--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -60,7 +60,7 @@ type TestBinaryArgs struct {
 }
 
 func makeGoTestArgs(name string) GoTestArgs {
-	fileName := fmt.Sprintf("build/TEST-go-%s", strings.Replace(strings.ToLower(name), " ", "_", -1))
+	fileName := fmt.Sprintf("build/TEST-go-%s", strings.ReplaceAll(strings.ToLower(name), " ", "_"))
 	params := GoTestArgs{
 		TestName:        name,
 		Race:            RaceDetector,
@@ -102,7 +102,7 @@ func makeGoTestArgsForPackage(name, pkg string) GoTestArgs {
 //
 //	[kafka kafka/broker kafka/consumer kafka/consumergroup kafka/partition kafka/producer]
 func fetchGoPackages(module string) ([]string, error) {
-	cmd := exec.Command("go", "list", "-tags", "integration", fmt.Sprintf("./%s/...", module)) // nolint:gosec // used only to run tests
+	cmd := exec.Command("go", "list", "-tags", "integration", fmt.Sprintf("./%s/...", module)) //nolint:gosec // used only to run tests
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -77,8 +77,10 @@ func makeGoTestArgs(name string) GoTestArgs {
 }
 
 func makeGoTestArgsForPackage(name, pkg string) GoTestArgs {
-	fileName := fmt.Sprintf("build/TEST-go-%s-%s", strings.Replace(strings.ToLower(name), " ", "_", -1),
-		strings.Replace(strings.ToLower(pkg), " ", "_", -1))
+	fileName := fmt.Sprintf(
+		"build/TEST-go-%s-%s",
+		strings.ReplaceAll(strings.ToLower(name), " ", "_"),
+		strings.ReplaceAll(strings.ToLower(pkg), " ", "_"))
 	params := GoTestArgs{
 		TestName:        fmt.Sprintf("%s-%s", name, pkg),
 		Race:            RaceDetector,
@@ -100,7 +102,7 @@ func makeGoTestArgsForPackage(name, pkg string) GoTestArgs {
 //
 //	[kafka kafka/broker kafka/consumer kafka/consumergroup kafka/partition kafka/producer]
 func fetchGoPackages(module string) ([]string, error) {
-	cmd := exec.Command("go", "list", "-tags", "integration", fmt.Sprintf("./%s/...", module))
+	cmd := exec.Command("go", "list", "-tags", "integration", fmt.Sprintf("./%s/...", module)) // nolint:gosec // used only to run tests
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -100,7 +100,7 @@ func makeGoTestArgsForPackage(name, pkg string) GoTestArgs {
 //
 //	[kafka kafka/broker kafka/consumer kafka/consumergroup kafka/partition kafka/producer]
 func fetchGoPackages(module string) ([]string, error) {
-	cmd := exec.Command("go", "list", fmt.Sprintf("./%s/...", module))
+	cmd := exec.Command("go", "list", "-tags", "integration", fmt.Sprintf("./%s/...", module))
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/kafka/broker/broker_integration_test.go
+++ b/metricbeat/module/kafka/broker/broker_integration_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),
@@ -45,7 +44,6 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),

--- a/metricbeat/module/kafka/consumer/consumer_integration_test.go
+++ b/metricbeat/module/kafka/consumer/consumer_integration_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),
@@ -45,7 +44,6 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),

--- a/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
@@ -44,15 +44,15 @@ func TestData(t *testing.T) {
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),
 	)
-	hostForPort := service.HostForPort(9092)
+	host := service.HostForPort(9092)
 
-	c, err := startConsumer(t, hostForPort, "test-group")
+	c, err := startConsumer(t, host, "test-group")
 	if err != nil {
 		t.Fatal(fmt.Errorf("starting kafka consumer: %w", err))
 	}
 	defer c.Close()
 
-	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(hostForPort))
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(host))
 	for retries := 0; retries < 3; retries++ {
 		err = mbtest.WriteEventsReporterV2Error(ms, t, "")
 		if err == nil {

--- a/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
@@ -40,19 +40,19 @@ const (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),
 	)
+	hostForPort := service.HostForPort(9092)
 
-	c, err := startConsumer(t, service.HostForPort(9092), "test-group")
+	c, err := startConsumer(t, hostForPort, "test-group")
 	if err != nil {
 		t.Fatal(fmt.Errorf("starting kafka consumer: %w", err))
 	}
 	defer c.Close()
 
-	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.HostForPort(9092)))
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(hostForPort))
 	for retries := 0; retries < 3; retries++ {
 		err = mbtest.WriteEventsReporterV2Error(ms, t, "")
 		if err == nil {
@@ -64,7 +64,6 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -66,7 +66,7 @@ func TestTopic(t *testing.T) {
 	)
 
 	logp.TestingSetup(logp.WithSelectors("kafka"))
-	id := strconv.Itoa(rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())).Int())
+	id := strconv.Itoa(rand.Int())
 	testTopic := fmt.Sprintf("test-metricbeat-%s", id)
 
 	// Create initial topic

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -21,7 +21,7 @@ package partition
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 	"time"
@@ -66,8 +66,7 @@ func TestTopic(t *testing.T) {
 	)
 
 	logp.TestingSetup(logp.WithSelectors("kafka"))
-
-	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
+	id := strconv.Itoa(rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())).Int())
 	testTopic := fmt.Sprintf("test-metricbeat-%s", id)
 
 	// Create initial topic

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -44,7 +44,6 @@ const (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),
@@ -61,7 +60,6 @@ func TestData(t *testing.T) {
 }
 
 func TestTopic(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -106,13 +106,13 @@ func TestTopic(t *testing.T) {
 
 	// Its possible that other topics exists -> select the right data
 	for _, data := range dataBefore {
-		if data.ModuleFields["topic"].(mapstr.M)["name"] == testTopic {
+		if data.ModuleFields["topic"].(mapstr.M)["name"] == testTopic { //nolint:errcheck // it's fine for a test
 			offsetBefore, _ = data.MetricSetFields["offset"].(mapstr.M)["newest"].(int64)
 		}
 	}
 
 	for _, data := range dataAfter {
-		if data.ModuleFields["topic"].(mapstr.M)["name"] == testTopic {
+		if data.ModuleFields["topic"].(mapstr.M)["name"] == testTopic { //nolint:errcheck // it's fine for a test
 			offsetAfter, _ = data.MetricSetFields["offset"].(mapstr.M)["newest"].(int64)
 		}
 	}

--- a/metricbeat/module/kafka/producer/producer_integration_test.go
+++ b/metricbeat/module/kafka/producer/producer_integration_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),
@@ -45,7 +44,6 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42808")
 	service := compose.EnsureUp(t, "kafka",
 		compose.UpWithTimeout(600*time.Second),
 		compose.UpWithAdvertisedHostEnvFileForPort(9092),

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -227,7 +227,6 @@ func TestPostgreSQL(t *testing.T) {
 }
 
 func TestOracle(t *testing.T) {
-	t.Skip("Flaky test: test containers fail over attempt to bind port 5500 https://github.com/elastic/beats/issues/35105")
 	service := compose.EnsureUp(t, "oracle")
 	host, port, _ := net.SplitHostPort(service.Host())
 	cfg := testFetchConfig{

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -285,9 +285,11 @@ func getConfig(cfg testFetchConfig) map[string]interface{} {
 func assertFieldNotContains(field, s string) func(t *testing.T, event beat.Event) {
 	return func(t *testing.T, event beat.Event) {
 		value, err := event.GetValue(field)
-		assert.NoError(t, err)
-		require.NotEmpty(t, value.(string))
-		require.NotContains(t, value.(string), s)
+		require.NoError(t, err)
+		val, ok := value.(string)
+		require.Truef(t, ok, "value is not a string, it's %T", value)
+		require.NotEmpty(t, val)
+		require.NotContains(t, val, s)
 	}
 }
 


### PR DESCRIPTION
## Proposed commit message

```
execute Go integration testes sequentially within a beat module

The current abstraction the modules integration tests use adds a lock on the `docker-compose.yml` being used by the tests. Some modules have several packages sharing a single `docker-compose.yml`, what would cause a timeout while the test waited to acquire the lock.

Right now it isn't viable to have each test using a unique docker compose project name as some of the setups bind to host ports, making it impossible to run some docker compose projects in parallel. Also, running several docker compose projects in parallel might overwhelm the CI runners. Therefore, running each Go package within a beats module patches the problem while we find a better solution.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

 - N/A

## How to test this PR locally

Run all integration tests for a beat. Eg:
```
cd filebeat
mage goIntegTest
```

## Related issues

- Closes https://github.com/elastic/beats/issues/42808
- Closes https://github.com/elastic/beats/issues/35105