### PR TITLE
[beat_receivers] move when monitoring is started

### DIFF
--- a/libbeat/otelbeat/beatreceiver/beat_receiver.go
+++ b/libbeat/otelbeat/beatreceiver/beat_receiver.go
@@ -20,30 +20,21 @@ package beatreceiver
 import (
 	"fmt"
 
-	"github.com/elastic/beats/v7/libbeat/api"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
-	"github.com/elastic/beats/v7/libbeat/version"
-	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
-	metricreport "github.com/elastic/elastic-agent-system-metrics/report"
 
 	"go.uber.org/zap"
 )
 
 // BaseReceiver holds common configurations for beatreceivers.
 type BeatReceiver struct {
-	HttpConf *config.C
-	Beat     *instance.Beat
-	Beater   beat.Beater
-	Logger   *zap.Logger
+	Beat   *instance.Beat
+	Beater beat.Beater
+	Logger *zap.Logger
 }
 
 // BeatReceiver.Stop() starts the beat receiver.
 func (b *BeatReceiver) Start() error {
-	if err := b.startMonitoring(); err != nil {
-		return fmt.Errorf("could not start the HTTP server for the monitoring API: %w", err)
-	}
 	if err := b.Beater.Run(&b.Beat.Beat); err != nil {
 		return fmt.Errorf("beat receiver run error: %w", err)
 	}
@@ -56,41 +47,6 @@ func (b *BeatReceiver) Shutdown() error {
 	if err := b.stopMonitoring(); err != nil {
 		return fmt.Errorf("error stopping monitoring server: %w", err)
 	}
-	return nil
-}
-
-func (b *BeatReceiver) startMonitoring() error {
-	if b.HttpConf == nil || !b.HttpConf.Enabled() {
-		return nil
-	}
-	var err error
-
-	b.Beat.RegisterMetrics()
-
-	statsReg := b.Beat.Info.Monitoring.StatsRegistry
-
-	// stats.beat
-	processReg := statsReg.GetRegistry("beat")
-	if processReg == nil {
-		processReg = statsReg.NewRegistry("beat")
-	}
-
-	// stats.system
-	systemReg := statsReg.GetRegistry("system")
-	if systemReg == nil {
-		systemReg = statsReg.NewRegistry("system")
-	}
-
-	err = metricreport.SetupMetrics(logp.NewLogger("metrics"), b.Beat.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
-	if err != nil {
-		return err
-	}
-	b.Beat.API, err = api.NewWithDefaultRoutes(logp.NewLogger("metrics.http"), b.HttpConf, api.RegistryLookupFunc(b.Beat.Info.Monitoring.Namespace))
-	if err != nil {
-		return err
-	}
-	b.Beat.API.Start()
-
 	return nil
 }
 

--- a/x-pack/filebeat/fbreceiver/factory.go
+++ b/x-pack/filebeat/fbreceiver/factory.go
@@ -63,7 +63,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 
 	b.RegisterMetrics()
 
-	statsReg := b.Beat.Info.Monitoring.StatsRegistry
+	statsReg := b.Info.Monitoring.StatsRegistry
 
 	// stats.beat
 	processReg := statsReg.GetRegistry("beat")
@@ -77,14 +77,14 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		systemReg = statsReg.NewRegistry("system")
 	}
 
-	err = metricreport.SetupMetrics(b.Beat.Info.Logger.Named("metrics"), b.Beat.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
+	err = metricreport.SetupMetrics(b.Info.Logger.Named("metrics"), b.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
 	if err != nil {
 		return nil, fmt.Errorf("error setting up metrics report: %w", err)
 	}
 
 	if b.Config.HTTP.Enabled() {
 		var err error
-		b.API, err = api.NewWithDefaultRoutes(b.Beat.Info.Logger.Named("metrics.http"), b.Config.HTTP, api.NamespaceLookupFunc())
+		b.API, err = api.NewWithDefaultRoutes(b.Info.Logger.Named("metrics.http"), b.Config.HTTP, api.NamespaceLookupFunc())
 		if err != nil {
 			return nil, fmt.Errorf("could not start the HTTP server for the API: %w", err)
 		}

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -6,6 +6,19 @@ package fbreceiver
 
 import (
 	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
@@ -21,28 +34,43 @@ import (
 )
 
 func TestNewReceiver(t *testing.T) {
+	monitorSocket := genSocketPath()
+	var monitorHost string
+	if runtime.GOOS == "windows" {
+		monitorHost = "npipe:///" + filepath.Base(monitorSocket)
+	} else {
+		monitorHost = "unix://" + monitorSocket
+	}
 	config := Config{
-		Beatconfig: map[string]interface{}{
-			"filebeat": map[string]interface{}{
-				"inputs": []map[string]interface{}{
+		Beatconfig: map[string]any{
+			"filebeat": map[string]any{
+				"inputs": []map[string]any{
 					{
 						"type":    "benchmark",
 						"enabled": true,
 						"message": "test",
 						"count":   1,
 					},
+					{
+						"type":    "filestream",
+						"enabled": true,
+						"id":      "must-be-unique",
+						"paths":   []string{"none"},
+					},
 				},
 			},
-			"output": map[string]interface{}{
-				"otelconsumer": map[string]interface{}{},
+			"output": map[string]any{
+				"otelconsumer": map[string]any{},
 			},
-			"logging": map[string]interface{}{
+			"logging": map[string]any{
 				"level": "debug",
 				"selectors": []string{
 					"*",
 				},
 			},
-			"path.home": t.TempDir(),
+			"path.home":    t.TempDir(),
+			"http.enabled": true,
+			"http.host":    monitorHost,
 		},
 	}
 
@@ -55,19 +83,26 @@ func TestNewReceiver(t *testing.T) {
 				Factory: NewFactory(),
 			},
 		},
-		AssertFunc: func(t *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
+		AssertFunc: func(c *assert.CollectT, logs map[string][]mapstr.M, zapLogs *observer.ObservedLogs) {
 			_ = zapLogs
-			require.Lenf(t, logs["r1"], 1, "expected 1 log, got %d", len(logs["r1"]))
-			assert.Condition(t, func() bool {
+			require.Lenf(c, logs["r1"], 1, "expected 1 log, got %d", len(logs["r1"]))
+			var lastError strings.Builder
+			assert.Conditionf(c, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket, "stats")
+			}, "failed to connect to monitoring socket, stats endpoint, last error was: %s", &lastError)
+			assert.Conditionf(c, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket, "inputs")
+			}, "failed to connect to monitoring socket, inputs endpoint, last error was: %s", &lastError)
+			assert.Condition(c, func() bool {
 				processorsLoaded := zapLogs.FilterMessageSnippet("Generated new processors").
 					FilterMessageSnippet("add_host_metadata").
 					FilterMessageSnippet("add_cloud_metadata").
 					FilterMessageSnippet("add_docker_metadata").
 					FilterMessageSnippet("add_kubernetes_metadata").
 					Len() == 1
-				assert.True(t, processorsLoaded, "processors not loaded")
+				assert.True(c, processorsLoaded, "processors not loaded")
 				// Check that add_host_metadata works, other processors are not guaranteed to add fields in all environments
-				return assert.Contains(t, logs["r1"][0].Flatten(), "host.architecture")
+				return assert.Contains(c, logs["r1"][0].Flatten(), "host.architecture")
 			}, "failed to check processors loaded")
 		},
 	})
@@ -77,9 +112,9 @@ func BenchmarkFactory(b *testing.B) {
 	tmpDir := b.TempDir()
 
 	cfg := &Config{
-		Beatconfig: map[string]interface{}{
-			"filebeat": map[string]interface{}{
-				"inputs": []map[string]interface{}{
+		Beatconfig: map[string]any{
+			"filebeat": map[string]any{
+				"inputs": []map[string]any{
 					{
 						"type":    "benchmark",
 						"enabled": true,
@@ -88,10 +123,10 @@ func BenchmarkFactory(b *testing.B) {
 					},
 				},
 			},
-			"output": map[string]interface{}{
-				"otelconsumer": map[string]interface{}{},
+			"output": map[string]any{
+				"otelconsumer": map[string]any{},
 			},
-			"logging": map[string]interface{}{
+			"logging": map[string]any{
 				"level": "info",
 				"selectors": []string{
 					"*",
@@ -114,7 +149,7 @@ func BenchmarkFactory(b *testing.B) {
 	receiverSettings.ID = component.NewIDWithName(factory.Type(), "r1")
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := factory.CreateLogs(b.Context(), receiverSettings, cfg, nil)
 		require.NoError(b, err)
 	}
@@ -126,45 +161,61 @@ func TestMultipleReceivers(t *testing.T) {
 	// with each other.
 
 	// Receivers need distinct home directories so wrap the config in a function.
-	config := func() *Config {
+	config := func(monitorSocket string) *Config {
+		var monitorHost string
+		if runtime.GOOS == "windows" {
+			monitorHost = "npipe:///" + filepath.Base(monitorSocket)
+		} else {
+			monitorHost = "unix://" + monitorSocket
+		}
 		return &Config{
-			Beatconfig: map[string]interface{}{
-				"filebeat": map[string]interface{}{
-					"inputs": []map[string]interface{}{
+			Beatconfig: map[string]any{
+				"filebeat": map[string]any{
+					"inputs": []map[string]any{
 						{
 							"type":    "benchmark",
 							"enabled": true,
 							"message": "test",
 							"count":   1,
 						},
+						{
+							"type":    "filestream",
+							"enabled": true,
+							"id":      "must-be-unique",
+							"paths":   []string{"none"},
+						},
 					},
 				},
-				"output": map[string]interface{}{
-					"otelconsumer": map[string]interface{}{},
+				"output": map[string]any{
+					"otelconsumer": map[string]any{},
 				},
-				"logging": map[string]interface{}{
+				"logging": map[string]any{
 					"level": "info",
 					"selectors": []string{
 						"*",
 					},
 				},
-				"path.home": t.TempDir(),
+				"path.home":    t.TempDir(),
+				"http.enabled": true,
+				"http.host":    monitorHost,
 			},
 		}
 	}
 
 	factory := NewFactory()
+	monitorSocket1 := genSocketPath()
+	monitorSocket2 := genSocketPath()
 	oteltest.CheckReceivers(oteltest.CheckReceiversParams{
 		T: t,
 		Receivers: []oteltest.ReceiverConfig{
 			{
 				Name:    "r1",
-				Config:  config(),
+				Config:  config(monitorSocket1),
 				Factory: factory,
 			},
 			{
 				Name:    "r2",
-				Config:  config(),
+				Config:  config(monitorSocket2),
 				Factory: factory,
 			},
 		},
@@ -180,6 +231,105 @@ func TestMultipleReceivers(t *testing.T) {
 			assert.Equal(c, 1, r1StartLogs.Len(), "r1 should have a single start log")
 			r2StartLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "r2"))
 			assert.Equal(c, 1, r2StartLogs.Len(), "r2 should have a single start log")
+			var lastError strings.Builder
+			assert.Conditionf(c, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket1, "stats")
+			}, "failed to connect to monitoring socket1, stats endpoint, last error was: %s", &lastError)
+			assert.Conditionf(c, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket1, "inputs")
+			}, "failed to connect to monitoring socket1, inputs endpoint, last error was: %s", &lastError)
+			assert.Conditionf(c, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket2, "stats")
+			}, "failed to connect to monitoring socket2, stats endpoint, last error was: %s", &lastError)
+			assert.Conditionf(c, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket2, "inputs")
+			}, "failed to connect to monitoring socket2, inputs endpoint, last error was: %s", &lastError)
 		},
 	})
+}
+
+func genSocketPath() string {
+	randData := make([]byte, 16)
+	for i := range len(randData) {
+		randData[i] = uint8(rand.UintN(255)) //nolint:gosec // 0-255 fits in a uint8
+	}
+	socketName := base64.URLEncoding.EncodeToString(randData) + ".sock"
+	socketDir := os.TempDir()
+	return filepath.Join(socketDir, socketName)
+}
+
+func getFromSocket(t *testing.T, sb *strings.Builder, socketPath string, endpoint string) bool {
+	// skip windows for now
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+	url, err := url.JoinPath("http://unix", endpoint)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "JoinPath failed: %s", err)
+		return false
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "error creating request: %s", err)
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "client.Get failed: %s", err)
+		return false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "io.ReadAll of body failed: %s", err)
+		return false
+	}
+	if len(body) <= 0 {
+		sb.Reset()
+		sb.WriteString("body too short")
+		return false
+	}
+
+	if endpoint == "inputs" {
+		var data []any
+		if err := json.Unmarshal(body, &data); err != nil {
+			sb.Reset()
+			fmt.Fprintf(sb, "json unmarshal of body failed: %s\n", err)
+			fmt.Fprintf(sb, "body was %v\n", body)
+			return false
+		}
+
+		if len(data) <= 0 {
+			sb.Reset()
+			sb.WriteString("json array didn't have any entries")
+			return false
+		}
+	} else {
+		var data map[string]any
+		if err := json.Unmarshal(body, &data); err != nil {
+			sb.Reset()
+			fmt.Fprintf(sb, "json unmarshal of body failed: %s\n", err)
+			fmt.Fprintf(sb, "body was %v\n", body)
+			return false
+		}
+
+		if len(data) <= 0 {
+			sb.Reset()
+			sb.WriteString("json didn't have any keys")
+			return false
+		}
+	}
+
+	return true
 }

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -62,7 +62,7 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 
 	b.RegisterMetrics()
 
-	statsReg := b.Beat.Info.Monitoring.StatsRegistry
+	statsReg := b.Info.Monitoring.StatsRegistry
 
 	// stats.beat
 	processReg := statsReg.GetRegistry("beat")
@@ -76,14 +76,14 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		systemReg = statsReg.NewRegistry("system")
 	}
 
-	err = metricreport.SetupMetrics(b.Beat.Info.Logger.Named("metrics"), b.Beat.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
+	err = metricreport.SetupMetrics(b.Info.Logger.Named("metrics"), b.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
 	if err != nil {
 		return nil, fmt.Errorf("error setting up metrics report: %w", err)
 	}
 
 	if b.Config.HTTP.Enabled() {
 		var err error
-		b.API, err = api.NewWithDefaultRoutes(b.Beat.Info.Logger.Named("metrics.http"), b.Config.HTTP, api.NamespaceLookupFunc())
+		b.API, err = api.NewWithDefaultRoutes(b.Info.Logger.Named("metrics.http"), b.Config.HTTP, api.NamespaceLookupFunc())
 		if err != nil {
 			return nil, fmt.Errorf("could not start the HTTP server for the API: %w", err)
 		}

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -12,15 +12,18 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
+	"github.com/elastic/beats/v7/libbeat/api"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/otelbeat/beatreceiver"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
+	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/beats/v7/metricbeat/beater"
 	"github.com/elastic/beats/v7/metricbeat/cmd"
 	"github.com/elastic/beats/v7/x-pack/filebeat/include"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	metricreport "github.com/elastic/elastic-agent-system-metrics/report"
 )
 
 const (
@@ -57,6 +60,36 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 		return nil, fmt.Errorf("error getting beat config: %w", err)
 	}
 
+	b.RegisterMetrics()
+
+	statsReg := b.Beat.Info.Monitoring.StatsRegistry
+
+	// stats.beat
+	processReg := statsReg.GetRegistry("beat")
+	if processReg == nil {
+		processReg = statsReg.NewRegistry("beat")
+	}
+
+	// stats.system
+	systemReg := statsReg.GetRegistry("system")
+	if systemReg == nil {
+		systemReg = statsReg.NewRegistry("system")
+	}
+
+	err = metricreport.SetupMetrics(b.Beat.Info.Logger.Named("metrics"), b.Beat.Info.Beat, version.GetDefaultVersion(), metricreport.WithProcessRegistry(processReg), metricreport.WithSystemRegistry(systemReg))
+	if err != nil {
+		return nil, fmt.Errorf("error setting up metrics report: %w", err)
+	}
+
+	if b.Config.HTTP.Enabled() {
+		var err error
+		b.API, err = api.NewWithDefaultRoutes(b.Beat.Info.Logger.Named("metrics.http"), b.Config.HTTP, api.NamespaceLookupFunc())
+		if err != nil {
+			return nil, fmt.Errorf("could not start the HTTP server for the API: %w", err)
+		}
+		b.API.Start()
+	}
+
 	mbBeater, err := beatCreator(&b.Beat, beatConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error getting %s creator:%w", Name, err)
@@ -70,10 +103,9 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 	}
 
 	beatReceiver := beatreceiver.BeatReceiver{
-		Beat:     b,
-		Beater:   mbBeater,
-		Logger:   set.Logger,
-		HttpConf: httpConf.HTTP,
+		Beat:   b,
+		Beater: mbBeater,
+		Logger: set.Logger,
 	}
 	return &metricbeatReceiver{BeatReceiver: beatReceiver}, nil
 }

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -8,11 +8,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand/v2"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -84,8 +86,11 @@ func TestNewReceiver(t *testing.T) {
 			}, "expected at least one ingest log, got logs: %v", logs["r1"])
 			var lastError strings.Builder
 			assert.Conditionf(c, func() bool {
-				return getFromSocket(t, &lastError, monitorSocket)
-			}, "failed to connect to monitoring socket, last error was: %s", &lastError)
+				return getFromSocket(t, &lastError, monitorSocket, "stats")
+			}, "failed to connect to monitoring socket stats endpoint, last error was: %s", &lastError)
+			assert.Conditionf(c, func() bool {
+				return getFromSocket(t, &lastError, monitorSocket, "inputs")
+			}, "failed to connect to monitoring socket inputs endpoint, last error was: %s", &lastError)
 			assert.Condition(c, func() bool {
 				processorsLoaded := zapLogs.FilterMessageSnippet("Generated new processors").
 					FilterMessageSnippet("add_host_metadata").
@@ -196,7 +201,10 @@ func TestMultipleReceivers(t *testing.T) {
 			assert.Conditionf(c, func() bool {
 				tests := []string{monitorSocket1, monitorSocket2}
 				for _, tc := range tests {
-					if ret := getFromSocket(t, &lastError, tc); ret == false {
+					if ret := getFromSocket(t, &lastError, tc, "stats"); ret == false {
+						return false
+					}
+					if ret := getFromSocket(t, &lastError, tc, "inputs"); ret == false {
 						return false
 					}
 				}
@@ -216,7 +224,7 @@ func genSocketPath() string {
 	return filepath.Join(socketDir, socketName)
 }
 
-func getFromSocket(t *testing.T, sb *strings.Builder, socketPath string) bool {
+func getFromSocket(t *testing.T, sb *strings.Builder, socketPath string, endpoint string) bool {
 	// skip windows for now
 	if runtime.GOOS == "windows" {
 		return true
@@ -228,7 +236,13 @@ func getFromSocket(t *testing.T, sb *strings.Builder, socketPath string) bool {
 			},
 		},
 	}
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://unix/stats", nil)
+	url, err := url.JoinPath("http://unix", endpoint)
+	if err != nil {
+		sb.Reset()
+		fmt.Fprintf(sb, "JoinPath failed: %s", err)
+		return false
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
 	if err != nil {
 		sb.Reset()
 		fmt.Fprintf(sb, "error creating request: %s", err)
@@ -251,6 +265,35 @@ func getFromSocket(t *testing.T, sb *strings.Builder, socketPath string) bool {
 		sb.Reset()
 		sb.WriteString("body too short")
 		return false
+	}
+	if endpoint == "inputs" {
+		var data []any
+		if err := json.Unmarshal(body, &data); err != nil {
+			sb.Reset()
+			fmt.Fprintf(sb, "json unmarshal of body failed: %s\n", err)
+			fmt.Fprintf(sb, "body was %v\n", body)
+			return false
+		}
+
+		if len(data) <= 0 {
+			sb.Reset()
+			sb.WriteString("json array didn't have any entries")
+			return false
+		}
+	} else {
+		var data map[string]any
+		if err := json.Unmarshal(body, &data); err != nil {
+			sb.Reset()
+			fmt.Fprintf(sb, "json unmarshal of body failed: %s\n", err)
+			fmt.Fprintf(sb, "body was %v\n", body)
+			return false
+		}
+
+		if len(data) <= 0 {
+			sb.Reset()
+			sb.WriteString("json didn't have any keys")
+			return false
+		}
 	}
 	return true
 }
@@ -297,7 +340,7 @@ func BenchmarkFactory(b *testing.B) {
 	receiverSettings.ID = component.NewIDWithName(factory.Type(), "r1")
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := factory.CreateLogs(b.Context(), receiverSettings, cfg, nil)
 		require.NoError(b, err)
 	}


### PR DESCRIPTION
## Proposed commit message

For beat receivers move when the HTTP endpoint is started to before when the `beater` is created.  This makes it like 
 normal" beats and will start the "stats" and "inputs" endpoints.

This does have duplication between mbreceiver and fbreceiver, we can refactor that back into `beatreceiver` package when we refactor the location of the `beatreceiver` package.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None.  Beats receivers not GA and this add "inputs" endpoint that was missing

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

### Filebeat
```shell
cd x-pack/filebeat/fbreceiver
go test .
```

### Metricbeat

```shell
cd x-pack/metricbeat/mbreceiver
go test .
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #43418

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
