### PR TITLE
[Flaky Test] Relax test assertion for metricbeat/module/apache/status TestFetchTimeout

### DIFF
--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -157,7 +157,7 @@ func TestFetchTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "text/plain; charset=ISO-8859-1")
-		time.Sleep(timeout)
+		time.Sleep(timeout + 5*time.Millisecond)
 		w.Write([]byte(response))
 	}))
 	defer server.Close()
@@ -180,7 +180,8 @@ func TestFetchTimeout(t *testing.T) {
 	elapsed := time.Since(start)
 	var found bool
 	for _, err := range errs {
-		if strings.Contains(err.Error(), "Client.Timeout exceeded") {
+		if strings.Contains(err.Error(), "Client.Timeout exceeded") ||
+			strings.Contains(err.Error(), "context deadline exceeded") {
 			found = true
 		}
 	}


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
fix metricbeat/module/apache/status TestFetchTimeout

relax test assertion for metricbeat/module/apache/status TestFetchTimeout to 
also include "context deadline exceeded". The current way we do HTTP request 
might fail with either error, the original "Client.Timeout exceeded" but also 
with only "context deadline exceeded".
```

The test fails with
```
expected an error containing 'Client.Timeout exceeded'. Got [error fetching data: error making http request: Get "http://127.0.0.1:36443/server-status?auto=": context deadline exceeded
```

the error is: 
```
Get "http://127.0.0.1:36443/server-status?auto=": context deadline exceeded
```

However the expected error is:
```
Get "http://127.0.0.1:37293/server-status?auto=": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The extra, expected message, is added by

https://github.com/golang/go/blob/3901409b5d0fb7c85a3e6730a59943cc93b2835c/src/net/http/client.go#L731-L734

Any way the error is a timeout. I did some digging and I believe the issue comes from

https://github.com/golang/go/blob/3901409b5d0fb7c85a3e6730a59943cc93b2835c/src/net/http/client.go#L401-L412

In order to get the extra `Client.Timeout exceeded`, `didTimeout()` must be true. This callback is the Load from `timedOut`, which is set to true here:
https://github.com/golang/go/blob/go1.24.0/src/net/http/client.go#L406-L407

However, not always this select+timer triggers, when it does not, the error is only the `Get "http://127.0.0.1:36443/server-status?auto=": context deadline exceeded`. Which was making the test fail, even though the error is due to the timeout defined by the config. Therefore relaxing the accepted error should fix the test.

The extra 5ms is to avoid the even more rare case where it does not time out at all:

```
--- FAIL: TestFetchTimeout (0.05s)
    status_test.go:228: Expected an error, had 0. []
```


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

 - N/A

## How to test this PR locally

From the beats root folder:

```
go test -run TestFetchTimeout -count 100 ./metricbeat/module/apache/status
```

## Related issues

- Closes #43242