### PR TITLE
Update APT and YUM docs with correct artifacts path

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -42,5 +42,6 @@ subs:
   monitor-features:   "monitoring features"
   stack-version: "9.0.0"
   major-version: "9.0"
+  major-release: "9.x"
   beats-pull: "https://github.com/elastic/beats/pull/"
   beats-issue: "https://github.com/elastic/beats/issue/"

--- a/docs/reference/auditbeat/setup-repositories.md
+++ b/docs/reference/auditbeat/setup-repositories.md
@@ -85,7 +85,7 @@ To add the Beats repository for YUM:
     ```shell subs=true
     [elastic-{{major-version}}]
     name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/9.x/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
     ```
     :::
 

--- a/docs/reference/auditbeat/setup-repositories.md
+++ b/docs/reference/auditbeat/setup-repositories.md
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-version}}]
-    name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/9.x/yum
+    [elastic-{{major-release}}]
+    name=Elastic repository for {{major-release}} packages
+    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
     ```
     :::
 

--- a/docs/reference/filebeat/setup-repositories.md
+++ b/docs/reference/filebeat/setup-repositories.md
@@ -85,7 +85,7 @@ To add the Beats repository for YUM:
     ```shell subs=true
     [elastic-{{major-version}}]
     name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/9.x/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
     ```
     :::
 

--- a/docs/reference/filebeat/setup-repositories.md
+++ b/docs/reference/filebeat/setup-repositories.md
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-version}}]
-    name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/9.x/yum
+    [elastic-{{major-release}}]
+    name=Elastic repository for {{major-release}} packages
+    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
     ```
     :::
 

--- a/docs/reference/heartbeat/setup-repositories.md
+++ b/docs/reference/heartbeat/setup-repositories.md
@@ -85,7 +85,7 @@ To add the Beats repository for YUM:
     ```shell subs=true
     [elastic-{{major-version}}]
     name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/9.x/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
     ```
     :::
 

--- a/docs/reference/heartbeat/setup-repositories.md
+++ b/docs/reference/heartbeat/setup-repositories.md
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-version}}]
-    name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/9.x/yum
+    [elastic-{{major-release}}]
+    name=Elastic repository for {{major-release}} packages
+    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
     ```
     :::
 

--- a/docs/reference/metricbeat/setup-repositories.md
+++ b/docs/reference/metricbeat/setup-repositories.md
@@ -85,7 +85,7 @@ To add the Beats repository for YUM:
     ```shell subs=true
     [elastic-{{major-version}}]
     name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/9.x/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
     ```
     :::
 

--- a/docs/reference/metricbeat/setup-repositories.md
+++ b/docs/reference/metricbeat/setup-repositories.md
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-version}}]
-    name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/9.x/yum
+    [elastic-{{major-release}}]
+    name=Elastic repository for {{major-release}} packages
+    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
     ```
     :::
 

--- a/docs/reference/packetbeat/setup-repositories.md
+++ b/docs/reference/packetbeat/setup-repositories.md
@@ -85,7 +85,7 @@ To add the Beats repository for YUM:
     ```shell subs=true
     [elastic-{{major-version}}]
     name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/9.x/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-version}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
     ```
     :::
 

--- a/docs/reference/packetbeat/setup-repositories.md
+++ b/docs/reference/packetbeat/setup-repositories.md
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-version}}]
-    name=Elastic repository for {{major-version}} packages
-    baseurl=https://artifacts.elastic.co/packages/9.x/yum
+    [elastic-{{major-release}}]
+    name=Elastic repository for {{major-release}} packages
+    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-9.x/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
     ```
     :::
 


### PR DESCRIPTION
The YUM setup instructions for each of the Beats currently have `9.0` in the Elastic Package Repo path (see [Filebeat](https://www.elastic.co/docs/reference/beats/filebeat/setup-repositories#_yum) for example). This fixes the instructions to have `9.x` instead.

Rel: https://github.com/elastic/beats/pull/43386
Closes: https://github.com/elastic/docs-content/issues/1227

---

<img width="662" alt="screen" src="https://github.com/user-attachments/assets/91bad92f-b084-4701-98e6-cf898d56fe4d" />


