### PR TITLE
[OTel] Serialize Maps and `nil` Better

### DIFF
--- a/libbeat/otelbeat/otelmap/otelmap.go
+++ b/libbeat/otelbeat/otelmap/otelmap.go
@@ -100,13 +100,11 @@ func ConvertNonPrimitive[T mapstrOrMap](m T) {
 			if ref.Kind() == reflect.Slice || ref.Kind() == reflect.Array {
 				s := make([]any, ref.Len())
 				for i := 0; i < ref.Len(); i++ {
-					elem := ref.Index(i)
-					if elem.Kind() == reflect.Map && elem.Type().Key().Kind() == reflect.String && elem.Type().Elem().Kind() == reflect.Interface {
-						if m, ok := elem.Interface().(map[string]any); ok {
-							ConvertNonPrimitive(m)
-						}
+					elem := ref.Index(i).Interface()
+					if m, ok := elem.(map[string]any); ok {
+						ConvertNonPrimitive(m)
 					}
-					s[i] = elem.Interface()
+					s[i] = elem
 				}
 				m[key] = s
 				break // we figured out the type, so we don't need the unknown type case

--- a/libbeat/otelbeat/otelmap/otelmap_test.go
+++ b/libbeat/otelbeat/otelmap/otelmap_test.go
@@ -281,7 +281,8 @@ func TestFromMapstrWithNestedData(t *testing.T) {
 		"bool_slice": []bool{false, true},
 		"inner": []mapstr.M{
 			{
-				"inner_int": 42,
+				"inner_int":       42,
+				"inner_map_slice": [1]any{nil},
 				"inner_slice": []map[string]any{ // slice -> slice
 					{"string": "string"},
 					{"number": 12.3},
@@ -289,6 +290,9 @@ func TestFromMapstrWithNestedData(t *testing.T) {
 			},
 			{
 				"inner_int": 43,
+				"inner_map_slice": []any{
+					map[string]any{"string": "string3"},
+				},
 				"inner_slice": [2]map[string]any{ // array -> slice
 					{"string": "string2"},
 					{"number": 12.4},
@@ -303,7 +307,8 @@ func TestFromMapstrWithNestedData(t *testing.T) {
 		"bool_slice": []any{false, true},
 		"inner": []any{
 			map[string]any{
-				"inner_int": 42,
+				"inner_int":       42,
+				"inner_map_slice": []any{nil},
 				"inner_slice": []any{
 					map[string]any{"string": "string"},
 					map[string]any{"number": 12.3},
@@ -311,6 +316,9 @@ func TestFromMapstrWithNestedData(t *testing.T) {
 			},
 			map[string]any{
 				"inner_int": 43,
+				"inner_map_slice": []any{
+					map[string]any{"string": "string3"},
+				},
 				"inner_slice": []any{
 					map[string]any{"string": "string2"},
 					map[string]any{"number": 12.4},


### PR DESCRIPTION
This simplifies the serialization of arrays / slices of `map[string]any` and add tests for inner `nil` handling.

## Proposed commit message

Add better tests for `otelmap` and simplified arrays and slices and use less reflection.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

No change.

## How to test this PR locally

- Run the tests in `otelmap`

## Related issues

- https://github.com/elastic/beats/issues/45007