### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/activedirectory: do not convert special values of accountExpires

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -219,6 +219,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Prevent computer details being returned for user queries by Activedirectory Entity Analytics provider. {issue}11818[11818] {pull}42796[42796]
 - Handle unexpectedEOF error in aws-s3 input and enforce retrying using download failed error {pull}42420[42756]
 - Prevent azureblobstorage input from logging key details during blob fetch operations. {pull}43169[43169]
+- Handle special values of accountExpires in the Activedirectory Entity Analytics provider. {pull}[]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -219,7 +219,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Prevent computer details being returned for user queries by Activedirectory Entity Analytics provider. {issue}11818[11818] {pull}42796[42796]
 - Handle unexpectedEOF error in aws-s3 input and enforce retrying using download failed error {pull}42420[42756]
 - Prevent azureblobstorage input from logging key details during blob fetch operations. {pull}43169[43169]
-- Handle special values of accountExpires in the Activedirectory Entity Analytics provider. {pull}[]
+- Handle special values of accountExpires in the Activedirectory Entity Analytics provider. {pull}43364[43364]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory.go
@@ -314,8 +314,9 @@ func entype(attr *ldap.EntryAttribute) any {
 			if err != nil {
 				return attr.Values
 			}
-			// Check for special values of accountExpires. See https://learn.microsoft.com/en-us/windows/win32/adschema/a-accountexpires.
-			if attr.Name == "accountExpires" && (ts == 0 || ts == 9223372036854775807) {
+			// Check for special values of accountExpires.
+			// See https://learn.microsoft.com/en-us/windows/win32/adschema/a-accountexpires.
+			if attr.Name == "accountExpires" && (ts == 0 || ts == 0x7fff_ffff_ffff_ffff) {
 				return v // Return the raw string instead of converting to time
 			}
 			if len(attr.Values) == 1 {

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory.go
@@ -314,6 +314,10 @@ func entype(attr *ldap.EntryAttribute) any {
 			if err != nil {
 				return attr.Values
 			}
+			// Check for special values of accountExpires. See https://learn.microsoft.com/en-us/windows/win32/adschema/a-accountexpires.
+			if attr.Name == "accountExpires" && (ts == 0 || ts == 9223372036854775807) {
+				return v // Return the raw string instead of converting to time
+			}
 			if len(attr.Values) == 1 {
 				return fromWindowsNT(ts)
 			}


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/input/entityanalytics/provider/activedirectory: do not convert special values of accountExpires

The accountExpires attribute will be set to 0 or 0x7fff_ffff_ffff_ffff
(9223372036854775807) if the account is set to never expire. Return the raw
int in these cases.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

* `beats\x-pack\filebeat\input\entityanalytics\provider\activedirectory> go test -v -run Test -log_response`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

![imagem](https://github.com/user-attachments/assets/8e3f3a10-3dfb-46bb-a1af-e182d02b33ec)


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
