### PR TITLE
Fix memqueue race condition during shutdown

### DIFF
--- a/libbeat/publisher/queue/memqueue/runloop_test.go
+++ b/libbeat/publisher/queue/memqueue/runloop_test.go
@@ -19,6 +19,7 @@ package memqueue
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -115,6 +116,38 @@ func TestFlushSettingsBlockPartialBatches(t *testing.T) {
 	rl.runIteration()
 	assert.Nil(t, rl.pendingGetRequest, "Queue should have no pending get request since adding an event should unblock the previous one")
 	assert.Equal(t, 101, rl.consumedCount, "Queue should have a consumedCount of 101 after adding an event unblocked the pending get request")
+}
+
+func TestClosedEmptyQueueDoesNotBlockGet(t *testing.T) {
+	broker := newQueue(
+		logp.NewLogger("testing"),
+		nil,
+		Settings{
+			Events:        1000,
+			MaxGetRequest: 500,
+			FlushTimeout:  10 * time.Second,
+		},
+		10, nil)
+	rl := broker.runLoop
+
+	// Signal close, and execute the run loop to make sure it's processed
+	go broker.Close()
+	rl.runIteration()
+
+	// Calling Get on the queue now should immediately return io.EOF, since
+	// a closed empty queue should cancel its context and terminate its
+	// run loop.
+	resultChan := make(chan error)
+	go func() {
+		_, err := broker.Get(1)
+		resultChan <- err
+	}()
+	select {
+	case err := <-resultChan:
+		assert.Equal(t, err, io.EOF, "Closed empty queue should return io.EOF on Get requests")
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "Get requests to a closed empty queue should not block")
+	}
 }
 
 func TestObserverAddEvent(t *testing.T) {


### PR DESCRIPTION
The memory queue had a bug where if `Close` was called on an already-empty queue, it would mark itself as closing but never cancel the final internal context. The main effect was that `Get` requests to such a queue would still block instead of correctly returning `io.EOF` immediately. This caused some test flakiness, e.g. `TestClient/no_infinite_loop_when_processing_fails` depended on the `io.EOF` return value to end the test, but whether `Close` was called before or after draining the queue depended on goroutine execution order. This PR moves the context cancellation check to the end of the run loop iteration, so it's updated after every state change and not just after event deletions. The accompanying unit test fails without this change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
