### PR TITLE
[Heartbeat] Add base64 encoding option to inline monitors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -260,6 +260,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 
 - Added maintenance windows support for Heartbeat. {pull}41508[41508]
 - Add missing dependencies to ubi9-minimal distro. {pull}44556[44556]
+- Add base64 encoding option to inline monitors. {pull}45100[45100]
 
 
 *Metricbeat*

--- a/x-pack/heartbeat/monitors/browser/source/inline.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline.go
@@ -6,12 +6,14 @@
 package source
 
 import (
+	"encoding/base64"
 	"fmt"
 	"regexp"
 )
 
 type InlineSource struct {
-	Script string `config:"script"`
+	Script   string `config:"script"`
+	Encoding string `config:"encoding"`
 	BaseSource
 }
 
@@ -20,6 +22,10 @@ var ErrNoInlineScript = fmt.Errorf("no 'script' value specified for inline sourc
 func (s *InlineSource) Validate() error {
 	if !regexp.MustCompile(`\S`).MatchString(s.Script) {
 		return ErrNoInlineScript
+	}
+
+	if s.Encoding != "" && s.Encoding != "base64" {
+		return fmt.Errorf("unsupported encoding: %v", s.Encoding)
 	}
 
 	return nil
@@ -34,5 +40,21 @@ func (s *InlineSource) Workdir() string {
 }
 
 func (s *InlineSource) Close() error {
+	return nil
+}
+
+func (s *InlineSource) Decode() error {
+	// Don't decode if flag is missing
+	if s.Encoding != "base64" {
+		return nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(s.Script)
+	if err != nil {
+		return fmt.Errorf("error decoding from base64: %w", err)
+	}
+
+	s.Script = string(decoded)
+
 	return nil
 }

--- a/x-pack/heartbeat/monitors/browser/source/local.go
+++ b/x-pack/heartbeat/monitors/browser/source/local.go
@@ -32,3 +32,7 @@ func (l *LocalSource) Workdir() string {
 func (l *LocalSource) Close() error {
 	return ecserr.NewUnsupportedMonitorTypeError(ErrLocalUnsupportedType)
 }
+
+func (l *LocalSource) Decode() error {
+	return nil
+}

--- a/x-pack/heartbeat/monitors/browser/source/project.go
+++ b/x-pack/heartbeat/monitors/browser/source/project.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -55,7 +54,7 @@ func (p *ProjectSource) Fetch() error {
 		return err
 	}
 
-	tf, err := ioutil.TempFile(os.TempDir(), "elastic-synthetics-zip-")
+	tf, err := os.CreateTemp(os.TempDir(), "elastic-synthetics-zip-")
 	if err != nil {
 		return fmt.Errorf("could not create tmpfile for project monitor source: %w", err)
 	}
@@ -67,7 +66,7 @@ func (p *ProjectSource) Fetch() error {
 		return err
 	}
 
-	p.TargetDirectory, err = ioutil.TempDir(os.TempDir(), "elastic-synthetics-unzip-")
+	p.TargetDirectory, err = os.MkdirTemp(os.TempDir(), "elastic-synthetics-unzip-")
 	if err != nil {
 		return fmt.Errorf("could not make temp dir for unzipping project source: %w", err)
 	}
@@ -132,7 +131,7 @@ func setupProjectDir(workdir string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(workdir, "package.json"), pkgJsonContent, defaultMod)
+	err = os.WriteFile(filepath.Join(workdir, "package.json"), pkgJsonContent, defaultMod)
 	if err != nil {
 		return err
 	}

--- a/x-pack/heartbeat/monitors/browser/source/project.go
+++ b/x-pack/heartbeat/monitors/browser/source/project.go
@@ -173,3 +173,7 @@ func runSimpleCommand(cmd *exec.Cmd, dir string) error {
 	logp.L().Infof("Ran %s (%d) got '%s': (%s) as (%d/%d)", cmd, cmd.ProcessState.ExitCode(), string(output), err, syscall.Getuid(), syscall.Geteuid())
 	return err
 }
+
+func (p *ProjectSource) Decode() error {
+	return nil
+}

--- a/x-pack/heartbeat/monitors/browser/source/source.go
+++ b/x-pack/heartbeat/monitors/browser/source/source.go
@@ -54,6 +54,7 @@ type ISource interface {
 	Fetch() error
 	Workdir() string
 	Close() error
+	Decode() error
 }
 
 type BaseSource struct {

--- a/x-pack/heartbeat/monitors/browser/source/zipurl.go
+++ b/x-pack/heartbeat/monitors/browser/source/zipurl.go
@@ -32,3 +32,7 @@ func (z *ZipURLSource) Workdir() string {
 func (z *ZipURLSource) Close() error {
 	return ecserr.NewUnsupportedMonitorTypeError(ErrZipURLUnsupportedType)
 }
+
+func (z *ZipURLSource) Decode() error {
+	return nil
+}

--- a/x-pack/heartbeat/monitors/browser/sourcejob.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob.go
@@ -60,10 +60,6 @@ func (sj *SourceJob) String() string {
 	panic("implement me")
 }
 
-func (sj *SourceJob) Decode() error {
-	return sj.browserCfg.Source.Active().Decode()
-}
-
 func (sj *SourceJob) Fetch() error {
 	return sj.browserCfg.Source.Active().Fetch()
 }

--- a/x-pack/heartbeat/monitors/browser/sourcejob.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob.go
@@ -44,6 +44,10 @@ func NewSourceJob(rawCfg *config.C) (*SourceJob, error) {
 	if err != nil {
 		return nil, ErrBadConfig(err)
 	}
+	err = s.browserCfg.Source.Active().Decode()
+	if err != nil {
+		return nil, ErrBadConfig(err)
+	}
 
 	return s, nil
 }
@@ -54,6 +58,10 @@ func ErrBadConfig(err error) error {
 
 func (sj *SourceJob) String() string {
 	panic("implement me")
+}
+
+func (sj *SourceJob) Decode() error {
+	return sj.browserCfg.Source.Active().Decode()
 }
 
 func (sj *SourceJob) Fetch() error {

--- a/x-pack/heartbeat/monitors/browser/sourcejob.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob.go
@@ -172,7 +172,7 @@ func (sj *SourceJob) jobs() []jobs.Job {
 	var j jobs.Job
 
 	isScript := sj.browserCfg.Source.Inline != nil
-	ctx := context.WithValue(sj.ctx, synthexec.SynthexecTimeout, sj.browserCfg.Timeout+30*time.Second)
+	ctx := context.WithValue(sj.ctx, synthexec.SynthexecTimeoutKey, sj.browserCfg.Timeout+30*time.Second)
 	sFields := sj.StdFields()
 
 	if isScript {

--- a/x-pack/heartbeat/monitors/browser/sourcejob_test.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob_test.go
@@ -6,6 +6,7 @@
 package browser
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -354,4 +355,53 @@ func TestFilterDevFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSourceDecoding(t *testing.T) {
+	script := "a script"
+	encoded := base64.StdEncoding.EncodeToString([]byte(script))
+	timeout := 30
+	cfg := conf.MustNewConfigFrom(mapstr.M{
+		"name": "My Name",
+		"id":   "myId",
+		"source": mapstr.M{
+			"inline": mapstr.M{
+				"script":   encoded,
+				"encoding": "base64",
+			},
+		},
+		"timeout": timeout,
+	})
+	s, e := NewSourceJob(cfg)
+	require.NoError(t, e)
+	require.NotNil(t, s)
+	require.Equal(t, script, s.browserCfg.Source.Inline.Script)
+	require.Equal(t, "", s.Workdir())
+
+	e = s.Close()
+	require.NoError(t, e)
+}
+
+func TestDisabledSourceDecoding(t *testing.T) {
+	script := "a script"
+	encoded := base64.StdEncoding.EncodeToString([]byte(script))
+	timeout := 30
+	cfg := conf.MustNewConfigFrom(mapstr.M{
+		"name": "My Name",
+		"id":   "myId",
+		"source": mapstr.M{
+			"inline": mapstr.M{
+				"script": encoded,
+			},
+		},
+		"timeout": timeout,
+	})
+	s, e := NewSourceJob(cfg)
+	require.NoError(t, e)
+	require.NotNil(t, s)
+	require.Equal(t, encoded, s.browserCfg.Source.Inline.Script)
+	require.Equal(t, "", s.Workdir())
+
+	e = s.Close()
+	require.NoError(t, e)
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -345,29 +344,6 @@ func lineToSynthEventFactory(typ string) func(bytes []byte, text string) (res *S
 			},
 		}, nil
 	}
-}
-
-var emptyStringRegexp = regexp.MustCompile(`^\s*$`)
-
-// jsonToSynthEvent can take a line from the scanner and transform it into a *SynthEvent. Will return
-// nil res on empty lines.
-func jsonToSynthEvent(bytes []byte, text string) (res *SynthEvent, err error) {
-	// Skip empty lines
-	if emptyStringRegexp.Match(bytes) {
-		return nil, nil
-	}
-
-	res = &SynthEvent{}
-	err = json.Unmarshal(bytes, res)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Type == "" {
-		return nil, fmt.Errorf("unmarshal succeeded, but no type found for: %s", text)
-	}
-	return res, err
 }
 
 // getNpmRoot gets the closest ancestor path that contains package.json.

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -43,7 +43,9 @@ type FilterJourneyConfig struct {
 // where these are unsupported
 var platformCmdMutate func(*SynthCmd) = func(*SynthCmd) {}
 
-var SynthexecTimeout = "synthexec_timeout"
+type SynthexecTimeout string
+
+var SynthexecTimeoutKey = SynthexecTimeout("synthexec_timeout")
 
 // ProjectJob will run a single journey by name from the given project.
 func ProjectJob(ctx context.Context, projectPath string, params mapstr.M, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {
@@ -249,7 +251,7 @@ func runCmd(
 	}
 
 	// Get timeout from parent ctx
-	timeout, _ := ctx.Value(SynthexecTimeout).(time.Duration)
+	timeout, _ := ctx.Value(SynthexecTimeoutKey).(time.Duration)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	go func() {
 		<-ctx.Done()
@@ -278,7 +280,7 @@ func runCmd(
 			logp.L().Warn("Error executing command '%s' (%d): %s", cmd, cmd.ProcessState.ExitCode(), err)
 
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				timeout, _ := ctx.Value(SynthexecTimeout).(time.Duration)
+				timeout, _ := ctx.Value(SynthexecTimeoutKey).(time.Duration)
 				cmdError = ECSErrToSynthError(ecserr.NewCmdTimeoutStatusErr(timeout, cmd.String()))
 			} else {
 				cmdError = ECSErrToSynthError(ecserr.NewBadCmdStatusErr(cmd.ProcessState.ExitCode(), cmd.String()))

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -43,7 +43,7 @@ type FilterJourneyConfig struct {
 // where these are unsupported
 var platformCmdMutate func(*SynthCmd) = func(*SynthCmd) {}
 
-var SynthexecTimeout struct{}
+var SynthexecTimeout = "synthexec_timeout"
 
 // ProjectJob will run a single journey by name from the given project.
 func ProjectJob(ctx context.Context, projectPath string, params mapstr.M, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
@@ -182,7 +182,7 @@ func runAndCollect(t *testing.T, cmd *exec.Cmd, stdinStr string, cmdTimeout time
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	cmd.Dir = filepath.Join(cwd, "testcmd")
-	ctx := context.WithValue(context.TODO(), SynthexecTimeout, cmdTimeout)
+	ctx := context.WithValue(context.TODO(), SynthexecTimeoutKey, cmdTimeout)
 
 	mpx, err := runCmd(ctx, &SynthCmd{cmd}, &stdinStr, nil, FilterJourneyConfig{})
 	require.NoError(t, err)

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
@@ -8,10 +8,12 @@ package synthexec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"testing"
 	"time"
@@ -96,6 +98,29 @@ func TestJsonToSynthEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+var emptyStringRegexp = regexp.MustCompile(`^\s*$`)
+
+// jsonToSynthEvent can take a line from the scanner and transform it into a *SynthEvent. Will return
+// nil res on empty lines.
+func jsonToSynthEvent(bytes []byte, text string) (res *SynthEvent, err error) {
+	// Skip empty lines
+	if emptyStringRegexp.Match(bytes) {
+		return nil, nil
+	}
+
+	res = &SynthEvent{}
+	err = json.Unmarshal(bytes, res)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Type == "" {
+		return nil, fmt.Errorf("unmarshal succeeded, but no type found for: %s", text)
+	}
+	return res, err
 }
 
 func goCmd(args ...string) *exec.Cmd {


### PR DESCRIPTION
## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Add `encoding: base64` option to inline monitors. This change allows inline monitors to support characters that would otherwise break yaml format.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build heartbeat locally
2. Specify a base64-encoded inline script monitor.
3. Execute heartbeat and check monitor is decoded at setup.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-
- Closes #45029.

