### PR TITLE
[docs] Update APT URL

### DIFF
--- a/docs/reference/auditbeat/setup-repositories.md
+++ b/docs/reference/auditbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-version}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
     :::
 

--- a/docs/reference/filebeat/setup-repositories.md
+++ b/docs/reference/filebeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-version}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
     :::
 

--- a/docs/reference/heartbeat/setup-repositories.md
+++ b/docs/reference/heartbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-version}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
     :::
 

--- a/docs/reference/metricbeat/setup-repositories.md
+++ b/docs/reference/metricbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-version}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
     :::
 

--- a/docs/reference/packetbeat/setup-repositories.md
+++ b/docs/reference/packetbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-version}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-version}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-version}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
     ```
     :::
 


### PR DESCRIPTION
Closes https://github.com/elastic/beats/issues/44707
Closes https://github.com/elastic/docs-content/issues/1302
Related to https://github.com/elastic/beats/pull/44447
Related to https://discuss.elastic.co/t/filebeat-incorrect-apt-repository-installation-documentation/378982

Updates APT URL to use `major-release` (`9.x`) instead of `major-version` (`9.0`).