### PR TITLE
Skip broken auditbeat system ebpf tests

### DIFF
--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -193,6 +193,7 @@ class Test(BaseTest):
         self._test_non_recursive("fsnotify")
 
     @unittest.skipUnless(is_root(), "Requires root")
+    @unittest.skip("ebpf backend is failing: https://github.com/elastic/beats/issues/44174")
     def test_non_recursive__ebpf(self):
         self._test_non_recursive("ebpf")
 


### PR DESCRIPTION
Skip the Auditbeat system ebpf tests, which are consistently failing as reported in https://github.com/elastic/beats/issues/44174.