### PR TITLE
x-pack/filebeat/input/streaming: fix crowdstrike cursor handling

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -249,6 +249,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - If a Filestream input fails to be created, its ID is removed from the list of running input IDs {pull}44697[44697]
 - Fix timeout handling by Crowdstrike streaming input. {pull}44720[44720]
 - Ensure DEPROVISIONED Okta entities are published by Okta entityanalytics provider. {issue}12658[12658] {pull}44719[44719]
+- Fix handling of cursors by the streaming input for Crowdstrike. {issue}44364[44364] {pull}44548[44548]
 
 *Heartbeat*
 

--- a/docs/reference/filebeat/filebeat-input-streaming.md
+++ b/docs/reference/filebeat/filebeat-input-streaming.md
@@ -67,7 +67,7 @@ After completion of a program’s execution it should return a single object wit
 ```
 
 1. The `events` field must be present, but may be empty or null. If it is not empty, it must only have objects as elements. The field could be an array or a single object that will be treated as an array with a single element. This depends completely on the streaming data source. The `events` field is the array of events to be published to the output. Each event must be a JSON object.
-2. If `cursor` is present it must be either be a single object or an array with the same length as events; each element *i* of the `cursor` will be the details for obtaining the events at and beyond event *i* in the `events` array. If the `cursor` is a single object, it will be the details for obtaining events after the last event in the `events` array and will only be retained on successful publication of all the events in the `events` array.
+2. If `cursor` is present it must be either be a single object or an array with the same length as events; each element *i* of the `cursor` will be the details for obtaining the events at and beyond event *i* in the `events` array. If the `cursor` is a single object, it will be the details for obtaining events after the last event in the `events` array and will only be retained on successful publication of all the events in the `events` array. Note that the Crowdstrike streaming input does not support array cursors.
 
 
 Example configurations:

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -197,8 +197,9 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	// is in order to avoid allocating defers in a loop.
 	defer delete(state, "feed")
 	for _, r := range body.Resources {
+		feedName := r.FeedURL // Retain this since we will mutate it to set the offset.
 		var offset int
-		if cursor, ok := cursors[r.FeedURL].(map[string]any); ok {
+		if cursor, ok := cursors[feedName].(map[string]any); ok {
 			switch off := cursor["offset"].(type) {
 			case int:
 				offset = off
@@ -271,7 +272,7 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 
 		// Prepare state to understand which feed is being processed.
 		// This is cleared by the deferred delete above the loop.
-		state["feed"] = r.FeedURL
+		state["feed"] = feedName
 		dec := json.NewDecoder(resp.Body)
 		for {
 			var msg json.RawMessage

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -29,23 +29,23 @@ func TestCrowdstrikeFalconHose(t *testing.T) {
 
 	feedURL, ok := os.LookupEnv("CROWDSTRIKE_URL")
 	if !ok {
-		t.Skip("okta tests require ${CROWDSTRIKE_URL} to be set")
+		t.Skip("crowdstrike tests require ${CROWDSTRIKE_URL} to be set")
 	}
 	tokenURL, ok := os.LookupEnv("CROWDSTRIKE_TOKEN_URL")
 	if !ok {
-		t.Skip("okta tests require ${CROWDSTRIKE_TOKEN_URL} to be set")
+		t.Skip("crowdstrike tests require ${CROWDSTRIKE_TOKEN_URL} to be set")
 	}
 	clientID, ok := os.LookupEnv("CROWDSTRIKE_CLIENT_ID")
 	if !ok {
-		t.Skip("okta tests require ${CROWDSTRIKE_CLIENT_ID} to be set")
+		t.Skip("crowdstrike tests require ${CROWDSTRIKE_CLIENT_ID} to be set")
 	}
 	clientSecret, ok := os.LookupEnv("CROWDSTRIKE_CLIENT_SECRET")
 	if !ok {
-		t.Skip("okta tests require ${CROWDSTRIKE_CLIENT_SECRET} to be set")
+		t.Skip("crowdstrike tests require ${CROWDSTRIKE_CLIENT_SECRET} to be set")
 	}
 	appID, ok := os.LookupEnv("CROWDSTRIKE_APPID")
 	if !ok {
-		t.Skip("okta tests require ${CROWDSTRIKE_APPID} to be set")
+		t.Skip("crowdstrike tests require ${CROWDSTRIKE_APPID} to be set")
 	}
 
 	u, err := url.Parse(feedURL)
@@ -58,10 +58,9 @@ func TestCrowdstrikeFalconHose(t *testing.T) {
 		Program: `
 				state.response.decode_json().as(body,{
 					"events": [body],
-					?"cursor": has(body.?metadata.offset) ?
-						optional.of({"offset": body.metadata.offset})
-					:
-						optional.none(),
+					"cursor": state.cursor.with({
+						?state.feed: body.?metadata.optMap(m, {"offset": m.offset}),
+					}),
 				})`,
 		Auth: authConfig{
 			OAuth2: oAuth2Config{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: fix crowdstrike cursor handling

When the follower is given a non-singular set of resource descriptions,
it incorrectly uses the offset obtained from the registry across all of
the resources, and each of those resources' work loops writes their
cursor updates to the same (incorrectly) shared offset. This results in
cursor offset confusion.

The fix here is to retain cursors for each of the resources, keyed on
the dataFeedURL for each resource.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #44364

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
