### PR TITLE
Add warning about Filestream only ingesting files >= 1024 bytes.

### DIFF
--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -6,17 +6,24 @@ mapped_pages:
 
 # filestream input [filebeat-input-filestream]
 
+::::{important}
+Filestream, with default settings will only start ingesting files when
+their size is >= 1024 bytes. To change this behaviour you can
+configure a different length for the fingerprint by setting
+[`prospector.scanner.fingerprint.length`](#filebeat-input-filestream-scan-fingerprint).
+::::
 
 Use the `filestream` input to read lines from active log files. It is the new, improved alternative to the `log` input. It comes with various improvements to the existing input:
 
-1. Checking of `close.on_state_change.*` options happens out of band. Thus, if an output is blocked, Filebeat can close the reader and avoid keeping too many files open.
-2. Detailed metrics are available for all files that match the `paths` configuration regardless of the `harvester_limit`. This way, you can keep track of all files, even ones that are not actively read.
-3. The order of `parsers` is configurable. So it is possible to parse JSON lines and then aggregate the contents into a multiline event.
-4. Some position updates and metadata changes no longer depend on the publishing pipeline. If the pipeline is blocked some changes are still applied to the registry.
-5. Only the most recent updates are serialized to the registry. In contrast, the `log` input has to serialize the complete registry on each ACK from the outputs. This makes the registry updates much quicker with this input.
-6. The input ensures that only offsets updates are written to the registry append only log. The `log` writes the complete file state.
-7. Stale entries can be removed from the registry, even if there is no active input.
-8. The default behaviour is to identify files based on their contents using the [`fingerprint`](#filebeat-input-filestream-file-identity-fingerprint) [`file_identity`](#filebeat-input-filestream-file-identity) This solves data duplication caused by inode reuse.
+1. The default behaviour is to identify files based on their contents using the [`fingerprint`](#filebeat-input-filestream-file-identity-fingerprint) [`file_identity`](#filebeat-input-filestream-file-identity) This solves data duplication caused by inode reuse.
+2. Checking of `close.on_state_change.*` options happens out of band. Thus, if an output is blocked, Filebeat can close the reader and avoid keeping too many files open.
+3. Detailed metrics are available for all files that match the `paths` configuration regardless of the `harvester_limit`. This way, you can keep track of all files, even ones that are not actively read.
+4. The order of `parsers` is configurable. So it is possible to parse JSON lines and then aggregate the contents into a multiline event.
+5. Some position updates and metadata changes no longer depend on the publishing pipeline. If the pipeline is blocked some changes are still applied to the registry.
+6. Only the most recent updates are serialized to the registry. In contrast, the `log` input has to serialize the complete registry on each ACK from the outputs. This makes the registry updates much quicker with this input.
+7. The input ensures that only offsets updates are written to the registry append only log. The `log` writes the complete file state.
+8. Stale entries can be removed from the registry, even if there is no active input.
+
 
 To configure this input, specify a list of glob-based [`paths`](#filestream-input-paths) that must be crawled to locate and fetch the log lines.
 


### PR DESCRIPTION
## Proposed commit message

Add a message at the top of Filestream's docs explaining it can only ingest files >= 1024 bytes in size.

## Checklist
- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

