### PR TITLE
Replace hard-coded '9.0.0-beta1' in migrated Beats docs

### DIFF
--- a/docs/reference/auditbeat/auditbeat-template.md
+++ b/docs/reference/auditbeat/auditbeat-template.md
@@ -96,8 +96,8 @@ auditbeat setup --index-management -E output.logstash.enabled=false -E 'output.e
 
 **docker:**
 
-```sh
-docker run --rm docker.elastic.co/beats/auditbeat:9.0.0-beta1 setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+```sh subs=true
+docker run --rm docker.elastic.co/beats/auditbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -170,59 +170,59 @@ auditbeat export template > auditbeat.template.json
 
 **win:**
 
-```sh
-PS > .\auditbeat.exe export template --es.version 9.0.0-beta1 | Out-File -Encoding UTF8 auditbeat.template.json
+```sh subs=true
+PS > .\auditbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 auditbeat.template.json
 ```
 
 To install the template, run:
 
 **deb and rpm:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-9.0.0-beta1 -d@auditbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{stack-version}} -d@auditbeat.template.json
 ```
 
 **mac:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-9.0.0-beta1 -d@auditbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{stack-version}} -d@auditbeat.template.json
 ```
 
 **linux:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-9.0.0-beta1 -d@auditbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{stack-version}} -d@auditbeat.template.json
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile auditbeat.template.json -Uri http://localhost:9200/_index_template/auditbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile auditbeat.template.json -Uri http://localhost:9200/_index_template/auditbeat-{{stack-version}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on auditbeat-9.0.0-beta1 index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on auditbeat-{{stack-version}} index.
 
 **deb and rpm:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/auditbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
 ```
 
 **mac:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/auditbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
 ```
 
 **linux:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/auditbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/auditbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
 ```
 

--- a/docs/reference/auditbeat/change-index-name.md
+++ b/docs/reference/auditbeat/change-index-name.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Change the index name [change-index-name]
 
-Auditbeat uses data streams named `auditbeat-9.0.0-beta1`. To use a different name, set the [`index`](/reference/auditbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
+Auditbeat uses data streams named `auditbeat-[version]`. To use a different name, set the [`index`](/reference/auditbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
 
 ```sh
 output.elasticsearch.index: "customname-%{[agent.version]}"

--- a/docs/reference/auditbeat/command-line-options.md
+++ b/docs/reference/auditbeat/command-line-options.md
@@ -89,9 +89,9 @@ Also see [Global flags](#global-flags).
 
 **EXAMPLES**
 
-```sh
+```sh subs=true
 auditbeat export config
-auditbeat export template --es.version 9.0.0-beta1
+auditbeat export template --es.version {{stack-version}}
 auditbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/auditbeat/elasticsearch-output.md
+++ b/docs/reference/auditbeat/elasticsearch-output.md
@@ -191,11 +191,11 @@ Additional headers to send to proxies during CONNECT requests.
 
 ### `index` [index-option-es]
 
-The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"auditbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"auditbeat-9.0.0-beta1-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/auditbeat/configuration-template.md)).
+The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"auditbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"auditbeat-[version]-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/auditbeat/configuration-template.md)).
 
 If you are using the pre-built Kibana dashboards, you also need to set the `setup.dashboards.index` option (see [Kibana dashboards](/reference/auditbeat/configuration-dashboards.md)).
 
-When [index lifecycle management (ILM)](/reference/auditbeat/ilm.md) is enabled, the default `index` is `"auditbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"auditbeat-9.0.0-beta1-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/auditbeat/ilm.md) to learn how to change the index name.
+When [index lifecycle management (ILM)](/reference/auditbeat/ilm.md) is enabled, the default `index` is `"auditbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"auditbeat-[version]-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/auditbeat/ilm.md) to learn how to change the index name.
 
 You can set the index dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `fields.log_type`, to set the index:
 
@@ -208,7 +208,7 @@ output.elasticsearch:
 1. We recommend including `agent.version` in the name to avoid mapping issues when you upgrade.
 
 
-With this configuration, all events with `log_type: normal` are sent to an index named `normal-9.0.0-beta1-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-9.0.0-beta1-2025-01-30`.
+With this configuration, all events with `log_type: normal` are sent to an index named `normal-[version]-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-[version]-2025-01-30`.
 
 ::::{tip}
 To learn how to add custom fields to events, see the [`fields`](/reference/auditbeat/configuration-general-options.md#libbeat-configuration-fields) option.
@@ -252,7 +252,7 @@ output.elasticsearch:
         message: "ERR"
 ```
 
-This configuration results in indices named `warning-9.0.0-beta1-2025-01-30` and `error-9.0.0-beta1-2025-01-30` (plus the default index if no matches are found).
+This configuration results in indices named `warning-[version]-2025-01-30` and `error-[version]-2025-01-30` (plus the default index if no matches are found).
 
 The following example sets the index by taking the name returned by the `index` format string and mapping it to a new name that’s used for the index:
 

--- a/docs/reference/auditbeat/http-endpoint.md
+++ b/docs/reference/auditbeat/http-endpoint.md
@@ -60,13 +60,13 @@ curl -XGET --unix-socket '/var/run/{beatname_lc}.sock' 'http:/stats/?pretty'
 curl -XGET 'localhost:5066/?pretty'
 ```
 
-```js
+```js subs=true
 {
   "beat": "auditbeat",
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "9.0.0-beta1"
+  "version": "{{stack-version}}"
 }
 ```
 

--- a/docs/reference/auditbeat/kafka-output.md
+++ b/docs/reference/auditbeat/kafka-output.md
@@ -144,7 +144,7 @@ output.kafka:
         message: "ERR"
 ```
 
-This configuration results in topics named `critical-9.0.0-beta1`, `error-9.0.0-beta1`, and `logs-9.0.0-beta1`.
+This configuration results in topics named `critical-[version]`, `error-[version]`, and `logs-[version]`.
 
 
 ### `key` [_key]

--- a/docs/reference/auditbeat/load-kibana-dashboards.md
+++ b/docs/reference/auditbeat/load-kibana-dashboards.md
@@ -43,8 +43,8 @@ auditbeat setup --dashboards
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/auditbeat:9.0.0-beta1 setup --dashboards
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/auditbeat:{{stack-version}} setup --dashboards
 ```
 ::::::
 
@@ -118,8 +118,8 @@ auditbeat setup -e \
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/auditbeat:9.0.0-beta1 setup -e \
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/auditbeat:{{stack-version}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=auditbeat_internal \

--- a/docs/reference/auditbeat/logstash-output.md
+++ b/docs/reference/auditbeat/logstash-output.md
@@ -33,12 +33,12 @@ For this configuration, you must [load the index template into {{es}} manually](
 
 Every event sent to {{ls}} contains the following metadata fields that you can use in {{ls}} for indexing and filtering:
 
-```json
+```json subs=true
 {
     ...
     "@metadata": { <1>
       "beat": "auditbeat", <2>
-      "version": "9.0.0-beta1" <3>
+      "version": "{{stack-version}}" <3>
     }
 }
 ```
@@ -68,7 +68,7 @@ output {
 }
 ```
 
-1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `auditbeat-9.0.0-beta1`.
+1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `auditbeat-[version]`.
 
 
 Events indexed into {{es}} with the {{ls}} configuration shown here will be similar to events directly indexed by Auditbeat into {{es}}.
@@ -178,7 +178,7 @@ The `proxy_use_local_resolver` option determines if {{ls}} hostnames are resolve
 
 ### `index` [logstash-index]
 
-The index root name to write events to. The default is the Beat name. For example `"auditbeat"` generates `"[auditbeat-]9.0.0-beta1-YYYY.MM.DD"` indices (for example, `"auditbeat-9.0.0-beta1-2017.04.26"`).
+The index root name to write events to. The default is the Beat name. For example `"auditbeat"` generates `"[auditbeat-][version]-YYYY.MM.DD"` indices (for example, `"auditbeat-[version]-2017.04.26"`).
 
 ::::{note}
 This parameter’s value will be assigned to the `metadata.beat` field. It can then be accessed in {{ls}}'s output section as `%{[@metadata][beat]}`.

--- a/docs/reference/auditbeat/running-on-docker.md
+++ b/docs/reference/auditbeat/running-on-docker.md
@@ -15,21 +15,21 @@ These images are free to use under the Elastic license. They contain open source
 
 Obtaining Auditbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
-% ::::{warning}
-% Version 9.0.0-beta1 of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat 9.0.0-beta1.
+% ::::{warning} subs=true
+% Version {{stack-version}} of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat {{stack-version}}.
 % ::::
 
 
-```sh
-docker pull docker.elastic.co/beats/auditbeat:9.0.0-beta1
+```sh subs=true
+docker pull docker.elastic.co/beats/auditbeat:{{stack-version}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
 
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
-```bash
-docker pull docker.elastic.co/beats/auditbeat-wolfi:9.0.0-beta1
+```bash subs=true
+docker pull docker.elastic.co/beats/auditbeat-wolfi:{{stack-version}}
 ```
 
 
@@ -37,20 +37,20 @@ docker pull docker.elastic.co/beats/auditbeat-wolfi:9.0.0-beta1
 
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Auditbeat Docker image signature.
 
-% ::::{warning}
-% Version 9.0.0-beta1 of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat 9.0.0-beta1.
+% ::::{warning} subs=true
+% Version {{stack-version}} of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat {{stack-version}}.
 % ::::
 
 
-```sh
+```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/auditbeat:9.0.0-beta1
+cosign verify --key cosign.pub docker.elastic.co/beats/auditbeat:{{stack-version}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
-```sh
-Verification for docker.elastic.co/beats/auditbeat:9.0.0-beta1 --
+```sh subs=true
+Verification for docker.elastic.co/beats/auditbeat:{{stack-version}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -67,11 +67,11 @@ A [known issue](https://github.com/elastic/beats/issues/42038) in version 8.17.0
 
 Running Auditbeat with the setup command will create the index pattern and load visualizations , dashboards, and machine learning jobs.  Run this command:
 
-```sh
+```sh subs=true
 docker run --rm \
   --cap-add="AUDIT_CONTROL" \
   --cap-add="AUDIT_READ" \
-  docker.elastic.co/beats/auditbeat:9.0.0-beta1 \
+  docker.elastic.co/beats/auditbeat:{{stack-version}} \
   setup -E setup.kibana.host=kibana:5601 \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -92,11 +92,11 @@ If you’d like to run Auditbeat in a Docker container on a read-only file syste
 
 For example:
 
-```sh
+```sh subs=true
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/auditbeat/data \
   --read-only \
-  docker.elastic.co/beats/auditbeat:9.0.0-beta1
+  docker.elastic.co/beats/auditbeat:{{stack-version}}
 ```
 
 
@@ -117,7 +117,7 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/
 
 One way to configure Auditbeat on Docker is to provide `auditbeat.docker.yml` via a volume mount. With `docker run`, the volume mount can be specified like this.
 
-```sh
+```sh subs=true
 docker run -d \
   --name=auditbeat \
   --user=root \
@@ -125,7 +125,7 @@ docker run -d \
   --cap-add="AUDIT_CONTROL" \
   --cap-add="AUDIT_READ" \
   --pid=host \
-  docker.elastic.co/beats/auditbeat:9.0.0-beta1 -e \
+  docker.elastic.co/beats/auditbeat:{{stack-version}} -e \
   --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -144,8 +144,8 @@ The `auditbeat.docker.yml` downloaded earlier should be customized for your envi
 
 It’s possible to embed your Auditbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
-```dockerfile
-FROM docker.elastic.co/beats/auditbeat:9.0.0-beta1
+```dockerfile subs=true
+FROM docker.elastic.co/beats/auditbeat:{{stack-version}}
 COPY auditbeat.yml /usr/share/auditbeat/auditbeat.yml
 ```
 
@@ -157,8 +157,8 @@ Under Docker, Auditbeat runs as a non-root user, but requires some privileged ca
 
 It is also essential to run Auditbeat in the host PID namespace.
 
-```sh
-docker run --cap-add=AUDIT_CONTROL --cap-add=AUDIT_READ --user=root --pid=host docker.elastic.co/beats/auditbeat:9.0.0-beta1
+```sh subs=true
+docker run --cap-add=AUDIT_CONTROL --cap-add=AUDIT_READ --user=root --pid=host docker.elastic.co/beats/auditbeat:{{stack-version}}
 ```
 
 

--- a/docs/reference/auditbeat/running-on-kubernetes.md
+++ b/docs/reference/auditbeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-However, version 9.0.0-beta1 of Auditbeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{stack-version}} of Auditbeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests [_kubernetes_deploy_manifests]

--- a/docs/reference/filebeat/change-index-name.md
+++ b/docs/reference/filebeat/change-index-name.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Change the index name [change-index-name]
 
-Filebeat uses data streams named `filebeat-9.0.0-beta1`. To use a different name, set the [`index`](/reference/filebeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
+Filebeat uses data streams named `filebeat-[version]`. To use a different name, set the [`index`](/reference/filebeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
 
 ```sh
 output.elasticsearch.index: "customname-%{[agent.version]}"

--- a/docs/reference/filebeat/command-line-options.md
+++ b/docs/reference/filebeat/command-line-options.md
@@ -90,9 +90,9 @@ Also see [Global flags](#global-flags).
 
 **EXAMPLES**
 
-```sh
+```sh subs=true
 filebeat export config
-filebeat export template --es.version 9.0.0-beta1
+filebeat export template --es.version {{stack-version}}
 filebeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/filebeat/elasticsearch-output.md
+++ b/docs/reference/filebeat/elasticsearch-output.md
@@ -191,11 +191,11 @@ Additional headers to send to proxies during CONNECT requests.
 
 ### `index` [index-option-es]
 
-The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"filebeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"filebeat-9.0.0-beta1-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/filebeat/configuration-template.md)).
+The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"filebeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"filebeat-[version]-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/filebeat/configuration-template.md)).
 
 If you are using the pre-built Kibana dashboards, you also need to set the `setup.dashboards.index` option (see [Kibana dashboards](/reference/filebeat/configuration-dashboards.md)).
 
-When [index lifecycle management (ILM)](/reference/filebeat/ilm.md) is enabled, the default `index` is `"filebeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"filebeat-9.0.0-beta1-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/filebeat/ilm.md) to learn how to change the index name.
+When [index lifecycle management (ILM)](/reference/filebeat/ilm.md) is enabled, the default `index` is `"filebeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"filebeat-[version]-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/filebeat/ilm.md) to learn how to change the index name.
 
 You can set the index dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `fields.log_type`, to set the index:
 
@@ -208,7 +208,7 @@ output.elasticsearch:
 1. We recommend including `agent.version` in the name to avoid mapping issues when you upgrade.
 
 
-With this configuration, all events with `log_type: normal` are sent to an index named `normal-9.0.0-beta1-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-9.0.0-beta1-2025-01-30`.
+With this configuration, all events with `log_type: normal` are sent to an index named `normal-[version]-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-[version]-2025-01-30`.
 
 ::::{tip}
 To learn how to add custom fields to events, see the [`fields`](/reference/filebeat/configuration-general-options.md#libbeat-configuration-fields) option.
@@ -252,7 +252,7 @@ output.elasticsearch:
         message: "ERR"
 ```
 
-This configuration results in indices named `warning-9.0.0-beta1-2025-01-30` and `error-9.0.0-beta1-2025-01-30` (plus the default index if no matches are found).
+This configuration results in indices named `warning-[version]-2025-01-30` and `error-[version]-2025-01-30` (plus the default index if no matches are found).
 
 The following example sets the index by taking the name returned by the `index` format string and mapping it to a new name that’s used for the index:
 

--- a/docs/reference/filebeat/filebeat-template.md
+++ b/docs/reference/filebeat/filebeat-template.md
@@ -96,8 +96,8 @@ filebeat setup --index-management -E output.logstash.enabled=false -E 'output.el
 
 **docker:**
 
-```sh
-docker run --rm docker.elastic.co/beats/filebeat:9.0.0-beta1 setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+```sh subs=true
+docker run --rm docker.elastic.co/beats/filebeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -170,59 +170,59 @@ filebeat export template > filebeat.template.json
 
 **win:**
 
-```sh
-PS > .\filebeat.exe export template --es.version 9.0.0-beta1 | Out-File -Encoding UTF8 filebeat.template.json
+```sh subs=true
+PS > .\filebeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 filebeat.template.json
 ```
 
 To install the template, run:
 
 **deb and rpm:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-9.0.0-beta1 -d@filebeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{stack-version}} -d@filebeat.template.json
 ```
 
 **mac:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-9.0.0-beta1 -d@filebeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{stack-version}} -d@filebeat.template.json
 ```
 
 **linux:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-9.0.0-beta1 -d@filebeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{stack-version}} -d@filebeat.template.json
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile filebeat.template.json -Uri http://localhost:9200/_index_template/filebeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile filebeat.template.json -Uri http://localhost:9200/_index_template/filebeat-{{stack-version}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on filebeat-9.0.0-beta1 index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on filebeat-{{stack-version}} index.
 
 **deb and rpm:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/filebeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/filebeat-{{stack-version}}
 ```
 
 **mac:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/filebeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/filebeat-{{stack-version}}
 ```
 
 **linux:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/filebeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/filebeat-{{stack-version}}
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/filebeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/filebeat-{{stack-version}}
 ```
 

--- a/docs/reference/filebeat/filtering-enhancing-data.md
+++ b/docs/reference/filebeat/filtering-enhancing-data.md
@@ -85,13 +85,13 @@ output.console.pretty: true
 
 The resulting output looks something like this:
 
-```json
+```json subs=true
 {
   "@timestamp": "2016-12-06T17:38:11.541Z",
   "beat": {
     "hostname": "host.example.com",
     "name": "host.example.com",
-    "version": "9.0.0-beta1"
+    "version": "{{stack-version}}"
   },
   "inner": {
     "data": "value"

--- a/docs/reference/filebeat/http-endpoint.md
+++ b/docs/reference/filebeat/http-endpoint.md
@@ -60,13 +60,13 @@ curl -XGET --unix-socket '/var/run/{beatname_lc}.sock' 'http:/stats/?pretty'
 curl -XGET 'localhost:5066/?pretty'
 ```
 
-```js
+```js subs=true
 {
   "beat": "filebeat",
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "9.0.0-beta1"
+  "version": "{{stack-version}}"
 }
 ```
 

--- a/docs/reference/filebeat/kafka-output.md
+++ b/docs/reference/filebeat/kafka-output.md
@@ -144,7 +144,7 @@ output.kafka:
         message: "ERR"
 ```
 
-This configuration results in topics named `critical-9.0.0-beta1`, `error-9.0.0-beta1`, and `logs-9.0.0-beta1`.
+This configuration results in topics named `critical-[version]`, `error-[version]`, and `logs-[version]`.
 
 
 ### `key` [_key_2]

--- a/docs/reference/filebeat/load-kibana-dashboards.md
+++ b/docs/reference/filebeat/load-kibana-dashboards.md
@@ -48,8 +48,8 @@ filebeat setup --dashboards
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/filebeat:9.0.0-beta1 setup --dashboards
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/filebeat:{{stack-version}} setup --dashboards
 ```
 ::::::
 
@@ -123,8 +123,8 @@ filebeat setup -e \
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/filebeat:9.0.0-beta1 setup -e \
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/filebeat:{{stack-version}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=filebeat_internal \

--- a/docs/reference/filebeat/logstash-output.md
+++ b/docs/reference/filebeat/logstash-output.md
@@ -35,12 +35,12 @@ Want to use [Filebeat modules](/reference/filebeat/filebeat-modules.md) with {{l
 
 Every event sent to {{ls}} contains the following metadata fields that you can use in {{ls}} for indexing and filtering:
 
-```json
+```json subs=true
 {
     ...
     "@metadata": { <1>
       "beat": "filebeat", <2>
-      "version": "9.0.0-beta1" <3>
+      "version": "{{stack-version}}" <3>
     }
 }
 ```
@@ -70,7 +70,7 @@ output {
 }
 ```
 
-1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `filebeat-9.0.0-beta1`.
+1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `filebeat-9[version]`.
 
 
 Events indexed into {{es}} with the {{ls}} configuration shown here will be similar to events directly indexed by Filebeat into {{es}}.
@@ -180,7 +180,7 @@ The `proxy_use_local_resolver` option determines if {{ls}} hostnames are resolve
 
 ### `index` [logstash-index]
 
-The index root name to write events to. The default is the Beat name. For example `"filebeat"` generates `"[filebeat-]9.0.0-beta1-YYYY.MM.DD"` indices (for example, `"filebeat-9.0.0-beta1-2017.04.26"`).
+The index root name to write events to. The default is the Beat name. For example `"filebeat"` generates `"[filebeat-][version]-YYYY.MM.DD"` indices (for example, `"filebeat-9.0.0-2017.04.26"`).
 
 ::::{note}
 This parameter’s value will be assigned to the `metadata.beat` field. It can then be accessed in {{ls}}'s output section as `%{[@metadata][beat]}`.

--- a/docs/reference/filebeat/running-on-cloudfoundry.md
+++ b/docs/reference/filebeat/running-on-cloudfoundry.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 You can use Filebeat on Cloud Foundry to retrieve and ship logs.
 
-However, version 9.0.0-beta1 of Filebeat has not yet been released, no build is currently available for this version.
+% However, version {{stack-version}} of Filebeat has not yet been released, no build is currently available for this version.
 
 ## Create Cloud Foundry credentials [_create_cloud_foundry_credentials]
 
@@ -30,10 +30,10 @@ You deploy Filebeat as an application with no route.
 
 Cloud Foundry requires that 3 files exist inside of a directory to allow Filebeat to be pushed. The commands below provide the basic steps for getting it up and running.
 
-```sh
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-9.0.0-beta1-linux-x86_64.tar.gz
-tar xzvf filebeat-9.0.0-beta1-linux-x86_64.tar.gz
-cd filebeat-9.0.0-beta1-linux-x86_64
+```sh subs=true
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-linux-x86_64.tar.gz
+tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
+cd filebeat-{{stack-version}}-linux-x86_64
 curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/filebeat/filebeat.yml
 curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/filebeat/manifest.yml
 ```

--- a/docs/reference/filebeat/running-on-docker.md
+++ b/docs/reference/filebeat/running-on-docker.md
@@ -16,20 +16,20 @@ These images are free to use under the Elastic license. They contain open source
 Obtaining Filebeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
 % ::::{warning}
-% Version 9.0.0-beta1 of Filebeat has not yet been released. No Docker image is currently available for Filebeat 9.0.0-beta1.
+% Version {{stack-version}} of Filebeat has not yet been released. No Docker image is currently available for Filebeat {{stack-version}}.
 % ::::
 
 
-```sh
-docker pull docker.elastic.co/beats/filebeat:9.0.0-beta1
+```sh subs=true
+docker pull docker.elastic.co/beats/filebeat:{{stack-version}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
 
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
-```bash
-docker pull docker.elastic.co/beats/filebeat-wolfi:9.0.0-beta1
+```bash subs=true
+docker pull docker.elastic.co/beats/filebeat-wolfi:{{stack-version}}
 ```
 
 
@@ -38,19 +38,19 @@ docker pull docker.elastic.co/beats/filebeat-wolfi:9.0.0-beta1
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Filebeat Docker image signature.
 
 % ::::{warning}
-% Version 9.0.0-beta1 of Filebeat has not yet been released. No Docker image is currently available for Filebeat 9.0.0-beta1.
+% Version {{stack-version}} of Filebeat has not yet been released. No Docker image is currently available for Filebeat {{stack-version}}.
 % ::::
 
 
-```sh
+```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/filebeat:9.0.0-beta1
+cosign verify --key cosign.pub docker.elastic.co/beats/filebeat:{{stack-version}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
-```sh
-Verification for docker.elastic.co/beats/filebeat:9.0.0-beta1 --
+```sh subs=true
+Verification for docker.elastic.co/beats/filebeat:{{stack-version}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -67,9 +67,9 @@ A [known issue](https://github.com/elastic/beats/issues/42038) in version 8.17.0
 
 Running Filebeat with the setup command will create the index pattern and load visualizations , dashboards, and machine learning jobs.  Run this command:
 
-```sh
+```sh subs=true
 docker run --rm \
-docker.elastic.co/beats/filebeat:9.0.0-beta1 \
+docker.elastic.co/beats/filebeat:{{stack-version}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -90,11 +90,11 @@ If you’d like to run Filebeat in a Docker container on a read-only file system
 
 For example:
 
-```sh
+```sh subs=true
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/filebeat/data \
   --read-only \
-  docker.elastic.co/beats/filebeat:9.0.0-beta1
+  docker.elastic.co/beats/filebeat:{{stack-version}}
 ```
 
 
@@ -115,7 +115,7 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/
 
 One way to configure Filebeat on Docker is to provide `filebeat.docker.yml` via a volume mount. With `docker run`, the volume mount can be specified like this.
 
-```sh
+```sh subs=true
 docker run -d \
   --name=filebeat \
   --user=root \
@@ -123,7 +123,7 @@ docker run -d \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
   --volume="registry:/usr/share/filebeat/data:rw" \
-  docker.elastic.co/beats/filebeat:9.0.0-beta1 filebeat -e --strict.perms=false \
+  docker.elastic.co/beats/filebeat:{{stack-version}} filebeat -e --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
 
@@ -155,8 +155,8 @@ docker run \
 
 It’s possible to embed your Filebeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
-```dockerfile
-FROM docker.elastic.co/beats/filebeat:9.0.0-beta1
+```dockerfile subs=true
+FROM docker.elastic.co/beats/filebeat:{{stack-version}}
 COPY --chown=root:filebeat filebeat.yml /usr/share/filebeat/filebeat.yml
 ```
 

--- a/docs/reference/filebeat/running-on-kubernetes.md
+++ b/docs/reference/filebeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-However, version 9.0.0-beta1 of Filebeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{stack-version}} of Filebeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests [_kubernetes_deploy_manifests]

--- a/docs/reference/heartbeat/change-index-name.md
+++ b/docs/reference/heartbeat/change-index-name.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Change the index name [change-index-name]
 
-Heartbeat uses data streams named `heartbeat-9.0.0-beta1`. To use a different name, set the [`index`](/reference/heartbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
+Heartbeat uses data streams named `heartbeat-[version]`. To use a different name, set the [`index`](/reference/heartbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
 
 ```sh
 output.elasticsearch.index: "customname-%{[agent.version]}"

--- a/docs/reference/heartbeat/command-line-options.md
+++ b/docs/reference/heartbeat/command-line-options.md
@@ -72,9 +72,9 @@ Also see [Global flags](#global-flags).
 
 **EXAMPLES**
 
-```sh
+```sh subs=true
 heartbeat export config
-heartbeat export template --es.version 9.0.0-beta1
+heartbeat export template --es.version {{stack-version}}
 ```
 
 

--- a/docs/reference/heartbeat/elasticsearch-output.md
+++ b/docs/reference/heartbeat/elasticsearch-output.md
@@ -191,9 +191,9 @@ Additional headers to send to proxies during CONNECT requests.
 
 ### `index` [index-option-es]
 
-The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"heartbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"heartbeat-9.0.0-beta1-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/heartbeat/configuration-template.md)).
+The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"heartbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"heartbeat-[version]-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/heartbeat/configuration-template.md)).
 
-When [index lifecycle management (ILM)](/reference/heartbeat/ilm.md) is enabled, the default `index` is `"heartbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"heartbeat-9.0.0-beta1-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/heartbeat/ilm.md) to learn how to change the index name.
+When [index lifecycle management (ILM)](/reference/heartbeat/ilm.md) is enabled, the default `index` is `"heartbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"heartbeat-[version]-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/heartbeat/ilm.md) to learn how to change the index name.
 
 You can set the index dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `fields.log_type`, to set the index:
 
@@ -206,7 +206,7 @@ output.elasticsearch:
 1. We recommend including `agent.version` in the name to avoid mapping issues when you upgrade.
 
 
-With this configuration, all events with `log_type: normal` are sent to an index named `normal-9.0.0-beta1-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-9.0.0-beta1-2025-01-30`.
+With this configuration, all events with `log_type: normal` are sent to an index named `normal-[version]-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-[version]-2025-01-30`.
 
 ::::{tip}
 To learn how to add custom fields to events, see the [`fields`](/reference/heartbeat/configuration-general-options.md#libbeat-configuration-fields) option.
@@ -250,7 +250,7 @@ output.elasticsearch:
         message: "ERR"
 ```
 
-This configuration results in indices named `warning-9.0.0-beta1-2025-01-30` and `error-9.0.0-beta1-2025-01-30` (plus the default index if no matches are found).
+This configuration results in indices named `warning-[version]-2025-01-30` and `error-[version]-2025-01-30` (plus the default index if no matches are found).
 
 The following example sets the index by taking the name returned by the `index` format string and mapping it to a new name that’s used for the index:
 

--- a/docs/reference/heartbeat/heartbeat-template.md
+++ b/docs/reference/heartbeat/heartbeat-template.md
@@ -96,8 +96,8 @@ heartbeat setup --index-management -E output.logstash.enabled=false -E 'output.e
 
 **docker:**
 
-```sh
-docker run --rm docker.elastic.co/beats/heartbeat:9.0.0-beta1 setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+```sh subs=true
+docker run --rm docker.elastic.co/beats/heartbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -170,59 +170,59 @@ heartbeat export template > heartbeat.template.json
 
 **win:**
 
-```sh
-PS > .\heartbeat.exe export template --es.version 9.0.0-beta1 | Out-File -Encoding UTF8 heartbeat.template.json
+```sh subs=true
+PS > .\heartbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 heartbeat.template.json
 ```
 
 To install the template, run:
 
 **deb and rpm:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-9.0.0-beta1 -d@heartbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{stack-version}} -d@heartbeat.template.json
 ```
 
 **mac:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-9.0.0-beta1 -d@heartbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{stack-version}} -d@heartbeat.template.json
 ```
 
 **linux:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-9.0.0-beta1 -d@heartbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{stack-version}} -d@heartbeat.template.json
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile heartbeat.template.json -Uri http://localhost:9200/_index_template/heartbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile heartbeat.template.json -Uri http://localhost:9200/_index_template/heartbeat-{{stack-version}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on heartbeat-9.0.0-beta1 index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on heartbeat-{{stack-version}} index.
 
 **deb and rpm:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/heartbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
 ```
 
 **mac:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/heartbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
 ```
 
 **linux:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/heartbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/heartbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
 ```
 

--- a/docs/reference/heartbeat/http-endpoint.md
+++ b/docs/reference/heartbeat/http-endpoint.md
@@ -60,13 +60,13 @@ curl -XGET --unix-socket '/var/run/{beatname_lc}.sock' 'http:/stats/?pretty'
 curl -XGET 'localhost:5066/?pretty'
 ```
 
-```js
+```js subs=true
 {
   "beat": "heartbeat",
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "9.0.0-beta1"
+  "version": "{{stack-version}}"
 }
 ```
 

--- a/docs/reference/heartbeat/kafka-output.md
+++ b/docs/reference/heartbeat/kafka-output.md
@@ -144,7 +144,7 @@ output.kafka:
         message: "ERR"
 ```
 
-This configuration results in topics named `critical-9.0.0-beta1`, `error-9.0.0-beta1`, and `logs-9.0.0-beta1`.
+This configuration results in topics named `critical-[version]`, `error-[version]`, and `logs-[version]`.
 
 
 ### `key` [_key]

--- a/docs/reference/heartbeat/logstash-output.md
+++ b/docs/reference/heartbeat/logstash-output.md
@@ -33,12 +33,12 @@ For this configuration, you must [load the index template into {{es}} manually](
 
 Every event sent to {{ls}} contains the following metadata fields that you can use in {{ls}} for indexing and filtering:
 
-```json
+```json subs=true
 {
     ...
     "@metadata": { <1>
       "beat": "heartbeat", <2>
-      "version": "9.0.0-beta1" <3>
+      "version": "{{stack-version}}" <3>
     }
 }
 ```
@@ -68,7 +68,7 @@ output {
 }
 ```
 
-1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `heartbeat-9.0.0-beta1`.
+1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `heartbeat-9[version]`.
 
 
 Events indexed into {{es}} with the {{ls}} configuration shown here will be similar to events directly indexed by Heartbeat into {{es}}.
@@ -178,7 +178,7 @@ The `proxy_use_local_resolver` option determines if {{ls}} hostnames are resolve
 
 ### `index` [logstash-index]
 
-The index root name to write events to. The default is the Beat name. For example `"heartbeat"` generates `"[heartbeat-]9.0.0-beta1-YYYY.MM.DD"` indices (for example, `"heartbeat-9.0.0-beta1-2017.04.26"`).
+The index root name to write events to. The default is the Beat name. For example `"heartbeat"` generates `"[heartbeat-][version]-YYYY.MM.DD"` indices (for example, `"heartbeat-9.0.0-2017.04.26"`).
 
 ::::{note}
 This parameter’s value will be assigned to the `metadata.beat` field. It can then be accessed in {{ls}}'s output section as `%{[@metadata][beat]}`.

--- a/docs/reference/heartbeat/running-on-docker.md
+++ b/docs/reference/heartbeat/running-on-docker.md
@@ -15,21 +15,21 @@ These images are free to use under the Elastic license. They contain open source
 
 Obtaining Heartbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
-% ::::{warning}
-% Version 9.0.0-beta1 of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat 9.0.0-beta1.
+% ::::{warning} subs=true
+% Version {{stack-version}} of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat {{stack-version}}.
 % ::::
 
 
-```sh
-docker pull docker.elastic.co/beats/heartbeat:9.0.0-beta1
+```sh subs=true
+docker pull docker.elastic.co/beats/heartbeat:{{stack-version}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
 
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
-```bash
-docker pull docker.elastic.co/beats/heartbeat-wolfi:9.0.0-beta1
+```bash subs=true
+docker pull docker.elastic.co/beats/heartbeat-wolfi:{{stack-version}}
 ```
 
 
@@ -37,20 +37,20 @@ docker pull docker.elastic.co/beats/heartbeat-wolfi:9.0.0-beta1
 
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Heartbeat Docker image signature.
 
-% ::::{warning}
-% Version 9.0.0-beta1 of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat 9.0.0-beta1.
+% ::::{warning} subs=true
+% Version {{stack-version}} of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat {{stack-version}}.
 % ::::
 
 
-```sh
+```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/heartbeat:9.0.0-beta1
+cosign verify --key cosign.pub docker.elastic.co/beats/heartbeat:{{stack-version}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
-```sh
-Verification for docker.elastic.co/beats/heartbeat:9.0.0-beta1 --
+```sh subs=true
+Verification for docker.elastic.co/beats/heartbeat:{{stack-version}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -67,10 +67,10 @@ A [known issue](https://github.com/elastic/beats/issues/42038) in version 8.17.0
 
 Running Heartbeat with the setup command will create the index pattern and load visualizations and machine learning jobs.  Run this command:
 
-```sh
+```sh subs=true
 docker run --rm \
 --cap-add=NET_RAW \
-docker.elastic.co/beats/heartbeat:9.0.0-beta1 \
+docker.elastic.co/beats/heartbeat:{{stack-version}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -91,11 +91,11 @@ If you’d like to run Heartbeat in a Docker container on a read-only file syste
 
 For example:
 
-```sh
+```sh subs=true
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/heartbeat/data \
   --read-only \
-  docker.elastic.co/beats/heartbeat:9.0.0-beta1
+  docker.elastic.co/beats/heartbeat:{{stack-version}}
 ```
 
 
@@ -116,13 +116,13 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/
 
 One way to configure Heartbeat on Docker is to provide `heartbeat.docker.yml` via a volume mount. With `docker run`, the volume mount can be specified like this.
 
-```sh
+```sh subs=true
 docker run -d \
   --name=heartbeat \
   --user=heartbeat \
   --volume="$(pwd)/heartbeat.docker.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --cap-add=NET_RAW \
-  docker.elastic.co/beats/heartbeat:9.0.0-beta1 \
+  docker.elastic.co/beats/heartbeat:{{stack-version}} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -141,8 +141,8 @@ The `heartbeat.docker.yml` downloaded earlier should be customized for your envi
 
 It’s possible to embed your Heartbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
-```dockerfile
-FROM docker.elastic.co/beats/heartbeat:9.0.0-beta1
+```dockerfile subs=true
+FROM docker.elastic.co/beats/heartbeat:{{stack-version}}
 COPY --chown=root:heartbeat heartbeat.yml /usr/share/heartbeat/heartbeat.yml
 ```
 
@@ -151,8 +151,8 @@ COPY --chown=root:heartbeat heartbeat.yml /usr/share/heartbeat/heartbeat.yml
 
 Under Docker, Heartbeat runs as a non-root user, but requires some privileged network capabilities to operate correctly. Ensure that the `NET_RAW` capability is available to the container.
 
-```sh
-docker run --cap-add=NET_RAW docker.elastic.co/beats/heartbeat:9.0.0-beta1
+```sh subs=true
+docker run --cap-add=NET_RAW docker.elastic.co/beats/heartbeat:{{stack-version}}
 ```
 
 

--- a/docs/reference/heartbeat/running-on-kubernetes.md
+++ b/docs/reference/heartbeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-However, version 9.0.0-beta1 of Heartbeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{stack-version}} of Heartbeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests [_kubernetes_deploy_manifests]
@@ -72,10 +72,10 @@ heartbeat   1/1     1            1           1m
 
 Under Kubernetes, Heartbeat can run as a non-root user, but requires some privileged network capabilities to operate correctly. Ensure that the `NET_RAW` capability is available to the container.
 
-```yaml
+```yaml subs=true
 containers:
 - name: heartbeat
-  image: docker.elastic.co/beats/heartbeat:9.0.0-beta1
+  image: docker.elastic.co/beats/heartbeat:{{stack-version}}
   securityContext:
     runAsUser: 1000
     runAsGroup: 1000

--- a/docs/reference/loggingplugin/log-driver-configuration.md
+++ b/docs/reference/loggingplugin/log-driver-configuration.md
@@ -17,8 +17,8 @@ Use the following options to configure the Elastic Logging Plugin for Docker. Yo
 
 To set configuration options when you start a container:
 
-```sh
-docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
+```sh subs=true
+docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
            --log-opt hosts="https://myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -27,9 +27,9 @@ docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
 
 To set configuration options for all containers in the `daemon.json` file:
 
-```json
+```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:9.0.0-beta1",
+  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
   "log-opts" : {
     "hosts" : "https://myhost:9200",
     "user" : "myusername",
@@ -73,27 +73,27 @@ This plugin fully supports `docker logs`, and it maintains a local copy of logs 
 
 1. Disable the plugin:
 
-    ```sh
-    docker plugin disable elastic/elastic-logging-plugin:9.0.0-beta1
+    ```sh subs=true
+    docker plugin disable elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
 2. Set the bindmount directory:
 
-    ```sh
-    docker plugin set elastic/elastic-logging-plugin:9.0.0-beta1 LOG_DIR.source=NEW_LOG_LOCATION
+    ```sh subs=true
+    docker plugin set elastic/elastic-logging-plugin:{{stack-version}} LOG_DIR.source=NEW_LOG_LOCATION
     ```
 
 3. Enable the plugin:
 
-    ```sh
-    docker plugin enable elastic/elastic-logging-plugin:9.0.0-beta1
+    ```sh subs=true
+    docker plugin enable elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
 
 The local log also supports the `max-file`, `max-size` and `compress` options that are [a part of the Docker default file logger](https://docs.docker.com/config/containers/logging/json-file/#options). For example:
 
-```sh
-docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
+```sh subs=true
+docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
            --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -107,20 +107,20 @@ In situations where logs can’t be easily managed, for example, you can also co
 
 1. Disable the plugin:
 
-    ```sh
-    docker plugin disable elastic/elastic-logging-plugin:9.0.0-beta1
+    ```sh subs=true
+    docker plugin disable elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
 2. Enable log removal:
 
-    ```sh
-    docker plugin set elastic/elastic-logging-plugin:9.0.0-beta1 DESTROY_LOGS_ON_STOP=true
+    ```sh subs=true
+    docker plugin set elastic/elastic-logging-plugin:{{stack-version}} DESTROY_LOGS_ON_STOP=true
     ```
 
 3. Enable the plugin:
 
-    ```sh
-    docker plugin enable elastic/elastic-logging-plugin:9.0.0-beta1
+    ```sh subs=true
+    docker plugin enable elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
 

--- a/docs/reference/loggingplugin/log-driver-installation.md
+++ b/docs/reference/loggingplugin/log-driver-installation.md
@@ -22,8 +22,8 @@ Make sure your system meets the following prerequisites:
 
     **To install from the Docker store:**
 
-    ```sh
-    docker plugin install elastic/elastic-logging-plugin:9.0.0-beta1
+    ```sh subs=true
+    docker plugin install elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
     **To build and install from source:**
@@ -37,8 +37,8 @@ Make sure your system meets the following prerequisites:
 
 2. If necessary, enable the plugin:
 
-    ```sh
-    docker plugin enable elastic/elastic-logging-plugin:9.0.0-beta1
+    ```sh subs=true
+    docker plugin enable elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
 3. Verify that the plugin is installed and enabled:
@@ -49,9 +49,9 @@ Make sure your system meets the following prerequisites:
 
     The output should say something like:
 
-    ```sh
+    ```sh subs=true
     ID                  NAME                                   DESCRIPTION              ENABLED
-    c2ff9d2cf090        elastic/elastic-logging-plugin:9.0.0-beta1   A beat for docker logs   true
+    c2ff9d2cf090        elastic/elastic-logging-plugin:{{stack-version}}   A beat for docker logs   true
     ```
 
 
@@ -64,8 +64,8 @@ You can set configuration options for a single container, or for all containers 
 
 Pass configuration options at run time when you start the container. For example:
 
-```sh
-docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
+```sh subs=true
+docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
            --log-opt hosts="https://myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -76,9 +76,9 @@ docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
 
 Set configuration options in the Docker `daemon.json` configuration file. For example:
 
-```json
+```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:9.0.0-beta1",
+  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
   "log-opts" : {
     "hosts" : "https://myhost:9200",
     "user" : "myusername",

--- a/docs/reference/loggingplugin/log-driver-usage-examples.md
+++ b/docs/reference/loggingplugin/log-driver-usage-examples.md
@@ -14,8 +14,8 @@ The following examples show common configurations for the Elastic Logging Plugin
 
 **Docker run command:**
 
-```sh
-docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
+```sh subs=true
+docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
            --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -24,9 +24,9 @@ docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
 
 **Daemon configuration:**
 
-```json
+```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:9.0.0-beta1",
+  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
   "log-opts" : {
     "hosts" : "myhost:9200",
     "user" : "myusername",
@@ -40,8 +40,8 @@ docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
 
 **Docker run command:**
 
-```sh
-docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
+```sh subs=true
+docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
            --log-opt cloud_id="MyElasticStack:daMbY2VudHJhbDekZ2NwLmN4b3VkLmVzLmliJDVkYmQwtGJiYjs0NTRiN4Q5ODJmNGUwm1IxZmFkNjM5JDFiNjdkMDE4MTgxMTQzNTM5ZGFiYWJjZmY0OWIyYWE5" \
            --log-opt cloud_auth="myusername:mypassword" \
            -it debian:jessie /bin/bash
@@ -49,9 +49,9 @@ docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
 
 **Daemon configuration:**
 
-```json
+```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:9.0.0-beta1",
+  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
   "log-opts" : {
     "cloud_id" : "MyElasticStack:daMbY2VudHJhbDekZ2NwLmN4b3VkLmVzLmliJDVkYmQwtGJiYjs0NTRiN4Q5ODJmNGUwm1IxZmFkNjM5JDFiNjdkMDE4MTgxMTQzNTM5ZGFiYWJjZmY0OWIyYWE5",
     "cloud_auth" : "myusername:mypassword",
@@ -65,8 +65,8 @@ docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
 
 **Docker run command:**
 
-```sh
-docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
+```sh subs=true
+docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
            --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -76,9 +76,9 @@ docker run --log-driver=elastic/elastic-logging-plugin:9.0.0-beta1 \
 
 **Daemon configuration:**
 
-```json
+```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:9.0.0-beta1",
+  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
   "log-opts" : {
     "hosts" : "myhost:9200",
     "user" : "myusername",

--- a/docs/reference/metricbeat/change-index-name.md
+++ b/docs/reference/metricbeat/change-index-name.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Change the index name [change-index-name]
 
-Metricbeat uses data streams named `metricbeat-9.0.0-beta1`. To use a different name, set the [`index`](/reference/metricbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
+Metricbeat uses data streams named `metricbeat-[version]`. To use a different name, set the [`index`](/reference/metricbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
 
 ```sh
 output.elasticsearch.index: "customname-%{[agent.version]}"

--- a/docs/reference/metricbeat/command-line-options.md
+++ b/docs/reference/metricbeat/command-line-options.md
@@ -90,9 +90,9 @@ Also see [Global flags](#global-flags).
 
 **EXAMPLES**
 
-```sh
+```sh subs=true
 metricbeat export config
-metricbeat export template --es.version 9.0.0-beta1
+metricbeat export template --es.version {{stack-version}}
 metricbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/metricbeat/elasticsearch-output.md
+++ b/docs/reference/metricbeat/elasticsearch-output.md
@@ -191,11 +191,11 @@ Additional headers to send to proxies during CONNECT requests.
 
 ### `index` [index-option-es]
 
-The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"metricbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"metricbeat-9.0.0-beta1-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/metricbeat/configuration-template.md)).
+The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"metricbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"metricbeat-[version]-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/metricbeat/configuration-template.md)).
 
 If you are using the pre-built Kibana dashboards, you also need to set the `setup.dashboards.index` option (see [Kibana dashboards](/reference/metricbeat/configuration-dashboards.md)).
 
-When [index lifecycle management (ILM)](/reference/metricbeat/ilm.md) is enabled, the default `index` is `"metricbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"metricbeat-9.0.0-beta1-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/metricbeat/ilm.md) to learn how to change the index name.
+When [index lifecycle management (ILM)](/reference/metricbeat/ilm.md) is enabled, the default `index` is `"metricbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"metricbeat-[version]-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/metricbeat/ilm.md) to learn how to change the index name.
 
 You can set the index dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `fields.log_type`, to set the index:
 
@@ -208,7 +208,7 @@ output.elasticsearch:
 1. We recommend including `agent.version` in the name to avoid mapping issues when you upgrade.
 
 
-With this configuration, all events with `log_type: normal` are sent to an index named `normal-9.0.0-beta1-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-9.0.0-beta1-2025-01-30`.
+With this configuration, all events with `log_type: normal` are sent to an index named `normal-[version]-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-[version]-2025-01-30`.
 
 ::::{tip}
 To learn how to add custom fields to events, see the [`fields`](/reference/metricbeat/configuration-general-options.md#libbeat-configuration-fields) option.
@@ -252,7 +252,7 @@ output.elasticsearch:
         message: "ERR"
 ```
 
-This configuration results in indices named `warning-9.0.0-beta1-2025-01-30` and `error-9.0.0-beta1-2025-01-30` (plus the default index if no matches are found).
+This configuration results in indices named `warning-[version]-2025-01-30` and `error-[version]-2025-01-30` (plus the default index if no matches are found).
 
 The following example sets the index by taking the name returned by the `index` format string and mapping it to a new name that’s used for the index:
 

--- a/docs/reference/metricbeat/http-endpoint.md
+++ b/docs/reference/metricbeat/http-endpoint.md
@@ -60,13 +60,13 @@ curl -XGET --unix-socket '/var/run/{beatname_lc}.sock' 'http:/stats/?pretty'
 curl -XGET 'localhost:5066/?pretty'
 ```
 
-```js
+```js subs=true
 {
   "beat": "metricbeat",
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "9.0.0-beta1"
+  "version": "{{stack-version}}"
 }
 ```
 

--- a/docs/reference/metricbeat/kafka-output.md
+++ b/docs/reference/metricbeat/kafka-output.md
@@ -144,7 +144,7 @@ output.kafka:
         message: "ERR"
 ```
 
-This configuration results in topics named `critical-9.0.0-beta1`, `error-9.0.0-beta1`, and `logs-9.0.0-beta1`.
+This configuration results in topics named `critical-[version]`, `error-[version]`, and `logs-[version]`.
 
 
 ### `key` [_key]

--- a/docs/reference/metricbeat/load-kibana-dashboards.md
+++ b/docs/reference/metricbeat/load-kibana-dashboards.md
@@ -48,8 +48,8 @@ metricbeat setup --dashboards
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/metricbeat:9.0.0-beta1 setup --dashboards
+```sh  subs=true
+docker run --rm --net="host" docker.elastic.co/beats/metricbeat:{{stack-version}} setup --dashboards
 ```
 ::::::
 
@@ -123,8 +123,8 @@ metricbeat setup -e \
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/metricbeat:9.0.0-beta1 setup -e \
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/metricbeat:{{stack-version}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=metricbeat_internal \

--- a/docs/reference/metricbeat/logstash-output.md
+++ b/docs/reference/metricbeat/logstash-output.md
@@ -33,12 +33,12 @@ For this configuration, you must [load the index template into {{es}} manually](
 
 Every event sent to {{ls}} contains the following metadata fields that you can use in {{ls}} for indexing and filtering:
 
-```json
+```json subs=true
 {
     ...
     "@metadata": { <1>
       "beat": "metricbeat", <2>
-      "version": "9.0.0-beta1" <3>
+      "version": "{{stack-version}}" <3>
     }
 }
 ```
@@ -68,7 +68,7 @@ output {
 }
 ```
 
-1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `metricbeat-9.0.0-beta1`.
+1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `metricbeat-9[version]`.
 
 
 Events indexed into {{es}} with the {{ls}} configuration shown here will be similar to events directly indexed by Metricbeat into {{es}}.
@@ -178,7 +178,7 @@ The `proxy_use_local_resolver` option determines if {{ls}} hostnames are resolve
 
 ### `index` [logstash-index]
 
-The index root name to write events to. The default is the Beat name. For example `"metricbeat"` generates `"[metricbeat-]9.0.0-beta1-YYYY.MM.DD"` indices (for example, `"metricbeat-9.0.0-beta1-2017.04.26"`).
+The index root name to write events to. The default is the Beat name. For example `"metricbeat"` generates `"[metricbeat-][version]-YYYY.MM.DD"` indices (for example, `"metricbeat-9.0.0-2017.04.26"`).
 
 ::::{note}
 This parameter’s value will be assigned to the `metadata.beat` field. It can then be accessed in {{ls}}'s output section as `%{[@metadata][beat]}`.

--- a/docs/reference/metricbeat/metricbeat-template.md
+++ b/docs/reference/metricbeat/metricbeat-template.md
@@ -96,8 +96,8 @@ metricbeat setup --index-management -E output.logstash.enabled=false -E 'output.
 
 **docker:**
 
-```sh
-docker run --rm docker.elastic.co/beats/metricbeat:9.0.0-beta1 setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+```sh subs=true
+docker run --rm docker.elastic.co/beats/metricbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -170,59 +170,59 @@ metricbeat export template > metricbeat.template.json
 
 **win:**
 
-```sh
-PS > .\metricbeat.exe export template --es.version 9.0.0-beta1 | Out-File -Encoding UTF8 metricbeat.template.json
+```sh subs=true
+PS > .\metricbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 metricbeat.template.json
 ```
 
 To install the template, run:
 
 **deb and rpm:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-9.0.0-beta1 -d@metricbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{stack-version}} -d@metricbeat.template.json
 ```
 
 **mac:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-9.0.0-beta1 -d@metricbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{stack-version}} -d@metricbeat.template.json
 ```
 
 **linux:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-9.0.0-beta1 -d@metricbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{stack-version}} -d@metricbeat.template.json
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile metricbeat.template.json -Uri http://localhost:9200/_index_template/metricbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile metricbeat.template.json -Uri http://localhost:9200/_index_template/metricbeat-{{stack-version}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on metricbeat-9.0.0-beta1 index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on metricbeat-{{stack-version}} index.
 
 **deb and rpm:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/metricbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
 ```
 
 **mac:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/metricbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
 ```
 
 **linux:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/metricbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/metricbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
 ```
 

--- a/docs/reference/metricbeat/running-on-cloudfoundry.md
+++ b/docs/reference/metricbeat/running-on-cloudfoundry.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 You can use Metricbeat on Cloud Foundry to retrieve and ship metrics.
 
-However, version 9.0.0-beta1 of Metricbeat has not yet been released, no build is currently available for this version.
+% However, version {{stack-version}} of Metricbeat has not yet been released, no build is currently available for this version.
 
 ## Create Cloud Foundry credentials [_create_cloud_foundry_credentials]
 
@@ -30,10 +30,10 @@ You deploy Metricbeat as an application with no route.
 
 Cloud Foundry requires that 3 files exist inside of a directory to allow Metricbeat to be pushed. The commands below provide the basic steps for getting it up and running.
 
-```sh
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-9.0.0-beta1-linux-x86_64.tar.gz
-tar xzvf metricbeat-9.0.0-beta1-linux-x86_64.tar.gz
-cd metricbeat-9.0.0-beta1-linux-x86_64
+```sh subs=true
+curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-linux-x86_64.tar.gz
+tar xzvf metricbeat-{{stack-version}}-linux-x86_64.tar.gz
+cd metricbeat-{{stack-version}}-linux-x86_64
 curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/metricbeat/metricbeat.yml
 curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/metricbeat/manifest.yml
 ```

--- a/docs/reference/metricbeat/running-on-docker.md
+++ b/docs/reference/metricbeat/running-on-docker.md
@@ -15,21 +15,21 @@ These images are free to use under the Elastic license. They contain open source
 
 Obtaining Metricbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
-::::{warning}
-Version 9.0.0-beta1 of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat 9.0.0-beta1.
-::::
+% ::::{warning} subs=true
+% Version {{stack-version}} of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat {{stack-version}}.
+% ::::
 
 
-```sh
-docker pull docker.elastic.co/beats/metricbeat:9.0.0-beta1
+```sh subs=true
+docker pull docker.elastic.co/beats/metricbeat:{{stack-version}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
 
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
-```bash
-docker pull docker.elastic.co/beats/metricbeat-wolfi:9.0.0-beta1
+```bash subs=true
+docker pull docker.elastic.co/beats/metricbeat-wolfi:{{stack-version}}
 ```
 
 
@@ -38,19 +38,19 @@ docker pull docker.elastic.co/beats/metricbeat-wolfi:9.0.0-beta1
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Metricbeat Docker image signature.
 
 % ::::{warning}
-% Version 9.0.0-beta1 of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat 9.0.0-beta1.
+% Version {{stack-version}} of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat {{stack-version}}.
 % ::::
 
 
-```sh
+```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/metricbeat:9.0.0-beta1
+cosign verify --key cosign.pub docker.elastic.co/beats/metricbeat:{{stack-version}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
-```sh
-Verification for docker.elastic.co/beats/metricbeat:9.0.0-beta1 --
+```sh subs=true
+Verification for docker.elastic.co/beats/metricbeat:{{stack-version}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -67,9 +67,9 @@ A [known issue](https://github.com/elastic/beats/issues/42038) in version 8.17.0
 
 Running Metricbeat with the setup command will create the index pattern and load visualizations , dashboards, and machine learning jobs.  Run this command:
 
-```sh
+```sh subs=true
 docker run --rm \
-docker.elastic.co/beats/metricbeat:9.0.0-beta1 \
+docker.elastic.co/beats/metricbeat:{{stack-version}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -90,11 +90,11 @@ If you’d like to run Metricbeat in a Docker container on a read-only file syst
 
 For example:
 
-```sh
+```sh subs=true
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/metricbeat/data \
   --read-only \
-  docker.elastic.co/beats/metricbeat:9.0.0-beta1
+  docker.elastic.co/beats/metricbeat:{{stack-version}}
 ```
 
 
@@ -115,7 +115,7 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/
 
 One way to configure Metricbeat on Docker is to provide `metricbeat.docker.yml` via a volume mount. With `docker run`, the volume mount can be specified like this.
 
-```sh
+```sh subs=true
 docker run -d \
   --name=metricbeat \
   --user=root \
@@ -124,7 +124,7 @@ docker run -d \
   --volume="/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro" \
   --volume="/proc:/hostfs/proc:ro" \
   --volume="/:/hostfs:ro" \
-  docker.elastic.co/beats/metricbeat:9.0.0-beta1 metricbeat -e \
+  docker.elastic.co/beats/metricbeat:{{stack-version}} metricbeat -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
 
@@ -156,8 +156,8 @@ docker run \
 
 It’s possible to embed your Metricbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
-```dockerfile
-FROM docker.elastic.co/beats/metricbeat:9.0.0-beta1
+```dockerfile subs=true
+FROM docker.elastic.co/beats/metricbeat:{{stack-version}}
 COPY --chown=root:metricbeat metricbeat.yml /usr/share/metricbeat/metricbeat.yml
 ```
 
@@ -168,7 +168,7 @@ When executing Metricbeat in a container, there are some important things to be 
 
 This example highlights the changes required to make the system module work properly inside of a container. This enables Metricbeat to monitor the host machine from within the container.
 
-```sh
+```sh subs=true
 docker run \
   --mount type=bind,source=/proc,target=/hostfs/proc,readonly \ <1>
   --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly \ <2>
@@ -177,7 +177,7 @@ docker run \
   --env DBUS_SYSTEM_BUS_ADDRESS='unix:path=/hostfs/var/run/dbus/system_bus_socket' \ <4>
   --net=host \ <5>
   --cgroupns=host \ <6>
-  docker.elastic.co/beats/metricbeat:9.0.0-beta1 -e --system.hostfs=/hostfs
+  docker.elastic.co/beats/metricbeat:{{stack-version}} -e --system.hostfs=/hostfs
 ```
 
 1. Metricbeat’s [system module](/reference/metricbeat/metricbeat-module-system.md) collects much of its data through the Linux proc filesystem, which is normally located at `/proc`. Because containers are isolated as much as possible from the host, the data inside of the container’s `/proc` is different than the host’s `/proc`. To account for this, you can mount the host’s `/proc` filesystem inside of the container and tell Metricbeat to look inside the `/hostfs` directory when looking for `/proc` by using the `hostfs=/hostfs` config value.
@@ -204,11 +204,11 @@ If the [system socket metricset](/reference/metricbeat/metricbeat-metricset-syst
 
 Next, let’s look at an example of monitoring a containerized service from a Metricbeat container.
 
-```sh
+```sh subs=true
 docker run \
   --network=mysqlnet \ <1>
   -e MYSQL_PASSWORD=secret \ <2>
-  docker.elastic.co/beats/metricbeat:9.0.0-beta1
+  docker.elastic.co/beats/metricbeat:{{stack-version}}
 ```
 
 1. Placing the Metricbeat and MySQL containers on the same Docker network allows Metricbeat access to the exposed ports of the MySQL container, and makes the hostname `mysql` resolvable to Metricbeat.

--- a/docs/reference/metricbeat/running-on-kubernetes.md
+++ b/docs/reference/metricbeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-However, version 9.0.0-beta1 of Metricbeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{stack-version}} of Metricbeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests [_kubernetes_deploy_manifests]

--- a/docs/reference/packetbeat/change-index-name.md
+++ b/docs/reference/packetbeat/change-index-name.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Change the index name [change-index-name]
 
-Packetbeat uses data streams named `packetbeat-9.0.0-beta1`. To use a different name, set the [`index`](/reference/packetbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
+Packetbeat uses data streams named `packetbeat-[version]`. To use a different name, set the [`index`](/reference/packetbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
 
 ```sh
 output.elasticsearch.index: "customname-%{[agent.version]}"

--- a/docs/reference/packetbeat/command-line-options.md
+++ b/docs/reference/packetbeat/command-line-options.md
@@ -89,9 +89,9 @@ Also see [Global flags](#global-flags).
 
 **EXAMPLES**
 
-```sh
+```sh subs=true
 packetbeat export config
-packetbeat export template --es.version 9.0.0-beta1
+packetbeat export template --es.version {{stack-version}}
 packetbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/packetbeat/configuration-flows.md
+++ b/docs/reference/packetbeat/configuration-flows.md
@@ -29,13 +29,13 @@ packetbeat.flows:
 
 Here’s an example of a flow information sent by Packetbeat. See [*Flow Event fields*](/reference/packetbeat/exported-fields-flows_event.md) for a description of each field.
 
-```json
+```json subs=true
 {
   "@timestamp": "2018-11-15T14:41:24.000Z",
   "agent": {
     "hostname": "host.example.com",
     "name": "host.example.com",
-    "version": "9.0.0-beta1"
+    "version": "{{stack-version}}"
   },
   "destination": {
     "bytes": 460,

--- a/docs/reference/packetbeat/elasticsearch-output.md
+++ b/docs/reference/packetbeat/elasticsearch-output.md
@@ -190,11 +190,11 @@ Additional headers to send to proxies during CONNECT requests.
 
 ### `index` [index-option-es]
 
-The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"packetbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"packetbeat-9.0.0-beta1-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/packetbeat/configuration-template.md)).
+The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"packetbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"packetbeat-[version]-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/packetbeat/configuration-template.md)).
 
 If you are using the pre-built Kibana dashboards, you also need to set the `setup.dashboards.index` option (see [Kibana dashboards](/reference/packetbeat/configuration-dashboards.md)).
 
-When [index lifecycle management (ILM)](/reference/packetbeat/ilm.md) is enabled, the default `index` is `"packetbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"packetbeat-9.0.0-beta1-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/packetbeat/ilm.md) to learn how to change the index name.
+When [index lifecycle management (ILM)](/reference/packetbeat/ilm.md) is enabled, the default `index` is `"packetbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"packetbeat-[version]-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/packetbeat/ilm.md) to learn how to change the index name.
 
 You can set the index dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `fields.log_type`, to set the index:
 
@@ -207,7 +207,7 @@ output.elasticsearch:
 1. We recommend including `agent.version` in the name to avoid mapping issues when you upgrade.
 
 
-With this configuration, all events with `log_type: normal` are sent to an index named `normal-9.0.0-beta1-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-9.0.0-beta1-2025-01-30`.
+With this configuration, all events with `log_type: normal` are sent to an index named `normal-[version]-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-[version]-2025-01-30`.
 
 ::::{tip}
 To learn how to add custom fields to events, see the [`fields`](/reference/packetbeat/configuration-general-options.md#libbeat-configuration-fields) option.
@@ -251,7 +251,7 @@ output.elasticsearch:
         message: "ERR"
 ```
 
-This configuration results in indices named `warning-9.0.0-beta1-2025-01-30` and `error-9.0.0-beta1-2025-01-30` (plus the default index if no matches are found).
+This configuration results in indices named `warning-[version]-2025-01-30` and `error-[version]-2025-01-30` (plus the default index if no matches are found).
 
 The following example sets the index by taking the name returned by the `index` format string and mapping it to a new name that’s used for the index:
 

--- a/docs/reference/packetbeat/http-endpoint.md
+++ b/docs/reference/packetbeat/http-endpoint.md
@@ -60,13 +60,13 @@ curl -XGET --unix-socket '/var/run/{beatname_lc}.sock' 'http:/stats/?pretty'
 curl -XGET 'localhost:5066/?pretty'
 ```
 
-```js
+```js subs=true
 {
   "beat": "packetbeat",
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "9.0.0-beta1"
+  "version": "{{stack-version}}"
 }
 ```
 

--- a/docs/reference/packetbeat/kafka-output.md
+++ b/docs/reference/packetbeat/kafka-output.md
@@ -144,7 +144,7 @@ output.kafka:
         message: "ERR"
 ```
 
-This configuration results in topics named `critical-9.0.0-beta1`, `error-9.0.0-beta1`, and `logs-9.0.0-beta1`.
+This configuration results in topics named `critical-[version]`, `error-[version]`, and `logs-[version]`.
 
 
 ### `key` [_key]

--- a/docs/reference/packetbeat/load-kibana-dashboards.md
+++ b/docs/reference/packetbeat/load-kibana-dashboards.md
@@ -48,8 +48,8 @@ packetbeat setup --dashboards
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/packetbeat:9.0.0-beta1 setup --dashboards
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/packetbeat:{{stack-version}} setup --dashboards
 ```
 ::::::
 
@@ -123,8 +123,8 @@ packetbeat setup -e \
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/packetbeat:9.0.0-beta1 setup -e \
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/packetbeat:{{stack-version}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=packetbeat_internal \

--- a/docs/reference/packetbeat/logstash-output.md
+++ b/docs/reference/packetbeat/logstash-output.md
@@ -33,12 +33,12 @@ For this configuration, you must [load the index template into {{es}} manually](
 
 Every event sent to {{ls}} contains the following metadata fields that you can use in {{ls}} for indexing and filtering:
 
-```json
+```json subs=true
 {
     ...
     "@metadata": { <1>
       "beat": "packetbeat", <2>
-      "version": "9.0.0-beta1" <3>
+      "version": "{{stack-version}}" <3>
     }
 }
 ```
@@ -68,7 +68,7 @@ output {
 }
 ```
 
-1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `packetbeat-9.0.0-beta1`.
+1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `packetbeat-9[version]`.
 
 
 Events indexed into {{es}} with the {{ls}} configuration shown here will be similar to events directly indexed by Packetbeat into {{es}}.
@@ -178,7 +178,7 @@ The `proxy_use_local_resolver` option determines if {{ls}} hostnames are resolve
 
 ### `index` [logstash-index]
 
-The index root name to write events to. The default is the Beat name. For example `"packetbeat"` generates `"[packetbeat-]9.0.0-beta1-YYYY.MM.DD"` indices (for example, `"packetbeat-9.0.0-beta1-2017.04.26"`).
+The index root name to write events to. The default is the Beat name. For example `"packetbeat"` generates `"[packetbeat-][version]-YYYY.MM.DD"` indices (for example, `"packetbeat-9.0.0-2017.04.26"`).
 
 ::::{note}
 This parameter’s value will be assigned to the `metadata.beat` field. It can then be accessed in {{ls}}'s output section as `%{[@metadata][beat]}`.

--- a/docs/reference/packetbeat/packetbeat-template.md
+++ b/docs/reference/packetbeat/packetbeat-template.md
@@ -101,8 +101,8 @@ packetbeat setup --index-management -E output.logstash.enabled=false -E 'output.
 
 **docker:**
 
-```sh
-docker run --rm docker.elastic.co/beats/packetbeat:9.0.0-beta1 setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+```sh subs=true
+docker run --rm docker.elastic.co/beats/packetbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -175,59 +175,59 @@ packetbeat export template > packetbeat.template.json
 
 **win:**
 
-```sh
-PS > .\packetbeat.exe export template --es.version 9.0.0-beta1 | Out-File -Encoding UTF8 packetbeat.template.json
+```sh subs=true
+PS > .\packetbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 packetbeat.template.json
 ```
 
 To install the template, run:
 
 **deb and rpm:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-9.0.0-beta1 -d@packetbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{stack-version}} -d@packetbeat.template.json
 ```
 
 **mac:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-9.0.0-beta1 -d@packetbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{stack-version}} -d@packetbeat.template.json
 ```
 
 **linux:**
 
-```sh
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-9.0.0-beta1 -d@packetbeat.template.json
+```sh subs=true
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{stack-version}} -d@packetbeat.template.json
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile packetbeat.template.json -Uri http://localhost:9200/_index_template/packetbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile packetbeat.template.json -Uri http://localhost:9200/_index_template/packetbeat-{{stack-version}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on packetbeat-9.0.0-beta1 index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on packetbeat-{{stack-version}} index.
 
 **deb and rpm:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/packetbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
 ```
 
 **mac:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/packetbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
 ```
 
 **linux:**
 
-```sh
-curl -XPUT http://localhost:9200/_data_stream/packetbeat-9.0.0-beta1
+```sh subs=true
+curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
 ```
 
 **win:**
 
-```sh
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/packetbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
 ```
 

--- a/docs/reference/packetbeat/running-on-docker.md
+++ b/docs/reference/packetbeat/running-on-docker.md
@@ -15,21 +15,21 @@ These images are free to use under the Elastic license. They contain open source
 
 Obtaining Packetbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
-::::{warning}
-Version 9.0.0-beta1 of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat 9.0.0-beta1.
-::::
+% ::::{warning} subs=true
+% Version {{stack-version}} of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat {{stack-version}}.
+% ::::
 
 
-```sh
-docker pull docker.elastic.co/beats/packetbeat:9.0.0-beta1
+```sh subs=true
+docker pull docker.elastic.co/beats/packetbeat:{{stack-version}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
 
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
-```bash
-docker pull docker.elastic.co/beats/packetbeat-wolfi:9.0.0-beta1
+```bash subs=true
+docker pull docker.elastic.co/beats/packetbeat-wolfi:{{stack-version}}
 ```
 
 
@@ -37,20 +37,20 @@ docker pull docker.elastic.co/beats/packetbeat-wolfi:9.0.0-beta1
 
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Packetbeat Docker image signature.
 
-% ::::{warning}
-% Version 9.0.0-beta1 of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat 9.0.0-beta1.
+% ::::{warning} subs=true
+% Version {{stack-version}} of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat {{stack-version}}.
 % ::::
 
 
-```sh
+```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/packetbeat:9.0.0-beta1
+cosign verify --key cosign.pub docker.elastic.co/beats/packetbeat:{{stack-version}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
-```sh
-Verification for docker.elastic.co/beats/packetbeat:9.0.0-beta1 --
+```sh subs=true
+Verification for docker.elastic.co/beats/packetbeat:{{stack-version}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -67,10 +67,10 @@ A [known issue](https://github.com/elastic/beats/issues/42038) in version 8.17.0
 
 Running Packetbeat with the setup command will create the index pattern and load visualizations , dashboards, and machine learning jobs.  Run this command:
 
-```sh
+```sh subs=true
 docker run --rm \
 --cap-add=NET_ADMIN \
-docker.elastic.co/beats/packetbeat:9.0.0-beta1 \
+docker.elastic.co/beats/packetbeat:{{stack-version}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -91,11 +91,11 @@ If you’d like to run Packetbeat in a Docker container on a read-only file syst
 
 For example:
 
-```sh
+```sh subs=true
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/packetbeat/data \
   --read-only \
-  docker.elastic.co/beats/packetbeat:9.0.0-beta1
+  docker.elastic.co/beats/packetbeat:{{stack-version}}
 ```
 
 
@@ -116,7 +116,7 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/
 
 One way to configure Packetbeat on Docker is to provide `packetbeat.docker.yml` via a volume mount. With `docker run`, the volume mount can be specified like this.
 
-```sh
+```sh subs=true
 docker run -d \
   --name=packetbeat \
   --user=packetbeat \
@@ -124,7 +124,7 @@ docker run -d \
   --cap-add="NET_RAW" \
   --cap-add="NET_ADMIN" \
   --network=host \
-  docker.elastic.co/beats/packetbeat:9.0.0-beta1 \
+  docker.elastic.co/beats/packetbeat:{{stack-version}} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -143,8 +143,8 @@ The `packetbeat.docker.yml` downloaded earlier should be customized for your env
 
 It’s possible to embed your Packetbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
-```dockerfile
-FROM docker.elastic.co/beats/packetbeat:9.0.0-beta1
+```dockerfile subs=true
+FROM docker.elastic.co/beats/packetbeat:{{stack-version}}
 COPY --chown=root:packetbeat packetbeat.yml /usr/share/packetbeat/packetbeat.yml
 ```
 
@@ -153,8 +153,8 @@ COPY --chown=root:packetbeat packetbeat.yml /usr/share/packetbeat/packetbeat.yml
 
 Under Docker, Packetbeat runs as a non-root user, but requires some privileged network capabilities to operate correctly. Ensure that the `NET_ADMIN` capability is available to the container.
 
-```sh
-docker run --cap-add=NET_ADMIN docker.elastic.co/beats/packetbeat:9.0.0-beta1
+```sh subs=true
+docker run --cap-add=NET_ADMIN docker.elastic.co/beats/packetbeat:{{stack-version}}
 ```
 
 
@@ -162,8 +162,8 @@ docker run --cap-add=NET_ADMIN docker.elastic.co/beats/packetbeat:9.0.0-beta1
 
 By default, Docker networking will connect the Packetbeat container to an isolated virtual network, with a limited view of network traffic. You may wish to connect the container directly to the host network in order to see traffic destined for, and originating from, the host system. With `docker run`, this can be achieved by specifying `--network=host`.
 
-```sh
-docker run --cap-add=NET_ADMIN --network=host docker.elastic.co/beats/packetbeat:9.0.0-beta1
+```sh subs=true
+docker run --cap-add=NET_ADMIN --network=host docker.elastic.co/beats/packetbeat:{{stack-version}}
 ```
 
 ::::{note}

--- a/docs/reference/winlogbeat/change-index-name.md
+++ b/docs/reference/winlogbeat/change-index-name.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Change the index name [change-index-name]
 
-Winlogbeat uses data streams named `winlogbeat-9.0.0-beta1`. To use a different name, set the [`index`](/reference/winlogbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
+Winlogbeat uses data streams named `winlogbeat-[version]`. To use a different name, set the [`index`](/reference/winlogbeat/elasticsearch-output.md#index-option-es) option in the {{es}} output. You also need to configure the `setup.template.name` and `setup.template.pattern` options to match the new name. For example:
 
 ```sh
 output.elasticsearch.index: "customname-%{[agent.version]}"

--- a/docs/reference/winlogbeat/command-line-options.md
+++ b/docs/reference/winlogbeat/command-line-options.md
@@ -85,9 +85,9 @@ Also see [Global flags](#global-flags).
 
 **EXAMPLES**
 
-```sh
+```sh subs=true
 winlogbeat export config
-winlogbeat export template --es.version 9.0.0-beta1
+winlogbeat export template --es.version {{stack-version}}
 winlogbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/winlogbeat/elasticsearch-output.md
+++ b/docs/reference/winlogbeat/elasticsearch-output.md
@@ -191,11 +191,11 @@ Additional headers to send to proxies during CONNECT requests.
 
 ### `index` [index-option-es]
 
-The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"winlogbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"winlogbeat-9.0.0-beta1-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/winlogbeat/configuration-template.md)).
+The indexing target to write events to. Can point to an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html), [alias](docs-content://manage-data/data-store/aliases.md), or [data stream](docs-content://manage-data/data-store/data-streams.md). When using daily indices, this will be the index name. The default is `"winlogbeat-%{[agent.version]}-%{+yyyy.MM.dd}"`, for example, `"winlogbeat-[version]-2025-01-30"`. If you change this setting, you also need to configure the `setup.template.name` and `setup.template.pattern` options (see [Elasticsearch index template](/reference/winlogbeat/configuration-template.md)).
 
 If you are using the pre-built Kibana dashboards, you also need to set the `setup.dashboards.index` option (see [Kibana dashboards](/reference/winlogbeat/configuration-dashboards.md)).
 
-When [index lifecycle management (ILM)](/reference/winlogbeat/ilm.md) is enabled, the default `index` is `"winlogbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"winlogbeat-9.0.0-beta1-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/winlogbeat/ilm.md) to learn how to change the index name.
+When [index lifecycle management (ILM)](/reference/winlogbeat/ilm.md) is enabled, the default `index` is `"winlogbeat-%{[agent.version]}-%{+yyyy.MM.dd}-%{{index_num}}"`, for example, `"winlogbeat-[version]-2025-01-30-000001"`. Custom `index` settings are ignored when ILM is enabled. If you’re sending events to a cluster that supports index lifecycle management, see [Index lifecycle management (ILM)](/reference/winlogbeat/ilm.md) to learn how to change the index name.
 
 You can set the index dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `fields.log_type`, to set the index:
 
@@ -208,7 +208,7 @@ output.elasticsearch:
 1. We recommend including `agent.version` in the name to avoid mapping issues when you upgrade.
 
 
-With this configuration, all events with `log_type: normal` are sent to an index named `normal-9.0.0-beta1-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-9.0.0-beta1-2025-01-30`.
+With this configuration, all events with `log_type: normal` are sent to an index named `normal-[version]-2025-01-30`, and all events with `log_type: critical` are sent to an index named `critical-[version]-2025-01-30`.
 
 ::::{tip}
 To learn how to add custom fields to events, see the [`fields`](/reference/winlogbeat/configuration-general-options.md#libbeat-configuration-fields) option.
@@ -252,7 +252,7 @@ output.elasticsearch:
         message: "ERR"
 ```
 
-This configuration results in indices named `warning-9.0.0-beta1-2025-01-30` and `error-9.0.0-beta1-2025-01-30` (plus the default index if no matches are found).
+This configuration results in indices named `warning-[version]-2025-01-30` and `error-[version]-2025-01-30` (plus the default index if no matches are found).
 
 The following example sets the index by taking the name returned by the `index` format string and mapping it to a new name that’s used for the index:
 

--- a/docs/reference/winlogbeat/http-endpoint.md
+++ b/docs/reference/winlogbeat/http-endpoint.md
@@ -60,13 +60,13 @@ curl -XGET --unix-socket '/var/run/{beatname_lc}.sock' 'http:/stats/?pretty'
 curl -XGET 'localhost:5066/?pretty'
 ```
 
-```js
+```js subs=true
 {
   "beat": "winlogbeat",
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "9.0.0-beta1"
+  "version": "{{stack-version}}"
 }
 ```
 

--- a/docs/reference/winlogbeat/kafka-output.md
+++ b/docs/reference/winlogbeat/kafka-output.md
@@ -144,7 +144,7 @@ output.kafka:
         message: "ERR"
 ```
 
-This configuration results in topics named `critical-9.0.0-beta1`, `error-9.0.0-beta1`, and `logs-9.0.0-beta1`.
+This configuration results in topics named `critical-[version]`, `error-[version]`, and `logs-[version]`.
 
 
 ### `key` [_key]

--- a/docs/reference/winlogbeat/load-kibana-dashboards.md
+++ b/docs/reference/winlogbeat/load-kibana-dashboards.md
@@ -43,8 +43,8 @@ winlogbeat setup --dashboards
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:9.0.0-beta1 setup --dashboards
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:{{stack-version}} setup --dashboards
 ```
 ::::::
 
@@ -118,8 +118,8 @@ winlogbeat setup -e \
 ::::::
 
 ::::::{tab-item} Docker
-```sh
-docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:9.0.0-beta1 setup -e \
+```sh subs=true
+docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:{{stack-version}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=winlogbeat_internal \

--- a/docs/reference/winlogbeat/logstash-output.md
+++ b/docs/reference/winlogbeat/logstash-output.md
@@ -33,12 +33,12 @@ For this configuration, you must [load the index template into {{es}} manually](
 
 Every event sent to {{ls}} contains the following metadata fields that you can use in {{ls}} for indexing and filtering:
 
-```json
+```json subs=true
 {
     ...
     "@metadata": { <1>
       "beat": "winlogbeat", <2>
-      "version": "9.0.0-beta1" <3>
+      "version": "{{stack-version}}" <3>
     }
 }
 ```
@@ -68,7 +68,7 @@ output {
 }
 ```
 
-1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `winlogbeat-9.0.0-beta1`.
+1. `%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to the Beat’s version. For example: `winlogbeat-9[version]`.
 
 
 Events indexed into {{es}} with the {{ls}} configuration shown here will be similar to events directly indexed by Winlogbeat into {{es}}.
@@ -178,7 +178,7 @@ The `proxy_use_local_resolver` option determines if {{ls}} hostnames are resolve
 
 ### `index` [logstash-index]
 
-The index root name to write events to. The default is the Beat name. For example `"winlogbeat"` generates `"[winlogbeat-]9.0.0-beta1-YYYY.MM.DD"` indices (for example, `"winlogbeat-9.0.0-beta1-2017.04.26"`).
+The index root name to write events to. The default is the Beat name. For example `"winlogbeat"` generates `"[winlogbeat-][version]-YYYY.MM.DD"` indices (for example, `"winlogbeat-9.0.0-2017.04.26"`).
 
 ::::{note}
 This parameter’s value will be assigned to the `metadata.beat` field. It can then be accessed in {{ls}}'s output section as `%{[@metadata][beat]}`.

--- a/docs/reference/winlogbeat/winlogbeat-template.md
+++ b/docs/reference/winlogbeat/winlogbeat-template.md
@@ -104,19 +104,19 @@ If the host running Winlogbeat does not have direct connectivity to {{es}}, you 
 
 To export the index template, run:
 
-```sh
-PS > .\winlogbeat.exe export template --es.version 9.0.0-beta1 | Out-File -Encoding UTF8 winlogbeat.template.json
+```sh subs=true
+PS > .\winlogbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 winlogbeat.template.json
 ```
 
 To install the template, run:
 
-```sh
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile winlogbeat.template.json -Uri http://localhost:9200/_index_template/winlogbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile winlogbeat.template.json -Uri http://localhost:9200/_index_template/winlogbeat-{{stack-version}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on winlogbeat-9.0.0-beta1 index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on winlogbeat-{{stack-version}} index.
 
-```sh
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/winlogbeat-9.0.0-beta1
+```sh subs=true
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/winlogbeat-{{stack-version}}
 ```
 


### PR DESCRIPTION
The docs migration for 9.0 replaced the `version` variables with hard-coded `9.0.0-beta` strings. Wherever possible I've replaced the string with a `{{stack-version}}` variable, such as in code blocks and ordinary text. However, variable substitutions are no longer supported within inline code strings (text enclosed in single backticks). For those I've used hardcoded `[version]` so people will know to replace that with the actual version number.

Notes: 
 - The docs team plan to implement global variables that can be applied across repos. Once that support comes, all instances of `{{stack-version}}` will need to be replaced again.
 - `{{stack-version}}` and `{{major-version}}` are defined [here](https://github.com/elastic/beats/blob/019fe1d13bb8edc552ddea00420a16376c5f4a13/docs/docset.yml#L42) in the Beats docs source.