### PR TITLE
Add Beats 9.0.1 Release Notes

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -46,4 +46,4 @@ subs:
   major-version: "9.0"
   major-release: "9.x"
   beats-pull: "https://github.com/elastic/beats/pull/"
-  beats-issue: "https://github.com/elastic/beats/issue/"
+  beats-issue: "https://github.com/elastic/beats/issues/"

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,6 +12,10 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 % Description and impact of the breaking change.
 % For more information, check [PR #](PR link).
 
+## 9.0.1 [beats-9.0.1-breaking-changes]
+
+_No breaking changes_
+
 ## 9.0.0 [beats-900-breaking-changes]
 
 % Description and impact of the breaking change.

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -17,6 +17,10 @@ To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrad
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
+## 9.0.0 [beats-9.0.1-deprecations]
+
+_No deprecations_
+
 ## 9.0.0 [beats-900-deprecations]
 
 _No deprecations_

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -17,9 +17,7 @@ To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrad
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
-## 9.0.0 [beats-9.0.1-deprecations]
-
-_No deprecations_
+% ## Going forward, please use this format for the ID: 9.0.x [beats-9.0.x-deprecations]
 
 ## 9.0.0 [beats-900-deprecations]
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -16,7 +16,23 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Features and enhancements [beats-versionext-features-enhancements]
 
 % ### Fixes [beats-versionext-fixes]
-* Filebeat Journald input now works on Docker containers (except Wolfi) [#41278]({{beats-issue}}41278) [#44040]({{beats-issue}}44040) [#44056]({{beats-pull}}44056)
+
+## 9.0.1 [beats-9.0.1-release-notes]
+
+### Features and enhancements [beats-9.0.1-features-enhancements]
+
+* For all Beats: Publish `cloud.availability_zone` by `add_cloud_metadata` processor in Azure environments. [#42601]({{beats-issue}}42601) [#43618]({{beats-pull}}43618)
+* Add pagination batch size support to Entity Analytics input's Okta provider in Filebeat. [#43655]({{beats-pull}}43655)
+* Update CEL mito extensions version to v1.19.0 in Filebeat. [#44098]({{beats-pull}}44098)
+* Upgrade node version to latest LTS v18.20.7 in Heartbeat. [#43511]({{beats-pull}}43511)
+* Add `enable_batch_api` option in Azure monitor to allow metrics collection of multiple resources using Azure batch API in Metricbeat. [#41790]({{beats-pull}}41790)
+
+### Fixes [beats-9.0.1-fixes]
+
+* For all Beats: Handle permission errors while collecting data from Windows services and don't interrupt the overall collection by skipping affected services. [#40765]({{beats-issue}}40765) [#43665]({{beats-pull}}43665).
+* Fixed websocket input panic on sudden network error or server crash in Filebeat. [#44063]({{beats-issue}}44063) [44068]({{beats-pull}}44068).
+* [Filestream] Log the "reader closed" message on the debug level to avoid log spam in Filebeat. [#44051]({{beats-pull}}44051)
+* Fix links to CEL mito extension functions in input documentation in Filebeat. [#44098]({{beats-pull}}44098)
 
 ## 9.0.0 [beats-900-release-notes]
 


### PR DESCRIPTION
Adds the Beats 9.0.1 Release Notes based off of https://github.com/elastic/beats/pull/44172

Please note: The "Handle permission errors while collecting data from Windows services" entry was in the "Breaking Changes" section of the Beats changelog. I moved it to the "Fixes" section, but let me know if it really is a breaking change.

---

<img width="627" alt="screen" src="https://github.com/user-attachments/assets/5a502248-168c-4766-a6cb-5d21ae91a1d1" />

