### PR TITLE
[docs] Add Beats 9.0.2 Release Notes

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -19,47 +19,47 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ## 9.0.2 [beats-9.0.2-release-notes]
 
-==== Bugfixes
+### Features and enhancements [beats-9.0.2-features-enhancements]
 
-*Affecting all Beats*
+**Affecting all Beats**
 
-- 'add_cloud_metadata' processor - improve AWS provider HTTP client overriding to support custom certificate bundle handling. {pull}44189[44189]
+- Update Go version to 1.24.3. [44270]({{beats-pull}}44270)
 
-*Auditbeat*
+**Filebeat**
 
-- system/package: Fix an error that can occur while migrating the internal package database schema. {issue}44294[44294] {pull}44296[44296]
+- Add support to the Active Directory entity analytics provider for device entities. [44309]({{beats-pull}}44309)
 
-*Filebeat*
+**Metricbeat**
 
-- Fix endpoint path typo in Okta entity analytics provider. {pull}44147[44147]
-- Fixed a websocket panic scenario which would occur after exhausting max retries. {pull}44342[44342]
+- Added checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. [44193]({{beats-pull}}44193)
+- Add latency config option to Azure Monitor module. [44366]({{beats-pull}}44366)
 
-*Metricbeat*
+**Osquerybeat**
 
-- Add AWS OwningAccount support for cross account monitoring. {issue}40570[40570] {pull}40691[40691]
-- Use namespace for GetListMetrics when exists in AWS. {pull}41022[41022]
-- Only fetch cluster-level index stats summary. {issue}36019[36019] {pull}42901[42901]
-- Changed `tier_preference`, `creation_date` and `version` fields to be omitted from the resulting documents when not pulled from source indices. {pull}43637[43637]
-- Add support for `_nodes/stats` URIs that work with legacy versions of Elasticsearch. {pull}44307[44307]
+- Upgrade osquery version to 5.15.0 [43426]({{beats-pull}}43426)
 
-==== Added
+### Fixes [beats-9.0.2-fixes]
 
-*Affecting all Beats*
+**Affecting all Beats**
 
-- Update Go version to 1.24.3. {pull}44270[44270]
+- 'add_cloud_metadata' processor - improve AWS provider HTTP client overriding to support custom certificate bundle handling. [44189]({{beats-pull}}44189)
 
-*Filebeat*
+**Auditbeat**
 
-- Add support to the Active Directory entity analytics provider for device entities. {pull}44309[44309]
+- system/package: Fix an error that can occur while migrating the internal package database schema. [44294]({{beats-issue}}44294) [44296]({{beats-pull}}44296)
 
-*Metricbeat*
+**Filebeat**
 
-- Added checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. {pull}44193[44193]
-- Add latency config option to Azure Monitor module. {pull}44366[44366]
+- Fix endpoint path typo in Okta entity analytics provider. [44147]({{beats-pull}}44147)
+- Fixed a websocket panic scenario which would occur after exhausting max retries. [44342]({{beats-pull}}44342)
 
-*Osquerybeat*
+**Metricbeat**
 
-- Upgrade osquery version to 5.15.0 {pull}43426[43426]
+- Add AWS OwningAccount support for cross account monitoring. [40570]({{beats-issue}}40570) [40691]({{beats-pull}}40691)
+- Use namespace for GetListMetrics when exists in AWS. [41022]({{beats-pull}}41022)
+- Only fetch cluster-level index stats summary. [36019]({{beats-issue}}36019) [42901]({{beats-pull}}42901)
+- Changed `tier_preference`, `creation_date` and `version` fields to be omitted from the resulting documents when not pulled from source indices. [43637]({{beats-pull}}43637)
+- Add support for `_nodes/stats` URIs that work with legacy versions of Elasticsearch. [44307]({{beats-pull}}44307)
 
 ## 9.0.1 [beats-9.0.1-release-notes]
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -17,6 +17,50 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % ### Fixes [beats-versionext-fixes]
 
+## 9.0.2 [beats-9.0.2-release-notes]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- 'add_cloud_metadata' processor - improve AWS provider HTTP client overriding to support custom certificate bundle handling. {pull}44189[44189]
+
+*Auditbeat*
+
+- system/package: Fix an error that can occur while migrating the internal package database schema. {issue}44294[44294] {pull}44296[44296]
+
+*Filebeat*
+
+- Fix endpoint path typo in Okta entity analytics provider. {pull}44147[44147]
+- Fixed a websocket panic scenario which would occur after exhausting max retries. {pull}44342[44342]
+
+*Metricbeat*
+
+- Add AWS OwningAccount support for cross account monitoring. {issue}40570[40570] {pull}40691[40691]
+- Use namespace for GetListMetrics when exists in AWS. {pull}41022[41022]
+- Only fetch cluster-level index stats summary. {issue}36019[36019] {pull}42901[42901]
+- Changed `tier_preference`, `creation_date` and `version` fields to be omitted from the resulting documents when not pulled from source indices. {pull}43637[43637]
+- Add support for `_nodes/stats` URIs that work with legacy versions of Elasticsearch. {pull}44307[44307]
+
+==== Added
+
+*Affecting all Beats*
+
+- Update Go version to 1.24.3. {pull}44270[44270]
+
+*Filebeat*
+
+- Add support to the Active Directory entity analytics provider for device entities. {pull}44309[44309]
+
+*Metricbeat*
+
+- Added checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. {pull}44193[44193]
+- Add latency config option to Azure Monitor module. {pull}44366[44366]
+
+*Osquerybeat*
+
+- Upgrade osquery version to 5.15.0 {pull}43426[43426]
+
 ## 9.0.1 [beats-9.0.1-release-notes]
 
 ### Features and enhancements [beats-9.0.1-features-enhancements]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -51,7 +51,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 **Filebeat**
 
 - Fix endpoint path typo in the Okta entity analytics provider. [44147]({{beats-pull}}44147)
-- Fix a websocket panic scenario that occured after exhausting the maximum number of retries. [44342]({{beats-pull}}44342)
+- Fix a WebSocket panic scenario that occured after exhausting the maximum number of retries. [44342]({{beats-pull}}44342)
 
 **Metricbeat**
 
@@ -74,7 +74,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ### Fixes [beats-9.0.1-fixes]
 
 * For all Beats: Handle permission errors while collecting data from Windows services and don't interrupt the overall collection by skipping affected services. [#40765]({{beats-issue}}40765) [#43665]({{beats-pull}}43665).
-* Fixed websocket input panic on sudden network error or server crash in Filebeat. [#44063]({{beats-issue}}44063) [44068]({{beats-pull}}44068).
+* Fixed WebSocket input panic on sudden network error or server crash in Filebeat. [#44063]({{beats-issue}}44063) [44068]({{beats-pull}}44068).
 * [Filestream] Log the "reader closed" message on the debug level to avoid log spam in Filebeat. [#44051]({{beats-pull}}44051)
 * Fix links to CEL mito extension functions in input documentation in Filebeat. [#44098]({{beats-pull}}44098)
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -23,43 +23,43 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 **Affecting all Beats**
 
-- Update Go version to 1.24.3. [44270]({{beats-pull}}44270)
+- Update Go version to v1.24.3. [44270]({{beats-pull}}44270)
 
 **Filebeat**
 
-- Add support to the Active Directory entity analytics provider for device entities. [44309]({{beats-pull}}44309)
+- Add support for collecting device entities in the Active Directory entity analytics provider. [44309]({{beats-pull}}44309)
 
 **Metricbeat**
 
-- Added checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. [44193]({{beats-pull}}44193)
-- Add latency config option to Azure Monitor module. [44366]({{beats-pull}}44366)
+- Add checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. [44193]({{beats-pull}}44193)
+- Add a latency configuration option to the Azure Monitor module. [44366]({{beats-pull}}44366)
 
 **Osquerybeat**
 
-- Upgrade osquery version to 5.15.0 [43426]({{beats-pull}}43426)
+- Update osquery version to v5.15.0. [43426]({{beats-pull}}43426)
 
 ### Fixes [beats-9.0.2-fixes]
 
 **Affecting all Beats**
 
-- 'add_cloud_metadata' processor - improve AWS provider HTTP client overriding to support custom certificate bundle handling. [44189]({{beats-pull}}44189)
+- Fix the 'add_cloud_metadata' processor to better support custom certificate bundles by improving how the AWS provider HTTP client is overridden. [44189]({{beats-pull}}44189)
 
 **Auditbeat**
 
-- system/package: Fix an error that can occur while migrating the internal package database schema. [44294]({{beats-issue}}44294) [44296]({{beats-pull}}44296)
+- Fix a potential error in the system/package component that could occur during internal package database schema migration. [44294]({{beats-issue}}44294) [44296]({{beats-pull}}44296)
 
 **Filebeat**
 
-- Fix endpoint path typo in Okta entity analytics provider. [44147]({{beats-pull}}44147)
-- Fixed a websocket panic scenario which would occur after exhausting max retries. [44342]({{beats-pull}}44342)
+- Fix endpoint path typo in the Okta entity analytics provider. [44147]({{beats-pull}}44147)
+- Fix a websocket panic scenario that occured after exhausting the maximum number of retries. [44342]({{beats-pull}}44342)
 
 **Metricbeat**
 
-- Add AWS OwningAccount support for cross account monitoring. [40570]({{beats-issue}}40570) [40691]({{beats-pull}}40691)
-- Use namespace for GetListMetrics when exists in AWS. [41022]({{beats-pull}}41022)
-- Only fetch cluster-level index stats summary. [36019]({{beats-issue}}36019) [42901]({{beats-pull}}42901)
-- Changed `tier_preference`, `creation_date` and `version` fields to be omitted from the resulting documents when not pulled from source indices. [43637]({{beats-pull}}43637)
-- Add support for `_nodes/stats` URIs that work with legacy versions of Elasticsearch. [44307]({{beats-pull}}44307)
+- Add AWS OwningAccount support for cross-account monitoring. [40570]({{beats-issue}}40570) [40691]({{beats-pull}}40691)
+- Use namespace for GetListMetrics calls in AWS when available. [41022]({{beats-pull}}41022)
+- Limit index stats collection to cluster-level summaries. [36019]({{beats-issue}}36019) [42901]({{beats-pull}}42901)
+- Omit `tier_preference`, `creation_date` and `version` fields in output documents when not pulled from source indices. [43637]({{beats-pull}}43637)
+- Add support for `_nodes/stats` URIs compatible with legacy Elasticsearch versions. [44307]({{beats-pull}}44307)
 
 ## 9.0.1 [beats-9.0.1-release-notes]
 


### PR DESCRIPTION
Part of https://github.com/elastic/observability-docs/issues/4902

Adds the Beats 9.0.2 Release Notes based off of the AsciiDoc generated content in https://github.com/elastic/beats/pull/44465. 

This still needs copy/style edits. You can use the existing 9.0.1 release notes below the 9.0.2 section for inspiration. 