### PR TITLE
Add more complete failure logs to python tests

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -123,7 +123,7 @@ class Test(BaseTest):
 
         # Check that 2 files are port of the registrar file
         assert len(data) == 2
-    
+
     def test_fae_verbose_log_always_fails(self):
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*"
@@ -139,7 +139,6 @@ class Test(BaseTest):
         logs = self.read_output_json()
         print(logs)
         assert len(logs) == 0
-
 
     def test_custom_registry_file_location(self):
         """

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -124,30 +124,6 @@ class Test(BaseTest):
         # Check that 2 files are port of the registrar file
         assert len(data) == 2
 
-    def test_fae_verbose_log_always_fails(self):
-        self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/*"
-        )
-        os.mkdir(self.working_dir + "/log/")
-        testfile_path1 = self.working_dir + "/log/test1.log"
-        file1 = open(testfile_path1, 'w')
-        file1.write("hello world")  # 11 chars
-        file1.write("\n")  # 1 char
-        file1.write("goodbye world")  # 11 chars
-        file1.write("\n")  # 1 char
-        file1.close()
-
-        filebeat = self.start_beat()
-        self.wait_until(
-            lambda: self.output_lines() >= 5,
-            max_timeout=30)
-
-        filebeat.check_kill_and_wait()
-
-        logs = self.read_output_json()
-        print(logs)
-        assert len(logs) == 0
-
     def test_custom_registry_file_location(self):
         """
         Check that when a custom registry file is used, the path

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -123,6 +123,23 @@ class Test(BaseTest):
 
         # Check that 2 files are port of the registrar file
         assert len(data) == 2
+    
+    def test_fae_verbose_log_always_fails(self):
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*"
+        )
+        os.mkdir(self.working_dir + "/log/")
+        filebeat = self.start_beat()
+        self.wait_until(
+            lambda: len(self.read_output_json()) >= 5,
+            max_timeout=30)
+
+        filebeat.check_kill_and_wait()
+
+        logs = self.read_output_json()
+        print(logs)
+        assert len(logs) == 0
+
 
     def test_custom_registry_file_location(self):
         """

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -129,6 +129,14 @@ class Test(BaseTest):
             path=os.path.abspath(self.working_dir) + "/log/*"
         )
         os.mkdir(self.working_dir + "/log/")
+        testfile_path1 = self.working_dir + "/log/test1.log"
+        file1 = open(testfile_path1, 'w')
+        file1.write("hello world")  # 11 chars
+        file1.write("\n")  # 1 char
+        file1.write("goodbye world")  # 11 chars
+        file1.write("\n")  # 1 char
+        file1.close()
+
         filebeat = self.start_beat()
         self.wait_until(
             lambda: self.output_lines() >= 5,

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -131,7 +131,7 @@ class Test(BaseTest):
         os.mkdir(self.working_dir + "/log/")
         filebeat = self.start_beat()
         self.wait_until(
-            lambda: len(self.read_output_json()) >= 5,
+            lambda: self.output_lines() >= 5,
             max_timeout=30)
 
         filebeat.check_kill_and_wait()

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -446,6 +446,12 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 print("Test has failed, here are the Beat logs")
                 for l in self.get_log_lines():
                     print(l)
+                if self.output_lines() == 0:
+                    print("\n\nBeat had no output file")
+                else:
+                    print("\n\nHere is the beat's output file:")
+                    for entry in self.read_output():
+                        print(entry)
                 raise WaitTimeoutError(
                     f"Timeout waiting for condition '{name}'. Waited {max_timeout} seconds: {err_msg}")
             time.sleep(poll_interval)


### PR DESCRIPTION
A common pattern in flaky python tests is that they `wait_until` expecting a particular set of values in the output file. When this condition fails, though, there's no way to see what the actual output mismatch was. For example, some tests wait until there is (exactly) one entry in the default output file, but fail because there are actually two. In that case the test times out, but there's no way to see if the two output events were actually a bug, or just an over-constrained test condition. Even if it is a genuine failure, there's no way to know what the extra event is. Many test checks are similar, depending on the output file but not reporting why they failed.

This PR updates the python test failure code to include the default output file along with the beat logs, if one is present. This will appear in the buildkite logs on CI failure.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
