### PR TITLE
Remove systemd from the Wolfi image

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -233,15 +233,6 @@ done; \
 # Journald input
 {{- if (eq .BeatName "filebeat") }}
 
-    {{- if (contains .from "wolfi") }}
-    RUN for iter in {1..10}; do \
-            apk update && \
-            apk add --no-interactive --no-progress --no-cache systemd && \
-            exit_code=0 && break || exit_code=$? && echo "apk error: retry $iter in 10s" && sleep 10; \
-        done; \
-        (exit $exit_code)
-    {{- end}}
-
     {{- if (contains .from "ubi") }}
     RUN for iter in {1..10}; do \
             microdnf -y update && \

--- a/docs/reference/filebeat/filebeat-input-journald.md
+++ b/docs/reference/filebeat/filebeat-input-journald.md
@@ -8,11 +8,15 @@ mapped_pages:
 
 [`journald`](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) is a system service that collects and stores logging data. The `journald` input reads this log data and the metadata associated with it. To read this log data Filebeat calls `journalctl` to read from the journal, therefore Filebeat needs permission to execute `journalctl`.
 
+:::{warning}
+The Wolfi-based Docker image does not contain the `journalctl` binary and the `journald` input type cannot be used with it.
+:::
+
 :::{important}
 When using the Journald input from a Docker container, make sure the
 `journalctl` binary in the container is compatible with your
 Systemd/journal version. To get the version of the `journalctl` binary
-in Filebeat's image run the following, adjusting the image name/tag 
+in Filebeat's image run the following, adjusting the image name/tag
 according to the version that you are running:
 
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -16,7 +16,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Features and enhancements [beats-versionext-features-enhancements]
 
 % ### Fixes [beats-versionext-fixes]
-* Filebeat Journald input now works on Docker containers [#41278]({{beats-issue}}41278) [#44040]({{beats-issue}}44040) [#44056]({{beats-pull}}44056)
+* Filebeat Journald input now works on Docker containers (except Wolfi) [#41278]({{beats-issue}}41278) [#44040]({{beats-issue}}44040) [#44056]({{beats-pull}}44056)
 
 ## 9.0.0 [beats-900-release-notes]
 


### PR DESCRIPTION
Due to the security focus and minimalistic nature of the image, systemd should not be present in the image.

Follow up to https://github.com/elastic/beats/pull/44056