### PR TITLE
Agentbeat: preserve the osquery.app/ directory and contents during Elastic Agent installation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -267,6 +267,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 
 *Osquerybeat*
 
+- Fix bug preventing installation of osqueryd. Preserve the osquery.app/ directory and its contents when installing the Elastic Agent. {agent-issue}8245[8245] {pull}44501[44501]
 
 *Packetbeat*
 

--- a/x-pack/agentbeat/agentbeat.spec.yml
+++ b/x-pack/agentbeat/agentbeat.spec.yml
@@ -5,7 +5,7 @@ component_files:
  - module/*
  - "osquery-extension.ext"
  - "osquery-extension.exe"
- - osqueryd 
+ - osqueryd
  - "osqueryd.exe"
 inputs:
   - name: audit/auditd

--- a/x-pack/agentbeat/agentbeat.spec.yml
+++ b/x-pack/agentbeat/agentbeat.spec.yml
@@ -7,6 +7,7 @@ component_files:
  - "osquery-extension.exe"
  - osqueryd
  - "osqueryd.exe"
+ - "osquery.app/*"
 inputs:
   - name: audit/auditd
     description: "Auditd"


### PR DESCRIPTION
- Fixes https://github.com/elastic/elastic-agent/issues/8245

See https://github.com/elastic/elastic-agent/issues/8245 for the problem description. To manually test this:

1. Create an agent policy and add the osquery_manager integration.
2. Install any 9.x version of Elastic Agent and enroll it in the policy above.
3. Observe that the osquery input shows in the starting state and the logs show it is existing and restarting.
4. Uninstall the agent.
5. Make the edit in this PR to the agentbeat.spec.yml file.
6. Reinstall the agent.
7. Observe the osquery input is healthy.
