### PR TITLE
chore: fix flakiness and add comments to explain testing logic

### DIFF
--- a/x-pack/filebeat/input/awss3/sqs_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_test.go
@@ -47,7 +47,7 @@ func TestSQSReceiver(t *testing.T) {
 		msg, err := newSQSMessage(newS3Event("log.json"))
 		require.NoError(t, err)
 
-		// Initial ReceiveMessage for maxMessages.
+		// Initial ReceiveMessage call returns the mock message.
 		mockSQS.EXPECT().
 			ReceiveMessage(gomock.Any(), gomock.Any()).
 			Times(1).
@@ -56,11 +56,10 @@ func TestSQSReceiver(t *testing.T) {
 				return []types.Message{msg}, nil
 			})
 
-		// Follow up ReceiveMessages for either maxMessages-1 or maxMessages
-		// depending on how long processing of previous message takes.
+		// Follow up ReceiveMessages returns empty message and could be called any times till validation is completed.
 		mockSQS.EXPECT().
 			ReceiveMessage(gomock.Any(), gomock.Any()).
-			Times(1).
+			AnyTimes().
 			DoAndReturn(func(_ context.Context, _ int) ([]types.Message, error) {
 				return nil, nil
 			})
@@ -71,6 +70,7 @@ func TestSQSReceiver(t *testing.T) {
 				return map[string]string{sqsApproximateNumberOfMessages: "10000"}, nil
 			}).AnyTimes()
 
+		// Deletion happens when message is fully processed. Cancel the context and mark for exit.
 		mockSQS.EXPECT().
 			DeleteMessage(gomock.Any(), gomock.Any()).Times(1).Do(
 			func(_ context.Context, _ *types.Message) {


### PR DESCRIPTION
## Proposed commit message

Fixes flakiness of SQS unit test. Fix focus on accepting `AnyTimes()` to the subsequent `ReceiveMessage` mock. The flakiness originated from `Times(1)` contract which may or may not happen due to the concurrency used in the processing logic. 

In short,

- `ReceiveMessage` reads messages from sqs api
- Messages read are pushed to workers that run concurrently 
    - Reader continues to read more messages while workers work
-  Worker deletes the sqs queue entry upon full processing of the message
    - This deletion in test is used to invoke context completion 

The flakiness came from reader continuing to read and cancellation of the context, where if context cancellation happens before next message, we end up with missing calls to the mock. 

## Related issues

Closes #41458