### PR TITLE
Explicitly crossbuild linux/arm with debian11

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -140,6 +140,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - 'add_cloud_metadata' processor - improve AWS provider HTTP client overriding to support custom certificate bundle handling {pull}44189[44189]
 - Fix `dns` processor to handle IPv6 server addresses properly. {pull}44526[44526]
 - Fix an issue where the Kafka output could get stuck if a proxied connection to the Kafka cluster was reset. {issue}44606[44606]
+- Use Debian 11 to build linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31. {issue}44816[44816]
 
 *Auditbeat*
 

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -238,7 +238,7 @@ func CrossBuildImage(platform string) (string, error) {
 	case platform == "darwin/universal":
 		tagSuffix = "darwin-arm64-debian11"
 	case platform == "linux/arm64":
-		tagSuffix = "base-arm-debian9"
+		tagSuffix = "base-arm-debian11"
 	case platform == "linux/armv5":
 		tagSuffix = "armel"
 	case platform == "linux/armv6":


### PR DESCRIPTION
- Relates https://github.com/elastic/elastic-agent/pull/8497

https://github.com/elastic/beats/issues/41270 missed updating linux/arm to crossbuild with Debian11 like we did for the other platforms. This corrects that.