### PR TITLE
Rename FIPS-compliant to FIPS-capable

### DIFF
--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -90,7 +90,7 @@ func Package() error {
 
 				// Filter out non fips-enabled beats
 				if FIPSBuild && !slices.Contains(FIPSConfig.Beats, BeatName) {
-					log.Printf("Skipping creation for beat %v package type %v because beat is not listed as FIPS compliant %v", BeatName, pkgType, FIPSConfig.Beats)
+					log.Printf("Skipping creation for beat %v package type %v because beat is not listed as FIPS-capable %v", BeatName, pkgType, FIPSConfig.Beats)
 					continue
 				}
 

--- a/x-pack/agentbeat/magefile.go
+++ b/x-pack/agentbeat/magefile.go
@@ -258,15 +258,15 @@ func getIncludedBeats() []string {
 	}
 
 	if devtools.FIPSBuild {
-		// If a FIPS-compliant version of agentbeat is being built, restrict the list of beats to the fips-compliant ones.
-		// This helps producing a FIPS-compliant agentbeat by excluding code from beats that are not required to be FIPS compliant.
-		fipsCompliantBeats := make([]string, 0, len(includedBeats))
+		// If a FIPS-capable version of agentbeat is being built, restrict the list of beats to the fips-capable ones.
+		// This helps producing a FIPS-capable agentbeat by excluding code from beats that are not required to be FIPS-capable.
+		fipsCapableBeats := make([]string, 0, len(includedBeats))
 		for _, beat := range includedBeats {
 			if slices.Contains(devtools.FIPSConfig.Beats, beat) {
-				fipsCompliantBeats = append(fipsCompliantBeats, beat)
+				fipsCapableBeats = append(fipsCapableBeats, beat)
 			}
 		}
-		return fipsCompliantBeats
+		return fipsCapableBeats
 	}
 
 	return includedBeats


### PR DESCRIPTION
This PR renames any occurrences in Beats code, comments, etc. matching `/fips.*compliant/i` to "FIPS-capable".  This is done to avoid giving the inaccurate impression that Beats are FIPS-compliant.