### PR TITLE
[Chore] Use logptest.NewTestingLogger

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12317,11 +12317,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/elastic-agent-libs
-Version: v0.19.1
+Version: v0.19.2
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.19.1/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.19.2/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/elastic/elastic-agent-autodiscover/bus"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -1109,7 +1109,7 @@ func TestGenerateHints(t *testing.T) {
 			Home: abs,
 		}))
 
-		logger := logp.NewTestingLogger(t, "")
+		logger := logptest.NewTestingLogger(t, "")
 		l, err := NewLogHints(test.config, logger)
 		if err != nil {
 			t.Fatal(err)
@@ -1344,7 +1344,7 @@ func TestGenerateHintsWithPaths(t *testing.T) {
 		require.NoError(t, paths.InitPaths(&paths.Path{
 			Home: abs,
 		}))
-		logger := logp.NewTestingLogger(t, "")
+		logger := logptest.NewTestingLogger(t, "")
 		l, err := NewLogHints(cfg, logger)
 		if err != nil {
 			t.Fatal(err)

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
 
@@ -82,7 +82,7 @@ func TestNewModuleRegistry(t *testing.T) {
 		},
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{})
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
@@ -150,7 +150,7 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 		},
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{})
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
@@ -177,7 +177,7 @@ func TestMovedModule(t *testing.T) {
 		},
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{})
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
@@ -449,7 +449,7 @@ func TestMissingModuleFolder(t *testing.T) {
 		load(t, map[string]interface{}{"module": "nginx"}),
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	reg, err := NewModuleRegistry(configs, beat.Info{Version: "5.2.0", Logger: logger}, true, FilesetOverrides{})
 	require.NoError(t, err)
 	assert.NotNil(t, reg)

--- a/filebeat/input/inputtest/input.go
+++ b/filebeat/input/inputtest/input.go
@@ -28,7 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -60,7 +60,7 @@ func AssertNotStartedInputCanBeDone(t *testing.T, factory input.Factory, configM
 		Done: make(chan struct{}),
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	_, err = factory(config, Connector, context, logger)
 	assert.NoError(t, err)
 

--- a/filebeat/input/log/input_test.go
+++ b/filebeat/input/log/input_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -215,7 +215,7 @@ func testInputLifecycle(t *testing.T, context input.Context, closer func(input.C
 		return channel.SubOutlet(capturer), nil
 	})
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := NewInput(config, connector, context, logger)
 	if err != nil {
 		t.Error(err)
@@ -265,7 +265,7 @@ func TestNewInputError(t *testing.T) {
 
 	context := input.Context{}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	_, err := NewInput(config, connector, context, logger)
 	assert.Error(t, err)
 }

--- a/filebeat/input/mqtt/input_test.go
+++ b/filebeat/input/mqtt/input_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common/backoff"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -42,7 +42,7 @@ func TestNewInput_MissingConfigField(t *testing.T) {
 	connector := new(mockedConnector)
 	var inputContext finput.Context
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := NewInput(config, connector, inputContext, logger)
 
 	require.Error(t, err)
@@ -60,7 +60,7 @@ func TestNewInput_ConnectWithFailed(t *testing.T) {
 	}
 	var inputContext finput.Context
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := NewInput(config, connector, inputContext, logger)
 
 	require.Equal(t, connectWithError, err)
@@ -117,7 +117,7 @@ func TestNewInput_Run(t *testing.T) {
 		return client
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := newInput(config, connector, inputContext, newMqttClient, backoff.NewEqualJitterBackoff, logger)
 	require.NoError(t, err)
 	require.NotNil(t, input)
@@ -191,7 +191,7 @@ func TestNewInput_Run_Wait(t *testing.T) {
 		return client
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := newInput(config, connector, inputContext, newMqttClient, backoff.NewEqualJitterBackoff, logger)
 	require.NoError(t, err)
 	require.NotNil(t, input)
@@ -210,7 +210,7 @@ func TestNewInput_Run_Wait(t *testing.T) {
 
 func TestRun_Once(t *testing.T) {
 	client := new(mockedClient)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input := &mqttInput{
 		client: client,
 		logger: logger,
@@ -223,7 +223,7 @@ func TestRun_Once(t *testing.T) {
 
 func TestRun_Twice(t *testing.T) {
 	client := new(mockedClient)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input := &mqttInput{
 		client: client,
 		logger: logger,
@@ -239,7 +239,7 @@ func TestWait(t *testing.T) {
 	clientDisconnected := new(sync.WaitGroup)
 	inflightMessages := new(sync.WaitGroup)
 	client := new(mockedClient)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input := &mqttInput{
 		client:             client,
 		clientDisconnected: clientDisconnected,
@@ -255,7 +255,7 @@ func TestWait(t *testing.T) {
 func TestStop(t *testing.T) {
 	client := new(mockedClient)
 	clientDisconnected := new(sync.WaitGroup)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input := &mqttInput{
 		client:             client,
 		clientDisconnected: clientDisconnected,
@@ -272,7 +272,7 @@ func TestOnCreateHandler_SubscribeMultiple_Succeeded(t *testing.T) {
 	newBackoff := func(done <-chan struct{}, init, max time.Duration) backoff.Backoff {
 		return backoff.NewEqualJitterBackoff(inputContext.Done, time.Nanosecond, 2*time.Nanosecond)
 	}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	handler := createOnConnectHandler(logger, inputContext, onMessageHandler, clientSubscriptions, newBackoff)
 
 	client := &mockedClient{
@@ -292,7 +292,7 @@ func TestOnCreateHandler_SubscribeMultiple_BackoffSucceeded(t *testing.T) {
 	newBackoff := func(done <-chan struct{}, init, max time.Duration) backoff.Backoff {
 		return backoff.NewEqualJitterBackoff(inputContext.Done, time.Nanosecond, 2*time.Nanosecond)
 	}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	handler := createOnConnectHandler(logger, inputContext, onMessageHandler, clientSubscriptions, newBackoff)
 
 	client := &mockedClient{
@@ -317,7 +317,7 @@ func TestOnCreateHandler_SubscribeMultiple_BackoffSignalDone(t *testing.T) {
 	newBackoff := func(done <-chan struct{}, init, max time.Duration) backoff.Backoff {
 		return mockedBackoff
 	}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	handler := createOnConnectHandler(logger, inputContext, onMessageHandler, clientSubscriptions, newBackoff)
 
 	client := &mockedClient{

--- a/filebeat/input/mqtt/mqtt_integration_test.go
+++ b/filebeat/input/mqtt/mqtt_integration_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -106,7 +106,7 @@ func TestInput(t *testing.T) {
 		BeatDone: make(chan struct{}),
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Setup the input
 	input, err := NewInput(config, connector, inputContext, logger)
 	require.NoError(t, err)

--- a/filebeat/input/redis/redis_integration_test.go
+++ b/filebeat/input/redis/redis_integration_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
@@ -114,7 +114,7 @@ func TestInput(t *testing.T) {
 		BeatDone: make(chan struct{}),
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Setup the input
 	input, err := NewInput(config, connector, inputContext, logger)
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.6.0
 	github.com/elastic/elastic-agent-autodiscover v0.9.0
-	github.com/elastic/elastic-agent-libs v0.19.1
+	github.com/elastic/elastic-agent-libs v0.19.2
 	github.com/elastic/elastic-agent-system-metrics v0.11.11
 	github.com/elastic/go-elasticsearch/v8 v8.17.1
 	github.com/elastic/go-quark v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -62,10 +62,10 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
-github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics v1.1.0 h1:X/C/tY3dxwsuFnSNArmTWKr0O6P59SRY6VsUcIkefEw=
-github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics v1.1.0/go.mod h1:wCAGp7Xm35A5laB8z8yK9p/kU8OEBFuTvUm4eKCzr/M=
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs v1.3.0 h1:skbmKp8umb8jMxl4A4CwvYyfCblujU00XUB/ytUjEac=
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs v1.3.0/go.mod h1:nynTZqX7jGM6FQy6Y+7uFT7Y+LhaAeO3q3d48VZzH5E=
+github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics v1.1.0 h1:X/C/tY3dxwsuFnSNArmTWKr0O6P59SRY6VsUcIkefEw=
+github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics v1.1.0/go.mod h1:wCAGp7Xm35A5laB8z8yK9p/kU8OEBFuTvUm4eKCzr/M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0 h1:0nGmzwBv5ougvzfGPCO2ljFRHvun57KpNrVCMrlk0ns=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0/go.mod h1:gYq8wyDgv6JLhGbAU6gg8amCPgQWRE+aCvrV2gyzdfs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement v1.1.1 h1:ehSLdbLah6kk6HTVc6e/lrbmbz7MMbpNxkOd3OYlhB0=
@@ -350,8 +350,8 @@ github.com/elastic/elastic-agent-autodiscover v0.9.0 h1:+iWIKh0u3e8I+CJa3FfWe9h0
 github.com/elastic/elastic-agent-autodiscover v0.9.0/go.mod h1:5iUxLHhVdaGSWYTveSwfJEY4RqPXTG13LPiFoxcpFd4=
 github.com/elastic/elastic-agent-client/v7 v7.15.0 h1:nDB7v8TBoNuD6IIzC3z7Q0y+7bMgXoT2DsHfolO2CHE=
 github.com/elastic/elastic-agent-client/v7 v7.15.0/go.mod h1:6h+f9QdIr3GO2ODC0Y8+aEXRwzbA5W4eV4dd/67z7nI=
-github.com/elastic/elastic-agent-libs v0.19.1 h1:6jiH0SPB5RzoF3W8Ipk+mI/Xl6zXqVPZkKADuzeChw0=
-github.com/elastic/elastic-agent-libs v0.19.1/go.mod h1:1HNxREH8C27kGrJCtKZh/ot8pV8joH8VREP21+FrH5s=
+github.com/elastic/elastic-agent-libs v0.19.2 h1:uOLUF/KQQf9t6iKr5mfp3jO7CxVZToCJKbb2iSWMswU=
+github.com/elastic/elastic-agent-libs v0.19.2/go.mod h1:1HNxREH8C27kGrJCtKZh/ot8pV8joH8VREP21+FrH5s=
 github.com/elastic/elastic-agent-system-metrics v0.11.11 h1:Qjh3Zef23PfGlG91AF+9ciNLNQf/8cDJ4CalnLZtV3g=
 github.com/elastic/elastic-agent-system-metrics v0.11.11/go.mod h1:GNqmKfvOt8PwORjbS6GllNdMfkLpOWyTa7P8oQq4E5o=
 github.com/elastic/elastic-transport-go/v8 v8.6.1 h1:h2jQRqH6eLGiBSN4eZbQnJLtL4bC5b4lfVFRjw2R4e4=

--- a/libbeat/api/server_test.go
+++ b/libbeat/api/server_test.go
@@ -31,11 +31,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestConfiguration(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	if runtime.GOOS != "windows" {
 		t.Skip("Check for User and Security Descriptor")
 		return
@@ -62,7 +62,7 @@ func TestConfiguration(t *testing.T) {
 }
 
 func TestSocket(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix Sockets don't work under windows")
@@ -170,7 +170,7 @@ func TestHTTP(t *testing.T) {
 	cfg := config.MustNewConfigFrom(map[string]interface{}{
 		"host": url,
 	})
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	s, err := New(logger, cfg)
 	require.NoError(t, err)
 	attachEchoHelloHandler(t, s)
@@ -202,7 +202,7 @@ func TestAttachHandler(t *testing.T) {
 		"host": "http://localhost:0",
 	})
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	s, err := New(logger, cfg)
 	require.NoError(t, err)
 

--- a/libbeat/api/server_test.go
+++ b/libbeat/api/server_test.go
@@ -105,7 +105,7 @@ func TestSocket(t *testing.T) {
 
 		c := client(sockFile)
 
-		r, err := c.Get("http://unix/echo-hello")
+		r, err := c.Get("http://unix/echo-hello") //nolint:noctx //Safe to not use ctx in test
 		require.NoError(t, err)
 		defer r.Body.Close()
 
@@ -148,7 +148,7 @@ func TestSocket(t *testing.T) {
 
 		c := client(sockFile)
 
-		r, err := c.Get("http://unix/echo-hello")
+		r, err := c.Get("http://unix/echo-hello") //nolint:noctx //Safe to not use ctx in test
 		require.NoError(t, err)
 		defer r.Body.Close()
 
@@ -179,7 +179,7 @@ func TestHTTP(t *testing.T) {
 		require.NoError(t, s.Stop())
 	}()
 
-	r, err := http.Get("http://" + s.l.Addr().String() + "/echo-hello")
+	r, err := http.Get("http://" + s.l.Addr().String() + "/echo-hello") //nolint:noctx //Safe to not use ctx in test
 	require.NoError(t, err)
 	defer r.Body.Close()
 

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -44,6 +44,7 @@ import (
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/keystore"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -212,7 +213,7 @@ func TestAutodiscover(t *testing.T) {
 	}
 	k, _ := keystore.NewFileKeystore("test")
 	// Create autodiscover manager
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k, logger)
 	if err != nil {
 		t.Fatal(err)
@@ -366,7 +367,7 @@ func TestAutodiscoverHash(t *testing.T) {
 		Providers: []*conf.C{providerConfig},
 	}
 	k, _ := keystore.NewFileKeystore("test")
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Create autodiscover manager
 	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k, logger)
 	if err != nil {
@@ -431,7 +432,7 @@ func TestAutodiscoverDuplicatedConfigConfigCheckCalledOnce(t *testing.T) {
 		Providers: []*conf.C{providerConfig},
 	}
 	k, _ := keystore.NewFileKeystore("test")
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Create autodiscover manager
 	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k, logger)
 	if err != nil {
@@ -500,7 +501,7 @@ func TestAutodiscoverWithConfigCheckFailures(t *testing.T) {
 		Providers: []*conf.C{providerConfig},
 	}
 	k, _ := keystore.NewFileKeystore("test")
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Create autodiscover manager
 	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k, logger)
 	if err != nil {
@@ -560,7 +561,7 @@ func TestAutodiscoverWithMutlipleEntries(t *testing.T) {
 		Providers: []*conf.C{providerConfig},
 	}
 	k, _ := keystore.NewFileKeystore("test")
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Create autodiscover manager
 	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k, logger)
 	if err != nil {
@@ -677,7 +678,7 @@ func TestAutodiscoverDebounce(t *testing.T) {
 	k, _ := keystore.NewFileKeystore("test")
 
 	adapter := mockAdapter{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Create autodiscover manager
 	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k, logger)
 	if err != nil {
@@ -863,7 +864,7 @@ func TestErrNonReloadableIsNotRetried(t *testing.T) {
 		Providers: []*conf.C{providerConfig},
 	}
 	k, _ := keystore.NewFileKeystore(filepath.Join(t.TempDir(), "keystore"))
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Create autodiscover manager
 	autodiscover, err := NewAutodiscover("test", nil, &adapter, &adapter, &config, k, logger)
 	if err != nil {

--- a/libbeat/cfgfile/glob_manager_test.go
+++ b/libbeat/cfgfile/glob_manager_test.go
@@ -22,8 +22,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestGlobManagerInit(t *testing.T) {

--- a/libbeat/cfgfile/glob_manager_test.go
+++ b/libbeat/cfgfile/glob_manager_test.go
@@ -22,14 +22,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestGlobManagerInit(t *testing.T) {
 	// Wrong settings return error
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	manager, err := NewGlobManager("dir/*.yml", ".noyml", ".disabled", logger)
 	assert.Error(t, err)
 	assert.Nil(t, manager)
@@ -52,7 +51,7 @@ func TestGlobManager(t *testing.T) {
 
 	// Init Glob Manager
 	glob := dir + "/*.yml"
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	manager, err := NewGlobManager(glob, ".yml", ".disabled", logger)
 	if err != nil {
 		t.Fatal(err)

--- a/libbeat/cfgfile/glob_watcher_test.go
+++ b/libbeat/cfgfile/glob_watcher_test.go
@@ -22,9 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestGlobWatcher(t *testing.T) {
@@ -32,7 +31,7 @@ func TestGlobWatcher(t *testing.T) {
 	dir := t.TempDir()
 	glob := dir + "/*.yml"
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	gcd := NewGlobWatcher(glob, logger)
 
 	content := []byte("test\n")

--- a/libbeat/cfgfile/glob_watcher_test.go
+++ b/libbeat/cfgfile/glob_watcher_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestGlobWatcher(t *testing.T) {

--- a/libbeat/cfgfile/list_test.go
+++ b/libbeat/cfgfile/list_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/reload"
 	pubtest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -116,7 +116,7 @@ func (r *testDiagHandler) Register(_ string, _ string, _ string, _ string, callb
 
 func TestDiagnostics(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	list := NewRunnerList("", factory, nil, logger)
 	cfg := createConfig(1)
 	callback := &testDiagHandler{}
@@ -131,7 +131,7 @@ func TestDiagnostics(t *testing.T) {
 
 func TestNewConfigs(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	list := NewRunnerList("", factory, nil, logger)
 
 	err := list.Reload([]*reload.ConfigWithMeta{
@@ -146,7 +146,7 @@ func TestNewConfigs(t *testing.T) {
 
 func TestReloadSameConfigs(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	list := NewRunnerList("", factory, nil, logger)
 
@@ -173,7 +173,7 @@ func TestReloadSameConfigs(t *testing.T) {
 
 func TestReloadDuplicateConfig(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	list := NewRunnerList("", factory, nil, logger)
 
 	err := list.Reload([]*reload.ConfigWithMeta{
@@ -198,7 +198,7 @@ func TestReloadDuplicateConfig(t *testing.T) {
 
 func TestReloadStopConfigs(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	list := NewRunnerList("", factory, nil, logger)
 
 	err := list.Reload([]*reload.ConfigWithMeta{
@@ -221,7 +221,7 @@ func TestReloadStopConfigs(t *testing.T) {
 
 func TestReloadStartStopConfigs(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	list := NewRunnerList("", factory, nil, logger)
 
@@ -248,7 +248,7 @@ func TestReloadStartStopConfigs(t *testing.T) {
 
 func TestStopAll(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	list := NewRunnerList("", factory, nil, logger)
 
@@ -270,7 +270,7 @@ func TestStopAll(t *testing.T) {
 
 func TestHas(t *testing.T) {
 	factory := &runnerFactory{}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	list := NewRunnerList("", factory, nil, logger)
 	config := createConfig(1)

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/go-ucfg/yaml"
 
 	"github.com/gofrs/uuid/v5"
@@ -124,7 +125,7 @@ func TestInitKibanaConfig(t *testing.T) {
 
 func TestEmptyMetaJson(t *testing.T) {
 	b, err := NewBeat("filebeat", "testidx", "0.9", false, nil)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	b.Info.Logger = logger
 	if err != nil {
 		panic(err)
@@ -147,7 +148,7 @@ func TestEmptyMetaJson(t *testing.T) {
 
 func TestMetaJsonWithTimestamp(t *testing.T) {
 	firstBeat, err := NewBeat("filebeat", "testidx", "0.9", false, nil)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	firstBeat.Info.Logger = logger
 	if err != nil {
 		panic(err)
@@ -337,7 +338,7 @@ output:
 			err = cfg.Unpack(&config)
 			require.NoError(t, err)
 
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 
 			b := &Beat{Config: config, Beat: beat.Beat{
 				Info: beat.Info{

--- a/libbeat/cmd/instance/locks/lock_test.go
+++ b/libbeat/cmd/instance/locks/lock_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
 
@@ -58,7 +58,7 @@ func TestLocker(t *testing.T) {
 	// Setup two beats with same name and data path
 	const beatName = "testbeat-testlocker"
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	b1 := beat.Info{Logger: logger}
 	b1.Beat = beatName
@@ -81,7 +81,7 @@ func TestLocker(t *testing.T) {
 
 func TestUnlock(t *testing.T) {
 	const beatName = "testbeat-testunlock"
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	b1 := beat.Info{Logger: logger}
 	b1.Beat = beatName
@@ -107,7 +107,7 @@ func TestUnlock(t *testing.T) {
 
 func TestUnlockWithRemainingFile(t *testing.T) {
 	const beatName = "testbeat-testunlockwithfile"
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	b1 := beat.Info{Logger: logger}
 	b1.Beat = beatName

--- a/libbeat/idxmgmt/std_test.go
+++ b/libbeat/idxmgmt/std_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/mapping"
 	"github.com/elastic/beats/v7/libbeat/template"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -80,7 +80,7 @@ func TestDefaultSupport_Enabled(t *testing.T) {
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			info := beat.Info{Beat: "test", Version: "9.9.9"}
 			factory := MakeDefaultSupport(makeMockILMSupport(test.ilmCalls...), logger)
 			im, err := factory(logger, info, config.MustNewConfigFrom(test.cfg))
@@ -179,7 +179,7 @@ func TestDefaultSupport_BuildSelector(t *testing.T) {
 	}
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 
 			ts := time.Now()
 			info := beat.Info{Beat: "test", Version: "9.9.9"}
@@ -261,7 +261,7 @@ func TestIndexManager_VerifySetup(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			cfg, err := config.NewConfigFrom(mapstr.M{
 				"setup.ilm.enabled":      setup.ilmEnabled,
 				"setup.ilm.overwrite":    setup.ilmOverwrite,
@@ -447,7 +447,7 @@ func TestIndexManager_Setup(t *testing.T) {
 	}
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			factory := MakeDefaultSupport(lifecycle.StdSupport, logger)
 			im, err := factory(logger, info, config.MustNewConfigFrom(test.cfg))
 			require.NoError(t, err)

--- a/libbeat/instrumentation/instrumentation_test.go
+++ b/libbeat/instrumentation/instrumentation_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestInstrumentationConfig(t *testing.T) {
@@ -34,7 +34,7 @@ func TestInstrumentationConfig(t *testing.T) {
 			"enabled": "true",
 		},
 	})
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	instrumentation, err := New(cfg, "my-beat", version.GetDefaultVersion(), logger)
 	require.NoError(t, err)
 
@@ -52,7 +52,7 @@ func TestInstrumentationConfigExplicitHosts(t *testing.T) {
 		},
 	},
 	)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	instrumentation, err := New(cfg, "my-beat", version.GetDefaultVersion(), logger)
 	require.NoError(t, err)
 	tracer := instrumentation.Tracer()
@@ -67,7 +67,7 @@ func TestInstrumentationConfigListener(t *testing.T) {
 			"enabled": "true",
 		},
 	})
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	instrumentation, err := New(cfg, "apm-server", version.GetDefaultVersion(), logger)
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestInstrumentationConfigListener(t *testing.T) {
 }
 
 func TestAPMTracerDisabledByDefault(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	instrumentation, err := New(config.NewConfig(), "beat", "8.0", logger)
 	require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestInstrumentationDisabled(t *testing.T) {
 			"enabled": "false",
 		},
 	})
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	instrumentation, err := New(cfg, "filebeat", version.GetDefaultVersion(), logger)
 	require.NoError(t, err)

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch_test.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/monitoring/report"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestMakeClientParams(t *testing.T) {
@@ -50,7 +50,7 @@ func TestMakeReporter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	r, err := makeReporter(beat.Info{Logger: logger}, report.Settings{}, c)
 	require.NoError(t, err)

--- a/libbeat/monitoring/report/log/log_test.go
+++ b/libbeat/monitoring/report/log/log_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
@@ -61,7 +62,7 @@ var (
 
 // Smoke test.
 func TestStartStop(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	r, err := MakeReporter(beat.Info{Logger: logger}, conf.NewConfig())
 	if err != nil {
 		t.Fatal(err)

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -114,7 +115,7 @@ func TestConsoleOutput(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.title, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			batch := outest.NewBatch(test.events...)
 			lines, err := run(test.codec, logger, batch)
 			assert.NoError(t, err)

--- a/libbeat/outputs/elasticsearch/bulk_test.go
+++ b/libbeat/outputs/elasticsearch/bulk_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -72,7 +73,7 @@ func TestBulkReadToItems(t *testing.T) {
 
 func TestBulkReadItemStatus(t *testing.T) {
 	response := []byte(`{"create": {"status": 200}}`)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	reader := newJSONReader(response)
 	code, _, err := bulkReadItemStatus(logger, reader)
@@ -82,7 +83,7 @@ func TestBulkReadItemStatus(t *testing.T) {
 
 func TestESNoErrorStatus(t *testing.T) {
 	response := []byte(`{"create": {"status": 200}}`)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	code, msg, err := readStatusItem(response, logger)
 
@@ -93,7 +94,7 @@ func TestESNoErrorStatus(t *testing.T) {
 
 func TestES1StyleErrorStatus(t *testing.T) {
 	response := []byte(`{"create": {"status": 400, "error": "test error"}}`)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	code, msg, err := readStatusItem(response, logger)
 
@@ -104,7 +105,7 @@ func TestES1StyleErrorStatus(t *testing.T) {
 
 func TestES2StyleErrorStatus(t *testing.T) {
 	response := []byte(`{"create": {"status": 400, "error": {"reason": "test_error"}}}`)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	code, msg, err := readStatusItem(response, logger)
 
@@ -125,7 +126,7 @@ func TestES2StyleExtendedErrorStatus(t *testing.T) {
         }
       }
     }`)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	code, _, err := readStatusItem(response, logger)
 
 	assert.NoError(t, err)

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
@@ -409,7 +409,7 @@ func connectTestEs(t *testing.T, cfg interface{}, stats outputs.Observer) (outpu
 		t.Fatal(err)
 	}
 
-	logger := logp.NewTestingLogger(t, "elasticsearch")
+	logger := logptest.NewTestingLogger(t, "elasticsearch")
 	info := beat.Info{Beat: "libbeat", Logger: logger}
 	// disable ILM if using specified index name
 	im, _ := idxmgmt.DefaultSupport(info, conf.MustNewConfigFrom(map[string]interface{}{"setup.ilm.enabled": "false"}))

--- a/libbeat/outputs/elasticsearch/client_proxy_test.go
+++ b/libbeat/outputs/elasticsearch/client_proxy_test.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/outputs/outil"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
@@ -208,7 +208,7 @@ func doClientPing(t *testing.T) {
 
 		clientSettings.connection.Transport.Proxy.URL = &proxyURL
 	}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(clientSettings, nil, logger)
 	require.NoError(t, err)
 

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/version"
 	c "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	libversion "github.com/elastic/elastic-agent-libs/version"
@@ -86,7 +87,7 @@ func (bm *batchMock) RetryEvents(events []publisher.Event) {
 
 func TestPublish(t *testing.T) {
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	makePublishTestClient := func(t *testing.T, url string) (*Client, *monitoring.Registry) {
 		reg := monitoring.NewRegistry()
 		client, err := NewClient(
@@ -289,7 +290,7 @@ func assertRegistryUint(t *testing.T, reg *monitoring.Registry, key string, expe
 }
 
 func TestCollectPublishFailsNone(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(
 		clientSettings{
 			observer: outputs.NewNilObserver(),
@@ -318,7 +319,7 @@ func TestCollectPublishFailsNone(t *testing.T) {
 }
 
 func TestCollectPublishFailMiddle(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(
 		clientSettings{
 			observer: outputs.NewNilObserver(),
@@ -355,7 +356,7 @@ func TestCollectPublishFailMiddle(t *testing.T) {
 
 func TestCollectPublishFailDeadLetterSuccess(t *testing.T) {
 	const deadLetterIndex = "test_index"
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(
 		clientSettings{
 			observer:        outputs.NewNilObserver(),
@@ -389,7 +390,7 @@ func TestCollectPublishFailFatalErrorNotRetried(t *testing.T) {
 	// Test that a fatal error sending to the dead letter index is reported as
 	// a dropped event, and is not retried forever
 	const deadLetterIndex = "test_index"
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(
 		clientSettings{
 			observer:        outputs.NewNilObserver(),
@@ -420,7 +421,7 @@ func TestCollectPublishFailFatalErrorNotRetried(t *testing.T) {
 }
 
 func TestCollectPublishFailInvalidBulkIndexResponse(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(
 		clientSettings{observer: outputs.NewNilObserver()},
 		nil,
@@ -451,7 +452,7 @@ func TestCollectPublishFailInvalidBulkIndexResponse(t *testing.T) {
 }
 
 func TestCollectPublishFailDeadLetterIndex(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	const deadLetterIndex = "test_index"
 	client, err := NewClient(
 		clientSettings{
@@ -501,7 +502,7 @@ func TestCollectPublishFailDeadLetterIndex(t *testing.T) {
 }
 
 func TestCollectPublishFailDrop(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(
 		clientSettings{
 			observer:        outputs.NewNilObserver(),
@@ -551,7 +552,7 @@ func TestCollectPublishFailDrop(t *testing.T) {
 }
 
 func TestCollectPublishFailAll(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(
 		clientSettings{
 			observer: outputs.NewNilObserver(),
@@ -583,7 +584,7 @@ func TestCollectPublishFailAll(t *testing.T) {
 }
 
 func TestCollectPipelinePublishFail(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	client, err := NewClient(
 		clientSettings{
@@ -844,7 +845,7 @@ func TestClientWithHeaders(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	client, err := NewClient(clientSettings{
 		observer: outputs.NewNilObserver(),
 		connection: eslegclient.ConnectionSettings{
@@ -902,7 +903,7 @@ func TestBulkEncodeEvents(t *testing.T) {
 	for name, test := range cases {
 		test := test
 		t.Run(name, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			cfg := c.MustNewConfigFrom(test.config)
 			info := beat.Info{
 				IndexPrefix: "test",
@@ -974,7 +975,7 @@ func TestBulkEncodeEventsWithOpType(t *testing.T) {
 	}
 
 	cfg := c.MustNewConfigFrom(mapstr.M{})
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	info := beat.Info{
 		IndexPrefix: "test",
 		Version:     version.GetDefaultVersion(),
@@ -1052,7 +1053,7 @@ func TestClientWithAPIKey(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	client, err := NewClient(clientSettings{
 		observer: outputs.NewNilObserver(),
@@ -1074,7 +1075,7 @@ func TestClientWithAPIKey(t *testing.T) {
 }
 
 func TestBulkRequestHasFilterPath(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	makePublishTestClient := func(t *testing.T, url string, configParams map[string]string) *Client {
 		client, err := NewClient(

--- a/libbeat/outputs/kafka/config_test.go
+++ b/libbeat/outputs/kafka/config_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/internal/testutil"
 	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -49,7 +49,7 @@ func TestConfigAcceptValid(t *testing.T) {
 		test := test
 		t.Run(name, func(t *testing.T) {
 			c := config.MustNewConfigFrom(test)
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			if err := c.SetString("hosts", 0, "localhost"); err != nil {
 				t.Fatalf("could not set 'hosts' on config: %s", err)
 			}

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -41,7 +41,7 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -273,7 +273,7 @@ func TestKafkaPublish(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			grp, err := makeKafka(nil, beat.Info{Beat: "libbeat", IndexPrefix: "testbeat", Logger: logger}, outputs.NewNilObserver(), cfg)
 			if err != nil {
 				t.Fatal(err)

--- a/libbeat/outputs/kafka/partition_test.go
+++ b/libbeat/outputs/kafka/partition_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -200,7 +200,7 @@ func TestPartitioners(t *testing.T) {
 			continue
 		}
 
-		logger := logp.NewTestingLogger(t, "")
+		logger := logptest.NewTestingLogger(t, "")
 		constr, err := makePartitioner(logger, pcfg.Partition)
 		if err != nil {
 			t.Error(err)

--- a/libbeat/outputs/logstash/deadlock_test.go
+++ b/libbeat/outputs/logstash/deadlock_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestDeadlockListener(t *testing.T) {

--- a/libbeat/outputs/logstash/deadlock_test.go
+++ b/libbeat/outputs/logstash/deadlock_test.go
@@ -21,10 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestDeadlockListener(t *testing.T) {
@@ -32,7 +31,7 @@ func TestDeadlockListener(t *testing.T) {
 	var currentTime time.Time
 	getTime := func() time.Time { return currentTime }
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	dl := idleDeadlockListener(logger, timeout, getTime)
 
 	// Channels get a buffer so we can trigger them deterministically in

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
@@ -188,7 +188,7 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 		"template.enabled": false,
 	})
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	info := beat.Info{Beat: "libbeat", Logger: logger}
 	im, err := idxmgmt.DefaultSupport(info, conf.MustNewConfigFrom(
 		map[string]interface{}{

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	v2 "github.com/elastic/go-lumber/server/v2"
 )
@@ -185,7 +185,7 @@ func newTestLumberjackOutput(
 		}
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	cfg, _ := conf.NewConfigFrom(config)
 	grp, err := outputs.Load(nil, beat.Info{Logger: logger}, nil, "logstash", cfg)
 	if err != nil {

--- a/libbeat/outputs/otelconsumer/otelconsumer_test.go
+++ b/libbeat/outputs/otelconsumer/otelconsumer_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -50,7 +50,7 @@ func TestPublish(t *testing.T) {
 	makeOtelConsumer := func(t *testing.T, consumeFn func(ctx context.Context, ld plog.Logs) error) *otelConsumer {
 		t.Helper()
 
-		logger := logp.NewTestingLogger(t, "")
+		logger := logptest.NewTestingLogger(t, "")
 		logConsumer, err := consumer.NewLogs(consumeFn)
 		assert.NoError(t, err)
 		consumer := &otelConsumer{

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -38,7 +38,7 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -350,7 +350,7 @@ func newRedisTestingOutput(t *testing.T, cfg map[string]interface{}) outputs.Cli
 		t.Fatalf("redis output module not registered")
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	out, err := plugin(nil, beat.Info{Beat: testBeatname, Version: testBeatversion, Logger: logger}, outputs.NewNilObserver(), config)
 	if err != nil {
 		t.Fatalf("Failed to initialize redis output: %v", err)

--- a/libbeat/outputs/redis/redis_test.go
+++ b/libbeat/outputs/redis/redis_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -107,7 +107,7 @@ func TestMakeRedis(t *testing.T) {
 	beatInfo := beat.Info{Beat: "libbeat", Version: "1.2.3"}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			beatInfo.Logger = logger
 			cfg, err := config.NewConfigFrom(test.config)
 			assert.NoError(t, err)

--- a/libbeat/processors/actions/append_test.go
+++ b/libbeat/processors/actions/append_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -60,7 +61,7 @@ func Test_cleanEmptyValues(t *testing.T) {
 }
 
 func Test_appendProcessor_appendValues(t *testing.T) {
-	log := logp.NewTestingLogger(t, "append_test")
+	log := logptest.NewTestingLogger(t, "append_test")
 	type fields struct {
 		config appendProcessorConfig
 		logger *logp.Logger
@@ -181,7 +182,7 @@ func Test_appendProcessor_appendValues(t *testing.T) {
 }
 
 func Test_appendProcessor_Run(t *testing.T) {
-	log := logp.NewTestingLogger(t, "append_test")
+	log := logptest.NewTestingLogger(t, "append_test")
 	type fields struct {
 		config appendProcessorConfig
 		logger *logp.Logger

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -20,7 +20,7 @@ package actions
 import (
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,7 @@ import (
 )
 
 func TestCopyFields(t *testing.T) {
-	log := logp.NewTestingLogger(t, "copy_fields_test")
+	log := logptest.NewTestingLogger(t, "copy_fields_test")
 	var tests = map[string]struct {
 		FromTo   fromTo
 		Input    mapstr.M

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -203,7 +203,7 @@ func TestDecodeBase64Run(t *testing.T) {
 			t.Parallel()
 
 			f := &decodeBase64Field{
-				log:    logp.NewTestingLogger(t, processorName),
+				log:    logptest.NewTestingLogger(t, processorName),
 				config: test.config,
 			}
 
@@ -238,7 +238,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		}
 
 		f := &decodeBase64Field{
-			log:    logp.NewTestingLogger(t, processorName),
+			log:    logptest.NewTestingLogger(t, processorName),
 			config: config,
 		}
 

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -37,13 +37,13 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
 func makePipeline(t *testing.T, settings Settings, qu queue.Queue) *Pipeline {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	p, err := New(beat.Info{Logger: logger},
 		Monitors{},
 		conf.Namespace{},
@@ -85,7 +85,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("no infinite loop when processing fails", func(t *testing.T) {
-		l := logp.NewTestingLogger(t, "")
+		l := logptest.NewTestingLogger(t, "")
 
 		// a small in-memory queue with a very short flush interval
 		q := memqueue.NewQueue(l, nil, memqueue.Settings{
@@ -192,7 +192,7 @@ func TestClient(t *testing.T) {
 }
 
 func TestClientWaitClose(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	makePipeline := func(settings Settings, qu queue.Queue) *Pipeline {
 		p, err := New(beat.Info{Logger: logger},
 			Monitors{},
@@ -299,7 +299,7 @@ func TestMonitoring(t *testing.T) {
 
 		metrics := monitoring.NewRegistry()
 		telemetry := monitoring.NewRegistry()
-		beatInfo := beat.Info{Logger: logp.NewTestingLogger(t, "")}
+		beatInfo := beat.Info{Logger: logptest.NewTestingLogger(t, "")}
 		pipeline, err := Load(
 			beatInfo,
 			Monitors{
@@ -357,7 +357,7 @@ func testInputMetrics(t *testing.T, beatInfo beat.Info, clientCfg beat.ClientCon
 
 	metrics := monitoring.NewRegistry()
 	telemetry := monitoring.NewRegistry()
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	pipeline, err := Load(
 		beat.Info{
 			Logger: logger,

--- a/libbeat/publisher/pipeline/consumer_test.go
+++ b/libbeat/publisher/pipeline/consumer_test.go
@@ -20,9 +20,8 @@ package pipeline
 import (
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestNoBatchAssemblyOnNilTarget(t *testing.T) {
@@ -32,7 +31,7 @@ func TestNoBatchAssemblyOnNilTarget(t *testing.T) {
 	// instead of starting up the full goroutine and relying on a timeout,
 	// which can cause flakiness on CI. (This test does not pass without the
 	// code change to check for a nil channel.)
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	c := &eventConsumer{
 		logger: logger.Named("eventConsumer test"),
 		queueReader: queueReader{

--- a/libbeat/publisher/pipeline/consumer_test.go
+++ b/libbeat/publisher/pipeline/consumer_test.go
@@ -20,8 +20,9 @@ package pipeline
 import (
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestNoBatchAssemblyOnNilTarget(t *testing.T) {

--- a/libbeat/publisher/pipeline/controller_test.go
+++ b/libbeat/publisher/pipeline/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	//"github.com/elastic/beats/v7/libbeat/tests/resources"
@@ -70,7 +71,7 @@ func TestOutputReload(t *testing.T) {
 					return nil
 				}
 
-				logger := logp.NewTestingLogger(t, "")
+				logger := logptest.NewTestingLogger(t, "")
 				pipeline, err := New(
 					beat.Info{Logger: logger},
 					Monitors{Logger: logger},
@@ -142,7 +143,7 @@ func TestSetEmptyOutputsSendsNilChannel(t *testing.T) {
 }
 
 func TestQueueCreatedOnlyAfterOutputExists(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	controller := outputController{
 		// Set event limit to 1 so we can easily tell if our settings
 		// were used to create the queue.
@@ -172,7 +173,7 @@ func TestQueueCreatedOnlyAfterOutputExists(t *testing.T) {
 }
 
 func TestOutputQueueFactoryTakesPrecedence(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// If there are queue settings provided by both the pipeline and
 	// the output, the output settings should be used.
 	controller := outputController{
@@ -202,7 +203,7 @@ func TestFailedQueueFactoryRevertsToDefault(t *testing.T) {
 	failedFactory := func(_ *logp.Logger, _ queue.Observer, _ int, _ queue.EncoderFactory) (queue.Queue, error) {
 		return nil, fmt.Errorf("This queue creation intentionally failed")
 	}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	controller := outputController{
 		queueFactory: failedFactory,
 		consumer: &eventConsumer{
@@ -224,7 +225,7 @@ func TestFailedQueueFactoryRevertsToDefault(t *testing.T) {
 }
 
 func TestQueueProducerBlocksUntilOutputIsSet(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	controller := outputController{
 		queueFactory: memqueue.FactoryForSettings(memqueue.Settings{Events: 1}),
 		consumer: &eventConsumer{
@@ -270,7 +271,7 @@ func TestQueueMetrics(t *testing.T) {
 	// here we just want to make sure that they appear under the right
 	// monitoring namespace.
 	reg := monitoring.NewRegistry()
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	controller := outputController{
 		queueFactory: memqueue.FactoryForSettings(memqueue.Settings{Events: 1000}),
 		consumer: &eventConsumer{

--- a/libbeat/publisher/pipeline/stress/stress_test.go
+++ b/libbeat/publisher/pipeline/stress/stress_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline/stress"
 	_ "github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 // additional flags
@@ -55,7 +55,7 @@ func TestPipeline(t *testing.T) {
 		Version:  "0",
 		Name:     "stresser.test",
 		Hostname: "stresser.test",
-		Logger:   logp.NewTestingLogger(t, ""),
+		Logger:   logptest.NewTestingLogger(t, ""),
 	}
 
 	if duration == 0 {

--- a/libbeat/publisher/queue/diskqueue/acks_test.go
+++ b/libbeat/publisher/queue/diskqueue/acks_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 type addFramesTestStep struct {
@@ -245,7 +245,7 @@ func runAddFramesTest(t *testing.T, name string, test addFramesTest) {
 	}
 	defer stateFile.Close()
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	dqa := newDiskQueueACKs(logger, test.position, stateFile)
 	dqa.nextFrameID = test.frameID
 	for _, step := range test.steps {

--- a/libbeat/publisher/queue/diskqueue/core_loop_test.go
+++ b/libbeat/publisher/queue/diskqueue/core_loop_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
@@ -127,7 +127,7 @@ func TestHandleProducerWriteRequest(t *testing.T) {
 	settings := DefaultSettings()
 	settings.MaxSegmentSize = 1000 + segmentHeaderSize
 	settings.MaxBufferSize = 10000
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	for description, test := range testCases {
 		dq := &diskQueue{
 			logger:   logger,
@@ -438,7 +438,7 @@ func TestHandleReaderLoopResponse(t *testing.T) {
 		},
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	for description, test := range testCases {
 		dq := &diskQueue{
 			logger:   logger,
@@ -981,7 +981,7 @@ func TestObserverDeleteSegment(t *testing.T) {
 	// Check that the results of segment deletions are reported to the
 	// metrics observer.
 	reg := monitoring.NewRegistry()
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	dq := diskQueue{
 		logger:   logger.Named("testing"),
 		observer: queue.NewQueueObserver(reg),

--- a/libbeat/publisher/queue/diskqueue/queue_test.go
+++ b/libbeat/publisher/queue/diskqueue/queue_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/queuetest"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 var seed int64
@@ -77,7 +77,7 @@ func makeTestQueue() queuetest.QueueFactory {
 		dir := t.TempDir()
 		settings := DefaultSettings()
 		settings.Path = dir
-		logger := logp.NewTestingLogger(t, "")
+		logger := logptest.NewTestingLogger(t, "")
 		queue, _ := NewQueue(logger, nil, settings, nil)
 		return testQueue{
 			diskQueue: queue,

--- a/libbeat/publisher/queue/memqueue/runloop_test.go
+++ b/libbeat/publisher/queue/memqueue/runloop_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
@@ -39,7 +40,7 @@ func TestFlushSettingsDoNotBlockFullBatches(t *testing.T) {
 	// available. This test verifies that Get requests that can be completely
 	// filled do not wait for the flush timer.
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	broker := newQueue(
 		logger.Named("testing"),
 		nil,
@@ -78,7 +79,7 @@ func TestFlushSettingsBlockPartialBatches(t *testing.T) {
 	// The previous test confirms that Get requests are handled immediately if
 	// there are enough events. This one uses the same setup to confirm that
 	// Get requests are delayed if there aren't enough events.
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	broker := newQueue(
 		logger.Named("testing"),
 		nil,

--- a/libbeat/statestore/backend/memlog/memlog_test.go
+++ b/libbeat/statestore/backend/memlog/memlog_test.go
@@ -31,19 +31,19 @@ import (
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/backend"
 	"github.com/elastic/beats/v7/libbeat/statestore/internal/storecompliance"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestCompliance_Default(t *testing.T) {
 	storecompliance.TestBackendCompliance(t, func(testPath string) (backend.Registry, error) {
-		logger := logp.NewTestingLogger(t, "")
+		logger := logptest.NewTestingLogger(t, "")
 		return New(logger.Named("test"), Settings{Root: testPath})
 	})
 }
 
 func TestCompliance_AlwaysCheckpoint(t *testing.T) {
 	storecompliance.TestBackendCompliance(t, func(testPath string) (backend.Registry, error) {
-		logger := logp.NewTestingLogger(t, "")
+		logger := logptest.NewTestingLogger(t, "")
 		return New(logger.Named("test"), Settings{
 			Root: testPath,
 			Checkpoint: func(filesize uint64) bool {
@@ -100,7 +100,7 @@ func testLoadVersion1Case(t *testing.T, dataPath string) {
 		t.Fatalf("Failed to parse expected.json: %v", err)
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// load store:
 	store, err := openStore(logger.Named("test"), path, 0660, 4096, true, func(_ uint64) bool {
 		return false

--- a/libbeat/statestore/backend/memlog/store_test.go
+++ b/libbeat/statestore/backend/memlog/store_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -35,7 +35,7 @@ func TestRecoverFromCorruption(t *testing.T) {
 		t.Fatalf("Failed to copy test file to the temporary directory: %v", err)
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	store, err := openStore(logger.Named("test"), path, 0660, 4096, false, func(_ uint64) bool {
 		return false
 	})

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegtest"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle"
 	"github.com/elastic/beats/v7/libbeat/version"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
@@ -70,7 +70,7 @@ func newTestSetup(t *testing.T, cfg TemplateConfig) *testSetup {
 		t.Fatal(err)
 	}
 	handler := &mockClientHandler{serverless: false, mode: lifecycle.ILM}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	loader, err := NewESLoader(client, handler, logger)
 	require.NoError(t, err)
 	s := testSetup{t: t, client: client, loader: loader, config: cfg}
@@ -88,7 +88,7 @@ func newTestSetupWithESClient(t *testing.T, client ESClient, cfg TemplateConfig)
 		cfg.Name = fmt.Sprintf("load-test-%+v", rand.Int())
 	}
 	handler := &mockClientHandler{serverless: false, mode: lifecycle.ILM}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	loader, err := NewESLoader(client, handler, logger)
 	require.NoError(t, err)
 	return &testSetup{t: t, client: client, loader: loader, config: cfg}

--- a/libbeat/template/load_test.go
+++ b/libbeat/template/load_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/version"
 
@@ -227,7 +227,7 @@ func TestFileLoader_Load(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			fc := newFileClient(ver)
-			logger := logp.NewTestingLogger(t, "")
+			logger := logptest.NewTestingLogger(t, "")
 			fl := NewFileLoader(fc, test.isServerless, logger)
 
 			cfg := DefaultConfig(info)

--- a/metricbeat/module/windows/service/reader_test.go
+++ b/metricbeat/module/windows/service/reader_test.go
@@ -22,13 +22,12 @@ package service
 import (
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestNewReader(t *testing.T) {
-	reader, err := NewReader(logp.NewTestingLogger(t, ""))
+	reader, err := NewReader(logptest.NewTestingLogger(t, ""))
 	assert.NoError(t, err)
 	assert.NotNil(t, reader)
 	defer reader.Close()
@@ -59,7 +58,7 @@ func TestGetMachineGUID(t *testing.T) {
 func TestRead(t *testing.T) {
 	t.Skip("Flaky test: https://github.com/elastic/beats/issues/22171")
 
-	reader, err := NewReader(logp.NewTestingLogger(t, ""))
+	reader, err := NewReader(logptest.NewTestingLogger(t, ""))
 	assert.NoError(t, err)
 	result, err := reader.Read()
 	assert.NoError(t, err)

--- a/metricbeat/module/windows/service/reader_test.go
+++ b/metricbeat/module/windows/service/reader_test.go
@@ -22,8 +22,9 @@ package service
 import (
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestNewReader(t *testing.T) {
@@ -46,7 +47,7 @@ func TestOpenSCManager(t *testing.T) {
 	handle, err = openSCManager("", "", ScManagerEnumerateService|ScManagerConnect)
 	assert.NoError(t, err)
 	assert.NotEqual(t, handle, InvalidDatabaseHandle)
-	closeHandle(handle)
+	closeHandle(handle) //nolint:errcheck //safe to ignore
 }
 
 func TestGetMachineGUID(t *testing.T) {

--- a/metricbeat/module/windows/service/service_integration_test.go
+++ b/metricbeat/module/windows/service/service_integration_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -53,7 +53,7 @@ func TestData(t *testing.T) {
 }
 
 func TestReadService(t *testing.T) {
-	reader, err := NewReader(logp.NewTestingLogger(t, ""))
+	reader, err := NewReader(logptest.NewTestingLogger(t, ""))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/module/windows/service/service_status_test.go
+++ b/metricbeat/module/windows/service/service_status_test.go
@@ -22,8 +22,9 @@ package service
 import (
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestGetServiceStates(t *testing.T) {
@@ -33,5 +34,5 @@ func TestGetServiceStates(t *testing.T) {
 	services, err := GetServiceStates(logptest.NewTestingLogger(t, ""), handle, ServiceStateAll, map[string]struct{}{})
 	assert.NoError(t, err)
 	assert.True(t, len(services) > 0)
-	closeHandle(handle)
+	closeHandle(handle) //nolint:errcheck //safe to ignore
 }

--- a/metricbeat/module/windows/service/service_status_test.go
+++ b/metricbeat/module/windows/service/service_status_test.go
@@ -22,16 +22,15 @@ package service
 import (
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestGetServiceStates(t *testing.T) {
 	handle, err := openSCManager("", "", ScManagerEnumerateService|ScManagerConnect)
 	assert.NoError(t, err)
 	assert.NotEqual(t, handle, InvalidDatabaseHandle)
-	services, err := GetServiceStates(logp.NewTestingLogger(t, ""), handle, ServiceStateAll, map[string]struct{}{})
+	services, err := GetServiceStates(logptest.NewTestingLogger(t, ""), handle, ServiceStateAll, map[string]struct{}{})
 	assert.NoError(t, err)
 	assert.True(t, len(services) > 0)
 	closeHandle(handle)

--- a/x-pack/filebeat/input/cometd/cometd_integration_test.go
+++ b/x-pack/filebeat/input/cometd/cometd_integration_test.go
@@ -18,7 +18,7 @@ import (
 
 	bay "github.com/elastic/bayeux"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -83,7 +83,7 @@ func TestInput(t *testing.T) {
 		BeatDone: make(chan struct{}),
 	}
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// Setup the input
 	input, err := NewInput(config, connector, inputContext, logger)
 	require.NoError(t, err)

--- a/x-pack/filebeat/input/cometd/input_test.go
+++ b/x-pack/filebeat/input/cometd/input_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -105,7 +106,7 @@ func TestSingleInput(t *testing.T) {
 
 	cfg := conf.MustNewConfigFrom(config)
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := NewInput(cfg, connector, inputContext, logger)
 	require.NoError(t, err)
 	require.NotNil(t, input)
@@ -164,7 +165,7 @@ func TestInputStop_Wait(t *testing.T) {
 
 	cfg := conf.MustNewConfigFrom(config)
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := NewInput(cfg, connector, inputContext, logger)
 	require.NoError(t, err)
 	require.NotNil(t, input)
@@ -328,7 +329,7 @@ func TestMultiInput(t *testing.T) {
 
 	var inputContext finput.Context
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	// initialize inputs
 	input1, err := NewInput(cfg1, connector, inputContext, logger)
 	require.NoError(t, err)
@@ -470,7 +471,7 @@ func TestMultiEventForEOFRetryHandlerInput(t *testing.T) {
 
 	cfg := conf.MustNewConfigFrom(config)
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := NewInput(cfg, connector, inputContext, logger)
 	require.NoError(t, err)
 	require.NotNil(t, input)
@@ -574,7 +575,7 @@ func TestNegativeCases(t *testing.T) {
 
 	cfg := conf.MustNewConfigFrom(config)
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	input, err := NewInput(cfg, connector, inputContext, logger)
 	require.NoError(t, err)
 	require.NotNil(t, input)

--- a/x-pack/filebeat/input/gcppubsub/pubsub_test.go
+++ b/x-pack/filebeat/input/gcppubsub/pubsub_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/tests/compose"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 const (
@@ -242,7 +242,7 @@ func runTestWithACKer(t *testing.T, cfg *conf.C, onEvent eventHandler, run func(
 		return eventOutlet, nil
 	})
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	in, err := NewInput(cfg, connector, inputCtx, logger)
 	if err != nil {
 		t.Fatal(err)

--- a/x-pack/libbeat/common/cloudfoundry/cache_test.go
+++ b/x-pack/libbeat/common/cloudfoundry/cache_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/testing/testutils"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestClientCacheWrap(t *testing.T) {
@@ -32,7 +32,7 @@ func TestClientCacheWrap(t *testing.T) {
 		Name: "Foo", // use this field to track if from cache or from client
 	}
 	fakeClient := &fakeCFClient{app, 0}
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	cache, err := newClientCacheWrap(fakeClient, "test", ttl, ttl, logger.Named("cloudfoundry"))
 	require.NoError(t, err)
 

--- a/x-pack/libbeat/persistentcache/persistentcache_test.go
+++ b/x-pack/libbeat/persistentcache/persistentcache_test.go
@@ -17,11 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestPutGet(t *testing.T) {
 	t.Parallel()
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 
 	cache, err := New("test", testOptions(t), logger)
 	require.NoError(t, err)
@@ -47,7 +48,7 @@ func TestPutGet(t *testing.T) {
 }
 
 func TestPersist(t *testing.T) {
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	t.Parallel()
 
 	options := testOptions(t)
@@ -85,7 +86,7 @@ func TestExpired(t *testing.T) {
 
 	options := testOptions(t)
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	cache, err := New("test", options, logger)
 	require.NoError(t, err)
 	defer cache.Close()
@@ -125,7 +126,7 @@ func TestRefreshOnAccess(t *testing.T) {
 	options.Timeout = 2 * time.Second
 	options.RefreshOnAccess = true
 
-	logger := logp.NewTestingLogger(t, "")
+	logger := logptest.NewTestingLogger(t, "")
 	cache, err := New("test", options, logger)
 	require.NoError(t, err)
 	defer cache.Close()

--- a/x-pack/libbeat/persistentcache/store_test.go
+++ b/x-pack/libbeat/persistentcache/store_test.go
@@ -7,10 +7,9 @@ package persistentcache
 import (
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestStandaloneStore(t *testing.T) {
@@ -20,7 +19,7 @@ func TestStandaloneStore(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	log := logp.NewTestingLogger(t, "")
+	log := logptest.NewTestingLogger(t, "")
 	store, err := newStore(log, tempDir, "store-cache")
 	require.NoError(t, err)
 

--- a/x-pack/libbeat/persistentcache/store_test.go
+++ b/x-pack/libbeat/persistentcache/store_test.go
@@ -7,9 +7,10 @@ package persistentcache
 import (
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestStandaloneStore(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
The `logp` package imported testing package - which should not be part of beats binary. The updated `logptest.NewTestingLogger` separates this dependency. See https://github.com/elastic/elastic-agent-libs/pull/309

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.




