### PR TITLE
[Docs] Improve documentation wording for  `worker` configuration

### DIFF
--- a/docs/reference/auditbeat/elasticsearch-output.md
+++ b/docs/reference/auditbeat/elasticsearch-output.md
@@ -108,7 +108,7 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-The number of workers per configured host publishing events to Elasticsearch. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
 
 The default value is `1`.
 

--- a/docs/reference/auditbeat/logstash-output.md
+++ b/docs/reference/auditbeat/logstash-output.md
@@ -120,7 +120,9 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-The number of workers per configured host publishing events to {{ls}}. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [loadbalance]

--- a/docs/reference/auditbeat/redis-output.md
+++ b/docs/reference/auditbeat/redis-output.md
@@ -131,7 +131,9 @@ See [Change the output codec](/reference/auditbeat/configuration-output-codec.md
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-The number of workers to use for each host configured to publish events to Redis. Use this setting along with the `loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [_loadbalance_2]

--- a/docs/reference/filebeat/elasticsearch-output.md
+++ b/docs/reference/filebeat/elasticsearch-output.md
@@ -108,7 +108,7 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-The number of workers per configured host publishing events to Elasticsearch. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
 
 The default value is `1`.
 

--- a/docs/reference/filebeat/logstash-output.md
+++ b/docs/reference/filebeat/logstash-output.md
@@ -122,7 +122,9 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-The number of workers per configured host publishing events to {{ls}}. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [loadbalance]

--- a/docs/reference/filebeat/redis-output.md
+++ b/docs/reference/filebeat/redis-output.md
@@ -131,7 +131,10 @@ See [Change the output codec](/reference/filebeat/configuration-output-codec.md)
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-The number of workers to use for each host configured to publish events to Redis. Use this setting along with the `loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
+
 
 
 ### `loadbalance` [_loadbalance_2]

--- a/docs/reference/heartbeat/elasticsearch-output.md
+++ b/docs/reference/heartbeat/elasticsearch-output.md
@@ -108,7 +108,7 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-The number of workers per configured host publishing events to Elasticsearch. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
 
 The default value is `1`.
 

--- a/docs/reference/heartbeat/logstash-output.md
+++ b/docs/reference/heartbeat/logstash-output.md
@@ -120,7 +120,9 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-The number of workers per configured host publishing events to {{ls}}. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [loadbalance]

--- a/docs/reference/heartbeat/redis-output.md
+++ b/docs/reference/heartbeat/redis-output.md
@@ -131,7 +131,10 @@ See [Change the output codec](/reference/heartbeat/configuration-output-codec.md
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-The number of workers to use for each host configured to publish events to Redis. Use this setting along with the `loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
+
 
 
 ### `loadbalance` [_loadbalance_2]

--- a/docs/reference/metricbeat/elasticsearch-output.md
+++ b/docs/reference/metricbeat/elasticsearch-output.md
@@ -108,7 +108,7 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-The number of workers per configured host publishing events to Elasticsearch. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
 
 The default value is `1`.
 

--- a/docs/reference/metricbeat/logstash-output.md
+++ b/docs/reference/metricbeat/logstash-output.md
@@ -120,7 +120,9 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-The number of workers per configured host publishing events to {{ls}}. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [loadbalance]

--- a/docs/reference/metricbeat/redis-output.md
+++ b/docs/reference/metricbeat/redis-output.md
@@ -131,7 +131,9 @@ See [Change the output codec](/reference/metricbeat/configuration-output-codec.m
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-The number of workers to use for each host configured to publish events to Redis. Use this setting along with the `loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [_loadbalance_2]

--- a/docs/reference/packetbeat/elasticsearch-output.md
+++ b/docs/reference/packetbeat/elasticsearch-output.md
@@ -107,7 +107,7 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-The number of workers per configured host publishing events to Elasticsearch. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
 
 The default value is `1`.
 

--- a/docs/reference/packetbeat/logstash-output.md
+++ b/docs/reference/packetbeat/logstash-output.md
@@ -120,7 +120,9 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-The number of workers per configured host publishing events to {{ls}}. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [loadbalance]

--- a/docs/reference/packetbeat/redis-output.md
+++ b/docs/reference/packetbeat/redis-output.md
@@ -131,7 +131,9 @@ See [Change the output codec](/reference/packetbeat/configuration-output-codec.m
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-The number of workers to use for each host configured to publish events to Redis. Use this setting along with the `loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [_loadbalance_2]

--- a/docs/reference/winlogbeat/elasticsearch-output.md
+++ b/docs/reference/winlogbeat/elasticsearch-output.md
@@ -108,7 +108,7 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-The number of workers per configured host publishing events to Elasticsearch. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
 
 The default value is `1`.
 

--- a/docs/reference/winlogbeat/logstash-output.md
+++ b/docs/reference/winlogbeat/logstash-output.md
@@ -120,7 +120,9 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-The number of workers per configured host publishing events to {{ls}}. This is best used with load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [loadbalance]

--- a/docs/reference/winlogbeat/redis-output.md
+++ b/docs/reference/winlogbeat/redis-output.md
@@ -131,7 +131,9 @@ See [Change the output codec](/reference/winlogbeat/configuration-output-codec.m
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-The number of workers to use for each host configured to publish events to Redis. Use this setting along with the `loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis parallely. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+
+The default value is `1`.
 
 
 ### `loadbalance` [_loadbalance_2]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This PR improves documentation wording for `worker` or `workers` configuration. It makes it clear that events will be published parallely only when `loadbalance` is true.  

`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch in parallel.


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

