### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,7 +96,7 @@ CHANGELOG*
 /metricbeat/module/memcached @elastic/obs-infraobs-integrations
 /metricbeat/module/mongodb @elastic/obs-infraobs-integrations
 /metricbeat/module/mysql @elastic/obs-infraobs-integrations
-/metricbeat/module/nats/ @elastic/obs-ds-hosted-services
+/metricbeat/module/nats @elastic/obs-infraobs-integrations
 /metricbeat/module/nginx @elastic/obs-infraobs-integrations
 /metricbeat/module/php_fpm @elastic/obs-infraobs-integrations
 /metricbeat/module/prometheus @elastic/obs-infraobs-integrations


### PR DESCRIPTION
Updating metricbeats NATS module

Update ownership from `elastic/obs-ds-hosted-services` to `elastic/obs-infraobs-integrations`