### PR TITLE
Remove nats Dockerfile from bump Golang action

### DIFF
--- a/.github/workflows/updatecli.d/bump-golang.yml
+++ b/.github/workflows/updatecli.d/bump-golang.yml
@@ -158,16 +158,6 @@ targets:
         keyword: "FROM"
         matcher: "golang"
       file: ./packetbeat/Dockerfile
-  update-nats-module-dockerfile:
-    name: "Update NATS module Dockerfile"
-    sourceid: latestGoVersion
-    scmid: githubConfig
-    kind: dockerfile
-    spec:
-      instruction:
-        keyword: "FROM"
-        matcher: "golang"
-      file: ./metricbeat/module/nats/_meta/Dockerfile
   update-http-module-dockerfile:
     name: "Update HTTP module Dockerfile"
     sourceid: latestGoVersion


### PR DESCRIPTION
## Proposed commit message

This commit removes the nats Dockerfile from the bump-golang GH action, since after #43310 it no longer references golang docker images.

