### PR TITLE
x-pack/filebeat/input/awss3: allow a grace time on shutdown

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -412,6 +412,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Winlog input now can report its status to Elastic-Agent {pull}43089[43089]
 - Add configuration option to limit HTTP Endpoint body size. {pull}43171[43171]
 - Refactor & cleanup with updates to default values and documentation. {pull}41834[41834]
+- Allow a grace time for awss3 input shutdown to enable incomplete SQS message processing to be completed. {pull}43369[43369]
 
 *Auditbeat*
 

--- a/docs/reference/filebeat/filebeat-input-aws-s3.md
+++ b/docs/reference/filebeat/filebeat-input-aws-s3.md
@@ -421,6 +421,11 @@ This sets the maximum number of JavaScript VM sessions that will be cached to av
 The maximum duration that an SQS `ReceiveMessage` call should wait for a message to arrive in the queue before returning. The default value is `20s`. The maximum value is `20s`.
 
 
+### `sqs.shutdown_grace_time` [_shutdown_grace_time]
+
+The duration that an SQS message processor will wait for a messages to arrive in the queue and be processed before allowing the input to terminate when a cancelation has been received. The default value is `20s`. It must not be negative.
+
+
 ### `bucket_arn` [_bucket_arn]
 
 ARN of the AWS S3 bucket that will be polled for list operation. (Required when `queue_url`, `access_point_arn, and `non_aws_bucket_name` are not set).

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -39,6 +39,7 @@ func TestConfig(t *testing.T) {
 			VisibilityTimeout:  300 * time.Second,
 			SQSMaxReceiveCount: 5,
 			SQSWaitTime:        20 * time.Second,
+			SQSGraceTime:       20 * time.Second,
 			BucketListInterval: 120 * time.Second,
 			BucketListPrefix:   "",
 			PathStyle:          false,

--- a/x-pack/filebeat/input/awss3/sqs_input.go
+++ b/x-pack/filebeat/input/awss3/sqs_input.go
@@ -270,12 +270,12 @@ func (w *sqsWorker) processMessage(ctx context.Context, msg types.Message) {
 		w.client.Publish(e)
 		publishCount++
 	})
-	w.pending.Add(int64(publishCount))
 
 	if publishCount == 0 {
 		// No events made it through (probably an error state), wrap up immediately
 		result.Done()
 	} else {
+		w.pending.Add(1)
 		// Add this result's Done callback to the pending ACKs list
 		w.ackHandler.Add(publishCount, func() {
 			result.Done()

--- a/x-pack/filebeat/input/awss3/sqs_input.go
+++ b/x-pack/filebeat/input/awss3/sqs_input.go
@@ -270,6 +270,11 @@ func (w *sqsWorker) run(ctx, graceCtx context.Context) {
 			return
 		case msg := <-w.input.workResponseChan:
 			w.processMessage(graceCtx, msg)
+		case <-ctx.Done():
+			// We're shutting down, so spin in the
+			// loop until we have exceeded our
+			// grace time, or we have no pending
+			// messages.
 		}
 	}
 }

--- a/x-pack/filebeat/input/awss3/sqs_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_test.go
@@ -284,3 +284,36 @@ func TestSQSReaderLoop(t *testing.T) {
 func TestSQSWorkerLoop(t *testing.T) {
 
 }
+
+func TestCancelWithGrace(t *testing.T) {
+	// TODO: Rewrite this to use testing/synctest when it is available without
+	// GOEXPERIMENT=synctest. See https://go.dev/blog/synctest.
+
+	const (
+		wait    = time.Second
+		tooLong = time.Second
+		tol     = 10 * time.Millisecond
+	)
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	childCtx, childCancel := cancelWithGrace(parentCtx, wait)
+	defer childCancel()
+
+	var parentCancelled, childCancelled time.Time
+	parentCancel()
+	select {
+	case <-time.After(tooLong):
+		t.Fatal("parent context failed to cancel within timeout")
+	case <-parentCtx.Done():
+		parentCancelled = time.Now()
+	}
+	select {
+	case <-time.After(wait + tooLong):
+		t.Fatal("child context failed to cancel within timeout after wait time")
+	case <-childCtx.Done():
+		childCancelled = time.Now()
+	}
+	waited := childCancelled.Sub(parentCancelled)
+	if waited.Round(tol) != wait {
+		t.Errorf("unexpected wait time between parent and child cancellation: got=%v want=%v", waited, wait)
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

```
x-pack/filebeat/input/awss3: allow a grace time on shutdown

We may have SQS message requests in flight that are being serviced when
the input's context is cancelled. This allows the user to specify a time
to wait after the context is cancelled before the processing and
publication work is terminated.

The approach is a little blunt; it merely waits for the grace period
after the requester has been stopped to allow for incoming messages to
be processed and published. Ideally, we would finish as soon as the set
of pending requests had been received and published, cut short after the
grace time. However, the current structure of data flow does not lend
itself to sharing that information between parts of the input, so a minimal
change is made.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes elastic/integrations#13062

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
