### PR TITLE
[Flaky test] Disable flaky metricbeat process test

### DIFF
--- a/metricbeat/module/system/process/process_test.go
+++ b/metricbeat/module/system/process/process_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
@@ -57,6 +58,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestFetchDegradeOnPartial(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/42809")
 	logp.DevelopmentSetup()
 	config := getConfig()
 	config["degrade_on_partial"] = true
@@ -74,7 +76,7 @@ func TestFetchDegradeOnPartial(t *testing.T) {
 		for _, err := range errs {
 			assert.ErrorIsf(t, err, process.NonFatalErr{}, "Expected non-fatal error, got %v", err)
 		}
-		assert.NotEmpty(t, events)
+		require.NotEmpty(t, events)
 
 		t.Logf("fetched %d events, showing events[0]:", len(events))
 		t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),


### PR DESCRIPTION
Disable `metricbeat/module/system/process TestFetchDegradeOnPartial` reported in https://github.com/elastic/beats/issues/42809.

Also change the failing `t.Assert` to `t.Require` so that when it does fail, it doesn't fall through to a panic on the next line by accessing the first element of an empty array.