### PR TITLE
Exclude Azure VM provider in `add_cloud_metadata` processor in FIPS builds

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -327,6 +327,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Disable sending telemetry to Microsoft when using their Go fork for producing FIPS-capable artifacts {pull}44865[44865]
 - The `add_cloud_metadata` processor does not support the Azure provider in FIPS-capable artifacts {pull}xxxx[xxxx]
 - The `add_cloud_metadata` processor does not support the Azure provider in FIPS-capable artifacts {pull}44891[44891]
+- The `add_cloud_metadata` processor does not support the Azure Virtual Machine provider in FIPS-capable artifacts {pull}44891[44891]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -326,6 +326,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Publish cloud.availability_zone by add_cloud_metadata processor in azure environments {issue}42601[42601] {pull}43618[43618]
 - Disable sending telemetry to Microsoft when using their Go fork for producing FIPS-capable artifacts {pull}44865[44865]
 - The `add_cloud_metadata` processor does not support the Azure provider in FIPS-capable artifacts {pull}xxxx[xxxx]
+- The `add_cloud_metadata` processor does not support the Azure provider in FIPS-capable artifacts {pull}44891[44891]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -325,9 +325,6 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Replace Ubuntu 20.04 with 24.04 for Docker base images {issue}40743[40743] {pull}40942[40942]
 - Publish cloud.availability_zone by add_cloud_metadata processor in azure environments {issue}42601[42601] {pull}43618[43618]
 - Disable sending telemetry to Microsoft when using their Go fork for producing FIPS-capable artifacts {pull}44865[44865]
-- The `add_cloud_metadata` processor does not support the Azure provider in FIPS-capable artifacts {pull}xxxx[xxxx]
-- The `add_cloud_metadata` processor does not support the Azure provider in FIPS-capable artifacts {pull}44891[44891]
-- The `add_cloud_metadata` processor does not support the Azure Virtual Machine provider in FIPS-capable artifacts {pull}44891[44891]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -325,6 +325,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Replace Ubuntu 20.04 with 24.04 for Docker base images {issue}40743[40743] {pull}40942[40942]
 - Publish cloud.availability_zone by add_cloud_metadata processor in azure environments {issue}42601[42601] {pull}43618[43618]
 - Disable sending telemetry to Microsoft when using their Go fork for producing FIPS-capable artifacts {pull}44865[44865]
+- The `add_cloud_metadata` processor does not support the Azure provider in FIPS-capable artifacts {pull}xxxx[xxxx]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -17,7 +17,7 @@ The following cloud providers are supported:
 - https://www.qcloud.com/?lang=en[Tencent Cloud] (QCloud)
 - Alibaba Cloud (ECS)
 - Huawei Cloud (ECS)
-- Azure Virtual Machine
+- Azure Virtual Machine (*not supported in FIPS-capable artifacts*)
 - Openstack Nova
 - Hetzner Cloud
 

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !requirefips
+
 package add_cloud_metadata
 
 import (

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !requirefips
+
 package add_cloud_metadata
 
 import (

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -58,7 +58,6 @@ type result struct {
 var cloudMetaProviders = map[string]provider{
 	"alibaba":       alibabaCloudMetadataFetcher,
 	"ecs":           alibabaCloudMetadataFetcher,
-	"azure":         azureVMMetadataFetcher,
 	"digitalocean":  doMetadataFetcher,
 	"aws":           ec2MetadataFetcher,
 	"ec2":           ec2MetadataFetcher,
@@ -78,7 +77,7 @@ var cloudMetaProviders = map[string]provider{
 // or other common endpoints. For example, Openstack supports EC2 compliant metadata endpoint. Thus adding possibility to
 // conflict metadata between EC2/AWS and Openstack.
 var priorityProviders = []string{
-	"aws", "ec2", "azure",
+	"aws", "ec2",
 }
 
 func selectProviders(configList providerList, providers map[string]provider) map[string]provider {

--- a/libbeat/processors/add_cloud_metadata/providers_nofips.go
+++ b/libbeat/processors/add_cloud_metadata/providers_nofips.go
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !requirefips
+
+package add_cloud_metadata
+
+func init() {
+	// Include the Azure provider ONLY in non-FIPS builds, as the Azure provider depends on
+	// the Azure SDK which, in turn, depends on the golang.org/x/crypto/pkcs12 package, which
+	// is not FIPS-compliant, and the SDK doesn't plan to offer a way to disable the use of
+	// this package at compile time (see https://github.com/Azure/azure-sdk-for-go/issues/24336).
+	cloudMetaProviders["azure"] = azureVMMetadataFetcher
+	priorityProviders = append(priorityProviders, "azure")
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR amends the `add_cloud_metadata` processor initialization such that the Azure Virtual Machine provider is included only in non-FIPS builds. 

The Azure Virtual Machine provider depends on the Azure SDK which, in turn, depends on the golang.org/x/crypto/pkcs12 package, which is not FIPS-compliant, and the SDK doesn't plan to offer a way to disable the use of this package at compile time (see https://github.com/Azure/azure-sdk-for-go/issues/24336).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

The `add_cloud_metadata` processor will not support the Azure Virtual Machine provider in FIPS-capable artifacts of Beats.
