### PR TITLE
[metricbeat] [system] add NTP metricset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,6 +275,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.2 // indirect
+	github.com/beevik/ntp v1.4.3 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bluekeyes/go-gitdiff v0.7.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -170,6 +170,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.28.3
 	github.com/aws/aws-sdk-go-v2/service/health v1.30.3
 	github.com/aws/smithy-go v1.22.2
+	github.com/beevik/ntp v1.4.3
 	github.com/dgraph-io/badger/v4 v4.6.0
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.7.0
@@ -275,7 +276,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.2 // indirect
-	github.com/beevik/ntp v1.4.3 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bluekeyes/go-gitdiff v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.21 h1:nyLjs8sYJShFYj6aiyjCBI3EcLn
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.21/go.mod h1:EhdxtZ+g84MSGrSrHzZiUm9PYiZkrADNja15wtRJSJo=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/beevik/ntp v1.4.3 h1:PlbTvE5NNy4QHmA4Mg57n7mcFTmr1W1j3gcK7L1lqho=
+github.com/beevik/ntp v1.4.3/go.mod h1:Unr8Zg+2dRn7d8bHFuehIMSvvUYssHMxW3Q5Nx4RW5Q=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/metricbeat/include/list_common.go
+++ b/metricbeat/include/list_common.go
@@ -168,6 +168,7 @@ import (
 	_ "github.com/elastic/beats/v7/metricbeat/module/system/memory"
 	_ "github.com/elastic/beats/v7/metricbeat/module/system/network"
 	_ "github.com/elastic/beats/v7/metricbeat/module/system/network_summary"
+	_ "github.com/elastic/beats/v7/metricbeat/module/system/ntp"
 	_ "github.com/elastic/beats/v7/metricbeat/module/system/process"
 	_ "github.com/elastic/beats/v7/metricbeat/module/system/process_summary"
 	_ "github.com/elastic/beats/v7/metricbeat/module/system/raid"

--- a/metricbeat/module/system/ntp/config.go
+++ b/metricbeat/module/system/ntp/config.go
@@ -1,0 +1,32 @@
+package ntp
+
+import (
+	"fmt"
+	"time"
+)
+
+type config struct {
+	Host    string        `config:"host"`
+	Timeout time.Duration `config:"timeout"`
+	Version int           `config:"version"`
+}
+
+func defaultConfig() config {
+	return config{
+		Timeout: 5 * time.Second,
+		Version: 4,
+	}
+}
+
+func validateConfig(cfg *config) error {
+	if cfg.Host == "" {
+		return fmt.Errorf("NTP host must be set in config")
+	}
+	if cfg.Timeout <= 0 {
+		return fmt.Errorf("invalid NTP timeout: %s", cfg.Timeout.String())
+	}
+	if cfg.Version != 3 && cfg.Version != 4 {
+		return fmt.Errorf("NTP version must be 3 or 4")
+	}
+	return nil
+}

--- a/metricbeat/module/system/ntp/config_test.go
+++ b/metricbeat/module/system/ntp/config_test.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor license agreements.
+// See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+// Elasticsearch B.V. licenses this file to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+
+package ntp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := defaultConfig()
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
+	assert.Equal(t, 4, cfg.Version)
+}
+
+func TestValidateConfig_Valid(t *testing.T) {
+	cfg := config{
+		Host:    "localhost:123",
+		Timeout: 5 * time.Second,
+		Version: 4,
+	}
+	assert.NoError(t, validateConfig(&cfg))
+}
+
+func TestValidateConfig_MissingHost(t *testing.T) {
+	cfg := config{
+		Timeout: 5 * time.Second,
+		Version: 4,
+	}
+	err := validateConfig(&cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NTP host must be set in config")
+}
+
+func TestValidateConfig_InvalidVersion(t *testing.T) {
+	cfg := config{
+		Host:    "localhost:123",
+		Timeout: 5 * time.Second,
+		Version: 2,
+	}
+	err := validateConfig(&cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NTP version must be 3 or 4")
+}
+
+func TestValidateConfig_InvalidTimeout(t *testing.T) {
+	cfg := config{
+		Host:    "localhost:123",
+		Timeout: 0,
+		Version: 2,
+	}
+	err := validateConfig(&cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid NTP timeout: 0s")
+}

--- a/metricbeat/module/system/ntp/ntp.go
+++ b/metricbeat/module/system/ntp/ntp.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ntp
+
+import (
+	"fmt"
+
+	"github.com/beevik/ntp"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+// MetricSet holds any configuration or state for the metricset
+// Ensure MetricSet implements mb.MetricSet and mb.ReportingMetricSetV2Error
+var (
+	_ mb.MetricSet                 = (*MetricSet)(nil)
+	_ mb.ReportingMetricSetV2Error = (*MetricSet)(nil)
+)
+
+type MetricSet struct {
+	mb.BaseMetricSet
+	config config
+}
+
+func init() {
+	mb.Registry.MustAddMetricSet("system", "ntp", New, mb.DefaultMetricSet())
+}
+
+// New creates a new instance of the MetricSet (used for both production and test construction)
+func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	cfg := defaultConfig()
+	if err := base.Module().UnpackConfig(&cfg); err != nil {
+		return nil, err
+	}
+	if err := validateConfig(&cfg); err != nil {
+		return nil, err
+	}
+	return &MetricSet{BaseMetricSet: base, config: cfg}, nil
+}
+
+// Fetch fetches the offset from the configured NTP server
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
+	response, err := ntpQueryWithOptions(m.config.Host, ntp.QueryOptions{
+		Timeout: m.config.Timeout,
+		Version: m.config.Version,
+	})
+
+	if err != nil {
+		err := fmt.Errorf("error querying NTP server %s: %w", m.config.Host, err)
+		reporter.Error(err)
+		return err
+	}
+
+	reporter.Event(mb.Event{MetricSetFields: mapstr.M{
+		"host":   m.config.Host,
+		"offset": response.ClockOffset.Seconds(),
+	}})
+
+	return nil
+}

--- a/metricbeat/module/system/ntp/ntp_test.go
+++ b/metricbeat/module/system/ntp/ntp_test.go
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ntp
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/beevik/ntp"
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"module":     "system",
+		"metricsets": []string{"ntp"},
+		"host":       "localhost:123",
+	}
+}
+
+func TestFetchOffset_Success(t *testing.T) {
+	ntpQueryOrig := ntpQueryWithOptions
+	ntpQueryWithOptions = func(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
+		return &ntp.Response{ClockOffset: time.Duration(1.23 * float64(time.Second))}, nil
+	}
+	defer func() { ntpQueryWithOptions = ntpQueryOrig }()
+
+	metricSet := mbtest.NewReportingMetricSetV2Error(t, getTestConfig())
+	events, errs := mbtest.ReportingFetchV2Error(metricSet)
+	assert.Empty(t, errs, "expected no errors, got: %v", errs)
+	assert.Len(t, events, 1, "expected 1 event")
+	msFields := events[0].MetricSetFields
+	offset, ok := msFields["offset"]
+	assert.True(t, ok, "offset not found in event")
+	assert.Equal(t, 1.23, offset, "offset should be 1.23 seconds")
+
+	host, ok := msFields["host"]
+	assert.True(t, ok, "host not found in event")
+	assert.Equal(t, "localhost:123", host, "host should match configured host")
+}
+
+func TestFetchOffset_Error(t *testing.T) {
+	ntpQueryOrig := ntpQueryWithOptions
+	ntpQueryWithOptions = func(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
+		return nil, errors.New("ntp error")
+	}
+	defer func() { ntpQueryWithOptions = ntpQueryOrig }()
+
+	metricSet := mbtest.NewReportingMetricSetV2Error(t, getTestConfig())
+	_, errs := mbtest.ReportingFetchV2Error(metricSet)
+	assert.NotEmpty(t, errs, "expected error, got none")
+}

--- a/metricbeat/module/system/ntp/patch.go
+++ b/metricbeat/module/system/ntp/patch.go
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ntp
+
+import "github.com/beevik/ntp"
+
+// ntpQueryWithOptions allows patching in tests
+var ntpQueryWithOptions = ntp.QueryWithOptions


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Add new Network Time Protocol (NTP) metricset to the system integration. 

This is a simple wrapper around an SNTP client which allows monitoring of system clock offset compared to the configured NTP server. 

<img width="1452" alt="Screenshot 2025-06-17 at 17 14 11" src="https://github.com/user-attachments/assets/be8f9d86-f1ab-4b6c-aa13-475a8de3b2d8" />

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
