### PR TITLE
[Flaky tests] Skip the entire ebpf test suite since all its tests are failing

### DIFF
--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -79,6 +79,7 @@ def wrap_except(expr):
         return False
 
 
+@unittest.skip("ebpf backend is failing: https://github.com/elastic/beats/issues/44174")
 class Test(BaseTest):
     def wait_output(self, min_events):
         self.wait_until(lambda: wrap_except(lambda: len(self.read_output()) >= min_events))
@@ -193,7 +194,6 @@ class Test(BaseTest):
         self._test_non_recursive("fsnotify")
 
     @unittest.skipUnless(is_root(), "Requires root")
-    @unittest.skip("ebpf backend is failing: https://github.com/elastic/beats/issues/44174")
     def test_non_recursive__ebpf(self):
         self._test_non_recursive("ebpf")
 


### PR DESCRIPTION
The auditbeat ebpf tests are failing because of https://github.com/elastic/beats/issues/44174. The [previous skip PR](https://github.com/elastic/beats/pull/44175) (mistakenly?) only skipped one of the ebpf tests, but all of them are failing. This one skips the whole `test_file_integrity` module.