### PR TITLE
Revert "[9.0](backport #43428) x-pack/metricbeat/module/aws: Use FIPS endpoint when metricbeat is running in FIPS 140-3 mode"

### DIFF
--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -6,7 +6,6 @@ package aws
 
 import (
 	"context"
-	"crypto/fips140"
 	"fmt"
 	"strconv"
 	"time"
@@ -125,14 +124,6 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	err := base.Module().UnpackConfig(&config)
 	if err != nil {
 		return nil, err
-	}
-
-	// Starting from Go 1.24, when FIPS 140-3 mode is active, fips140.Enabled() will return true.
-	// So, regardless of whether `fips_enabled` is set to true or false, when FIPS 140-3 mode is active, the
-	// resolver will resolve to the FIPS endpoint.
-	// See: https://go.dev/doc/security/fips140#fips-140-3-mode
-	if fips140.Enabled() {
-		config.AWSConfig.FIPSEnabled = true
 	}
 
 	awsConfig, err := awscommon.InitializeAWSConfig(config.AWSConfig)

--- a/x-pack/metricbeat/module/aws/awshealth/awshealth.go
+++ b/x-pack/metricbeat/module/aws/awshealth/awshealth.go
@@ -6,7 +6,6 @@ package awshealth
 
 import (
 	"context"
-	"crypto/fips140"
 	"fmt"
 	"time"
 
@@ -116,14 +115,6 @@ func (m *MetricSet) Fetch(ctx context.Context, report mb.ReporterV2) error {
 	var config aws.Config
 	if err := m.Module().UnpackConfig(&config); err != nil {
 		return err
-	}
-
-	// Starting from Go 1.24, when FIPS 140-3 mode is active, fips140.Enabled() will return true.
-	// So, regardless of whether `fips_enabled` is set to true or false, when FIPS 140-3 mode is active, the
-	// resolver will resolve to the FIPS endpoint.
-	// See: https://go.dev/doc/security/fips140#fips-140-3-mode
-	if fips140.Enabled() {
-		config.AWSConfig.FIPSEnabled = true
 	}
 
 	awsConfig := m.MetricSet.AwsConfig.Copy()

--- a/x-pack/metricbeat/module/aws/billing/billing.go
+++ b/x-pack/metricbeat/module/aws/billing/billing.go
@@ -6,7 +6,6 @@ package billing
 
 import (
 	"context"
-	"crypto/fips140"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -119,15 +118,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	if err != nil {
 		return err
 	}
-
-	// Starting from Go 1.24, when FIPS 140-3 mode is active, fips140.Enabled() will return true.
-	// So, regardless of whether `fips_enabled` is set to true or false, when FIPS 140-3 mode is active, the
-	// resolver will resolve to the FIPS endpoint.
-	// See: https://go.dev/doc/security/fips140#fips-140-3-mode
-	if fips140.Enabled() {
-		config.AWSConfig.FIPSEnabled = true
-	}
-
 	// Get startDate and endDate
 	startDate, endDate := getStartDateEndDate(m.Period)
 
@@ -237,15 +227,6 @@ func (m *MetricSet) getCostGroupBy(svcCostExplorer *costexplorer.Client, groupBy
 	if err != nil {
 		return nil
 	}
-
-	// Starting from Go 1.24, when FIPS 140-3 mode is active, fips140.Enabled() will return true.
-	// So, regardless of whether `fips_enabled` is set to true or false, when FIPS 140-3 mode is active, the
-	// resolver will resolve to the FIPS endpoint.
-	// See: https://go.dev/doc/security/fips140#fips-140-3-mode
-	if fips140.Enabled() {
-		config.AWSConfig.FIPSEnabled = true
-	}
-
 	if ok, _ := aws.StringInSlice("LINKED_ACCOUNT", groupByDimKeys); ok {
 		awsConfig := m.MetricSet.AwsConfig.Copy()
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -5,7 +5,6 @@
 package cloudwatch
 
 import (
-	"crypto/fips140"
 	"fmt"
 	"maps"
 	"reflect"
@@ -156,14 +155,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	err = m.Module().UnpackConfig(&config)
 	if err != nil {
 		return err
-	}
-
-	// Starting from Go 1.24, when FIPS 140-3 mode is active, fips140.Enabled() will return true.
-	// So, regardless of whether `fips_enabled` is set to true or false, when FIPS 140-3 mode is active, the
-	// resolver will resolve to the FIPS endpoint.
-	// See: https://go.dev/doc/security/fips140#fips-140-3-mode
-	if fips140.Enabled() {
-		config.AWSConfig.FIPSEnabled = true
 	}
 
 	// Create events based on listMetricDetailTotal from configuration


### PR DESCRIPTION
Reverts elastic/beats#43777