### PR TITLE
[Docs] Clarify 'worker' and 'workers' setting descriptions

### DIFF
--- a/docs/reference/auditbeat/elasticsearch-output.md
+++ b/docs/reference/auditbeat/elasticsearch-output.md
@@ -108,7 +108,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+ Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -116,6 +117,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance]
 
 When `loadbalance: true` is set, Auditbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Auditbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Auditbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Auditbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/auditbeat/logstash-output.md
+++ b/docs/reference/auditbeat/logstash-output.md
@@ -120,7 +120,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -128,6 +129,7 @@ The default value is `1`.
 ### `loadbalance` [loadbalance]
 
 When `loadbalance: true` is set, Auditbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Auditbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Auditbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Auditbeat can connect to at least one of its configured hosts. To rotate through the list of configured hosts over time, use this option in conjunction with the `ttl` setting to close the connection at the configured interval and choose a new target host.
 

--- a/docs/reference/auditbeat/redis-output.md
+++ b/docs/reference/auditbeat/redis-output.md
@@ -131,7 +131,8 @@ See [Change the output codec](/reference/auditbeat/configuration-output-codec.md
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -139,6 +140,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance_2]
 
 When `loadbalance: true` is set, Auditbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Auditbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Auditbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Auditbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/filebeat/elasticsearch-output.md
+++ b/docs/reference/filebeat/elasticsearch-output.md
@@ -108,7 +108,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -116,6 +117,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance]
 
 When `loadbalance: true` is set, Filebeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Filebeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Filebeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Filebeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/filebeat/logstash-output.md
+++ b/docs/reference/filebeat/logstash-output.md
@@ -122,7 +122,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -130,6 +131,7 @@ The default value is `1`.
 ### `loadbalance` [loadbalance]
 
 When `loadbalance: true` is set, Filebeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Filebeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Filebeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Filebeat can connect to at least one of its configured hosts. To rotate through the list of configured hosts over time, use this option in conjunction with the `ttl` setting to close the connection at the configured interval and choose a new target host.
 

--- a/docs/reference/filebeat/redis-output.md
+++ b/docs/reference/filebeat/redis-output.md
@@ -131,7 +131,8 @@ See [Change the output codec](/reference/filebeat/configuration-output-codec.md)
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -140,6 +141,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance_2]
 
 When `loadbalance: true` is set, Filebeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Filebeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Filebeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Filebeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/heartbeat/elasticsearch-output.md
+++ b/docs/reference/heartbeat/elasticsearch-output.md
@@ -108,7 +108,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -116,6 +117,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance]
 
 When `loadbalance: true` is set, Heartbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Heartbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Heartbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Heartbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/heartbeat/logstash-output.md
+++ b/docs/reference/heartbeat/logstash-output.md
@@ -120,7 +120,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -128,6 +129,7 @@ The default value is `1`.
 ### `loadbalance` [loadbalance]
 
 When `loadbalance: true` is set, Heartbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Heartbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Heartbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Heartbeat can connect to at least one of its configured hosts. To rotate through the list of configured hosts over time, use this option in conjunction with the `ttl` setting to close the connection at the configured interval and choose a new target host.
 

--- a/docs/reference/heartbeat/redis-output.md
+++ b/docs/reference/heartbeat/redis-output.md
@@ -131,7 +131,8 @@ See [Change the output codec](/reference/heartbeat/configuration-output-codec.md
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -140,6 +141,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance_2]
 
 When `loadbalance: true` is set, Heartbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Heartbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Heartbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Heartbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/metricbeat/elasticsearch-output.md
+++ b/docs/reference/metricbeat/elasticsearch-output.md
@@ -108,7 +108,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -116,6 +117,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance]
 
 When `loadbalance: true` is set, Metricbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Metricbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Metricbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Metricbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/metricbeat/logstash-output.md
+++ b/docs/reference/metricbeat/logstash-output.md
@@ -120,7 +120,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -128,6 +129,7 @@ The default value is `1`.
 ### `loadbalance` [loadbalance]
 
 When `loadbalance: true` is set, Metricbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Metricbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Metricbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Metricbeat can connect to at least one of its configured hosts. To rotate through the list of configured hosts over time, use this option in conjunction with the `ttl` setting to close the connection at the configured interval and choose a new target host.
 

--- a/docs/reference/metricbeat/redis-output.md
+++ b/docs/reference/metricbeat/redis-output.md
@@ -131,7 +131,8 @@ See [Change the output codec](/reference/metricbeat/configuration-output-codec.m
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -139,6 +140,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance_2]
 
 When `loadbalance: true` is set, Metricbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Metricbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Metricbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Metricbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/packetbeat/elasticsearch-output.md
+++ b/docs/reference/packetbeat/elasticsearch-output.md
@@ -107,7 +107,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Elasticsearch in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -115,6 +116,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance]
 
 When `loadbalance: true` is set, Packetbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Packetbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Packetbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Packetbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/packetbeat/logstash-output.md
+++ b/docs/reference/packetbeat/logstash-output.md
@@ -120,7 +120,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -128,6 +129,7 @@ The default value is `1`.
 ### `loadbalance` [loadbalance]
 
 When `loadbalance: true` is set, Packetbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Packetbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Packetbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Packetbeat can connect to at least one of its configured hosts. To rotate through the list of configured hosts over time, use this option in conjunction with the `ttl` setting to close the connection at the configured interval and choose a new target host.
 

--- a/docs/reference/packetbeat/redis-output.md
+++ b/docs/reference/packetbeat/redis-output.md
@@ -131,7 +131,8 @@ See [Change the output codec](/reference/packetbeat/configuration-output-codec.m
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -139,6 +140,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance_2]
 
 When `loadbalance: true` is set, Packetbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Packetbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Packetbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Packetbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/winlogbeat/elasticsearch-output.md
+++ b/docs/reference/winlogbeat/elasticsearch-output.md
@@ -108,7 +108,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [worker-option]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -116,6 +117,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance]
 
 When `loadbalance: true` is set, Winlogbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Winlogbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Winlogbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Winlogbeat can connect to at least one of its configured hosts.
 

--- a/docs/reference/winlogbeat/logstash-output.md
+++ b/docs/reference/winlogbeat/logstash-output.md
@@ -120,7 +120,8 @@ The default value is `false`.
 
 ### `worker` or `workers` [_worker_or_workers]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to {{ls}} in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -128,6 +129,7 @@ The default value is `1`.
 ### `loadbalance` [loadbalance]
 
 When `loadbalance: true` is set, Winlogbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Winlogbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Winlogbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Winlogbeat can connect to at least one of its configured hosts. To rotate through the list of configured hosts over time, use this option in conjunction with the `ttl` setting to close the connection at the configured interval and choose a new target host.
 

--- a/docs/reference/winlogbeat/redis-output.md
+++ b/docs/reference/winlogbeat/redis-output.md
@@ -131,7 +131,8 @@ See [Change the output codec](/reference/winlogbeat/configuration-output-codec.m
 
 ### `worker` or `workers` [_worker_or_workers_2]
 
-`worker` or `workers` specifies the number of connections created per host for publishing events. It is best used with `loadbalance:true` which publishes events to Redis in parallel. Example: If you have 2 hosts and 3 workers, in total 6 connections are started (3 for each host).
+`worker` or `workers` specifies the number of connections created per host for publishing events.
+Refer to the `loadblance` setting for details about how the load balancing works to distribute requests across the Elasticsearch cluster nodes.
 
 The default value is `1`.
 
@@ -139,6 +140,7 @@ The default value is `1`.
 ### `loadbalance` [_loadbalance_2]
 
 When `loadbalance: true` is set, Winlogbeat connects to all configured hosts and sends data through all connections in parallel. If a connection fails, data is sent to the remaining hosts until it can be reestablished. Data will still be sent as long as Winlogbeat can connect to at least one of its configured hosts.
+Use the `worker` or `workers` setting to specify the number of connections per host.
 
 When `loadbalance: false` is set, Winlogbeat sends data to a single host at a time. The target host is chosen at random from the list of configured hosts, and all data is sent to that target until the connection fails, when a new target is selected. Data will still be sent as long as Winlogbeat can connect to at least one of its configured hosts.
 


### PR DESCRIPTION
This is a follow up to https://github.com/elastic/beats/pull/44214 as discussed with Bill over Slack. It just adds a bit more clarification to the `worker`/ `workers` setting in the Beats docs.
