### PR TITLE
[Disk queue] Don't check the serialization format unless there's a valid handle

### DIFF
--- a/libbeat/publisher/queue/diskqueue/reader_loop.go
+++ b/libbeat/publisher/queue/diskqueue/reader_loop.go
@@ -108,11 +108,11 @@ func (rl *readerLoop) processRequest(request readerLoopRequest) readerLoopRespon
 
 	// Open the file and seek to the starting position.
 	handle, err := request.segment.getReader(rl.settings)
-	rl.decoder.serializationFormat = handle.serializationFormat
 	if err != nil {
 		return readerLoopResponse{err: err}
 	}
 	defer handle.Close()
+	rl.decoder.serializationFormat = handle.serializationFormat
 
 	_, err = handle.Seek(int64(request.startPosition), io.SeekStart)
 	if err != nil {


### PR DESCRIPTION
An oversight in the reader loop checks the serialization format of an incoming request before confirming that the segment handle is valid. In the special case that an active segment file from the current session is deleted or truncated to zero length before it is read, this can cause a panic (https://github.com/elastic/beats/issues/43617). This PR moves the format read to after the error check.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Fixes https://github.com/elastic/beats/issues/43617
