### PR TITLE
[filebeat][streaming] - Fixed a websocket panic scenario which would occur after exhausting max retries

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -236,7 +236,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - [Filestream] Log the "reader closed" message on the debug level to avoid log spam. {pull}44051[44051]
 - Fix links to CEL mito extension functions in input documentation. {pull}44098[44098]
 - Fix endpoint path typo in Okta entity analytics provider. {pull}44147[44147]
-
+- Fixed a websocket panic scenario which would occur after exhausting max retries. {pull}44342[44342]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -460,7 +460,7 @@ var inputTests = []struct {
 				"wait_max":     "2s",
 			},
 		},
-		wantErr: fmt.Errorf("failed to establish WebSocket connection after 2 attempts with error websocket: bad handshake"),
+		wantErr: fmt.Errorf("failed to establish WebSocket connection after 2 attempts with error websocket: bad handshake and (status 403)"),
 	},
 	{
 		name:    "single_event_tls",

--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -128,7 +128,8 @@ var inputTests = []struct {
 					"events": [inner_body],
 				})`,
 		},
-		response: []string{`
+		response: []string{
+			`
 			{
 				"pps": {
 					"agent": "example.proofpoint.com",
@@ -178,7 +179,8 @@ var inputTests = []struct {
 					"pri": 35342
 				},
 				"id": "ZeYGULpZmL5N0151HN1OyX"
-	   }`},
+	   }`,
+		},
 		want: []map[string]interface{}{
 			{
 				"pps": map[string]interface{}{
@@ -279,7 +281,8 @@ var inputTests = []struct {
 				},
 			},
 		},
-		response: []string{`
+		response: []string{
+			`
 	       {
 	          "pps": {
 	              "agent": "example.proofpoint.com",
@@ -318,7 +321,8 @@ var inputTests = []struct {
 				"basic_token": basicToken,
 			},
 		},
-		response: []string{`
+		response: []string{
+			`
 	       {
 	          "pps": {
 	              "agent": "example.proofpoint.com",
@@ -350,7 +354,8 @@ var inputTests = []struct {
 				"bearer_token": bearerToken,
 			},
 		},
-		response: []string{`
+		response: []string{
+			`
 	       {
 	          "pps": {
 	              "agent": "example.proofpoint.com",
@@ -385,7 +390,8 @@ var inputTests = []struct {
 				},
 			},
 		},
-		response: []string{`
+		response: []string{
+			`
 	       {
 	          "pps": {
 	              "agent": "example.proofpoint.com",
@@ -419,7 +425,8 @@ var inputTests = []struct {
 				"wait_max":     "2s",
 			},
 		},
-		response: []string{`
+		response: []string{
+			`
 	       {
 	          "pps": {
 	              "agent": "example.proofpoint.com",
@@ -453,7 +460,7 @@ var inputTests = []struct {
 				"wait_max":     "2s",
 			},
 		},
-		wantErr: fmt.Errorf("failed to establish WebSocket connection after 2 attempts with error websocket: bad handshake and (status 403)"),
+		wantErr: fmt.Errorf("failed to establish WebSocket connection after 2 attempts with error websocket: bad handshake"),
 	},
 	{
 		name:    "single_event_tls",
@@ -816,7 +823,6 @@ func TestURLEval(t *testing.T) {
 	logp.TestingSetup()
 	for _, test := range urlEvalTests {
 		t.Run(test.name, func(t *testing.T) {
-
 			cfg := conf.MustNewConfigFrom(test.config)
 
 			conf := config{}

--- a/x-pack/filebeat/input/streaming/websocket.go
+++ b/x-pack/filebeat/input/streaming/websocket.go
@@ -425,7 +425,7 @@ func connectWebSocket(ctx context.Context, cfg config, url string, log *logp.Log
 				waitTime := calculateWaitTime(retryConfig.WaitMin, retryConfig.WaitMax, attempt)
 				time.Sleep(waitTime)
 			}
-			return nil, nil, fmt.Errorf("failed to establish WebSocket connection after %d attempts with error %w and (status %d)", retryConfig.MaxAttempts, err, response.StatusCode)
+			return nil, nil, fmt.Errorf("failed to establish WebSocket connection after %d attempts with error %w", retryConfig.MaxAttempts, err)
 		} else {
 			for attempt := 1; ; attempt++ {
 				conn, response, err = dialer.DialContext(ctx, url, headers)

--- a/x-pack/filebeat/input/streaming/websocket.go
+++ b/x-pack/filebeat/input/streaming/websocket.go
@@ -425,7 +425,10 @@ func connectWebSocket(ctx context.Context, cfg config, url string, log *logp.Log
 				waitTime := calculateWaitTime(retryConfig.WaitMin, retryConfig.WaitMax, attempt)
 				time.Sleep(waitTime)
 			}
-			return nil, nil, fmt.Errorf("failed to establish WebSocket connection after %d attempts with error %w", retryConfig.MaxAttempts, err)
+			if response == nil {
+				return nil, nil, fmt.Errorf("failed to establish WebSocket connection after %d attempts with error %w", retryConfig.MaxAttempts, err)
+			}
+			return nil, nil, fmt.Errorf("failed to establish WebSocket connection after %d attempts with error %w and (status %d)", retryConfig.MaxAttempts, err, response.StatusCode)
 		} else {
 			for attempt := 1; ; attempt++ {
 				conn, response, err = dialer.DialContext(ctx, url, headers)


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
In some scenarios the websocket response object can become nil and
cause  certain logging statements to cause an unexpected panic. This PR
fixes once  such identified scenario.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact
None
<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
