### PR TITLE
Disable Metricbeat `mssql` module in FIPS builds

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -533,7 +533,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Added checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. {pull}44193[44193]
 - Add latency config option to Azure Monitor module. {pull}44366[44366]
 - Increase default polling period for MongoDB module from 10s to 60s {pull}44781[44781]
-- Do not include the `mssql` module in FIPS-capable Metricbeat artifacts. {pull}44885[44885]
+- Do not include the `mssql` module in FIPS-capable Metricbeat artifacts. {pull}44890[44890]
 
 
 *Osquerybeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -533,8 +533,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Added checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. {pull}44193[44193]
 - Add latency config option to Azure Monitor module. {pull}44366[44366]
 - Increase default polling period for MongoDB module from 10s to 60s {pull}44781[44781]
-
-*Metricbeat*
+- Do not include the `mssql` module in FIPS-capable Metricbeat artifacts. {pull}44885[44885]
 
 
 *Osquerybeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -533,7 +533,8 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Added checks for the Resty response object in all Meraki module API calls to ensure proper handling of nil responses. {pull}44193[44193]
 - Add latency config option to Azure Monitor module. {pull}44366[44366]
 - Increase default polling period for MongoDB module from 10s to 60s {pull}44781[44781]
-- Do not include the `mssql` module in FIPS-capable Metricbeat artifacts. {pull}44890[44890]
+
+*Metricbeat*
 
 
 *Osquerybeat*

--- a/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
+WARNING: This module is not available in FIPS-capable Metricbeat.
+
 This is the https://www.microsoft.com/en-us/sql-server/sql-server-2017[Microsoft SQL 2017] Metricbeat module. It is still under active development to add new Metricsets and introduce enhancements.
 
 [float]

--- a/x-pack/metricbeat/module/mssql/connection.go
+++ b/x-pack/metricbeat/module/mssql/connection.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package mssql
 
 import (

--- a/x-pack/metricbeat/module/mssql/mssql.go
+++ b/x-pack/metricbeat/module/mssql/mssql.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package mssql
 
 import (

--- a/x-pack/metricbeat/module/mssql/performance/data.go
+++ b/x-pack/metricbeat/module/mssql/performance/data.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package performance
 
 import (

--- a/x-pack/metricbeat/module/mssql/performance/data_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/performance/data_integration_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package performance
 
 import (

--- a/x-pack/metricbeat/module/mssql/performance/doc.go
+++ b/x-pack/metricbeat/module/mssql/performance/doc.go
@@ -1,0 +1,6 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package performance is for the performance metricset of the mssql module.
+package performance

--- a/x-pack/metricbeat/module/mssql/performance/performance.go
+++ b/x-pack/metricbeat/module/mssql/performance/performance.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package performance
 
 import (
@@ -81,16 +83,16 @@ WHERE  counter_name = 'SQL Compilations/sec'
         OR counter_name = 'Batch Requests/sec'
         OR ( counter_name = 'Lock Waits/sec'
              AND instance_name = '_Total' )
-        OR ( counter_name IN ( 'Page life expectancy', 
-                  'Buffer cache hit ratio', 
+        OR ( counter_name IN ( 'Page life expectancy',
+                  'Buffer cache hit ratio',
 	          'Buffer cache hit ratio base',
-                  'Target pages', 'Database pages', 
+                  'Target pages', 'Database pages',
                   'Checkpoint pages/sec' )
              AND object_name LIKE '%:Buffer Manager%' )
-        OR ( counter_name IN ( 'Transactions', 
-                  'Logins/sec', 
-                  'Logouts/sec', 
-                  'Connection Reset/sec', 
+        OR ( counter_name IN ( 'Transactions',
+                  'Logins/sec',
+                  'Logouts/sec',
+                  'Connection Reset/sec',
                   'Active Temp Tables' )
              AND object_name LIKE '%:General Statistics%' )`)
 	if err != nil {

--- a/x-pack/metricbeat/module/mssql/performance/performance_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/performance/performance_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration
+//go:build !requirefips && integration
 
 package performance
 

--- a/x-pack/metricbeat/module/mssql/testing/mssql.go
+++ b/x-pack/metricbeat/module/mssql/testing/mssql.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package testing
 
 import "os"

--- a/x-pack/metricbeat/module/mssql/transaction_log/data_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/transaction_log/data_integration_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package transaction_log
 
 import (

--- a/x-pack/metricbeat/module/mssql/transaction_log/doc.go
+++ b/x-pack/metricbeat/module/mssql/transaction_log/doc.go
@@ -1,0 +1,6 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package transaction_log is for the transaction_log metricset of the mssql module.
+package transaction_log

--- a/x-pack/metricbeat/module/mssql/transaction_log/transaction_log.go
+++ b/x-pack/metricbeat/module/mssql/transaction_log/transaction_log.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !requirefips
+
 package transaction_log
 
 import (

--- a/x-pack/metricbeat/module/mssql/transaction_log/transaction_log_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/transaction_log/transaction_log_integration_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build integration
+//go:build !requirefips && integration
 
 package transaction_log
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR (similar to #43480) ensures that the Metricbeat `mssql` module code is only compiled in non-FIPS builds of Metricbeat and is, therefore, unavailable in FIPS-capable Metricbeat artifacts.

The module indirectly depends on the Azure Go SDK. The SDK's code uses the `golang.org/x/crypto/pkcs12` package, which is not FIPS-compliant, and the SDK doesn't plan to offer a way to disable the use of this package at compile time (see https://github.com/Azure/azure-sdk-for-go/issues/24336).  

As such, we have little choice but to exclude the `mssql` module from FIPS-capable Metricbeat builds.

The `doc.go` files added to every metricset in the `mssql` module are to prevent compile-time errors like so:
```
build constraints exclude all Go files in x-pack/metricbeat/module/mssql/performance
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

FIPS-capable artifacts of Metricbeat will not contain the `mssql` module.
