### PR TITLE
[docs] Ensure docs are built for version branches

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '\d+.\d+'
   pull_request_target: ~
   merge_group: ~
 


### PR DESCRIPTION
Ensures that the docs are built for version branches ([see docs](https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/migration/versioning#ci-configuration)), which is needed to start onboarding `9.0` to the documentation build.

cc @belimawr 