### PR TITLE
- Bug/Enhancement: Update metricbeat test modules timeout to be configurable

### DIFF
--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -305,7 +305,7 @@ func (msw *metricSetWrapper) String() string {
 func (msw *metricSetWrapper) Test(d testing.Driver) {
 	d.Run(msw.Name(), func(d testing.Driver) {
 		events := make(chan beat.Event, 1)
-		done := receiveOneEvent(d, events, msw.module.maxStartDelay+5*time.Second)
+		done := receiveOneEvent(d, events, time.Duration(msw.module.maxStartDelay.Seconds()+msw.module.Config().Timeout.Seconds())*time.Second)
 		msw.run(done, events)
 	})
 }


### PR DESCRIPTION
The timeout when running metricbeat test modules <my_module> was intermittently giving an error "ERROR timeout waiting for an event".  It seemed to be intermittent since our module was taking between 5 to 6 seconds to respond. 
 
Unfortunately we discovered the timeout was hardcoded to 5 seconds and not configurable.  This fix that we tested, will adjust the timeout to be now configurable by setting http timeout, it also appears to default to period if timeout is unset. 

Reference Links: 
https://www.elastic.co/docs/reference/beats/metricbeat/command-line-options#test-command https://www.elastic.co/docs/reference/beats/metricbeat/configuration-metricbeat#_timeout
https://www.elastic.co/docs/reference/beats/metricbeat/command-line-options#test-command

Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement


## Proposed commit message
Update metricbeat test modules timeout to be configurable

Explain here the changes you made on the PR.
Updated the command metricbeat test modules <my_module> timeout value instead of heard-coded to be set to the http timeout value. 

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
   N/A it is simple fix, one line of code.

- WHY:  the rationale/motivation for the changes
   We were getting this intermittent error when demoing the testing of modules to client and it made metribeat look odd with random event failures, that were due to hard coded timeout. 

See Title

## Checklist

- [x ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact
No, it should have no impact. 

## Author's Checklist

Review single line code change, it was tested and it works as described and is now configurable. 

## How to test this PR locally
Go into any metricbeat/module.d/my_module.yml that uses http/https and set the  yml file timeout at 1s and you should see an error, that we were encountering.  


## Related issues
None: 

## Use cases
Command: metricbeat test modules my_module -v -e 
Test:  Prior to code integration, test hardcoded timeout with response time of an http API request with greater than 5 seconds, then build metricbeat based on this one line code change and it should default my_module.yml time period, if timeout is unset, so you can set period to 1s and then it should fail, adjust period to 10s it should work, then set timeout to 1s it should fail, and adjust to 10s and it should work. 

## Screenshots

N/A

## Logs
metricbeat test modules my_module -v -e
{"log.level":"info","@timestamp":"2025-05-18T12:27:29.940-0600","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).configure","file.name":"instance/beat.go","file.line":1062},"message":"Home path: [/Users/danh/github/danh/beats/metricbeat] Config path: [/Users/danh/github/danh/beats/metricbeat] Data path: [/Users/danh/github/danh/beats/metricbeat/data] Logs path: [/Users/danh/github/danh/beats/metricbeat/logs]","service.name":"metricbeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2025-05-18T12:27:29.940-0600","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).configure","file.name":"instance/beat.go","file.line":1070},"message":"Beat ID: cc12c183-8e7d-40ce-8e7d-5cfd9395df71","service.name":"metricbeat","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2025-05-18T12:27:30.102-0600","log.logger":"cfgwarn","log.origin":{"function":"github.com/elastic/beats/v7/metricbeat/module/my_module/health.New","file.name":"health/health.go","file.line":65},"message":"BETA: The my_module health metricset is beta.","service.name":"metricbeat","ecs.version":"1.6.0"}
my_module...
  health...

    error... ERROR timeout waiting for an event
