### PR TITLE
[filebeat][microsoft][m365_defender] Fix cursor - incidents are in ascending order

### DIFF
--- a/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
+++ b/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
@@ -32,7 +32,7 @@ response.split:
       keep_parent: true
 cursor:
   lastUpdateTime:
-    value: "[[.last_event.lastUpdateTime]]"
+    value: "[[.first_event.lastUpdateTime]]" # alerts are returned in ascending order
     ignore_empty_value: true
 
 {{ else if eq .input "file" }}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This PR is about the configuration of collector filebeat, module microsoft, fileset m365_defender.

We noticed that when multiple alerts are returned by the API, the next time filebeat executes (every 5 minutes by default), same alerts (newer than the last collected alert) are returned and collected.

The documentation says : "The default order is ascending order" (see [here](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#orderby-parameter)).

The solution to prevent retrieving multiple time the same alert(s) is to set the cursor to **first event timestamp** instead of **last event timestamp**.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

Microsoft M365_defender collected alerts should not be collected multiple times now.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
