### PR TITLE
Fix links to the former 'Beats Developer Guide'

### DIFF
--- a/docs/reference/auditbeat/command-line-options.md
+++ b/docs/reference/auditbeat/command-line-options.md
@@ -241,7 +241,7 @@ auditbeat setup [FLAGS]
 **FLAGS**
 
 **`--dashboards`**
-:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Auditbeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md) in the *Beats Developer Guide*.
+:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Auditbeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
 
 **`-h, --help`**
 :   Shows help for the `setup` command.

--- a/docs/reference/auditbeat/contributing-to-beats.md
+++ b/docs/reference/auditbeat/contributing-to-beats.md
@@ -3,11 +3,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/beats/auditbeat/current/contributing-to-beats.html
 ---
 
-# Contribute to Beats [contributing-to-beats]
+# Contribute [contributing-to-beats]
 
 The Beats are open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code that implements a whole new protocol, module, or Beat.
 
-The [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md) is your one-stop shop for everything related to developing code for the Beats project.
+See [Contribute to Beats](../../extend/index.md)  for your one-stop shop for everything related to developing code for the Beats project.
 

--- a/docs/reference/filebeat/command-line-options.md
+++ b/docs/reference/filebeat/command-line-options.md
@@ -297,7 +297,7 @@ filebeat setup [FLAGS]
 **FLAGS**
 
 **`--dashboards`**
-:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Filebeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md) in the *Beats Developer Guide*.
+:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Filebeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md) in [Contribute to Beats](../../extend/index.md).
 
 **`-h, --help`**
 :   Shows help for the `setup` command.

--- a/docs/reference/filebeat/contributing-to-beats.md
+++ b/docs/reference/filebeat/contributing-to-beats.md
@@ -3,11 +3,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/contributing-to-beats.html
 ---
 
-# Contribute to Beats [contributing-to-beats]
+# Contribute [contributing-to-beats]
 
 The Beats are open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code that implements a whole new protocol, module, or Beat.
 
-The [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md) is your one-stop shop for everything related to developing code for the Beats project.
+See [Contribute to Beats](../../extend/index.md)  for your one-stop shop for everything related to developing code for the Beats project.
 

--- a/docs/reference/heartbeat/contributing-to-beats.md
+++ b/docs/reference/heartbeat/contributing-to-beats.md
@@ -3,11 +3,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/beats/heartbeat/current/contributing-to-beats.html
 ---
 
-# Contribute to Beats [contributing-to-beats]
+# Contribute [contributing-to-beats]
 
 The Beats are open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code that implements a whole new protocol, module, or Beat.
 
-The [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md) is your one-stop shop for everything related to developing code for the Beats project.
+See [Contribute to Beats](../../extend/index.md)  for your one-stop shop for everything related to developing code for the Beats project.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -39,4 +39,4 @@ Want to get up and running quickly with infrastructure metrics monitoring and ce
 
 ## Need to capture other kinds of data? [_need_to_capture_other_kinds_of_data]
 
-If you have a specific use case to solve, we encourage you to create a [community Beat](/reference/libbeat/community-beats.md). We’ve created an infrastructure to simplify the process. The *libbeat* library, written entirely in Go, offers the API that all Beats use to ship data to Elasticsearch, configure the input options, implement logging, and more. To learn how to create a new Beat, see the [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md).
+If you have a specific use case to solve, we encourage you to create a [community Beat](/reference/libbeat/community-beats.md). We’ve created an infrastructure to simplify the process. The *libbeat* library, written entirely in Go, offers the API that all Beats use to ship data to Elasticsearch, configure the input options, implement logging, and more. To learn how to create a new Beat, see [Contribute to Beats](../../extend/index.md).

--- a/docs/reference/libbeat/contributing-to-beats.md
+++ b/docs/reference/libbeat/contributing-to-beats.md
@@ -3,11 +3,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/beats/libbeat/current/contributing-to-beats.html
 ---
 
-# Contribute to Beats [contributing-to-beats]
+# Contribute [contributing-to-beats]
 
 The Beats are open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code that implements a whole new protocol, module, or Beat.
 
-The [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md) is your one-stop shop for everything related to developing code for the Beats project.
+See [Contribute to Beats](../../extend/index.md)  for your one-stop shop for everything related to developing code for the Beats project.
 

--- a/docs/reference/loggingplugin/log-driver-installation.md
+++ b/docs/reference/loggingplugin/log-driver-installation.md
@@ -28,7 +28,7 @@ Make sure your system meets the following prerequisites:
 
     **To build and install from source:**
 
-    [Set up your development environment](/extend/index.md#setting-up-dev-environment) as described in the *Beats Developer Guide* then run:
+    [Set up your development environment](/extend/index.md#setting-up-dev-environment) and then run:
 
     ```shell
     cd x-pack/dockerlogbeat

--- a/docs/reference/metricbeat/command-line-options.md
+++ b/docs/reference/metricbeat/command-line-options.md
@@ -280,7 +280,7 @@ metricbeat setup [FLAGS]
 **FLAGS**
 
 **`--dashboards`**
-:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Metricbeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md) in the *Beats Developer Guide*.
+:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Metricbeat package. For more options, such as loading customized dashboards, see see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
 
 **`-h, --help`**
 :   Shows help for the `setup` command.

--- a/docs/reference/metricbeat/contributing-to-beats.md
+++ b/docs/reference/metricbeat/contributing-to-beats.md
@@ -3,11 +3,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/beats/metricbeat/current/contributing-to-beats.html
 ---
 
-# Contribute to Beats [contributing-to-beats]
+# Contribute [contributing-to-beats]
 
 The Beats are open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code that implements a whole new protocol, module, or Beat.
 
-The [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md) is your one-stop shop for everything related to developing code for the Beats project.
+See [Contribute to Beats](../../extend/index.md)  for your one-stop shop for everything related to developing code for the Beats project.
 

--- a/docs/reference/packetbeat/command-line-options.md
+++ b/docs/reference/packetbeat/command-line-options.md
@@ -264,7 +264,7 @@ packetbeat setup [FLAGS]
 **FLAGS**
 
 **`--dashboards`**
-:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Packetbeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md) in the *Beats Developer Guide*.
+:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Packetbeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
 
 **`-h, --help`**
 :   Shows help for the `setup` command.

--- a/docs/reference/packetbeat/contributing-to-beats.md
+++ b/docs/reference/packetbeat/contributing-to-beats.md
@@ -3,11 +3,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/beats/packetbeat/current/contributing-to-beats.html
 ---
 
-# Contribute to Beats [contributing-to-beats]
+# Contribute [contributing-to-beats]
 
 The Beats are open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code that implements a whole new protocol, module, or Beat.
 
-The [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md) is your one-stop shop for everything related to developing code for the Beats project.
+See [Contribute to Beats](../../extend/index.md)  for your one-stop shop for everything related to developing code for the Beats project.
 

--- a/docs/reference/winlogbeat/command-line-options.md
+++ b/docs/reference/winlogbeat/command-line-options.md
@@ -237,7 +237,7 @@ winlogbeat setup [FLAGS]
 **FLAGS**
 
 **`--dashboards`**
-:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Winlogbeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md) in the *Beats Developer Guide*.
+:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Winlogbeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
 
 **`-h, --help`**
 :   Shows help for the `setup` command.

--- a/docs/reference/winlogbeat/contributing-to-beats.md
+++ b/docs/reference/winlogbeat/contributing-to-beats.md
@@ -3,11 +3,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/beats/winlogbeat/current/contributing-to-beats.html
 ---
 
-# Contribute to Beats [contributing-to-beats]
+# Contribute [contributing-to-beats]
 
 The Beats are open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code that implements a whole new protocol, module, or Beat.
 
-The [Beats Developer Guide](http://www.elastic.co/guide/en/beats/devguide/master/index.md) is your one-stop shop for everything related to developing code for the Beats project.
+See [Contribute to Beats](../../extend/index.md)  for your one-stop shop for everything related to developing code for the Beats project.
 


### PR DESCRIPTION
The Beats Developer Guide is now in the docs general "Extend and Contribute" section, specifically [Contribute to Beats](https://staging-website.elastic.co/docs/extend/beats). This updates the various links in to the Beats guide either to the main page or to a page within that section about Kibana dashboards.

Rel: https://github.com/elastic/docs-content/issues/1055