### PR TITLE
[Flaky test] Disable flaky zookeeper tests

### DIFF
--- a/metricbeat/module/zookeeper/test_zookeeper.py
+++ b/metricbeat/module/zookeeper/test_zookeeper.py
@@ -37,7 +37,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assert_no_logged_warnings()
 
         output = self.read_output_json()
-        self.assertEqual(len(output), 1)
+        self.assertEqual(len(output), 1, f"expected one output result, got: {output}")
         evt = output[0]
 
         self.assertCountEqual(self.de_dot(ZK_FIELDS), evt.keys())
@@ -99,7 +99,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assert_no_logged_warnings()
 
         output = self.read_output_json()
-        self.assertEqual(len(output), 1)
+        self.assertEqual(len(output), 1, f"expected one output result, got: {output}")
         evt = output[0]
 
         self.assertCountEqual(self.de_dot(ZK_FIELDS + ["client"]), evt.keys())

--- a/metricbeat/module/zookeeper/test_zookeeper.py
+++ b/metricbeat/module/zookeeper/test_zookeeper.py
@@ -14,6 +14,7 @@ MNTR_FIELDS = ["latency.avg", "latency.max",
                "approximate_data_size", "num_alive_connections"]
 
 
+@unittest.skip("flaky test suite: https://github.com/elastic/beats/issues/43385")
 @metricbeat.parameterized_with_supported_versions
 class ZooKeeperMntrTest(metricbeat.BaseTest):
 

--- a/metricbeat/module/zookeeper/test_zookeeper.py
+++ b/metricbeat/module/zookeeper/test_zookeeper.py
@@ -71,7 +71,7 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assert_no_logged_warnings()
 
         output = self.read_output_json()
-        self.assertEqual(len(output), 1)
+        self.assertEqual(len(output), 1, f"expected one output result, got: {output}")
         evt = output[0]
 
         self.assertCountEqual(self.de_dot(ZK_FIELDS), evt.keys())


### PR DESCRIPTION
Disable the flaky test `metricbeat/module/zookeeper/test_zookeeper`, reported in https://github.com/elastic/beats/issues/43385.

Also add a message to the failing assertions indicating the actual data the tests failed on, so when a failure does happen we can see what caused it.