### PR TITLE
[Metricbeat][WMI][Internal] Improve nil checks robustness

### DIFF
--- a/metricbeat/module/windows/wmi/utils_test.go
+++ b/metricbeat/module/windows/wmi/utils_test.go
@@ -229,3 +229,56 @@ func mustParseTime(layout, value string) time.Time {
 	}
 	return parsed
 }
+
+// TestIsNil contains test cases for the isNil function.
+func TestIsNil(t *testing.T) {
+	// Define a custom struct for testing typed pointers
+	type MyStruct struct {
+		Name string
+	}
+
+	// Define test cases using a slice of structs
+	tests := []struct {
+		name     string      // Name of the test case
+		input    interface{} // Input value to the isNil function
+		expected bool        // Expected boolean result
+	}{
+		// --- Cases where the function should return true (is nil) ---
+		{
+			name:     "Untyped nil interface",
+			input:    nil, // Direct untyped nil
+			expected: true,
+		},
+		{
+			name:     "int32 nil interface",
+			input:    (*int32)(nil),
+			expected: true,
+		},
+		{
+			name:     "custom struct interface",
+			input:    (*MyStruct)(nil),
+			expected: true,
+		},
+		{
+			name:     "String literals are not nil",
+			input:    "test",
+			expected: false,
+		},
+		{
+			name:     "Numeric literals are not nil",
+			input:    35,
+			expected: false,
+		},
+	}
+
+	// Iterate over the test cases and run each one
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNil(tt.input) // Call the function under test
+			if got != tt.expected {
+				// Report an error if the actual result doesn't match the expected result
+				t.Errorf("isNil(%v) = %v; want %v (Type: %T, Kind: %s)", tt.input, got, tt.expected, tt.input, reflect.TypeOf(tt.input).Kind())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed commit message

Metricbeat Module WMI: Add implementation and tests for the `isNil` function

Covers untyped nil and typed nil pointers for robust interface nil checks.

**WHY**
Although we never encountered the case in our tests, it's possible that the library returns a "typed" pointer and we want to avoid undefined behaviors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

This change is purely technical/internal and should not have affect on external users.

## Author's Checklist

## How to test this PR locally



## Related issues

- https://github.com/elastic/beats/pull/45003: Adds more checks to the changes introduced in this PR.

## Use cases
N/A

## Screenshots
N/A

## Logs
N/A
