### PR TITLE
[Stack Monitoring] Support Legacy URIs for _nodes/stats

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -76,6 +76,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 
 *Metricbeat*
 
+- Add support for `_nodes/stats` URIs that work with legacy versions of Elasticsearch {pull}44307[44307]
 - Setting period for counter cache for Prometheus remote_write at least to 60sec {pull}38553[38553]
 - Remove fallback to the node limit for the `kubernetes.pod.cpu.usage.limit.pct` and `kubernetes.pod.memory.usage.limit.pct` metrics calculation
 - Add support for Kibana status metricset in v8 format {pull}40275[40275]

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -39,6 +39,9 @@ const (
 	indexMetrics       = "bulk,docs,get,merge,translog,fielddata,indexing,query_cache,request_cache,search,shard_stats,store,segments,refresh,flush"
 	nodeLocalStatsPath = "/_nodes/_local/stats/" + statsMetrics + "/" + indexMetrics
 	nodesAllStatsPath  = "/_nodes/_all/stats/" + statsMetrics + "/" + indexMetrics
+	// versions < 8
+	legacyLocalStatsPath = "/_nodes/_local/stats"
+	legacyAllStatsPath   = "/_nodes/_all/stats"
 )
 
 // MetricSet type defines all fields of the MetricSet
@@ -58,7 +61,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
-	if err := m.updateServiceURI(); err != nil {
+	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
+	if err != nil {
+		return err
+	}
+
+	if err := m.updateServiceURI(info.Version.Number.Major); err != nil {
 		return err
 	}
 
@@ -67,16 +75,11 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return err
 	}
 
-	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
-	if err != nil {
-		return err
-	}
-
 	return eventsMapping(r, m.MetricSet, info, content, m.XPackEnabled)
 }
 
-func (m *MetricSet) updateServiceURI() error {
-	u, err := getServiceURI(m.GetURI(), m.Scope)
+func (m *MetricSet) updateServiceURI(majorVersion int) error {
+	u, err := getServiceURI(m.GetURI(), m.Scope, majorVersion)
 	if err != nil {
 		return err
 	}
@@ -86,15 +89,24 @@ func (m *MetricSet) updateServiceURI() error {
 
 }
 
-func getServiceURI(currURI string, scope elasticsearch.Scope) (string, error) {
+func getServiceURI(currURI string, scope elasticsearch.Scope, majorVersion int) (string, error) {
 	u, err := url.Parse(currURI)
 	if err != nil {
 		return "", err
 	}
 
-	u.Path = nodeLocalStatsPath
-	if scope == elasticsearch.ScopeCluster {
-		u.Path = nodesAllStatsPath
+	if majorVersion >= 8 {
+		if scope == elasticsearch.ScopeCluster {
+			u.Path = nodesAllStatsPath
+		} else {
+			u.Path = nodeLocalStatsPath
+		}
+	} else {
+		if scope == elasticsearch.ScopeCluster {
+			u.Path = legacyAllStatsPath
+		} else {
+			u.Path = legacyLocalStatsPath
+		}
 	}
 
 	return u.String(), nil


### PR DESCRIPTION
This adds support for versions that exist before v8 for both scoped requests (local or cluster) by reverting to the older, wider request approach.

## Proposed commit message

Adds support for Stack Monitoring to request node stats from clusters that are older than 8.x. 
This checks the clsuter's version before making the node stats request to properly request the
expected URI.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

This actually makes it easier to use Stack Monitoring.

## Author's Checklist

- [ ] Verify that it continues to work

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Point the `elasticsearch` module to a cluster that exists before 8.x to see it still reports the node stats metricset, and 8.x+ continue to report the node stats metricsets.

## Related issues

- Closes #44082

## Use cases

Support running against older verisons of Elasticsearch.