### PR TITLE
fix(otel): register default processors for mbreceiver

### DIFF
--- a/libbeat/otelbeat/oteltest/oteltest.go
+++ b/libbeat/otelbeat/oteltest/oteltest.go
@@ -122,12 +122,19 @@ func CheckReceivers(params CheckReceiversParams) {
 		}()
 	}
 
+	t.Cleanup(func() {
+		if t.Failed() {
+			logsMu.Lock()
+			defer logsMu.Unlock()
+			t.Logf("Ingested Logs: %v", logs)
+		}
+	})
+
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		logsMu.Lock()
 		defer logsMu.Unlock()
 
 		// Ensure the logger fields from the otel collector are present in the logs.
-
 		for _, zl := range zapLogs.All() {
 			require.Contains(t, zl.ContextMap(), "otelcol.component.id")
 			require.Equal(t, zl.ContextMap()["otelcol.component.kind"], "Receiver")

--- a/x-pack/filebeat/fbreceiver/factory.go
+++ b/x-pack/filebeat/fbreceiver/factory.go
@@ -81,6 +81,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 	return &filebeatReceiver{BeatReceiver: base}, nil
 }
 
+// copied from filebeat cmd.
 func defaultProcessors() []mapstr.M {
 	// processors:
 	// - add_host_metadata:

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -7,7 +7,6 @@ package fbreceiver
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
@@ -163,26 +162,18 @@ func TestMultipleReceivers(t *testing.T) {
 				Factory: factory,
 			},
 		},
-		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
-			r1ok := assert.Greater(t, len(logs["r1"]), 0, "receive r1 does not have any logs")
-			r2ok := assert.Greater(t, len(logs["r2"]), 0, "receive r2 does not have any logs")
-			// logs for debug if it fails again
-			fmt.Printf("len(logs[\"r1\"]): %d\n", len(logs["r1"]))
-			fmt.Printf("len(logs[\"r2\"]): %d\n", len(logs["r2"]))
-			if !r1ok || !r2ok {
-				fmt.Printf("logs[\"r1\"]: %v\n", logs["r1"])
-				fmt.Printf("logs[\"r2\"]: %v\n", logs["r2"])
-				fmt.Printf("all logs: %v\n", logs)
-			}
+		AssertFunc: func(c *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
+			require.Greater(c, len(logs["r1"]), 0, "receiver r1 does not have any logs")
+			require.Greater(c, len(logs["r2"]), 0, "receiver r2 does not have any logs")
 
 			// Make sure that each receiver has a separate logger
 			// instance and does not interfere with others. Previously, the
 			// logger in Beats was global, causing logger fields to be
 			// overwritten when multiple receivers started in the same process.
 			r1StartLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "r1"))
-			assert.Equal(t, 1, r1StartLogs.Len(), "r1 should have a single start log")
+			assert.Equal(c, 1, r1StartLogs.Len(), "r1 should have a single start log")
 			r2StartLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "r2"))
-			require.Equal(t, 1, r2StartLogs.Len(), "r2 should have a single start log")
+			assert.Equal(c, 1, r2StartLogs.Len(), "r2 should have a single start log")
 		},
 	})
 }

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -78,20 +78,15 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 	return &metricbeatReceiver{BeatReceiver: beatReceiver}, nil
 }
 
+// copied from metricbeat cmd.
 func defaultProcessors() []mapstr.M {
 	// processors:
-	// - add_host_metadata:
-	// 	when.not.contains.tags: forwarded
-	// - add_cloud_metadata: ~
-	// - add_docker_metadata: ~
-	// - add_kubernetes_metadata: ~
-
+	//   - add_host_metadata: ~
+	//   - add_cloud_metadata: ~
+	//   - add_docker_metadata: ~
+	//   - add_kubernetes_metadata: ~
 	return []mapstr.M{
-		{
-			"add_host_metadata": mapstr.M{
-				"when.not.contains.tags": "forwarded",
-			},
-		},
+		{"add_host_metadata": nil},
 		{"add_cloud_metadata": nil},
 		{"add_docker_metadata": nil},
 		{"add_kubernetes_metadata": nil},

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -14,9 +14,13 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/otelbeat/beatreceiver"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/metricbeat/beater"
 	"github.com/elastic/beats/v7/metricbeat/cmd"
+	"github.com/elastic/beats/v7/x-pack/filebeat/include"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 const (
@@ -33,9 +37,15 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("could not convert otel config to metricbeat config")
 	}
 	settings := cmd.MetricbeatSettings(Name)
+	globalProcs, err := processors.NewPluginConfigFromList(defaultProcessors())
+	if err != nil {
+		return nil, fmt.Errorf("error making global processors: %w", err)
+	}
+	settings.Processing = processing.MakeDefaultSupport(true, globalProcs, processing.WithECS, processing.WithHost, processing.WithAgentMeta())
 	settings.ElasticLicensed = true
+	settings.Initialize = append(settings.Initialize, include.InitializeModule)
 
-	b, err := instance.NewBeatReceiver(settings, cfg.Beatconfig, false, consumer, set.Logger.Core())
+	b, err := instance.NewBeatReceiver(settings, cfg.Beatconfig, true, consumer, set.Logger.Core())
 	if err != nil {
 		return nil, fmt.Errorf("error creating %s: %w", Name, err)
 	}
@@ -66,6 +76,26 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		HttpConf: httpConf.HTTP,
 	}
 	return &metricbeatReceiver{BeatReceiver: beatReceiver}, nil
+}
+
+func defaultProcessors() []mapstr.M {
+	// processors:
+	// - add_host_metadata:
+	// 	when.not.contains.tags: forwarded
+	// - add_cloud_metadata: ~
+	// - add_docker_metadata: ~
+	// - add_kubernetes_metadata: ~
+
+	return []mapstr.M{
+		{
+			"add_host_metadata": mapstr.M{
+				"when.not.contains.tags": "forwarded",
+			},
+		},
+		{"add_cloud_metadata": nil},
+		{"add_docker_metadata": nil},
+		{"add_kubernetes_metadata": nil},
+	}
 }
 
 func NewFactory() receiver.Factory {


### PR DESCRIPTION
## Proposed commit message

Previously, default processors were only enabled for fbreceiver. This change ensures mbreceiver also uses the default processors. While at it, unify TestDefaultProcessors and TestNewReceiver for fbreceiver.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates to https://github.com/elastic/beats/issues/42631

