### PR TITLE
[AutoOps] Serialize custom struct before sending as event

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/cat_shards/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/data.go
@@ -98,7 +98,7 @@ func eventsMapping(m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.Clus
 }
 
 func sendNodeShardsEvent(r mb.ReporterV2, info *utils.ClusterInfo, nodeToShards []NodeShardCount, transactionId string) {
-	r.Event(events.CreateEvent(info, mapstr.M{"node_shards_count": nodeToShards}, transactionId))
+	r.Event(events.CreateEvent(info, mapstr.M{"node_shards_count": convertObjectArrayToMapArray(nodeToShards)}, transactionId))
 }
 
 func sendNodeIndexShardsEvent(r mb.ReporterV2, info *utils.ClusterInfo, nodeIndexShards []NodeIndexShards, transactionId string) {
@@ -111,7 +111,7 @@ func sendNodeIndexShardsEvent(r mb.ReporterV2, info *utils.ClusterInfo, nodeInde
 	for i := 0; i < size; i += nodeIndexShardsPerEvent {
 		group := nodeIndexShards[i:min(i+nodeIndexShardsPerEvent, size)]
 
-		groups = append(groups, mapstr.M{"node_index_shards": group})
+		groups = append(groups, mapstr.M{"node_index_shards": convertObjectArrayToMapArray(group)})
 	}
 
 	events.CreateAndReportEvents(r, info, groups, transactionId)

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/struct_to_map.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/struct_to_map.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cat_shards
+
+import (
+	"encoding/json"
+)
+
+// convertObjectArrayToMapArray converts an array of structs to an array of maps one by one.
+func convertObjectArrayToMapArray[T any](objects []T) []map[string]any {
+	mapArray := make([]map[string]any, 0, len(objects))
+
+	for _, object := range objects {
+		if data, err := json.Marshal(object); err == nil {
+			// Unmarshal the JSON into a map
+			var result map[string]any
+
+			if err := json.Unmarshal(data, &result); err == nil {
+				mapArray = append(mapArray, result)
+			}
+		}
+	}
+
+	return mapArray
+}

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/struct_to_map_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/struct_to_map_test.go
@@ -1,0 +1,87 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cat_shards
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConvertObjectArrayToMapArray(t *testing.T) {
+	type testStruct struct {
+		Name   string `json:"name"`
+		Value  int    `json:"value"`
+		Active bool   `json:"active"`
+	}
+
+	tests := []struct {
+		name  string
+		input []testStruct
+		want  []map[string]any
+	}{
+		{
+			name:  "nil slice",
+			input: nil,
+			want:  []map[string]any{},
+		},
+		{
+			name:  "empty slice",
+			input: []testStruct{},
+			want:  []map[string]any{},
+		},
+		{
+			name: "single item",
+			input: []testStruct{
+				{Name: "A", Value: 1, Active: true},
+			},
+			want: []map[string]any{
+				{"name": "A", "value": float64(1), "active": true},
+			},
+		},
+		{
+			name: "multiple items",
+			input: []testStruct{
+				{Name: "A", Value: 1, Active: true},
+				{Name: "B", Value: 2, Active: false},
+			},
+			want: []map[string]any{
+				{"name": "A", "value": float64(1), "active": true},
+				{"name": "B", "value": float64(2), "active": false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertObjectArrayToMapArray(tt.input)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertObjectArrayToMapArray() got = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertObjectArrayToMapArray_MarshalError(t *testing.T) {
+	type errorStruct struct {
+		C chan int `json:"c,omitempty"`
+	}
+
+	input := []any{
+		errorStruct{C: make(chan int)}, // This will cause json.Marshal to fail
+		map[string]any{},               // This will be an empty object
+	}
+
+	got := convertObjectArrayToMapArray(input)
+	want := []map[string]any{
+		{},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("convertObjectArrayToMapArray() with marshal error got = %#v, want %#v", got, want)
+	}
+}

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/testing.go
@@ -8,6 +8,7 @@
 package cat_shards
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +18,24 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func objectToType[T any](content any) T {
+	data, err := json.Marshal(content)
+
+	if err == nil {
+		var result T
+
+		if err = json.Unmarshal(data, &result); err == nil {
+			return result
+		}
+	}
+
+	panic(err)
+}
+
+func mapArrayToType[T any](content []map[string]any) []T {
+	return objectToType[[]T](content)
+}
 
 func SetupSuccessfulServerWithResolvedIndexes(resolvedIndexes []byte) auto_ops_testing.SetupServerCallback {
 	return func(t *testing.T, clusterInfo []byte, data []byte, _ string) *httptest.Server {


### PR DESCRIPTION
This pre-serialization step is unnecessary for AutoOps running as part of Metricbeat, but it is necessary to allow it to work with OTel because the OTel Consumer cannot handle the serialization of structs.

## Proposed commit message

Pre-serialize AutoOps `cat_shards` metricset for OTel mode.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

Wasted performance in Metricbeat mode, but required to work in OTel mode.

## Author's Checklist

- [ ] Compile and run this code with https://github.com/elastic/beats/pull/45008 (required for the inner array that needs to be converted to `[]any` to make OTel happy)

## How to test this PR locally

Merge this branch with https://github.com/elastic/beats/pull/45008, then compile it with Elastic Agent and run it in OTel mode with this metricset.

## Related issues

- Relates https://github.com/elastic/beats/issues/45005