### PR TITLE
oteltest: fix logger fields added by pipeline telemetry

### DIFF
--- a/libbeat/otelbeat/oteltest/oteltest.go
+++ b/libbeat/otelbeat/oteltest/oteltest.go
@@ -79,22 +79,19 @@ func CheckReceivers(params CheckReceiversParams) {
 		receiverCore := core.
 			With([]zapcore.Field{
 				zap.String("otelcol.component.id", rc.Name),
-				zap.String("otelcol.component.kind", "Receiver"),
-				zap.String("otelcol.signals", "logs"),
+				zap.String("otelcol.component.kind", "receiver"),
+				zap.String("otelcol.signal", "logs"),
 			})
 
 		receiverSettings.Logger = zap.New(receiverCore)
 		receiverSettings.ID = component.NewIDWithName(rc.Factory.Type(), rc.Name)
 
 		logConsumer, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
-			for i := 0; i < ld.ResourceLogs().Len(); i++ {
-				rl := ld.ResourceLogs().At(i)
-				for j := 0; j < rl.ScopeLogs().Len(); j++ {
-					sl := rl.ScopeLogs().At(j)
-					for k := 0; k < sl.LogRecords().Len(); k++ {
-						log := sl.LogRecords().At(k)
+			for _, rl := range ld.ResourceLogs().All() {
+				for _, sl := range rl.ScopeLogs().All() {
+					for _, lr := range sl.LogRecords().All() {
 						logsMu.Lock()
-						logs[rc.Name] = append(logs[rc.Name], log.Body().Map().AsRaw())
+						logs[rc.Name] = append(logs[rc.Name], lr.Body().Map().AsRaw())
 						logsMu.Unlock()
 					}
 				}
@@ -137,8 +134,8 @@ func CheckReceivers(params CheckReceiversParams) {
 		// Ensure the logger fields from the otel collector are present in the logs.
 		for _, zl := range zapLogs.All() {
 			require.Contains(t, zl.ContextMap(), "otelcol.component.id")
-			require.Equal(t, zl.ContextMap()["otelcol.component.kind"], "Receiver")
-			require.Equal(t, zl.ContextMap()["otelcol.signals"], "logs")
+			require.Equal(t, zl.ContextMap()["otelcol.component.kind"], "receiver")
+			require.Equal(t, zl.ContextMap()["otelcol.signal"], "logs")
 			break
 		}
 


### PR DESCRIPTION
## Proposed commit message

These logger fields are added by the OTel collector.

- otelcol.component.kind should be lowercase. See https://github.com/open-telemetry/opentelemetry-collector/pull/12865
- otelcol.signal and not signals

See the proposal at https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/rfcs/component-universal-telemetry.md#receivers.

While at it, use the newer All iterator function for logs.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/8120