### PR TITLE
otel: add system metrics test to mbreceiver

### DIFF
--- a/x-pack/auditbeat/module/system/host/host.go
+++ b/x-pack/auditbeat/module/system/host/host.go
@@ -118,6 +118,12 @@ func (host *Host) changeDetectionHash() uint64 {
 }
 
 func (host *Host) toMapStr() mapstr.M {
+	var containerized bool
+
+	if host.Info.Containerized != nil {
+		containerized = *host.Info.Containerized
+	}
+
 	mapstr := mapstr.M{
 		// https://github.com/elastic/ecs#-host-fields
 		"uptime":              host.Uptime,
@@ -127,6 +133,7 @@ func (host *Host) toMapStr() mapstr.M {
 		"hostname":            host.Info.Hostname,
 		"id":                  host.Info.UniqueID,
 		"architecture":        host.Info.Architecture,
+		"containerized":       containerized,
 
 		// https://github.com/elastic/ecs#-operating-system-fields
 		"os": mapstr.M{
@@ -136,10 +143,6 @@ func (host *Host) toMapStr() mapstr.M {
 			"version":  host.Info.OS.Version,
 			"kernel":   host.Info.KernelVersion,
 		},
-	}
-
-	if host.Info.Containerized != nil {
-		mapstr.Put("containerized", host.Info.Containerized)
 	}
 
 	if host.Info.OS.Codename != "" {


### PR DESCRIPTION
## Proposed commit message

This test ensures that documents ingested by mbreceiver contain the same fields as those documented for standard Metricbeat.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/8148
