### PR TITLE
Update input-aws-cloudwatch.asciidoc

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-cloudwatch.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-cloudwatch.asciidoc
@@ -144,7 +144,7 @@ Please see <<aws-credentials-config,AWS credentials options>> for more details.
 === AWS Permissions
 Specific AWS permissions are required for IAM user to access aws-cloudwatch:
 ----
-cloudwatchlogs:DescribeLogGroups
+logs:DescribeLogGroups
 logs:FilterLogEvents
 ----
 


### PR DESCRIPTION
cloudwatchlogs doesn't exists anymore

Please label this PR with one of the following labels, depending on the scope of your change:
- Bug

## Proposed commit message
Fix outdated documentation.

Please explain:

- WHAT: policy simulator from AWS
- WHY:  documentation is outdated

## Checklist

- [X ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact
N/A

## Author's Checklist
N/A

## How to test this PR locally
N/A

## Related issues
N/A

## Use cases
Installing filebeat agent

## Screenshots
![image](https://github.com/user-attachments/assets/e94ebb29-ce33-4c62-b5c4-2108bcda23b5)

## Logs
N/A
