### PR TITLE
[azure-eventhub] Fix handling of connection strings with entity path

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -291,6 +291,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 +{pull}46373[46373]
 - Fix metrics from TCP & UDP inputs when the port number is > 32767 {pull}46486[46486]
 - [Journald input] Fix reading all files in a folder and watching for new ones. {issue}46657[46657] {pull}46682[46682]
+- [azure-eventhub] Fix handling of connection strings with entity path. {issue}43715[43715] {pull}43716[43716]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -211,43 +211,23 @@ func (conf *azureInputConfig) Validate() error {
 }
 
 // checkUnsupportedParams checks if unsupported/deprecated/discouraged parameters are set and logs a warning
-func (c *azureInputConfig) checkUnsupportedParams(logger *logp.Logger) {
+func (conf *azureInputConfig) checkUnsupportedParams(logger *logp.Logger) {
 	logger = logger.Named("azureeventhub.config")
 
 	// log a warning for each sanitization option not supported
-	for _, opt := range c.LegacySanitizeOptions {
+	for _, opt := range conf.LegacySanitizeOptions {
 		logger.Warnw("legacy sanitization `sanitize_options` options are deprecated and will be removed in the 9.0 release; use the `sanitizers` option instead", "option", opt)
 		err := sanitizeOptionsValidate(opt)
 		if err != nil {
 			logger.Warnf("%s: %v", opt, err)
 		}
 	}
-	if c.ProcessorVersion == processorV2 {
-		if c.SAKey != "" {
+	if conf.ProcessorVersion == processorV2 {
+		if conf.SAKey != "" {
 			logger.Warnf("storage_account_key is not used in processor v2, please remove it from the configuration (config: storage_account_key)")
 		}
 	}
 }
-
-// validateConnectionStringV2 validates the connection string for processor v2.
-// func (conf *azureInputConfig) validateConnectionStringV2(props ConnectionStringProperties) error {
-// First, check if the connection string is valid. We need to parse it
-// to get the endpoint and the entity path.
-// // validateConnectionStringV2 validates the connection string for processor v2.
-// func (conf *azureInputConfig) validateConnectionStringV2(props ConnectionStringProperties) error {
-// 	// First, check if the connection string is valid. We need to parse it
-// 	// to get the endpoint and the entity path.
-
-// 	if props.EntityPath != nil {
-// 		if *props.EntityPath != conf.EventHubName {
-// 			return fmt.Errorf("invalid connection string: entity path (%s) does not match event hub name (%s)", *props.EntityPath, conf.EventHubName)
-// 		}
-
-// 		conf.ConnectionStringContainsEntityPath = true
-// 	}
-
-// 	return nil
-// }
 
 // storageContainerValidate validated the storage_account_container to make sure it is conforming to all the Azure
 // naming rules.

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -210,7 +210,7 @@ func (conf *azureInputConfig) Validate() error {
 	return nil
 }
 
-// checkUnsupportedParams checks if unsupported/deprecated/discouraged paramaters are set and logs a warning
+// checkUnsupportedParams checks if unsupported/deprecated/discouraged parameters are set and logs a warning
 func (c *azureInputConfig) checkUnsupportedParams(logger *logp.Logger) {
 	logger = logger.Named("azureeventhub.config")
 

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -265,7 +265,7 @@ func storageContainerValidate(name string) error {
 		return fmt.Errorf("storage_account_container (%s) must end with a lowercase letter or number", name)
 	}
 	for i := 0; i < length; i++ {
-		if !(unicode.IsLower(runes[i]) || unicode.IsNumber(runes[i]) || runes[i] == '-') {
+		if !unicode.IsLower(runes[i]) && !unicode.IsNumber(runes[i]) && runes[i] != '-' {
 			return fmt.Errorf("rune (%d) of storage_account_container (%s) is not a lowercase letter, number or dash", i, name)
 		}
 		if runes[i] == '-' && previousRune == runes[i] {

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -147,6 +147,7 @@ func (conf *azureInputConfig) Validate() error {
 		return errors.New("no storage account configured (config: storage_account)")
 	}
 	if conf.SAContainer == "" {
+		// side effect: set the default storage account container name
 		conf.SAContainer = fmt.Sprintf("%s-%s", ephContainerName, conf.EventHubName)
 	}
 
@@ -161,6 +162,8 @@ func (conf *azureInputConfig) Validate() error {
 		//
 		// So instead of throwing an error to the user, we decided to replace
 		// underscores (_) characters with hyphens (-).
+
+		// side effect: replace underscores (_) with hyphens (-) in the storage account container name
 		conf.SAContainer = strings.ReplaceAll(conf.SAContainer, "_", "-")
 		logger.Warnf("replaced underscores (_) with hyphens (-) in the storage account container name (before: %s, now: %s", originalValue, conf.SAContainer)
 	}

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -265,13 +265,14 @@ func storageContainerValidate(name string) error {
 		return fmt.Errorf("storage_account_container (%s) must end with a lowercase letter or number", name)
 	}
 	for i := 0; i < length; i++ {
-		if !unicode.IsLower(runes[i]) && !unicode.IsNumber(runes[i]) && !(runes[i] == '-') {
-			return fmt.Errorf("rune %d of storage_account_container (%s) is not a lowercase letter, number or dash", i, name)
+		if !(unicode.IsLower(runes[i]) || unicode.IsNumber(runes[i]) || runes[i] == '-') {
+			return fmt.Errorf("rune (%d) of storage_account_container (%s) is not a lowercase letter, number or dash", i, name)
 		}
 		if runes[i] == '-' && previousRune == runes[i] {
 			return fmt.Errorf("consecutive dashes ('-') are not permitted in storage_account_container (%s)", name)
 		}
 		previousRune = runes[i]
 	}
+
 	return nil
 }

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -120,7 +120,7 @@ func defaultConfig() azureInputConfig {
 func (conf *azureInputConfig) Validate() error {
 	logger := logp.NewLogger("azureeventhub.config")
 
-	connectionStringProperties, err := parseConnectionString(conf.SAConnectionString)
+	connectionStringProperties, err := parseConnectionString(conf.ConnectionString)
 	if err != nil {
 		return fmt.Errorf("invalid connection string: %w", err)
 	}

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -132,7 +132,7 @@ func (conf *azureInputConfig) Validate() error {
 	// check that it matches the event hub name.
 	if conf.ConnectionStringProperties.EntityPath != nil && *conf.ConnectionStringProperties.EntityPath != conf.EventHubName {
 		return fmt.Errorf(
-			"invalid connection string: entity path (%s) does not match event hub name (%s)",
+			"invalid config: the entity path (%s) in the connection string does not match event hub name (%s)",
 			*conf.ConnectionStringProperties.EntityPath,
 			conf.EventHubName,
 		)

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -123,7 +123,7 @@ func TestValidateConnectionStringV2(t *testing.T) {
 
 		err := config.Validate()
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "invalid connection string: entity path (my-event-hub) does not match event hub name (not-my-event-hub)")
+		assert.ErrorContains(t, err, "invalid config: the entity path (my-event-hub) in the connection string does not match event hub name (not-my-event-hub)")
 
 		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
 		require.NotEqual(t, *config.ConnectionStringProperties.EntityPath, config.EventHubName)

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStorageContainerValidate(t *testing.T) {
@@ -43,9 +44,7 @@ func TestValidate(t *testing.T) {
 		config.SAKey = "secret"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
-		if err := config.Validate(); err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
+		require.NoError(t, config.Validate())
 
 		assert.Equal(
 			t,
@@ -66,10 +65,7 @@ func TestValidateConnectionStringV1(t *testing.T) {
 		config.SAKey = "my-secret"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
-		err := config.Validate()
-		require.NoError(t, err, "unexpected validation error)
-		
-
+		require.NoError(t, config.Validate())
 		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
 		assert.Equal(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
 	})
@@ -83,11 +79,8 @@ func TestValidateConnectionStringV1(t *testing.T) {
 		config.SAKey = "my-secret"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
-		if err := config.Validate(); err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
-
-		assert.Nil(t, config.ConnectionStringProperties.EntityPath)
+		require.NoError(t, config.Validate())
+		require.Nil(t, config.ConnectionStringProperties.EntityPath)
 	})
 }
 
@@ -101,12 +94,9 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
-		if err := config.Validate(); err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
-
+		require.NoError(t, config.Validate())
 		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
-		assert.Equal(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
+		require.Equal(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
 	})
 
 	t.Run("Connection string does not contain entity path", func(t *testing.T) {
@@ -118,11 +108,8 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
-		if err := config.Validate(); err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
-
-		assert.Nil(t, config.ConnectionStringProperties.EntityPath)
+		require.NoError(t, config.Validate())
+		require.Nil(t, config.ConnectionStringProperties.EntityPath)
 	})
 
 	t.Run("Connection string contains entity path but does not match event hub name", func(t *testing.T) {
@@ -135,12 +122,10 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
 		err := config.Validate()
-		if err == nil {
-			t.Fatalf("expected validation error")
-		}
-
-		assert.NotNil(t, config.ConnectionStringProperties.EntityPath)
-		assert.NotEqual(t, *config.ConnectionStringProperties.EntityPath, config.EventHubName)
+		require.Error(t, err)
 		assert.ErrorContains(t, err, "invalid connection string: entity path (my-event-hub) does not match event hub name (not-my-event-hub)")
+
+		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
+		require.NotEqual(t, *config.ConnectionStringProperties.EntityPath, config.EventHubName)
 	})
 }

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -66,11 +66,11 @@ func TestValidateConnectionStringV1(t *testing.T) {
 		config.SAKey = "my-secret"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
-		if err := config.Validate(); err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
+		err := config.Validate()
+		require.NoError(t, err, "unexpected validation error)
+		
 
-		assert.NotNil(t, config.ConnectionStringProperties.EntityPath)
+		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
 		assert.Equal(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
 	})
 
@@ -105,7 +105,7 @@ func TestValidateConnectionStringV2(t *testing.T) {
 			t.Fatalf("unexpected validation error: %v", err)
 		}
 
-		assert.NotNil(t, config.ConnectionStringProperties.EntityPath)
+		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
 		assert.Equal(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
 	})
 

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -128,7 +128,7 @@ func TestValidateConnectionStringV2(t *testing.T) {
 	t.Run("Connection string contains entity path but does not match event hub name", func(t *testing.T) {
 		config := defaultConfig()
 		config.ProcessorVersion = "v2"
-		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub;"
+		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub"
 		config.EventHubName = "my-event-hub-2"
 		config.SAName = "teststorageaccount"
 		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -57,6 +57,7 @@ func TestValidate(t *testing.T) {
 
 func TestValidateConnectionStringV1(t *testing.T) {
 	t.Run("Connection string contains entity path", func(t *testing.T) {
+		// Check the Validate() function
 		config := defaultConfig()
 		config.ProcessorVersion = "v1"
 		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub;"
@@ -64,13 +65,17 @@ func TestValidateConnectionStringV1(t *testing.T) {
 		config.SAName = "teststorageaccount"
 		config.SAKey = "my-secret"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
-
 		require.NoError(t, config.Validate())
-		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
-		assert.Equal(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
+
+		// Check the parseConnectionString() function
+		connectionStringProperties, err := parseConnectionString(config.ConnectionString)
+		require.NoError(t, err)
+		require.NotNil(t, connectionStringProperties.EntityPath)
+		assert.Equal(t, config.EventHubName, *connectionStringProperties.EntityPath)
 	})
 
 	t.Run("Connection string does not contain entity path", func(t *testing.T) {
+		// Check the Validate() function
 		config := defaultConfig()
 		config.ProcessorVersion = "v1"
 		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret"
@@ -78,14 +83,18 @@ func TestValidateConnectionStringV1(t *testing.T) {
 		config.SAName = "teststorageaccount"
 		config.SAKey = "my-secret"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
-
 		require.NoError(t, config.Validate())
-		require.Nil(t, config.ConnectionStringProperties.EntityPath)
+
+		// Check the parseConnectionString() function
+		connectionStringProperties, err := parseConnectionString(config.ConnectionString)
+		require.NoError(t, err)
+		require.Nil(t, connectionStringProperties.EntityPath)
 	})
 }
 
 func TestValidateConnectionStringV2(t *testing.T) {
 	t.Run("Connection string contains entity path", func(t *testing.T) {
+		// Check the Validate() function
 		config := defaultConfig()
 		config.ProcessorVersion = "v2"
 		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub"
@@ -93,13 +102,17 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		config.SAName = "teststorageaccount"
 		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
-
 		require.NoError(t, config.Validate())
-		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
-		require.Equal(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
+
+		// Check the parseConnectionString() function
+		connectionStringProperties, err := parseConnectionString(config.ConnectionString)
+		require.NoError(t, err)
+		require.NotNil(t, connectionStringProperties.EntityPath)
+		require.Equal(t, config.EventHubName, *connectionStringProperties.EntityPath)
 	})
 
 	t.Run("Connection string does not contain entity path", func(t *testing.T) {
+		// Check the Validate() function
 		config := defaultConfig()
 		config.ProcessorVersion = "v2"
 		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;"
@@ -107,9 +120,12 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		config.SAName = "teststorageaccount"
 		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
-
 		require.NoError(t, config.Validate())
-		require.Nil(t, config.ConnectionStringProperties.EntityPath)
+
+		// Check the parseConnectionString() function
+		connectionStringProperties, err := parseConnectionString(config.ConnectionString)
+		require.NoError(t, err)
+		require.Nil(t, connectionStringProperties.EntityPath)
 	})
 
 	t.Run("Connection string contains entity path but does not match event hub name", func(t *testing.T) {
@@ -124,8 +140,5 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		err := config.Validate()
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "invalid config: the entity path (my-event-hub) in the connection string does not match event hub name (not-my-event-hub)")
-
-		require.NotNil(t, config.ConnectionStringProperties.EntityPath)
-		require.NotEqual(t, *config.ConnectionStringProperties.EntityPath, config.EventHubName)
 	})
 }

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -77,7 +77,7 @@ func TestValidateConnectionStringV1(t *testing.T) {
 	t.Run("Connection string does not contain entity path", func(t *testing.T) {
 		config := defaultConfig()
 		config.ProcessorVersion = "v1"
-		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;"
+		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret"
 		config.EventHubName = "my-event-hub"
 		config.SAName = "teststorageaccount"
 		config.SAKey = "my-secret"
@@ -95,7 +95,7 @@ func TestValidateConnectionStringV2(t *testing.T) {
 	t.Run("Connection string contains entity path", func(t *testing.T) {
 		config := defaultConfig()
 		config.ProcessorVersion = "v2"
-		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub;"
+		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub"
 		config.EventHubName = "my-event-hub"
 		config.SAName = "teststorageaccount"
 		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
@@ -129,16 +129,18 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		config := defaultConfig()
 		config.ProcessorVersion = "v2"
 		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub"
-		config.EventHubName = "my-event-hub-2"
+		config.EventHubName = "not-my-event-hub"
 		config.SAName = "teststorageaccount"
 		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
-		if err := config.Validate(); err == nil {
+		err := config.Validate()
+		if err == nil {
 			t.Fatalf("expected validation error")
 		}
 
 		assert.NotNil(t, config.ConnectionStringProperties.EntityPath)
-		assert.NotEqual(t, config.EventHubName, *config.ConnectionStringProperties.EntityPath)
+		assert.NotEqual(t, *config.ConnectionStringProperties.EntityPath, config.EventHubName)
+		assert.ErrorContains(t, err, "invalid connection string: entity path (my-event-hub) does not match event hub name (not-my-event-hub)")
 	})
 }

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -55,3 +55,50 @@ func TestValidate(t *testing.T) {
 		)
 	})
 }
+
+func TestValidateConnectionStringV2(t *testing.T) {
+	t.Run("Connection string contains entity path", func(t *testing.T) {
+		config := defaultConfig()
+		config.ProcessorVersion = "v2"
+		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub;"
+		config.EventHubName = "my-event-hub"
+		config.ConnectionStringContainsEntityPath = true
+		config.SAName = "teststorageaccount"
+		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
+		config.SAContainer = "filebeat-activitylogs-event_hub_00"
+
+		if err := config.Validate(); err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("Connection string does not contain entity path", func(t *testing.T) {
+		config := defaultConfig()
+		config.ProcessorVersion = "v2"
+		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;"
+		config.EventHubName = "my-event-hub"
+		config.ConnectionStringContainsEntityPath = true
+		config.SAName = "teststorageaccount"
+		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
+		config.SAContainer = "filebeat-activitylogs-event_hub_00"
+
+		if err := config.Validate(); err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("Connection string contains entity path but does not match event hub name", func(t *testing.T) {
+		config := defaultConfig()
+		config.ProcessorVersion = "v2"
+		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub;"
+		config.EventHubName = "my-event-hub-2"
+		config.ConnectionStringContainsEntityPath = true
+		config.SAName = "teststorageaccount"
+		config.SAConnectionString = "DefaultEndpointsProtocol=https;AccountName=teststorageaccount;AccountKey=my-secret;EndpointSuffix=core.windows.net"
+		config.SAContainer = "filebeat-activitylogs-event_hub_00"
+
+		if err := config.Validate(); err == nil {
+			t.Fatalf("expected validation error")
+		}
+	})
+}

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -138,7 +138,6 @@ func TestValidateConnectionStringV2(t *testing.T) {
 		config.SAContainer = "filebeat-activitylogs-event_hub_00"
 
 		err := config.Validate()
-		require.Error(t, err)
 		assert.ErrorContains(t, err, "invalid config: the entity path (my-event-hub) in the connection string does not match event hub name (not-my-event-hub)")
 	})
 }

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -90,6 +90,19 @@ func TestValidateConnectionStringV1(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, connectionStringProperties.EntityPath)
 	})
+
+	t.Run("Connection string contains entity path but does not match event hub name", func(t *testing.T) {
+		config := defaultConfig()
+		config.ProcessorVersion = "v1"
+		config.ConnectionString = "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=my-key;SharedAccessKey=my-secret;EntityPath=my-event-hub"
+		config.EventHubName = "not-my-event-hub"
+		config.SAName = "teststorageaccount"
+		config.SAKey = "my-secret"
+		config.SAContainer = "filebeat-activitylogs-event_hub_00"
+
+		err := config.Validate()
+		assert.ErrorContains(t, err, "invalid config: the entity path (my-event-hub) in the connection string does not match event hub name (not-my-event-hub)")
+	})
 }
 
 func TestValidateConnectionStringV2(t *testing.T) {

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -6,6 +6,7 @@
 // Licensed under the MIT License.
 //
 // This code is a modified version of the code from the Azure SDK for Go.
+// Check NOTICE.txt for full licence details.
 //
 // The original code is available at:
 // https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -96,7 +96,6 @@ func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
 			csp.SharedAccessSignature = &value
 		case strings.EqualFold(useEmulator, key):
 			v, err := strconv.ParseBool(value)
-
 			if err != nil {
 				return ConnectionStringProperties{}, err
 			}

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -121,7 +121,6 @@ func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
 			// there should always be at least two parts "sb:" and "//<emulator hostname>"
 			// with an optional 3rd piece that's the port "1111".
 			// (we don't need to validate it's a valid host since it's been through url.Parse() above)
-			// return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://<emulator hostname> or sb://<emulator hostname>:<port number>, not %s", csp.Endpoint)
 			errs = append(errs, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://<emulator hostname> or sb://<emulator hostname>:<port number>, not %s", csp.Endpoint))
 		}
 	}

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -96,6 +96,7 @@ func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
 			csp.SharedAccessSignature = &value
 		case strings.EqualFold(useEmulator, key):
 			v, err := strconv.ParseBool(value)
+
 			if err != nil {
 				return ConnectionStringProperties{}, err
 			}
@@ -105,14 +106,13 @@ func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
 	}
 
 	if csp.Emulator {
-		// check that they're only connecting to localhost
 		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
 
-		if len(endpointParts) < 2 || endpointParts[0] != "sb" || endpointParts[1] != "//localhost" {
-			// there should always be at least two parts "sb:" and "//localhost"
+		if len(endpointParts) < 2 || endpointParts[0] != "sb" {
+			// there should always be at least two parts "sb:" and "//<emulator hostname>"
 			// with an optional 3rd piece that's the port "1111".
 			// (we don't need to validate it's a valid host since it's been through url.Parse() above)
-			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not %s", csp.Endpoint)
+			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://<emulator hostname> or sb://<emulator hostname>:<port number>, not %s", csp.Endpoint)
 		}
 	}
 

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -131,12 +131,10 @@ func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
 	}
 
 	if (csp.SharedAccessSignature == nil || *csp.SharedAccessSignature == "") && (csp.SharedAccessKeyName == nil || *csp.SharedAccessKeyName == "") {
-		// return ConnectionStringProperties{}, fmt.Errorf("key %q must not be empty", sharedAccessKeyNameKey)
 		errs = append(errs, fmt.Errorf("key %q and %q must not be empty", sharedAccessKeyNameKey, sharedAccessSignatureKey))
 	}
 
 	if (csp.SharedAccessSignature == nil || *csp.SharedAccessSignature == "") && (csp.SharedAccessKey == nil || *csp.SharedAccessKey == "") {
-		// return ConnectionStringProperties{}, fmt.Errorf("key %q or %q cannot both be empty", sharedAccessKeyKey, sharedAccessSignatureKey)
 		errs = append(errs, fmt.Errorf("key %q or %q cannot both be empty", sharedAccessKeyKey, sharedAccessSignatureKey))
 	}
 

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -5,8 +5,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 //
-// This code is a modified version of the code from the Azure SDK for Go.
 // Check NOTICE.txt for full licence details.
+
+// Please note that this code is a modified version of the code from
+// the Azure SDK for Go.
+//
+// We made some minor modifications to the code to improve the following aspects:
+//
+// - Returns all the errors instead of returning the first error.
+// - Checks the connection string keys for empty values instead of
+//   checking for nil values.
 //
 // The original code is available at:
 // https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azeventhubs/internal/exported/connection_string_properties.go

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -91,7 +91,7 @@ func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
 		case strings.EqualFold(endpointKey, key):
 			u, err := url.Parse(value)
 			if err != nil {
-				return ConnectionStringProperties{}, errors.New("failed parsing connection string due to an incorrectly formatted Endpoint value")
+				return ConnectionStringProperties{}, fmt.Errorf("failed parsing connection string due to an incorrectly formatted Endpoint value (%s): %w", value, err)
 			}
 			csp.Endpoint = value
 			csp.FullyQualifiedNamespace = u.Host

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -1,10 +1,10 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
 // This code is a modified version of the code from the Azure SDK for Go.
 //
 // The original code is available at:

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -1,0 +1,133 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !aix
+
+package azureeventhub
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ConnectionStringProperties are the properties of a connection string
+// as returned by [ParseConnectionString].
+type ConnectionStringProperties struct {
+	// Endpoint is the Endpoint value in the connection string.
+	// Ex: sb://example.servicebus.windows.net
+	Endpoint string
+
+	// EntityPath is EntityPath value in the connection string.
+	EntityPath *string
+
+	// FullyQualifiedNamespace is the Endpoint value without the protocol scheme.
+	// Ex: example.servicebus.windows.net
+	FullyQualifiedNamespace string
+
+	// SharedAccessKey is the SharedAccessKey value in the connection string.
+	SharedAccessKey *string
+
+	// SharedAccessKeyName is the SharedAccessKeyName value in the connection string.
+	SharedAccessKeyName *string
+
+	// SharedAccessSignature is the SharedAccessSignature value in the connection string.
+	SharedAccessSignature *string
+
+	// Emulator indicates that the connection string is for an emulator:
+	// ex: Endpoint=localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true
+	Emulator bool
+}
+
+// ParseConnectionString takes a connection string from the Azure portal and returns the
+// parsed representation.
+//
+// There are two supported formats:
+//
+//  1. Connection strings generated from the portal (or elsewhere) that contain an embedded key and keyname.
+//
+//  2. A connection string with an embedded SharedAccessSignature:
+//     Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"
+func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
+	const (
+		endpointKey              = "Endpoint"
+		sharedAccessKeyNameKey   = "SharedAccessKeyName"
+		sharedAccessKeyKey       = "SharedAccessKey"
+		entityPathKey            = "EntityPath"
+		sharedAccessSignatureKey = "SharedAccessSignature"
+		useEmulator              = "UseDevelopmentEmulator"
+	)
+
+	csp := ConnectionStringProperties{}
+
+	splits := strings.Split(connStr, ";")
+
+	for _, split := range splits {
+		if split == "" {
+			continue
+		}
+
+		keyAndValue := strings.SplitN(split, "=", 2)
+		if len(keyAndValue) < 2 {
+			return ConnectionStringProperties{}, errors.New("failed parsing connection string due to unmatched key value separated by '='")
+		}
+
+		// if a key value pair has `=` in the value, recombine them
+		key := keyAndValue[0]
+		value := strings.Join(keyAndValue[1:], "=")
+		switch {
+		case strings.EqualFold(endpointKey, key):
+			u, err := url.Parse(value)
+			if err != nil {
+				return ConnectionStringProperties{}, errors.New("failed parsing connection string due to an incorrectly formatted Endpoint value")
+			}
+			csp.Endpoint = value
+			csp.FullyQualifiedNamespace = u.Host
+		case strings.EqualFold(sharedAccessKeyNameKey, key):
+			csp.SharedAccessKeyName = &value
+		case strings.EqualFold(sharedAccessKeyKey, key):
+			csp.SharedAccessKey = &value
+		case strings.EqualFold(entityPathKey, key):
+			csp.EntityPath = &value
+		case strings.EqualFold(sharedAccessSignatureKey, key):
+			csp.SharedAccessSignature = &value
+		case strings.EqualFold(useEmulator, key):
+			v, err := strconv.ParseBool(value)
+
+			if err != nil {
+				return ConnectionStringProperties{}, err
+			}
+
+			csp.Emulator = v
+		}
+	}
+
+	if csp.Emulator {
+		// check that they're only connecting to localhost
+		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
+
+		if len(endpointParts) < 2 || endpointParts[0] != "sb" || endpointParts[1] != "//localhost" {
+			// there should always be at least two parts "sb:" and "//localhost"
+			// with an optional 3rd piece that's the port "1111".
+			// (we don't need to validate it's a valid host since it's been through url.Parse() above)
+			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not %s", csp.Endpoint)
+		}
+	}
+
+	if csp.FullyQualifiedNamespace == "" {
+		return ConnectionStringProperties{}, fmt.Errorf("key %q must not be empty", endpointKey)
+	}
+
+	if csp.SharedAccessSignature == nil && csp.SharedAccessKeyName == nil {
+		return ConnectionStringProperties{}, fmt.Errorf("key %q must not be empty", sharedAccessKeyNameKey)
+	}
+
+	if csp.SharedAccessKey == nil && csp.SharedAccessSignature == nil {
+		return ConnectionStringProperties{}, fmt.Errorf("key %q or %q cannot both be empty", sharedAccessKeyKey, sharedAccessSignatureKey)
+	}
+
+	return csp, nil
+}

--- a/x-pack/filebeat/input/azureeventhub/connection_string_test.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string_test.go
@@ -89,12 +89,17 @@ func TestNewConnectionStringProperties(t *testing.T) {
 
 	t.Run("WithoutEndpoint", func(t *testing.T) {
 		_, err := parseConnectionString("NoEndpoint=Blah")
-		require.EqualError(t, err, "key \"Endpoint\" must not be empty")
+		require.EqualError(t, err, "key \"Endpoint\" must not be empty\nkey \"SharedAccessKeyName\" and \"SharedAccessSignature\" must not be empty\nkey \"SharedAccessKey\" or \"SharedAccessSignature\" cannot both be empty")
 	})
 
 	t.Run("NoSASOrKeyName", func(t *testing.T) {
 		_, err := parseConnectionString("Endpoint=sb://" + namespace + ".servicebus.windows.net/")
-		require.EqualError(t, err, "key \"SharedAccessKeyName\" must not be empty")
+		require.EqualError(t, err, "key \"SharedAccessKeyName\" and \"SharedAccessSignature\" must not be empty\nkey \"SharedAccessKey\" or \"SharedAccessSignature\" cannot both be empty")
+	})
+
+	t.Run("EmptySASOrKeyName", func(t *testing.T) {
+		_, err := parseConnectionString("Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=;SharedAccessKey=;SharedAccessSignature=")
+		require.EqualError(t, err, "key \"SharedAccessKeyName\" and \"SharedAccessSignature\" must not be empty\nkey \"SharedAccessKey\" or \"SharedAccessSignature\" cannot both be empty")
 	})
 
 	t.Run("NoSASOrKeyValue", func(t *testing.T) {

--- a/x-pack/filebeat/input/azureeventhub/connection_string_test.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string_test.go
@@ -1,0 +1,143 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !aix
+
+package azureeventhub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+)
+
+var (
+	namespace = "mynamespace"
+	keyName   = "keyName"
+	secret    = "superSecret="
+	hubName   = "myhub"
+)
+
+func TestNewConnectionStringProperties(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		var happyConnStr = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";EntityPath=" + hubName
+
+		props, err := parseConnectionString(happyConnStr)
+		require.NoError(t, err)
+
+		require.Equal(t, ConnectionStringProperties{
+			EntityPath:              &hubName,
+			Endpoint:                "sb://" + namespace + ".servicebus.windows.net/",
+			FullyQualifiedNamespace: namespace + ".servicebus.windows.net",
+			SharedAccessKeyName:     &keyName,
+			SharedAccessKey:         &secret,
+			SharedAccessSignature:   nil,
+			Emulator:                false,
+		}, props)
+	})
+
+	t.Run("CaseIndifference", func(t *testing.T) {
+		var lowerCase = "endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccesskeyName=" + keyName + ";sharedAccessKey=" + secret + ";Entitypath=" + hubName
+
+		props, err := parseConnectionString(lowerCase)
+		require.NoError(t, err)
+
+		require.Equal(t, ConnectionStringProperties{
+			EntityPath:              &hubName,
+			Endpoint:                "sb://" + namespace + ".servicebus.windows.net/",
+			FullyQualifiedNamespace: namespace + ".servicebus.windows.net",
+			SharedAccessKeyName:     &keyName,
+			SharedAccessKey:         &secret,
+			SharedAccessSignature:   nil,
+		}, props)
+	})
+
+	t.Run("NoEntityPath", func(t *testing.T) {
+		var noEntityPath = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret
+
+		props, err := parseConnectionString(noEntityPath)
+		require.NoError(t, err)
+
+		require.Equal(t, ConnectionStringProperties{
+			EntityPath:              nil,
+			Endpoint:                "sb://" + namespace + ".servicebus.windows.net/",
+			FullyQualifiedNamespace: namespace + ".servicebus.windows.net",
+			SharedAccessKeyName:     &keyName,
+			SharedAccessKey:         &secret,
+			SharedAccessSignature:   nil,
+		}, props)
+	})
+
+	t.Run("EmbeddedSAS", func(t *testing.T) {
+		var withEmbeddedSAS = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessSignature=SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"
+
+		props, err := parseConnectionString(withEmbeddedSAS)
+		require.NoError(t, err)
+
+		require.Equal(t, ConnectionStringProperties{
+			EntityPath:              nil,
+			Endpoint:                "sb://" + namespace + ".servicebus.windows.net/",
+			FullyQualifiedNamespace: namespace + ".servicebus.windows.net",
+			SharedAccessKeyName:     nil,
+			SharedAccessKey:         nil,
+			SharedAccessSignature:   to.Ptr("SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"),
+		}, props)
+	})
+
+	t.Run("WithoutEndpoint", func(t *testing.T) {
+		_, err := parseConnectionString("NoEndpoint=Blah")
+		require.EqualError(t, err, "key \"Endpoint\" must not be empty")
+	})
+
+	t.Run("NoSASOrKeyName", func(t *testing.T) {
+		_, err := parseConnectionString("Endpoint=sb://" + namespace + ".servicebus.windows.net/")
+		require.EqualError(t, err, "key \"SharedAccessKeyName\" must not be empty")
+	})
+
+	t.Run("NoSASOrKeyValue", func(t *testing.T) {
+		var s = "Endpoint=sb://" + namespace + ".servicebus.windows.net/;SharedAccessKeyName=" + keyName + ";EntityPath=" + hubName
+
+		_, err := parseConnectionString(s)
+		require.EqualError(t, err, "key \"SharedAccessKey\" or \"SharedAccessSignature\" cannot both be empty")
+	})
+
+	t.Run("UseDevelopmentEmulator", func(t *testing.T) {
+		cs := "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
+		parsed, err := parseConnectionString(cs)
+		require.NoError(t, err)
+		require.True(t, parsed.Emulator)
+		require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
+
+		// also allowed _without_ a port.
+		cs = "Endpoint=sb://localhost;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
+		parsed, err = parseConnectionString(cs)
+		require.NoError(t, err)
+		require.True(t, parsed.Emulator)
+		require.Equal(t, "sb://localhost", parsed.Endpoint)
+
+		// emulator can give connection strings that have a trailing ';'
+		cs = "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true;"
+		parsed, err = parseConnectionString(cs)
+		require.NoError(t, err)
+		require.True(t, parsed.Emulator)
+		require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
+
+		// UseDevelopmentEmulator works for any hostname. This allows for cases where the emulator is used
+		// in testing with multiple containers, where the hostname will not be localhost but development
+		// will still be local.
+		cs = "Endpoint=sb://myserver.com:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
+		parsed, err = parseConnectionString(cs)
+		require.NoError(t, err)
+
+		// there's no reason for a person to pass False, but it's allowed.
+		// If they're not using the dev emulator then there's no special behavior, it's like a normal connection string
+		cs = "Endpoint=sb://localhost:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=false"
+		parsed, err = parseConnectionString(cs)
+		require.NoError(t, err)
+		require.False(t, parsed.Emulator)
+		require.Equal(t, "sb://localhost:6765", parsed.Endpoint)
+	})
+}

--- a/x-pack/filebeat/input/azureeventhub/connection_string_test.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string_test.go
@@ -129,7 +129,7 @@ func TestNewConnectionStringProperties(t *testing.T) {
 		// in testing with multiple containers, where the hostname will not be localhost but development
 		// will still be local.
 		cs = "Endpoint=sb://myserver.com:6765;SharedAccessKeyName=" + keyName + ";SharedAccessKey=" + secret + ";UseDevelopmentEmulator=true"
-		parsed, err = parseConnectionString(cs)
+		_, err = parseConnectionString(cs)
 		require.NoError(t, err)
 
 		// there's no reason for a person to pass False, but it's allowed.

--- a/x-pack/filebeat/input/azureeventhub/v2_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input.go
@@ -191,7 +191,7 @@ func (in *eventHubInputV2) setup(ctx context.Context) error {
 
 	connectionString := in.config.ConnectionString
 	eventHubName := in.config.EventHubName
-	if in.config.ConnectionStringContainsEntityPath {
+	if in.config.ConnectionStringProperties.EntityPath != nil {
 		// If the connection string contains an entity path, we need to
 		// set the event hub name to an empty string.
 		eventHubName = ""

--- a/x-pack/filebeat/input/azureeventhub/v2_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input.go
@@ -199,7 +199,12 @@ func (in *eventHubInputV2) setup(ctx context.Context) error {
 	//
 	// We need to handle both cases.
 	eventHubName := in.config.EventHubName
-	if in.config.ConnectionStringProperties.EntityPath != nil {
+
+	connectionStringProperties, err := parseConnectionString(in.config.ConnectionString)
+	if err != nil {
+		return fmt.Errorf("failed to parse connection string: %w", err)
+	}
+	if connectionStringProperties.EntityPath != nil {
 		// If the connection string contains an entity path, we need to
 		// set the event hub name to an empty string.
 		//

--- a/x-pack/filebeat/input/azureeventhub/v2_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input.go
@@ -224,6 +224,7 @@ func (in *eventHubInputV2) setup(ctx context.Context) error {
 	// Manage the migration of the checkpoint information
 	// from the old Event Hub SDK to the new Event Hub SDK.
 	in.migrationAssistant = newMigrationAssistant(
+		in.config,
 		in.log,
 		consumerClient,
 		containerClient,
@@ -256,7 +257,6 @@ func (in *eventHubInputV2) run(ctx context.Context) error {
 		err := in.migrationAssistant.checkAndMigrate(
 			ctx,
 			in.config.ConnectionString,
-			in.config.EventHubName,
 			in.config.ConsumerGroup,
 		)
 		if err != nil {

--- a/x-pack/filebeat/input/azureeventhub/v2_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input.go
@@ -189,10 +189,18 @@ func (in *eventHubInputV2) setup(ctx context.Context) error {
 	}
 	in.checkpointStore = checkpointStore
 
+	connectionString := in.config.ConnectionString
+	eventHubName := in.config.EventHubName
+	if in.config.ConnectionStringContainsEntityPath {
+		// If the connection string contains an entity path, we need to
+		// set the event hub name to an empty string.
+		eventHubName = ""
+	}
+
 	// Create the event hub consumerClient to receive events.
 	consumerClient, err := azeventhubs.NewConsumerClientFromConnectionString(
-		in.config.ConnectionString,
-		in.config.EventHubName,
+		connectionString,
+		eventHubName,
 		in.config.ConsumerGroup,
 		nil,
 	)

--- a/x-pack/filebeat/input/azureeventhub/v2_migration.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_migration.go
@@ -9,11 +9,8 @@ package azureeventhub
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -215,122 +212,4 @@ type LegacyCheckpoint struct {
 		SequenceNumber int64  `json:"sequenceNumber"`
 		EnqueueTime    string `json:"enqueueTime"` // ": "0001-01-01T00:00:00Z"
 	} `json:"checkpoint"`
-}
-
-// ConnectionStringProperties are the properties of a connection string
-// as returned by [ParseConnectionString].
-type ConnectionStringProperties struct {
-	// Endpoint is the Endpoint value in the connection string.
-	// Ex: sb://example.servicebus.windows.net
-	Endpoint string
-
-	// EntityPath is EntityPath value in the connection string.
-	EntityPath *string
-
-	// FullyQualifiedNamespace is the Endpoint value without the protocol scheme.
-	// Ex: example.servicebus.windows.net
-	FullyQualifiedNamespace string
-
-	// SharedAccessKey is the SharedAccessKey value in the connection string.
-	SharedAccessKey *string
-
-	// SharedAccessKeyName is the SharedAccessKeyName value in the connection string.
-	SharedAccessKeyName *string
-
-	// SharedAccessSignature is the SharedAccessSignature value in the connection string.
-	SharedAccessSignature *string
-
-	// Emulator indicates that the connection string is for an emulator:
-	// ex: Endpoint=localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true
-	Emulator bool
-}
-
-// ParseConnectionString takes a connection string from the Azure portal and returns the
-// parsed representation.
-//
-// There are two supported formats:
-//
-//  1. Connection strings generated from the portal (or elsewhere) that contain an embedded key and keyname.
-//
-//  2. A connection string with an embedded SharedAccessSignature:
-//     Endpoint=sb://<sb>.servicebus.windows.net;SharedAccessSignature=SharedAccessSignature sr=<sb>.servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"
-func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
-	const (
-		endpointKey              = "Endpoint"
-		sharedAccessKeyNameKey   = "SharedAccessKeyName"
-		sharedAccessKeyKey       = "SharedAccessKey"
-		entityPathKey            = "EntityPath"
-		sharedAccessSignatureKey = "SharedAccessSignature"
-		useEmulator              = "UseDevelopmentEmulator"
-	)
-
-	csp := ConnectionStringProperties{}
-
-	splits := strings.Split(connStr, ";")
-
-	for _, split := range splits {
-		if split == "" {
-			continue
-		}
-
-		keyAndValue := strings.SplitN(split, "=", 2)
-		if len(keyAndValue) < 2 {
-			return ConnectionStringProperties{}, errors.New("failed parsing connection string due to unmatched key value separated by '='")
-		}
-
-		// if a key value pair has `=` in the value, recombine them
-		key := keyAndValue[0]
-		value := strings.Join(keyAndValue[1:], "=")
-		switch {
-		case strings.EqualFold(endpointKey, key):
-			u, err := url.Parse(value)
-			if err != nil {
-				return ConnectionStringProperties{}, errors.New("failed parsing connection string due to an incorrectly formatted Endpoint value")
-			}
-			csp.Endpoint = value
-			csp.FullyQualifiedNamespace = u.Host
-		case strings.EqualFold(sharedAccessKeyNameKey, key):
-			csp.SharedAccessKeyName = &value
-		case strings.EqualFold(sharedAccessKeyKey, key):
-			csp.SharedAccessKey = &value
-		case strings.EqualFold(entityPathKey, key):
-			csp.EntityPath = &value
-		case strings.EqualFold(sharedAccessSignatureKey, key):
-			csp.SharedAccessSignature = &value
-		case strings.EqualFold(useEmulator, key):
-			v, err := strconv.ParseBool(value)
-
-			if err != nil {
-				return ConnectionStringProperties{}, err
-			}
-
-			csp.Emulator = v
-		}
-	}
-
-	if csp.Emulator {
-		// check that they're only connecting to localhost
-		endpointParts := strings.SplitN(csp.Endpoint, ":", 3) // allow for a port, if it exists.
-
-		if len(endpointParts) < 2 || endpointParts[0] != "sb" || endpointParts[1] != "//localhost" {
-			// there should always be at least two parts "sb:" and "//localhost"
-			// with an optional 3rd piece that's the port "1111".
-			// (we don't need to validate it's a valid host since it's been through url.Parse() above)
-			return ConnectionStringProperties{}, fmt.Errorf("UseDevelopmentEmulator=true can only be used with sb://localhost or sb://localhost:<port number>, not %s", csp.Endpoint)
-		}
-	}
-
-	if csp.FullyQualifiedNamespace == "" {
-		return ConnectionStringProperties{}, fmt.Errorf("key %q must not be empty", endpointKey)
-	}
-
-	if csp.SharedAccessSignature == nil && csp.SharedAccessKeyName == nil {
-		return ConnectionStringProperties{}, fmt.Errorf("key %q must not be empty", sharedAccessKeyNameKey)
-	}
-
-	if csp.SharedAccessKey == nil && csp.SharedAccessSignature == nil {
-		return ConnectionStringProperties{}, fmt.Errorf("key %q or %q cannot both be empty", sharedAccessKeyKey, sharedAccessSignatureKey)
-	}
-
-	return csp, nil
 }

--- a/x-pack/filebeat/input/azureeventhub/v2_migration.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_migration.go
@@ -78,12 +78,17 @@ func (m *migrationAssistant) checkAndMigrate(ctx context.Context, eventHubConnec
 		return err
 	}
 
+	connectionStringProperties, err := parseConnectionString(m.config.ConnectionString)
+	if err != nil {
+		return fmt.Errorf("migration assistant: failed to parse connection string: %w", err)
+	}
+
 	for _, partitionID := range eventHubProperties.PartitionIDs {
 		err = m.checkAndMigratePartition(
 			ctx,
 			blobs,
 			partitionID,
-			m.config.ConnectionStringProperties.FullyQualifiedNamespace,
+			connectionStringProperties.FullyQualifiedNamespace,
 			eventHubProperties.Name,
 			consumerGroup,
 		)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Fix entity path handling in the event hub connection string (v1 and v2 processors).

For context on this issue, see https://github.com/elastic/beats/issues/43715.

Changes:

- v1 & v2: fully parse the connection string for validation and to check the event hub name and entity path match.
- v2: handle event hub name and connection string according to the new Event Hub SDK requirements to support all connection string formats.

Unrelated changes:

- I had to fix an unrelated problem to `metricbeat/module/windows/service/service_integration_test.go` to make the linter happy again.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!--
## Disruptive User Impact
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

<!-- Recommended
## Author's Checklist

Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #43715 


<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
