### PR TITLE
x-pack/filebeat/input/netflow/decoder/...: move testing helpers out of exported package

### DIFF
--- a/x-pack/filebeat/input/netflow/decoder/ipfix/decoder_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/ipfix/decoder_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/fields"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 	v9 "github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/v9"
 )
@@ -146,7 +147,7 @@ func TestDecoderV9_ReadFields(t *testing.T) {
 			assert.Equal(t, tc.expected.Length, record.Length)
 			assert.Equal(t, tc.expected.VariableLength, record.VariableLength)
 			assert.Equal(t, tc.expected.ID, record.ID)
-			template.AssertFieldsEquals(t, tc.expected.Fields, record.Fields)
+			tmpltest.AssertFieldsEquals(t, tc.expected.Fields, record.Fields)
 		})
 	}
 }
@@ -267,7 +268,7 @@ func TestReadOptionsTemplateFlowSet(t *testing.T) {
 			assert.Equal(t, tc.err, err)
 			if assert.Len(t, templates, len(tc.expected)) {
 				for idx := range tc.expected {
-					template.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
+					tmpltest.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
 				}
 			}
 		})
@@ -340,7 +341,7 @@ func TestReadRecordTemplateFlowSet(t *testing.T) {
 			assert.Equal(t, tc.err, err)
 			if assert.Len(t, templates, len(tc.expected)) {
 				for idx := range tc.expected {
-					template.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
+					tmpltest.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
 				}
 			}
 		})

--- a/x-pack/filebeat/input/netflow/decoder/template/template_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/template/template_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package template
+package template_test
 
 import (
 	"bytes"
@@ -14,6 +14,8 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/fields"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/record"
+	. "github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 )
 
@@ -639,7 +641,7 @@ func TestTemplateEquals(t *testing.T) {
 		VariableLength: true,
 		ScopeFields:    0,
 	}
-	assert.True(t, ValidateTemplate(t, &a))
+	assert.True(t, tmpltest.ValidateTemplate(t, &a))
 	b := a
-	assert.True(t, AssertTemplateEquals(t, &a, &b))
+	assert.True(t, tmpltest.AssertTemplateEquals(t, &a, &b))
 }

--- a/x-pack/filebeat/input/netflow/decoder/template/tmpltest/test_helpers.go
+++ b/x-pack/filebeat/input/netflow/decoder/template/tmpltest/test_helpers.go
@@ -2,7 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package template
+// Package tmpltest provides shared template testing functions for netflow templates.
+package tmpltest
 
 import (
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/fields"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
 )
 
 var (
@@ -26,13 +28,13 @@ func buildDecoderByNameMap() {
 	}
 }
 
-func ValidateTemplate(t testing.TB, template *Template) bool {
+func ValidateTemplate(t testing.TB, tmpl *template.Template) bool {
 	once.Do(buildDecoderByNameMap)
 
 	sum := 0
 	seen := make(map[string]bool)
-	for idx, field := range template.Fields {
-		isVariable := template.VariableLength && field.Length == VariableLength
+	for idx, field := range tmpl.Fields {
+		isVariable := tmpl.VariableLength && field.Length == template.VariableLength
 		if !isVariable {
 			sum += int(field.Length)
 		} else {
@@ -55,11 +57,11 @@ func ValidateTemplate(t testing.TB, template *Template) bool {
 			}
 		}
 	}
-	return assert.Equal(t, template.Length, sum) &&
-		assert.Equal(t, 0, template.ScopeFields)
+	return assert.Equal(t, tmpl.Length, sum) &&
+		assert.Equal(t, 0, tmpl.ScopeFields)
 }
 
-func AssertFieldsEquals(t testing.TB, expected []FieldTemplate, actual []FieldTemplate) (succeeded bool) {
+func AssertFieldsEquals(t testing.TB, expected []template.FieldTemplate, actual []template.FieldTemplate) (succeeded bool) {
 	if succeeded = assert.Len(t, actual, len(expected)); succeeded {
 		for idx := range expected {
 			succeeded = assert.Equal(t, expected[idx].Length, actual[idx].Length, strconv.Itoa(idx)) && succeeded
@@ -69,7 +71,7 @@ func AssertFieldsEquals(t testing.TB, expected []FieldTemplate, actual []FieldTe
 	return
 }
 
-func AssertTemplateEquals(t testing.TB, expected *Template, actual *Template) bool {
+func AssertTemplateEquals(t testing.TB, expected *template.Template, actual *template.Template) bool {
 	if expected == nil && actual == nil {
 		return true
 	}

--- a/x-pack/filebeat/input/netflow/decoder/v1/v1_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v1/v1_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/config"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/record"
-	template2 "github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -123,5 +123,5 @@ func TestNetflowProtocol_BadPacket(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-	template2.ValidateTemplate(t, &templateV1)
+	tmpltest.ValidateTemplate(t, &templateV1)
 }

--- a/x-pack/filebeat/input/netflow/decoder/v5/v5_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v5/v5_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/config"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/record"
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 )
 
@@ -138,5 +138,5 @@ func TestNetflowProtocol_BadPacket(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-	template.ValidateTemplate(t, &templateV5)
+	tmpltest.ValidateTemplate(t, &templateV5)
 }

--- a/x-pack/filebeat/input/netflow/decoder/v6/v6_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v6/v6_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/config"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/record"
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 )
 
@@ -140,5 +140,5 @@ func TestNetflowProtocol_BadPacket(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-	template.ValidateTemplate(t, &templateV6)
+	tmpltest.ValidateTemplate(t, &templateV6)
 }

--- a/x-pack/filebeat/input/netflow/decoder/v7/v7_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v7/v7_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/config"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/record"
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 )
 
@@ -134,5 +134,5 @@ func TestNetflowProtocol_BadPacket(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-	template.ValidateTemplate(t, &v7template)
+	tmpltest.ValidateTemplate(t, &v7template)
 }

--- a/x-pack/filebeat/input/netflow/decoder/v8/v8_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v8/v8_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/config"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/record"
-	template2 "github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 )
 
@@ -28,7 +28,7 @@ func init() {
 
 func TestTemplates(t *testing.T) {
 	for code, template := range templates {
-		if !template2.ValidateTemplate(t, template) {
+		if !tmpltest.ValidateTemplate(t, template) {
 			t.Fatal("Failed validating template for V8 record", code)
 		}
 	}

--- a/x-pack/filebeat/input/netflow/decoder/v9/decoder_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/decoder_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/fields"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/template/tmpltest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow/decoder/test"
 )
 
@@ -188,7 +189,7 @@ func TestDecoderV9_ReadFields(t *testing.T) {
 			assert.Equal(t, tc.expected.Length, record.Length)
 			assert.Equal(t, tc.expected.VariableLength, record.VariableLength)
 			assert.Equal(t, tc.expected.ID, record.ID)
-			template.AssertFieldsEquals(t, tc.expected.Fields, record.Fields)
+			tmpltest.AssertFieldsEquals(t, tc.expected.Fields, record.Fields)
 		})
 	}
 }
@@ -277,7 +278,7 @@ func TestReadOptionsTemplateFlowSet(t *testing.T) {
 			assert.Equal(t, tc.err, err)
 			if assert.Len(t, templates, len(tc.expected)) {
 				for idx := range tc.expected {
-					template.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
+					tmpltest.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
 				}
 			}
 		})
@@ -350,7 +351,7 @@ func TestReadTemplateFlowSet(t *testing.T) {
 			assert.Equal(t, tc.err, err)
 			if assert.Len(t, templates, len(tc.expected)) {
 				for idx := range tc.expected {
-					template.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
+					tmpltest.AssertTemplateEquals(t, tc.expected[idx], templates[idx])
 				}
 			}
 		})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/netflow/decoder/...: move testing helpers out of exported package

Including the testing helpers in the template package results in
unnecessarily polluting the filebeat binary with the testing package.
So move it into its own package that is only imported by _test.go files.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
### Before:

![testing import paths](https://github.com/user-attachments/assets/96aa7534-055c-4992-ba7b-170740f686bd)

### After (still importing "testing", but not in our control):

![remaining testing import paths](https://github.com/user-attachments/assets/ba0d2999-210b-4dde-87cd-03d03b3a23af)

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
