### PR TITLE
docs: remove incorrect sentence

### DIFF
--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -258,8 +258,6 @@ Following are some scenarios where this can happen:
 
 **Configuration**
 
-Fingerprint mode is disabled by default.
-
 ::::{warning}
 Enabling fingerprint mode delays ingesting new files until they grow to at least `offset`+`length` bytes in size, so they can be fingerprinted. Until then these files are ignored.
 ::::


### PR DESCRIPTION
Fingerprint mode is enabled by default since v9.0.0.