### PR TITLE
fix:  Use of insecure SSL/TLS version

### DIFF
--- a/filebeat/tests/system/test_tcp_tls.py
+++ b/filebeat/tests/system/test_tcp_tls.py
@@ -341,6 +341,7 @@ class Test(BaseTest):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
         context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.verify_mode = ssl.CERT_REQUIRED
         context.load_verify_locations(CACERT)
         context.load_cert_chain(certfile=CLIENT2, keyfile=CLIENTKEY2)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
https://github.com/elastic/beats/blob/1f57a4e37a6357a3bc784b725461851bd1246ce1/filebeat/tests/system/test_tcp_tls.py#L349-L349

To fix the problem, we need to ensure that the SSL/TLS context created by `ssl.create_default_context` only allows secure protocol versions (TLS 1.2 and above). This can be achieved by setting the `minimum_version` attribute of the context to `ssl.TLSVersion.TLSv1_2`. This change ensures that the context will not use any insecure versions of SSL/TLS.


## POC
The following code shows a variety of ways of setting up a connection using SSL or TLS. They are all insecure because of the version specified.
```py
import ssl
import socket

# Using the deprecated ssl.wrap_socket method
ssl.wrap_socket(socket.socket(), ssl_version=ssl.PROTOCOL_SSLv2)

# Using SSLContext
context = ssl.SSLContext(ssl_version=ssl.PROTOCOL_SSLv3)

# Using pyOpenSSL

from pyOpenSSL import SSL

context = SSL.Context(SSL.TLSv1_METHOD)
```
All cases should be updated to use a secure protocol, such as `PROTOCOL_TLSv1_2`.

Note that `ssl.wrap_socket` has been deprecated in Python 3.7. The recommended alternatives are:
 - `ssl.SSLContext` - supported in Python 2.7.9, 3.2, and later versions
 - `ssl.create_default_context` - a convenience function, supported in Python 3.4 and later versions.
Even when you use these alternatives, you should ensure that a safe protocol is used. The following code illustrates how to use flags (available since Python 3.2) or the `minimum_version` field (favored since Python 3.7) to restrict the protocols accepted when creating a connection.


```py
import ssl

# Using flags to restrict the protocol
context = ssl.SSLContext()
context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1

# Declaring a minimum version to restrict the protocol
context = ssl.create_default_context()
context.minimum_version = ssl.TLSVersion.TLSv1_2
```
References
[Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security)
[class ssl.SSLContext](https://docs.python.org/3/library/ssl.html#ssl.SSLContext)
[ssl.wrap_socket](https://docs.python.org/3/library/ssl.html#ssl.wrap_socket)
[notes on context creation](https://docs.python.org/3/library/ssl.html#functions-constants-and-exceptions)
[notes on security considerations](https://docs.python.org/3/library/ssl.html#ssl-security)
[An interface to the SSL-specific parts of OpenSSL](https://pyopenssl.org/en/stable/api/ssl.html)
[CWE-327](https://cwe.mitre.org/data/definitions/327.html)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



