### PR TITLE
Adding the option to disable the DNS failure or success cache

### DIFF
--- a/libbeat/processors/dns/config.go
+++ b/libbeat/processors/dns/config.go
@@ -120,6 +120,9 @@ type cacheConfig struct {
 
 // cacheSettings define the caching behavior for an individual cache.
 type cacheSettings struct {
+	// Disable the use of the cache.
+	Disabled bool `config:"disabled" default:"false"`
+
 	// TTL value for items in cache. Not used for success because we use TTL
 	// from the DNS record.
 	TTL time.Duration `config:"ttl"`
@@ -189,11 +192,13 @@ func defaultConfig() config {
 	return config{
 		cacheConfig: cacheConfig{
 			SuccessCache: cacheSettings{
+				Disabled:        false,
 				MinTTL:          time.Minute,
 				InitialCapacity: 1000,
 				MaxCapacity:     10000,
 			},
 			FailureCache: cacheSettings{
+				Disabled:        false,
 				MinTTL:          time.Minute,
 				TTL:             time.Minute,
 				InitialCapacity: 1000,

--- a/libbeat/processors/dns/dns_test.go
+++ b/libbeat/processors/dns/dns_test.go
@@ -155,6 +155,36 @@ func TestDNSProcessorTagOnFailure(t *testing.T) {
 	}
 }
 
+func TestDNSProcessorDisabledCache(t *testing.T) {
+	c := defaultConfig()
+	c.Type = typePTR
+	c.SuccessCache.Disabled = true
+	c.FailureCache.Disabled = true
+	p := &processor{
+		config:   c,
+		resolver: &stubResolver{},
+		log:      logptest.NewTestingLogger(t, logName),
+	}
+	p.config.reverseFlat = map[string]string{
+		"source.ip": "source.domain",
+	}
+	t.Log(p.String())
+
+	t.Run("default", func(t *testing.T) {
+		event, err := p.Run(&beat.Event{
+			Fields: mapstr.M{
+				"source.ip": gatewayIP,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		v, _ := event.GetValue("source.domain")
+		assert.Equal(t, gatewayName, v)
+	})
+}
+
 func TestDNSProcessorRunInParallel(t *testing.T) {
 	// This is a simple smoke test to make sure that there are no concurrency
 	// issues. It is most effective when run with the race detector.


### PR DESCRIPTION
## Proposed commit message

Adds the option to disable the success and failure cache. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

non known, the default values leave the old behavior and the setting is added with this commit

## How to test this PR locally

Define the DNS processor, observe cache stats / resolver requests.

## Related issues

-
