### PR TITLE
Fix tabs not syncing bug in Beats quickstart guides

### DIFF
--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -22,12 +22,15 @@ This guide describes how to get started quickly with audit data collection. Youâ
 You need {{es}} for storing and searching your data, and {{kib}} for visualizing and managing it.
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 To install and run {{es}} and {{kib}}, see [Installing the {{stack}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
 ::::::
 
@@ -40,8 +43,10 @@ Install Auditbeat on all the servers you want to monitor.
 To download and install Auditbeat, use the commands that work with your system:
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-amd64.deb
 sudo dpkg -i auditbeat-{{stack-version}}-amd64.deb
@@ -49,6 +54,7 @@ sudo dpkg -i auditbeat-{{stack-version}}-amd64.deb
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-x86_64.rpm
 sudo rpm -vi auditbeat-{{stack-version}}-x86_64.rpm
@@ -56,6 +62,7 @@ sudo rpm -vi auditbeat-{{stack-version}}-x86_64.rpm
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-darwin-x86_64.tar.gz
 tar xzvf auditbeat-{{stack-version}}-darwin-x86_64.tar.gz
@@ -63,6 +70,7 @@ tar xzvf auditbeat-{{stack-version}}-darwin-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-linux-x86_64.tar.gz
 tar xzvf auditbeat-{{stack-version}}-linux-x86_64.tar.gz
@@ -70,6 +78,7 @@ tar xzvf auditbeat-{{stack-version}}-linux-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 1. Download the [Auditbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
@@ -109,8 +118,10 @@ Connections to {{es}} and {{kib}} are required to set up Auditbeat.
 Set the connection information in `auditbeat.yml`. To locate this configuration file, see [Directory layout](/reference/auditbeat/directory-layout.md).
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 Specify the [cloud.id](/reference/auditbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/auditbeat/configure-cloud-id.md) to a user who is authorized to set up Auditbeat. For example:
 
 ```yaml
@@ -122,6 +133,7 @@ cloud.auth: "auditbeat_setup:YOUR_PASSWORD" <1>
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 1. Set the host and port where Auditbeat can find the {{es}} installation, and set the username and password of a user who is authorized to set up Auditbeat. For example:
 
     ```yaml
@@ -201,32 +213,38 @@ Auditbeat comes with predefined assets for parsing, indexing, and visualizing yo
 2. From the installation directory, run:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     auditbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     auditbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./auditbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./auditbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\auditbeat.exe setup -e
     ```
@@ -248,7 +266,10 @@ Before starting Auditbeat, modify the user credentials in `auditbeat.yml` and sp
 To start Auditbeat, run:
 
 :::::::{tab-set}
+:group: platform
+
 ::::::{tab-item} DEB
+:sync: deb
 ```sh
 sudo service auditbeat start
 ```
@@ -261,6 +282,7 @@ Also see [Auditbeat and systemd](/reference/auditbeat/running-with-systemd.md).
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```sh
 sudo service auditbeat start
 ```
@@ -273,6 +295,7 @@ Also see [Auditbeat and systemd](/reference/auditbeat/running-with-systemd.md).
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```sh
 sudo chown root auditbeat.yml <1>
 sudo ./auditbeat -e
@@ -282,6 +305,7 @@ sudo ./auditbeat -e
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```sh
 sudo chown root auditbeat.yml <1>
 sudo ./auditbeat -e
@@ -291,6 +315,7 @@ sudo ./auditbeat -e
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 ```sh
 PS C:\Program Files\auditbeat> Start-Service auditbeat
 ```
@@ -314,13 +339,16 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
+    :group: deployment
 
     ::::::{tab-item} Elasticsearch Service
+    :sync: hosted
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::
 
     ::::::{tab-item} Self-managed
+    :sync: self
     Point your browser to [http://localhost:5601](http://localhost:5601), replacing `localhost` with the name of the {{kib}} host.
     ::::::
 

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -22,12 +22,15 @@ This guide describes how to get started quickly with log collection. You’ll le
 You need {{es}} for storing and searching your data, and {{kib}} for visualizing and managing it.
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 To install and run {{es}} and {{kib}}, see [Installing the {{stack}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
 ::::::
 
@@ -40,8 +43,9 @@ Install Filebeat on all the servers you want to monitor.
 To download and install Filebeat, use the commands that work with your system:
 
 :::::::{tab-set}
-
+:group: platform
 ::::::{tab-item} DEB
+:sync: deb
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-amd64.deb
 sudo dpkg -i filebeat-{{stack-version}}-amd64.deb
@@ -49,6 +53,7 @@ sudo dpkg -i filebeat-{{stack-version}}-amd64.deb
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-x86_64.rpm
 sudo rpm -vi filebeat-{{stack-version}}-x86_64.rpm
@@ -56,6 +61,7 @@ sudo rpm -vi filebeat-{{stack-version}}-x86_64.rpm
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-darwin-x86_64.tar.gz
 tar xzvf filebeat-{{stack-version}}-darwin-x86_64.tar.gz
@@ -63,6 +69,7 @@ tar xzvf filebeat-{{stack-version}}-darwin-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-linux-x86_64.tar.gz
 tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
@@ -70,6 +77,7 @@ tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 1. Download the [Filebeat Windows zip file](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
@@ -110,8 +118,10 @@ Connections to {{es}} and {{kib}} are required to set up Filebeat.
 Set the connection information in `filebeat.yml`. To locate this configuration file, see [Directory layout](/reference/filebeat/directory-layout.md).
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 Specify the [cloud.id](/reference/filebeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/filebeat/configure-cloud-id.md) to a user who is authorized to set up Filebeat. For example:
 
 ```yaml
@@ -123,6 +133,7 @@ cloud.auth: "filebeat_setup:YOUR_PASSWORD" <1>
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 1. Set the host and port where Filebeat can find the {{es}} installation, and set the username and password of a user who is authorized to set up Filebeat. For example:
 
     ```yaml
@@ -175,32 +186,38 @@ There are several ways to collect log data with Filebeat:
 1. Identify the modules you need to enable. To see a list of available [modules](/reference/filebeat/filebeat-modules.md), run:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     filebeat modules list
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     filebeat modules list
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./filebeat modules list
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./filebeat modules list
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\filebeat.exe modules list
     ```
@@ -211,32 +228,38 @@ There are several ways to collect log data with Filebeat:
 2. From the installation directory, enable one or more modules. For example, the following command enables the `nginx` module config:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     filebeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     filebeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./filebeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./filebeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\filebeat.exe modules enable nginx
     ```
@@ -292,31 +315,37 @@ visualizing your data. To load these assets:
 1. From the installation directory, run:
 
     :::::::{tab-set}
+    :group: platform
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     filebeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     filebeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./filebeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./filebeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\filebeat.exe setup -e
     ```
@@ -348,7 +377,9 @@ Before starting Filebeat, modify the user credentials in `filebeat.yml` and spec
 To start Filebeat, run:
 
 :::::::{tab-set}
+:group: platform
 ::::::{tab-item} DEB
+:sync: deb
 ```sh
 sudo service filebeat start
 ```
@@ -362,6 +393,7 @@ Also see [Filebeat and systemd](/reference/filebeat/running-with-systemd.md).
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```sh
 sudo service filebeat start
 ```
@@ -375,6 +407,7 @@ Also see [Filebeat and systemd](/reference/filebeat/running-with-systemd.md).
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```sh
 sudo chown root filebeat.yml <1>
 sudo chown root modules.d/nginx.yml <1>
@@ -385,6 +418,7 @@ sudo ./filebeat -e
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```sh
 sudo chown root filebeat.yml <1>
 sudo chown root modules.d/nginx.yml <1>
@@ -395,6 +429,7 @@ sudo ./filebeat -e
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 ```sh
 PS C:\Program Files\filebeat> Start-Service filebeat
 ```
@@ -415,11 +450,14 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
+    :group: deployment
     ::::::{tab-item} Elasticsearch Service
+    :sync: hosted
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::
     ::::::{tab-item} Self-managed
+    :sync: self
     Point your browser to [http://localhost:5601](http://localhost:5601), replacing `localhost` with the name of the {{kib}} host.
     ::::::
     :::::::

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -23,12 +23,15 @@ This guide describes how to get started quickly collecting uptime data about you
 You need {{es}} for storing and searching your data, and {{kib}} for visualizing and managing it.
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 To install and run {{es}} and {{kib}}, see [Installing the {{stack}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
 ::::::
 
@@ -41,8 +44,10 @@ Unlike most Beats, which you install on edge nodes, you typically install Heartb
 To download and install Heartbeat, use the commands that work with your system:
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-amd64.deb
 sudo dpkg -i heartbeat-{{stack-version}}-amd64.deb
@@ -50,6 +55,7 @@ sudo dpkg -i heartbeat-{{stack-version}}-amd64.deb
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-x86_64.rpm
 sudo rpm -vi heartbeat-{{stack-version}}-x86_64.rpm
@@ -57,6 +63,7 @@ sudo rpm -vi heartbeat-{{stack-version}}-x86_64.rpm
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-darwin-x86_64.tar.gz
 tar xzvf heartbeat-{{stack-version}}-darwin-x86_64.tar.gz
@@ -64,6 +71,7 @@ tar xzvf heartbeat-{{stack-version}}-darwin-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-linux-x86_64.tar.gz
 tar xzvf heartbeat-{{stack-version}}-linux-x86_64.tar.gz
@@ -71,6 +79,7 @@ tar xzvf heartbeat-{{stack-version}}-linux-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 1. Download the [Heartbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
@@ -109,8 +118,10 @@ Connections to {{es}} and {{kib}} are required to set up Heartbeat.
 Set the connection information in `heartbeat.yml`. To locate this configuration file, see [Directory layout](/reference/heartbeat/directory-layout.md).
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 Specify the [cloud.id](/reference/heartbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/heartbeat/configure-cloud-id.md) to a user who is authorized to set up Heartbeat. For example:
 
 ```yaml
@@ -122,6 +133,7 @@ cloud.auth: "heartbeat_setup:YOUR_PASSWORD" <1>
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 1. Set the host and port where Heartbeat can find the {{es}} installation, and set the username and password of a user who is authorized to set up Heartbeat. For example:
 
     ```yaml
@@ -248,32 +260,38 @@ Heartbeat comes with predefined assets for parsing, indexing, and visualizing yo
 2. From the installation directory, run:
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```sh
 heartbeat setup -e
 ```
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```sh
 heartbeat setup -e
 ```
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```sh
 ./heartbeat setup -e
 ```
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```sh
 ./heartbeat setup -e
 ```
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 ```sh
 PS > .\heartbeat.exe setup -e
 ```
@@ -287,8 +305,10 @@ Before starting Heartbeat, modify the user credentials in heartbeat.yml and spec
 To start Heartbeat, run:
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```sh
 sudo service heartbeat-elastic start
 ```
@@ -301,6 +321,7 @@ Also see [Heartbeat and systemd](/reference/heartbeat/running-with-systemd.md).
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```sh
 sudo service heartbeat-elastic start
 ```
@@ -314,6 +335,7 @@ Also see [Heartbeat and systemd](/reference/heartbeat/running-with-systemd.md).
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```sh
 sudo chown root heartbeat.yml <1>
 sudo ./heartbeat -e
@@ -323,6 +345,7 @@ sudo ./heartbeat -e
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```sh
 sudo chown root heartbeat.yml <1>
 sudo ./heartbeat -e
@@ -332,6 +355,7 @@ sudo ./heartbeat -e
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 ```sh
 PS C:\Program Files\heartbeat> Start-Service heartbeat
 ```
@@ -353,11 +377,14 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
+    :group: deployment
     ::::::{tab-item} Elasticsearch Service
+    :sync: hosted
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::
     ::::::{tab-item} Self-managed
+    :sync: self
     Point your browser to [http://localhost:5601](http://localhost:5601), replacing `localhost` with the name of the {{kib}} host.
     ::::::
     :::::::

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -25,12 +25,15 @@ This guide describes how to get started quickly with metrics collection. You’l
 You need {{es}} for storing and searching your data, and {{kib}} for visualizing and managing it.
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 To install and run {{es}} and {{kib}}, see [Installing the {{stack}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
 ::::::
 
@@ -43,8 +46,10 @@ Install Metricbeat as close as possible to the service you want to monitor. For 
 To download and install Metricbeat, use the commands that work with your system:
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-amd64.deb
 sudo dpkg -i metricbeat-{{stack-version}}-amd64.deb
@@ -52,6 +57,7 @@ sudo dpkg -i metricbeat-{{stack-version}}-amd64.deb
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-x86_64.rpm
 sudo rpm -vi metricbeat-{{stack-version}}-x86_64.rpm
@@ -59,6 +65,7 @@ sudo rpm -vi metricbeat-{{stack-version}}-x86_64.rpm
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-darwin-x86_64.tar.gz
 tar xzvf metricbeat-{{stack-version}}-darwin-x86_64.tar.gz
@@ -66,6 +73,7 @@ tar xzvf metricbeat-{{stack-version}}-darwin-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-linux-x86_64.tar.gz
 tar xzvf metricbeat-{{stack-version}}-linux-x86_64.tar.gz
@@ -73,6 +81,7 @@ tar xzvf metricbeat-{{stack-version}}-linux-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 1. Download the [Metricbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
@@ -113,8 +122,10 @@ Connections to {{es}} and {{kib}} are required to set up Metricbeat.
 Set the connection information in `metricbeat.yml`. To locate this configuration file, see [Directory layout](/reference/metricbeat/directory-layout.md).
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 Specify the [cloud.id](/reference/metricbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/metricbeat/configure-cloud-id.md) to a user who is authorized to set up Metricbeat. For example:
 
 ```yaml
@@ -126,6 +137,7 @@ cloud.auth: "metricbeat_setup:YOUR_PASSWORD" <1>
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 1. Set the host and port where Metricbeat can find the {{es}} installation, and set the username and password of a user who is authorized to set up Metricbeat. For example:
 
     ```yaml
@@ -171,32 +183,38 @@ Metricbeat uses modules to collect metrics. Each module defines the basic logic 
 1. Identify the modules you need to enable. To see the list of available [modules](/reference/metricbeat/metricbeat-modules.md), run:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     metricbeat modules list
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     metricbeat modules list
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./metricbeat modules list
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./metricbeat modules list
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\metricbeat.exe modules list
     ```
@@ -209,32 +227,38 @@ Metricbeat uses modules to collect metrics. Each module defines the basic logic 
     The following command enables the nginx config in the `modules.d` directory:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     metricbeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     metricbeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./metricbeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./metricbeat modules enable nginx
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\metricbeat.exe modules enable nginx
     ```
@@ -264,32 +288,38 @@ Metricbeat comes with predefined assets for parsing, indexing, and visualizing y
 2. From the installation directory, run:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     metricbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     metricbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./metricbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./metricbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\metricbeat.exe setup -e
     ```
@@ -312,8 +342,10 @@ Before starting Metricbeat, modify the user credentials in metricbeat.yml and sp
 To start Metricbeat, run:
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```sh
 sudo service metricbeat start
 ```
@@ -327,6 +359,7 @@ Also see [Metricbeat and systemd](/reference/metricbeat/running-with-systemd.md)
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```sh
 sudo service metricbeat start
 ```
@@ -340,6 +373,7 @@ Also see [Metricbeat and systemd](/reference/metricbeat/running-with-systemd.md)
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```sh
 sudo chown root metricbeat.yml <1>
 sudo chown root modules.d/nginx.yml <1>
@@ -350,6 +384,7 @@ sudo ./metricbeat -e
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```sh
 sudo chown root metricbeat.yml <1>
 sudo chown root modules.d/nginx.yml <1>
@@ -360,6 +395,7 @@ sudo ./metricbeat -e
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 ```sh
 PS C:\Program Files\metricbeat> Start-Service metricbeat
 ```
@@ -385,11 +421,14 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
+    :group: deployment
     ::::::{tab-item} Elasticsearch Service
+    :sync: hosted
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::
     ::::::{tab-item} Self-managed
+    :sync: self
     Point your browser to [http://localhost:5601](http://localhost:5601), replacing `localhost` with the name of the {{kib}} host.
     ::::::
     :::::::

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -25,12 +25,15 @@ This guide describes how to get started quickly with network packets analytics. 
 * You need {{es}} for storing and searching your data, and {{kib}} for visualizing and managing it.
 
     :::::::{tab-set}
+    :group: deployment
 
     ::::::{tab-item} Elasticsearch Service
+    :sync: hosted
     To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
     ::::::
 
     ::::::{tab-item} Self-managed
+    :sync: self
     To install and run {{es}} and {{kib}}, see [Installing the {{stack}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
     ::::::
 
@@ -39,28 +42,34 @@ This guide describes how to get started quickly with network packets analytics. 
 * On most platforms, Packetbeat requires the libpcap packet capture library. Depending on your OS, you might need to install it:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     sudo apt-get install libpcap0.8
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     sudo yum install libpcap
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     You probably do not need to install libpcap.
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     You probably do not need to install libpcap.
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     You probably do not need to install libpcap. The default distribution of {{packetbeat}} for Windows comes bundled with the Npcap library.
 
         For the OSS-only distribution, you must download and install a packet sniffing library, such as [Npcap](https://nmap.org/npcap/), that implements the [libpcap](https://github.com/the-tcpdump-group/libpcap) interfaces.
@@ -74,8 +83,10 @@ This guide describes how to get started quickly with network packets analytics. 
 ## Step 1: Install Packetbeat [install]
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-amd64.deb
 sudo dpkg -i packetbeat-{{stack-version}}-amd64.deb
@@ -83,6 +94,7 @@ sudo dpkg -i packetbeat-{{stack-version}}-amd64.deb
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-x86_64.rpm
 sudo rpm -vi packetbeat-{{stack-version}}-x86_64.rpm
@@ -90,6 +102,7 @@ sudo rpm -vi packetbeat-{{stack-version}}-x86_64.rpm
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-darwin-x86_64.tar.gz
 tar xzvf packetbeat-{{stack-version}}-darwin-x86_64.tar.gz
@@ -97,6 +110,7 @@ tar xzvf packetbeat-{{stack-version}}-darwin-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```shell subs=true
 curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-linux-x86_64.tar.gz
 tar xzvf packetbeat-{{stack-version}}-linux-x86_64.tar.gz
@@ -104,6 +118,7 @@ tar xzvf packetbeat-{{stack-version}}-linux-x86_64.tar.gz
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 1. Download the [Packetbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
@@ -142,8 +157,10 @@ Connections to {{es}} and {{kib}} are required to set up Packetbeat.
 Set the connection information in `packetbeat.yml`. To locate this configuration file, see [Directory layout](/reference/packetbeat/directory-layout.md).
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 Specify the [cloud.id](/reference/packetbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/packetbeat/configure-cloud-id.md) to a user who is authorized to set up Packetbeat. For example:
 
 ```yaml
@@ -155,6 +172,7 @@ cloud.auth: "packetbeat_setup:YOUR_PASSWORD" <1>
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 1. Set the host and port where Packetbeat can find the {{es}} installation, and set the username and password of a user who is authorized to set up Packetbeat. For example:
 
     ```yaml
@@ -220,32 +238,38 @@ In `packetbeat.yml`, configure the network devices and protocols to capture traf
     To see a list of available devices, run:
 
     :::::::{tab-set}
+    :group: platform
 
     ::::::{tab-item} DEB
+    :sync: deb
     ```shell
     packetbeat devices
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```shell
     packetbeat devices
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```shell
     ./packetbeat devices
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```shell
     ./packetbeat devices
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```shell
     PS C:\Program Files\Packetbeat> .\packetbeat.exe devices
 
@@ -321,31 +345,37 @@ Packetbeat comes with predefined assets for parsing, indexing, and visualizing y
 2. From the installation directory, run:
 
     :::::::{tab-set}
+    :group: platform
     ::::::{tab-item} DEB
+    :sync: deb
     ```sh
     packetbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} RPM
+    :sync: rpm
     ```sh
     packetbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} MacOS
+    :sync: macos
     ```sh
     ./packetbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Linux
+    :sync: linux
     ```sh
     ./packetbeat setup -e
     ```
     ::::::
 
     ::::::{tab-item} Windows
+    :sync: windows
     ```sh
     PS > .\packetbeat.exe setup -e
     ```
@@ -368,8 +398,10 @@ Before starting Packetbeat, modify the user credentials in `packetbeat.yml` and 
 To start Packetbeat, run:
 
 :::::::{tab-set}
+:group: platform
 
 ::::::{tab-item} DEB
+:sync: deb
 ```sh
 sudo service packetbeat start
 ```
@@ -383,6 +415,7 @@ Also see [Packetbeat and systemd](/reference/packetbeat/running-with-systemd.md)
 ::::::
 
 ::::::{tab-item} RPM
+:sync: rpm
 ```sh
 sudo service packetbeat start
 ```
@@ -396,6 +429,7 @@ Also see [Packetbeat and systemd](/reference/packetbeat/running-with-systemd.md)
 ::::::
 
 ::::::{tab-item} MacOS
+:sync: macos
 ```sh
 sudo chown root packetbeat.yml <1>
 sudo ./packetbeat -e
@@ -405,6 +439,7 @@ sudo ./packetbeat -e
 ::::::
 
 ::::::{tab-item} Linux
+:sync: linux
 ```sh
 sudo chown root packetbeat.yml <1>
 sudo ./packetbeat -e
@@ -414,6 +449,7 @@ sudo ./packetbeat -e
 ::::::
 
 ::::::{tab-item} Windows
+:sync: windows
 ```sh
 PS C:\Program Files\packetbeat> Start-Service packetbeat
 ```
@@ -434,11 +470,14 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
+    :group: deployment
     ::::::{tab-item} Elasticsearch Service
+    :sync: hosted
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::
     ::::::{tab-item} Self-managed
+    :sync: self
     Point your browser to [http://localhost:5601](http://localhost:5601), replacing `localhost` with the name of the {{kib}} host.
     ::::::
     :::::::

--- a/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
@@ -23,12 +23,15 @@ This guide describes how to get started quickly with Windows log monitoring. You
 You need {{es}} for storing and searching your data, and {{kib}} for visualizing and managing it.
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 To install and run {{es}} and {{kib}}, see [Installing the {{stack}}](docs-content://deploy-manage/deploy/self-managed/installing-elasticsearch.md).
 ::::::
 
@@ -76,8 +79,10 @@ Connections to {{es}} and {{kib}} are required to set up Winlogbeat.
 Set the connection information in `winlogbeat.yml`. To locate this configuration file, see [Directory layout](/reference/winlogbeat/directory-layout.md).
 
 :::::::{tab-set}
+:group: deployment
 
 ::::::{tab-item} Elasticsearch Service
+:sync: hosted
 Specify the [cloud.id](/reference/winlogbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/winlogbeat/configure-cloud-id.md) to a user who is authorized to set up Winlogbeat. For example:
 
 ```yaml
@@ -89,6 +94,7 @@ cloud.auth: "winlogbeat_setup:YOUR_PASSWORD" <1>
 ::::::
 
 ::::::{tab-item} Self-managed
+:sync: self
 1. Set the host and port where Winlogbeat can find the {{es}} installation, and set the username and password of a user who is authorized to set up Winlogbeat. For example:
 
     ```yaml
@@ -222,11 +228,14 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
+    :group: deployment
     ::::::{tab-item} Elasticsearch Service
+    :sync: hosted
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::
     ::::::{tab-item} Self-managed
+    :sync: self
     Point your browser to [http://localhost:5601](http://localhost:5601), replacing `localhost` with the name of the {{kib}} host.
     ::::::
     :::::::


### PR DESCRIPTION
As reported in https://github.com/elastic/ingest-docs/issues/1784, the tabs aren't syncing in the six Beat Quickstart guides. This adds the [tab groups](https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/tabs#tab-groups) properties to fix that.

Closes: https://github.com/elastic/ingest-docs/issues/1784