### PR TITLE
filebeat: input/v2: NewPipelineClientListener reuses existing metrics

### DIFF
--- a/filebeat/input/v2/input_test.go
+++ b/filebeat/input/v2/input_test.go
@@ -1,0 +1,109 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestNewPipelineClientListener_emptyReg(t *testing.T) {
+	reg := monitoring.NewRegistry()
+
+	listener := NewPipelineClientListener(reg, nil)
+	require.NotNil(t, listener, "Listener should not be nil")
+
+	pcl, ok := listener.(*PipelineClientListener)
+	require.True(t, ok,
+		"listener should be of type %T", &PipelineClientListener{})
+	assert.NotNilf(t, pcl.eventsTotal,
+		"%q metric should be created", metricEventsPipelineTotal)
+	assert.NotNilf(t, pcl.eventsFiltered,
+		"%q metric should be created", metricEventsPipelineFiltered)
+	assert.NotNilf(t, pcl.eventsPublished,
+		"%q metric should be created", metricEventsPipelinePublished)
+}
+
+func TestNewPipelineClientListener_reusedReg(t *testing.T) {
+	reg := monitoring.NewRegistry()
+
+	listener := NewPipelineClientListener(reg, nil)
+	require.NotNil(t, listener, "Listener should not be nil")
+	pcl, ok := listener.(*PipelineClientListener)
+	require.True(t, ok,
+		"listener should be of type %T", &PipelineClientListener{})
+	gotTotal := pcl.eventsTotal
+	gotFiltered := pcl.eventsFiltered
+	gotPublished := pcl.eventsPublished
+
+	assert.NotPanics(t, func() {
+		// Call NewPipelineClientListener again reusing the metrics registry
+		listener = NewPipelineClientListener(reg, nil)
+	}, "Should not panic when reusing a metrics registry")
+	require.NotNil(t, listener, "Listener should not be nil")
+
+	pcl, ok = listener.(*PipelineClientListener)
+	require.True(t, ok,
+		"listener should be of type %T", &PipelineClientListener{})
+
+	assert.Equalf(t, pcl.eventsTotal, gotTotal,
+		"%q metric should have been reused", metricEventsPipelineTotal)
+	assert.Equalf(t, pcl.eventsFiltered, gotFiltered,
+		"%q metric should have been reused", metricEventsPipelineFiltered)
+	assert.Equalf(t, pcl.eventsPublished, gotPublished,
+		"%q metric should have been reused", metricEventsPipelinePublished)
+}
+
+func TestNewPipelineClientListener_ClientListener(t *testing.T) {
+	tcs := []struct {
+		name   string
+		cl     beat.ClientListener
+		assert func(*testing.T, any)
+	}{
+		{
+			name: "nil clientListener",
+			cl:   nil,
+			assert: func(t *testing.T, got any) {
+				assert.IsTypef(t, &PipelineClientListener{}, got,
+					"want %T, got %T", &PipelineClientListener{}, got)
+			},
+		},
+		{
+			name: "existing clientListener",
+			cl:   &PipelineClientListener{},
+			assert: func(t *testing.T, got any) {
+				assert.IsTypef(t, &beat.CombinedClientListener{}, got,
+					"want %T, got %T", &PipelineClientListener{}, got)
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := monitoring.NewRegistry()
+			got := NewPipelineClientListener(reg, tc.cl)
+			assert.NotNil(t, got, "ClientListener should not be nil")
+			tc.assert(t, got)
+		})
+	}
+}


### PR DESCRIPTION
The input/v2.NewPipelineClientListener function now checks if pipeline metrics are already registered in the registry. If found, the existing metrics instance is reused instead of creating a new one.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
filebeat: input/v2: NewPipelineClientListener reuses existing metrics

The input/v2.NewPipelineClientListener function now checks if pipeline
metrics are already registered in the registry. If found, the existing
metrics instance is reused instead of creating a new one.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

 - n/a

## How to test this PR locally

 - TODO

## Related issues

- Closes #43884
- Closes https://github.com/elastic/integrations/issues/13524