### PR TITLE
[8.x](backport #43711) Fix filebeat module golden files and update elastic stack version for testing

### DIFF
--- a/filebeat/module/apache/access/test/test-vhost.log-expected.json
+++ b/filebeat/module/apache/access/test/test-vhost.log-expected.json
@@ -28,6 +28,6 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     }
 ]

--- a/filebeat/module/apache/access/test/test.log-expected.json
+++ b/filebeat/module/apache/access/test/test.log-expected.json
@@ -50,7 +50,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     },
     {
         "@timestamp": "2016-12-26T14:16:48.000Z",

--- a/filebeat/module/apache/access/test/ubuntu-2.2.22.log-expected.json
+++ b/filebeat/module/apache/access/test/ubuntu-2.2.22.log-expected.json
@@ -116,7 +116,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     },
     {
         "@timestamp": "2016-12-26T16:22:08.000Z",
@@ -147,7 +147,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     },
     {
         "@timestamp": "2016-12-26T16:22:08.000Z",
@@ -178,7 +178,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     },
     {
         "@timestamp": "2016-12-26T16:22:10.000Z",
@@ -208,7 +208,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     },
     {
         "@timestamp": "2016-12-26T16:22:13.000Z",
@@ -238,7 +238,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     },
     {
         "@timestamp": "2016-12-26T16:22:17.000Z",
@@ -268,6 +268,6 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "50.0."
+        "user_agent.version": "50.0"
     }
 ]

--- a/filebeat/module/iis/access/test/test-x-forward-for-extended.log-expected.json
+++ b/filebeat/module/iis/access/test/test-x-forward-for-extended.log-expected.json
@@ -49,7 +49,7 @@
         "user_agent.os.full": "Windows 10",
         "user_agent.os.name": "Windows",
         "user_agent.os.version": "10",
-        "user_agent.version": "81.0."
+        "user_agent.version": "81.0"
     },
     {
         "@timestamp": "2020-10-05T21:40:30.000Z",

--- a/filebeat/module/iis/access/test/test.log-expected.json
+++ b/filebeat/module/iis/access/test/test.log-expected.json
@@ -48,7 +48,7 @@
         "user_agent.os.full": "Windows 7",
         "user_agent.os.name": "Windows",
         "user_agent.os.version": "7",
-        "user_agent.version": "57.0."
+        "user_agent.version": "57.0"
     },
     {
         "@timestamp": "2018-01-01T09:10:11.000Z",
@@ -88,7 +88,7 @@
         "user_agent.os.full": "Windows 7",
         "user_agent.os.name": "Windows",
         "user_agent.os.version": "7",
-        "user_agent.version": "57.0."
+        "user_agent.version": "57.0"
     },
     {
         "@timestamp": "2018-01-01T10:11:12.000Z",

--- a/filebeat/module/nginx/access/test/access.log-expected.json
+++ b/filebeat/module/nginx/access/test/access.log-expected.json
@@ -481,7 +481,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0."
+        "user_agent.version": "49.0"
     },
     {
         "@timestamp": "2016-12-07T10:04:59.000Z",
@@ -521,7 +521,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0."
+        "user_agent.version": "49.0"
     },
     {
         "@timestamp": "2016-12-07T10:05:07.000Z",
@@ -561,7 +561,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0."
+        "user_agent.version": "49.0"
     },
     {
         "@timestamp": "2020-06-09T19:10:39.000Z",

--- a/filebeat/module/nginx/access/test/test-with-host.log-expected.json
+++ b/filebeat/module/nginx/access/test/test-with-host.log-expected.json
@@ -41,7 +41,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0."
+        "user_agent.version": "49.0"
     },
     {
         "@timestamp": "2017-05-29T19:02:48.000Z",
@@ -135,7 +135,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0."
+        "user_agent.version": "49.0"
     },
     {
         "@timestamp": "2016-12-07T10:05:07.000Z",

--- a/filebeat/module/nginx/access/test/test.log-expected.json
+++ b/filebeat/module/nginx/access/test/test.log-expected.json
@@ -39,7 +39,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0."
+        "user_agent.version": "49.0"
     },
     {
         "@timestamp": "2017-05-29T19:02:48.000Z",
@@ -129,7 +129,7 @@
         "user_agent.os.full": "Mac OS X 10.12",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.12",
-        "user_agent.version": "49.0."
+        "user_agent.version": "49.0"
     },
     {
         "@timestamp": "2016-12-07T10:05:07.000Z",

--- a/filebeat/module/nginx/ingress_controller/test/test.log-expected.json
+++ b/filebeat/module/nginx/ingress_controller/test/test.log-expected.json
@@ -1220,7 +1220,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T12:02:38.000Z",
@@ -1285,7 +1285,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T12:02:42.000Z",
@@ -1349,7 +1349,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T12:02:42.000Z",
@@ -1417,7 +1417,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T12:02:42.000Z",
@@ -1486,7 +1486,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2022-08-24T21:04:17.000Z",
@@ -1826,6 +1826,6 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     }
 ]

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -141,6 +141,10 @@ class Test(BaseTest):
     def test_fileset_file(self, module, fileset, test_file):
         self.init()
 
+        if module == 'threatintel' and fileset == 'misp':
+            self.skipTest(
+                "Skipping test for module='threatintel' and fileset='misp'. It needs https://github.com/elastic/elasticsearch/pull/126417 to get merged and published in the SNAPSHOT")
+
         # generate a minimal configuration
         cfgfile = os.path.join(self.working_dir, "filebeat.yml")
         self.render_config_template(

--- a/libbeat/tests/integration/dashboard_test.go
+++ b/libbeat/tests/integration/dashboard_test.go
@@ -150,7 +150,7 @@ queue.mem:
 		"--dashboards",
 		"-E", "setup.dashboards.file="+filepath.Join("./testdata", "testbeat-dashboards.zip"),
 		"-E", "setup.dashboards.beat=testbeat",
-		"-E", "setup.dashboards.only_index=true",
+		"-E", "setup.dashboards.only_index=false",
 		"-E", "setup.kibana.protocol=http",
 		"-E", "setup.kibana.host="+kURL.Hostname(),
 		"-E", "setup.kibana.port="+kURL.Port(),
@@ -177,7 +177,7 @@ queue.mem:
 	procState, err = mockbeat.Process.Wait()
 	require.NoError(t, err)
 	require.Equal(t, 0, procState.ExitCode(), "incorrect exit code")
-	dbPath := filepath.Join(mockbeat.TempDir(), "system-overview", "_meta", "kibana", "8", "dashboard", "Metricbeat-system-overview.json")
+	dbPath := filepath.Join(mockbeat.TempDir(), "system-overview", "_meta", "kibana", "9", "dashboard", "Metricbeat-system-overview.json")
 	require.FileExists(t, dbPath, "dashboard file not exported")
 	b, err := os.ReadFile(dbPath)
 	require.NoError(t, err)

--- a/testing/environments/docker/logstash/pipeline-xpack/default.conf
+++ b/testing/environments/docker/logstash/pipeline-xpack/default.conf
@@ -1,12 +1,12 @@
 input {
   beats {
     port => 5044
-    ssl => false
+    ssl_enabled => false
   }
 
   beats {
     port => 5055
-    ssl => true
+    ssl_enabled => true
     ssl_certificate => "/etc/pki/tls/certs/logstash.crt"
     ssl_key => "/etc/pki/tls/private/logstash.key"
   }

--- a/testing/environments/docker/logstash/pipeline/default.conf
+++ b/testing/environments/docker/logstash/pipeline/default.conf
@@ -1,12 +1,12 @@
 input {
   beats {
     port => 5044
-    ssl => false
+    ssl_enabled => false
   }
 
   beats {
     port => 5055
-    ssl => true
+    ssl_enabled => true
     ssl_certificate => "/etc/pki/tls/certs/logstash.crt"
     ssl_key => "/etc/pki/tls/private/logstash.key"
   }

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -2,7 +2,7 @@
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.0-07587139-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.0-e0282968-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -30,7 +30,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.16.0-07587139-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:9.1.0-e0282968-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -43,7 +43,7 @@ services:
       - 5055:5055
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.16.0-07587139-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:9.1.0-e0282968-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -2,7 +2,7 @@
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.0-e0282968-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0-1db1483f-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -30,7 +30,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:9.1.0-e0282968-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.19.0-1db1483f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -43,7 +43,7 @@ services:
       - 5055:5055
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:9.1.0-e0282968-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.19.0-1db1483f-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/x-pack/filebeat/module/aws/cloudtrail/test/console-login-json.log-expected.json
+++ b/x-pack/filebeat/module/aws/cloudtrail/test/console-login-json.log-expected.json
@@ -49,7 +49,7 @@
         "user_agent.os.full": "Windows 7",
         "user_agent.os.name": "Windows",
         "user_agent.os.version": "7",
-        "user_agent.version": "24.0."
+        "user_agent.version": "24.0"
     },
     {
         "@timestamp": "2014-07-08T17:35:27.000Z",
@@ -102,7 +102,7 @@
         "user_agent.os.full": "Windows 7",
         "user_agent.os.name": "Windows",
         "user_agent.os.version": "7",
-        "user_agent.version": "24.0."
+        "user_agent.version": "24.0"
     },
     {
         "@timestamp": "2014-07-08T17:35:27.000Z",
@@ -158,6 +158,6 @@
         "user_agent.os.full": "Windows 7",
         "user_agent.os.name": "Windows",
         "user_agent.os.version": "7",
-        "user_agent.version": "24.0."
+        "user_agent.version": "24.0"
     }
 ]

--- a/x-pack/filebeat/module/fortinet/firewall/test/utm.log-expected.json
+++ b/x-pack/filebeat/module/fortinet/firewall/test/utm.log-expected.json
@@ -1762,6 +1762,7 @@
         "log.level": "warning",
         "log.offset": 14716,
         "message": "File was blocked by file filter.",
+        "network.community_id": "1:rvPv+zcw0vwFn1vndUF/kdLu6zs=",
         "network.direction": "inbound",
         "network.iana_number": "16",
         "network.protocol": "cifs",

--- a/x-pack/filebeat/module/gcp/audit/test/audit-log-entries.json.log-expected.json
+++ b/x-pack/filebeat/module/gcp/audit/test/audit-log-entries.json.log-expected.json
@@ -85,7 +85,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "71.0."
+        "user_agent.version": "71.0"
     },
     {
         "@timestamp": "2019-12-19T00:44:25.051Z",
@@ -142,7 +142,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "71.0."
+        "user_agent.version": "71.0"
     },
     {
         "@timestamp": "2019-12-19T00:44:25.051Z",
@@ -194,7 +194,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "71.0."
+        "user_agent.version": "71.0"
     },
     {
         "@timestamp": "2020-08-05T21:07:30.974750Z",
@@ -344,7 +344,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "79.0."
+        "user_agent.version": "79.0"
     },
     {
         "@timestamp": "2021-04-23T14:47:07.535383Z",

--- a/x-pack/filebeat/module/o365/audit/test/04-sharepoint.log-expected.json
+++ b/x-pack/filebeat/module/o365/audit/test/04-sharepoint.log-expected.json
@@ -65,7 +65,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:53.000Z",
@@ -133,7 +133,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:53.000Z",
@@ -201,7 +201,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:53.000Z",
@@ -269,6 +269,6 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     }
 ]

--- a/x-pack/filebeat/module/o365/audit/test/06-sharepointfileop.log-expected.json
+++ b/x-pack/filebeat/module/o365/audit/test/06-sharepointfileop.log-expected.json
@@ -77,7 +77,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:07.000Z",
@@ -157,7 +157,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:08.000Z",
@@ -237,7 +237,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:08.000Z",
@@ -317,7 +317,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:21.000Z",
@@ -398,7 +398,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:23.000Z",
@@ -478,7 +478,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:07.000Z",
@@ -558,7 +558,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:21.000Z",
@@ -639,7 +639,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:23.000Z",
@@ -719,7 +719,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:23.000Z",
@@ -799,7 +799,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:23.000Z",
@@ -879,6 +879,6 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     }
 ]

--- a/x-pack/filebeat/module/o365/audit/test/14-sp-sharing-op.log-expected.json
+++ b/x-pack/filebeat/module/o365/audit/test/14-sp-sharing-op.log-expected.json
@@ -328,7 +328,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "73.0."
+        "user_agent.version": "73.0"
     },
     {
         "@timestamp": "2020-02-14T18:25:45.000Z",
@@ -403,7 +403,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "73.0."
+        "user_agent.version": "73.0"
     },
     {
         "@timestamp": "2020-02-14T18:25:45.000Z",
@@ -479,7 +479,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "73.0."
+        "user_agent.version": "73.0"
     },
     {
         "@timestamp": "2020-02-14T18:25:44.000Z",
@@ -555,7 +555,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "73.0."
+        "user_agent.version": "73.0"
     },
     {
         "@timestamp": "2020-02-14T18:25:44.000Z",
@@ -631,6 +631,6 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "73.0."
+        "user_agent.version": "73.0"
     }
 ]

--- a/x-pack/filebeat/module/o365/audit/test/15-azuread-sts-logon.log-expected.json
+++ b/x-pack/filebeat/module/o365/audit/test/15-azuread-sts-logon.log-expected.json
@@ -94,7 +94,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:53:24.000Z",
@@ -192,7 +192,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:29:01.000Z",
@@ -289,7 +289,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:52:06.000Z",
@@ -387,7 +387,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:53:22.000Z",
@@ -485,7 +485,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:23.000Z",
@@ -582,7 +582,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:41.000Z",
@@ -679,7 +679,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:22.000Z",
@@ -776,7 +776,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:52:05.000Z",
@@ -874,7 +874,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:45.000Z",
@@ -971,7 +971,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:51:49.000Z",
@@ -1069,7 +1069,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:29:02.000Z",
@@ -1166,7 +1166,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:08.000Z",
@@ -1263,7 +1263,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:27.000Z",
@@ -1360,7 +1360,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-08T14:33:54.000Z",
@@ -1455,7 +1455,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:12.000Z",
@@ -1552,7 +1552,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:35.000Z",
@@ -1650,7 +1650,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-08T14:38:40.000Z",
@@ -1745,7 +1745,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:16.000Z",
@@ -1842,7 +1842,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:16.000Z",
@@ -1939,7 +1939,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:25.000Z",
@@ -2037,7 +2037,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:04.000Z",
@@ -2134,7 +2134,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:51:45.000Z",
@@ -2232,7 +2232,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:01.000Z",
@@ -2329,7 +2329,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:51.000Z",
@@ -2426,7 +2426,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:29.000Z",
@@ -2524,7 +2524,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:37.000Z",
@@ -2622,7 +2622,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:51:50.000Z",
@@ -2720,7 +2720,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:42.000Z",
@@ -2817,7 +2817,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:42:59.000Z",
@@ -2913,7 +2913,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:02.000Z",
@@ -3011,7 +3011,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:19.000Z",
@@ -3095,7 +3095,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:40.000Z",
@@ -3192,7 +3192,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:30:58.000Z",
@@ -3275,7 +3275,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:31:33.000Z",
@@ -3373,7 +3373,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:14:25.000Z",
@@ -3456,7 +3456,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:14:51.000Z",
@@ -3554,7 +3554,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:29:56.000Z",
@@ -3651,7 +3651,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-11T16:51:23.000Z",
@@ -3748,7 +3748,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:39:45.000Z",
@@ -3832,7 +3832,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:40:16.000Z",
@@ -3931,7 +3931,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-08T14:33:52.000Z",
@@ -4026,7 +4026,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:53:24.000Z",
@@ -4124,7 +4124,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:22.000Z",
@@ -4221,7 +4221,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-06T09:28:04.000Z",
@@ -4304,7 +4304,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:35.000Z",
@@ -4402,7 +4402,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:36.000Z",
@@ -4499,7 +4499,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:51:49.000Z",
@@ -4597,7 +4597,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:37.000Z",
@@ -4694,7 +4694,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:36.000Z",
@@ -4791,7 +4791,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:37.000Z",
@@ -4889,7 +4889,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-06T09:28:00.000Z",
@@ -4986,7 +4986,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:28:52.000Z",
@@ -5083,7 +5083,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:37.000Z",
@@ -5180,7 +5180,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:28:52.000Z",
@@ -5277,7 +5277,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:01.000Z",
@@ -5374,7 +5374,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:53:12.000Z",
@@ -5472,7 +5472,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T10:52:06.000Z",
@@ -5570,7 +5570,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-08T14:33:50.000Z",
@@ -5665,7 +5665,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-10T15:13:38.000Z",
@@ -5762,7 +5762,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:05.000Z",
@@ -5859,7 +5859,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:28:51.000Z",
@@ -5956,7 +5956,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:25:21.000Z",
@@ -6053,7 +6053,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-12T21:38:20.000Z",
@@ -6151,7 +6151,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:02.000Z",
@@ -6248,7 +6248,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:44:03.000Z",
@@ -6345,7 +6345,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:29:02.000Z",
@@ -6442,7 +6442,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-09T15:25:21.000Z",
@@ -6539,7 +6539,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-07T16:43:39.000Z",
@@ -6636,6 +6636,6 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     }
 ]

--- a/x-pack/filebeat/module/o365/audit/test/25-ms-teams-groups.log-expected.json
+++ b/x-pack/filebeat/module/o365/audit/test/25-ms-teams-groups.log-expected.json
@@ -2649,7 +2649,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "85.0."
+        "user_agent.version": "85.0"
     },
     {
         "@timestamp": "2021-02-05T09:06:08.000Z",
@@ -2743,7 +2743,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "85.0."
+        "user_agent.version": "85.0"
     },
     {
         "@timestamp": "2021-02-05T09:06:34.000Z",
@@ -2837,7 +2837,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "85.0."
+        "user_agent.version": "85.0"
     },
     {
         "@timestamp": "2021-02-05T09:06:07.000Z",
@@ -2931,7 +2931,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "85.0."
+        "user_agent.version": "85.0"
     },
     {
         "@timestamp": "2021-02-04T16:33:17.000Z",
@@ -3223,7 +3223,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "85.0."
+        "user_agent.version": "85.0"
     },
     {
         "@timestamp": "2021-02-05T09:05:59.000Z",
@@ -3319,7 +3319,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "85.0."
+        "user_agent.version": "85.0"
     },
     {
         "@timestamp": "2021-02-05T09:06:07.000Z",
@@ -3413,6 +3413,6 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "85.0."
+        "user_agent.version": "85.0"
     }
 ]

--- a/x-pack/filebeat/module/okta/system/test/okta-system-test.json.log-expected.json
+++ b/x-pack/filebeat/module/okta/system/test/okta-system-test.json.log-expected.json
@@ -99,7 +99,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-14T20:18:57.718Z",
@@ -201,7 +201,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-14T20:18:57.762Z",
@@ -316,7 +316,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-14T20:18:57.762Z",
@@ -453,7 +453,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2020-02-14T20:18:57.762Z",
@@ -582,7 +582,7 @@
         "user_agent.os.full": "Mac OS X 10.15",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.15",
-        "user_agent.version": "72.0."
+        "user_agent.version": "72.0"
     },
     {
         "@timestamp": "2022-05-11T09:25:18.716Z",
@@ -1179,6 +1179,6 @@
         "user_agent.name": "Firefox",
         "user_agent.original": "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/109.0",
         "user_agent.os.name": "Linux",
-        "user_agent.version": "109.0."
+        "user_agent.version": "109.0"
     }
 ]

--- a/x-pack/filebeat/module/sophos/xg/test/firewall.log-expected.json
+++ b/x-pack/filebeat/module/sophos/xg/test/firewall.log-expected.json
@@ -1046,6 +1046,7 @@
         "log.level": "informational",
         "log.offset": 11047,
         "network.bytes": 0,
+        "network.community_id": "1:LFE/FJ5zfsQGP8HTeu6b6rxLS78=",
         "network.packets": 0,
         "network.transport": "0",
         "observer.product": "XG",

--- a/x-pack/filebeat/module/suricata/eve/test/eve-small.log-expected.json
+++ b/x-pack/filebeat/module/suricata/eve/test/eve-small.log-expected.json
@@ -717,7 +717,7 @@
         "user_agent.os.full": "Mac OS X 10.14",
         "user_agent.os.name": "Mac OS X",
         "user_agent.os.version": "10.14",
-        "user_agent.version": "84.0."
+        "user_agent.version": "84.0"
     },
     {
         "@timestamp": "2020-12-09T16:03:50.083307Z",


### PR DESCRIPTION
## New, semi-manual backport of #43711


## Proposed commit message

```
fix filebeat module golden files and update test stack


Elasticsearch introduced a fix on 8.16.2 to its ingest pipeline user_agent processor preventing it to add a `.` at the end of the user agent version.
This change adjusts the golden files relying on the output of this processor

It also updates the elastic stack version for testing
```

## Checklist



- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-~~developer.next.asciidoc`.

## Disruptive User Impact

- N/A

## How to test this PR locally

### run the python integration tests for filebeat modules:

 - start the stack
```sh
cd filebeat
mage docker:composeUp
```

 - ensure the right stack is being used. Check the ES version is `9.1.0-de2e77fc-SNAPSHOT`
```
docker ps

> e69b9df423bf   docker.elastic.co/elasticsearch/elasticsearch:9.1.0-de2e77fc-SNAPSHOT   "/bin/tini -- /usr/l…"   2 hours ago   Up 2 hours (unhealthy)   0.0.0.0:9200->9200/tcp, [::]:9200->9200/tcp, 9300/tcp                                                          filebeat_9_0_0_3be7328fa1-snapshot_elasticsearch_1
```

 - run the test
```
source $(mage pythonVirtualEnv)/bin/activate
BEAT_STRICT_PERMS=false ES_PASS="testing" INTEGRATION_TESTS=1 pytest ./tests/system/test_modules.py
```
 - stop the stack
```sh
mage docker:composeDown
```

## Related issues

- Relates https://github.com/elastic/elasticsearch/issues/116950

<hr>This is an automatic backport of pull request #43711 done by [Mergify](https://mergify.com).