### PR TITLE
[Flaky test] Give test filebeat receivers distinct home directories

### DIFF
--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -124,29 +124,33 @@ func TestMultipleReceivers(t *testing.T) {
 	// This test verifies that multiple receivers can be instantiated
 	// in isolation, started, and can ingest logs without interfering
 	// with each other.
-	config := Config{
-		Beatconfig: map[string]interface{}{
-			"filebeat": map[string]interface{}{
-				"inputs": []map[string]interface{}{
-					{
-						"type":    "benchmark",
-						"enabled": true,
-						"message": "test",
-						"count":   1,
+
+	// Receivers need distinct home directories so wrap the config in a function.
+	config := func() *Config {
+		return &Config{
+			Beatconfig: map[string]interface{}{
+				"filebeat": map[string]interface{}{
+					"inputs": []map[string]interface{}{
+						{
+							"type":    "benchmark",
+							"enabled": true,
+							"message": "test",
+							"count":   1,
+						},
 					},
 				},
-			},
-			"output": map[string]interface{}{
-				"otelconsumer": map[string]interface{}{},
-			},
-			"logging": map[string]interface{}{
-				"level": "info",
-				"selectors": []string{
-					"*",
+				"output": map[string]interface{}{
+					"otelconsumer": map[string]interface{}{},
 				},
+				"logging": map[string]interface{}{
+					"level": "info",
+					"selectors": []string{
+						"*",
+					},
+				},
+				"path.home": t.TempDir(),
 			},
-			"path.home": t.TempDir(),
-		},
+		}
 	}
 
 	factory := NewFactory()
@@ -155,12 +159,12 @@ func TestMultipleReceivers(t *testing.T) {
 		Receivers: []oteltest.ReceiverConfig{
 			{
 				Name:    "r1",
-				Config:  &config,
+				Config:  config(),
 				Factory: factory,
 			},
 			{
 				Name:    "r2",
-				Config:  &config,
+				Config:  config(),
 				Factory: factory,
 			},
 		},


### PR DESCRIPTION
`fbreceiver.TestMultipleReceivers` created two Filebeat receivers using the same config, which meant they both had the same home directory. This can cause conflicts that prevent a beat from starting, which is likely the cause of this test's [recent flakiness](https://buildkite.com/elastic/beats-xpack-filebeat/builds/14573#019691c7-e3d0-430b-83a1-334343b57ef0/97-593). This PR wraps the config in a helper function so the two receivers get different temporary directories.
