### PR TITLE
[OTel] Convert `[]any`-nested `mapstr.M`

### DIFF
--- a/libbeat/otelbeat/otelmap/otelmap.go
+++ b/libbeat/otelbeat/otelmap/otelmap.go
@@ -101,10 +101,15 @@ func ConvertNonPrimitive[T mapstrOrMap](m T) {
 				s := make([]any, ref.Len())
 				for i := 0; i < ref.Len(); i++ {
 					elem := ref.Index(i).Interface()
-					if m, ok := elem.(map[string]any); ok {
-						ConvertNonPrimitive(m)
+					if mi, ok := elem.(map[string]any); ok {
+						ConvertNonPrimitive(mi)
+						s[i] = mi
+					} else if mi, ok := elem.(mapstr.M); ok {
+						ConvertNonPrimitive(mi)
+						s[i] = map[string]any(mi)
+					} else {
+						s[i] = elem
 					}
-					s[i] = elem
 				}
 				m[key] = s
 				break // we figured out the type, so we don't need the unknown type case

--- a/libbeat/otelbeat/otelmap/otelmap_test.go
+++ b/libbeat/otelbeat/otelmap/otelmap_test.go
@@ -198,7 +198,7 @@ func TestFromMapstrMapstr(t *testing.T) {
 }
 
 func TestFromMapstrSliceMapstr(t *testing.T) {
-	inputSlice := []mapstr.M{mapstr.M{"item": 1}, mapstr.M{"item": 1}, mapstr.M{"item": 1}}
+	inputSlice := []mapstr.M{{"item": 1}, {"item": 1}, {"item": 1}}
 	inputMap := mapstr.M{
 		"slice": inputSlice,
 	}
@@ -292,6 +292,7 @@ func TestFromMapstrWithNestedData(t *testing.T) {
 				"inner_int": 43,
 				"inner_map_slice": []any{
 					map[string]any{"string": "string3"},
+					mapstr.M{"number": 12.4},
 				},
 				"inner_slice": [2]map[string]any{ // array -> slice
 					{"string": "string2"},
@@ -318,6 +319,7 @@ func TestFromMapstrWithNestedData(t *testing.T) {
 				"inner_int": 43,
 				"inner_map_slice": []any{
 					map[string]any{"string": "string3"},
+					map[string]any{"number": 12.4},
 				},
 				"inner_slice": []any{
 					map[string]any{"string": "string2"},


### PR DESCRIPTION
This adds the reflective capture of `mapstr.M` in addition to `map[string]any` for `[]any`.

I noticed, at runtime, the `cat_shards` metricset produces `mapstr.M` in a nested array even though the `autoops_es` code does not produce it that way, `libbeat` does:

https://github.com/elastic/beats/blob/0dd36b9c6031fb50deb0a2cef9cbd85861a87e9a/libbeat/common/event.go#L240-L246

## Proposed commit message

Convert inner slice/array `mapstr.M` to `map[string]any`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None. This improves compatibility.

## Author's Checklist

- [ ] Validate tests.

## How to test this PR locally

Run the Elastic Agent with `autoops_es` 

## Related issues

- Relates https://github.com/elastic/beats/issues/45007