### PR TITLE
Install systemd on Filebeat Docker images

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -230,6 +230,30 @@ done; \
 (exit $exit_code)
 {{- end }}
 
+# Journald input
+{{- if (eq .BeatName "filebeat") }}
+
+    {{- if (contains .from "wolfi") }}
+    RUN for iter in {1..10}; do \
+            apk update && \
+            apk add --no-interactive --no-progress --no-cache systemd && \
+            exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
+        done; \
+        (exit $exit_code)
+    {{- end}}
+
+    {{- if (contains .from "ubi") }}
+    RUN for iter in {1..10}; do \
+            microdnf -y update && \
+            microdnf -y install systemd && \
+            microdnf clean all && \
+            exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; \
+        done; \
+        (exit $exit_code)
+    {{- end}}
+
+{{- end }}
+
 {{- if eq .user "root" }}
 USER 0
 {{- else }}

--- a/docs/reference/filebeat/filebeat-input-journald.md
+++ b/docs/reference/filebeat/filebeat-input-journald.md
@@ -11,9 +11,10 @@ mapped_pages:
 :::{important}
 When using the Journald input from a Docker container, make sure the
 `journalctl` binary in the container is compatible with your
-Systemd/journal version, to get the version of the `journalctl` binary
-in Filebeat's image run (adjust the image name/tag accordingly to the
-version you are running):
+Systemd/journal version. To get the version of the `journalctl` binary
+in Filebeat's image run the following, adjusting the image name/tag 
+according to the version that you are running:
+
 
 ```sh
 docker run --rm -it --entrypoint "journalctl" docker.elastic.co/beats/filebeat-wolfi:<VERSION> --version

--- a/docs/reference/filebeat/filebeat-input-journald.md
+++ b/docs/reference/filebeat/filebeat-input-journald.md
@@ -8,6 +8,18 @@ mapped_pages:
 
 [`journald`](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) is a system service that collects and stores logging data. The `journald` input reads this log data and the metadata associated with it. To read this log data Filebeat calls `journalctl` to read from the journal, therefore Filebeat needs permission to execute `journalctl`.
 
+:::{important}
+When using the Journald input from a Docker container, make sure the
+`journalctl` binary in the container is compatible with your
+Systemd/journal version, to get the version of the `journalctl` binary
+in Filebeat's image run (adjust the image name/tag accordingly to the
+version you are running):
+
+```sh
+docker run --rm -it --entrypoint "journalctl" docker.elastic.co/beats/filebeat-wolfi:<VERSION> --version
+```
+:::
+
 If the `journalctl` process exits unexpectedly the journald input will terminate with an error and Filebeat will need to be restarted to start reading from the journal again.
 
 The simplest configuration example is one that reads all logs from the default journal.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -16,6 +16,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Features and enhancements [beats-versionext-features-enhancements]
 
 % ### Fixes [beats-versionext-fixes]
+* Filebeat Journald input now works on Docker containers [#41278]({{beats-issue}}41278) [#44040]({{beats-issue}}44040) [#44056]({{beats-pull}}44056)
 
 ## 9.0.0 [beats-900-release-notes]
 


### PR DESCRIPTION
## Proposed commit message

The journald input from Filebeat requires the `journalctl` binary to ingest journal logs, this commit adds it by installing systemd in all Filebeat Docker container images

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

1. Package Filebeat
    ```sh
    DEV=true SNAPSHOT=true PACKAGES="docker" PLATFORMS=linux/amd64 mage -v package
    ```
2. Ensure `journalctl` is present in the containers (adjust the image name/tag according to the version you built, oss or not)
   ```sh
   docker run --rm -it --user root --entrypoint "journalctl" docker.elastic.co/beats/filebeat-wolfi:9.1.0-SNAPSHOT --version
   docker run --rm -it --user root --entrypoint "journalctl" docker.elastic.co/beats/filebeat-ubi:9.1.0-SNAPSHOT --version
   # Only for x-pack
   docker run --rm -it --user root --entrypoint "journalctl" docker.elastic.co/beats/filebeat:9.1.0-SNAPSHOT --version
   ```
3. Start a stack. E.g: using elastic-package: `elastic-package stack up --version=9.1.0-SNAPSHOT -v -d`
4. Create the following `filebeat.yml` (adjust the IP address/ES host as needed)
   <details><summary>filebeat.yml</summary>
   <p>
   
   ```yaml
   filebeat.inputs:
     - type: journald
       id: foo-bar
       paths:
         - /var/log/journal/*/*.journal
   
   output.elasticsearch:
     hosts:
       - https://192.168.42.42:9200
     username: elastic
     password: changeme
     ssl.verification_mode: none
   ```
   
   </p>
   </details> 

5. Then run Filebeat from the docker image (adjust the journald folder if needed)
   ```sh
   docker run --rm \
     --name=filebeat \
     --user=root \
     --volume="/var/log/journal:/var/log/journal:ro" \
     --volume="$(pwd)/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro" \
     --volume="registry:/usr/share/filebeat/data:rw" \
     docker.elastic.co/beats/filebeat-wolfi:9.1.0-SNAPSHOT filebeat -e --strict.perms=false setup
   ```
5. Ensure there are no errors and data is ingested


## Related issues
- Relates https://github.com/elastic/beats/issues/44040
- Fixes https://github.com/elastic/beats/issues/41278

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
