### PR TITLE
[Chore] Update golangci-lint to the latest V1 release: `v1.64.8`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,7 +42,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.55.2
+          version: v1.64.8
 
           # Give the job more time to execute.
           # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,


### PR DESCRIPTION
## Proposed commit message

See title

## Checklist


- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

```
mage llc
```

It should run successfully, it may report lint issues, however the lint itself should not break.

## Related issues

- Closes https://github.com/elastic/beats/issues/43489
- Related elastic-agent-libs udpate https://github.com/elastic/elastic-agent-libs/pull/299


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~