### PR TITLE
Add a note that `api_key` and `cloud.auth` are not related

### DIFF
--- a/docs/reference/auditbeat/configure-cloud-id.md
+++ b/docs/reference/auditbeat/configure-cloud-id.md
@@ -30,7 +30,7 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Auditbea
 ## `cloud.auth` [_cloud_auth]
 
 ::::{important}
-`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+`cloud.auth` should not be confused with API keys generated in {{ecloud}} stack management. Although these values look similar, they are unrelated.
 ::::
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.

--- a/docs/reference/auditbeat/configure-cloud-id.md
+++ b/docs/reference/auditbeat/configure-cloud-id.md
@@ -29,6 +29,8 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Auditbea
 
 ## `cloud.auth` [_cloud_auth]
 
+::::{important}
+`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+::::
+
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.
-
-

--- a/docs/reference/filebeat/configure-cloud-id.md
+++ b/docs/reference/filebeat/configure-cloud-id.md
@@ -30,7 +30,7 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Filebeat
 ## `cloud.auth` [_cloud_auth]
 
 ::::{important}
-`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+`cloud.auth` should not be confused with API keys generated in {{ecloud}} stack management. Although these values look similar, they are unrelated.
 ::::
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.

--- a/docs/reference/filebeat/configure-cloud-id.md
+++ b/docs/reference/filebeat/configure-cloud-id.md
@@ -29,6 +29,8 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Filebeat
 
 ## `cloud.auth` [_cloud_auth]
 
+::::{important}
+`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+::::
+
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.
-
-

--- a/docs/reference/heartbeat/configure-cloud-id.md
+++ b/docs/reference/heartbeat/configure-cloud-id.md
@@ -30,7 +30,7 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Heartbea
 ## `cloud.auth` [_cloud_auth]
 
 ::::{important}
-`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+`cloud.auth` should not be confused with API keys generated in {{ecloud}} stack management. Although these values look similar, they are unrelated.
 ::::
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.

--- a/docs/reference/heartbeat/configure-cloud-id.md
+++ b/docs/reference/heartbeat/configure-cloud-id.md
@@ -29,6 +29,8 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Heartbea
 
 ## `cloud.auth` [_cloud_auth]
 
+::::{important}
+`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+::::
+
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.
-
-

--- a/docs/reference/metricbeat/configure-cloud-id.md
+++ b/docs/reference/metricbeat/configure-cloud-id.md
@@ -30,7 +30,7 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Metricbe
 ## `cloud.auth` [_cloud_auth]
 
 ::::{important}
-`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+`cloud.auth` should not be confused with API keys generated in {{ecloud}} stack management. Although these values look similar, they are unrelated.
 ::::
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.

--- a/docs/reference/metricbeat/configure-cloud-id.md
+++ b/docs/reference/metricbeat/configure-cloud-id.md
@@ -29,6 +29,8 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Metricbe
 
 ## `cloud.auth` [_cloud_auth]
 
+::::{important}
+`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+::::
+
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.
-
-

--- a/docs/reference/packetbeat/configure-cloud-id.md
+++ b/docs/reference/packetbeat/configure-cloud-id.md
@@ -30,7 +30,7 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Packetbe
 ## `cloud.auth` [_cloud_auth]
 
 ::::{important}
-`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+`cloud.auth` should not be confused with API keys generated in {{ecloud}} stack management. Although these values look similar, they are unrelated.
 ::::
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.

--- a/docs/reference/packetbeat/configure-cloud-id.md
+++ b/docs/reference/packetbeat/configure-cloud-id.md
@@ -29,6 +29,8 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Packetbe
 
 ## `cloud.auth` [_cloud_auth]
 
+::::{important}
+`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+::::
+
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.
-
-

--- a/docs/reference/winlogbeat/configure-cloud-id.md
+++ b/docs/reference/winlogbeat/configure-cloud-id.md
@@ -29,6 +29,8 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Winlogbe
 
 ## `cloud.auth` [_cloud_auth]
 
+::::{important}
+`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+::::
+
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.
-
-

--- a/docs/reference/winlogbeat/configure-cloud-id.md
+++ b/docs/reference/winlogbeat/configure-cloud-id.md
@@ -30,7 +30,7 @@ The Cloud ID, which can be found in the {{ess}} web console, is used by Winlogbe
 ## `cloud.auth` [_cloud_auth]
 
 ::::{important}
-`cloud.auth` should not be confused with API keys generated in the cloud stack management. Although these values look similar, they are unrelated.
+`cloud.auth` should not be confused with API keys generated in {{ecloud}} stack management. Although these values look similar, they are unrelated.
 ::::
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and `output.elasticsearch.password` settings. Because the Kibana settings inherit the username and password from the {{es}} output, this can also be used to set the `setup.kibana.username` and `setup.kibana.password` options.


### PR DESCRIPTION
The similarity of the values might mislead users into thinking that they are interchangeable.

Preview https://docs-v3-preview.elastic.dev/elastic/beats/pull/44053/reference/filebeat/configure-cloud-id#_cloud_auth

<img width="750" alt="Screenshot 2025-04-24 at 16 56 28" src="https://github.com/user-attachments/assets/7d0a9668-9031-4a24-8a27-c6114c3933a6" />
