### PR TITLE
fix(auditbeat system/package): handle empty package.v1 bucket

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -144,6 +144,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - hasher: Add a cached hasher for upcoming backend. {pull}41952[41952]
 - Split common tty definitions. {pull}42004[42004]
 - Fix potential data loss in add_session_metadata. {pull}42795[42795]
+- system/package: Fix an error that can occur while migrating the internal package database schema. {issue}44294[44294] {pull}44296[44296]
 
 *Auditbeat*
 

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -241,6 +241,28 @@ func TestPackageDatabaseMigration(t *testing.T) {
 	}
 }
 
+// TestPackageDatabaseMigrationWithEmptyPackageV1Bucket verifies that an
+// empty package.v1 bucket can be migrated to the new schema without errors.
+//
+// This is a reproduction of https://github.com/elastic/beats/issues/44294.
+func TestPackageDatabaseMigrationWithEmptyPackageV1Bucket(t *testing.T) {
+	// Create empty package.v1 bucket.
+	dbPath := filepath.Join(t.TempDir(), "beat.db")
+	ds := datastore.New(dbPath, 0o600)
+
+	bucket, err := ds.OpenBucket("package.v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = bucket.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Update(migrateDatastoreSchema); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func copyFile(old, new string) error {
 	o, err := os.Open(old)
 	if err != nil {


### PR DESCRIPTION
## Proposed commit message

Ensure the schema migration logic properly handles cases where the package.v1 bucket exists but is empty, avoiding assumptions about the presence of the state_timestamp key.

Fixes #44294

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
