### PR TITLE
[Flaky Test] skip x-pack/filebeat/input/netflow TestNetFlow/ipfix_cisco.reversed

### DIFF
--- a/x-pack/filebeat/input/netflow/netflow_test.go
+++ b/x-pack/filebeat/input/netflow/netflow_test.go
@@ -97,9 +97,7 @@ func TestNetFlow(t *testing.T) {
 			pluginCfg, err := conf.NewConfigFrom(mapstr.M{})
 			require.NoError(t, err)
 			if isReversed {
-				if runtime.GOOS == "darwin" {
-					t.Skip("Flaky on macOS: https://github.com/elastic/beats/issues/43670")
-				}
+				t.Skip("Flaky on macOS: https://github.com/elastic/beats/issues/43670")
 
 				// if pcap is reversed packet order we need to have multiple workers
 				// and thus enable the input packets lru

--- a/x-pack/filebeat/input/netflow/netflow_test.go
+++ b/x-pack/filebeat/input/netflow/netflow_test.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"

--- a/x-pack/filebeat/input/netflow/netflow_test.go
+++ b/x-pack/filebeat/input/netflow/netflow_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +97,10 @@ func TestNetFlow(t *testing.T) {
 			pluginCfg, err := conf.NewConfigFrom(mapstr.M{})
 			require.NoError(t, err)
 			if isReversed {
+				if runtime.GOOS == "darwin" {
+					t.Skip("Flaky on macOS: https://github.com/elastic/beats/issues/43670")
+				}
+
 				// if pcap is reversed packet order we need to have multiple workers
 				// and thus enable the input packets lru
 				err = pluginCfg.SetInt("workers", -1, 2)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
skip x-pack/filebeat/input/netflow TestNetFlow/ipfix_cisco.reversed
```


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

 - N/A



## How to test this PR locally

Run the test, ensure it's skipped:
```
❯ go test -v -run "TestNetFlow/ipfix_cisco.reversed" ./x-pack/filebeat/input/netflow
=== RUN   TestNetFlow
=== RUN   TestNetFlow/ipfix_cisco.reversed
    netflow_test.go:99: Flaky on macOS: https://github.com/elastic/beats/issues/43670
--- PASS: TestNetFlow (0.00s)
    --- SKIP: TestNetFlow/ipfix_cisco.reversed (0.00s)
PASS
ok  	github.com/elastic/beats/v7/x-pack/filebeat/input/netflow	0.073s
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #43670
