### PR TITLE
Clarify support of Podman (8.x docs)

### DIFF
--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -22,7 +22,7 @@ The Docker module is currently tested on Linux and Mac with the community
 edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,
 but it should also work there.
 
-The Docker module supports collection of metrics from Podman's Docker-compatible API.
+The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1 or more recent.
 It has been tested on Linux and Mac with Podman Rest API v2.0.0 and above.
 
 [float]

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -22,7 +22,7 @@ The Docker module is currently tested on Linux and Mac with the community
 edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,
 but it should also work there.
 
-The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1 or more recent.
+The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1, and more recent versions.
 It has been tested on Linux and Mac with Podman Rest API v2.0.0 and above.
 
 [float]

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -22,7 +22,7 @@ The Docker module is currently tested on Linux and Mac with the community
 edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,
 but it should also work there.
 
-The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1, and more recent versions.
+The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1, and higher versions.
 It has been tested on Linux and Mac with Podman Rest API v2.0.0 and above.
 
 [float]

--- a/metricbeat/module/docker/_meta/docs.asciidoc
+++ b/metricbeat/module/docker/_meta/docs.asciidoc
@@ -11,7 +11,7 @@ The Docker module is currently tested on Linux and Mac with the community
 edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,
 but it should also work there.
 
-The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1, and more recent versions.
+The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1, and higher versions.
 It has been tested on Linux and Mac with Podman Rest API v2.0.0 and above.
 
 [float]

--- a/metricbeat/module/docker/_meta/docs.asciidoc
+++ b/metricbeat/module/docker/_meta/docs.asciidoc
@@ -11,7 +11,7 @@ The Docker module is currently tested on Linux and Mac with the community
 edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,
 but it should also work there.
 
-The Docker module supports collection of metrics from Podman's Docker-compatible API.
+The Docker module supports collection of metrics from Podman's Docker-compatible API on Metricbeat 8.16.2 and 8.17.1, and more recent versions.
 It has been tested on Linux and Mac with Podman Rest API v2.0.0 and above.
 
 [float]


### PR DESCRIPTION
Redo of https://github.com/elastic/beats/pull/42303 for 8.18 and 8.17 docs.