### PR TITLE
[Agent Spec] Add AutoOps

### DIFF
--- a/x-pack/agentbeat/agentbeat.spec.yml
+++ b/x-pack/agentbeat/agentbeat.spec.yml
@@ -314,11 +314,6 @@ inputs:
     platforms: *platforms
     outputs: *outputs
     command: *heartbeat_command
-  - name: autoops_es/metrics
-    description: "AutoOps Elasticsearch metrics"
-    platforms: *platforms
-    outputs: *outputs
-    command: *metricbeat_command
   - name: beat/metrics
     description: "Beat metrics"
     platforms: *platforms
@@ -351,6 +346,11 @@ inputs:
         - "logging.event_data.to_stderr=true"
         - "-E"
         - "logging.event_data.to_files=false"
+  - name: autoops_es/metrics
+    description: "AutoOps Elasticsearch metrics"
+    platforms: *platforms
+    outputs: *outputs
+    command: *metricbeat_command
   - name: docker/metrics
     description: "Docker metrics"
     platforms: *platforms

--- a/x-pack/agentbeat/agentbeat.spec.yml
+++ b/x-pack/agentbeat/agentbeat.spec.yml
@@ -314,6 +314,11 @@ inputs:
     platforms: *platforms
     outputs: *outputs
     command: *heartbeat_command
+  - name: autoops_es/metrics
+    description: "AutoOps Elasticsearch metrics"
+    platforms: *platforms
+    outputs: *outputs
+    command: *metricbeat_command
   - name: beat/metrics
     description: "Beat metrics"
     platforms: *platforms


### PR DESCRIPTION
This adds the `autoops_es` module to Elastic Agent.

## Proposed commit message

Add `autoops_es` module to Elastic Agent.

## Checklist

- [x] My code follows the style guidelines of this project

## Disruptive User Impact

None.

## Author's Checklist

- [ ] Should be exposed in Elastic Agent

## How to test this PR locally

Run it from Elastic Agent.

## Related issues

- Relates https://github.com/elastic/opex-product/issues/501

## Use cases

- Use AutoOps ES module from Elastic Agent with OTel.

## Screenshots

N/A

## Logs

N/A