### PR TITLE
K8's only logger changes

### DIFF
--- a/metricbeat/module/apache/status/data.go
+++ b/metricbeat/module/apache/status/data.go
@@ -24,6 +24,7 @@ import (
 
 	s "github.com/elastic/beats/v7/libbeat/common/schema"
 	c "github.com/elastic/beats/v7/libbeat/common/schema/mapstrstr"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -107,7 +108,7 @@ func applySchema(event mapstr.M, fullEvent map[string]interface{}) error {
 }
 
 // Map body to MapStr
-func eventMapping(scanner *bufio.Scanner, hostname string) (mapstr.M, error) {
+func eventMapping(scanner *bufio.Scanner, hostname string, logger *logp.Logger) (mapstr.M, error) {
 	var (
 		totalS          int
 		totalR          int
@@ -172,7 +173,7 @@ func eventMapping(scanner *bufio.Scanner, hostname string) (mapstr.M, error) {
 			totalDot = strings.Count(match[2], ".")
 			totalAll = totalUnderscore + totalS + totalR + totalW + totalK + totalD + totalC + totalL + totalG + totalI + totalDot
 		} else {
-			debugf("Unexpected line in apache server-status output: %s", scanner.Text())
+			logger.Named("apache-status").Debugf("Unexpected line in apache server-status output: %s", scanner.Text())
 		}
 	}
 

--- a/metricbeat/module/apache/status/status.go
+++ b/metricbeat/module/apache/status/status.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 const (
@@ -43,8 +42,6 @@ const (
 )
 
 var (
-	debugf = logp.MakeDebug("apache-status")
-
 	hostParser = parse.URLHostParserBuilder{
 		DefaultScheme: defaultScheme,
 		PathConfigKey: "server_status_path",
@@ -90,7 +87,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		return fmt.Errorf("error fetching data: %w", err)
 	}
 
-	data, _ := eventMapping(scanner, m.Host())
+	data, _ := eventMapping(scanner, m.Host(), m.Logger())
 	event := mb.Event{
 		MetricSetFields: data,
 	}

--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	"github.com/stretchr/testify/assert"
@@ -268,7 +269,7 @@ func TestStatusOutputs(t *testing.T) {
 		assert.NoError(t, err, "cannot open test file "+filename)
 		scanner := bufio.NewScanner(f)
 
-		_, err = eventMapping(scanner, "localhost")
+		_, err = eventMapping(scanner, "localhost", logptest.NewTestingLogger(t, ""))
 		assert.NoError(t, err, "error mapping "+filename)
 	}
 }


### PR DESCRIPTION
This is a smaller PR of the backport PR https://github.com/elastic/beats/pull/44775

The parent PR consistently fails on CI with no obvious reasons. 
This PR aims to isolate the problematic code. 