### PR TITLE
[CI] Fix failing libbeat unit test pipeline

### DIFF
--- a/.buildkite/libbeat/pipeline.libbeat.yml
+++ b/.buildkite/libbeat/pipeline.libbeat.yml
@@ -79,7 +79,7 @@ steps:
           - "libbeat/build/*.json"
         plugins:
           - test-collector#v1.10.2:
-              files: "libbeat/build/TEST-*-unit.xml"
+              files: "libbeat/build/TEST-*.xml"
               format: "junit"
               branches: "main"
               debug: true
@@ -107,7 +107,7 @@ steps:
           - "libbeat/build/*.json"
         plugins:
           - test-collector#v1.10.2:
-              files: "libbeat/build/TEST-*-unit.xml"
+              files: "libbeat/build/TEST-*.xml"
               format: "junit"
               branches: "main"
               debug: true
@@ -135,7 +135,7 @@ steps:
           - "libbeat/build/*.json"
         plugins:
           - test-collector#v1.10.2:
-              files: "libbeat/build/TEST-*-unit.xml"
+              files: "libbeat/build/TEST-*.xml"
               format: "junit"
               branches: "main"
               debug: true


### PR DESCRIPTION
The libbeat unit test pipeline is hitting failures ([example](https://buildkite.com/elastic/beats-libbeat/builds/14977#01969138-60b6-4e11-bf7f-72a2af7720b6/535-537)) on "successful" fips-enabled runs because the buildkite rule uses an overly-specific file pattern to collect test results, giving failure messages like `No files found matching 'libbeat/build/TEST-*-unit.xml'` (because the fips tests have filenames like `libbeat/build/TEST-go-unit-fips-only.xml`). This PR replaces the rules with a more general file pattern.