### PR TITLE
Add fipsonly test step for metricbeat

### DIFF
--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -136,7 +136,7 @@ steps:
         key: "mandatory-linux-unit-test-fips-only"
         command: |
           cd metricbeat
-          mage goFIPSOnlyUnitTest
+          mage fipsOnlyUnitTest
         retry:
           automatic:
             - limit: 1

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -132,6 +132,33 @@ steps:
           - github_commit_status:
               context: "metricbeat: Ubuntu x86_64 Unit Tests FIPS"
 
+      - label: ":ubuntu: Metricbeat: Ubuntu x86_64 fips140=only Unit Tests"
+        key: "mandatory-linux-unit-test-fips-only"
+        command: |
+          cd metricbeat
+          mage goFIPSOnlyUnitTest
+        retry:
+          automatic:
+            - limit: 1
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+        env:
+          FIPS: "true"
+        artifact_paths:
+          - "metricbeat/build/*.xml"
+          - "metricbeat/build/*.json"
+        plugins:
+          - test-collector#v1.10.2:
+              files: "metricbeat/build/TEST-*.xml"
+              format: "junit"
+              branches: "main"
+              debug: true
+        notify:
+          - github_commit_status:
+              context: "metricbeat: Ubuntu x86_64 fips140=only Unit Tests"
+
       - label: ":ubuntu: Metricbeat: Go Integration Tests (Module)"
         key: "mandatory-int-test"
         command: |

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -24,11 +24,13 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/gotool"
 	metricbeat "github.com/elastic/beats/v7/metricbeat/scripts/mage"
 
 	// register kubernetes runner
@@ -254,4 +256,27 @@ func PythonIntegTest(ctx context.Context) error {
 		args.ForceCreateVenv = true
 		return devtools.PythonTestForModule(args)
 	})
+}
+
+// FIPSOnlyUnitTest sets GODEBUG=fips140=only when running unit tests
+// Will also filter out packages that fail to run with the GODEBUG=fips140=only var set
+func FIPSOnlyUnitTest() error {
+	ctx := context.Background()
+
+	fipsArgs := devtools.DefaultGoFIPSOnlyTestArgs()
+	packages, err := gotool.ListProjectPackages()
+	if err != nil {
+		return err
+	}
+	filteredPackages := make([]string, 0, len(packages))
+	for _, pkg := range packages {
+		// Filter out tests from metricbeat/module/vsphere as the github.com/vmware/govmomi simulator uses SHA-1.
+		// This causes tests to panic on load before TestMain is ran.
+		if !strings.Contains(pkg, "github.com/elastic/beats/v7/metricbeat/module/vsphere") {
+			filteredPackages = append(filteredPackages, pkg)
+		}
+	}
+	fipsArgs.Packages = filteredPackages
+
+	return devtools.GoTest(ctx, fipsArgs)
 }


### PR DESCRIPTION
## Proposed commit message

Add buildkite step to run unit tests with GODEBUG=fip140=only and FIPS=true in order to use go 1.24's FIPS mechanisms to detect non-compliant code paths for metricbeat.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

N/A