### PR TITLE
Remove incorrect entry from 8.17.2 changelog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -105,7 +105,6 @@ https://github.com/elastic/beats/compare/v8.17.1\...v8.17.2[View commits]
 - Fix a bug where log files are rotated on startup when interval is configured and rotateonstartup is disabled. {issue}41894[41894] {pull}41895[41895]
 - Fix setting unique registry for non Beat receivers. {issue}42288[42288] {pull}42292[42292]
 - The Kafka output now drops events when there is an authorization error. {issue}42343[42343] {pull}42401[42401]
-- Fix autodiscovery memory leak related to metadata of start events. {pull}41748[41748]
 - All standard queue metrics are now included in metrics monitoring, including: `added.{events, bytes}`, `consumed.{events, bytes}`, `removed.{events, bytes}`, and `filled.{events, bytes, pct}`. {pull}42439[42439]
 - The following output latency metrics are now included in metrics monitoring: `output.latency.{count, max, median, p99}`. {pull}42439[42439]
 


### PR DESCRIPTION
This removes an entry from the 8.17.2 changelog for a change that didn't make it into that branch. See https://github.com/elastic/beats/pull/42654#issuecomment-2752694456 for details.

