### PR TITLE
[mbreceiver] Add Metricbeat `includes`

### DIFF
--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -16,7 +16,15 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/metricbeat/beater"
 	"github.com/elastic/beats/v7/metricbeat/cmd"
-	"github.com/elastic/beats/v7/x-pack/filebeat/include"
+
+	// Import OSS modules.
+	_ "github.com/elastic/beats/v7/metricbeat/include"
+	_ "github.com/elastic/beats/v7/metricbeat/include/fields"
+
+	// Import X-Pack modules.
+	_ "github.com/elastic/beats/v7/x-pack/libbeat/include"
+	_ "github.com/elastic/beats/v7/x-pack/metricbeat/include"
+
 	xpInstance "github.com/elastic/beats/v7/x-pack/libbeat/cmd/instance"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -41,7 +49,6 @@ func createReceiver(_ context.Context, set receiver.Settings, baseCfg component.
 	}
 	settings.Processing = processing.MakeDefaultSupport(true, globalProcs, processing.WithECS, processing.WithHost, processing.WithAgentMeta())
 	settings.ElasticLicensed = true
-	settings.Initialize = append(settings.Initialize, include.InitializeModule)
 
 	b, err := xpInstance.NewBeatForReceiver(settings, cfg.Beatconfig, true, consumer, set.Logger.Core())
 	if err != nil {


### PR DESCRIPTION
This adds the X-Pack and OSS Metricbeat includes (modules / metricsets) to the mbreceiver for OTel.

## Proposed commit message

This trades the `filebeat` includes for the `metricbeat` and `libbeat` includes for the `mbreceiver`. This drops the added initialization required for the Filebeat includes as none is needed for Metricbeat.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

This adds missing modules that are expected from Metricbeat.

## Author's Checklist

- [ ] Validate that mbreceiver still works with Elastic Agent in `otel` mode.
- [ ] Should work with existing modules from the OSS Metricbeat codebase (`elasticsearch` is an easy one to test)
- [ ] Should work with modules from the X-Pack Metricbeat codebase (`autoops_es` is an easy one to test)

## How to test this PR locally

Using the configurations below as `conf.yml`:

```sh
elastic-agent otel  --config conf.yml
```

<details>
<summary>OSS <code>elasticsearch</code> module</summary>

```
receivers:
  metricbeatreceiver:
    metricbeat:
      modules:
        - module: elasticsearch
          hosts: ["http://localhost:9200"]
          period: 10s
          metricsets:
            - node_stats
    output:
      otelconsumer:
    logging:
      level: debug
    telemetry_types: ["logs"]

exporters:
  debug:
    verbosity: detailed
    sampling_initial: 1

service:
  pipelines:
    logs:
      receivers: [metricbeatreceiver]
      exporters: [debug]
  telemetry:
    logs:
      level: "debug"
```

</details>

<details>
<summary>X-Pack <code>autoops_es</code> module</summary>

```
receivers:
  metricbeatreceiver:
    metricbeat:
      modules:
        - module: autoops_es
          hosts: ["http://localhost:9200"]
          period: 10s
          metricsets:
            - node_stats
    output:
      otelconsumer:
    logging:
      level: debug
    telemetry_types: ["logs"]

exporters:
  debug:
    verbosity: detailed
    sampling_initial: 1

service:
  pipelines:
    logs:
      receivers: [metricbeatreceiver]
      exporters: [debug]
  telemetry:
    logs:
      level: "debug"
```

</details>

## Related issues

- Closes https://github.com/elastic/elastic-agent/issues/8381

## Use cases

Allow X-Pack modules to be used from the Elastic Agent in OTel mode.
