### PR TITLE
[Flaky Test] oteltest.CheckReceivers increase timeout

### DIFF
--- a/libbeat/otelbeat/oteltest/oteltest.go
+++ b/libbeat/otelbeat/oteltest/oteltest.go
@@ -134,5 +134,6 @@ func CheckReceivers(params CheckReceiversParams) {
 		}
 
 		params.AssertFunc(ct, logs, zapLogs)
-	}, time.Minute, 100*time.Millisecond, "timeout waiting for assertion to pass")
+	}, 2*time.Minute, 100*time.Millisecond,
+		"timeout waiting for logger fields from the OTel collector are present in the logs and other assertions to be met")
 }

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -7,6 +7,7 @@ package fbreceiver
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
@@ -203,8 +204,11 @@ func TestMultipleReceivers(t *testing.T) {
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
-			assert.Greater(t, len(logs["r1"]), 0, "receive r1 does not have ny logs")
-			assert.Greater(t, len(logs["r2"]), 0, "receive r2 does not have ny logs")
+			assert.Greater(t, len(logs["r1"]), 0, "receive r1 does not have any logs")
+			assert.Greater(t, len(logs["r2"]), 0, "receive r2 does not have any logs")
+			// logs for debug if it fails again
+			fmt.Printf("len(logs[\"r1\"]): %d\n", len(logs["r1"]))
+			fmt.Printf("len(logs[\"r2\"]): %d\n", len(logs["r2"]))
 
 			// Make sure that each receiver has a separate logger
 			// instance and does not interfere with others. Previously, the

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -203,9 +203,8 @@ func TestMultipleReceivers(t *testing.T) {
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
-			require.Conditionf(t, func() bool {
-				return len(logs["r1"]) > 0 && len(logs["r2"]) > 0
-			}, "expected receivers to have logs, got logs: %v", logs)
+			assert.Len(t, logs["r1"], 1, "receive r1 does not have ny logs")
+			assert.Len(t, logs["r2"], 1, "receive r2 does not have ny logs")
 
 			// Make sure that each receiver has a separate logger
 			// instance and does not interfere with others. Previously, the

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -203,8 +203,8 @@ func TestMultipleReceivers(t *testing.T) {
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
-			assert.Len(t, logs["r1"], 1, "receive r1 does not have ny logs")
-			assert.Len(t, logs["r2"], 1, "receive r2 does not have ny logs")
+			assert.Greater(t, len(logs["r1"]), 0, "receive r1 does not have ny logs")
+			assert.Greater(t, len(logs["r2"]), 0, "receive r2 does not have ny logs")
 
 			// Make sure that each receiver has a separate logger
 			// instance and does not interfere with others. Previously, the

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -204,11 +204,16 @@ func TestMultipleReceivers(t *testing.T) {
 			},
 		},
 		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
-			assert.Greater(t, len(logs["r1"]), 0, "receive r1 does not have any logs")
-			assert.Greater(t, len(logs["r2"]), 0, "receive r2 does not have any logs")
+			r1ok := assert.Greater(t, len(logs["r1"]), 0, "receive r1 does not have any logs")
+			r2ok := assert.Greater(t, len(logs["r2"]), 0, "receive r2 does not have any logs")
 			// logs for debug if it fails again
 			fmt.Printf("len(logs[\"r1\"]): %d\n", len(logs["r1"]))
 			fmt.Printf("len(logs[\"r2\"]): %d\n", len(logs["r2"]))
+			if !r1ok || !r2ok {
+				fmt.Printf("logs[\"r1\"]: %v\n", logs["r1"])
+				fmt.Printf("logs[\"r2\"]: %v\n", logs["r2"])
+				fmt.Printf("all logs: %v\n", logs)
+			}
 
 			// Make sure that each receiver has a separate logger
 			// instance and does not interfere with others. Previously, the


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
oteltest.CheckReceivers increase timeout

There are test failing, the issue seems to be a too short timeout, so this change relaxes it.
```
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

- N/A

## How to test this PR locally

run the test until you're satisfied

```
go test -count 1000 -timeout=0 -run TestMultipleReceivers ./x-pack/filebeat/fbreceiver
```

## Related issues

- Relates #43832