### PR TITLE
Fix typo in "store/set" operation name

### DIFF
--- a/libbeat/statestore/store.go
+++ b/libbeat/statestore/store.go
@@ -132,7 +132,7 @@ func (s *Store) Get(key string, into interface{}) error {
 // Set returns an error if the store has been closed, the value can not be
 // encoded by the store, or the storage backend did failed.
 func (s *Store) Set(key string, from interface{}) error {
-	const operation = "store/get"
+	const operation = "store/set"
 	if err := s.active.Add(1); err != nil {
 		return &ErrorClosed{operation: operation, name: s.shared.name}
 	}


### PR DESCRIPTION
## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

This is expected to change the error message reported when the Set operation fails. I don't expect this to be disruptive to users.

## How to test this PR locally

How I tested this:

```console
cd libbeat/statestore && go test -v .
```