### PR TITLE
Exclude dotted indices from settings pull

### DIFF
--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -192,7 +192,7 @@ func eventsMapping(r mb.ReporterV2, httpClient *helper.HTTP, info elasticsearch.
 		return fmt.Errorf("failure retrieving cluster state from Elasticsearch: %w", err)
 	}
 
-	indicesSettingsPattern := "*"
+	indicesSettingsPattern := "*,-.*"
 	indicesSettingsFilterPaths := []string{"*.settings.index.creation_date", "*.settings.index.**._tier_preference", "*.settings.index.version.created"}
 	indicesSettings, err := elasticsearch.GetIndexSettings(httpClient, httpClient.GetURI(), indicesSettingsPattern, indicesSettingsFilterPaths)
 	if err != nil {


### PR DESCRIPTION
## Proposed commit message

"Actually" prevents system indices from being pulled by the `_settings` API call. The wildcard expansion requires dotted indices to be explicitly excluded.

Follow-up to https://github.com/elastic/beats/pull/43243