### PR TITLE
Change ESS instances to ECH

### DIFF
--- a/deploy/kubernetes/metricbeat/README.md
+++ b/deploy/kubernetes/metricbeat/README.md
@@ -20,7 +20,7 @@ This file uses a set of environment variables to configure Elasticsearch output.
     | ELASTICSEARCH_USERNAME | elastic       | Elasticsearch username for HTTP auth |
     | ELASTICSEARCH_PASSWORD | changeme      | Elasticsearch password               |
 
-  * [Elastic Cloud Hosted](https://www.elastic.co/docs/reference/beats/metricbeat/configure-cloud-id):
+  * Elasticsearch service on [Elastic Cloud](https://www.elastic.co/guide/en/beats/metricbeat/current/configure-cloud-id.html):
 
       | Variable           | Default | Description        |
       |--------------------|---------|--------------------|

--- a/deploy/kubernetes/metricbeat/README.md
+++ b/deploy/kubernetes/metricbeat/README.md
@@ -20,7 +20,7 @@ This file uses a set of environment variables to configure Elasticsearch output.
     | ELASTICSEARCH_USERNAME | elastic       | Elasticsearch username for HTTP auth |
     | ELASTICSEARCH_PASSWORD | changeme      | Elasticsearch password               |
 
-  * Elasticsearch service on [Elastic Cloud](https://www.elastic.co/guide/en/beats/metricbeat/current/configure-cloud-id.html):
+  * [Elastic Cloud Hosted](https://www.elastic.co/guide/en/beats/metricbeat/current/configure-cloud-id.html):
 
       | Variable           | Default | Description        |
       |--------------------|---------|--------------------|

--- a/deploy/kubernetes/metricbeat/README.md
+++ b/deploy/kubernetes/metricbeat/README.md
@@ -20,7 +20,7 @@ This file uses a set of environment variables to configure Elasticsearch output.
     | ELASTICSEARCH_USERNAME | elastic       | Elasticsearch username for HTTP auth |
     | ELASTICSEARCH_PASSWORD | changeme      | Elasticsearch password               |
 
-  * [Elastic Cloud Hosted](https://www.elastic.co/guide/en/beats/metricbeat/current/configure-cloud-id.html):
+  * [Elastic Cloud Hosted](https://www.elastic.co/docs/reference/beats/metricbeat/configure-cloud-id):
 
       | Variable           | Default | Description        |
       |--------------------|---------|--------------------|

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -16,6 +16,7 @@ subs:
   beats-ref:   "https://www.elastic.co/guide/en/beats/libbeat/current"
   ecloud:   "Elastic Cloud"
   ess:   "Elasticsearch Service"
+  ech: "Elastic Cloud Hosted"
   es-serverless:   "Elasticsearch Serverless"
   uptime-app:   "Uptime app"
   logs-app:   "Logs app"

--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -23,8 +23,8 @@ You need {{es}} for storing and searching your data, and {{kib}} for visualizing
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
+::::::{tab-item} {{ech}}
+To get started quickly, spin up an [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body) deployment. {{ech}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
@@ -110,8 +110,8 @@ Set the connection information in `auditbeat.yml`. To locate this configuration 
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-Specify the [cloud.id](/reference/auditbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/auditbeat/configure-cloud-id.md) to a user who is authorized to set up Auditbeat. For example:
+::::::{tab-item} {{ech}}
+Specify the [cloud.id](/reference/auditbeat/configure-cloud-id.md) of your {{ech}} deployment, and set [cloud.auth](/reference/auditbeat/configure-cloud-id.md) to a user who is authorized to set up Auditbeat. For example:
 
 ```yaml
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
@@ -238,7 +238,7 @@ Auditbeat comes with predefined assets for parsing, indexing, and visualizing yo
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to {{es}} and deploys the sample dashboards for visualizing the data in {{kib}}.
 
 :::{tip}
-A connection to {{es}} (or {{ess}}) is required to set up the initial environment. If you're using a different output, such as {{ls}}, see [](/reference/auditbeat/auditbeat-template.md#load-template-manually) and [](/reference/auditbeat/load-kibana-dashboards.md).
+A connection to {{es}} (or {{ech}}) is required to set up the initial environment. If you're using a different output, such as {{ls}}, see [](/reference/auditbeat/auditbeat-template.md#load-template-manually) and [](/reference/auditbeat/load-kibana-dashboards.md).
 :::
 
 ## Step 5: Start Auditbeat [start]
@@ -315,7 +315,7 @@ To open the dashboards:
 
     :::::::{tab-set}
 
-    ::::::{tab-item} Elasticsearch Service
+    ::::::{tab-item} {{ech}}
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::

--- a/docs/reference/auditbeat/auditbeat-template.md
+++ b/docs/reference/auditbeat/auditbeat-template.md
@@ -13,7 +13,7 @@ mapped_pages:
 The recommended index template file for Auditbeat is installed by the Auditbeat packages. If you accept the default configuration in the `auditbeat.yml` config file, Auditbeat loads the template automatically after successfully connecting to {{es}}. If the template already exists, it’s not overwritten unless you configure Auditbeat to do so.
 
 ::::{note}
-A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ess}}), you must [load the template manually](#load-template-manually).
+A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ech}}), you must [load the template manually](#load-template-manually).
 ::::
 
 

--- a/docs/reference/auditbeat/configuration-template.md
+++ b/docs/reference/auditbeat/configuration-template.md
@@ -10,7 +10,7 @@ mapped_pages:
 The `setup.template` section of the `auditbeat.yml` config file specifies the [index template](docs-content://manage-data/data-store/templates.md) to use for setting mappings in Elasticsearch. If template loading is enabled (the default), Auditbeat loads the index template automatically after successfully connecting to Elasticsearch.
 
 ::::{note}
-A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ess}}), you must [load the template manually](/reference/auditbeat/auditbeat-template.md#load-template-manually).
+A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ech}}), you must [load the template manually](/reference/auditbeat/auditbeat-template.md#load-template-manually).
 ::::
 
 

--- a/docs/reference/auditbeat/configure-cloud-id.md
+++ b/docs/reference/auditbeat/configure-cloud-id.md
@@ -1,13 +1,13 @@
 ---
-navigation_title: "{{ess}}"
+navigation_title: "{{ech}}"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/auditbeat/current/configure-cloud-id.html
 ---
 
-# Configure the output for {{ess}} on {{ecloud}} [configure-cloud-id]
+# Configure the output for {{ech}} [configure-cloud-id]
 
 
-Auditbeat comes with two settings that simplify the output configuration when used together with [{{ess}}](https://www.elastic.co/cloud/elasticsearch-service?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
+Auditbeat comes with two settings that simplify the output configuration when used together with [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
 
 Example:
 
@@ -24,7 +24,7 @@ auditbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 ## `cloud.id` [_cloud_id]
 
-The Cloud ID, which can be found in the {{ess}} web console, is used by Auditbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Configure Beats and Logstash with Cloud ID](docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md).
+The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Auditbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
 
 ## `cloud.auth` [_cloud_auth]

--- a/docs/reference/auditbeat/configuring-output.md
+++ b/docs/reference/auditbeat/configuring-output.md
@@ -11,7 +11,7 @@ You configure Auditbeat to write to a specific output by setting options in the 
 
 The following topics describe how to configure each supported output. If you’ve secured the {{stack}}, also read [Secure](/reference/auditbeat/securing-auditbeat.md) for more about security-related configuration options.
 
-* [{{ess}}](/reference/auditbeat/configure-cloud-id.md)
+* [{{ech}}](/reference/auditbeat/configure-cloud-id.md)
 * [Elasticsearch](/reference/auditbeat/elasticsearch-output.md)
 * [Logstash](/reference/auditbeat/logstash-output.md)
 * [Kafka](/reference/auditbeat/kafka-output.md)

--- a/docs/reference/auditbeat/privileges-to-publish-monitoring.md
+++ b/docs/reference/auditbeat/privileges-to-publish-monitoring.md
@@ -12,7 +12,7 @@ mapped_pages:
 ::::{admonition} Important note for {{ecloud}} users
 :class: important
 
-Built-in users are not available when running our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service) on {{ecloud}}. To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
+Built-in users are not available when running [{{ech}}](https://www.elastic.co/cloud). To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
 
 ::::
 

--- a/docs/reference/auditbeat/running-on-docker.md
+++ b/docs/reference/auditbeat/running-on-docker.md
@@ -77,11 +77,11 @@ docker run --rm \
 ```
 
 1. Substitute your Kibana and Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
 
 
 ```shell
--E cloud.id=<Cloud ID from Elasticsearch Service> \
+-E cloud.id=<Cloud ID from Elastic Cloud Hosted> \
 -E cloud.auth=elastic:<elastic password>
 ```
 
@@ -131,7 +131,7 @@ docker run -d \
 ```
 
 1. Substitute your Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
 
 
 

--- a/docs/reference/filebeat/configuration-template.md
+++ b/docs/reference/filebeat/configuration-template.md
@@ -10,7 +10,7 @@ mapped_pages:
 The `setup.template` section of the `filebeat.yml` config file specifies the [index template](docs-content://manage-data/data-store/templates.md) to use for setting mappings in Elasticsearch. If template loading is enabled (the default), Filebeat loads the index template automatically after successfully connecting to Elasticsearch.
 
 ::::{note}
-A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ess}}), you must [load the template manually](/reference/filebeat/filebeat-template.md#load-template-manually).
+A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ech}}), you must [load the template manually](/reference/filebeat/filebeat-template.md#load-template-manually).
 ::::
 
 

--- a/docs/reference/filebeat/configure-cloud-id.md
+++ b/docs/reference/filebeat/configure-cloud-id.md
@@ -1,13 +1,13 @@
 ---
-navigation_title: "{{ess}}"
+navigation_title: "{{ech}}"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/configure-cloud-id.html
 ---
 
-# Configure the output for {{ess}} on {{ecloud}} [configure-cloud-id]
+# Configure the output for {{ech}} [configure-cloud-id]
 
 
-Filebeat comes with two settings that simplify the output configuration when used together with [{{ess}}](https://www.elastic.co/cloud/elasticsearch-service?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
+Filebeat comes with two settings that simplify the output configuration when used together with [{{ech}}](https://www.elastic.co/cloud/elasticsearch-service?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
 
 Example:
 
@@ -24,7 +24,7 @@ filebeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 ## `cloud.id` [_cloud_id]
 
-The Cloud ID, which can be found in the {{ess}} web console, is used by Filebeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Configure Beats and Logstash with Cloud ID](docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md).
+The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Filebeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
 
 ## `cloud.auth` [_cloud_auth]

--- a/docs/reference/filebeat/configuring-output.md
+++ b/docs/reference/filebeat/configuring-output.md
@@ -11,7 +11,7 @@ You configure Filebeat to write to a specific output by setting options in the O
 
 The following topics describe how to configure each supported output. If you’ve secured the {{stack}}, also read [Secure](/reference/filebeat/securing-filebeat.md) for more about security-related configuration options.
 
-* [{{ess}}](/reference/filebeat/configure-cloud-id.md)
+* [{{ech}}](/reference/filebeat/configure-cloud-id.md)
 * [Elasticsearch](/reference/filebeat/elasticsearch-output.md)
 * [Logstash](/reference/filebeat/logstash-output.md)
 * [Kafka](/reference/filebeat/kafka-output.md)

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -23,8 +23,8 @@ You need {{es}} for storing and searching your data, and {{kib}} for visualizing
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
+::::::{tab-item} {{ech}}
+To get started quickly, spin up an [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body) deployment. {{ech}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
@@ -111,8 +111,8 @@ Set the connection information in `filebeat.yml`. To locate this configuration f
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-Specify the [cloud.id](/reference/filebeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/filebeat/configure-cloud-id.md) to a user who is authorized to set up Filebeat. For example:
+::::::{tab-item} {{ech}}
+Specify the [cloud.id](/reference/filebeat/configure-cloud-id.md) of your {{ech}} deployment, and set [cloud.auth](/reference/filebeat/configure-cloud-id.md) to a user who is authorized to set up Filebeat. For example:
 
 ```yaml
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
@@ -330,7 +330,7 @@ This step loads the recommended [index template](docs-content://manage-data/data
 This step does not load the ingest pipelines used to parse log lines. By default, ingest pipelines are set up automatically the first time you run the module and connect to {{es}}.
 
 :::{tip}
-A connection to {{es}} (or {{ess}}) is required to set up the initial environment. If you're using a different output, such as {{ls}}, see:
+A connection to {{es}} (or {{ech}}) is required to set up the initial environment. If you're using a different output, such as {{ls}}, see:
 
 * [](/reference/filebeat/filebeat-template.md#load-template-manually)
 * [](/reference/filebeat/load-kibana-dashboards.md)
@@ -415,7 +415,7 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
-    ::::::{tab-item} Elasticsearch Service
+    ::::::{tab-item} {{ech}}
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::

--- a/docs/reference/filebeat/filebeat-template.md
+++ b/docs/reference/filebeat/filebeat-template.md
@@ -13,7 +13,7 @@ mapped_pages:
 The recommended index template file for Filebeat is installed by the Filebeat packages. If you accept the default configuration in the `filebeat.yml` config file, Filebeat loads the template automatically after successfully connecting to {{es}}. If the template already exists, it’s not overwritten unless you configure Filebeat to do so.
 
 ::::{note}
-A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ess}}), you must [load the template manually](#load-template-manually).
+A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ech}}), you must [load the template manually](#load-template-manually).
 ::::
 
 

--- a/docs/reference/filebeat/privileges-to-publish-monitoring.md
+++ b/docs/reference/filebeat/privileges-to-publish-monitoring.md
@@ -12,7 +12,7 @@ mapped_pages:
 ::::{admonition} Important note for {{ecloud}} users
 :class: important
 
-Built-in users are not available when running our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service) on {{ecloud}}. To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
+Built-in users are not available when running [{{ech}}](https://www.elastic.co/cloud). To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
 
 ::::
 

--- a/docs/reference/filebeat/running-on-docker.md
+++ b/docs/reference/filebeat/running-on-docker.md
@@ -75,11 +75,11 @@ setup -E setup.kibana.host=kibana:5601 \
 ```
 
 1. Substitute your Kibana and Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
 
 
 ```shell
--E cloud.id=<Cloud ID from Elasticsearch Service> \
+-E cloud.id=<Cloud ID from Elastic Cloud Hosted> \
 -E cloud.auth=elastic:<elastic password>
 ```
 
@@ -128,7 +128,7 @@ docker run -d \
 ```
 
 1. Substitute your Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
 
 
 

--- a/docs/reference/heartbeat/configuration-template.md
+++ b/docs/reference/heartbeat/configuration-template.md
@@ -10,7 +10,7 @@ mapped_pages:
 The `setup.template` section of the `heartbeat.yml` config file specifies the [index template](docs-content://manage-data/data-store/templates.md) to use for setting mappings in Elasticsearch. If template loading is enabled (the default), Heartbeat loads the index template automatically after successfully connecting to Elasticsearch.
 
 ::::{note}
-A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ess}}), you must [load the template manually](/reference/heartbeat/heartbeat-template.md#load-template-manually).
+A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ech}}), you must [load the template manually](/reference/heartbeat/heartbeat-template.md#load-template-manually).
 ::::
 
 

--- a/docs/reference/heartbeat/configure-cloud-id.md
+++ b/docs/reference/heartbeat/configure-cloud-id.md
@@ -1,13 +1,13 @@
 ---
-navigation_title: "{{ess}}"
+navigation_title: "{{ech}}"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/heartbeat/current/configure-cloud-id.html
 ---
 
-# Configure the output for {{ess}} on {{ecloud}} [configure-cloud-id]
+# Configure the output for {{ech}} [configure-cloud-id]
 
 
-Heartbeat comes with two settings that simplify the output configuration when used together with [{{ess}}](https://www.elastic.co/cloud/elasticsearch-service?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
+Heartbeat comes with two settings that simplify the output configuration when used together with [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
 
 Example:
 
@@ -24,7 +24,7 @@ heartbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 ## `cloud.id` [_cloud_id]
 
-The Cloud ID, which can be found in the {{ess}} web console, is used by Heartbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Configure Beats and Logstash with Cloud ID](docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md).
+The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Heartbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
 
 ## `cloud.auth` [_cloud_auth]

--- a/docs/reference/heartbeat/configuring-output.md
+++ b/docs/reference/heartbeat/configuring-output.md
@@ -11,7 +11,7 @@ You configure Heartbeat to write to a specific output by setting options in the 
 
 The following topics describe how to configure each supported output. If you’ve secured the {{stack}}, also read [Secure](/reference/heartbeat/securing-heartbeat.md) for more about security-related configuration options.
 
-* [{{ess}}](/reference/heartbeat/configure-cloud-id.md)
+* [{{ech}}](/reference/heartbeat/configure-cloud-id.md)
 * [Elasticsearch](/reference/heartbeat/elasticsearch-output.md)
 * [Logstash](/reference/heartbeat/logstash-output.md)
 * [Kafka](/reference/heartbeat/kafka-output.md)

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -24,8 +24,8 @@ You need {{es}} for storing and searching your data, and {{kib}} for visualizing
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
+::::::{tab-item} {{ech}}
+To get started quickly, spin up an [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body) deployment. {{ech}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
@@ -110,8 +110,8 @@ Set the connection information in `heartbeat.yml`. To locate this configuration 
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-Specify the [cloud.id](/reference/heartbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/heartbeat/configure-cloud-id.md) to a user who is authorized to set up Heartbeat. For example:
+::::::{tab-item} {{ech}}
+Specify the [cloud.id](/reference/heartbeat/configure-cloud-id.md) of your {{ech}} deployment, and set [cloud.auth](/reference/heartbeat/configure-cloud-id.md) to a user who is authorized to set up Heartbeat. For example:
 
 ```yaml
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
@@ -353,7 +353,7 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
-    ::::::{tab-item} Elasticsearch Service
+    ::::::{tab-item} {{ech}}
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::

--- a/docs/reference/heartbeat/heartbeat-template.md
+++ b/docs/reference/heartbeat/heartbeat-template.md
@@ -13,7 +13,7 @@ mapped_pages:
 The recommended index template file for Heartbeat is installed by the Heartbeat packages. If you accept the default configuration in the `heartbeat.yml` config file, Heartbeat loads the template automatically after successfully connecting to {{es}}. If the template already exists, it’s not overwritten unless you configure Heartbeat to do so.
 
 ::::{note}
-A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ess}}), you must [load the template manually](#load-template-manually).
+A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ech}}), you must [load the template manually](#load-template-manually).
 ::::
 
 

--- a/docs/reference/heartbeat/privileges-to-publish-monitoring.md
+++ b/docs/reference/heartbeat/privileges-to-publish-monitoring.md
@@ -12,7 +12,7 @@ mapped_pages:
 ::::{admonition} Important note for {{ecloud}} users
 :class: important
 
-Built-in users are not available when running our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service) on {{ecloud}}. To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
+Built-in users are not available when running [{{ech}}](https://www.elastic.co/cloud). To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
 
 ::::
 

--- a/docs/reference/heartbeat/running-on-docker.md
+++ b/docs/reference/heartbeat/running-on-docker.md
@@ -76,11 +76,11 @@ setup -E setup.kibana.host=kibana:5601 \
 ```
 
 1. Substitute your Kibana and Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
 
 
 ```shell
--E cloud.id=<Cloud ID from Elasticsearch Service> \
+-E cloud.id=<Cloud ID from Elastic Cloud Hosted> \
 -E cloud.auth=elastic:<elastic password>
 ```
 
@@ -128,7 +128,7 @@ docker run -d \
 ```
 
 1. Substitute your Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
 
 
 

--- a/docs/reference/loggingplugin/log-driver-configuration.md
+++ b/docs/reference/loggingplugin/log-driver-configuration.md
@@ -45,8 +45,8 @@ For more examples, see [Usage examples](/reference/loggingplugin/log-driver-usag
 
 | Option | Description |
 | --- | --- |
-| `cloud_id` | The Cloud ID found in the Elastic Cloud web console. This ID isused to resolve the {{stack}} URLs when connecting to {{ess}} on {{ecloud}}. |
-| `cloud_auth` | The username and password combination for connecting to {{ess}} on {{ecloud}}. Theformat is `"username:password"`. |
+| `cloud_id` | The Cloud ID found in the Elastic Cloud web console. This ID isused to resolve the {{stack}} URLs when connecting to {{ech}}. |
+| `cloud_auth` | The username and password combination for connecting to {{ech}}. Theformat is `"username:password"`. |
 
 
 ## {{es}} output options [es-output-options]

--- a/docs/reference/loggingplugin/log-driver-usage-examples.md
+++ b/docs/reference/loggingplugin/log-driver-usage-examples.md
@@ -36,7 +36,7 @@ docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
 ```
 
 
-## Send Docker logs to {{ess}} on {{ecloud}} [_send_docker_logs_to_ess_on_ecloud]
+## Send Docker logs to {{ech}} [_send_docker_logs_to_ess_on_ecloud]
 
 **Docker run command:**
 

--- a/docs/reference/metricbeat/configuration-template.md
+++ b/docs/reference/metricbeat/configuration-template.md
@@ -10,7 +10,7 @@ mapped_pages:
 The `setup.template` section of the `metricbeat.yml` config file specifies the [index template](docs-content://manage-data/data-store/templates.md) to use for setting mappings in Elasticsearch. If template loading is enabled (the default), Metricbeat loads the index template automatically after successfully connecting to Elasticsearch.
 
 ::::{note}
-A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ess}}), you must [load the template manually](/reference/metricbeat/metricbeat-template.md#load-template-manually).
+A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ech}}), you must [load the template manually](/reference/metricbeat/metricbeat-template.md#load-template-manually).
 ::::
 
 

--- a/docs/reference/metricbeat/configure-cloud-id.md
+++ b/docs/reference/metricbeat/configure-cloud-id.md
@@ -1,13 +1,13 @@
 ---
-navigation_title: "{{ess}}"
+navigation_title: "{{ech}}"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/metricbeat/current/configure-cloud-id.html
 ---
 
-# Configure the output for {{ess}} on {{ecloud}} [configure-cloud-id]
+# Configure the output for {{ech}} [configure-cloud-id]
 
 
-Metricbeat comes with two settings that simplify the output configuration when used together with [{{ess}}](https://www.elastic.co/cloud/elasticsearch-service?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
+Metricbeat comes with two settings that simplify the output configuration when used together with [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
 
 Example:
 
@@ -24,7 +24,7 @@ metricbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 ## `cloud.id` [_cloud_id]
 
-The Cloud ID, which can be found in the {{ess}} web console, is used by Metricbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Configure Beats and Logstash with Cloud ID](docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md).
+The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Metricbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
 
 ## `cloud.auth` [_cloud_auth]

--- a/docs/reference/metricbeat/configuring-output.md
+++ b/docs/reference/metricbeat/configuring-output.md
@@ -11,7 +11,7 @@ You configure Metricbeat to write to a specific output by setting options in the
 
 The following topics describe how to configure each supported output. If you’ve secured the {{stack}}, also read [Secure](/reference/metricbeat/securing-metricbeat.md) for more about security-related configuration options.
 
-* [{{ess}}](/reference/metricbeat/configure-cloud-id.md)
+* [{{ech}}](/reference/metricbeat/configure-cloud-id.md)
 * [Elasticsearch](/reference/metricbeat/elasticsearch-output.md)
 * [Logstash](/reference/metricbeat/logstash-output.md)
 * [Kafka](/reference/metricbeat/kafka-output.md)

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -26,8 +26,8 @@ You need {{es}} for storing and searching your data, and {{kib}} for visualizing
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
+::::::{tab-item} {{ech}}
+To get started quickly, spin up an [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body) deployment. {{ech}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
@@ -114,8 +114,8 @@ Set the connection information in `metricbeat.yml`. To locate this configuration
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-Specify the [cloud.id](/reference/metricbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/metricbeat/configure-cloud-id.md) to a user who is authorized to set up Metricbeat. For example:
+::::::{tab-item} {{ech}}
+Specify the [cloud.id](/reference/metricbeat/configure-cloud-id.md) of your {{ech}} deployment, and set [cloud.auth](/reference/metricbeat/configure-cloud-id.md) to a user who is authorized to set up Metricbeat. For example:
 
 ```yaml
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
@@ -302,7 +302,7 @@ Metricbeat comes with predefined assets for parsing, indexing, and visualizing y
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to Elasticsearch and deploys the sample dashboards for visualizing the data in Kibana.
 
 :::{tip}
-A connection to Elasticsearch (or Elasticsearch Service) is required to set up the initial environment. If you’re using a different output, such as Logstash, see [Load the index template manually](/reference/metricbeat/metricbeat-template.md#load-template-manually) and [Load Kibana dashboards](/reference/metricbeat/load-kibana-dashboards.md).
+A connection to Elasticsearch (or {{ech}}) is required to set up the initial environment. If you’re using a different output, such as Logstash, see [Load the index template manually](/reference/metricbeat/metricbeat-template.md#load-template-manually) and [Load Kibana dashboards](/reference/metricbeat/load-kibana-dashboards.md).
 :::
 
 ## Step 5: Start Metricbeat
@@ -385,7 +385,7 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
-    ::::::{tab-item} Elasticsearch Service
+    ::::::{tab-item} {{ech}}
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::

--- a/docs/reference/metricbeat/metricbeat-template.md
+++ b/docs/reference/metricbeat/metricbeat-template.md
@@ -13,7 +13,7 @@ mapped_pages:
 The recommended index template file for Metricbeat is installed by the Metricbeat packages. If you accept the default configuration in the `metricbeat.yml` config file, Metricbeat loads the template automatically after successfully connecting to {{es}}. If the template already exists, it’s not overwritten unless you configure Metricbeat to do so.
 
 ::::{note}
-A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ess}}), you must [load the template manually](#load-template-manually).
+A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ech}}), you must [load the template manually](#load-template-manually).
 ::::
 
 

--- a/docs/reference/metricbeat/privileges-to-publish-monitoring.md
+++ b/docs/reference/metricbeat/privileges-to-publish-monitoring.md
@@ -12,7 +12,7 @@ mapped_pages:
 ::::{admonition} Important note for {{ecloud}} users
 :class: important
 
-Built-in users are not available when running our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service) on {{ecloud}}. To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
+Built-in users are not available when running [{{ech}}](https://www.elastic.co/cloud). To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
 
 ::::
 

--- a/docs/reference/metricbeat/running-on-docker.md
+++ b/docs/reference/metricbeat/running-on-docker.md
@@ -75,11 +75,11 @@ setup -E setup.kibana.host=kibana:5601 \
 ```
 
 1. Substitute your Kibana and Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
 
 
 ```shell
--E cloud.id=<Cloud ID from Elasticsearch Service> \
+-E cloud.id=<Cloud ID from Elastic Cloud Hosted> \
 -E cloud.auth=elastic:<elastic password>
 ```
 
@@ -129,7 +129,7 @@ docker run -d \
 ```
 
 1. Substitute your Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
 
 
 

--- a/docs/reference/packetbeat/configuration-template.md
+++ b/docs/reference/packetbeat/configuration-template.md
@@ -10,7 +10,7 @@ mapped_pages:
 The `setup.template` section of the `packetbeat.yml` config file specifies the [index template](docs-content://manage-data/data-store/templates.md) to use for setting mappings in Elasticsearch. If template loading is enabled (the default), Packetbeat loads the index template automatically after successfully connecting to Elasticsearch.
 
 ::::{note}
-A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ess}}), you must [load the template manually](/reference/packetbeat/packetbeat-template.md#load-template-manually).
+A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ech}}), you must [load the template manually](/reference/packetbeat/packetbeat-template.md#load-template-manually).
 ::::
 
 

--- a/docs/reference/packetbeat/configure-cloud-id.md
+++ b/docs/reference/packetbeat/configure-cloud-id.md
@@ -1,13 +1,13 @@
 ---
-navigation_title: "{{ess}}"
+navigation_title: "{{ech}}"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/packetbeat/current/configure-cloud-id.html
 ---
 
-# Configure the output for {{ess}} on {{ecloud}} [configure-cloud-id]
+# Configure the output for {{ech}} [configure-cloud-id]
 
 
-Packetbeat comes with two settings that simplify the output configuration when used together with [{{ess}}](https://www.elastic.co/cloud/elasticsearch-service?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
+Packetbeat comes with two settings that simplify the output configuration when used together with [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
 
 Example:
 
@@ -24,7 +24,7 @@ packetbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 ## `cloud.id` [_cloud_id]
 
-The Cloud ID, which can be found in the {{ess}} web console, is used by Packetbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Configure Beats and Logstash with Cloud ID](docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md).
+The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Packetbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
 
 ## `cloud.auth` [_cloud_auth]

--- a/docs/reference/packetbeat/configuring-output.md
+++ b/docs/reference/packetbeat/configuring-output.md
@@ -11,7 +11,7 @@ You configure Packetbeat to write to a specific output by setting options in the
 
 The following topics describe how to configure each supported output. If you’ve secured the {{stack}}, also read [Secure](/reference/packetbeat/securing-packetbeat.md) for more about security-related configuration options.
 
-* [{{ess}}](/reference/packetbeat/configure-cloud-id.md)
+* [{{ech}}](/reference/packetbeat/configure-cloud-id.md)
 * [Elasticsearch](/reference/packetbeat/elasticsearch-output.md)
 * [Logstash](/reference/packetbeat/logstash-output.md)
 * [Kafka](/reference/packetbeat/kafka-output.md)

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -26,8 +26,8 @@ This guide describes how to get started quickly with network packets analytics. 
 
     :::::::{tab-set}
 
-    ::::::{tab-item} Elasticsearch Service
-    To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
+    ::::::{tab-item} {{ech}}
+    To get started quickly, spin up a deployment of [{{ech}}](https://www.elastic.co/cloud). The {{ech}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
     ::::::
 
     ::::::{tab-item} Self-managed
@@ -143,8 +143,8 @@ Set the connection information in `packetbeat.yml`. To locate this configuration
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-Specify the [cloud.id](/reference/packetbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/packetbeat/configure-cloud-id.md) to a user who is authorized to set up Packetbeat. For example:
+::::::{tab-item} {{ech}}
+Specify the [cloud.id](/reference/packetbeat/configure-cloud-id.md) of your {{ech}} deployment, and set [cloud.auth](/reference/packetbeat/configure-cloud-id.md) to a user who is authorized to set up Packetbeat. For example:
 
 ```yaml
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
@@ -358,7 +358,7 @@ Packetbeat comes with predefined assets for parsing, indexing, and visualizing y
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to Elasticsearch and deploys the sample dashboards for visualizing the data in Kibana.
 
 :::{tip}
-A connection to Elasticsearch (or Elasticsearch Service) is required to set up the initial environment. If you’re using a different output, such as Logstash, see [Load the index template manually](/reference/packetbeat/packetbeat-template.md#load-template-manually) and [Load Kibana dashboards](/reference/packetbeat/load-kibana-dashboards.md).
+A connection to Elasticsearch (or {{ech}}) is required to set up the initial environment. If you’re using a different output, such as Logstash, see [Load the index template manually](/reference/packetbeat/packetbeat-template.md#load-template-manually) and [Load Kibana dashboards](/reference/packetbeat/load-kibana-dashboards.md).
 :::
 
 ## Step 5: Start Packetbeat
@@ -434,7 +434,7 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
-    ::::::{tab-item} Elasticsearch Service
+    ::::::{tab-item} {{ech}}
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::

--- a/docs/reference/packetbeat/packetbeat-template.md
+++ b/docs/reference/packetbeat/packetbeat-template.md
@@ -13,7 +13,7 @@ mapped_pages:
 The recommended index template file for Packetbeat is installed by the Packetbeat packages. If you accept the default configuration in the `packetbeat.yml` config file, Packetbeat loads the template automatically after successfully connecting to {{es}}. If the template already exists, it’s not overwritten unless you configure Packetbeat to do so.
 
 ::::{note}
-A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ess}}), you must [load the template manually](#load-template-manually).
+A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ech}}), you must [load the template manually](#load-template-manually).
 ::::
 
 

--- a/docs/reference/packetbeat/privileges-to-publish-monitoring.md
+++ b/docs/reference/packetbeat/privileges-to-publish-monitoring.md
@@ -12,7 +12,7 @@ mapped_pages:
 ::::{admonition} Important note for {{ecloud}} users
 :class: important
 
-Built-in users are not available when running our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service) on {{ecloud}}. To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
+Built-in users are not available when running [{{ech}}](https://www.elastic.co/cloud). To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
 
 ::::
 

--- a/docs/reference/packetbeat/running-on-docker.md
+++ b/docs/reference/packetbeat/running-on-docker.md
@@ -76,11 +76,11 @@ setup -E setup.kibana.host=kibana:5601 \
 ```
 
 1. Substitute your Kibana and Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using this syntax:
 
 
 ```shell
--E cloud.id=<Cloud ID from Elasticsearch Service> \
+-E cloud.id=<Cloud ID from Elastic Cloud Hosted> \
 -E cloud.auth=elastic:<elastic password>
 ```
 
@@ -130,7 +130,7 @@ docker run -d \
 ```
 
 1. Substitute your Elasticsearch hosts and ports.
-2. If you are using the hosted {{ess}} in {{ecloud}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
+2. If you are using the {{ech}}, replace the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password using the syntax shown earlier.
 
 
 

--- a/docs/reference/winlogbeat/configuration-template.md
+++ b/docs/reference/winlogbeat/configuration-template.md
@@ -10,7 +10,7 @@ mapped_pages:
 The `setup.template` section of the `winlogbeat.yml` config file specifies the [index template](docs-content://manage-data/data-store/templates.md) to use for setting mappings in Elasticsearch. If template loading is enabled (the default), Winlogbeat loads the index template automatically after successfully connecting to Elasticsearch.
 
 ::::{note}
-A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ess}}), you must [load the template manually](/reference/winlogbeat/winlogbeat-template.md#load-template-manually).
+A connection to Elasticsearch is required to load the index template. If the configured output is not Elasticsearch (or {{ech}}), you must [load the template manually](/reference/winlogbeat/winlogbeat-template.md#load-template-manually).
 ::::
 
 

--- a/docs/reference/winlogbeat/configure-cloud-id.md
+++ b/docs/reference/winlogbeat/configure-cloud-id.md
@@ -1,13 +1,13 @@
 ---
-navigation_title: "{{ess}}"
+navigation_title: "{{ech}}"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/winlogbeat/current/configure-cloud-id.html
 ---
 
-# Configure the output for {{ess}} on {{ecloud}} [configure-cloud-id]
+# Configure the output for {{ech}} [configure-cloud-id]
 
 
-Winlogbeat comes with two settings that simplify the output configuration when used together with [{{ess}}](https://www.elastic.co/cloud/elasticsearch-service?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
+Winlogbeat comes with two settings that simplify the output configuration when used together with [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body). When defined, these setting overwrite settings from other parts in the configuration.
 
 Example:
 
@@ -24,7 +24,7 @@ winlogbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 ## `cloud.id` [_cloud_id]
 
-The Cloud ID, which can be found in the {{ess}} web console, is used by Winlogbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Configure Beats and Logstash with Cloud ID](docs-content://deploy-manage/deploy/cloud-enterprise/connect-elasticsearch.md).
+The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Winlogbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
 
 ## `cloud.auth` [_cloud_auth]

--- a/docs/reference/winlogbeat/configuring-output.md
+++ b/docs/reference/winlogbeat/configuring-output.md
@@ -11,7 +11,7 @@ You configure Winlogbeat to write to a specific output by setting options in the
 
 The following topics describe how to configure each supported output. If you’ve secured the {{stack}}, also read [Secure](/reference/winlogbeat/securing-winlogbeat.md) for more about security-related configuration options.
 
-* [{{ess}}](/reference/winlogbeat/configure-cloud-id.md)
+* [{{ech}}](/reference/winlogbeat/configure-cloud-id.md)
 * [Elasticsearch](/reference/winlogbeat/elasticsearch-output.md)
 * [Logstash](/reference/winlogbeat/logstash-output.md)
 * [Kafka](/reference/winlogbeat/kafka-output.md)

--- a/docs/reference/winlogbeat/privileges-to-publish-monitoring.md
+++ b/docs/reference/winlogbeat/privileges-to-publish-monitoring.md
@@ -12,7 +12,7 @@ mapped_pages:
 ::::{admonition} Important note for {{ecloud}} users
 :class: important
 
-Built-in users are not available when running our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service) on {{ecloud}}. To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
+Built-in users are not available when running [{{ech}}](https://www.elastic.co/cloud). To send monitoring data securely, create a monitoring user and grant it the roles described in the following sections.
 
 ::::
 

--- a/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
@@ -24,8 +24,8 @@ You need {{es}} for storing and searching your data, and {{kib}} for visualizing
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-To get started quickly, spin up a deployment of our [hosted {{ess}}](https://www.elastic.co/cloud/elasticsearch-service). The {{ess}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
+::::::{tab-item} {{ech}}
+To get started quickly, spin up an [{{ech}}](https://www.elastic.co/cloud?page=docs&placement=docs-body) deployment. {{ech}} is available on AWS, GCP, and Azure. [Try it out for free](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 ::::::
 
 ::::::{tab-item} Self-managed
@@ -77,8 +77,8 @@ Set the connection information in `winlogbeat.yml`. To locate this configuration
 
 :::::::{tab-set}
 
-::::::{tab-item} Elasticsearch Service
-Specify the [cloud.id](/reference/winlogbeat/configure-cloud-id.md) of your {{ess}}, and set [cloud.auth](/reference/winlogbeat/configure-cloud-id.md) to a user who is authorized to set up Winlogbeat. For example:
+::::::{tab-item} {{ech}}
+Specify the [cloud.id](/reference/winlogbeat/configure-cloud-id.md) of your {{ech}} deployment, and set [cloud.auth](/reference/winlogbeat/configure-cloud-id.md) to a user who is authorized to set up Winlogbeat. For example:
 
 ```yaml
 cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
@@ -175,7 +175,7 @@ Winlogbeat comes with predefined assets for parsing, indexing, and visualizing y
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to {{es}} , loads the ingest pipelines to parse the events (x-pack only), and deploys the sample dashboards for visualizing the data in {{kib}}.
 
 ::::{tip}
-A connection to {{es}} (or {{ess}}) is required to set up the initial environment. If you’re using a different output, such as {{ls}}, see:
+A connection to {{es}} (or {{ech}}) is required to set up the initial environment. If you’re using a different output, such as {{ls}}, see:
 
 * [Load the index template manually](/reference/winlogbeat/winlogbeat-template.md#load-template-manually)
 * [*Load {{kib}} dashboards*](/reference/winlogbeat/load-kibana-dashboards.md)
@@ -222,7 +222,7 @@ To open the dashboards:
 1. Launch {{kib}}:
 
     :::::::{tab-set}
-    ::::::{tab-item} Elasticsearch Service
+    ::::::{tab-item} {{ech}}
     1. [Log in](https://cloud.elastic.co/) to your {{ecloud}} account.
     2. Navigate to the {{kib}} endpoint in your deployment.
     ::::::

--- a/docs/reference/winlogbeat/winlogbeat-template.md
+++ b/docs/reference/winlogbeat/winlogbeat-template.md
@@ -13,7 +13,7 @@ mapped_pages:
 The recommended index template file for Winlogbeat is installed by the Winlogbeat packages. If you accept the default configuration in the `winlogbeat.yml` config file, Winlogbeat loads the template automatically after successfully connecting to {{es}}. If the template already exists, it’s not overwritten unless you configure Winlogbeat to do so.
 
 ::::{note}
-A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ess}}), you must [load the template manually](#load-template-manually).
+A connection to {{es}} is required to load the index template. If the output is not {{es}} (or {{ech}}), you must [load the template manually](#load-template-manually).
 ::::
 
 


### PR DESCRIPTION
"Elasticsearch Service" on Elastic Cloud was rebranded to "Elastic Cloud Hosted" - I'm working on making sure that the branding is changed across all docs sets.

I've updated all instances of ESS, ensuring that the context is retained. Also fixed some links in an ECH context that were pointing to a cloud enterprise resource.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation

~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Disruptive User Impact

N/A - suggest just using the [preview](https://docs-v3-preview.elastic.dev/elastic/beats/pull/44185/reference/)

## Author's Checklist

- [ ] Spot check the docs changes
       
    Examples:
   - https://docs-v3-preview.elastic.dev/elastic/beats/pull/44185/reference/auditbeat/auditbeat-installation-configuration#_before_you_begin
   - https://docs-v3-preview.elastic.dev/elastic/beats/pull/44185/reference/auditbeat/configure-cloud-id
- [ ] Question for reviewers: right now, the instructions are limited to ECH and self-managed (vanilla) ES. Do we care about ECE, ECK, serverless deployments? Should ECE follow cloud instructions and ECK follow self-managed?

## How to test this PR locally

N/A

## Related issues

- Part of https://github.com/elastic/platform-docs-team/issues/366
