### PR TITLE
Rename buildkite test step to avoid confusion

### DIFF
--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -103,7 +103,7 @@ steps:
           - github_commit_status:
               context: "auditbeat: Ubuntu x86_64 Unit Tests"
 
-      - label: ":ubuntu: Auditbeat: Ubuntu x86_64 Unit Tests FIPS"
+      - label: ":ubuntu: Auditbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
         command: |
           set -euo pipefail
           cd auditbeat
@@ -128,7 +128,7 @@ steps:
               debug: true
         notify:
           - github_commit_status:
-              context: "auditbeat: Ubuntu x86_64 Unit Tests FIPS"
+              context: "auditbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: Auditbeat: Ubuntu x86_64 fips140=only Unit Tests"
         command: |

--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -101,7 +101,7 @@ steps:
           - github_commit_status:
               context: "filebeat: Ubuntu x86_64 Unit Tests"
 
-      - label: ":ubuntu: Filebeat: Ubuntu x86_64 Unit Tests FIPS"
+      - label: ":ubuntu: Filebeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
         command: |
           cd filebeat
           mage unitTest
@@ -125,7 +125,7 @@ steps:
               debug: true
         notify:
           - github_commit_status:
-              context: "filebeat: Ubuntu x86_64 Unit Tests FIPS"
+              context: "filebeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: Filebeat: Ubuntu x86_64 fips140=only Unit Tests"
         command: |

--- a/.buildkite/libbeat/pipeline.libbeat.yml
+++ b/.buildkite/libbeat/pipeline.libbeat.yml
@@ -87,8 +87,8 @@ steps:
           - github_commit_status:
               context: "libbeat: Ubuntu x86_64 Unit Tests"
 
-      - label: ":ubuntu: Libbeat: Ubuntu x86_64 Unit Tests FIPS"
-        key: "mandatory-linux-unit-test-fips"
+      - label: ":ubuntu: Libbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
+        key: "mandatory-linux-unit-test-fips-tag"
         command: |
           set -euo pipefail
           cd libbeat
@@ -113,7 +113,7 @@ steps:
               debug: true
         notify:
           - github_commit_status:
-              context: "libbeat: Ubuntu x86_64 Unit Tests FIPS"
+              context: "libbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: Libbeat: Ubuntu x86_64 fips140=only Unit Tests"
         key: "mandatory-linux-unit-test-fips-only"

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -105,8 +105,8 @@ steps:
           - github_commit_status:
               context: "metricbeat: Ubuntu x86_64 Unit Tests"
 
-      - label: ":ubuntu: Metricbeat: Ubuntu x86_64 Unit Tests FIPS"
-        key: "mandatory-linux-unit-test-fips"
+      - label: ":ubuntu: Metricbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
+        key: "mandatory-linux-unit-test-fips-tag"
         command: |
           cd metricbeat
           mage unitTest
@@ -130,7 +130,7 @@ steps:
               debug: true
         notify:
           - github_commit_status:
-              context: "metricbeat: Ubuntu x86_64 Unit Tests FIPS"
+              context: "metricbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: Metricbeat: Ubuntu x86_64 fips140=only Unit Tests"
         key: "mandatory-linux-unit-test-fips-only"

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -106,8 +106,8 @@ steps:
           - github_commit_status:
               context: "x-pack/auditbeat: Build Tests (Module)"
 
-      - label: ":ubuntu: x-pack/auditbeat: Ubuntu Unit Tests FIPS"
-        key: "mandatory-linux-unit-test-fips"
+      - label: ":ubuntu: x-pack/auditbeat: Ubuntu Unit Tests with requirefips build tag"
+        key: "mandatory-linux-unit-test-fips-tag"
         command: |
           cd x-pack/auditbeat
           mage unitTest
@@ -131,7 +131,7 @@ steps:
               debug: true
         notify:
           - github_commit_status:
-              context: "x-pack/auditbeat: Ubuntu Unit Tests FIPS"
+              context: "x-pack/auditbeat: Ubuntu Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: x-pack/auditbeat: Ubuntu fips140=only Unit Tests"
         key: "mandatory-linux-unit-test-fips-only"

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -103,8 +103,8 @@ steps:
           - github_commit_status:
               context: "x-pack/filebeat: Ubuntu x86_64 Unit Tests"
 
-      - label: ":ubuntu: x-pack/filebeat: Ubuntu x86_64 Unit Tests FIPS"
-        key: "x-pack-filebeat-mandatory-linux-unit-test-FIPS"
+      - label: ":ubuntu: x-pack/filebeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
+        key: "x-pack-filebeat-mandatory-linux-unit-test-FIPS-tag"
         command: |
           cd x-pack/filebeat
           mage unitTest
@@ -128,7 +128,7 @@ steps:
               debug: true
         notify:
           - github_commit_status:
-              context: "x-pack/filebeat: Ubuntu x86_64 Unit Tests FIPS"
+              context: "x-pack/filebeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: x-pack/filebeat: Ubuntu x86_64 fips140=only Unit Tests"
         key: "x-pack-filebeat-mandatory-linux-unit-test-FIPS-only"

--- a/.buildkite/x-pack/pipeline.xpack.libbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.libbeat.yml
@@ -86,8 +86,8 @@ steps:
           - github_commit_status:
               context: "x-pack/libbeat: Ubuntu x86_64 Unit Tests"
 
-      - label: ":ubuntu: x-pack/libbeat: Ubuntu x86_64 Unit Tests FIPS"
-        key: "mandatory-linux-unit-test-fips"
+      - label: ":ubuntu: x-pack/libbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
+        key: "mandatory-linux-unit-test-fips-tag"
         command: |
           cd x-pack/libbeat
           mage unitTest
@@ -105,7 +105,7 @@ steps:
           - "x-pack/libbeat/build/*.json"
         notify:
           - github_commit_status:
-              context: "x-pack/libbeat: Ubuntu x86_64 Unit Tests FIPS"
+              context: "x-pack/libbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: x-pack/libbeat: Ubuntu x86_64 fips140=only Unit Tests"
         key: "mandatory-linux-unit-test-fips-only"

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -99,8 +99,8 @@ steps:
           - github_commit_status:
               context: "x-pack/metricbeat: Ubuntu x86_64 Unit Tests"
 
-      - label: ":ubuntu: x-pack/metricbeat: Ubuntu x86_64 Unit Tests FIPS"
-        key: "mandatory-linux-unit-test-fips"
+      - label: ":ubuntu: x-pack/metricbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
+        key: "mandatory-linux-unit-test-fips-tag"
         command: |
           cd x-pack/metricbeat
           mage unitTest
@@ -124,7 +124,7 @@ steps:
               debug: true
         notify:
           - github_commit_status:
-              context: "x-pack/metricbeat: Ubuntu x86_64 Unit Tests FIPS"
+              context: "x-pack/metricbeat: Ubuntu x86_64 Unit Tests with requirefips build tag"
 
       - label: ":ubuntu: x-pack/metricbeat: Ubuntu x86_64 fips140=only Unit Tests"
         key: "mandatory-linux-unit-test-fips-only"


### PR DESCRIPTION
Rename the step in buildkite so it is very clear that tests are ran for files (or libraries) that make use of the requirefips build tag.