### PR TITLE
otel: fix data race with config opts in NewBeatReceiver

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -306,11 +306,11 @@ func NewBeatReceiver(settings Settings, receiverConfig map[string]interface{}, u
 	}
 
 	if settings.DisableConfigResolver {
-		cfg.MergeWithOpts(obfuscateConfigOpts())
+		cfg.MergeWithOpts(mapstr.M{}, obfuscateConfigOpts()...)
 	} else if store != nil {
 		// TODO: Allow the options to be more flexible for dynamic changes
 		// note that if the store is nil it should be excluded as an option
-		cfg.MergeWithOpts(configOptsWithKeystore(store))
+		cfg.MergeWithOpts(mapstr.M{}, configOptsWithKeystore(store)...)
 	}
 
 	b.Beat.Info.Monitoring.Namespace = monitoring.GetNamespace(b.Info.Beat + "-" + b.Info.ID.String())
@@ -1027,11 +1027,11 @@ func (b *Beat) configure(settings Settings) error {
 	}
 
 	if settings.DisableConfigResolver {
-		config.OverwriteConfigOpts(obfuscateConfigOpts())
+		cfg.MergeWithOpts(mapstr.M{}, obfuscateConfigOpts()...)
 	} else if store != nil {
 		// TODO: Allow the options to be more flexible for dynamic changes
 		// note that if the store is nil it should be excluded as an option
-		config.OverwriteConfigOpts(configOptsWithKeystore(store))
+		cfg.MergeWithOpts(mapstr.M{}, configOptsWithKeystore(store)...)
 	}
 
 	instrumentation, err := instrumentation.New(cfg, b.Info.Beat, b.Info.Version)

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -306,11 +306,11 @@ func NewBeatReceiver(settings Settings, receiverConfig map[string]interface{}, u
 	}
 
 	if settings.DisableConfigResolver {
-		config.OverwriteConfigOpts(obfuscateConfigOpts())
+		cfg.MergeWithOpts(obfuscateConfigOpts())
 	} else if store != nil {
 		// TODO: Allow the options to be more flexible for dynamic changes
 		// note that if the store is nil it should be excluded as an option
-		config.OverwriteConfigOpts(configOptsWithKeystore(store))
+		cfg.MergeWithOpts(configOptsWithKeystore(store))
 	}
 
 	b.Beat.Info.Monitoring.Namespace = monitoring.GetNamespace(b.Info.Beat + "-" + b.Info.ID.String())


### PR DESCRIPTION
## Proposed commit message

NewBeatReceiver updates the global configOpts which causes data races when there are multiple receivers on the same process. Instead, set the config opts in the `*config.C` instance.

```bash
$ GORACE='halt_on_error=1' go test -race -run ^TestMultipleReceivers$ ./x-pack/filebeat/fbreceiver -v -count=100

==================
WARNING: DATA RACE
Write at 0x00000f958990 by goroutine 315:
  github.com/elastic/elastic-agent-libs/config.OverwriteConfigOpts()
      /home/mauri870/gopath/pkg/mod/github.com/elastic/elastic-agent-libs@v0.18.9/config/config.go:141 +0xa11
  github.com/elastic/beats/v7/libbeat/cmd/instance.NewBeatReceiver()
      /home/mauri870/git/elastic/beats/libbeat/cmd/instance/beat.go:313 +0x88c
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

## Related issues

- For https://github.com/elastic/ingest-dev/issues/5202
