### PR TITLE
improve unexpected EOF detection

### DIFF
--- a/x-pack/filebeat/input/awss3/s3_objects.go
+++ b/x-pack/filebeat/input/awss3/s3_objects.go
@@ -144,7 +144,11 @@ func (p *s3ObjectProcessor) ProcessS3Object(log *logp.Logger, eventCallback func
 	p.s3Metadata = s3Obj.metadata
 
 	mReader := newMonitoredReader(s3Obj.body, p.metrics.s3BytesProcessedTotal)
-	reader, err := p.addGzipDecoderIfNeeded(mReader)
+
+	// Wrap to detect S3 body streaming errors so we can retry them
+	wrappedReader := s3DownloadFailedWrappedReader{r: mReader}
+
+	streamReader, err := p.addGzipDecoderIfNeeded(wrappedReader)
 	if err != nil {
 		return fmt.Errorf("failed checking for gzip content: %w", err)
 	}
@@ -155,7 +159,7 @@ func (p *s3ObjectProcessor) ProcessS3Object(log *logp.Logger, eventCallback func
 	}
 
 	// try to create a dec from the using the codec config
-	dec, err := newDecoder(p.readerConfig.Decoding, reader)
+	dec, err := newDecoder(p.readerConfig.Decoding, streamReader)
 	if err != nil {
 		return err
 	}
@@ -203,9 +207,9 @@ func (p *s3ObjectProcessor) ProcessS3Object(log *logp.Logger, eventCallback func
 		// Process object content stream.
 		switch {
 		case strings.HasPrefix(s3Obj.contentType, contentTypeJSON) || strings.HasPrefix(s3Obj.contentType, contentTypeNDJSON):
-			err = p.readJSON(reader)
+			err = p.readJSON(streamReader)
 		default:
-			err = p.readFile(reader)
+			err = p.readFile(streamReader)
 		}
 	}
 	if err != nil {
@@ -266,12 +270,7 @@ func (p *s3ObjectProcessor) addGzipDecoderIfNeeded(body io.Reader) (io.Reader, e
 }
 
 func (p *s3ObjectProcessor) readJSON(r io.Reader) error {
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		// If an error occurs during the download, handle it here
-		return fmt.Errorf("%w: %w", errS3DownloadFailed, err)
-	}
-	dec := json.NewDecoder(&buf)
+	dec := json.NewDecoder(r)
 	dec.UseNumber()
 
 	for dec.More() && p.ctx.Err() == nil {
@@ -586,4 +585,19 @@ func s3Metadata(resp *s3.GetObjectOutput, keys ...string) mapstr.M {
 	}
 
 	return metadata
+}
+
+// s3DownloadFailedWrappedReader implements io.Reader interface.
+// Internally, it validates Read errors for io.ErrUnexpectedEOF and wraps them with errS3DownloadFailed.
+type s3DownloadFailedWrappedReader struct {
+	r io.Reader
+}
+
+func (e s3DownloadFailedWrappedReader) Read(p []byte) (n int, err error) {
+	n, err = e.r.Read(p)
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return n, fmt.Errorf("%w: %w", errS3DownloadFailed, err)
+	}
+
+	return n, err
 }


### PR DESCRIPTION
## Proposed commit message

This PR revisits the implementation introduced in https://github.com/elastic/beats/pull/42420 and improves the detection of ErrUnexpectedEOF.

The `io.ErrUnexpectedEOF` error can occur while streaming the S3 object body. The previous approach relied on reading the entire body into memory using `io.Copy` which unfortunately led to increased memory usage in Beats deployments.

This change introduces a wrapper around `io.Reader` to catch and handle `io.ErrUnexpectedEOF. This allows us to handle stream errors (retriable) and content parsing errors (non-retriable) separately. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

Fixes https://github.com/elastic/beats/issues/44735
