### PR TITLE
Fix EvtVarTypeAnsiString conversion in winlogbeat

### DIFF
--- a/winlogbeat/sys/strings_windows.go
+++ b/winlogbeat/sys/strings_windows.go
@@ -19,6 +19,7 @@ package sys
 
 import (
 	"sync"
+	"bytes"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/text/encoding"
@@ -48,6 +49,8 @@ func initANSIDecoder() *encoding.Decoder {
 }
 
 func ANSIBytesToString(enc []byte) (string, error) {
-	out, err := getCachedANSIDecoder().Bytes(enc)
+	// Trim to the null terminator
+	prefix, _, _ := bytes.Cut(enc, []byte("\x00"))
+	out, err := getCachedANSIDecoder().Bytes(prefix)
 	return string(out), err
 }


### PR DESCRIPTION
- Bug

## Handle null terminator in ANSIBytesToString

### WHAT:
Trim `AnsiStringVal` to the null terminator in the `ANSIBytesToString` function.

### WHY:
(Details, including logs, TBC)

In `winlogbeat/sys/wineventlog/syscall_windows.go`, there's a recurring pattern of `_EvtGet*` WinAPI functions called twice, first with a `nil` buffer pointer, to establish the required buffer size. Indeed, looking at e.g. [documentation for EvtGetEventMetadataProperty](https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtgeteventmetadataproperty) this seems to be the right way. However, despite the phrase "required buffer size" in the docs, the value returned via `EventMetadataPropertyBufferUsed` is not guaranteed to exactly describe the retrieved property size.
The `EvtVariant.Data` method makes an implicit assumption that variable-length event data types fill the `buf[offset:]` byte slice exactly, factoring in further golang-specific interpretation. This certainly isn't true for both flavours of strings, for two reasons:
 - The null terminator is not part of a string in golang.
 - `wevtapi.dll!EvtGetEventMetadataProperty` occasionally returns a buffer size rounded up to align to 4 or 8

I have no clue why inflating the returned buffer size happens, but I have oberved it with my very own eyes, tracing a v9.0.0 winlogbeat on a Win10 machine with default sysmon+winlogbeat configuration. I have it on good authority that a similar thing happens on Windows Server machines.

Anyway, this detail makes no difference for consumers written in languages with first-class null-terminated strings. According to [the EVT_VARIANT documentation](https://learn.microsoft.com/en-us/windows/win32/api/winevt/ns-winevt-evt_variant), both `StringVal` and `AnsiStringVal` are null terminated.
The parsing logic for `StringVal`/`EvtVarTypeString` is not affected, because it relies on `common.UTF16ToUTF8Bytes`, which explicitly handles the (wide) null terminator. However, the `EvtVarTypeAnsiString` case passes the byte slice directly to a `Decoder` from `golang.org/x/text/encoding`, which happily interprets null bytes as `U+0000`.

The end result is that events with fields with declared `inType="win:AnsiString"` contain extra code points beyond the correct string; at the very least, a trailing `U+0000`. This is especially severe for empty strings.
It's easiest to spot with the `Microsoft-Windows-Kernel-Boot` event provider, event code 27, field `LoadOptions`. The [decompiled manifest](https://github.com/repnz/etw-providers-docs/blob/master/Manifests-Win10-18990/Microsoft-Windows-Kernel-Boot.xml#L1128) confirms that its type is `AnsiString`.

**Please note that I'm not a golang developer. I am sure the event provider mentioned above is affected (see below for reproduction steps), I am convinced the current implementation is incorrect, but I have no evidence my proposed changes fix anything. Until I figure out the build process, I submit this wall of text for your consideration.**

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [Hopefully] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

I can't imagine anyone relies on this bug.

## How to test this PR locally
TBC 

* Install sysmon with default configuration
* Start Winlogbeat with the default configuration, but edited to only use `output.file`
* Check the output files for events containing stray `\u0000` codepoints

## Related issues

- Relates #41418
- Relates #40684

## Logs

TBC