### PR TITLE
Add Beats Release Notes for 9.0.0

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -42,3 +42,5 @@ subs:
   monitor-features:   "monitoring features"
   stack-version: "9.0.0"
   major-version: "9.0"
+  beats-pull: "https://github.com/elastic/beats/pull/"
+  beats-issue: "https://github.com/elastic/beats/issue/"

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -16,3 +16,65 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 
 % Description and impact of the breaking change.
 % For more information, check [PR #](PR link).
+
+::::{dropdown} Set default Kafka version to 2.1.0 in Kafka output and Filebeat.
+For more information, check [#41662]({{beats-pull}}41662).
+::::
+
+::::{dropdown} Replaced default Ubuntu-based images with UBI-minimal-based ones.
+For more information, check  [#42150]({{beats-pull}}42150).
+::::
+
+::::{dropdown} Removed support for a single `-` to precede multi-letter command line arguments.  Use `--` instead.
+For more information, check [#42117]({{beats-issue}}42117) [#42209]({{beats-pull}}42209).
+::::
+
+::::{dropdown} Filebeat fails to start if there is any input with a duplicated ID. It logs the duplicated IDs and the offending inputs configurations.
+For more information, check [#41731]({{beats-pull}}41731).
+::::
+
+::::{dropdown} Filestream inputs with duplicated IDs will fail to start. An error is logged showing the ID and the full input configuration.
+For more information, check [#41938]({{beats-issue}}41938) [#41954]({{beats-pull}}41954).
+::::
+
+::::{dropdown} Filestream inputs can define `allow_deprecated_id_duplication: true` to run keep the previous behaviour of running inputs with duplicated IDs.
+For more information, check [#41938]({{beats-issue}}41938) [#41954]({{beats-pull}}41954).
+::::
+
+::::{dropdown} Filestream inputs now starts ingesting files only if they are 1024 bytes or larger because the default file identity has changed from `native` to `fingerprint`.
+
+At startup Filebeat automatically updates the state from known, active files (i.e: files that are still present on the disk and have not changed path since Filebeat was stopped) to use the new file identity. If Filebeat cannot migrate the state to the new file identity, the file will be re-ingested. To preserve the behaviour from 8.x, set `file_identity.native: ~` and `prospector.scanner.fingerprint.enabled: false`.
+
+Refer to the file identity documentation for more details. You can also check [#40197]({{beats-issue}}40197) [#41762]({{beats-pull}}41762).
+::::
+
+::::{dropdown} Filebeat fails to start when its configuration contains usage of the deprecated `log` or `container` inputs. However, they can still be used when `allow_deprecated_use: true` is set in their configuration.
+For more information, check [#42295]({{beats-pull}}42295).
+::::
+
+::::{dropdown} Upgrade osquery version to 5.13.1.
+For more information, check [#40849]({{beats-pull}}40849).
+::::
+
+::::{dropdown} Use base-16 for reporting `serial_number` value in TLS fields in line with the ECS recommendation.
+For more information, check [#41542]({{beats-pull}}41542).
+::::
+
+::::{dropdown} Default to use raw API and delete older XML implementation.
+For more information, check [#42275]({{beats-pull}}42275).
+::::
+
+::::{dropdown} The Beats logger and file output rotate files when necessary. The beat now forces a file rotation when unexpectedly writing to a file through a symbolic link.
+::::
+
+::::{dropdown} Remove kibana.settings metricset since the API was removed in 8.0 in Metricbeat.
+For more information, check [#30592]({{beats-issue}}30592). [#42937]({{beats-pull}}42937).
+::::
+
+::::{dropdown} Removed support for the Enterprise Search module in Metricbeat.
+For more information, check [#42915]({{beats-pull}}42915).
+::::
+
+::::{dropdown} Allow faccessat(2) in seccomp.
+For more information, check [#43322]({{beats-pull}}43322).
+::::

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,44 +20,60 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ## 9.0.0 [beats-900-release-notes]
 
 ### Features and enhancements [beats-900-features-enhancements]
-* Improves logging in system/socket in Auditbeat {pull}41571[41571]
-* Adds out of the box support for Amazon EventBridge notifications over SQS to S3 input in Filebeat {pull}40006[40006]
-* Update CEL mito extensions to v1.16.0 in Filebeat {pull}41727[41727]
-* Filebeat's registry is now added to the Elastic-Agent diagnostics bundle {issue}33238[33238] and {pull}41795[41795]
-* Adds `unifiedlogs` input for MacOS in Filebeat {pull}41791[41791]
-* Adds evaluation state dump debugging option to CEL input in Filebeat {pull}41335[41335]
-* Rate limiting operability improvements in the Okta provider of the Entity Analytics input in Filebeat {issue}40106[40106] and {pull}41977[41977]
-* Rate limiting fault tolerance improvements in the Okta provider of the Entity Analytics input in Filebeat {issue}40106[40106] {pull}42094[42094]
-* Introduces ignore older and start timestamp filters for AWS S3 input in Filebeat {pull}41804[41804]
-* Journald input now can report its status to Elastic-Agent in Filebeat {issue}39791[39791] and {pull}42462[42462]
-* Publish events progressively in the Okta provider of the Entity Analytics input in Filebeat {issue}40106[40106] and {pull}42567[42567]
-* Journald `include_matches.match` now accepts `+` to represent a logical disjunction (OR) in Filebeat {issue}40185[40185] and {pull}42517[42517]
-* The journald input is now generally available in Filebeat {pull}42107[42107]
-* Adds support for RFC7231 methods to HTTP monitors in Heartbeat {pull}41975[41975]
-* Adds `use_kubeadm` config option in kubernetes module in order to toggle kubeadm-config API requests in Metricbeat {pull}40086[40086]
-* Preserve queries for debugging when `merge_results: true` in SQL module in Metricbeat {pull}42271[42271]
-* Collect more fields from ES node/stats metrics and only those that are necessary in Metricbeat {pull}42421[42421]
-* Adds benchmark module in Metricbeat {pull}41801[41801]
-* Increase maximum query timeout to 24 hours in Osquerybeat {pull}42356[42356]
-* Properly set events `UserData` when experimental API is used in Winlogbeat {pull}41525[41525]
-* Include XML is respected for experimental API in Winlogbeat {pull}41525[41525]
-* Forwarded events use renderedtext info for experimental API in Winlogbeat {pull}41525[41525]
-* Language setting is respected for experimental API in Winlogbeat {pull}41525[41525]
-* Language setting also added to decode XML wineventlog processor in Winlogbeat {pull}41525[41525]
-* Format embedded messages in the experimental API in Winlogbeat {pull}41525[41525]
-* Make the experimental API GA and rename it to winlogbeat-raw in Winlogbeat {issue}39580[39580] and {pull}41770[41770]
-* Removes 22 clause limitation in Winlogbeat {issue}35047[35047] and {pull}42187[42187]
-* Adds handling for recoverable publisher disabled errorsin Winlogbeat {issue}35316[35316] and {pull}42187[42187]
-* Removes Functionbeat binaries from CI pipelines {issue}40745[40745] and {pull}41506[41506]
+* Improves logging in system/socket in Auditbeat. [#41571]({{beats-pull}}41571)
+* Adds out of the box support for Amazon EventBridge notifications over SQS to S3 input in Filebeat. [#40006]({{beats-pull}}40006)
+* Update CEL mito extensions to v1.16.0 in Filebeat. [#41727]({{beats-pull}}41727)
+* Filebeat's registry is now added to the Elastic-Agent diagnostics bundle. [#33238]({{beats-issue}}33238) and [#41795]({{beats-pull}}41795)
+* Adds `unifiedlogs` input for MacOS in Filebeat. [#41791]({{beats-pull}}41791)
+* Adds evaluation state dump debugging option to CEL input in Filebeat. [#41335]({{beats-pull}}41335)
+* Rate limiting operability improvements in the Okta provider of the Entity Analytics input in Filebeat. [#40106]({{beats-issue}}40106) and [#41977]({{beats-pull}}41977)
+* Rate limiting fault tolerance improvements in the Okta provider of the Entity Analytics input in Filebeat. [#40106]({{beats-issue}}40106) [#42094]({{beats-pull}}42094)
+* Introduces ignore older and start timestamp filters for AWS S3 input in Filebeat. [#41804]({{beats-pull}}41804)
+* Journald input now can report its status to Elastic-Agent in Filebeat. [#39791]({{beats-issue}}39791) and [#42462]({{beats-pull}}42462)
+* Publish events progressively in the Okta provider of the Entity Analytics input in Filebeat. [#40106]({{beats-issue}}40106) and [#42567]({{beats-pull}}42567)
+* Journald `include_matches.match` now accepts `+` to represent a logical disjunction (OR) in Filebeat. [#40185]({{beats-issue}}40185) and #[42517]({{beats-pull}}42517)
+* The journald input is now generally available in Filebeat. [#42107]({{beats-pull}}42107)
+* Adds support for RFC7231 methods to HTTP monitors in Heartbeat. [#41975]({{beats-pull}}41975)
+* Adds `use_kubeadm` config option in kubernetes module in order to toggle kubeadm-config API requests in Metricbeat. [#40086]({{beats-pull}}40086)
+* Preserve queries for debugging when `merge_results: true` in SQL module in Metricbeat. [#42271]({{beats-pull}}42271)
+* Collect more fields from ES node/stats metrics and only those that are necessary in Metricbeat. [#42421]({{beats-pull}}42421)
+* Adds benchmark module in Metricbeat. [#41801]({{beats-pull}}41801)
+* Increase maximum query timeout to 24 hours in Osquerybeat. [42356]({{beats-pull}}42356)
+* Properly set events `UserData` when experimental API is used in Winlogbeat. [#41525]({{beats-pull}}41525)
+* Include XML is respected for experimental API in Winlogbeat. [#41525]({{beats-pull}}41525)
+* Forwarded events use renderedtext info for experimental API in Winlogbeat. [#41525]({{beats-pull}}41525)
+* Language setting is respected for experimental API in Winlogbeat. [#41525]({{beats-pull}}41525)
+* Language setting also added to decode XML wineventlog processor in Winlogbeat. [#41525]({{beats-pull}}41525)
+* Format embedded messages in the experimental API in Winlogbeat. [#41525]({{beats-pull}}41525)
+* Make the experimental API GA and rename it to winlogbeat-raw in Winlogbeat. [#39580]({{beats-issue}}39580) and [#41770]({{beats-pull}}41770)
+* Removes 22 clause limitation in Winlogbeat. [#35047]({{beats-issue}}35047) and [#42187]({{beats-pull}}42187)
+* Adds handling for recoverable publisher disabled errorsin Winlogbeat. [#35316]({{beats-issue}}35316) and [#42187]({{beats-pull}}42187)
+* Removes Functionbeat binaries from CI pipelines. [#40745]({{beats-issue}}40745) and [#41506]({{beats-pull}}41506)
+* Update Go version to 1.24.0. [#42705]({{beats-pull}}42705)
+* Add `etw` input fallback to attach an already existing session in Filebeat. [#42847]({{beats-pull}}42847)
+* Update CEL mito extensions to v1.17.0 in Filebeat. [#42851]({{beats-pull}}42851)
+* Winlog input  in Filebeat cam now report its status to Elastic Agent. [#43089]({{beats-pull}}43089)
+* Add configuration option to limit HTTP Endpoint body size in Filebeat. [#43171]({{beats-pull}}43171)
+* Add a new `match_by_parent_instance` option to `perfmon` module in Metricbeat. [#43002]({{beats-pull}}43002)
+* Add a warning log to `metricbeat.vsphere` in Metricbeat in case vSphere connection has been configured as insecure. [#43104]({{beats-pull}}43104)
 
 ### Fixes [beats-900-fixes]
-* hasher: Add a cached hasher for upcoming backend in Auditbeat {pull}41952[41952]
-* Split common tty definitions in Auditbeat {pull}42004[42004]
-* Redact authorization headers in HTTPJSON debug logs in Filebeat {pull}41920[41920]
-* Further rate limiting fix in the Okta provider of the Entity Analytics input in Filebeat {issue}40106[40106] and {pull}41977[41977]
-* The `_id` generation process for S3 events has been updated to incorporate the LastModified field. This enhancement ensures that the `_id` is unique in Filebeat {pull}42078[42078]
-* Fixes truncation of bodies in request tracing by limiting bodies to 10% of the maximum file size in Filebeat {pull}42327[42327]
-* [Journald] Fixes handling of `journalctl` restart. A known symptom was broken multiline messages when there was a restart of journalctl while aggregating the lines in Filebeat {issue}41331[41331] and {pull}42595[42595]
-* Fixwa bug where Metricbeat unintentionally triggers Windows ASR in Metricbeat {pull}42177[42177]
-* Removes `hostname` field from ZooKeeper's `mntr` data stream in Metricbeat {pull}41887[41887]
-* Properly marshal nested structs in ECS fields, fixing issues with mixed cases in field names in Packetbeat {pull}42116[42116]
+* hasher: Add a cached hasher for upcoming backend in Auditbeat. [#41952]({{beats-pull}}41952)
+* Split common tty definitions in Auditbeat. [#42004]({{beats-pull}}42004)
+* Redact authorization headers in HTTPJSON debug logs in Filebeat. [#41920]({{beats-pull}}41920)
+* Further rate limiting fix in the Okta provider of the Entity Analytics input in Filebeat. [#40106]({{beats-issue}}40106) and [#41977]({{beats-pull}}41977)
+* The `_id` generation process for S3 events has been updated to incorporate the LastModified field. This enhancement ensures that the `_id` is unique in Filebeat. [#42078]({{beats-pull}}42078)
+* Fixes truncation of bodies in request tracing by limiting bodies to 10% of the maximum file size in Filebeat. [#42327]({{beats-pull}}42327)
+* [Journald] Fixes handling of `journalctl` restart. A known symptom was broken multiline messages when there was a restart of journalctl while aggregating the lines in Filebeat. [#41331]({{beats-issue}}41331) and [#42595]({{beats-pull}}42595)
+* Fixwa bug where Metricbeat unintentionally triggers Windows ASR in Metricbeat. [#42177]({{beats-pull}}42177)
+* Removes `hostname` field from ZooKeeper's `mntr` data stream in Metricbeat. [41887]({{beats-pull}}41887)
+* Properly marshal nested structs in ECS fields, fixing issues with mixed cases in field names in Packetbeat. [42116]({{beats-pull}}42116)
+* Fixed race conditions in the global ratelimit processor that could drop events or apply rate limiting incorrectly in Filebeat. [42966]({{beats-pull}}42966)
+* Prevent computer details being returned for user queries by Activedirectory Entity Analytics provider in Filebeat. [#11818]({{beats-issue}}11818) and [#42796]({{beats-pull}}42796)
+* Handle unexpected EOF error in aws-s3 input and enforce retrying using download failed error in Filebeat. [#42420]({{beats-pull}}42420)
+* Prevent azureblobstorage input from logging key details during blob fetch operations in Filebeat. [#43169]({{beats-pull}}43169)
+* Add AWS OwningAccount support for cross account monitoring in Metricbeat. [#40570]({{beats-issue}}40570) and [#40691]({{beats-pull}}40691)
+* Fix logging argument number mismatch in Metricbeat(Redis). [#43072]({{beats-pull}}43072)
+* Reset EventLog if error EOF is encountered in Winlogbeat. [#42826]({{beats-pull}}42826)
+* Implement backoff on error retrial in Winlogbeat. [#42826]({{beats-pull}}42826)
+* Fix boolean key in security pipelines and sync pipelines with integration in Winlogbeat. [#43027]({{beats-pull}}43027)


### PR DESCRIPTION
This adds the Beats Release Notes for 9.0.0. These have been ported over (and converted to Markdown) from:
 - The 9.0.0-beta and 9.0.0-rc1 [stack docs](https://github.com/elastic/beats/compare/main...kilfoyle:beats:9.0.0-rn?expand=1)
 - The Beats [9.0.0-rc1 changelog PR](https://github.com/elastic/beats/pull/43419)
 - The Beats [9.0.0 changelog PR](https://github.com/elastic/beats/pull/43741)