### PR TITLE
fix: elastic-agent packaging after #44701

### DIFF
--- a/.buildkite/x-pack/elastic-agent/pipeline.xpack.elastic-agent.package.yml
+++ b/.buildkite/x-pack/elastic-agent/pipeline.xpack.elastic-agent.package.yml
@@ -74,7 +74,6 @@ steps:
       - label: "Package ARM elastic-agent"
         env:
           PLATFORMS: "linux/arm64"
-          PACKAGES: "docker"
         key: package_elastic-agent-arm
         command: |
           if [[ -z "$${MANIFEST_URL}" ]]; then


### PR DESCRIPTION
## Proposed commit message

This commit fixes the elastic-agent pipeline, that was missed in the fixes brought in #44843, to unblock the unified release.
It splits the jobs to arm64 and non-arm64 ones as done elsewhere.

## How to test this PR locally

Can only be tested in BK.

Test run imitating the trigger from the unified release:

✅ https://buildkite.com/elastic/beats-xpack-elastic-agent-package-7-17/builds/1272

## Related issues

PR #44843 and PR #44701
