### PR TITLE
mergify: new way of backporting to active branches

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -1,0 +1,22 @@
+name: Backport to active branches
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  backport:
+    # Only run if the PR was merged (not just closed) and has one of the backport labels
+    if: |
+      github.event.pull_request.merged == true && 
+      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: elastic/oblt-actions/github/backport-active@v1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,22 @@
+commands_restrictions:
+  backport:
+    conditions:
+      - or:
+        - sender-permission>=write
+        - sender=github-actions[bot]
 queue_rules:
   - name: default
     merge_method: squash
     conditions:
       - check-success=buildkite/beats
+defaults:
+  actions:
+    backport:
+      title: "[{{ destination_branch }}] (backport #{{ number }}) {{ title }}"
+      assignees:
+        - "{{ author }}"
+      labels:
+        - "backport"
 pull_request_rules:
   - name: self-assign PRs
     conditions:
@@ -406,60 +420,6 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "9.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-
-  - name: backport patches to all active minor branches for the 8 major.
-    conditions:
-      - merged
-      - label=backport-active-8
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing minor branch reached EOL.
-        branches:
-          - "8.x"
-          - "8.18"
-          - "8.17"
-          - "8.16"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to all active minor branches for the 9 major.
-    conditions:
-      - merged
-      - label=backport-active-9
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing minor branch reached EOL.
-        branches:
-          - "9.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to all active branches
-    conditions:
-      - merged
-      - label=backport-active-all
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        # NOTE: this list needs to be changed when a new minor branch is created
-        #       or an existing release branch reached EOL.
-        branches:
-          - "9.0"
-          - "8.18"
-          - "8.17"
-          - "8.16"
-          - "8.x"
-          - "7.17"
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,7 @@ queue_rules:
 defaults:
   actions:
     backport:
-      title: "[{{ destination_branch }}] (backport #{{ number }}) {{ title }}"
+      title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
       assignees:
         - "{{ author }}"
       labels:


### PR DESCRIPTION
## Proposed commit message

New way of backporting to active branches using new github action.

## Why

No need to support the hardcoded branches in the `.mergify.yml` file anymore.

We use a dynamic approach by fetching https://storage.googleapis.com/artifacts-api/snapshots/branches.json and filtering the branches.

## Issues

Already enabled in Elastic Agent:
- https://github.com/elastic/elastic-agent/actions/workflows/backport-active.yml
