### PR TITLE
[Flaky test] Prevent event coalescing in auditbeat file integrity test

### DIFF
--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -312,29 +312,28 @@ class Test(BaseTest):
             self.wait_output(1)
 
             # FSNotify can't catch the events if operations happens too fast
-            #time.sleep(1)
+            # time.sleep(1)
 
             # Event 2: chmod
             os.chmod(f, 0o777)
             self.wait_output(2)
 
             # FSNotify can't catch the events if operations happens too fast
-            #time.sleep(1)
+            # time.sleep(1)
 
             with open(f, "w") as fd:
                 # Event 3: write
                 fd.write("data")
                 # fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
-                #time.sleep(1)
+                # time.sleep(1)
                 self.wait_output(3)
-
 
                 # Event 4: truncate
                 fd.truncate(0)
                 # fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
-                #time.sleep(1)
+                # time.sleep(1)
                 self.wait_output(4)
 
             proc.check_kill_and_wait()

--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -320,11 +320,13 @@ class Test(BaseTest):
             with open(f, "w") as fd:
                 # Event 3: write
                 fd.write("data")
+                fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
                 time.sleep(1)
 
                 # Event 4: truncate
                 fd.truncate(0)
+                fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
                 time.sleep(1)
 

--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -309,31 +309,26 @@ class Test(BaseTest):
             f = os.path.join(dirs[0], f'file_{backend}.txt')
             self.create_file(f, "hello world!")
 
+            # Wait for file creation to be reported
             self.wait_output(1)
-
-            # FSNotify can't catch the events if operations happens too fast
-            # time.sleep(1)
 
             # Event 2: chmod
             os.chmod(f, 0o777)
-            self.wait_output(2)
 
-            # FSNotify can't catch the events if operations happens too fast
-            # time.sleep(1)
+            # Wait for mode change to be reported
+            self.wait_output(2)
 
             with open(f, "w") as fd:
                 # Event 3: write
                 fd.write("data")
-                # fd.flush()
-                # FSNotify can't catch the events if operations happens too fast
-                # time.sleep(1)
+                fd.flush()
+                # Wait for write to be reported
                 self.wait_output(3)
 
                 # Event 4: truncate
                 fd.truncate(0)
-                # fd.flush()
-                # FSNotify can't catch the events if operations happens too fast
-                # time.sleep(1)
+                fd.flush()
+                # Wait for truncate to be reported
                 self.wait_output(4)
 
             proc.check_kill_and_wait()

--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -320,13 +320,13 @@ class Test(BaseTest):
             with open(f, "w") as fd:
                 # Event 3: write
                 fd.write("data")
-                fd.flush()
+                # fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
                 time.sleep(1)
 
                 # Event 4: truncate
                 fd.truncate(0)
-                fd.flush()
+                # fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
                 time.sleep(1)
 

--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -309,29 +309,33 @@ class Test(BaseTest):
             f = os.path.join(dirs[0], f'file_{backend}.txt')
             self.create_file(f, "hello world!")
 
+            self.wait_output(1)
+
             # FSNotify can't catch the events if operations happens too fast
-            time.sleep(1)
+            #time.sleep(1)
 
             # Event 2: chmod
             os.chmod(f, 0o777)
+            self.wait_output(2)
+
             # FSNotify can't catch the events if operations happens too fast
-            time.sleep(1)
+            #time.sleep(1)
 
             with open(f, "w") as fd:
                 # Event 3: write
                 fd.write("data")
                 # fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
-                time.sleep(1)
+                #time.sleep(1)
+                self.wait_output(3)
+
 
                 # Event 4: truncate
                 fd.truncate(0)
                 # fd.flush()
                 # FSNotify can't catch the events if operations happens too fast
-                time.sleep(1)
-
-            # Wait N events
-            self.wait_output(4)
+                #time.sleep(1)
+                self.wait_output(4)
 
             proc.check_kill_and_wait()
             self.assert_no_logged_warnings()


### PR DESCRIPTION
Auditbeat's `test_file_integrity.test_file_modified__ebpf` has been failing frequently on main ([for example](https://buildkite.com/elastic/auditbeat/builds/16043#0196f9cd-f6f8-43dc-bb92-500ebee05463)). The cause is that two file operations, a write followed by a truncate, are coalesced and reported as a single event. The test tries to guard against this by sleeping for 1 second between changes, but this does not reliably separate the events (especially without explicit i/o flush). This change adds flushes after file writes, and replaces the 1-second sleeps with an explicit wait for the expected event, so the file is not truncated until after the write has been reported.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
