### PR TITLE
add basic grok processor functionality

### DIFF
--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -25,12 +25,11 @@ filebeat.inputs:
   id: my-filestream-id
 
   # Change to true to enable this input configuration.
-  enabled: false
+  enabled: true
 
   # Paths that should be crawled and fetched. Glob based paths.
   paths:
-    - /var/log/*.log
-    #- c:\programdata\elasticsearch\logs\*
+    - ./haproxy.log
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list.
@@ -168,12 +167,14 @@ output.elasticsearch:
   preset: balanced
 
   # Protocol - either `http` (default) or `https`.
-  #protocol: "https"
+  protocol: "https"
+  ssl:
+    verification_mode: "none"
 
   # Authentication credentials - either API key or username/password.
   #api_key: "id:api_key"
-  #username: "elastic"
-  #password: "changeme"
+  username: "elastic"
+  password: "changeme"
 
 # ------------------------------ Logstash Output -------------------------------
 #output.logstash:
@@ -192,11 +193,17 @@ output.elasticsearch:
 
 # ================================= Processors =================================
 processors:
-  - add_host_metadata:
-      when.not.contains.tags: forwarded
-  - add_cloud_metadata: ~
-  - add_docker_metadata: ~
-  - add_kubernetes_metadata: ~
+  #- add_host_metadata:
+  #    when.not.contains.tags: forwarded
+  #- add_cloud_metadata: ~
+  #- add_docker_metadata: ~
+  #- add_kubernetes_metadata: ~
+  - grok:
+      field: "message"
+      pattern: '%{IP:source.address}:%{NUMBER:source.port} \[%{HAPROXYDATE:haproxy.request_date}\] %{NOTSPACE:haproxy.frontend_name} %{USERNAME:haproxy.backend_name}/%{NOTSPACE:haproxy.server_name} %{NUMBER:haproxy.http.request.time_wait_ms:long}/%{NUMBER:haproxy.total_waiting_time_ms:long}/%{NUMBER:haproxy.connection_wait_time_ms:long}/%{NUMBER:haproxy.http.request.time_wait_without_data_ms:long}/%{NUMBER:temp.duration:long} %{NUMBER:http.response.status_code:long} %{NUMBER:haproxy.bytes_read:long} %{NOTSPACE:haproxy.http.request.captured_cookie} %{NOTSPACE:haproxy.http.response.captured_cookie} %{NOTSPACE:haproxy.termination_state} %{NUMBER:haproxy.connections.active:long}/%{NUMBER:haproxy.connections.frontend:long}/%{NUMBER:haproxy.connections.backend:long}/%{NUMBER:haproxy.connections.server:long}/%{NUMBER:haproxy.connections.retries:long} %{NUMBER:haproxy.server_queue:long}/%{NUMBER:haproxy.backend_queue:long} "%{GREEDYDATA:haproxy.http.request.raw_request_line}"'
+      customPatterns:
+        HAPROXYDATE: '%{MONTHDAY}/%{MONTH}/%{YEAR}:%{HOUR}:%{MINUTE}:%{SECOND}.%{INT}'
+      
 
 # ================================== Logging ===================================
 

--- a/go.mod
+++ b/go.mod
@@ -178,6 +178,7 @@ require (
 	github.com/elastic/elastic-agent-libs v0.19.2
 	github.com/elastic/elastic-agent-system-metrics v0.11.11
 	github.com/elastic/go-elasticsearch/v8 v8.17.1
+	github.com/elastic/go-grok v0.3.1
 	github.com/elastic/go-quark v0.3.0
 	github.com/elastic/go-sfdc v0.0.0-20241010131323-8e176480d727
 	github.com/elastic/mito v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/elastic/go-elasticsearch/v8 v8.17.1 h1:bOXChDoCMB4TIwwGqKd031U8OXssmW
 github.com/elastic/go-elasticsearch/v8 v8.17.1/go.mod h1:MVJCtL+gJJ7x5jFeUmA20O7rvipX8GcQmo5iBcmaJn4=
 github.com/elastic/go-freelru v0.16.0 h1:gG2HJ1WXN2tNl5/p40JS/l59HjvjRhjyAa+oFTRArYs=
 github.com/elastic/go-freelru v0.16.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
+github.com/elastic/go-grok v0.3.1 h1:WEhUxe2KrwycMnlvMimJXvzRa7DoByJB4PVUIE1ZD/U=
+github.com/elastic/go-grok v0.3.1/go.mod h1:n38ls8ZgOboZRgKcjMY8eFeZFMmcL9n2lP0iHhIDk64=
 github.com/elastic/go-libaudit/v2 v2.6.2 h1:1PM6wVBTJHJQYsKl8jfA9/Aw9pFty5uUezPiUfKtOI4=
 github.com/elastic/go-libaudit/v2 v2.6.2/go.mod h1:8205nkf2oSrXFlO4H5j8/cyVMoSF3Y7jt+FjgS4ubQU=
 github.com/elastic/go-licenser v0.4.2 h1:bPbGm8bUd8rxzSswFOqvQh1dAkKGkgAmrPxbUi+Y9+A=

--- a/libbeat/cmd/instance/imports_common.go
+++ b/libbeat/cmd/instance/imports_common.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/processors/dns"
 	_ "github.com/elastic/beats/v7/libbeat/processors/extract_array"
 	_ "github.com/elastic/beats/v7/libbeat/processors/fingerprint"
+	_ "github.com/elastic/beats/v7/libbeat/processors/grok"
 	_ "github.com/elastic/beats/v7/libbeat/processors/move_fields"
 	_ "github.com/elastic/beats/v7/libbeat/processors/ratelimit"
 	_ "github.com/elastic/beats/v7/libbeat/processors/registered_domain"

--- a/libbeat/processors/grok/docs/grok.asciidoc
+++ b/libbeat/processors/grok/docs/grok.asciidoc
@@ -1,0 +1,99 @@
+[[grok]]
+=== grok
+
+++++
+<titleabbrev>grok</titleabbrev>
+++++
+
+The `grok` processor parses a given string the same way as it is used in Logstash or Elasticsearch.
+
+For example, given the following event:
+
+[source,json]
+----
+{
+  "someotherfield": "foo",
+  "message": "1.2.3.4:5678 [30/Apr/2025:14:05:13.969] my_frontend~ my_service_1443/srv002 0/0/3/1/4 200 73 - - ---- 67/65/0/0/0 0/0 \"POST /some/path/here HTTP/1.0\"",
+}
+----
+
+Giving the following grok configuration
+
+[source,yaml]
+----
+processors:
+  - grok:
+      field: "message"
+      pattern: '%{IP:source.address}:%{NUMBER:source.port} \[%{HAPROXYDATE:haproxy.request_date}\] %{NOTSPACE:haproxy.frontend_name} %{USERNAME:haproxy.backend_name}/%{NOTSPACE:haproxy.server_name} %{NUMBER:haproxy.http.request.time_wait_ms:long}/%{NUMBER:haproxy.total_waiting_time_ms:long}/%{NUMBER:haproxy.connection_wait_time_ms:long}/%{NUMBER:haproxy.http.request.time_wait_without_data_ms:long}/%{NUMBER:temp.duration:long} %{NUMBER:http.response.status_code:long} %{NUMBER:haproxy.bytes_read:long} %{NOTSPACE:haproxy.http.request.captured_cookie} %{NOTSPACE:haproxy.http.response.captured_cookie} %{NOTSPACE:haproxy.termination_state} %{NUMBER:haproxy.connections.active:long}/%{NUMBER:haproxy.connections.frontend:long}/%{NUMBER:haproxy.connections.backend:long}/%{NUMBER:haproxy.connections.server:long}/%{NUMBER:haproxy.connections.retries:long} %{NUMBER:haproxy.server_queue:long}/%{NUMBER:haproxy.backend_queue:long} "%{GREEDYDATA:haproxy.http.request.raw_request_line}"'
+      customPatterns:
+        HAPROXYDATE: '%{MONTHDAY}/%{MONTH}/%{YEAR}:%{HOUR}:%{MINUTE}:%{SECOND}.%{INT}'
+----
+
+Your final event will be:
+
+[source,json]
+----
+{
+  "someotherfield": "foo",
+  "message": "1.2.3.4:5678 [30/Apr/2025:14:05:13.969] my_frontend~ my_service_1443/srv002 0/0/3/1/4 200 73 - - ---- 67/65/0/0/0 0/0 \"POST /some/path/here HTTP/1.0\"",
+  "haproxy": {
+    "connections": {
+      "frontend": 65,
+      "backend": 0,
+      "server": 0,
+      "retries": 0,
+      "active": 67
+    },
+    "request_date": "30/Apr/2025:14:05:13.969",
+    "server_name": "srv002",
+    "termination_state": "----",
+    "http": {
+      "request": {
+        "time_wait_without_data_ms": 1,
+        "raw_request_line": "POST /some/path/here HTTP/1.0",
+        "time_wait_ms": 0,
+        "captured_cookie": "-"
+      },
+      "response": {
+        "captured_cookie": "-"
+      }
+    },
+    "frontend_name": "my_frontend~",
+    "backend_queue": 0,
+    "bytes_read": 73,
+    "backend_name": "my_service_1443",
+    "connection_wait_time_ms": 3,
+    "server_queue": 0,
+    "total_waiting_time_ms": 0
+  },
+  "source": {
+    "address": "1.2.3.4",
+    "port": "5678"
+  },
+  "http": {
+    "response": {
+      "status_code": 200
+    }
+  }
+  ...
+}
+----
+
+.grok options
+[options="header"]
+|======
+| Name                    | Required | Default                  | Description                                                                                           |
+| `field`                 | yes      |                          | The name of the field with the event you want to parse         |
+| `pattern`               | yes      |                          | The pattern that should be used to parse.                   |
+| `customPatterns`        | no       |                          | Additional custom patterns can be given (besides all the default patterns, that already exist)|
+|======
+
+[source,yaml]
+----
+processors:
+  - grok:
+      from: "message"
+      pattern: '%{HAPROXYDATE:haproxy.request_data}'
+      customPatterns:
+        HAPROXYDATE: '%{MONTHDAY}/%{MONTH}/%{YEAR}:%{HOUR}:%{MINUTE}:%{SECOND}.%{INT}'
+----

--- a/libbeat/processors/grok/docs/grok.asciidoc
+++ b/libbeat/processors/grok/docs/grok.asciidoc
@@ -92,7 +92,7 @@ Your final event will be:
 ----
 processors:
   - grok:
-      from: "message"
+      field: "message"
       pattern: '%{HAPROXYDATE:haproxy.request_data}'
       customPatterns:
         HAPROXYDATE: '%{MONTHDAY}/%{MONTH}/%{YEAR}:%{HOUR}:%{MINUTE}:%{SECOND}.%{INT}'

--- a/libbeat/processors/grok/grok.go
+++ b/libbeat/processors/grok/grok.go
@@ -1,0 +1,100 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grok
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/processors/checks"
+	"github.com/elastic/elastic-agent-libs/config"
+	gogrok "github.com/elastic/go-grok"
+)
+
+func init() {
+	processors.RegisterPlugin("grok",
+		checks.ConfigChecked(NewGrok, checks.RequireFields("field", "pattern")))
+}
+
+type grokConfig struct {
+	Pattern        string            `config:"pattern"`
+	Field          string            `config:"field"`
+	CustomPatterns map[string]string `config:"customPatterns"`
+}
+
+type grokProcessor struct {
+	config grokConfig
+	grok   gogrok.Grok
+}
+
+func (u grokProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	root := event.Fields.Clone()
+	field, err := root.GetValue(u.config.Field)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get field '%s' from event: %w", field, err)
+	}
+
+	input, ok := field.(string)
+	if !ok {
+		return nil, fmt.Errorf("field '%s' is not a string", field)
+	}
+
+	values, err := u.grok.ParseTypedString(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse input with grok pattern: %w", err)
+	}
+
+	for k, v := range values {
+		_, err := event.PutValue(k, v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update event with parsed data: %w", err)
+		}
+	}
+
+	return event, nil
+}
+
+func (u grokProcessor) String() string {
+	return "grok"
+}
+
+func NewGrok(c *config.C) (beat.Processor, error) {
+	gc := grokConfig{}
+	err := c.Unpack(&gc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack grok config: %w", err)
+	}
+
+	gk, err := gogrok.NewComplete(gc.CustomPatterns)
+	if err != nil {
+		return nil, fmt.Errorf("faild to build grok parser: %w", err)
+	}
+
+	err = gk.Compile(gc.Pattern, true)
+	if err != nil {
+		return nil, fmt.Errorf("cannot compile pattern %w", gc.Pattern, err)
+	}
+
+	p := &grokProcessor{
+		config: gc,
+		grok:   *gk,
+	}
+
+	return p, nil
+}

--- a/metricbeat/include/list_init.go
+++ b/metricbeat/include/list_init.go
@@ -21,10 +21,9 @@ package include
 
 import (
 	// Import packages to perform 'func InitializeModule()' when in-use.
-	m0 "github.com/elastic/beats/v7/metricbeat/autodiscover/builder/hints"
 	m1 "github.com/elastic/beats/v7/metricbeat/autodiscover/appender/kubernetes/token"
+	m0 "github.com/elastic/beats/v7/metricbeat/autodiscover/builder/hints"
 	m2 "github.com/elastic/beats/v7/metricbeat/processor/add_kubernetes_metadata"
-
 	// Import packages that perform 'func init()'.
 )
 

--- a/metricbeat/include/list_init.go
+++ b/metricbeat/include/list_init.go
@@ -21,8 +21,8 @@ package include
 
 import (
 	// Import packages to perform 'func InitializeModule()' when in-use.
-	m1 "github.com/elastic/beats/v7/metricbeat/autodiscover/appender/kubernetes/token"
 	m0 "github.com/elastic/beats/v7/metricbeat/autodiscover/builder/hints"
+	m1 "github.com/elastic/beats/v7/metricbeat/autodiscover/appender/kubernetes/token"
 	m2 "github.com/elastic/beats/v7/metricbeat/processor/add_kubernetes_metadata"
 	// Import packages that perform 'func init()'.
 )

--- a/metricbeat/include/list_init.go
+++ b/metricbeat/include/list_init.go
@@ -24,6 +24,7 @@ import (
 	m0 "github.com/elastic/beats/v7/metricbeat/autodiscover/builder/hints"
 	m1 "github.com/elastic/beats/v7/metricbeat/autodiscover/appender/kubernetes/token"
 	m2 "github.com/elastic/beats/v7/metricbeat/processor/add_kubernetes_metadata"
+
 	// Import packages that perform 'func init()'.
 )
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This PR adds a `grok` processor to `beats`. Mainly, this might only be used within `filebeat` to parse logfiles the same way, that `logstash` or the `grok` processor within an ingest pipeline is doing it.

Please explain:

The goal is to have more flexibility and ability to *parse* a log file already on the `client` side, where `filebeat` might be running, instead of relying on a `logstash` or elasticsearch `ingest pipeline` to do the parsing.

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

Possible impact while using this processor is that a final `mapping` on the final elasticsearch `index` might not match and therefore might cause an `index mapping conflict`.

Depending on the number of log entries to parse and the complexity of the `grok` patterns, CPU and memory usage might increase significantly.

## Author's Checklist

I truly need help to write `tests`. Also requesting some hints, how this processor might be further improved. Maybe to add `tags` (if parsing fails)

I also need to fully confirm the ingestion into a running demo elasticsearch cluster. So far, I was only able to *see* the `events` from the internal `filebeat` **/logs** directly, how they *should* look. I will try to do this today.

## How to test this PR locally

This is described in the corresponding ascii docs.

## Related issues

- Closes https://github.com/elastic/beats/issues/30073

## Use cases

You do not need to maintain the `ingest pipelines` on elasticsearch itself and allows proper parsing already on the `client` side

## Screenshots

![image](https://github.com/user-attachments/assets/d69afc96-1e5a-4240-af5e-56edd495937f)


## Logs

```
./filebeat -e -d '*'
{"log.level":"info","@timestamp":"2025-05-06T15:04:05.785+0200","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).configure","file.name":"instance/beat.go","file.line":1052},"message":"Home path: [/Users/I561014/go/src/github.com/elastic/beats/filebeat] Config path: [/Users/I561014/go/src/github.com/elastic/beats/filebeat] Data path: [/Users/I561014/go/src/github.com/elastic/beats/filebeat/data] Logs path: [/Users/I561014/go/src/github.com/elastic/beats/filebeat/logs]","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:05.785+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).loadMeta","file.name":"instance/beat.go","file.line":1176},"message":"Beat metadata path: /Users/I561014/go/src/github.com/elastic/beats/filebeat/data/meta.json","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:05.794+0200","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).configure","file.name":"instance/beat.go","file.line":1060},"message":"Beat ID: 18da9fbc-207f-46af-8bdb-16995551fb85","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2025-05-06T15:04:06.151+0200","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).configure","file.name":"instance/beat.go","file.line":1075},"message":"unable to lookup FQDN: could not get FQDN, all methods failed: failed looking up CNAME: lookup MQWLD9W6PP on 10.17.220.88:53: no such host: failed looking up IP: lookup MQWLD9W6PP: no such host, using hostname = MQWLD9W6PP as FQDN","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.153+0200","log.logger":"processors","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/processors.New","file.name":"processors/processor.go","file.line":113},"message":"Generated new processors: grok","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.154+0200","log.logger":"seccomp","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/common/seccomp.loadFilter","file.name":"seccomp/seccomp.go","file.line":97},"message":"Syscall filtering is only supported on Linux","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.154+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).createBeater","file.name":"instance/beat.go","file.line":558},"message":"Setup Beat: filebeat; Version: 9.1.0 (FIPS-distribution: false)","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.154+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).logSystemInfo","file.name":"instance/beat.go","file.line":1612},"message":"Beat info","service.name":"filebeat","system_info":{"beat":{"path":{"config":"/Users/I561014/go/src/github.com/elastic/beats/filebeat","data":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/data","home":"/Users/I561014/go/src/github.com/elastic/beats/filebeat","logs":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/logs"},"type":"filebeat","uuid":"18da9fbc-207f-46af-8bdb-16995551fb85"},"ecs.version":"1.6.0"}}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.154+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).logSystemInfo","file.name":"instance/beat.go","file.line":1621},"message":"Build info","service.name":"filebeat","system_info":{"build":{"commit":"bf2e6931023480fda956d1ed62dee54bb98bfc60","libbeat":"9.1.0","time":"2025-05-06T09:38:33.000Z","version":"9.1.0"},"ecs.version":"1.6.0"}}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.154+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).logSystemInfo","file.name":"instance/beat.go","file.line":1624},"message":"Go runtime info","service.name":"filebeat","system_info":{"go":{"os":"darwin","arch":"arm64","max_procs":12,"version":"go1.24.1"},"ecs.version":"1.6.0"}}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.155+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).logSystemInfo","file.name":"instance/beat.go","file.line":1630},"message":"Host info","service.name":"filebeat","system_info":{"host":{"architecture":"arm64","native_architecture":"arm64","boot_time":"2025-04-22T12:08:40.009663+02:00","name":"MQWLD9W6PP","ip":["127.0.0.1","::1","fe80::1","fe80::145e:bc80:e9c6:40b7","2a02:810c:892:6a00:87c:251c:f984:4c3a","192.168.30.207","2a02:810c:892:6a00:145e:bc80:e9c6:40b7","2a02:810c:892:6a00:2992:3b14:9d91:198f","2a02:810c:892:6a00:b02e:85d5:11d6:a736","2a02:810c:892:6a00:55d0:2085:4552:c4d2","2a02:810c:892:6a00:2ca0:d0b:facc:ae9d","2a02:810c:892:6a00:8949:2e5:688c:41b","2a02:810c:892:6a00:5031:d6cf:b28b:afe4","2a02:810c:892:6a00:3190:c9c9:649d:1d1d","fe80::bc2a:e5ff:fea3:2ce2","fe80::bc2a:e5ff:fea3:2ce2","fe80::5cb4:14c9:57ef:bfd","fe80::6c18:210f:2aeb:af1d","fe80::ccca:b99d:411c:4a61","fe80::ce81:b1c:bd2c:69e","10.177.84.24"],"kernel_version":"24.4.0","mac":["d2:b0:6e:80:52:78","d2:b0:6e:80:52:76","d2:b0:6e:80:52:77","d2:b0:6e:80:52:56","d2:b0:6e:80:52:57","d2:b0:6e:80:52:58","36:0f:25:13:5a:c0","36:0f:25:13:5a:c4","36:0f:25:13:5a:c8","36:0f:25:13:5a:c0","7e:f5:5c:cc:e8:4c","82:73:31:b0:bf:26","be:2a:e5:a3:2c:e2","be:2a:e5:a3:2c:e2","00:50:b6:ec:83:c3"],"os":{"type":"macos","family":"darwin","platform":"darwin","name":"macOS","version":"15.4.1","major":15,"minor":4,"patch":1,"build":"24E263"},"timezone":"CEST","timezone_offset_sec":7200,"id":"95B35F89-5364-50C6-A145-231201054AC5"},"ecs.version":"1.6.0"}}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.155+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).logSystemInfo","file.name":"instance/beat.go","file.line":1659},"message":"Process info","service.name":"filebeat","system_info":{"process":{"cwd":"/Users/I561014/go/src/github.com/elastic/beats/filebeat","exe":"./filebeat","name":"filebeat","pid":84360,"ppid":82702,"start_time":"2025-05-06T15:04:05.743+0200"},"ecs.version":"1.6.0"}}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.156+0200","log.logger":"beat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).createBeater","file.name":"instance/beat.go","file.line":587},"message":"Initializing output plugins","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.160+0200","log.logger":"elasticsearch","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch.makeES","file.name":"elasticsearch/elasticsearch.go","file.line":56},"message":"Applying performance preset 'balanced': {\n  \"bulk_max_size\": 1600,\n  \"compression_level\": 1,\n  \"idle_connection_timeout\": \"3s\",\n  \"queue\": {\n    \"mem\": {\n      \"events\": 3200,\n      \"flush\": {\n        \"min_events\": 1600,\n        \"timeout\": \"10s\"\n      }\n    }\n  },\n  \"worker\": 1\n}","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.161+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.NewConnection","file.name":"eslegclient/connection.go","file.line":132},"message":"elasticsearch url: https://localhost:9200","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2025-05-06T15:04:06.161+0200","log.logger":"tls","log.origin":{"function":"github.com/elastic/elastic-agent-libs/transport/tlscommon.(*TLSConfig).ToConfig","file.name":"tlscommon/tls_config.go","file.line":107},"message":"SSL/TLS verifications disabled.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.161+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*eventConsumer).run","file.name":"pipeline/consumer.go","file.line":110},"message":"start pipeline event consumer","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.161+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*queueReader).run","file.name":"pipeline/queue_reader.go","file.line":49},"message":"pipeline event consumer queue reader: start","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.161+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.LoadWithSettings","file.name":"pipeline/module.go","file.line":105},"message":"Beat name: MQWLD9W6PP","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.162+0200","log.logger":"modules","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/fileset.newModuleRegistry","file.name":"fileset/modules.go","file.line":135},"message":"Enabled modules/filesets: ","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.162+0200","log.logger":"monitoring","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/monitoring/report/log.(*reporter).snapshotLoop","file.name":"log/log.go","file.line":150},"message":"Starting metrics logging every 30s","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.162+0200","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).launch","file.name":"instance/beat.go","file.line":759},"message":"filebeat start running.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.162+0200","log.logger":"test","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.isFile","file.name":"registrar/migrate.go","file.line":288},"message":"isFile(/Users/I561014/go/src/github.com/elastic/beats/filebeat/data/registry) -> false","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.162+0200","log.logger":"test","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.isFile","file.name":"registrar/migrate.go","file.line":288},"message":"isFile() -> false","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.162+0200","log.logger":"test","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.isDir","file.name":"registrar/migrate.go","file.line":281},"message":"isDir(/Users/I561014/go/src/github.com/elastic/beats/filebeat/data/registry/filebeat) -> false","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.162+0200","log.logger":"registrar","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.(*Migrator).Run","file.name":"registrar/migrate.go","file.line":83},"message":"Registry type '' found","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.162+0200","log.logger":"test","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.isFile","file.name":"registrar/migrate.go","file.line":288},"message":"isFile(.bak) -> false","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"filebeat","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/statestore/backend/memlog.openStore","file.name":"memlog/store.go","file.line":134},"message":"Finished loading transaction log file for '/Users/I561014/go/src/github.com/elastic/beats/filebeat/data/registry/filebeat'. Active transaction id=0","service.name":"filebeat","store":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"registrar","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.(*Registrar).loadStates","file.name":"registrar/registrar.go","file.line":103},"message":"States Loaded from registrar: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).Start","file.name":"beater/crawler.go","file.line":72},"message":"Loading Inputs: 1","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).startInput","file.name":"beater/crawler.go","file.line":118},"message":"starting input, keys present on the config: [filebeat.inputs.0.enabled filebeat.inputs.0.id filebeat.inputs.0.paths.0 filebeat.inputs.0.type]","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"registrar","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.(*Registrar).Run","file.name":"registrar/registrar.go","file.line":134},"message":"Starting Registrar","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"scanner","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.newFileScanner","file.name":"filestream/fswatch.go","file.line":311},"message":"fingerprint mode enabled: offset 0, length 1024","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"scanner","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileScanner).resolveRecursiveGlobs","file.name":"filestream/fswatch.go","file.line":334},"message":"recursive glob enabled","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.172+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.newProspector","file.name":"filestream/prospector_creator.go","file.line":57},"message":"file identity is set to fingerprint","service.name":"filebeat","filestream_id":"my-filestream-id","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"input.filestream.prospector","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileProspector).Init","file.name":"filestream/prospector.go","file.line":135},"message":"trying to migrate file identity to fingerprint","service.name":"filebeat","filestream_id":"my-filestream-id","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).startInput","file.name":"beater/crawler.go","file.line":149},"message":"Starting input (ID: 7184716629260632359)","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/v2/compat.(*runner).Start.func1","file.name":"compat/compat.go","file.line":137},"message":"Input 'filestream' starting","service.name":"filebeat","id":"my-filestream-id","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Check","file.name":"cfgfile/reload.go","file.line":131},"message":"Checking module configs from: /Users/I561014/go/src/github.com/elastic/beats/filebeat/modules.d/*.yml","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"input.filestream.metric_registry","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/monitoring/inputmon.NewMetricsRegistry","file.name":"inputmon/input.go","file.line":145},"message":"registering","service.name":"filebeat","id":"my-filestream-id","registry_id":"my-filestream-id","input_id":"my-filestream-id","input_type":"filestream","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileProspector).Run","file.name":"filestream/prospector.go","file.line":284},"message":"Starting prospector","service.name":"filebeat","id":"my-filestream-id","prospector":"file_prospector","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"file_watcher","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileWatcher).watch","file.name":"filestream/fswatch.go","file.line":125},"message":"Start next scan","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"file_watcher","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileWatcher).watch","file.name":"filestream/fswatch.go","file.line":229},"message":"File scan complete","service.name":"filebeat","total":1,"written":0,"truncated":0,"renamed":0,"removed":0,"created":1,"ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Check","file.name":"cfgfile/reload.go","file.line":145},"message":"Number of module configs found: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).Start","file.name":"beater/crawler.go","file.line":107},"message":"Loading and starting Inputs completed. Enabled inputs: 1","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileProspector).onFSEvent","file.name":"filestream/prospector.go","file.line":330},"message":"A new file /Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log has been found","service.name":"filebeat","id":"my-filestream-id","prospector":"file_prospector","operation":"create","source_name":"fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","fingerprint":"1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","os_id":"27696711-16777233","new_path":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Run","file.name":"cfgfile/reload.go","file.line":163},"message":"Config reloader started","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Run","file.name":"cfgfile/reload.go","file.line":193},"message":"Scan for new config files","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Run","file.name":"cfgfile/reload.go","file.line":212},"message":"Number of module configs found: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader.reload","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*RunnerList).Reload","file.name":"cfgfile/list.go","file.line":91},"message":"Starting reload procedure, current runners: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader.reload","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*RunnerList).Reload","file.name":"cfgfile/list.go","file.line":109},"message":"Start list: 0, Stop list: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.(*defaultHarvesterGroup).Start","file.name":"input-logfile/harvester.go","file.line":140},"message":"Starting harvester for file","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Run","file.name":"cfgfile/reload.go","file.line":223},"message":"error '<nil>' cannot retried. Modify any input file to reload.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.173+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Run","file.name":"cfgfile/reload.go","file.line":229},"message":"Loading of config files completed.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.174+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*filestream).open","file.name":"filestream/input.go","file.line":207},"message":"newLogFileReader with config.MaxBytes:10485760","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","path":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log","state-id":"fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:06.174+0200","log.logger":"detect_null_bytes","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/reader/debug.(*Reader).Read","file.name":"debug/debug.go","file.line":95},"message":"Starting debug reader with a buffer size of 16384 and max failures of 100","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:06.193+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*logFile).Read","file.name":"filestream/filestream.go","file.line":131},"message":"End of file reached: /Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log; Backoff now.","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","path":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log","state-id":"fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:08.194+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*logFile).Read","file.name":"filestream/filestream.go","file.line":131},"message":"End of file reached: /Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log; Backoff now.","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","path":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log","state-id":"fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:12.195+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*logFile).Read","file.name":"filestream/filestream.go","file.line":131},"message":"End of file reached: /Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log; Backoff now.","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","path":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log","state-id":"fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.174+0200","log.logger":"file_watcher","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileWatcher).watch","file.name":"filestream/fswatch.go","file.line":125},"message":"Start next scan","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.174+0200","log.logger":"file_watcher","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileWatcher).watch","file.name":"filestream/fswatch.go","file.line":229},"message":"File scan complete","service.name":"filebeat","total":1,"written":0,"truncated":0,"renamed":0,"removed":0,"created":0,"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.176+0200","log.logger":"publisher_pipeline_output","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*netClientWorker).run","file.name":"pipeline/client_worker.go","file.line":138},"message":"Connecting to backoff(elasticsearch(https://localhost:9200))","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.176+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.(*Connection).Ping","file.name":"eslegclient/connection.go","file.line":303},"message":"ES Ping(url=https://localhost:9200)","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2025-05-06T15:04:16.176+0200","log.logger":"tls","log.origin":{"function":"github.com/elastic/elastic-agent-libs/transport/tlscommon.(*TLSConfig).ToConfig","file.name":"tlscommon/tls_config.go","file.line":107},"message":"SSL/TLS verifications disabled.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.190+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/elastic-agent-libs/transport/httpcommon.(*HTTPTransportSettings).RoundTripper.LoggingDialer.func2","file.name":"transport/logging.go","file.line":43},"message":"Completed dialing successfully","service.name":"filebeat","network.transport":"tcp","server.address":"localhost:9200","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.194+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.(*Connection).Ping","file.name":"eslegclient/connection.go","file.line":322},"message":"Ping status code: 200","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.194+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.(*Connection).Ping","file.name":"eslegclient/connection.go","file.line":323},"message":"Attempting to connect to Elasticsearch version 8.17.4 (default)","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.194+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.(*Connection).Request","file.name":"eslegclient/connection.go","file.line":380},"message":"GET https://localhost:9200/_license?human=false  <nil>","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.197+0200","log.logger":"index-management","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/idxmgmt.(*indexManager).Setup","file.name":"idxmgmt/index_support.go","file.line":254},"message":"Auto lifecycle enable success.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.197+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.(*Connection).Request","file.name":"eslegclient/connection.go","file.line":380},"message":"GET https://localhost:9200/_ilm/policy/filebeat  <nil>","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.203+0200","log.logger":"index-management.ilm","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle.(*stdManager).EnsurePolicy","file.name":"lifecycle/standard_manager.go","file.line":111},"message":"lifecycle policy filebeat exists already.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.204+0200","log.logger":"index-management","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/idxmgmt.applyLifecycleSettingsToTemplate","file.name":"idxmgmt/index_support.go","file.line":402},"message":"Set settings.index.lifecycle.name in template to filebeat as ILM is enabled.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.204+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.(*Connection).Request","file.name":"eslegclient/connection.go","file.line":380},"message":"HEAD https://localhost:9200/_index_template/filebeat-9.1.0  <nil>","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.209+0200","log.logger":"template_loader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/template.(*ESLoader).Load","file.name":"template/load.go","file.line":121},"message":"Template \"filebeat-9.1.0\" already exists and will not be overwritten.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.209+0200","log.logger":"index-management","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/idxmgmt.(*indexManager).Setup","file.name":"idxmgmt/index_support.go","file.line":299},"message":"Loaded index template.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.209+0200","log.logger":"esclientleg","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/esleg/eslegclient.(*Connection).Request","file.name":"eslegclient/connection.go","file.line":380},"message":"GET https://localhost:9200/  <nil>","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:16.211+0200","log.logger":"publisher_pipeline_output","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*netClientWorker).run","file.name":"pipeline/client_worker.go","file.line":146},"message":"Connection to backoff(elasticsearch(https://localhost:9200)) established","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.320+0200","log.logger":"elasticsearch.elasticsearch","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch.(*Client).doBulkRequest","file.name":"elasticsearch/client.go","file.line":303},"message":"doBulkRequest: 53 events have been sent to elasticsearch in 108.932167ms.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.320+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue.(*ackLoop).handleBatchSig","file.name":"memqueue/ackloop.go","file.line":80},"message":"ackloop: return ack to broker loop:53","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:16.320+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue.(*ackLoop).handleBatchSig","file.name":"memqueue/ackloop.go","file.line":82},"message":"ackloop:  done send ack","service.name":"filebeat","ecs.version":"1.6.0"}
^C{"log.level":"info","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"service","log.origin":{"function":"github.com/elastic/elastic-agent-libs/service.HandleSignals.func1","file.name":"service/service.go","file.line":52},"message":"Received signal \"interrupt\", stopping","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*Pipeline).Close","file.name":"pipeline/pipeline.go","file.line":166},"message":"close pipeline","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*queueReader).run","file.name":"pipeline/queue_reader.go","file.line":68},"message":"pipeline event consumer queue reader: stop","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.401+0200","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*Filebeat).Stop","file.name":"beater/filebeat.go","file.line":538},"message":"Stopping filebeat","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).Stop","file.name":"beater/crawler.go","file.line":156},"message":"Stopping Crawler","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).Stop","file.name":"beater/crawler.go","file.line":166},"message":"Stopping 1 inputs","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"crawler.module.reloader","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cfgfile.(*Reloader).Run","file.name":"cfgfile/reload.go","file.line":231},"message":"Dynamic config reloader stopped","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).Stop.func2","file.name":"beater/crawler.go","file.line":171},"message":"Stopping input: 7184716629260632359","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*filestream).Run.func1","file.name":"filestream/input.go","file.line":161},"message":"Closing reader of filestream","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","path":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log","state-id":"fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*filestream).readFromSource","file.name":"filestream/input.go","file.line":369},"message":"Reader was closed. Closing. Path='/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log'","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","path":"/Users/I561014/go/src/github.com/elastic/beats/filebeat/haproxy.log","state-id":"fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close","file.name":"pipeline/client.go","file.line":137},"message":"client: closing acker","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close","file.name":"pipeline/client.go","file.line":142},"message":"client: done closing acker","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close","file.name":"pipeline/client.go","file.line":144},"message":"client: close queue producer","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close","file.name":"pipeline/client.go","file.line":147},"message":"client: done producer close","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close","file.name":"pipeline/client.go","file.line":150},"message":"client: closing processors","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"publisher","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close","file.name":"pipeline/client.go","file.line":155},"message":"client: done closing processors","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.401+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.startHarvester.func1","file.name":"input-logfile/harvester.go","file.line":250},"message":"Stopped harvester for file","service.name":"filebeat","id":"my-filestream-id","source_file":"filestream::my-filestream-id::fingerprint::1e41174870f9cde0921bbf02e6f5b4b615bb415f0ef2da3a435ab33f17599b8b","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/filestream.(*fileProspector).Run","file.name":"filestream/prospector.go","file.line":316},"message":"Prospector has stopped","service.name":"filebeat","id":"my-filestream-id","prospector":"file_prospector","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/v2/compat.(*runner).Start.func1","file.name":"compat/compat.go","file.line":168},"message":"Input 'filestream' stopped (goroutine)","service.name":"filebeat","id":"my-filestream-id","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"input.filestream.metric_registry","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/monitoring/inputmon.CancelMetricsRegistry","file.name":"inputmon/input.go","file.line":161},"message":"unregistering","service.name":"filebeat","id":"my-filestream-id","registry_id":"my-filestream-id","input_id":"my-filestream-id","input_type":"filestream","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"input.filestream","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/input/v2/compat.(*runner).Stop","file.name":"compat/compat.go","file.line":176},"message":"Input 'filestream' stopped (runner)","service.name":"filebeat","id":"my-filestream-id","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"crawler","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/beater.(*crawler).Stop","file.name":"beater/crawler.go","file.line":186},"message":"Crawler stopped","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"registrar","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.(*Registrar).Stop","file.name":"registrar/registrar.go","file.line":126},"message":"Stopping Registrar","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"registrar","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.(*Registrar).Run","file.name":"registrar/registrar.go","file.line":162},"message":"Ending Registrar","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"registrar","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.(*Registrar).Run","file.name":"registrar/registrar.go","file.line":163},"message":"Stopping Registrar","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.402+0200","log.logger":"registrar","log.origin":{"function":"github.com/elastic/beats/v7/filebeat/registrar.(*Registrar).Stop","file.name":"registrar/registrar.go","file.line":131},"message":"Registrar stopped","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.407+0200","log.origin":{"function":"github.com/elastic/elastic-agent-system-metrics/metric/system/numcpu.NumCPU","file.name":"numcpu/numcpu.go","file.line":41},"message":"Accurate CPU counts not available on platform, falling back to runtime.NumCPU for metrics","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2025-05-06T15:04:18.407+0200","log.origin":{"function":"github.com/elastic/elastic-agent-system-metrics/metric/system/numcpu.NumCPU","file.name":"numcpu/numcpu.go","file.line":41},"message":"Accurate CPU counts not available on platform, falling back to runtime.NumCPU for metrics","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.407+0200","log.logger":"monitoring","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/monitoring/report/log.(*reporter).logTotals","file.name":"log/log.go","file.line":200},"message":"Total metrics","service.name":"filebeat","monitoring":{"metrics":{"beat":{"cpu":{"system":{"ticks":1,"time":{"ms":1}},"total":{"ticks":2,"time":{"ms":2},"value":2},"user":{"ticks":1,"time":{"ms":1}}},"info":{"ephemeral_id":"08d0b639-0fd9-4789-8ce0-96fec22e1628","name":"filebeat","uptime":{"ms":12632},"version":"9.1.0"},"memstats":{"gc_next":13723746,"memory_alloc":9731608,"memory_sys":24790280,"memory_total":15818808,"rss":54099968},"runtime":{"goroutines":8}},"filebeat":{"harvester":{"closed":1,"open_files":0,"running":0,"skipped":0,"started":1},"input":{"log":{"files":{"renamed":0,"truncated":0}}}},"libbeat":{"config":{"module":{"running":0,"starts":0,"stops":0},"reloads":1,"scans":1},"output":{"batches":{"split":0},"events":{"acked":53,"active":0,"batches":1,"dead_letter":0,"dropped":0,"duplicates":0,"failed":0,"toomany":0,"total":53},"read":{"bytes":3942,"errors":0},"type":"elasticsearch","write":{"bytes":8556,"errors":0,"latency":{"histogram":{"count":1,"max":108,"mean":108,"median":108,"min":108,"p75":108,"p95":108,"p99":108,"p999":108,"stddev":0}}}}},"registrar":{"states":{"cleanup":0,"current":0,"update":0},"writes":{"fail":0,"success":0,"total":0}},"system":{"cpu":{"cores":12},"load":{"1":2.5737,"15":3.085,"5":2.9614,"norm":{"1":0.2145,"15":0.2571,"5":0.2468}}}},"ecs.version":"1.6.0"}}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.407+0200","log.logger":"monitoring","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/monitoring/report/log.(*reporter).logTotals","file.name":"log/log.go","file.line":201},"message":"Uptime: 12.627499792s","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.407+0200","log.logger":"monitoring","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/monitoring/report/log.(*reporter).snapshotLoop","file.name":"log/log.go","file.line":168},"message":"Stopping metrics logging.","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-06T15:04:18.408+0200","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).launch","file.name":"instance/beat.go","file.line":768},"message":"filebeat stopped.","service.name":"filebeat","ecs.version":"1.6.0"}
```