### PR TITLE
feat: Introduce lastSync start position to AWS CloudWatch input backed by state registry

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -447,6 +447,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fix handling of ADC (Application Default Credentials) metadata server credentials in HTTPJSON input. {issue}44349[44349] {pull}44436[44436]
 - Fix handling of ADC (Application Default Credentials) metadata server credentials in CEL input. {issue}44349[44349] {pull}44571[44571]
 - Added support for specifying custom content-types and encodings in azureblobstorage input. {issue}44330[44330] {pull}44402[44402]
+- Introduce lastSync start position to AWS CloudWatch input backed by state registry. {pull}43251[43251]
 
 *Auditbeat*
 

--- a/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
+++ b/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
@@ -77,29 +77,29 @@ A string to filter the results to include only log events from log streams that 
 
 ### `start_position` [_start_position]
 
-`start_position` allows user to specify if this input should read log files from the `beginning`, `end` or from the last known successful sync (`lastSync`).
+`start_position` allows the user to specify if this input should read log files starting from the `beginning`, the `end`, or from the last known successful sync (`lastSync`).
 
-* `beginning`: Reads from the beginning of the log group (default).
-* `end`: Read only new messages from current time minus `scan_frequency` going forward
-* `lastSync`: Read messages starting from the last known sync time if available. If there is no last known sync, then
-  falls back to beginning (default mode). This value is stored in the registry, so it persists across restarts.
+* `beginning`: Read messages starting from the beginning of the log group (default).
+* `end`: Read messages starting from the current time minus `scan_frequency`.
+* `lastSync`: Read messages starting from the last known sync time, if available. If there is no last known sync, then
+  fall back to the default mode (`beginning`). This value is stored in the registry, so it persists across restarts.
 
-For example, with `scan_frequency: 30s` and if the current timestamp is `2020-06-24 12:00:00`:
+For example, in the case where `scan_frequency: 30s` and the current timestamp is `2020-06-24 12:00:00`:
 
-* When `start_position: beginning`, reading starts from the earliest possible timestamp of unix epoch zero value,
+* If `start_position: beginning`, reading starts from the earliest possible timestamp of unix epoch zero value:
 
-    * First read: startTime=0, endTime=2020-06-24 12:00:00
-    * Next read: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
+    * First read: `startTime=0`, `endTime=2020-06-24 12:00:00`
+    * Next read: `startTime=2020-06-24 12:00:00`, `endTime=2020-06-24 12:00:30`
 
-* When `start_position: end`, reading starts with a look back equals to the `scan_frequency`,
+* If `start_position: end`, reading starts with a look back that equals the `scan_frequency`:
 
-    * First read: startTime=2020-06-24 11:59:30, endTime=2020-06-24 12:00:00
-    * Next read: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
+    * First read: `startTime=2020-06-24 11:59:30`, `endTime=2020-06-24 12:00:00`
+    * Next read: `startTime=2020-06-24 12:00:00`, `endTime=2020-06-24 12:00:30`
 
-* When `start_position: lastSync`, reading starts from the last known sync timestamp. Assuming last sync timestamp stored in the registry is `2020-06-23 12:00:00`,
+* If `start_position: lastSync`, reading starts from the last known sync timestamp. Assuming the last sync timestamp stored in the registry is `2020-06-23 12:00:00`:
 
-    * First read: startTime=2020-06-23 12:00:00, endTime=2020-06-24 12:00:00
-    * Next read: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
+    * First read: `startTime=2020-06-23 12:00:00`, `endTime=2020-06-24 12:00:00`
+    * Next read: `startTime=2020-06-24 12:00:00`, `endTime=2020-06-24 12:00:30`
 
 
 

--- a/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
+++ b/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
@@ -77,22 +77,29 @@ A string to filter the results to include only log events from log streams that 
 
 ### `start_position` [_start_position]
 
-`start_position` allows user to specify if this input should read log files from the `beginning` or from the `end`.
+`start_position` allows user to specify if this input should read log files from the `beginning`, `end` or from the last known successful sync (`lastSync`).
 
-* `beginning`: reads from the beginning of the log group (default).
-* `end`: read only new messages from current time minus `scan_frequency` going forward
+* `beginning`: Reads from the beginning of the log group (default).
+* `end`: Read only new messages from current time minus `scan_frequency` going forward
+* `lastSync`: Read messages starting from the last known sync time if available. If there is no last known sync, then
+  falls back to beginning (default mode). This value is stored in the registry, so it persists across restarts.
 
-For example, with `scan_frequency` equals to `30s` and current timestamp is `2020-06-24 12:00:00`:
+For example, with `scan_frequency: 30s` and if the current timestamp is `2020-06-24 12:00:00`:
 
-* with `start_position = beginning`:
+* When `start_position: beginning`, reading starts from the earliest possible timestamp of unix epoch zero value,
 
-    * first iteration: startTime=0, endTime=2020-06-24 12:00:00
-    * second iteration: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
+    * First read: startTime=0, endTime=2020-06-24 12:00:00
+    * Next read: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
 
-* with `start_position = end`:
+* When `start_position: end`, reading starts with a look back equals to the `scan_frequency`,
 
-    * first iteration: startTime=2020-06-24 11:59:30, endTime=2020-06-24 12:00:00
-    * second iteration: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
+    * First read: startTime=2020-06-24 11:59:30, endTime=2020-06-24 12:00:00
+    * Next read: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
+
+* When `start_position: lastSync`, reading starts from the last known sync timestamp. Assuming last sync timestamp stored in the registry is `2020-06-23 12:00:00`,
+
+    * First read: startTime=2020-06-23 12:00:00, endTime=2020-06-24 12:00:00
+    * Next read: startTime=2020-06-24 12:00:00, endTime=2020-06-24 12:00:30
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -390,6 +390,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rs/cors v1.11.1 // indirect
+	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -908,6 +908,8 @@ github.com/samuel/go-parser v0.0.0-20130731160455-ca8abbf65d0e h1:hUGyBE/4CXRPTh
 github.com/samuel/go-parser v0.0.0-20130731160455-ca8abbf65d0e/go.mod h1:Sb6li54lXV0yYEjI4wX8cucdQ9gqUJV3+Ngg3l9g30I=
 github.com/samuel/go-thrift v0.0.0-20140522043831-2187045faa54 h1:jbchLJWyhKcmOjkbC4zDvT/n5EEd7g6hnnF760rEyRA=
 github.com/samuel/go-thrift v0.0.0-20140522043831-2187045faa54/go.mod h1:Vrkh1pnjV9Bl8c3P9zH0/D4NlOHWP5d4/hF4YTULaec=
+github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
+github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
@@ -6,14 +6,12 @@ package awscloudwatch
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync"
 	"time"
 
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -67,85 +65,18 @@ func newCloudwatchPoller(log *logp.Logger, metrics *inputMetrics,
 	}
 }
 
-func (p *cloudwatchPoller) run(svc *cloudwatchlogs.Client, logGroupId string, startTime, endTime time.Time, logProcessor *logProcessor) {
-	err := p.getLogEventsFromCloudWatch(svc, logGroupId, startTime, endTime, logProcessor)
-	if err != nil {
-		var errRequestCanceled *awssdk.RequestCanceledError
-		if errors.As(err, &errRequestCanceled) {
-			p.log.Error("getLogEventsFromCloudWatch failed with RequestCanceledError: ", errRequestCanceled)
-		}
-		p.log.Error("getLogEventsFromCloudWatch failed: ", err)
-	}
-}
-
-// getLogEventsFromCloudWatch uses FilterLogEvents API to collect logs from CloudWatch
-func (p *cloudwatchPoller) getLogEventsFromCloudWatch(svc *cloudwatchlogs.Client, logGroupId string, startTime, endTime time.Time, logProcessor *logProcessor) error {
-	// construct FilterLogEventsInput
-	filterLogEventsInput := p.constructFilterLogEventsInput(startTime, endTime, logGroupId)
-	paginator := cloudwatchlogs.NewFilterLogEventsPaginator(svc, filterLogEventsInput)
-	for paginator.HasMorePages() {
-		filterLogEventsOutput, err := paginator.NextPage(context.TODO())
-		if err != nil {
-			return fmt.Errorf("error FilterLogEvents with Paginator: %w", err)
-		}
-
-		p.metrics.apiCallsTotal.Inc()
-		logEvents := filterLogEventsOutput.Events
-		p.metrics.logEventsReceivedTotal.Add(uint64(len(logEvents)))
-
-		// This sleep is to avoid hitting the FilterLogEvents API limit(5 transactions per second (TPS)/account/Region).
-		p.log.Debugf("sleeping for %v before making FilterLogEvents API call again", p.config.APISleep)
-		time.Sleep(p.config.APISleep)
-		p.log.Debug("done sleeping")
-
-		p.log.Debugf("Processing #%v events", len(logEvents))
-		logProcessor.processLogEvents(logEvents, logGroupId, p.region)
-	}
-	return nil
-}
-
-func (p *cloudwatchPoller) constructFilterLogEventsInput(startTime, endTime time.Time, logGroupId string) *cloudwatchlogs.FilterLogEventsInput {
-	p.log.Debugf("FilterLogEventsInput for log group: '%s' with startTime = '%v' and endTime = '%v'", logGroupId, unixMsFromTime(startTime), unixMsFromTime(endTime))
-	filterLogEventsInput := &cloudwatchlogs.FilterLogEventsInput{
-		LogGroupIdentifier: awssdk.String(logGroupId),
-		StartTime:          awssdk.Int64(unixMsFromTime(startTime)),
-		EndTime:            awssdk.Int64(unixMsFromTime(endTime)),
-	}
-
-	if len(p.config.LogStreams) > 0 {
-		for _, stream := range p.config.LogStreams {
-			filterLogEventsInput.LogStreamNames = append(filterLogEventsInput.LogStreamNames, *stream)
-		}
-	}
-
-	if p.config.LogStreamPrefix != "" {
-		filterLogEventsInput.LogStreamNamePrefix = awssdk.String(p.config.LogStreamPrefix)
-	}
-	return filterLogEventsInput
-}
-
-func (p *cloudwatchPoller) startWorkers(
-	ctx context.Context,
-	svc *cloudwatchlogs.Client,
-	logProcessor *logProcessor,
-) {
+func (p *cloudwatchPoller) startWorkers(ctx context.Context, svc *cloudwatchlogs.Client, pipeline beat.Pipeline) {
 	for i := 0; i < p.config.NumberOfWorkers; i++ {
 		p.workerWg.Add(1)
 		go func() {
 			defer p.workerWg.Done()
-			for {
-				var work workResponse
-				select {
-				case <-ctx.Done():
-					return
-				case p.workRequestChan <- struct{}{}:
-					work = <-p.workResponseChan
-				}
 
-				p.log.Infof("aws-cloudwatch input worker for log group: '%v' has started", work.logGroupId)
-				p.run(svc, work.logGroupId, work.startTime, work.endTime, logProcessor)
-				p.log.Infof("aws-cloudwatch input worker for log group '%v' has stopped.", work.logGroupId)
+			worker, err := newCWWorker(p.config, p.region, p.metrics, svc, pipeline, p.log)
+			if err != nil {
+				p.log.Error("Error creating CloudWatch worker: ", err)
+				return
 			}
+			worker.Start(ctx, p.workRequestChan, p.workResponseChan, p.stateHandler)
 		}()
 	}
 }
@@ -170,7 +101,7 @@ func (p *cloudwatchPoller) receive(ctx context.Context, logGroupIDs []string, cl
 	}
 
 	if p.config.StartPosition == lastSync {
-		state, err := p.stateHandler.GetState(p.config)
+		state, err := p.stateHandler.GetState()
 		if err != nil {
 			p.log.Errorf("error retrieving state from stateHandler: %v, falling back to %s", err, beginning)
 			startTime = time.Unix(0, 0)
@@ -180,6 +111,8 @@ func (p *cloudwatchPoller) receive(ctx context.Context, logGroupIDs []string, cl
 	}
 
 	for ctx.Err() == nil {
+		p.stateHandler.WorkRegister(endTime.UnixMilli(), len(logGroupIDs))
+
 		for _, lg := range logGroupIDs {
 			select {
 			case <-ctx.Done():
@@ -203,11 +136,6 @@ func (p *cloudwatchPoller) receive(ctx context.Context, logGroupIDs []string, cl
 
 		// Advance to the next time span
 		startTime, endTime = endTime, clock().Add(-p.config.Latency)
-
-		// Store the last sync timestamp
-		if err := p.stateHandler.StoreState(p.config, StorableState{LastSyncEpoch: startTime.UnixMilli()}); err != nil {
-			p.log.Errorf("error storing state: %v, next sync(s) will continue without state storage support", err)
-		}
 	}
 }
 

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker.go
@@ -1,0 +1,214 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awscloudwatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common/acker"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+type cwWorker struct {
+	client    beat.Client
+	config    config
+	log       *logp.Logger
+	metrics   *inputMetrics
+	processor *logProcessor
+	region    string
+	svc       *cloudwatchlogs.Client
+	tracker   *ackTracker
+}
+
+func newCWWorker(cfg config,
+	region string,
+	metrics *inputMetrics,
+	svc *cloudwatchlogs.Client,
+	pipeline beat.Pipeline,
+	log *logp.Logger) (*cwWorker, error) {
+
+	cw := &cwWorker{
+		config:  cfg,
+		region:  region,
+		metrics: metrics,
+		svc:     svc,
+		log:     log,
+	}
+
+	tracker := newACKTracker()
+	client, err := pipeline.ConnectWith(beat.ClientConfig{
+		EventListener: acker.TrackingCounter(func(_ int, by int) {
+			tracker.increaseAck(by)
+		}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pipeline client: %w", err)
+	}
+
+	cw.client = client
+	cw.processor = newLogProcessor(log, metrics, client)
+	cw.tracker = tracker
+	return cw, nil
+}
+
+// Start the CloudWatch worker that requests and wait for work. Contains blocking operations, hence must be called concurrently.
+func (w *cwWorker) Start(ctx context.Context, workReq chan struct{}, workRsp chan workResponse, handler *stateHandler) {
+	defer w.client.Close()
+	defer w.tracker.close()
+
+	for {
+		var work workResponse
+		select {
+		case <-ctx.Done():
+			return
+		case workReq <- struct{}{}:
+			work = <-workRsp
+		}
+
+		w.log.Infof("aws-cloudwatch input worker for log group: '%v' has started", work.logGroupId)
+		workedCount := w.run(work.logGroupId, work.startTime, work.endTime)
+		w.log.Infof("aws-cloudwatch input worker for log group '%v' has completed.", work.logGroupId)
+
+		select {
+		case <-ctx.Done():
+			w.log.Debugf("context completed before acknowledging delivery for log group '%v'", work.logGroupId)
+		case <-w.tracker.waitFor(workedCount):
+			handler.WorkComplete(work.endTime.UnixMilli())
+			w.log.Debugf("all events (%d) acknowledged for log group '%v'", workedCount, work.logGroupId)
+		}
+	}
+}
+
+func (w *cwWorker) run(logGroupId string, startTime, endTime time.Time) int {
+	count, err := w.getLogEventsFromCloudWatch(logGroupId, startTime, endTime)
+	if err != nil {
+		var errRequestCanceled *awssdk.RequestCanceledError
+		if errors.As(err, &errRequestCanceled) {
+			w.log.Error("getLogEventsFromCloudWatch failed with RequestCanceledError: ", errRequestCanceled)
+		}
+		w.log.Error("getLogEventsFromCloudWatch failed: ", err)
+	}
+
+	return count
+}
+
+// getLogEventsFromCloudWatch uses FilterLogEvents API to collect logs from CloudWatch
+func (w *cwWorker) getLogEventsFromCloudWatch(logGroupId string, startTime, endTime time.Time) (int, error) {
+	var logCount int
+	// construct FilterLogEventsInput
+	filterLogEventsInput := w.constructFilterLogEventsInput(startTime, endTime, logGroupId)
+	paginator := cloudwatchlogs.NewFilterLogEventsPaginator(w.svc, filterLogEventsInput)
+	for paginator.HasMorePages() {
+		filterLogEventsOutput, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return 0, fmt.Errorf("error FilterLogEvents with Paginator: %w", err)
+		}
+
+		w.metrics.apiCallsTotal.Inc()
+		logEvents := filterLogEventsOutput.Events
+		w.metrics.logEventsReceivedTotal.Add(uint64(len(logEvents)))
+
+		// This sleep is to avoid hitting the FilterLogEvents API limit(5 transactions per second (TPS)/account/Region).
+		w.log.Debugf("sleeping for %v before making FilterLogEvents API call again", w.config.APISleep)
+		time.Sleep(w.config.APISleep)
+		w.log.Debug("done sleeping")
+
+		w.log.Debugf("Processing #%v events", len(logEvents))
+		w.processor.processLogEvents(logEvents, logGroupId, w.region)
+		logCount += len(logEvents)
+	}
+
+	return logCount, nil
+}
+
+func (w *cwWorker) constructFilterLogEventsInput(startTime, endTime time.Time, logGroupId string) *cloudwatchlogs.FilterLogEventsInput {
+	w.log.Debugf("FilterLogEventsInput for log group: '%s' with startTime = '%v' and endTime = '%v'", logGroupId, unixMsFromTime(startTime), unixMsFromTime(endTime))
+	filterLogEventsInput := &cloudwatchlogs.FilterLogEventsInput{
+		LogGroupIdentifier: awssdk.String(logGroupId),
+		StartTime:          awssdk.Int64(unixMsFromTime(startTime)),
+		EndTime:            awssdk.Int64(unixMsFromTime(endTime)),
+	}
+
+	if len(w.config.LogStreams) > 0 {
+		for _, stream := range w.config.LogStreams {
+			filterLogEventsInput.LogStreamNames = append(filterLogEventsInput.LogStreamNames, *stream)
+		}
+	}
+
+	if w.config.LogStreamPrefix != "" {
+		filterLogEventsInput.LogStreamNamePrefix = awssdk.String(w.config.LogStreamPrefix)
+	}
+	return filterLogEventsInput
+}
+
+// ackTracker tracks acknowledgements of an individual worker
+type ackTracker struct {
+	increment  chan int
+	checkTotal chan int
+	complete   chan interface{}
+	done       chan interface{}
+}
+
+func newACKTracker() *ackTracker {
+	tracker := &ackTracker{
+		increment:  make(chan int, 1),
+		checkTotal: make(chan int, 1),
+		complete:   make(chan interface{}, 1),
+		done:       make(chan interface{}, 1),
+	}
+
+	go tracker.runner()
+
+	return tracker
+}
+
+func (ac *ackTracker) close() {
+	close(ac.done)
+}
+
+// increaseAck allows to increase acknowledged count.
+// See runner for internal work.
+func (ac *ackTracker) increaseAck(by int) {
+	ac.increment <- by
+}
+
+// waitFor accepts a total value to be completed where completion will be communicated through returned channel.
+// See runner for internal work.
+func (ac *ackTracker) waitFor(total int) <-chan interface{} {
+	ac.checkTotal <- total
+
+	return ac.complete
+}
+
+// runner contains blocking calls and tracks acknowledgements and totals.
+// If acknowledgements reach total, it emits complete signal.
+// Acknowledgements can be taken for zero total value.
+func (ac *ackTracker) runner() {
+	total := -1
+	count := 0
+	for {
+		select {
+		case <-ac.done:
+			return
+		case t := <-ac.checkTotal:
+			total = t
+		case c := <-ac.increment:
+			count += c
+		}
+
+		if total >= 0 && count >= total {
+			count -= total
+			total = -1
+			ac.complete <- nil
+		}
+	}
+}

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker.go
@@ -107,7 +107,7 @@ func (w *cwWorker) getLogEventsFromCloudWatch(ctx context.Context, logGroupId st
 	// construct FilterLogEventsInput
 	filterLogEventsInput := w.constructFilterLogEventsInput(startTime, endTime, logGroupId)
 	paginator := cloudwatchlogs.NewFilterLogEventsPaginator(w.svc, filterLogEventsInput)
-	for paginator.HasMorePages() && ctx.Err() != nil {
+	for paginator.HasMorePages() && ctx.Err() == nil {
 		filterLogEventsOutput, err := paginator.NextPage(ctx)
 		if err != nil {
 			return 0, fmt.Errorf("error FilterLogEvents with Paginator: %w", err)

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker_test.go
@@ -79,7 +79,7 @@ func TestAckTracker(t *testing.T) {
 		// delay the wait call
 		<-time.After(200 * time.Millisecond)
 
-		// verify increments are done
+		// verify increments are shutdown
 		select {
 		case <-time.After(50 * time.Millisecond):
 			t.Errorf("increments have not completed")

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker_test.go
@@ -1,0 +1,136 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awscloudwatch
+
+import (
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestAckTracker(t *testing.T) {
+	t.Run("Simple run - increase and wait", func(t *testing.T) {
+		tracker := newACKTracker()
+
+		tracker.increaseAck(10)
+
+		select {
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("timed out waiting for acks")
+		case <-tracker.waitFor(10):
+			// test completed
+		}
+	})
+
+	t.Run("Tracker can be reused for zero or more values", func(t *testing.T) {
+		tracker := newACKTracker()
+
+		go func() {
+			tracker.increaseAck(0)
+			tracker.increaseAck(5)
+			tracker.increaseAck(0)
+		}()
+
+		// validate first with 0 value
+		select {
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("wait failed, increments did not get acknowledged")
+		case <-tracker.waitFor(0):
+			// validated
+		}
+
+		// validate second 5 ack
+		select {
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("wait failed, increments did not get acknowledged")
+		case <-tracker.waitFor(5):
+			// validated
+		}
+
+		// validate final 0 value
+		select {
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("wait failed, increments did not get acknowledged")
+		case <-tracker.waitFor(0):
+			// validated
+		}
+
+	})
+
+	t.Run("increments should not get blocked even if wait is not called", func(t *testing.T) {
+		tracker := newACKTracker()
+		done := make(chan interface{})
+
+		go func() {
+			tracker.increaseAck(1)
+			tracker.increaseAck(1)
+
+			close(done)
+		}()
+
+		// delay the wait call
+		<-time.After(200 * time.Millisecond)
+
+		// verify increments are done
+		select {
+		case <-time.After(50 * time.Millisecond):
+			t.Errorf("increments have not completed")
+		case <-done:
+			// increments are complete
+		}
+
+		// verify count is tracked
+		select {
+		case <-time.After(50 * time.Millisecond):
+			t.Errorf("wait must be completed, but failed")
+		case <-tracker.waitFor(2):
+			// wait complete
+		}
+	})
+}
+
+type filterLogEventsTestCase struct {
+	name       string
+	logGroupId string
+	startTime  time.Time
+	endTime    time.Time
+	expected   *cloudwatchlogs.FilterLogEventsInput
+}
+
+func TestFilterLogEventsInput(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2024-07-12T13:00:00+00:00")
+	id := "myLogGroup"
+
+	testCases := []filterLogEventsTestCase{
+		{
+			name:       "StartPosition: beginning, first iteration",
+			logGroupId: id,
+			// The zero value of type time.Time{} is January 1, year 1, 00:00:00.000000000 UTC
+			// Events with a timestamp before the time - January 1, 1970, 00:00:00 UTC are not returned by AWS API
+			// make sure zero value of time.Time{} was converted
+			startTime: time.Time{},
+			endTime:   now,
+			expected: &cloudwatchlogs.FilterLogEventsInput{
+				LogGroupIdentifier: awssdk.String(id),
+				StartTime:          awssdk.Int64(0),
+				EndTime:            awssdk.Int64(1720789200000),
+			},
+		},
+	}
+	for _, test := range testCases {
+		cw := cwWorker{
+			log: logp.NewLogger("test"),
+		}
+		result := cw.constructFilterLogEventsInput(test.startTime, test.endTime, test.logGroupId)
+		assert.Equal(t, test.expected, result)
+	}
+
+}

--- a/x-pack/filebeat/input/awscloudwatch/config.go
+++ b/x-pack/filebeat/input/awscloudwatch/config.go
@@ -6,10 +6,17 @@ package awscloudwatch
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/elastic/beats/v7/filebeat/harvester"
 	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
+)
+
+const (
+	beginning = "beginning"
+	end       = "end"
+	lastSync  = "lastSync"
 )
 
 type config struct {
@@ -35,7 +42,7 @@ func defaultConfig() config {
 		ForwarderConfig: harvester.ForwarderConfig{
 			Type: "aws-cloudwatch",
 		},
-		StartPosition:   "beginning",
+		StartPosition:   beginning,
 		ScanFrequency:   60 * time.Second,
 		APITimeout:      120 * time.Second,
 		APISleep:        200 * time.Millisecond, // FilterLogEvents has a limit of 5 transactions per second (TPS)/account/Region: 1s / 5 = 200 ms
@@ -44,9 +51,8 @@ func defaultConfig() config {
 }
 
 func (c *config) Validate() error {
-	if c.StartPosition != "beginning" && c.StartPosition != "end" {
-		return errors.New("start_position config parameter can only be " +
-			"either 'beginning' or 'end'")
+	if c.StartPosition != beginning && c.StartPosition != end && c.StartPosition != lastSync {
+		return fmt.Errorf("start_position config parameter can only be one of %s, %s or %s", beginning, end, lastSync)
 	}
 
 	if c.LogGroupARN == "" && c.LogGroupName == "" && c.LogGroupNamePrefix == "" {

--- a/x-pack/filebeat/input/awscloudwatch/input_integration_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/input_integration_test.go
@@ -84,7 +84,7 @@ func newV2Context() (v2.Context, func()) {
 }
 
 func createInput(t *testing.T, cfg *conf.C) *cloudwatchInput {
-	inputV2, err := Plugin().Manager.Create(cfg)
+	inputV2, err := Plugin(createTestInputStore()).Manager.Create(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/filebeat/input/awscloudwatch/processor.go
+++ b/x-pack/filebeat/input/awscloudwatch/processor.go
@@ -5,7 +5,6 @@
 package awscloudwatch
 
 import (
-	"context"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
@@ -21,7 +20,7 @@ type logProcessor struct {
 	publisher beat.Client
 }
 
-func newLogProcessor(log *logp.Logger, metrics *inputMetrics, publisher beat.Client, ctx context.Context) *logProcessor {
+func newLogProcessor(log *logp.Logger, metrics *inputMetrics, publisher beat.Client) *logProcessor {
 	if metrics == nil {
 		metrics = newInputMetrics("", nil)
 	}

--- a/x-pack/filebeat/input/awscloudwatch/state_handler.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_handler.go
@@ -1,0 +1,109 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awscloudwatch
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/elastic/beats/v7/libbeat/statestore"
+)
+
+const (
+	statePrefix      = "filebeat::aws-cloudwatch::state::"
+	inputGroupArn    = "groupArn"
+	inputGroupName   = "groupName"
+	inputGroupPrefix = "groupPrefix"
+)
+
+type StorableState struct {
+	LastSyncEpoch int64 `json:"last_sync_epoch" struct:"last_sync_epoch"`
+}
+
+type stateHandler struct {
+	lock  sync.Mutex
+	store *statestore.Store
+}
+
+func createStateHandler(store statestore.States) (*stateHandler, error) {
+	st, err := store.StoreFor("")
+	if err != nil {
+		return nil, fmt.Errorf("error accessing persistence store: %w", err)
+	}
+
+	return &stateHandler{store: st}, nil
+}
+
+func (s *stateHandler) GetState(forCfg config) (StorableState, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	var ss StorableState
+
+	id, err := generateID(forCfg)
+	if err != nil {
+		return ss, err
+	}
+
+	got, err := s.store.Has(id)
+	if err != nil {
+		return StorableState{}, err
+	}
+
+	if !got {
+		// Set to Epoch Zero, which is as if start from beginning
+		return StorableState{LastSyncEpoch: 0}, nil
+	}
+
+	err = s.store.Get(id, &ss)
+	if err != nil {
+		return StorableState{}, err
+	}
+
+	return ss, nil
+}
+
+func (s *stateHandler) StoreState(forCfg config, ss StorableState) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	id, err := generateID(forCfg)
+	if err != nil {
+		return err
+	}
+
+	err = s.store.Set(id, ss)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *stateHandler) Close() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.store.Close()
+}
+
+func generateID(forCfg config) (string, error) {
+	// first check group ARN
+	if forCfg.LogGroupARN != "" {
+		return fmt.Sprintf("%s%s::%s", statePrefix, inputGroupArn, forCfg.LogGroupARN), nil
+	}
+
+	// then fallback to log group name
+	if forCfg.LogGroupName != "" {
+		return fmt.Sprintf("%s%s::%s::%s", statePrefix, inputGroupName, forCfg.LogGroupName, forCfg.RegionName), nil
+	}
+
+	// finally fallback to log group prefix
+	if forCfg.LogGroupNamePrefix != "" {
+		return fmt.Sprintf("%s%s::%s::%s", statePrefix, inputGroupPrefix, forCfg.LogGroupNamePrefix, forCfg.RegionName), nil
+	}
+
+	return "", fmt.Errorf("incorrect configurations received, missing log_group_arn, log_group_name and log_group_name_prefix properties")
+}

--- a/x-pack/filebeat/input/awscloudwatch/state_handler_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_handler_test.go
@@ -76,12 +76,28 @@ func TestStateHandler(t *testing.T) {
 		// pause for backgroundRunner to run
 		<-time.After(100 * time.Millisecond)
 
+		// Validation #1 : State is not updated as oldest is not complete
 		state, err := st.GetState()
 		assert.NoError(t, err)
 		assert.NotNil(t, state)
 
 		// we get zero so that sync starts from epoch zero
 		assert.Equal(t, int64(0), state.LastSyncEpoch)
+
+		// complete the oldest
+		st.WorkComplete(100)
+
+		// pause for backgroundRunner to run
+		<-time.After(100 * time.Millisecond)
+
+		// Validation #2 : State is updated to the latest once completion get registered
+		state, err = st.GetState()
+		assert.NoError(t, err)
+		assert.NotNil(t, state)
+
+		// we get most recent completion
+		assert.Equal(t, int64(200), state.LastSyncEpoch)
+
 	})
 }
 

--- a/x-pack/filebeat/input/awscloudwatch/state_handler_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_handler_test.go
@@ -1,0 +1,156 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awscloudwatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+)
+
+func TestStateHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		storeWithCfg    config
+		storingState    StorableState
+		retrieveWithCfg config
+		expectEpoch     int64
+	}{
+		{
+			name: "Simple store and retrival",
+			storeWithCfg: config{
+				LogGroupARN: "logGroupARN",
+			},
+			storingState: StorableState{
+				LastSyncEpoch: 1111111111,
+			},
+			retrieveWithCfg: config{
+				LogGroupARN: "logGroupARN",
+			},
+			expectEpoch: 1111111111,
+		},
+		{
+			name: "Missing retrival should return epoch zero - different ARN",
+			storeWithCfg: config{
+				LogGroupARN: "MyLogGroup_A",
+			},
+			storingState: StorableState{
+				LastSyncEpoch: 1111111111,
+			},
+			retrieveWithCfg: config{
+				LogGroupARN: "MyLogGroup_B",
+			},
+			expectEpoch: 0,
+		},
+		{
+			name: "Missing retrival should return epoch zero - different log group identification",
+			storeWithCfg: config{
+				LogGroupARN: "MyLogGroup_A",
+			},
+			storingState: StorableState{
+				LastSyncEpoch: 1111111111,
+			},
+			retrieveWithCfg: config{
+				LogGroupName: "logGroupName",
+				RegionName:   "region-A",
+			},
+			expectEpoch: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stHandler, err := createStateHandler(createTestInputStore())
+			require.NoError(t, err)
+
+			err = stHandler.StoreState(test.storeWithCfg, test.storingState)
+			require.NoError(t, err)
+
+			retried, err := stHandler.GetState(test.retrieveWithCfg)
+			require.NoError(t, err)
+
+			require.Equal(t, test.expectEpoch, retried.LastSyncEpoch)
+		})
+	}
+}
+
+func Test_getID(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config
+		want    string
+		isError bool
+	}{
+		{
+			name: "ID using ARN",
+			cfg: config{
+				LogGroupARN: "logGroupARN",
+			},
+			want: "filebeat::aws-cloudwatch::state::groupArn::logGroupARN",
+		},
+		{
+			name: "ID using Group Name",
+			cfg: config{
+				LogGroupName: "logGroupName",
+				RegionName:   "region-A",
+			},
+			want: "filebeat::aws-cloudwatch::state::groupName::logGroupName::region-A",
+		},
+		{
+			name: "ID using Group Name",
+			cfg: config{
+				LogGroupNamePrefix: "groupPrefix",
+				RegionName:         "region-A",
+			},
+			want: "filebeat::aws-cloudwatch::state::groupPrefix::groupPrefix::region-A",
+		},
+		{
+			name:    "Invalid configuration results in an error",
+			isError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			id, err := generateID(test.cfg)
+
+			if test.isError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, id)
+		})
+	}
+
+}
+
+// testInputStore - State registry for testing needs
+type testInputStore struct {
+	registry *statestore.Registry
+}
+
+func (s *testInputStore) StoreFor(typ string) (*statestore.Store, error) {
+	return s.registry.Get(typ)
+}
+
+func createTestInputStore() *testInputStore {
+	return &testInputStore{
+		registry: statestore.NewRegistry(storetest.NewMemoryStoreBackend()),
+	}
+}
+
+func (s *testInputStore) CleanupInterval() time.Duration {
+	return 24 * time.Hour
+}
+
+func (s *testInputStore) Close() {
+	_ = s.registry.Close()
+}

--- a/x-pack/filebeat/input/default-inputs/inputs_darwin.go
+++ b/x-pack/filebeat/input/default-inputs/inputs_darwin.go
@@ -42,7 +42,7 @@ func xpackInputs(info beat.Info, log *logp.Logger, store statestore.States) []v2
 		httpjson.Plugin(log, store),
 		o365audit.Plugin(log, store),
 		awss3.Plugin(store),
-		awscloudwatch.Plugin(),
+		awscloudwatch.Plugin(store),
 		lumberjack.Plugin(),
 		salesforce.Plugin(log, store),
 		streaming.Plugin(log, store),

--- a/x-pack/filebeat/input/default-inputs/inputs_other.go
+++ b/x-pack/filebeat/input/default-inputs/inputs_other.go
@@ -41,7 +41,7 @@ func xpackInputs(info beat.Info, log *logp.Logger, store statestore.States) []v2
 		httpjson.Plugin(log, store),
 		o365audit.Plugin(log, store),
 		awss3.Plugin(store),
-		awscloudwatch.Plugin(),
+		awscloudwatch.Plugin(store),
 		lumberjack.Plugin(),
 		salesforce.Plugin(log, store),
 		streaming.Plugin(log, store),

--- a/x-pack/filebeat/input/default-inputs/inputs_windows.go
+++ b/x-pack/filebeat/input/default-inputs/inputs_windows.go
@@ -41,7 +41,7 @@ func xpackInputs(info beat.Info, log *logp.Logger, store statestore.States) []v2
 		httpjson.Plugin(log, store),
 		o365audit.Plugin(log, store),
 		awss3.Plugin(store),
-		awscloudwatch.Plugin(),
+		awscloudwatch.Plugin(store),
 		lumberjack.Plugin(),
 		etw.Plugin(),
 		netflow.Plugin(log),


### PR DESCRIPTION
## Proposed commit message

Introduce `lastSync` option to AWS CloudWatch input's `start_position` configuration. This feature utilizes the state registry, which with this update stores the last successful sync timestamp under the `last_sync_epoch` key. 

`start_position` configuration by default uses `beginning` option. This can cause data duplications when restarting filebeats or migrating it to a newer version. Users can avoid such data duplocates by utilizing `lastSync` option for the `start_position` configuration while targeting beats to use the same registry location. 

### Acknowledgement backed state updates 

After the initial review, the need for acknowledgments prior to the state registry update was identified thanks to this remark - https://github.com/elastic/beats/pull/43251#discussion_r1999503090

Based on this feedback, I have implemented the state registry update with following component interactions, 

![image](https://github.com/user-attachments/assets/42ba5ed0-5642-4171-abd0-72e7f22c16da)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None - `start_position` by default use `beginning`. So this new option is an opt-in feature.

## Screenshots

Example `filebeat.yml` configuration,

![image](https://github.com/user-attachments/assets/342bf252-58cd-4fd0-a7df-10560d420e9f)

Example state entries with last sync timestamp updates,

![image](https://github.com/user-attachments/assets/6eb00a51-1b08-4a38-8e81-0585cbba595a)




