### PR TITLE
Optionally ignore MAC address in flow matching in Packetbeat

### DIFF
--- a/packetbeat/_meta/config/beat.reference.yml.tmpl
+++ b/packetbeat/_meta/config/beat.reference.yml.tmpl
@@ -83,6 +83,7 @@ packetbeat.interfaces.internal_networks:
 # every time a new Elasticsearch connection is established.
 #packetbeat.overwrite_pipelines: false
 
+
 {{- template "windows_npcap.yml.tmpl" .}}
 
 {{header "Flows"}}
@@ -103,6 +104,12 @@ packetbeat.flows:
 
   # Overrides where flow events are indexed.
   #index: my-custom-flow-index
+
+  # In situations where flows can contain different src/dst pairs on the return
+  # route, enabling this allows the flow to be constructed matching based on
+  # higher level protocol details if available.
+  allow_mismatched_eth: false
+
 
 {{header "Transaction protocols"}}
 

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -146,6 +146,7 @@ type Flows struct {
 	Index string `config:"index"`
 	// DeltaFlowReports when enabled will report flow network stats(bytes, packets) as delta values
 	EnableDeltaFlowReports bool `config:"enable_delta_flow_reports"`
+	AllowMismatchedEth     bool `config:"allow_mismatched_eth"`
 }
 
 type ProtocolCommon struct {

--- a/packetbeat/decoder/decoder.go
+++ b/packetbeat/decoder/decoder.go
@@ -69,7 +69,8 @@ type Decoder struct {
 	flowID              *flows.FlowID // buffer flowID among many calls
 	flowIDBufferBacking [flows.SizeFlowIDMax]byte
 
-	logger *logp.Logger
+	allowMismatchedEth bool
+	logger             *logp.Logger
 }
 
 const (
@@ -80,13 +81,14 @@ const (
 )
 
 // New creates and initializes a new packet decoder.
-func New(f *flows.Flows, datalink layers.LinkType, icmp4 icmp.ICMPv4Processor, icmp6 icmp.ICMPv6Processor, tcp tcp.Processor, udp udp.Processor) (*Decoder, error) {
+func New(f *flows.Flows, datalink layers.LinkType, icmp4 icmp.ICMPv4Processor, icmp6 icmp.ICMPv6Processor, tcp tcp.Processor, udp udp.Processor, allowMismatchedEth bool) (*Decoder, error) {
 	d := Decoder{
 		flows:     f,
 		decoders:  make(map[gopacket.LayerType]gopacket.DecodingLayer),
 		icmp4Proc: icmp4, icmp6Proc: icmp6, tcpProc: tcp, udpProc: udp,
-		fragments: fragmentCache{collected: make(map[uint16]fragments)},
-		logger:    logp.NewLogger("decoder"),
+		fragments:          fragmentCache{collected: make(map[uint16]fragments)},
+		allowMismatchedEth: allowMismatchedEth,
+		logger:             logp.NewLogger("decoder"),
 	}
 	d.stD1Q.init(&d.d1q[0], &d.d1q[1])
 	d.stIP4.init(&d.ip4[0], &d.ip4[1])
@@ -370,7 +372,7 @@ func (d *Decoder) process(packet *protos.Packet, layerType gopacket.LayerType) (
 
 	switch layerType {
 	case layers.LayerTypeEthernet:
-		if withFlow {
+		if withFlow && !d.allowMismatchedEth {
 			d.flowID.AddEth(d.eth.SrcMAC, d.eth.DstMAC)
 		}
 

--- a/packetbeat/decoder/decoder_test.go
+++ b/packetbeat/decoder/decoder_test.go
@@ -212,7 +212,7 @@ func newTestDecoder(t *testing.T) (*Decoder, *TestTCPProcessor, *TestUDPProcesso
 	icmp6Layer := &TestIcmp6Processor{}
 	tcpLayer := &TestTCPProcessor{}
 	udpLayer := &TestUDPProcessor{}
-	d, err := New(nil, layers.LinkTypeEthernet, icmp4Layer, icmp6Layer, tcpLayer, udpLayer)
+	d, err := New(nil, layers.LinkTypeEthernet, icmp4Layer, icmp6Layer, tcpLayer, udpLayer, false)
 	if err != nil {
 		t.Fatalf("Error creating decoder %v", err)
 	}

--- a/packetbeat/sniffer/decoders.go
+++ b/packetbeat/sniffer/decoders.go
@@ -72,8 +72,12 @@ func DecodersFor(id string, publisher *publish.TransactionPublisher, protocols *
 		if err != nil {
 			return nil, nil, err
 		}
+		allowMismatchedEth := false
+		if cfg.Flows != nil {
+			allowMismatchedEth = cfg.Flows.AllowMismatchedEth
+		}
 
-		worker, err := decoder.New(flows, dl, icmp4, icmp6, tcp, udp)
+		worker, err := decoder.New(flows, dl, icmp4, icmp6, tcp, udp, allowMismatchedEth)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION

## Proposed commit message
This adds a new configuration field under flows `allow_mismatched_eth` which if set to true, will not add the MAC address to the flowId. This allows correlating packets that for one reason or another end up with a differing return route. E.g. a DNS response is returned on a different interface or from a different source than the request was sent on/to.

This change is to support the enhancement request 


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

There should be none, as this is a default false configuration, so unless the field is added no behaviour in packetbeat changes.

