### PR TITLE
Set MAGE VERSION to 1.15.0 for deploy-k8s-pipeline

### DIFF
--- a/.buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml
+++ b/.buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml
@@ -7,6 +7,7 @@ env:
 
   # Other deps
   ASDF_KIND_VERSION: "0.24.0"
+  ASDF_MAGE_VERSION: "1.15.0"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 


### PR DESCRIPTION
## Proposed commit message

This commit fixes failures like

```
make: Entering directory '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1746625288052333369/elastic/deploy-k8s/metricbeat'
Installing mage v1.15.0.
go: downloading github.com/magefile/mage v1.15.0
No version is set for command mage
Consider adding one of the following versions in your config file at /opt/buildkite-agent/builds/bk-agent-prod-gcp-1746625288052333369/elastic/deploy-k8s/.tool-versions
mage 1.14.0
mage 1.15.0
```

as seen e.g. in https://github..com/elastic/beats/pull/44202#issuecomment-2854583273

due to the lack of defining the mage version as done in the rest of pipelines.

## How to test this PR locally

Tested only in CI, this PR should result in green CI for the deploy-k8s-pipeline
