### PR TITLE
[Draft] Fix broken mssql python integration tests

### DIFF
--- a/x-pack/metricbeat/module/mssql/test_mssql.py
+++ b/x-pack/metricbeat/module/mssql/test_mssql.py
@@ -18,7 +18,7 @@ class Test(XPackTest):
     def asdf_start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
-        #super().start_beat()  # env={"GODEBUG": "x509negativeserial=1"})
+        # super().start_beat()  # env={"GODEBUG": "x509negativeserial=1"})
         pass
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")

--- a/x-pack/metricbeat/module/mssql/test_mssql.py
+++ b/x-pack/metricbeat/module/mssql/test_mssql.py
@@ -15,7 +15,7 @@ class Test(XPackTest):
 
     COMPOSE_SERVICES = ['mssql']
 
-    def start_beat():
+    def start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
         super().start_beat(env={"GODEBUG": "x509negativeserial=1"})

--- a/x-pack/metricbeat/module/mssql/test_mssql.py
+++ b/x-pack/metricbeat/module/mssql/test_mssql.py
@@ -18,7 +18,7 @@ class Test(XPackTest):
     def start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
-        super().start_beat()#env={"GODEBUG": "x509negativeserial=1"})
+        super().start_beat()  # env={"GODEBUG": "x509negativeserial=1"})
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @pytest.mark.tag('integration')

--- a/x-pack/metricbeat/module/mssql/test_mssql.py
+++ b/x-pack/metricbeat/module/mssql/test_mssql.py
@@ -15,6 +15,11 @@ class Test(XPackTest):
 
     COMPOSE_SERVICES = ['mssql']
 
+    def start_beat():
+        # go 1.23 no longer accepts the negative serials used in mssql test
+        # container certificates, add a debug flag to allow them.
+        super().start_beat(env={"GODEBUG": "x509negativeserial=1"})
+
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @pytest.mark.tag('integration')
     def test_status(self):

--- a/x-pack/metricbeat/module/mssql/test_mssql.py
+++ b/x-pack/metricbeat/module/mssql/test_mssql.py
@@ -15,10 +15,11 @@ class Test(XPackTest):
 
     COMPOSE_SERVICES = ['mssql']
 
-    def start_beat(self):
+    def asdf_start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
-        super().start_beat()  # env={"GODEBUG": "x509negativeserial=1"})
+        #super().start_beat()  # env={"GODEBUG": "x509negativeserial=1"})
+        pass
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @pytest.mark.tag('integration')

--- a/x-pack/metricbeat/module/mssql/test_mssql.py
+++ b/x-pack/metricbeat/module/mssql/test_mssql.py
@@ -18,7 +18,7 @@ class Test(XPackTest):
     def start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
-        super().start_beat(env={"GODEBUG": "x509negativeserial=1"})
+        super().start_beat()#env={"GODEBUG": "x509negativeserial=1"})
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @pytest.mark.tag('integration')

--- a/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
@@ -8,6 +8,11 @@ from xpack_metricbeat import XPackTest, metricbeat
 class Test(XPackTest):
     COMPOSE_SERVICES = ['mssql']
 
+    def start_beat():
+        # go 1.23 no longer accepts the negative serials used in mssql test
+        # container certificates, add a debug flag to allow them.
+        super().start_beat(env={"GODEBUG": "x509negativeserial=1"})
+
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_query_without_fetch_from_all_databases(self):
         """

--- a/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
@@ -11,7 +11,7 @@ class Test(XPackTest):
     def start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
-        super().start_beat(env={"GODEBUG": "x509negativeserial=1"})
+        super().start_beat()#env={"GODEBUG": "x509negativeserial=1"})
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_query_without_fetch_from_all_databases(self):

--- a/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
@@ -11,7 +11,7 @@ class Test(XPackTest):
     def start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
-        super().start_beat()#env={"GODEBUG": "x509negativeserial=1"})
+        super().start_beat()  # env={"GODEBUG": "x509negativeserial=1"})
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_query_without_fetch_from_all_databases(self):

--- a/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_mssql.py
@@ -8,7 +8,7 @@ from xpack_metricbeat import XPackTest, metricbeat
 class Test(XPackTest):
     COMPOSE_SERVICES = ['mssql']
 
-    def start_beat():
+    def start_beat(self):
         # go 1.23 no longer accepts the negative serials used in mssql test
         # container certificates, add a debug flag to allow them.
         super().start_beat(env={"GODEBUG": "x509negativeserial=1"})


### PR DESCRIPTION
Go 1.23 changed the handling of some TLS certificate corner cases, which breaks the certificates used in mssql test containers. This PR adds a godebug environment variable to the mssql integration tests to allow the mssql test containers to be used.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

