### PR TITLE
fix: add missing beats to linux/arm64 packaging

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -8,7 +8,7 @@ env:
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
 
-  PLATFORMS: "+all linux/amd64 linux/arm64 linux/386 windows/amd64 windows/386 darwin/amd64"
+  PLATFORMS: "+all linux/amd64 linux/386 windows/amd64 windows/386 darwin/amd64"
   PLATFORMS_ARM: "+all linux/arm64"
 
 steps:
@@ -145,11 +145,27 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
-          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/osquerybeat
           - x-pack/packetbeat
+
+      - label: "SNAPSHOT: x-pack/functionbeat Linux/arm64"
+        env:
+          PLATFORMS: "linux/arm64"
+          SNAPSHOT: true
+          DEV: true
+        command: ".buildkite/scripts/packaging/package-dra.sh x-pack/functionbeat"
+        agents:
+          provider: gcp
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
 
   - group: Packaging staging
     key: packaging-staging
@@ -215,11 +231,27 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
-          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/osquerybeat
           - x-pack/packetbeat
+
+      - label: "STAGING: x-pack/functionbeat Linux/arm64"
+        env:
+          PLATFORMS: "linux/arm64"
+          SNAPSHOT: true
+          DEV: true
+        command: ".buildkite/scripts/packaging/package-dra.sh x-pack/functionbeat"
+        agents:
+          provider: gcp
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
+        timeout_in_minutes: 40
+        retry:
+          automatic:
+            - limit: 1
+        artifact_paths:
+          - build/distributions/**/*
 
   - group: DRA publish
     key: dra

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -145,8 +145,10 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
+          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
+          - x-pack/osquerybeat
           - x-pack/packetbeat
 
   - group: Packaging staging
@@ -213,8 +215,10 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
+          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
+          - x-pack/osquerybeat
           - x-pack/packetbeat
 
   - group: DRA publish

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -145,27 +145,11 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
+          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/osquerybeat
           - x-pack/packetbeat
-
-      - label: "SNAPSHOT: x-pack/functionbeat Linux/arm64"
-        env:
-          PLATFORMS: "linux/arm64"
-          SNAPSHOT: true
-          DEV: true
-        command: ".buildkite/scripts/packaging/package-dra.sh x-pack/functionbeat"
-        agents:
-          provider: gcp
-          image: "${IMAGE_UBUNTU_X86_64}"
-          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
-        timeout_in_minutes: 40
-        retry:
-          automatic:
-            - limit: 1
-        artifact_paths:
-          - build/distributions/**/*
 
   - group: Packaging staging
     key: packaging-staging
@@ -231,27 +215,11 @@ steps:
           - x-pack/auditbeat
           - x-pack/dockerlogbeat
           - x-pack/filebeat
+          - x-pack/functionbeat
           - x-pack/heartbeat
           - x-pack/metricbeat
           - x-pack/osquerybeat
           - x-pack/packetbeat
-
-      - label: "STAGING: x-pack/functionbeat Linux/arm64"
-        env:
-          PLATFORMS: "linux/arm64"
-          SNAPSHOT: true
-          DEV: true
-        command: ".buildkite/scripts/packaging/package-dra.sh x-pack/functionbeat"
-        agents:
-          provider: gcp
-          image: "${IMAGE_UBUNTU_X86_64}"
-          machineType: "${GCP_DEFAULT_MACHINE_TYPE}"
-        timeout_in_minutes: 40
-        retry:
-          automatic:
-            - limit: 1
-        artifact_paths:
-          - build/distributions/**/*
 
   - group: DRA publish
     key: dra

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -8,7 +8,7 @@ env:
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
 
-  PLATFORMS: "+all linux/amd64 linux/386 windows/amd64 windows/386 darwin/amd64"
+  PLATFORMS: "+all linux/amd64 linux/arm64 linux/386 windows/amd64 windows/386 darwin/amd64"
   PLATFORMS_ARM: "+all linux/arm64"
 
 steps:

--- a/x-pack/functionbeat/dev-tools/packaging/packages.yml
+++ b/x-pack/functionbeat/dev-tools/packaging/packages.yml
@@ -63,7 +63,7 @@ shared:
   - &functionbeat_binaries
     files:
       pkg/functionbeat-aws:
-        source: 'provider/aws/build/golang-crossbuild/aws-linux-amd64'
+        source: 'provider/aws/build/golang-crossbuild/aws-linux-{{.Platform.Arch}}'
         mode: 0755
 
 # specs is a list of named packaging "flavors".


### PR DESCRIPTION
## Proposed commit message

The PR https://github.com/elastic/beats/pull/44701 made changes shifting linux-arm64 from the amd64 packaging pipeline to the arm64. The packaging for functionbeat and osquerybeat were silently removed with this change, since they are not present in the arm64 packaging stage. This commit adds them.

## Related issues

- Relates https://github.com/elastic/beats/pull/44701