### PR TITLE
enable internal http monitoring for metricbeat receiver

### DIFF
--- a/x-pack/filebeat/fbreceiver/factory.go
+++ b/x-pack/filebeat/fbreceiver/factory.go
@@ -68,7 +68,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		HTTP *config.C `config:"http"`
 	}{}
 	if err := b.RawConfig.Unpack(&httpConf); err != nil {
-		return nil, fmt.Errorf("error starting API :%w", err)
+		return nil, fmt.Errorf("error unpacking monitoring config: %w", err)
 	}
 
 	base := beatreceiver.BeatReceiver{

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/otelbeat/beatreceiver"
 	"github.com/elastic/beats/v7/metricbeat/beater"
 	"github.com/elastic/beats/v7/metricbeat/cmd"
 	"github.com/elastic/elastic-agent-libs/config"
@@ -58,7 +59,13 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("error starting API :%w", err)
 	}
 
-	return &metricbeatReceiver{beat: b, beater: mbBeater, logger: set.Logger, httpConf: httpConf.HTTP}, nil
+	beatReceiver := beatreceiver.BeatReceiver{
+		Beat:     b,
+		Beater:   mbBeater,
+		Logger:   set.Logger,
+		HttpConf: httpConf.HTTP,
+	}
+	return &metricbeatReceiver{BeatReceiver: beatReceiver}, nil
 }
 
 func NewFactory() receiver.Factory {

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -56,7 +56,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		HTTP *config.C `config:"http"`
 	}{}
 	if err := b.RawConfig.Unpack(&httpConf); err != nil {
-		return nil, fmt.Errorf("error starting API: %w", err)
+		return nil, fmt.Errorf("error unpacking monitoring config: %w", err)
 	}
 
 	beatReceiver := beatreceiver.BeatReceiver{

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -56,7 +56,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		HTTP *config.C `config:"http"`
 	}{}
 	if err := b.RawConfig.Unpack(&httpConf); err != nil {
-		return nil, fmt.Errorf("error starting API :%w", err)
+		return nil, fmt.Errorf("error starting API: %w", err)
 	}
 
 	beatReceiver := beatreceiver.BeatReceiver{

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/metricbeat/beater"
 	"github.com/elastic/beats/v7/metricbeat/cmd"
+	"github.com/elastic/elastic-agent-libs/config"
 )
 
 const (
@@ -50,7 +51,14 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("error getting %s creator:%w", Name, err)
 	}
 
-	return &metricbeatReceiver{beat: &b.Beat, beater: mbBeater, logger: set.Logger}, nil
+	httpConf := struct {
+		HTTP *config.C `config:"http"`
+	}{}
+	if err := b.RawConfig.Unpack(&httpConf); err != nil {
+		return nil, fmt.Errorf("error starting API :%w", err)
+	}
+
+	return &metricbeatReceiver{beat: b, beater: mbBeater, logger: set.Logger, httpConf: httpConf.HTTP}, nil
 }
 
 func NewFactory() receiver.Factory {

--- a/x-pack/metricbeat/mbreceiver/receiver.go
+++ b/x-pack/metricbeat/mbreceiver/receiver.go
@@ -9,89 +9,34 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/elastic/beats/v7/libbeat/api"
-	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/cmd/instance"
-	"github.com/elastic/beats/v7/libbeat/version"
-	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
-	metricreport "github.com/elastic/elastic-agent-system-metrics/report"
+	"github.com/elastic/beats/v7/libbeat/otelbeat/beatreceiver"
 
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 )
 
 type metricbeatReceiver struct {
-	beat     *instance.Beat
-	beater   beat.Beater
-	logger   *zap.Logger
-	wg       sync.WaitGroup
-	httpConf *config.C
+	beatreceiver.BeatReceiver
+	wg sync.WaitGroup
 }
 
 func (mb *metricbeatReceiver) Start(ctx context.Context, host component.Host) error {
 	mb.wg.Add(1)
 	go func() {
 		defer mb.wg.Done()
-		mb.logger.Info("starting metricbeat receiver")
-		if err := mb.startMonitoring(); err != nil {
-			mb.logger.Error("could not start the HTTP server for the monitoring API", zap.Error(err))
-		}
-		if err := mb.beater.Run(&mb.beat.Beat); err != nil {
-			mb.logger.Error("metricbeat receiver run error", zap.Error(err))
+		mb.Logger.Info("starting metricbeat receiver")
+		if err := mb.BeatReceiver.Start(); err != nil {
+			mb.Logger.Error("error starting metricbeat receiver", zap.Error(err))
 		}
 	}()
 	return nil
 }
 
 func (mb *metricbeatReceiver) Shutdown(ctx context.Context) error {
-	mb.logger.Info("stopping metricbeat receiver")
-	mb.beater.Stop()
-	if err := mb.stopMonitoring(); err != nil {
+	mb.Logger.Info("stopping metricbeat receiver")
+	if err := mb.BeatReceiver.Shutdown(); err != nil {
 		return fmt.Errorf("error stopping monitoring server: %w", err)
 	}
 	mb.wg.Wait()
 	return nil
-}
-
-func (mb *metricbeatReceiver) startMonitoring() error {
-	if !mb.httpConf.Enabled() {
-		return nil
-	}
-	var err error
-
-	mb.beat.RegisterMetrics()
-
-	statsReg := mb.beat.Info.Monitoring.StatsRegistry
-
-	// stats.beat
-	processReg := statsReg.GetRegistry("beat")
-	if processReg == nil {
-		processReg = statsReg.NewRegistry("beat")
-	}
-
-	// stats.system
-	systemReg := statsReg.GetRegistry("system")
-	if systemReg == nil {
-		systemReg = statsReg.NewRegistry("system")
-	}
-
-	err = metricreport.SetupMetrics(logp.NewLogger("metrics"), mb.beat.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
-	if err != nil {
-		return err
-	}
-	mb.beat.API, err = api.NewWithDefaultRoutes(logp.NewLogger("metrics.http"), mb.httpConf, api.RegistryLookupFunc(mb.beat.Info.Monitoring.Namespace))
-	if err != nil {
-		return err
-	}
-	mb.beat.API.Start()
-
-	return nil
-}
-
-func (mb *metricbeatReceiver) stopMonitoring() error {
-	if mb.beat.API == nil {
-		return nil
-	}
-	return mb.beat.API.Stop()
 }

--- a/x-pack/metricbeat/mbreceiver/receiver.go
+++ b/x-pack/metricbeat/mbreceiver/receiver.go
@@ -6,19 +6,27 @@ package mbreceiver
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
+	"github.com/elastic/beats/v7/libbeat/api"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/version"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	metricreport "github.com/elastic/elastic-agent-system-metrics/report"
 
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 )
 
 type metricbeatReceiver struct {
-	beat   *beat.Beat
-	beater beat.Beater
-	logger *zap.Logger
-	wg     sync.WaitGroup
+	beat     *instance.Beat
+	beater   beat.Beater
+	logger   *zap.Logger
+	wg       sync.WaitGroup
+	httpConf *config.C
 }
 
 func (mb *metricbeatReceiver) Start(ctx context.Context, host component.Host) error {
@@ -26,8 +34,10 @@ func (mb *metricbeatReceiver) Start(ctx context.Context, host component.Host) er
 	go func() {
 		defer mb.wg.Done()
 		mb.logger.Info("starting metricbeat receiver")
-		err := mb.beater.Run(mb.beat)
-		if err != nil {
+		if err := mb.startMonitoring(); err != nil {
+			mb.logger.Error("could not start the HTTP server for the monitoring API", zap.Error(err))
+		}
+		if err := mb.beater.Run(&mb.beat.Beat); err != nil {
 			mb.logger.Error("metricbeat receiver run error", zap.Error(err))
 		}
 	}()
@@ -37,6 +47,51 @@ func (mb *metricbeatReceiver) Start(ctx context.Context, host component.Host) er
 func (mb *metricbeatReceiver) Shutdown(ctx context.Context) error {
 	mb.logger.Info("stopping metricbeat receiver")
 	mb.beater.Stop()
+	if err := mb.stopMonitoring(); err != nil {
+		return fmt.Errorf("error stopping monitoring server: %w", err)
+	}
 	mb.wg.Wait()
 	return nil
+}
+
+func (mb *metricbeatReceiver) startMonitoring() error {
+	if !mb.httpConf.Enabled() {
+		return nil
+	}
+	var err error
+
+	mb.beat.RegisterMetrics()
+
+	statsReg := mb.beat.Info.Monitoring.StatsRegistry
+
+	// stats.beat
+	processReg := statsReg.GetRegistry("beat")
+	if processReg == nil {
+		processReg = statsReg.NewRegistry("beat")
+	}
+
+	// stats.system
+	systemReg := statsReg.GetRegistry("system")
+	if systemReg == nil {
+		systemReg = statsReg.NewRegistry("system")
+	}
+
+	err = metricreport.SetupMetrics(logp.NewLogger("metrics"), mb.beat.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
+	if err != nil {
+		return err
+	}
+	mb.beat.API, err = api.NewWithDefaultRoutes(logp.NewLogger("metrics.http"), mb.httpConf, api.RegistryLookupFunc(mb.beat.Info.Monitoring.Namespace))
+	if err != nil {
+		return err
+	}
+	mb.beat.API.Start()
+
+	return nil
+}
+
+func (mb *metricbeatReceiver) stopMonitoring() error {
+	if mb.beat.API == nil {
+		return nil
+	}
+	return mb.beat.API.Stop()
 }

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -84,14 +84,20 @@ func TestNewReceiver(t *testing.T) {
 						},
 					},
 				}
-				r, err := client.Get("http://unix/stats")
+				req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://unix/stats", nil)
+				if err != nil {
+					lastError.Reset()
+					lastError.WriteString(fmt.Sprintf("error creating request: %s", err))
+					return false
+				}
+				resp, err := client.Do(req)
 				if err != nil {
 					lastError.Reset()
 					lastError.WriteString(fmt.Sprintf("client.Get failed: %s", err))
 					return false
 				}
-				defer r.Body.Close()
-				body, err := io.ReadAll(r.Body)
+				defer resp.Body.Close()
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					lastError.Reset()
 					lastError.WriteString(fmt.Sprintf("io.ReadAll of body failed: %s", err))
@@ -162,7 +168,7 @@ func TestMultipleReceivers(t *testing.T) {
 func genSocketPath() string {
 	randData := make([]byte, 16)
 	for i := range len(randData) {
-		randData[i] = uint8(rand.UintN(255))
+		randData[i] = uint8(rand.UintN(255)) //nolint:gosec // 0-255 fits in a unint8
 	}
 	socketName := base64.URLEncoding.EncodeToString(randData) + ".sock"
 	socketDir := os.TempDir()

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -28,7 +28,12 @@ import (
 
 func TestNewReceiver(t *testing.T) {
 	monitorSocket := genSocketPath()
-	monitorHost := "unix://" + monitorSocket
+	monitorHost := ""
+	if runtime.GOOS == "windows" {
+		monitorHost = "npipe:///" + filepath.Base(monitorSocket)
+	} else {
+		monitorHost = "unix://" + monitorSocket
+	}
 	config := Config{
 		Beatconfig: map[string]any{
 			"metricbeat": map[string]any{


### PR DESCRIPTION
## Proposed commit message

Enable internal monitoring for metricbeat receiver.  This is analogous to #42886 which enabled internal monitoring for filebeat receiver

The internal monitoring is configured exactly the same way as beats with the `http` configuration block.

Example:

```yaml
http:
  enabled: true
  host: unix:///tmp/monitoring.socket
```



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

No user impact.  Beats receivers are not GA yet.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

The `TestNewReceiver` unit test start the monitoring endpoint and makes sure that data can be read from it.

```shell
cd x-pack/metricbeat/mbreceiver
go test .
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #42886
- Closes #43875

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
