### PR TITLE
Migrate the 'test' and 'unit' root make targets to mage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,6 @@ setup-commit-hook:
 stop-environments:
 	@$(foreach var,$(PROJECTS_ENV),$(MAKE) -C $(var) stop-environment || exit 0;)
 
-## test : Runs unit and system tests without coverage and race detection.
-.PHONY: test
-test:
-	@$(foreach var,$(PROJECTS),$(MAKE) -C $(var) test || exit 1;)
-
-## unit : Runs unit tests without coverage and race detection.
-.PHONY: unit
-unit:
-	@$(foreach var,$(PROJECTS),$(MAKE) -C $(var) unit || exit 1;)
-
 ## crosscompile : Crosscompile all beats.
 .PHONY: crosscompile
 crosscompile:

--- a/magefile.go
+++ b/magefile.go
@@ -16,16 +16,18 @@
 // under the License.
 
 //go:build mage
-// +build mage
 
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
 	"go.uber.org/multierr"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
@@ -45,6 +47,31 @@ var (
 		"x-pack/auditbeat",
 		"x-pack/filebeat",
 		"x-pack/metricbeat",
+	}
+
+	// Beats are all beats projects, including libbeat
+	Beats = []string{
+		"auditbeat",
+		"filebeat",
+		"heartbeat",
+		"libbeat",
+		"metricbeat",
+		"packetbeat",
+		"winlogbeat",
+	}
+
+	// XPack are all x-pack beats projects, including libbeat
+	XPack = []string{
+		"agentbeat",
+		"auditbeat",
+		"dockerlogbeat",
+		"filebeat",
+		"heartbeat",
+		"libbeat",
+		"metricbeat",
+		"osquerybeat",
+		"packetbeat",
+		"winlogbeat",
 	}
 )
 
@@ -151,4 +178,108 @@ func CheckLicenseHeaders() error {
 // DumpVariables writes the template variables and values to stdout.
 func DumpVariables() error {
 	return devtools.DumpVariables()
+}
+
+// UnitTest runs unit tests for all OSS and x-pack beats projects
+// (Go and Python).
+func UnitTest() error {
+	fmt.Println(">> running UnitTest for all beats")
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not ger current working directory: %v", err)
+	}
+	defer func() {
+		err = os.Chdir(wd)
+		if err != nil {
+			err = fmt.Errorf("could not restore work directory: %w", err)
+		}
+	}()
+
+	var beats []string
+	for _, d := range Beats {
+		beats = append(beats, filepath.Join(wd, d))
+	}
+	for _, d := range XPack {
+		if d == "agentbeat" {
+			fmt.Println(">> skipping x-pack/agentbeat")
+			continue
+		}
+		beats = append(beats, filepath.Join(wd, "x-pack", d))
+	}
+
+	return runOnEveryBeat(beats, "unitTest")
+}
+
+// IntegTest runs integration tests for all OSS and x-pack beats projects (it
+// uses Docker to run the tests).
+func IntegTest() error {
+	fmt.Println(">> running IntegTest for all beats")
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not ger current working directory: %v", err)
+	}
+	defer func() {
+		err = os.Chdir(wd)
+		if err != nil {
+			err = fmt.Errorf("could not restore work directory: %w", err)
+		}
+	}()
+
+	var beats []string
+
+	for _, d := range Beats {
+		if d == "winlogbeat" {
+			fmt.Println(">> skipping winlogbeat")
+			continue
+		}
+		beats = append(beats, filepath.Join(wd, d))
+	}
+
+	xpackSkip := []string{"packetbeat", "winlogbeat"}
+	for _, d := range XPack {
+		if slices.Contains(xpackSkip, d) {
+			fmt.Printf(">> skipping x-pack/%s\n", d)
+			continue
+		}
+		beats = append(beats, filepath.Join(wd, "x-pack", d))
+	}
+
+	return runOnEveryBeat(beats, "integTest")
+}
+
+func runOnEveryBeat(beatDirs []string, mageTarget string) error {
+	failedBeats := map[string]error{}
+
+	fmt.Println("")
+	for _, p := range beatDirs {
+		fmt.Println(">> entering", p)
+		err := os.Chdir(p)
+		if err != nil {
+			return fmt.Errorf("could not change to %q: %v", p, err)
+		}
+
+		err = sh.RunV("mage", mageTarget)
+		if err != nil {
+			failedBeats[p] = err
+		}
+		fmt.Println("")
+	}
+
+	if len(failedBeats) > 0 {
+		fmt.Print("\n\n")
+		fmt.Println(">> some tests failed:\n")
+		var errs error
+
+		for p, err := range failedBeats {
+			fmt.Printf("%s failed: %v\n", p, err)
+			errs = errors.Join(errs, err)
+		}
+
+		fmt.Println("")
+		return errs
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
migrate the 'test' and 'unit' root make targets to mage

 - removes the 'test' and 'unit' make targets from the root Makefile.
 - adds `unitTest` and `integTest` to the root magefile. They call the respective mage target for each project directory. 
```



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

 - N/A

## How to test this PR locally

 - apply [this patch](https://github.com/user-attachments/files/19472221/dry-run.patch.txt) so you can "dry-run" the tests.
 - run `mage unitTest integTest` from the repo root.
 - you should see the dry run for all tests and the skipped beats as they do not have the respective mage target
```
❯ mage unitTest integTest
>> running UnitTest for all beats
>> skipping x-pack/agentbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/auditbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/auditbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/filebeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/filebeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/heartbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/heartbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/libbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/libbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/metricbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/metricbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/packetbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/packetbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/winlogbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/winlogbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/auditbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/auditbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/dockerlogbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/dockerlogbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/filebeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/filebeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/heartbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/heartbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/libbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/libbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/metricbeat
>> dry run unit tests x-pack/metricbeat ...

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/osquerybeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/osquerybeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/packetbeat
>> dry run unit tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/packetbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/winlogbeat
>> dry run unit tests x-pack/winlogbeat ...

>> running IntegTest for all beats
>> skipping winlogbeat
>> skipping x-pack/packetbeat
>> skipping x-pack/winlogbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/auditbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/auditbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/filebeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/filebeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/heartbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/heartbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/libbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/libbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/metricbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/metricbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/packetbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/packetbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/agentbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/agentbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/auditbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/auditbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/dockerlogbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/dockerlogbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/filebeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/filebeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/heartbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/heartbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/libbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/libbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/metricbeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/metricbeat

>> entering /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/osquerybeat
>> dry run integration tests on  /home/ainsoph/devel/github.com/elastic/beats-tmp/x-pack/osquerybeat
``` 


 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A

## Use cases

Easy way to locally run tests for all beats

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
