### PR TITLE
catalog-info: Enable Buildkite status comments in PR

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -55,8 +55,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
-        ELASTIC_PR_COMMENTS_ENABLED: "false"
+        ELASTIC_PR_COMMENTS_ENABLED: "true"
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
@@ -106,7 +105,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
-        # TODO set to truue once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -153,7 +152,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
-        # TODO set to truue once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -200,7 +199,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -247,7 +246,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -294,7 +293,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.* !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -341,7 +340,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -388,7 +387,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -434,7 +433,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -481,7 +480,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -528,7 +527,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -575,7 +574,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -622,7 +621,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -669,7 +668,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -786,7 +785,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -833,7 +832,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -880,7 +879,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -927,7 +926,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -974,7 +973,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !7.17 !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:
@@ -1021,7 +1020,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: "!main !8.* !9.*"
       env:
-        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        # NOTE: This pipeline does not run on github events but it is triggered by the main pipeline
         ELASTIC_PR_COMMENTS_ENABLED: "false"
       teams:
         ingest-fp:


### PR DESCRIPTION
## Proposed commit message

Enable a GH comment with the build status.

It was reverted in https://github.com/elastic/beats/pull/38554

However, we are gonna take a stab and enable it back.

We won't run for the specific beats pipelines but for the main, that's the one acting as an orchestrator.

There will be a follow up to replace:

```diff
diff --git a/.buildkite/pipeline.yml b/.buildkite/pipeline.yml
index 7bc0916239..f48dcc420e 100644
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -558,14 +558,12 @@ steps:
                 - libbeat/
                 - testing/
               config:
-                trigger: "beats-winlogbeat"
-                build:
-                  commit: "${BUILDKITE_COMMIT}"
-                  branch: "${BUILDKITE_BRANCH}"
-                  env:
-                    - BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST}
-                    - BUILDKITE_PULL_REQUEST_BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
-                    - GITHUB_PR_LABELS=${GITHUB_PR_LABELS}
+                label: ":pipeline: Upload beats-winlogbeat"
+                command: "buildkite-agent pipeline upload ..buildkite/winlogbeat/pipeline.winlogbeat.yml"
+                env:
+                  - BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST}
+                  - BUILDKITE_PULL_REQUEST_BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
+                  - GITHUB_PR_LABELS=${GITHUB_PR_LABELS}
 
   - label: "Triggering Build for Winlogbeat"
     if: build.pull_request.id == null

```

We don't need to backport, `catalog-info.yml` does not need to b backported, it only honours the main branch.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
