### PR TITLE
oteltest: make CheckReceivers environment more similar to the collector

### DIFF
--- a/libbeat/otelbeat/oteltest/oteltest.go
+++ b/libbeat/otelbeat/oteltest/oteltest.go
@@ -115,7 +115,6 @@ func CheckReceivers(params CheckReceiversParams) {
 	}
 
 	for i, r := range receivers {
-		i++
 		err := r.Start(ctx, nil)
 		require.NoErrorf(t, err, "Error starting receiver %d", i)
 		defer func() {

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
@@ -54,9 +55,9 @@ func TestNewReceiver(t *testing.T) {
 				Config: &config,
 			},
 		},
-		AssertFunc: func(t *testing.T, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) bool {
+		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
 			_ = zapLogs
-			return len(logs["r1"]) == 1
+			assert.Len(t, logs["r1"], 1)
 		},
 	})
 }
@@ -96,10 +97,8 @@ func TestReceiverDefaultProcessors(t *testing.T) {
 				Config: &config,
 			},
 		},
-		AssertFunc: func(t *testing.T, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) bool {
-			if len(logs["r1"]) == 0 {
-				return false
-			}
+		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
+			require.Len(t, logs["r1"], 1)
 
 			processorsLoaded := zapLogs.FilterMessageSnippet("Generated new processors").
 				FilterMessageSnippet("add_host_metadata").
@@ -110,8 +109,6 @@ func TestReceiverDefaultProcessors(t *testing.T) {
 			require.True(t, processorsLoaded, "processors not loaded")
 			// Check that add_host_metadata works, other processors are not guaranteed to add fields in all environments
 			require.Contains(t, logs["r1"][0].Flatten(), "host.architecture")
-
-			return true
 		},
 	})
 }
@@ -200,9 +197,10 @@ func TestMultipleReceivers(t *testing.T) {
 				Config: &config,
 			},
 		},
-		AssertFunc: func(t *testing.T, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) bool {
+		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
 			_ = zapLogs
-			return len(logs["r1"]) == 1 && len(logs["r2"]) == 1
+			require.Len(t, logs["r1"], 1)
+			require.Len(t, logs["r2"], 1)
 		},
 	})
 }

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -47,12 +47,12 @@ func TestNewReceiver(t *testing.T) {
 	}
 
 	oteltest.CheckReceivers(oteltest.CheckReceiversParams{
-		T:       t,
-		Factory: NewFactory(),
+		T: t,
 		Receivers: []oteltest.ReceiverConfig{
 			{
-				Name:   "r1",
-				Config: &config,
+				Name:    "r1",
+				Config:  &config,
+				Factory: NewFactory(),
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
@@ -89,12 +89,12 @@ func TestReceiverDefaultProcessors(t *testing.T) {
 	}
 
 	oteltest.CheckReceivers(oteltest.CheckReceiversParams{
-		T:       t,
-		Factory: NewFactory(),
+		T: t,
 		Receivers: []oteltest.ReceiverConfig{
 			{
-				Name:   "r1",
-				Config: &config,
+				Name:    "r1",
+				Config:  &config,
+				Factory: NewFactory(),
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
@@ -184,17 +184,19 @@ func TestMultipleReceivers(t *testing.T) {
 		},
 	}
 
+	factory := NewFactory()
 	oteltest.CheckReceivers(oteltest.CheckReceiversParams{
-		T:       t,
-		Factory: NewFactory(),
+		T: t,
 		Receivers: []oteltest.ReceiverConfig{
 			{
-				Name:   "r1",
-				Config: &config,
+				Name:    "r1",
+				Config:  &config,
+				Factory: factory,
 			},
 			{
-				Name:   "r2",
-				Config: &config,
+				Name:    "r2",
+				Config:  &config,
+				Factory: factory,
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/stretchr/testify/assert"
 
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -49,9 +50,11 @@ func TestNewReceiver(t *testing.T) {
 				Config: &config,
 			},
 		},
-		AssertFunc: func(t *testing.T, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) bool {
+		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
 			_ = zapLogs
-			return len(logs["r1"]) > 0
+			assert.Conditionf(t, func() bool {
+				return len(logs["r1"]) > 0
+			}, "expected at least one ingest log, got logs: %v", logs["r1"])
 		},
 	})
 }
@@ -96,9 +99,11 @@ func TestMultipleReceivers(t *testing.T) {
 				Config: &config,
 			},
 		},
-		AssertFunc: func(t *testing.T, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) bool {
+		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
 			_ = zapLogs
-			return len(logs["r1"]) > 0 && len(logs["r2"]) > 0
+			assert.Conditionf(t, func() bool {
+				return len(logs["r1"]) > 0 && len(logs["r2"]) > 0
+			}, "expected at least one ingest log for each receiver, got logs: %v", logs)
 		},
 	})
 }

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -43,12 +43,12 @@ func TestNewReceiver(t *testing.T) {
 	}
 
 	oteltest.CheckReceivers(oteltest.CheckReceiversParams{
-		T:       t,
-		Factory: NewFactory(),
+		T: t,
 		Receivers: []oteltest.ReceiverConfig{
 			{
-				Name:   "r1",
-				Config: &config,
+				Name:    "r1",
+				Config:  &config,
+				Factory: NewFactory(),
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
@@ -87,17 +87,19 @@ func TestMultipleReceivers(t *testing.T) {
 		},
 	}
 
+	factory := NewFactory()
 	oteltest.CheckReceivers(oteltest.CheckReceiversParams{
-		T:       t,
-		Factory: NewFactory(),
+		T: t,
 		Receivers: []oteltest.ReceiverConfig{
 			{
-				Name:   "r1",
-				Config: &config,
+				Name:    "r1",
+				Config:  &config,
+				Factory: factory,
 			},
 			{
-				Name:   "r2",
-				Config: &config,
+				Name:    "r2",
+				Config:  &config,
+				Factory: factory,
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+
 	"github.com/stretchr/testify/assert"
 
 	"go.uber.org/zap/zaptest/observer"


### PR DESCRIPTION
The CheckReceivers function is designed to start receivers in the same process to assert conditions. This simulated environment should closely resemble the real OTel collector startup.

This PR fixes some inconsistencies in the test environment.

First, when instantiating receivers, the collector first [creates them](https://github.com/open-telemetry/opentelemetry-collector/blob/27ff48958a38992b7812af301967132b1a4006ca/service/internal/graph/graph.go#L292) using the factory and only then [starts each component](https://github.com/open-telemetry/opentelemetry-collector/blob/27ff48958a38992b7812af301967132b1a4006ca/service/internal/graph/graph.go#L403). Previously, we were creating and starting each receiver sequentially, which is incorrect and masked issues with global state when multiple receivers were present.

Second, a Beats receiver logger inherits from the zap.Core of the collector logger. This core includes certain fields—specifically data_type, kind, and name. In the tests, these fields were previously missing, so this PR ensures they are included.

Last but not least, replace Eventually with EventuallyWithT so we aggregate assertions properly.

## Proposed commit message

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- For https://github.com/elastic/ingest-dev/issues/5202