### PR TITLE
Use encoded api key on es-exporter config

### DIFF
--- a/libbeat/otelbeat/beatconverter/beatconverter_test.go
+++ b/libbeat/otelbeat/beatconverter/beatconverter_test.go
@@ -31,12 +31,11 @@ import (
 var esCommonOutput = `
 exporters:
   elasticsearch:
-    api_key: ""
     endpoints:
       - https://localhost:9200
     idle_conn_timeout: 3s
     logs_index: form-otel-exporter
-    num_workers: 0
+    num_workers: 1
     password: changeme
     retry:
       enabled: true
@@ -174,12 +173,11 @@ service:
 		var expectedOutput = `
 exporters:
   elasticsearch:
-    api_key: ""
     endpoints:
       - https://es-hostname.elastic.co:443
     idle_conn_timeout: 3s
     logs_index: form-otel-exporter
-    num_workers: 0
+    num_workers: 1
     password: password
     retry:
       enabled: true

--- a/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
+++ b/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
@@ -126,17 +126,14 @@ func ToOTelConfig(output *config.C) (map[string]any, error) {
 	}
 
 	// get number of workers
-	var worker int // Default value is 1
-	if escfg.NumWorkers() < 1 {
-		worker = 1
-	} else {
-		worker = escfg.NumWorkers()
+	workers := 1 // Default value is 1
+	if escfg.NumWorkers() > 1 {
+		workers = escfg.NumWorkers()
 	}
-
 	otelYAMLCfg := map[string]any{
 		"logs_index":  escfg.Index, // index
 		"endpoints":   hosts,       // hosts, protocol, path, port
-		"num_workers": worker,      // worker/workers
+		"num_workers": workers,     // worker/workers
 
 		// ClientConfig
 		"timeout":           escfg.Transport.Timeout,         // timeout

--- a/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
+++ b/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
@@ -18,6 +18,7 @@
 package elasticsearchtranslate
 
 import (
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"strings"
@@ -69,7 +70,7 @@ var defaultOptions = esToOTelOptions{
 	Preset:   "custom", // default is custom if not set
 }
 
-// ToOTelConfig converts a Beat config into an OTel elasticsearch exporter config
+// ToOTelConfig converts a Beat config into OTel elasticsearch exporter config
 // Ensure cloudid is handled before calling this method
 // Note: This method may override output queue settings defined by user.
 func ToOTelConfig(output *config.C) (map[string]any, error) {
@@ -108,6 +109,7 @@ func ToOTelConfig(output *config.C) (map[string]any, error) {
 		return nil, err
 	}
 
+	//Create url using host name, protocol and path
 	hosts := []string{}
 	for _, h := range escfg.Hosts {
 		esURL, err := common.MakeURL(escfg.Protocol, escfg.Path, h, 9200)
@@ -123,19 +125,22 @@ func ToOTelConfig(output *config.C) (map[string]any, error) {
 		return nil, fmt.Errorf("cannot convert SSL config into OTel: %w", err)
 	}
 
-	otelYAMLCfg := map[string]any{
-		"logs_index":  escfg.Index,        // index
-		"endpoints":   hosts,              // hosts, protocol, path, port
-		"num_workers": escfg.NumWorkers(), // worker/workers
+	// get number of workers
+	var worker int // Default value is 1
+	if escfg.NumWorkers() < 1 {
+		worker = 1
+	} else {
+		worker = escfg.NumWorkers()
+	}
 
-		// Authentication
-		"user":     escfg.Username, // username
-		"password": escfg.Password, // password
-		"api_key":  escfg.APIKey,   // api_key
+	otelYAMLCfg := map[string]any{
+		"logs_index":  escfg.Index, // index
+		"endpoints":   hosts,       // hosts, protocol, path, port
+		"num_workers": worker,      // worker/workers
 
 		// ClientConfig
 		"timeout":           escfg.Transport.Timeout,         // timeout
-		"idle_conn_timeout": escfg.Transport.IdleConnTimeout, // idle_connection_connection_timeout
+		"idle_conn_timeout": escfg.Transport.IdleConnTimeout, // idle_connection_timeout
 
 		// Retry
 		"retry": map[string]any{
@@ -157,6 +162,11 @@ func ToOTelConfig(output *config.C) (map[string]any, error) {
 			"mode": "bodymap",
 		},
 	}
+
+	// Authentication
+	setIfNotNil(otelYAMLCfg, "user", escfg.Username)                                             // username
+	setIfNotNil(otelYAMLCfg, "password", escfg.Password)                                         // password
+	setIfNotNil(otelYAMLCfg, "api_key", base64.StdEncoding.EncodeToString([]byte(escfg.APIKey))) // api_key
 
 	setIfNotNil(otelYAMLCfg, "headers", escfg.Headers)    // headers
 	setIfNotNil(otelYAMLCfg, "tls", otelTLSConfg)         // tls config

--- a/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
+++ b/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
@@ -109,7 +109,7 @@ func ToOTelConfig(output *config.C) (map[string]any, error) {
 		return nil, err
 	}
 
-	//Create url using host name, protocol and path
+	// Create url using host name, protocol and path
 	hosts := []string{}
 	for _, h := range escfg.Hosts {
 		esURL, err := common.MakeURL(escfg.Protocol, escfg.Path, h, 9200)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
Beats uses unencoded api key to connect to elasticsearch - whereas es-exporter expects encoded api key. This PR addresses this. 

It also ensures `num_workers` is always >=1.  
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Create an api key using using following curl command 
``` sh
curl -u "admin:testing" \
  --request PUT 'http://localhost:9200/_security/api_key' \
  --header "Content-Type: application/json" \
  --data '{
    "name": "my-api-key",
    "expiration": "1d",
    "role_descriptors": {
      "role-a": {
        "cluster": ["all"],
        "indices": [
          {
            "names": ["logs-*"],
            "privileges": ["read"]
          }
        ]
      }
    },
    "metadata": {
      "application": "my-application",
      "environment": {
        "level": 1,
        "trusted": true,
        "tags": ["dev", "staging"]
      }
    }
  }'
```

Start filebeat otel with unencoded api key and you can observe logs correctly being indexed
