### PR TITLE
Add better GOPROXY fallback to docker-based tests

### DIFF
--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -111,7 +111,7 @@ func (d *DockerIntegrationTester) Test(dir string, mageTarget string, env map[st
 		"-e", "GOCACHE=" + dockerGoCache,
 		// Use the host machine's pkg cache to minimize external downloads.
 		"-v", goPkgCache + ":" + dockerGoPkgCache + ":ro",
-		"-e", "GOPROXY=file://" + dockerGoPkgCache + ",direct",
+		"-e", "GOPROXY=file://" + dockerGoPkgCache + ",https://proxy.golang.org/,direct",
 	}
 	args, err = addUidGidEnvArgs(args)
 	if err != nil {


### PR DESCRIPTION
Add the standard golang proxy to the GOPROXY passed to docker-based integration tests. If a module isn't in the cache, it will be fetched from the standard proxy first, and only read directly if that fails.

This is to address errors in this branch like:

`/go/pkg/mod/code.cloudfoundry.org/go-loggregator@v7.4.0+incompatible/rpc/loggregator_v2/syslog.go:9:2: unrecognized import path "code.cloudfoundry.org/rfc5424": parse https://code.cloudfoundry.org/rfc5424?go-get=1: no go-import meta tags ()`

which is caused because `code.cloudfoundry.org` shut down their project hosting site, and their auto-forwarder doesn't include the golang meta tags that go needs to find the real repository. The standard proxy preserves the proper meta tags for relocated projects, avoiding this error.