### PR TITLE
Fix Docker and K8s install instructions

### DIFF
--- a/docs/reference/auditbeat/load-kibana-dashboards.md
+++ b/docs/reference/auditbeat/load-kibana-dashboards.md
@@ -59,7 +59,8 @@ PS > .\auditbeat.exe setup --dashboards
 ::::::
 
 :::::::
-For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md). If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
+For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
+If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
 
 
 ## Load dashboards for Logstash output [load-dashboards-logstash]

--- a/docs/reference/auditbeat/running-on-docker.md
+++ b/docs/reference/auditbeat/running-on-docker.md
@@ -108,8 +108,8 @@ The Docker image provides several methods for configuring Auditbeat. The convent
 
 Download this example configuration file as a starting point:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/auditbeat.docker.yml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/auditbeat.docker.yml
 ```
 
 

--- a/docs/reference/auditbeat/running-on-kubernetes.md
+++ b/docs/reference/auditbeat/running-on-kubernetes.md
@@ -23,8 +23,8 @@ Everything is deployed under `kube-system` namespace, you can change that by upd
 
 To get the manifests just run:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/kubernetes/auditbeat-kubernetes.yaml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/auditbeat-kubernetes.yaml
 ```
 
 ::::{warning}

--- a/docs/reference/filebeat/command-line-options.md
+++ b/docs/reference/filebeat/command-line-options.md
@@ -297,7 +297,7 @@ filebeat setup [FLAGS]
 **FLAGS**
 
 **`--dashboards`**
-:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Filebeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md) in [Contribute to Beats](../../extend/index.md).
+:   Sets up the {{kib}} dashboards (when available). This option loads the dashboards from the Filebeat package. For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
 
 **`-h, --help`**
 :   Shows help for the `setup` command.

--- a/docs/reference/filebeat/running-on-cloudfoundry.md
+++ b/docs/reference/filebeat/running-on-cloudfoundry.md
@@ -34,8 +34,8 @@ Cloud Foundry requires that 3 files exist inside of a directory to allow Filebea
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-linux-x86_64.tar.gz
 tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
 cd filebeat-{{stack-version}}-linux-x86_64
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/filebeat/filebeat.yml
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/filebeat/manifest.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/filebeat/filebeat.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/filebeat/manifest.yml
 ```
 
 You need to modify the `filebeat.yml` file to set the `api_address`, `client_id` and `client_secret`.

--- a/docs/reference/filebeat/running-on-docker.md
+++ b/docs/reference/filebeat/running-on-docker.md
@@ -106,8 +106,8 @@ The Docker image provides several methods for configuring Filebeat. The conventi
 
 Download this example configuration file as a starting point:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/filebeat.docker.yml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/filebeat.docker.yml
 ```
 
 

--- a/docs/reference/filebeat/running-on-kubernetes.md
+++ b/docs/reference/filebeat/running-on-kubernetes.md
@@ -25,8 +25,8 @@ Everything is deployed under the `kube-system` namespace by default. To change t
 
 To download the manifest file, run:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/kubernetes/filebeat-kubernetes.yaml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/filebeat-kubernetes.yaml
 ```
 
 ::::{warning}

--- a/docs/reference/heartbeat/running-on-docker.md
+++ b/docs/reference/heartbeat/running-on-docker.md
@@ -107,8 +107,8 @@ The Docker image provides several methods for configuring Heartbeat. The convent
 
 Download this example configuration file as a starting point:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/heartbeat.docker.yml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/heartbeat.docker.yml
 ```
 
 

--- a/docs/reference/heartbeat/running-on-kubernetes.md
+++ b/docs/reference/heartbeat/running-on-kubernetes.md
@@ -23,8 +23,8 @@ Everything is deployed under `kube-system` namespace, you can change that by upd
 
 To get the manifests just run:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/kubernetes/heartbeat-kubernetes.yaml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/heartbeat-kubernetes.yaml
 ```
 
 ::::{warning}

--- a/docs/reference/metricbeat/load-kibana-dashboards.md
+++ b/docs/reference/metricbeat/load-kibana-dashboards.md
@@ -64,7 +64,8 @@ PS > .\metricbeat.exe setup --dashboards
 ::::::
 
 :::::::
-For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md). If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
+For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
+If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
 
 
 ## Load dashboards for Logstash output [load-dashboards-logstash]

--- a/docs/reference/metricbeat/running-on-cloudfoundry.md
+++ b/docs/reference/metricbeat/running-on-cloudfoundry.md
@@ -34,8 +34,8 @@ Cloud Foundry requires that 3 files exist inside of a directory to allow Metricb
 curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-linux-x86_64.tar.gz
 tar xzvf metricbeat-{{stack-version}}-linux-x86_64.tar.gz
 cd metricbeat-{{stack-version}}-linux-x86_64
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/metricbeat/metricbeat.yml
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/cloudfoundry/metricbeat/manifest.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/metricbeat/metricbeat.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/metricbeat/manifest.yml
 ```
 
 You need to modify the `metricbeat.yml` file to set the `api_address`, `client_id` and `client_secret`.

--- a/docs/reference/metricbeat/running-on-docker.md
+++ b/docs/reference/metricbeat/running-on-docker.md
@@ -106,8 +106,8 @@ The Docker image provides several methods for configuring Metricbeat. The conven
 
 Download this example configuration file as a starting point:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/metricbeat.docker.yml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/metricbeat.docker.yml
 ```
 
 

--- a/docs/reference/metricbeat/running-on-kubernetes.md
+++ b/docs/reference/metricbeat/running-on-kubernetes.md
@@ -27,8 +27,8 @@ Everything is deployed under the `kube-system` namespace by default. To change t
 
 To download the manifest file, run:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/kubernetes/metricbeat-kubernetes.yaml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/metricbeat-kubernetes.yaml
 ```
 
 ::::{warning}

--- a/docs/reference/packetbeat/load-kibana-dashboards.md
+++ b/docs/reference/packetbeat/load-kibana-dashboards.md
@@ -64,7 +64,8 @@ PS > .\packetbeat.exe setup --dashboards
 ::::::
 
 :::::::
-For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md). If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
+For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
+If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
 
 
 ## Load dashboards for Logstash output [load-dashboards-logstash]

--- a/docs/reference/packetbeat/running-on-docker.md
+++ b/docs/reference/packetbeat/running-on-docker.md
@@ -107,8 +107,8 @@ The Docker image provides several methods for configuring Packetbeat. The conven
 
 Download this example configuration file as a starting point:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/docker/packetbeat.docker.yml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/packetbeat.docker.yml
 ```
 
 

--- a/docs/reference/winlogbeat/load-kibana-dashboards.md
+++ b/docs/reference/winlogbeat/load-kibana-dashboards.md
@@ -59,7 +59,8 @@ PS > .\winlogbeat.exe setup --dashboards
 ::::::
 
 :::::::
-For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](http://www.elastic.co/guide/en/beats/devguide/master/import-dashboards.md). If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
+For more options, such as loading customized dashboards, see [Importing Existing Beat Dashboards](../../extend/import-dashboards.md).
+If you’ve configured the Logstash output, see [Load dashboards for Logstash output](#load-dashboards-logstash).
 
 
 ## Load dashboards for Logstash output [load-dashboards-logstash]


### PR DESCRIPTION
This fixes two issues:

 - In the "Run [Beat] on Kubernetes/Docker pages" (for example [here](https://www.elastic.co/docs/reference/beats/metricbeat/running-on-kubernetes)) the yaml file link has `master` in the path: 
       (`curl -L -O https://raw.githubusercontent.com/elastic/beats/master/deploy/kubernetes/metricbeat-kubernetes.yaml`). This needs to be replaced by a variable for the current major version:
      (`curl -L -O https://raw.githubusercontent.com/elastic/beats/9.0/deploy/kubernetes/metricbeat-kubernetes.yaml`).
 - Some pages had a broken link to [Importing existing Beats dashboards](https://www.elastic.co/docs/extend/beats/import-dashboards). 

Closes: https://github.com/elastic/ingest-docs/issues/1776