### PR TITLE
[Elasticsearch] Allow Env Injected Auth

### DIFF
--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -133,7 +133,7 @@ func (m *MetricSet) GetServiceURI() string {
 // SetServiceURI updates the URI of the Elasticsearch service being monitored by this metricset
 func (m *MetricSet) SetServiceURI(servicePath string) {
 	m.servicePath = servicePath
-	m.HTTP.SetURI(m.GetServiceURI())
+	m.SetURI(m.GetServiceURI())
 }
 
 func (m *MetricSet) ShouldSkipFetch() (bool, error) {
@@ -157,10 +157,9 @@ func (m *MetricSet) ShouldSkipFetch() (bool, error) {
 
 // GetMasterNodeID returns the ID of the Elasticsearch cluster's master node
 func (m *MetricSet) GetMasterNodeID() (string, error) {
-	http := m.HTTP
 	resetURI := m.GetServiceURI()
 
-	content, err := fetchPath(http, resetURI, "_nodes/_master", "filter_path=nodes.*.name")
+	content, err := fetchPath(m.HTTP, resetURI, "_nodes/_master", "filter_path=nodes.*.name")
 	if err != nil {
 		return "", err
 	}
@@ -182,10 +181,9 @@ func (m *MetricSet) GetMasterNodeID() (string, error) {
 
 // IsMLockAllEnabled returns if the given Elasticsearch node has mlockall enabled
 func (m *MetricSet) IsMLockAllEnabled(nodeID string) (bool, error) {
-	http := m.HTTP
 	resetURI := m.GetServiceURI()
 
-	content, err := fetchPath(http, resetURI, "_nodes/"+nodeID, "filter_path=nodes.*.process.mlockall")
+	content, err := fetchPath(m.HTTP, resetURI, "_nodes/"+nodeID, "filter_path=nodes.*.process.mlockall")
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This allows tools to inject the auth parameters via the environment, which enables usage of dynamically deciding what to use for auth in OTel mode while still supporting blank values.

Specifically, this allows end users to specify either username and password _or_ the API Key via configuration, which is not currently possible in the OTel configuration due to https://github.com/elastic/beats/issues/45102.

## Proposed commit message

Allow `ELASTICSEARCH_READ_USERNAME`, `ELASTICSEARCH_READ_PASSWORD`, and `ELASTICSEARCH_READ_API_KEY` to be specified in the environment to control auth for Elasticsearch in a receiver context (not the exporter / output layer of Elasticsearch). This also enables the usage of them for the `autoops_es` module.

## Disruptive User Impact

I intentionally added `READ_` to avoid disruption. These variables also never existed before, so anyone using them would have been using them to set the configuration already, which helpfully avoids collisions.

## Author's Checklist

- These default to blank, so no functionality really changes.

## How to test this PR locally

- Try using the Elasticsearch module with and without these environment variables.
- Try using the Elasticsearch module with environment variables, but also config that overrides them and observe that they _are_ overridden (easiest to provide invalid auth in env, but valid in config to test).
- Try setting all three at the same time (Metricbeat will fail to start because that is an invalid setup just like putting all three directly in config)

## Related issues

- Relates https://github.com/elastic/beats/issues/45102

## Use cases

- Use `elasticsearch` and `autoops_es` modules via Kubernetes / Docker
- Use those modules with something dynamically specifying the auth (i.e., Buildkite) without three (no auth, user/pass, and api key) separate config files