### PR TITLE
[Filebeat] Allow v2 inputs to opt out of FIPS distributions

### DIFF
--- a/filebeat/input/v2/loader.go
+++ b/filebeat/input/v2/loader.go
@@ -19,6 +19,7 @@ package v2
 
 import (
 	"fmt"
+	"github.com/elastic/beats/v7/libbeat/common"
 
 	"github.com/elastic/beats/v7/libbeat/feature"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -94,6 +95,10 @@ func (l *Loader) Configure(cfg *conf.C) (Input, error) {
 	}
 	if p.Deprecated {
 		log.Warnf("DEPRECATED: The %v input is deprecated", name)
+	}
+
+	if common.FIPSMode && p.ExcludeFromFIPS {
+		return nil, fmt.Errorf("running a FIPS-capable distribution but input [%s] is not FIPS capable", name)
 	}
 
 	return p.Manager.Create(cfg)

--- a/filebeat/input/v2/loader.go
+++ b/filebeat/input/v2/loader.go
@@ -19,8 +19,8 @@ package v2
 
 import (
 	"fmt"
-	"github.com/elastic/beats/v7/libbeat/common"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"

--- a/filebeat/input/v2/loader_test.go
+++ b/filebeat/input/v2/loader_test.go
@@ -19,10 +19,11 @@ package v2
 
 import (
 	"errors"
-	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/stretchr/testify/require"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"

--- a/filebeat/input/v2/plugin.go
+++ b/filebeat/input/v2/plugin.go
@@ -60,6 +60,11 @@ type Plugin struct {
 
 	// Manager MUST be configured. The manager is used to create the inputs.
 	Manager InputManager
+
+	// ExcludeFromFIPS indicates whether this plugin should not be usable in
+	// FIPS-capable Filebeat distributions. If set to true, FIPS-capable Filebeat
+	// distributions will exit with an error if this plugin is configured for use.
+	ExcludeFromFIPS bool
 }
 
 func (p Plugin) validate() error {

--- a/libbeat/common/mode_fips.go
+++ b/libbeat/common/mode_fips.go
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package common
+
+// FIPSMode = true indicates that this is a FIPS-capable distribution.const FIPSMode = true
+const FIPSMode = true

--- a/libbeat/common/mode_fips.go
+++ b/libbeat/common/mode_fips.go
@@ -19,5 +19,5 @@
 
 package common
 
-// FIPSMode = true indicates that this is a FIPS-capable distribution.const FIPSMode = true
+// FIPSMode = true indicates that this is a FIPS-capable distribution.
 const FIPSMode = true

--- a/libbeat/common/mode_nofips.go
+++ b/libbeat/common/mode_nofips.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 //go:build !requirefips
 
 package common

--- a/libbeat/common/mode_nofips.go
+++ b/libbeat/common/mode_nofips.go
@@ -1,0 +1,6 @@
+//go:build !requirefips
+
+package common
+
+// FIPSMode = false indicates that this is not a FIPS-capable distribution.
+const FIPSMode = false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR adds a new boolean field, `ExcludeFromFIPS` to the [`v2.Plugin` struct](https://github.com/elastic/beats/blob/c63e539cf8ea40302340ea6ab640a020740e86dd/filebeat/input/v2/plugin.go#L43) for optional use by v2 inputs.  Inputs that set this field to `true` are indicating that they should NOT be usable in FIPS-capable distributions of Filebeat.  If an input that sets this field to `true` is configured in a FIPS-capable Filebeat distribution, Filebeat will exit with an error like so:

```
{"log.level":"error","@timestamp":"2025-06-25T11:22:14.686-0700","log.origin":{"function":"github.com/elastic/beats/v7/libbeat/cmd/instance.handleError","file.name":"instance/beat.go","file.line":1355},"message":"Exiting: Failed to start crawler: starting input failed: error while initializing input: running a FIPS-capable distribution but input [o365audit] is not FIPS capable","service.name":"filebeat","ecs.version":"1.6.0"}
Exiting: Failed to start crawler: starting input failed: error while initializing input: running a FIPS-capable distribution but input [o365audit] is not FIPS capable
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

None; the changes in this PR merely allow for Filebeat v2 inputs to be excluded from FIPS-capable Filebeat artifacts; there are no inputs actually being excluded in this PR.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
$ go test ./filebeat/input/v2/ -test.run TestLoader_ConfigureFIPS -test.count 1 -test.v
=== RUN   TestLoader_ConfigureFIPS
    loader_test.go:209: FIPS mode = false; err = <nil>
--- PASS: TestLoader_ConfigureFIPS (0.00s)
PASS
ok  	github.com/elastic/beats/v7/filebeat/input/v2	0.006s
```

In an environment configured for FIPS, i.e. with the Microsoft Go fork [installed](https://github.com/microsoft/go?tab=readme-ov-file#binary-archive) and with the OpenSSL FIPS provider [installed](https://github.com/openssl/openssl/blob/master/README-FIPS.md#installing-the-fips-provider):

```
$ GOEXPERIMENT=systemcrypto go test -tags requirefips ./filebeat/input/v2/ -test.run TestLoader_ConfigureFIPS -test.count 1 -test.v
=== RUN   TestLoader_ConfigureFIPS
    loader_test.go:209: FIPS mode = true; err = running a FIPS-capable distribution but input [a] is not FIPS capable
--- PASS: TestLoader_ConfigureFIPS (0.00s)
PASS
ok  	github.com/elastic/beats/v7/filebeat/input/v2	0.014s
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
This PR replaces the implementation done in #44920