### PR TITLE
fix Arbitrary file access during archive extraction ("Zip Slip") Path Traversal

### DIFF
--- a/x-pack/heartbeat/monitors/browser/source/unzip.go
+++ b/x-pack/heartbeat/monitors/browser/source/unzip.go
@@ -67,7 +67,10 @@ func unzipFile(workdir string, folder string, f *zip.File) error {
 		}
 
 		sansFolder := splitZipFileName[folderDepth:]
-		destPath = filepath.Join(workdir, filepath.Join(sansFolder...))
+		destPath, err = sanitizeFilePath(filepath.Join(sansFolder...), workdir)
+		if err != nil {
+			return err
+		}
 	} else {
 		destPath, err = sanitizeFilePath(f.Name, workdir)
 		if err != nil {


### PR DESCRIPTION
https://github.com/elastic/beats/blob/9ecf8c484c1069faed077bf8de72076b87ce7ae5/x-pack/heartbeat/monitors/browser/source/unzip.go#L25-L34

fix the problem ensure that all paths derived from the zip archive entries are properly validated to prevent directory traversal attacks. This involves using the `sanitizeFilePath` function to validate paths in all cases, not just when the `folder` parameter is empty.
1. Modify the `unzipFile` function to always use the `sanitizeFilePath` function to validate paths, regardless of the `folder` parameter.
2. Ensure that the `sanitizeFilePath` function is robust and correctly identifies and rejects unsafe paths.


Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths. Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element `(..)`. If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

vulnerable, if a zip file contains a file entry `..\elastic-file`, and the zip file is extracted to the directory `c:\output`, then naively combining the paths would result in an output file path of `c:\output\..\elastic-file`, which would cause the file to be written to `c:\elastic-file`.

## POC
In this vulnerable an archive is extracted without validating file paths. If `v8.17.4.zip` contained relative paths (for instance, if it were created by something like zip `v8.17.4.zip ../file.txt`) then executing this code could write to locations outside the destination directory.
```js
package main

import (
	"archive/zip"
	"io/ioutil"
	"elastic/beats"
	"path/filepath"
)

func unzip(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// BAD: This could overwrite any file on the file system
		ioutil.WriteFile(p, []byte("present"), 0666)
	}
}
```
To fix this vulnerability, we need to check that the path does not contain any "`..`" elements in it.
```js
package main

import (
	"archive/zip"
	"io/ioutil"
	"elastic/beats"
	"path/filepath"
	"strings"
)

func unzipGood(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// GOOD: Check that path does not contain ".." before using it
		if !strings.Contains(f.Name, "..") {
			ioutil.WriteFile(p, []byte("present"), 0666)
		}
	}
}
```

## References
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability).
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).
[CWE-22](https://cwe.mitre.org/data/definitions/22.html).


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

