### PR TITLE
[Metricbeat] [Prometheus] Add proper error handling for query dataset when the auth/ssl is misconfigured

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -92,6 +92,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Updated list of supported vSphere versions in the documentation. {pull}43642[43642]
 - Handle permission errors while collecting data from Windows services and don't interrupt the overall collection by skipping affected services {issue}40765[40765] {pull}43665[43665]
 - Fixed a bug where `event.duration` could be missing from an event on Windows systems due to low-resolution clock. {pull}44440[44440]
+- Add check for http error codes in the Metricbeat's Prometheus query submodule {pull}44493[44493]
 
 *Osquerybeat*
 

--- a/metricbeat/module/prometheus/query/query.go
+++ b/metricbeat/module/prometheus/query/query.go
@@ -98,8 +98,8 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		}
 
 		if response.StatusCode > 399 {
-			m.Logger().Debug("error received from prometheus endpoint: ", string(body))
-			reporter.Error(fmt.Errorf("unexpected status code %d from server", response.StatusCode))
+			m.Logger().Debugf("error received from prometheus endpoint %v: %v", url, string(body))
+			reporter.Error(fmt.Errorf("unexpected status code %d from %v", response.StatusCode, url))
 			continue
 		}
 

--- a/metricbeat/module/prometheus/query/query.go
+++ b/metricbeat/module/prometheus/query/query.go
@@ -97,6 +97,11 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 			return err
 		}
 
+		if response.StatusCode > 399 {
+			reporter.Error(fmt.Errorf("unexpected status code %d from server: %s", response.StatusCode, string(body)))
+			continue
+		}
+
 		events, parseErr := parseResponse(body, pathConfig)
 		if parseErr != nil {
 			reporter.Error(fmt.Errorf("error parsing response from %v: %w", url, parseErr))

--- a/metricbeat/module/prometheus/query/query.go
+++ b/metricbeat/module/prometheus/query/query.go
@@ -98,7 +98,8 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		}
 
 		if response.StatusCode > 399 {
-			reporter.Error(fmt.Errorf("unexpected status code %d from server: %s", response.StatusCode, string(body)))
+			m.Logger().Debug("error received from prometheus endpoint: ", string(body))
+			reporter.Error(fmt.Errorf("unexpected status code %d from server", response.StatusCode))
 			continue
 		}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

[Metricbeat] [Prometheus] Query dataset: make understandable error messages in case for http error codes

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

No impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

My test environment:
- Metricbeat built locally
- Prometheus running in docker, configured to listen on HTTPS with local self-signed certs
- Cloud deployment of Elastic stack

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #44446
- Relates https://github.com/elastic/integrations/issues/13751
- Relates https://github.com/elastic/integrations/pull/13969
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Screenshots & Logs

### When running Metricbeat with wrong Prometheus' username and password the error message looks like that now:

<img width="439" alt="Screenshot 2025-05-26 at 15 58 40" src="https://github.com/user-attachments/assets/727e3a95-8b36-400d-b2e5-1c2b5438d47a" />

and the debug message to the logs

```
{"log.level":"debug","@timestamp":"2025-05-26T16:07:31.937+0300","log.logger":"prometheus.query","log.origin":{"function":"github.com/elastic/beats/v7/metricbeat/module/prometheus/query.(*MetricSet).Fetch","file.name":"query/query.go","file.line":101},"message":"error received from prometheus endpoint: Unauthorized\n","service.name":"metricbeat","ecs.version":"1.6.0"}
```

### When the protocol is HTTP but the Prometheus is configured to use HTTPS:

<img width="443" alt="Screenshot 2025-05-26 at 16 01 44" src="https://github.com/user-attachments/assets/356bf895-7ae6-449a-bcd1-2d574a836581" />

and the debug message to the logs:

```
{"log.level":"debug","@timestamp":"2025-05-26T16:06:09.560+0300","log.logger":"prometheus.query","log.origin":{"function":"github.com/elastic/beats/v7/metricbeat/module/prometheus/query.(*MetricSet).Fetch","file.name":"query/query.go","file.line":101},"message":"error received from prometheus endpoint: Client sent an HTTP request to an HTTPS server.\n","service.name":"metricbeat","ecs.version":"1.6.0"}
```

Which is now the same behavior as of `collector` submodule

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
