### PR TITLE
[libbeat] Fix 'dns' processor to handle IPv6 server addresses properly.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -136,6 +136,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Lower logging level to debug when attempting to configure beats with unknown fields from autodiscovered events/environments {pull}[37816][37816]
 - Set timeout of 1 minute for FQDN requests {pull}37756[37756]
 - 'add_cloud_metadata' processor - improve AWS provider HTTP client overriding to support custom certificate bundle handling {pull}44189[44189]
+- Fix `dns` processor to handle IPv6 server addresses properly. {pull}44526[44526]
 
 *Auditbeat*
 

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"math"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -77,6 +78,9 @@ func newMiekgResolver(reg *monitoring.Registry, timeout time.Duration, transport
 
 	// Add port if one was not specified.
 	for i, s := range servers {
+		if isIPv6Address(s) {
+			s = "[" + s + "]" // Add brackets for IPv6 addresses.
+		}
 		if _, _, err := net.SplitHostPort(s); err != nil {
 			var withPort string
 			switch transport {
@@ -257,4 +261,12 @@ func min(a, b uint32) uint32 {
 		return a
 	}
 	return b
+}
+
+func isIPv6Address(addr string) bool {
+	ip, err := netip.ParseAddr(addr)
+	if err != nil {
+		return false
+	}
+	return ip.Is6()
 }

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -33,6 +33,15 @@ import (
 
 var _ resolver = (*miekgResolver)(nil)
 
+func TestNewMiekgResolverWithIPv6(t *testing.T) {
+	// This test ensures that we handle properly IPv6 addresses, inclding ones with zone indices.
+	const addr = `fe80::1%en0` // Example IPv6 address with zone index.
+
+	reg := monitoring.NewRegistry()
+	_, err := newMiekgResolver(reg.NewRegistry(logName), 0, "udp", addr)
+	assert.NoError(t, err)
+}
+
 func TestMiekgResolverLookupPTR(t *testing.T) {
 	stop, addr, err := serveDNS(fakeDNSHandler)
 	if err != nil {

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -34,7 +34,7 @@ import (
 var _ resolver = (*miekgResolver)(nil)
 
 func TestNewMiekgResolverWithIPv6(t *testing.T) {
-	// This test ensures that we handle properly IPv6 addresses, inclding ones with zone indices.
+	// This test ensures that we handle properly IPv6 addresses, including ones with zone indices.
 	const addr = `fe80::1%en0` // Example IPv6 address with zone index.
 
 	reg := monitoring.NewRegistry()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Fix 'dns' processor to handle IPv6 server addresses properly.

Previously we did not account for IPV6 server addresses, and some of them would trigger a `too many colons in address` error when not properly enclosed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

