### PR TITLE
[Flaky test] Increase timeout on flaky SQS test

### DIFF
--- a/x-pack/filebeat/input/awss3/sqs_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_test.go
@@ -292,7 +292,7 @@ func TestCancelWithGrace(t *testing.T) {
 	const (
 		wait    = time.Second
 		tooLong = time.Second
-		tol     = 10 * time.Millisecond
+		tol     = 100 * time.Millisecond
 	)
 	parentCtx, parentCancel := context.WithCancel(context.Background())
 	childCtx, childCancel := cancelWithGrace(parentCtx, wait)


### PR DESCRIPTION
`TestCancelWithGrace` in `sqs_test.go` has a timer correctness margin of only 5ms. This is much too low for a reliable test, timers are not guaranteed to have that granularity (especially on CI nodes where there are often execution delays). I saw it "failing" a couple times because it expected a duration of 1.0 seconds and instead got 1.006. This PR increases the acceptable margin to 50ms instead of 5.

Closes https://github.com/elastic/beats/issues/43668.
