### PR TITLE
[docs] Make the first `h2` heading text more specific in each Running on Kubernetes page

### DIFF
--- a/docs/reference/auditbeat/running-on-kubernetes.md
+++ b/docs/reference/auditbeat/running-on-kubernetes.md
@@ -15,7 +15,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 % However, version {{stack-version}} of Auditbeat has not yet been released, so no Docker image is currently available for this version.
 
 
-## Kubernetes deploy manifests [_kubernetes_deploy_manifests]
+## Kubernetes deploy manifests for Auditbeat [_kubernetes_deploy_manifests]
 
 By deploying Auditbeat as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) we ensure we get a running instance on each node of the cluster.
 

--- a/docs/reference/filebeat/running-on-kubernetes.md
+++ b/docs/reference/filebeat/running-on-kubernetes.md
@@ -15,7 +15,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 % However, version {{stack-version}} of Filebeat has not yet been released, so no Docker image is currently available for this version.
 
 
-## Kubernetes deploy manifests [_kubernetes_deploy_manifests]
+## Kubernetes deploy manifests for Filebeat [_kubernetes_deploy_manifests]
 
 You deploy Filebeat as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) to ensure there’s a running instance on each node of the cluster.
 

--- a/docs/reference/heartbeat/running-on-kubernetes.md
+++ b/docs/reference/heartbeat/running-on-kubernetes.md
@@ -15,7 +15,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 % However, version {{stack-version}} of Heartbeat has not yet been released, so no Docker image is currently available for this version.
 
 
-## Kubernetes deploy manifests [_kubernetes_deploy_manifests]
+## Kubernetes deploy manifests for Heartbeat [_kubernetes_deploy_manifests]
 
 A single Heartbeat can check for uptime of the whole cluster.
 

--- a/docs/reference/metricbeat/running-on-kubernetes.md
+++ b/docs/reference/metricbeat/running-on-kubernetes.md
@@ -15,7 +15,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 % However, version {{stack-version}} of Metricbeat has not yet been released, so no Docker image is currently available for this version.
 
 
-## Kubernetes deploy manifests [_kubernetes_deploy_manifests]
+## Kubernetes deploy manifests for Metricbeat [_kubernetes_deploy_manifests]
 
 You deploy Metricbeat as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) to ensure that there’s a running instance on each node of the cluster. These instances are used to retrieve most metrics from the host, such as system metrics, Docker stats, and metrics from all the services running on top of Kubernetes.
 


### PR DESCRIPTION
Make the first `h2` heading text more specific in each Running on Kubernetes page. This in intended to help clarify that these pages are not duplicates when being indexed by search engines. I'm not sure if the wording makes sense in the context of Kubernetes so I'm tagging in @eedugon for review. 🙂 
