### PR TITLE
Disable Metricbeat `azure` module in FIPS builds

### DIFF
--- a/x-pack/metricbeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/azure/_meta/docs.asciidoc
@@ -5,6 +5,8 @@ include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 :modulename!:
 
+WARNING: This module is not available in FIPS-capable Metricbeat.
+
 The Azure Monitor feature collects and aggregates logs and metrics from a variety of sources into a common data platform where it can be used for analysis, visualization, and alerting.
 
 
@@ -100,7 +102,7 @@ Users can also use this in case of a Hybrid Cloud model, where one may define th
 `enable_batch_api` ::
 _boolean_
 Optional, by default is set to False. Set this to True when facing scalability issues. When configured, the azure batch api will be used
-to fetch metrics of multiple resources in one api call. 
+to fetch metrics of multiple resources in one api call.
 Currently supported metricsets are monitor, container_registry, container_instance, container_service, compute_vm, compute_vm_scaleset, database_account and storage.
 
 [float]

--- a/x-pack/metricbeat/module/azure/add_metadata.go
+++ b/x-pack/metricbeat/module/azure/add_metadata.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/app_insights/app_insights.go
+++ b/x-pack/metricbeat/module/azure/app_insights/app_insights.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_insights
 
 import (

--- a/x-pack/metricbeat/module/azure/app_insights/app_insights_integration_test.go
+++ b/x-pack/metricbeat/module/azure/app_insights/app_insights_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package app_insights
 

--- a/x-pack/metricbeat/module/azure/app_insights/client.go
+++ b/x-pack/metricbeat/module/azure/app_insights/client.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_insights
 
 import (

--- a/x-pack/metricbeat/module/azure/app_insights/client_test.go
+++ b/x-pack/metricbeat/module/azure/app_insights/client_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_insights
 
 import (

--- a/x-pack/metricbeat/module/azure/app_insights/data.go
+++ b/x-pack/metricbeat/module/azure/app_insights/data.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_insights
 
 import (

--- a/x-pack/metricbeat/module/azure/app_insights/data_test.go
+++ b/x-pack/metricbeat/module/azure/app_insights/data_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_insights
 
 import (

--- a/x-pack/metricbeat/module/azure/app_insights/mock_service.go
+++ b/x-pack/metricbeat/module/azure/app_insights/mock_service.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_insights
 
 import (

--- a/x-pack/metricbeat/module/azure/app_insights/service.go
+++ b/x-pack/metricbeat/module/azure/app_insights/service.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_insights
 
 import (

--- a/x-pack/metricbeat/module/azure/app_state/app_state_integration_test.go
+++ b/x-pack/metricbeat/module/azure/app_state/app_state_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package app_state
 

--- a/x-pack/metricbeat/module/azure/app_state/app_state_test.go
+++ b/x-pack/metricbeat/module/azure/app_state/app_state_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package app_state
 
 import (

--- a/x-pack/metricbeat/module/azure/azure.go
+++ b/x-pack/metricbeat/module/azure/azure.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/azure_test.go
+++ b/x-pack/metricbeat/module/azure/azure_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/billing.go
+++ b/x-pack/metricbeat/module/azure/billing/billing.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/billing_integration_test.go
+++ b/x-pack/metricbeat/module/azure/billing/billing_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package billing
 

--- a/x-pack/metricbeat/module/azure/billing/billing_test.go
+++ b/x-pack/metricbeat/module/azure/billing/billing_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/client.go
+++ b/x-pack/metricbeat/module/azure/billing/client.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/client_test.go
+++ b/x-pack/metricbeat/module/azure/billing/client_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/data.go
+++ b/x-pack/metricbeat/module/azure/billing/data.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/data_test.go
+++ b/x-pack/metricbeat/module/azure/billing/data_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/mock_service.go
+++ b/x-pack/metricbeat/module/azure/billing/mock_service.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/billing/service.go
+++ b/x-pack/metricbeat/module/azure/billing/service.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package billing
 
 import (

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/client_batch.go
+++ b/x-pack/metricbeat/module/azure/client_batch.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/client_batch_test.go
+++ b/x-pack/metricbeat/module/azure/client_batch_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/client_test.go
+++ b/x-pack/metricbeat/module/azure/client_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/client_utils.go
+++ b/x-pack/metricbeat/module/azure/client_utils.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/client_utils_test.go
+++ b/x-pack/metricbeat/module/azure/client_utils_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/compute_vm/compute_vm_integration_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm/compute_vm_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package compute_vm
 

--- a/x-pack/metricbeat/module/azure/compute_vm/compute_vm_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm/compute_vm_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package compute_vm
 
 import (

--- a/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_integration_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package compute_vm_scaleset
 

--- a/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package compute_vm_scaleset
 
 import (

--- a/x-pack/metricbeat/module/azure/config.go
+++ b/x-pack/metricbeat/module/azure/config.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/container_instance/container_instance_integration_test.go
+++ b/x-pack/metricbeat/module/azure/container_instance/container_instance_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package container_instance
 

--- a/x-pack/metricbeat/module/azure/container_instance/container_instance_test.go
+++ b/x-pack/metricbeat/module/azure/container_instance/container_instance_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package container_instance
 
 import (

--- a/x-pack/metricbeat/module/azure/container_registry/container_registry_integration_test.go
+++ b/x-pack/metricbeat/module/azure/container_registry/container_registry_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package container_registry
 

--- a/x-pack/metricbeat/module/azure/container_registry/container_registry_test.go
+++ b/x-pack/metricbeat/module/azure/container_registry/container_registry_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package container_registry
 
 import (

--- a/x-pack/metricbeat/module/azure/container_service/container_service_integration_test.go
+++ b/x-pack/metricbeat/module/azure/container_service/container_service_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package container_service
 

--- a/x-pack/metricbeat/module/azure/container_service/container_service_test.go
+++ b/x-pack/metricbeat/module/azure/container_service/container_service_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package container_service
 
 import (

--- a/x-pack/metricbeat/module/azure/data.go
+++ b/x-pack/metricbeat/module/azure/data.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/data_test.go
+++ b/x-pack/metricbeat/module/azure/data_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/database_account/database_account_integration_test.go
+++ b/x-pack/metricbeat/module/azure/database_account/database_account_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package database_account
 

--- a/x-pack/metricbeat/module/azure/database_account/database_account_test.go
+++ b/x-pack/metricbeat/module/azure/database_account/database_account_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package database_account
 
 import (

--- a/x-pack/metricbeat/module/azure/doc.go
+++ b/x-pack/metricbeat/module/azure/doc.go
@@ -2,5 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 // Package azure is a Metricbeat module that contains MetricSets.
 package azure

--- a/x-pack/metricbeat/module/azure/metric_registry.go
+++ b/x-pack/metricbeat/module/azure/metric_registry.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/metric_registry_test.go
+++ b/x-pack/metricbeat/module/azure/metric_registry_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/mock_service.go
+++ b/x-pack/metricbeat/module/azure/mock_service.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor/client_helper.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package monitor
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package monitor
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package monitor
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package monitor
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor/monitor.go
+++ b/x-pack/metricbeat/module/azure/monitor/monitor.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package monitor
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor/monitor_integration_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/monitor_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package monitor
 

--- a/x-pack/metricbeat/module/azure/monitor/monitor_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/monitor_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package monitor
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor_service.go
+++ b/x-pack/metricbeat/module/azure/monitor_service.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/monitor_service_test.go
+++ b/x-pack/metricbeat/module/azure/monitor_service_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/resources.go
+++ b/x-pack/metricbeat/module/azure/resources.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/service_interface.go
+++ b/x-pack/metricbeat/module/azure/service_interface.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package azure
 
 import (

--- a/x-pack/metricbeat/module/azure/storage/client_helper.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package storage
 
 import (

--- a/x-pack/metricbeat/module/azure/storage/client_helper_concurrent.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper_concurrent.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package storage
 
 import (

--- a/x-pack/metricbeat/module/azure/storage/client_helper_concurrent_test.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper_concurrent_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package storage
 
 import (

--- a/x-pack/metricbeat/module/azure/storage/client_helper_test.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package storage
 
 import (

--- a/x-pack/metricbeat/module/azure/storage/storage.go
+++ b/x-pack/metricbeat/module/azure/storage/storage.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package storage
 
 import (

--- a/x-pack/metricbeat/module/azure/storage/storage_integration_test.go
+++ b/x-pack/metricbeat/module/azure/storage/storage_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration && azure
+//go:build !requirefips && integration && azure
 
 package storage
 

--- a/x-pack/metricbeat/module/azure/storage/storage_test.go
+++ b/x-pack/metricbeat/module/azure/storage/storage_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package storage
 
 import (

--- a/x-pack/metricbeat/module/azure/test/integration.go
+++ b/x-pack/metricbeat/module/azure/test/integration.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package test
 
 import (


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR (similar to #43480) ensures that the Metricbeat `azure` module code is only compiled in non-FIPS builds of Metricbeat. 

The module uses the Azure Go SDK and the SDK's code uses the `golang.org/x/crypto/pkcs12` package, which is not FIPS-compliant, and the SDK doesn't plan to offer a way to disable the use of this package at compile time (see https://github.com/Azure/azure-sdk-for-go/issues/24336).  

As such, we have little choice but to exclude the `azure` module from FIPS-capable Metricbeat builds.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

FIPS-capable artifacts of Metricbeat will not contain the `azure` module.
