### PR TITLE
Increase disk size for vm agents used for Packaging

### DIFF
--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -470,6 +470,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_2204_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "auditbeat: Packaging Linux"
@@ -488,6 +489,7 @@ steps:
           provider: "aws"
           imagePrefix: "${IMAGE_UBUNTU_2204_ARM64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "auditbeat: Packaging Linux arm64"

--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -485,8 +485,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "filebeat: Packaging Linux"
@@ -505,6 +504,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "filebeat: Packaging Linux arm64"

--- a/.buildkite/heartbeat/heartbeat-pipeline.yml
+++ b/.buildkite/heartbeat/heartbeat-pipeline.yml
@@ -325,6 +325,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "heartbeat: Packaging Linux"
@@ -343,6 +344,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "heartbeat: Packaging Linux arm64"

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -464,8 +464,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "metricbeat: Packaging Linux"
@@ -484,6 +483,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "metricbeat: Packaging Linux arm64"

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -101,6 +101,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -134,6 +135,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -167,6 +169,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "c2-standard-16"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -186,6 +189,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -209,6 +213,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -234,6 +239,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "c2-standard-16"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -259,6 +265,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -293,6 +300,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -327,6 +335,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "c2-standard-16"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -348,6 +357,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -373,6 +383,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -400,6 +411,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "c2-standard-16"
+          diskSizeGb: 100
         timeout_in_minutes: 40
         retry:
           automatic:
@@ -428,6 +440,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+          diskSizeGb: 100
 
       - label: DRA Staging
         # TODO remove OR clause below (see earlier comment)
@@ -448,6 +461,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+          diskSizeGb: 100
 
   - wait
 

--- a/.buildkite/packetbeat/pipeline.packetbeat.yml
+++ b/.buildkite/packetbeat/pipeline.packetbeat.yml
@@ -340,8 +340,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "packetbeat: Packaging Linux"
@@ -360,6 +359,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "packetbeat: Packaging Linux arm64"

--- a/.buildkite/winlogbeat/pipeline.winlogbeat.yml
+++ b/.buildkite/winlogbeat/pipeline.winlogbeat.yml
@@ -224,6 +224,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "winlogbeat: Packaging Linux"

--- a/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.agentbeat.yml
@@ -94,8 +94,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "agentbeat: Packaging"
@@ -121,8 +120,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "agentbeat: Packaging linux/amd64 FIPS"
@@ -148,6 +146,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "agentbeat: Packaging linux/arm64 FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -448,8 +448,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/auditbeat: Packaging Linux amd64 FIPS"
@@ -469,6 +468,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/auditbeat: Packaging Linux arm64 FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
@@ -151,6 +151,7 @@ steps:
           provider: gcp
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/dockerlogbeat: Packaging Linux"
@@ -169,6 +170,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/dockerlogbeat: Packaging Linux arm64"

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -507,8 +507,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/filebeat: Packaging Linux amd64 FIPS"
@@ -528,6 +527,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/filebeat: Packaging Linux arm64 FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
@@ -331,8 +331,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/heartbeat: Packaging Linux"
@@ -351,6 +350,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/heartbeat: Packaging Linux arm64"

--- a/.buildkite/x-pack/pipeline.xpack.libbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.libbeat.yml
@@ -322,6 +322,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         artifact_paths:
           - "x-pack/libbeat/build/*.xml"
           - "x-pack/libbeat/build/*.json"

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -518,8 +518,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/metricbeat: Packaging Linux amd64 FIPS"
@@ -539,6 +538,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/metricbeat: Packaging Linux arm64 FIPS"

--- a/.buildkite/x-pack/pipeline.xpack.osquerybeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.osquerybeat.yml
@@ -264,8 +264,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/osquerybeat: Packaging Linux"
@@ -284,6 +283,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/osquerybeat: Packaging Linux arm64"

--- a/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
@@ -469,8 +469,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/packetbeat: Packaging Linux"
@@ -489,6 +488,7 @@ steps:
           provider: "aws"
           imagePrefix: "${AWS_IMAGE_UBUNTU_ARM_64}"
           instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/packetbeat: Packaging Linux arm64"

--- a/.buildkite/x-pack/pipeline.xpack.winlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.winlogbeat.yml
@@ -290,8 +290,7 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           machineType: "${GCP_HI_PERF_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          diskSizeGb: 100
         notify:
           - github_commit_status:
               context: "x-pack/winlogbeat: Packaging Linux"


### PR DESCRIPTION
## Proposed commit message

As discovered in https://github.com/elastic/beats/pull/44696 (e.g. for `auditbeat`) we are running dangerously close to the default 30Gi allocated for the VM agent disk size.

This commit increases it to 100Gi as a future proofing mechanism. While at it, we fix wrong specifications of disk size related to packaging steps.

## How to test this PR locally

Can't be tested locally, only in CI:

1. CI of this PR should be green (TBD: provide links/screenshots)
2. Main packaging job successful.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
