### PR TITLE
Fix flaky http_endpoint test

### DIFF
--- a/x-pack/filebeat/tests/system/test_http_endpoint.py
+++ b/x-pack/filebeat/tests/system/test_http_endpoint.py
@@ -246,15 +246,20 @@ class Test(BaseTest):
         assert r.json()[
             'message'] == 'wrong Content-Type header, expecting application/json'
 
-    @unittest.skipIf(os.getenv("CI") is not None and platform.system() == 'Darwin', 'Flaky test: https://github.com/elastic/beats/issues/30028')
     def test_http_endpoint_missing_auth_value(self):
         """
         Test http_endpoint input with missing basic auth values.
         """
+        # Include a benchmark input to keep the beat alive, otherwise it might
+        # shut down before logging the error we're looking for
         options = """
   basic_auth: true
   username: testuser
   password:
+#- type: benchmark
+#  enabled: true
+#  message: "placeholder"
+#  eps: 1
 """
         self.get_config(options)
         filebeat = self.start_beat()

--- a/x-pack/filebeat/tests/system/test_http_endpoint.py
+++ b/x-pack/filebeat/tests/system/test_http_endpoint.py
@@ -256,10 +256,10 @@ class Test(BaseTest):
   basic_auth: true
   username: testuser
   password:
-#- type: benchmark
-#  enabled: true
-#  message: "placeholder"
-#  eps: 1
+- type: benchmark
+  enabled: true
+  message: "placeholder"
+  eps: 1
 """
         self.get_config(options)
         filebeat = self.start_beat()


### PR DESCRIPTION
Address [flakiness](https://github.com/elastic/beats/issues/30028) [issues](https://github.com/elastic/beats/issues/43098) in `test_http_endpoint_missing_auth_value`.

`test_http_endpoint_missing_auth_value` involves providing an invalid configuration to the `http_endpoint` input and verifying that the right error message appears in the logs. Logs on failed runs show that (because there are no valid inputs) sometimes the beat shuts down too quickly, before the input's log message about the failure appears in the log files, leading the test to time out waiting for a message on unchanging log files for a (correctly) shut down beat.

This PR addresses that by adding a second (ignored) input to the test configuration, so the beat will not shut down until the test is over. This gives the desired error message time to propagate to the logs.

It is hard to completely verify that this fixes the test's flakiness, since the failure itself can't be reliably reproduced, but it does address the most apparent cause.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Closes #30028 
- Closes #43098 
