### PR TITLE
Fix Elasticsearch output retry backoff when receiving 429s

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -141,6 +141,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fix `dns` processor to handle IPv6 server addresses properly. {pull}44526[44526]
 - Fix an issue where the Kafka output could get stuck if a proxied connection to the Kafka cluster was reset. {issue}44606[44606]
 - Use Debian 11 to build linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31. {issue}44816[44816]
+- The Elasticsearch output now correctly applies exponential backoff when being throttled by 429s ("too many requests") from Elasticsarch. {issue}36926[36926] {pull}45073[45073]
 
 *Auditbeat*
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -45,7 +45,7 @@ var (
 
 	ErrTooOld = errors.New("Elasticsearch is too old. Please upgrade the instance. If you would like to connect to older instances set output.elasticsearch.allow_older_versions to true") //nolint:staticcheck //false positive
 
-	errTooMany = errors.New("Elasticsearch returned error 429 Too Many Requests, throttling connection.")
+	errTooMany = errors.New("Elasticsearch returned error 429 Too Many Requests, throttling connection")
 )
 
 // Client is an elasticsearch client.

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -44,6 +44,8 @@ var (
 	errPayloadTooLarge = errors.New("the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped")
 
 	ErrTooOld = errors.New("Elasticsearch is too old. Please upgrade the instance. If you would like to connect to older instances set output.elasticsearch.allow_older_versions to true") //nolint:staticcheck //false positive
+
+	errTooMany = errors.New("Elasticsearch returned error 429 Too Many Requests, throttling connection.")
 )
 
 // Client is an elasticsearch client.
@@ -266,6 +268,11 @@ func (client *Client) Publish(ctx context.Context, batch publisher.Batch) error 
 	if len(eventsToRetry) > 0 {
 		span.Context.SetLabel("events_failed", len(eventsToRetry))
 		batch.RetryEvents(eventsToRetry)
+		if stats.tooMany > 0 {
+			// We're being throttled by Elasticsearch, return an error so we
+			// retry the connection with exponential backoff
+			return errTooMany
+		}
 	} else {
 		batch.ACK()
 	}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -268,13 +268,17 @@ func (client *Client) Publish(ctx context.Context, batch publisher.Batch) error 
 	if len(eventsToRetry) > 0 {
 		span.Context.SetLabel("events_failed", len(eventsToRetry))
 		batch.RetryEvents(eventsToRetry)
-		if stats.tooMany > 0 {
-			// We're being throttled by Elasticsearch, return an error so we
-			// retry the connection with exponential backoff
-			return errTooMany
-		}
 	} else {
 		batch.ACK()
+	}
+	return publishResultForStats(stats)
+}
+
+func publishResultForStats(stats bulkResultStats) error {
+	if stats.tooMany > 0 {
+		// We're being throttled by Elasticsearch, return an error so we
+		// retry the connection with exponential backoff
+		return errTooMany
 	}
 	return nil
 }

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -43,9 +43,9 @@ import (
 var (
 	errPayloadTooLarge = errors.New("the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped")
 
-	ErrTooOld = errors.New("Elasticsearch is too old. Please upgrade the instance. If you would like to connect to older instances set output.elasticsearch.allow_older_versions to true") //nolint:staticcheck //false positive
+	ErrTooOld = errors.New("Elasticsearch is too old. Please upgrade the instance. If you would like to connect to older instances set output.elasticsearch.allow_older_versions to true") //nolint:staticcheck //false positive (Elasticsearch should be capitalized)
 
-	errTooMany = errors.New("Elasticsearch returned error 429 Too Many Requests, throttling connection")
+	errTooMany = errors.New("Elasticsearch returned error 429 Too Many Requests, throttling connection") //nolint:staticcheck //false positive (Elasticsearch should be capitalized)
 )
 
 // Client is an elasticsearch client.

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -636,6 +636,26 @@ func TestCollectPipelinePublishFail(t *testing.T) {
 	assert.Equal(t, events, res)
 }
 
+func TestPublishResultForStats(t *testing.T) {
+	// publishResultForStats should return errTooMany if it is given
+	// stats with tooMany > 0, and nil otherwise (all other errors are
+	// either caused by encoding or connection failures, or are
+	// immediately retryable).
+	stats := bulkResultStats{
+		acked:        1,
+		duplicates:   2,
+		fails:        3,
+		nonIndexable: 4,
+		deadLetter:   5,
+		tooMany:      1,
+	}
+
+	assert.Equal(t, errTooMany, publishResultForStats(stats), "publishResultForStats should return errTooMany if tooMany > 0")
+
+	stats.tooMany = 0
+	assert.Nil(t, publishResultForStats(stats), "publishResultForStats should return nil if tooMany == 0")
+}
+
 func BenchmarkCollectPublishFailsNone(b *testing.B) {
 	logger, err := logp.NewDevelopmentLogger("")
 	require.NoError(b, err)


### PR DESCRIPTION
See https://github.com/elastic/beats/issues/36926. This fix has two components:
- Return an error from `Publish` when the Elasticsearch output gets a 429 (too many requests) from Elasticsearch. This triggers a retry delay and reconnection attempt in the pipeline.
- Break the backoff counters for `Publish` and `Connect` into separate values, so a successful `Connect` call (which for Elasticsearch just means that an empty http GET gave an ok response) doesn't reset the exponential backoff for bulk ingest requests when they are being throttled.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

[This comment](https://github.com/elastic/beats/issues/36926#issuecomment-3005085250) on the issue has local testing instructions.

## Related issues

- Fixes https://github.com/elastic/beats/issues/36926.