### PR TITLE
[Flaky test] Fix memqueue testing race condition

### DIFF
--- a/libbeat/publisher/queue/memqueue/runloop_test.go
+++ b/libbeat/publisher/queue/memqueue/runloop_test.go
@@ -20,6 +20,7 @@ package memqueue
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -53,10 +54,16 @@ func TestFlushSettingsDoNotBlockFullBatches(t *testing.T) {
 
 	producer := newProducer(broker, nil, nil)
 	rl := broker.runLoop
+	// iterLock is used to ensure distinct runIteration calls can never overlap
+	iterLock := sync.Mutex{}
 	for i := 0; i < 100; i++ {
 		// Pair each publish call with an iteration of the run loop so we
 		// get a response.
-		go rl.runIteration()
+		go func() {
+			iterLock.Lock()
+			rl.runIteration()
+			iterLock.Unlock()
+		}()
 		_, ok := producer.Publish(i)
 		require.True(t, ok, "Queue publish call must succeed")
 	}
@@ -70,7 +77,11 @@ func TestFlushSettingsDoNotBlockFullBatches(t *testing.T) {
 		// there's a logical error.
 		_, _ = broker.Get(100)
 	}()
+	// Still have to lock here even though we aren't running asynchronously,
+	// since it's possible that the last asynchronous call is still running.
+	iterLock.Lock()
 	rl.runIteration()
+	iterLock.Unlock()
 	assert.Nil(t, rl.pendingGetRequest, "Queue should have no pending get request since the request should succeed immediately")
 	assert.Equal(t, 100, rl.consumedCount, "Queue should have a consumedCount of 100 after a consumer requested all its events")
 }


### PR DESCRIPTION
`TestFlushSettingsDoNotBlockFullBatches` has a rare race condition ([example](https://buildkite.com/elastic/beats-libbeat/builds/17172#0197a533-4fd2-413d-b07f-ada64cc067e3)) where the test can fail because it's possible in the testing setup for two calls to `runIteration` to partially overlap, causing the later call to potentially receive stale internal metadata. This PR adds a lock before/after calls to `runIteration` to ensure each one finishes completely before the next begins.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
