### PR TITLE
x-pack/filebeat/input/httpjson: share oauth2 clients where possible

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -481,6 +481,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Add support for blob filtering using path_prefix in azureblobstorage input. {issue}35186[35186] {pull}45214[45214]
 - Update CEL mito extensions to v1.22.0. {pull}45245[45245]
 - Allow empty HTTPJSON cursor template value evaluations to be ignored by Fleet health status updates. {pull}45361[45361]
+- Reuse OAuth2 clients in HTTP JSON input where possible. {issue}34834[34834] {pull}44976[44976]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/httpjson/config_auth.go
+++ b/x-pack/filebeat/input/httpjson/config_auth.go
@@ -105,6 +105,8 @@ type oAuth2Config struct {
 	OktaJWKFile string          `config:"okta.jwk_file"`
 	OktaJWKJSON common.JSONBlob `config:"okta.jwk_json"`
 	OktaJWKPEM  string          `config:"okta.jwk_pem"`
+
+	prepared *http.Client
 }
 
 // IsEnabled returns true if the `enable` field is set to true in the yaml.

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -325,7 +325,7 @@ func newRequestFactory(ctx context.Context, config config, stat status.StatusRep
 		if ch.Step != nil {
 			ts, _ := newBasicTransformsFromConfig(registeredTransforms, ch.Step.Request.Transforms, requestNamespace, stat, log)
 			ch.Step.Auth = tryAssignAuth(config.Auth, ch.Step.Auth)
-			client, err := newChainHTTPClient(ctx, ch.Step.Auth, ch.Step.Request, stat, log, reg)
+			client, err := newHTTPClient(ctx, ch.Step.Auth, ch.Step.Request, stat, log, reg, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed in creating chain http client with error: %w", err)
 			}
@@ -352,7 +352,7 @@ func newRequestFactory(ctx context.Context, config config, stat status.StatusRep
 			ts, _ := newBasicTransformsFromConfig(registeredTransforms, ch.While.Request.Transforms, requestNamespace, stat, log)
 			policy := newHTTPPolicy(evaluateResponse, ch.While.Until, stat, log)
 			ch.While.Auth = tryAssignAuth(config.Auth, ch.While.Auth)
-			client, err := newChainHTTPClient(ctx, ch.While.Auth, ch.While.Request, stat, log, reg, policy)
+			client, err := newHTTPClient(ctx, ch.While.Auth, ch.While.Request, stat, log, reg, policy)
 			if err != nil {
 				return nil, fmt.Errorf("failed in creating chain http client with error: %w", err)
 			}

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -58,7 +58,7 @@ func TestCtxAfterDoRequest(t *testing.T) {
 
 	log := logp.NewLogger("")
 	ctx := context.Background()
-	client, err := newHTTPClient(ctx, config, noopReporter{}, log, nil)
+	client, err := newHTTPClient(ctx, config.Auth, config.Request, noopReporter{}, log, nil, nil)
 	assert.NoError(t, err)
 
 	requestFactory, err := newRequestFactory(ctx, config, noopReporter{}, log, nil, nil)
@@ -216,7 +216,7 @@ func Test_newChainHTTPClient(t *testing.T) {
 		authCfg    *authConfig
 		requestCfg *requestConfig
 		log        *logp.Logger
-		p          []*Policy
+		p          *Policy
 	}
 	tests := []struct {
 		name string
@@ -235,7 +235,7 @@ func Test_newChainHTTPClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newChainHTTPClient(tt.args.ctx, tt.args.authCfg, tt.args.requestCfg, noopReporter{}, tt.args.log, nil, tt.args.p...)
+			got, err := newHTTPClient(tt.args.ctx, tt.args.authCfg, tt.args.requestCfg, noopReporter{}, tt.args.log, nil, tt.args.p)
 			assert.NoError(t, err)
 			assert.NotNil(t, got)
 		})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/httpjson: share oauth2 clients where possible

The httpjson input makes new http.Client values for every chain step.
This is inefficient for a variety of reasons, but the configuration API
that we expose makes the general fix for this non-trivial. It is,
however, possible to fix the OAuth2 behaviour that arises from this
where root parent steps in a chain make use of OAuth2 and so do its
children, but the children needlessly request tokens because they do
not have access to the oauth2.Transports token cache. The fix here is
to retain the prepared OAuth2 client in the relevant config and use
that if it is non-nil. This does not fix the case that a non-root
parent shares OAuth2 authentication with its children, but this is
likely to be uncommon.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #34834

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
