### PR TITLE
Allow agentbeat to be importable

### DIFF
--- a/x-pack/agentbeat/cmd/cmd.go
+++ b/x-pack/agentbeat/cmd/cmd.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	"github.com/elastic/beats/v7/libbeat/cmd"
+
+	"github.com/spf13/cobra"
+)
+
+func AgentBeat() *cobra.Command {
+	return prepareRootCommand()
+}
+
+func prepareCommand(rootCmd *cmd.BeatsRootCmd) *cobra.Command {
+	var origPersistentPreRun func(cmd *cobra.Command, args []string)
+	var origPersistentPreRunE func(cmd *cobra.Command, args []string) error
+	origPersistentPreRun = rootCmd.PersistentPreRun
+	origPersistentPreRunE = rootCmd.PersistentPreRunE
+	rootCmd.PersistentPreRun = nil
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// same logic is used inside of *cobra.Command; if both are set the E version is used instead
+		if origPersistentPreRunE != nil {
+			if err := origPersistentPreRunE(cmd, args); err != nil {
+				// no context is added by cobra, same approach here
+				return err
+			}
+		} else if origPersistentPreRun != nil {
+			origPersistentPreRun(cmd, args)
+		}
+		// must be set to the correct file before the actual Run is performed otherwise it will not be the correct
+		// filename, as all the beats set this in the initialization.
+		err := cfgfile.ChangeDefaultCfgfileFlag(rootCmd.Use)
+		if err != nil {
+			panic(fmt.Errorf("failed to set default config file path: %w", err))
+		}
+		return nil
+	}
+	return &rootCmd.Command
+}

--- a/x-pack/agentbeat/cmd/prepare_root_command.go
+++ b/x-pack/agentbeat/cmd/prepare_root_command.go
@@ -2,30 +2,37 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build requirefips
+//go:build !requirefips
 
-package main
+package cmd
 
 import (
 	"github.com/spf13/cobra"
 
 	auditbeat "github.com/elastic/beats/v7/x-pack/auditbeat/cmd"
 	filebeat "github.com/elastic/beats/v7/x-pack/filebeat/cmd"
+	heartbeat "github.com/elastic/beats/v7/x-pack/heartbeat/cmd"
 	metricbeat "github.com/elastic/beats/v7/x-pack/metricbeat/cmd"
+	osquerybeat "github.com/elastic/beats/v7/x-pack/osquerybeat/cmd"
+	packetbeat "github.com/elastic/beats/v7/x-pack/packetbeat/cmd"
 )
 
 func prepareRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "agentbeat",
 		Short: "Combined beat ran only by the Elastic Agent",
-		Long: `Combines auditbeat, filebeat and metricbeat
+		Long: `Combines auditbeat, filebeat, heartbeat, metricbeat, osquerybeat, and packetbeat
 into a single agentbeat binary.`,
 		Example: "agentbeat filebeat run",
 	}
+
 	rootCmd.AddCommand(
 		prepareCommand(auditbeat.RootCmd),
 		prepareCommand(filebeat.Filebeat()),
+		prepareCommand(heartbeat.RootCmd),
 		prepareCommand(metricbeat.Initialize()),
+		prepareCommand(osquerybeat.RootCmd),
+		prepareCommand(packetbeat.RootCmd),
 	)
 
 	return rootCmd

--- a/x-pack/agentbeat/cmd/prepare_root_command_fips.go
+++ b/x-pack/agentbeat/cmd/prepare_root_command_fips.go
@@ -2,37 +2,30 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build !requirefips
+//go:build requirefips
 
-package main
+package cmd
 
 import (
 	"github.com/spf13/cobra"
 
 	auditbeat "github.com/elastic/beats/v7/x-pack/auditbeat/cmd"
 	filebeat "github.com/elastic/beats/v7/x-pack/filebeat/cmd"
-	heartbeat "github.com/elastic/beats/v7/x-pack/heartbeat/cmd"
 	metricbeat "github.com/elastic/beats/v7/x-pack/metricbeat/cmd"
-	osquerybeat "github.com/elastic/beats/v7/x-pack/osquerybeat/cmd"
-	packetbeat "github.com/elastic/beats/v7/x-pack/packetbeat/cmd"
 )
 
 func prepareRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "agentbeat",
 		Short: "Combined beat ran only by the Elastic Agent",
-		Long: `Combines auditbeat, filebeat, heartbeat, metricbeat, osquerybeat, and packetbeat
+		Long: `Combines auditbeat, filebeat and metricbeat
 into a single agentbeat binary.`,
 		Example: "agentbeat filebeat run",
 	}
-
 	rootCmd.AddCommand(
 		prepareCommand(auditbeat.RootCmd),
 		prepareCommand(filebeat.Filebeat()),
-		prepareCommand(heartbeat.RootCmd),
 		prepareCommand(metricbeat.Initialize()),
-		prepareCommand(osquerybeat.RootCmd),
-		prepareCommand(packetbeat.RootCmd),
 	)
 
 	return rootCmd

--- a/x-pack/agentbeat/main.go
+++ b/x-pack/agentbeat/main.go
@@ -5,50 +5,15 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	_ "time/tzdata" // for timezone handling
 
-	"github.com/elastic/beats/v7/libbeat/cfgfile"
-	"github.com/elastic/beats/v7/libbeat/cmd"
-
-	"github.com/spf13/cobra"
+	agentbeatcmd "github.com/elastic/beats/v7/x-pack/agentbeat/cmd"
 )
 
 func main() {
-	rootCmd := AgentBeat()
+	rootCmd := agentbeatcmd.AgentBeat()
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-}
-
-func AgentBeat() *cobra.Command {
-	return prepareRootCommand()
-}
-
-func prepareCommand(rootCmd *cmd.BeatsRootCmd) *cobra.Command {
-	var origPersistentPreRun func(cmd *cobra.Command, args []string)
-	var origPersistentPreRunE func(cmd *cobra.Command, args []string) error
-	origPersistentPreRun = rootCmd.PersistentPreRun
-	origPersistentPreRunE = rootCmd.PersistentPreRunE
-	rootCmd.PersistentPreRun = nil
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		// same logic is used inside of *cobra.Command; if both are set the E version is used instead
-		if origPersistentPreRunE != nil {
-			if err := origPersistentPreRunE(cmd, args); err != nil {
-				// no context is added by cobra, same approach here
-				return err
-			}
-		} else if origPersistentPreRun != nil {
-			origPersistentPreRun(cmd, args)
-		}
-		// must be set to the correct file before the actual Run is performed otherwise it will not be the correct
-		// filename, as all the beats set this in the initialization.
-		err := cfgfile.ChangeDefaultCfgfileFlag(rootCmd.Use)
-		if err != nil {
-			panic(fmt.Errorf("failed to set default config file path: %w", err))
-		}
-		return nil
-	}
-	return &rootCmd.Command
 }

--- a/x-pack/agentbeat/main_test.go
+++ b/x-pack/agentbeat/main_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/elastic/beats/v7/x-pack/agentbeat/cmd"
 )
 
 var (
@@ -20,7 +22,7 @@ var (
 func init() {
 	testing.Init()
 	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
-	abCommand = AgentBeat()
+	abCommand = cmd.AgentBeat()
 	abCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
 	abCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Refactor `x-pack/agentbeat` to be importable.

This allows the `AgentBeat` command to be imported from Elastic Agent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

None

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] `x-pack/agentbeat/cmd` is importable
