### PR TITLE
Change incorrect module name

### DIFF
--- a/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
@@ -350,7 +350,7 @@ can be either a CIDR value or one of the named ranges supported by the
 which classifies RFC 1918 (IPv4) and RFC 4193 (IPv6) addresses as internal.
 
 [float]
-==== `ntls` log fileset settings
+==== `ntlm` log fileset settings
 
 include::../include/var-paths.asciidoc[]
 


### PR DESCRIPTION
NTLS -> NTLM

Zeek modules list:
https://github.com/elastic/beats/blob/v8.17.4/x-pack/filebeat/modules.d/zeek.yml.disabled

Reported by user via support.
