### PR TITLE
Remove functionbeat from DRA in 8x branch

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -147,7 +147,6 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
-          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat
@@ -240,7 +239,6 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
-          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/packetbeat


### PR DESCRIPTION
## Proposed commit message

This commit removes x-pack/functionbeat from the DRA process in the 8.x branch, which was missed from #43090
It fixes the currently broken 8.x DRA which is still attempting to build x-pack/functionbeat after the corresponding
scripts got removed via #43090


## How to test this PR locally

Can only be tested in CI: [link](https://buildkite.com/elastic/beats-packaging-pipeline/builds/2784) (only available to Elastic internal)

## Related issues

- Relates #43090 
