### PR TITLE
filebeat: fix Redis auth method to support username/password

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -68,7 +68,7 @@ already present as `container.id` and `container.log.tag` is dropped because it 
 `log.syslog.appname`. The field `container.partial` is replaced by the tag `partial_message` if it was `true`,
 otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fixed race conditions in the global ratelimit processor that could drop events or apply rate limiting incorrectly.
-- Fixed Redis input in Filebeat to support username and password authentication. {pull}44137[44137]
+- Fixed password authentication for ACL users in the Redis input of Filebeat. {pull}44137[44137]
 
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -68,6 +68,7 @@ already present as `container.id` and `container.log.tag` is dropped because it 
 `log.syslog.appname`. The field `container.partial` is replaced by the tag `partial_message` if it was `true`,
 otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fixed race conditions in the global ratelimit processor that could drop events or apply rate limiting incorrectly.
+- Fixed Redis input in Filebeat to support username and password authentication. {pull}44137[44137]
 
 
 *Heartbeat*

--- a/filebeat/input/redis/_meta/redis.conf
+++ b/filebeat/input/redis/_meta/redis.conf
@@ -5,5 +5,6 @@ tls-key-file /certs/server-key.pem
 tls-ca-cert-file /certs/root-ca.pem
 requirepass password
 user default on >password ~* &* +@all
+user testuser on >testpass &* +@all
 slowlog-log-slower-than 0
 slowlog-max-len 128

--- a/filebeat/input/redis/input.go
+++ b/filebeat/input/redis/input.go
@@ -137,6 +137,7 @@ func CreatePool(host string, cfg config) *rd.Pool {
 		Dial: func() (rd.Conn, error) {
 			dialOptions := []rd.DialOption{
 				rd.DialUsername(cfg.Username),
+				rd.DialPassword(cfg.Password),
 				rd.DialConnectTimeout(cfg.IdleTimeout),
 				rd.DialReadTimeout(cfg.IdleTimeout),
 				rd.DialWriteTimeout(cfg.IdleTimeout),
@@ -149,19 +150,7 @@ func CreatePool(host string, cfg config) *rd.Pool {
 				)
 			}
 
-			c, err := rd.Dial(cfg.Network, host, dialOptions...)
-			if err != nil {
-				return nil, err
-			}
-
-			if cfg.Password != "" {
-				if _, err := c.Do("AUTH", cfg.Password); err != nil {
-					c.Close()
-					return nil, err
-				}
-			}
-
-			return c, err
+			return rd.Dial(cfg.Network, host, dialOptions...)
 		},
 	}
 }

--- a/filebeat/input/redis/redis_integration_test.go
+++ b/filebeat/input/redis/redis_integration_test.go
@@ -230,3 +230,77 @@ func getOrDefault(s, defaultString string) string {
 	}
 	return s
 }
+
+func TestAuthenticate(t *testing.T) {
+	var redisConfig config
+	var pool *rd.Pool
+	var conn rd.Conn
+	var err error
+
+	redisConfig = createRedisConfig("", "password")
+	require.NotEmpty(t, redisConfig, "redisConfig should not be empty")
+	pool = CreatePool(hostPort, redisConfig)
+	conn, err = pool.Dial()
+	require.NoError(t, err)
+	_, err = conn.Do("PING")
+	require.NoError(t, err)
+
+	redisConfig = createRedisConfig("", "password1")
+	require.NotEmpty(t, redisConfig, "redisConfig should not be empty")
+	pool = CreatePool(hostPort, redisConfig)
+	_, err = pool.Dial()
+	require.Error(t, err)
+	require.Equal(t, rd.Error("WRONGPASS invalid username-password pair or user is disabled."), err)
+
+	redisConfig = createRedisConfig("testuser", "testpass")
+	require.NotEmpty(t, redisConfig, "redisConfig should not be empty")
+	pool = CreatePool(hostPort, redisConfig)
+	conn, err = pool.Dial()
+	require.NoError(t, err)
+	_, err = conn.Do("PING")
+	require.NoError(t, err)
+
+	redisConfig = createRedisConfig("testuser", "testpass1")
+	require.NotEmpty(t, redisConfig, "redisConfig should not be empty")
+	pool = CreatePool(hostPort, redisConfig)
+	_, err = pool.Dial()
+	require.Error(t, err)
+	require.Equal(t, rd.Error("WRONGPASS invalid username-password pair or user is disabled."), err)
+}
+
+func createRedisConfig(username string, password string) config {
+	cfg := conf.MustNewConfigFrom(mapstr.M{
+		"network":      "tcp",
+		"type":         "redis",
+		"hosts":        []string{hostPort},
+		"maxconn":      10,
+		"idle_timeout": 60 * time.Second,
+		"ssl": mapstr.M{
+			"enabled":                 true,
+			"certificate_authorities": []string{"_meta/certs/root-ca.pem"},
+			"certificate":             "_meta/certs/server-cert.pem",
+			"key":                     "_meta/certs/server-key.pem",
+		},
+	})
+
+	redisConfig := defaultConfig()
+	err := cfg.Unpack(&redisConfig)
+	if err != nil {
+		return config{}
+	}
+
+	if username != "" {
+		redisConfig.Username = username
+	}
+
+	if password != "" {
+		redisConfig.Password = password
+	}
+
+	if redisConfig.TLS.IsEnabled() {
+		tlsConfig, _ := tlscommon.LoadTLSConfig(redisConfig.TLS)
+		redisConfig.tlsConfig = tlsConfig.ToConfig()
+	}
+
+	return redisConfig
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

filebeat: fix Redis auth method to support username/password

- **WHAT**: Updated the Redis authentication logic within the Filebeat input module to correctly handle username/password combinations. The AUTH command has been improved to use both username and password.
- **WHY**: The previous implementation attempted to authenticate using only the password, causing failures. Redis authentication requires two arguments: a username and a password. This update resolves the issue.
  Reference: [Redis AUTH Documentation](https://redis.io/docs/latest/commands/auth/)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Verify correct authentication with username/password.
- [x] Validate no impact on existing configurations.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `redis_integration_test.go` to verify changes.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/beats/pull/40111

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
