### PR TITLE
[BeatReceivers] setup http monitoring during receiver creation

### DIFF
--- a/libbeat/otelbeat/beatreceiver/beat_receiver.go
+++ b/libbeat/otelbeat/beatreceiver/beat_receiver.go
@@ -39,11 +39,26 @@ type BeatReceiver struct {
 	Logger   *zap.Logger
 }
 
+// NewBeatReceiver creates a new BeatReceiver instance.
+func NewBeatReceiver(
+	beat *instance.Beat,
+	beater beat.Beater,
+	httpConf *config.C,
+	logger *zap.Logger,
+) (BeatReceiver, error) {
+	b := BeatReceiver{
+		Beat:     beat,
+		Beater:   beater,
+		HttpConf: httpConf,
+		Logger:   logger,
+	}
+
+	err := b.startMonitoring()
+	return b, err
+}
+
 // BeatReceiver.Stop() starts the beat receiver.
 func (b *BeatReceiver) Start() error {
-	if err := b.startMonitoring(); err != nil {
-		return fmt.Errorf("could not start the HTTP server for the monitoring API: %w", err)
-	}
 	if err := b.Beater.Run(&b.Beat.Beat); err != nil {
 		return fmt.Errorf("beat receiver run error: %w", err)
 	}

--- a/x-pack/filebeat/fbreceiver/factory.go
+++ b/x-pack/filebeat/fbreceiver/factory.go
@@ -71,13 +71,10 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("error unpacking monitoring config: %w", err)
 	}
 
-	base := beatreceiver.BeatReceiver{
-		HttpConf: httpConf.HTTP,
-		Beat:     b,
-		Beater:   fbBeater,
-		Logger:   set.Logger,
+	base, err := beatreceiver.NewBeatReceiver(b, fbBeater, httpConf.HTTP, set.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("error creating base receiver: %w", err)
 	}
-
 	return &filebeatReceiver{BeatReceiver: base}, nil
 }
 

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -6,6 +6,17 @@ package fbreceiver
 
 import (
 	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
@@ -21,6 +32,16 @@ import (
 )
 
 func TestNewReceiver(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	monitorSocket := genSocketPath()
+	var monitorHost string
+	if runtime.GOOS == "windows" {
+		monitorHost = "npipe:///" + filepath.Base(monitorSocket)
+	} else {
+		monitorHost = "unix://" + monitorSocket
+	}
+
 	config := Config{
 		Beatconfig: map[string]interface{}{
 			"filebeat": map[string]interface{}{
@@ -42,7 +63,9 @@ func TestNewReceiver(t *testing.T) {
 					"*",
 				},
 			},
-			"path.home": t.TempDir(),
+			"path.home":    tmpDir,
+			"http.enabled": true,
+			"http.host":    monitorHost,
 		},
 	}
 
@@ -55,22 +78,137 @@ func TestNewReceiver(t *testing.T) {
 				Factory: NewFactory(),
 			},
 		},
-		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
-			_ = zapLogs
-			require.Lenf(t, logs["r1"], 1, "expected 1 log, got %d", len(logs["r1"]))
-			assert.Condition(t, func() bool {
+		AssertFunc: func(ct *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
+			require.Lenf(ct, logs["r1"], 1, "expected 1 log, got %d", len(logs["r1"]))
+
+			var lastError strings.Builder
+			assert.Conditionf(t, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket)
+			}, "failed to connect to monitoring socket, last error was: %s", &lastError)
+
+			assert.Condition(ct, func() bool {
 				processorsLoaded := zapLogs.FilterMessageSnippet("Generated new processors").
 					FilterMessageSnippet("add_host_metadata").
 					FilterMessageSnippet("add_cloud_metadata").
 					FilterMessageSnippet("add_docker_metadata").
 					FilterMessageSnippet("add_kubernetes_metadata").
 					Len() == 1
-				assert.True(t, processorsLoaded, "processors not loaded")
+				assert.True(ct, processorsLoaded, "processors not loaded")
 				// Check that add_host_metadata works, other processors are not guaranteed to add fields in all environments
-				return assert.Contains(t, logs["r1"][0].Flatten(), "host.architecture")
+				return assert.Contains(ct, logs["r1"][0].Flatten(), "host.architecture")
 			}, "failed to check processors loaded")
 		},
 	})
+}
+
+func TestFactory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	monitorSocket := genSocketPath()
+	var monitorHost string
+	if runtime.GOOS == "windows" {
+		monitorHost = "npipe:///" + filepath.Base(monitorSocket)
+	} else {
+		monitorHost = "unix://" + monitorSocket
+	}
+
+	cfg := &Config{
+		Beatconfig: map[string]interface{}{
+			"filebeat": map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{
+						"type":    "benchmark",
+						"enabled": true,
+						"message": "test",
+						"count":   10,
+					},
+				},
+			},
+			"output": map[string]interface{}{
+				"otelconsumer": map[string]interface{}{},
+			},
+			"logging": map[string]interface{}{
+				"level": "info",
+				"selectors": []string{
+					"*",
+				},
+			},
+			"path.home":    tmpDir,
+			"http.enabled": true,
+			"http.host":    monitorHost,
+		},
+	}
+
+	var zapLogs bytes.Buffer
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.Lock(zapcore.AddSync(&zapLogs)),
+		zapcore.InfoLevel)
+
+	factory := NewFactory()
+
+	receiverSettings := receiver.Settings{}
+	receiverSettings.Logger = zap.New(core)
+	receiverSettings.ID = component.NewIDWithName(factory.Type(), "r1")
+
+	rc, err := factory.CreateLogs(t.Context(), receiverSettings, cfg, nil)
+	require.NotEmpty(t, rc, "receiver should not be nil")
+	require.NoError(t, err)
+
+	// Ensure http metrics endpoint is reachable on receiver creation
+	var lastError strings.Builder
+	assert.Conditionf(t, func() bool {
+		return getFromSocket(t, &lastError, monitorSocket)
+	}, "failed to connect to monitoring socket, last error was: %s", &lastError)
+}
+
+func genSocketPath() string {
+	randData := make([]byte, 16)
+	for i := range len(randData) {
+		randData[i] = uint8(rand.UintN(255)) //nolint:gosec // 0-255 fits in a uint8
+	}
+	socketName := base64.URLEncoding.EncodeToString(randData) + ".sock"
+	socketDir := os.TempDir()
+	return filepath.Join(socketDir, socketName)
+}
+
+func getFromSocket(t *testing.T, sb *strings.Builder, socketPath string) bool {
+	// skip windows for now
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://unix/stats", nil)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "error creating request: %s", err)
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "client.Get failed: %s", err)
+		return false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "io.ReadAll of body failed: %s", err)
+		return false
+	}
+	if len(body) <= 0 {
+		sb.Reset()
+		sb.WriteString("body too short")
+		return false
+	}
+	return true
 }
 
 func BenchmarkFactory(b *testing.B) {
@@ -125,32 +263,74 @@ func TestMultipleReceivers(t *testing.T) {
 	// in isolation, started, and can ingest logs without interfering
 	// with each other.
 
+	monitorSocket1 := genSocketPath()
+	var monitorHost1 string
+	if runtime.GOOS == "windows" {
+		monitorHost1 = "npipe:///" + filepath.Base(monitorSocket1)
+	} else {
+		monitorHost1 = "unix://" + monitorSocket1
+	}
+	monitorSocket2 := genSocketPath()
+	var monitorHost2 string
+	if runtime.GOOS == "windows" {
+		monitorHost2 = "npipe:///" + filepath.Base(monitorSocket2)
+	} else {
+		monitorHost2 = "unix://" + monitorSocket2
+	}
+
 	// Receivers need distinct home directories so wrap the config in a function.
-	config := func() *Config {
-		return &Config{
-			Beatconfig: map[string]interface{}{
-				"filebeat": map[string]interface{}{
-					"inputs": []map[string]interface{}{
-						{
-							"type":    "benchmark",
-							"enabled": true,
-							"message": "test",
-							"count":   1,
-						},
+	config1 := Config{
+		Beatconfig: map[string]interface{}{
+			"filebeat": map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{
+						"type":    "benchmark",
+						"enabled": true,
+						"message": "test",
+						"count":   1,
 					},
 				},
-				"output": map[string]interface{}{
-					"otelconsumer": map[string]interface{}{},
-				},
-				"logging": map[string]interface{}{
-					"level": "info",
-					"selectors": []string{
-						"*",
-					},
-				},
-				"path.home": t.TempDir(),
 			},
-		}
+			"output": map[string]interface{}{
+				"otelconsumer": map[string]interface{}{},
+			},
+			"logging": map[string]interface{}{
+				"level": "info",
+				"selectors": []string{
+					"*",
+				},
+			},
+			"path.home":    t.TempDir(),
+			"http.enabled": true,
+			"http.host":    monitorHost1,
+		},
+	}
+
+	config2 := Config{
+		Beatconfig: map[string]interface{}{
+			"filebeat": map[string]interface{}{
+				"inputs": []map[string]interface{}{
+					{
+						"type":    "benchmark",
+						"enabled": true,
+						"message": "test",
+						"count":   1,
+					},
+				},
+			},
+			"output": map[string]interface{}{
+				"otelconsumer": map[string]interface{}{},
+			},
+			"logging": map[string]interface{}{
+				"level": "info",
+				"selectors": []string{
+					"*",
+				},
+			},
+			"path.home":    t.TempDir(),
+			"http.enabled": true,
+			"http.host":    monitorHost2,
+		},
 	}
 
 	factory := NewFactory()
@@ -159,18 +339,29 @@ func TestMultipleReceivers(t *testing.T) {
 		Receivers: []oteltest.ReceiverConfig{
 			{
 				Name:    "r1",
-				Config:  config(),
+				Config:  &config1,
 				Factory: factory,
 			},
 			{
 				Name:    "r2",
-				Config:  config(),
+				Config:  &config2,
 				Factory: factory,
 			},
 		},
 		AssertFunc: func(c *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
 			require.Greater(c, len(logs["r1"]), 0, "receiver r1 does not have any logs")
 			require.Greater(c, len(logs["r2"]), 0, "receiver r2 does not have any logs")
+
+			var lastError strings.Builder
+			assert.Conditionf(c, func() bool {
+				tests := []string{monitorSocket1, monitorSocket2}
+				for _, tc := range tests {
+					if ret := getFromSocket(t, &lastError, tc); ret == false {
+						return false
+					}
+				}
+				return true
+			}, "failed to connect to monitoring socket, last error was: %s", &lastError)
 
 			// Make sure that each receiver has a separate logger
 			// instance and does not interfere with others. Previously, the

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -69,13 +69,11 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("error unpacking monitoring config: %w", err)
 	}
 
-	beatReceiver := beatreceiver.BeatReceiver{
-		Beat:     b,
-		Beater:   mbBeater,
-		Logger:   set.Logger,
-		HttpConf: httpConf.HTTP,
+	base, err := beatreceiver.NewBeatReceiver(b, mbBeater, httpConf.HTTP, set.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("error creating base receiver: %w", err)
 	}
-	return &metricbeatReceiver{BeatReceiver: beatReceiver}, nil
+	return &metricbeatReceiver{BeatReceiver: base}, nil
 }
 
 // copied from metricbeat cmd.


### PR DESCRIPTION


## Proposed commit message

Currently, beats receivers http monitoring is started on the call to receiver Start. On the OTel collector pipeline, the receiver is first instanciated via the CreateLogs factory, and only then started. This commit moves the http monitoring to the receiver creation, ensuring the monitoring endpoints are available as soon as possible during the collector startup.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/43418