### PR TITLE
[AutoOps] Reuse Common Fields and Drop non-standard ones

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/auto_ops_testing/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/auto_ops_testing/testing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/require"
 
-	libbeatversion "github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/autoops_es/utils"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -346,10 +345,6 @@ func CheckEvent(t *testing.T, event mb.Event, info utils.ClusterInfo) {
 	require.Equal(t, info.ClusterID, GetObjectValue(event.ModuleFields, "cluster.id"))
 	require.Equal(t, info.ClusterName, GetObjectValue(event.ModuleFields, "cluster.name"))
 	require.Equal(t, info.Version.Number.String(), GetObjectValue(event.ModuleFields, "cluster.version"))
-
-	require.Equal(t, "autoops_es", GetObjectValue(event.RootFields, "service.name"))
-	require.Equal(t, libbeatversion.GetDefaultVersion(), GetObjectValue(event.RootFields, "metricbeatVersion"))
-	require.Equal(t, libbeatversion.Commit(), GetObjectValue(event.RootFields, "commit"))
 }
 
 func CheckEventWithTransactionId(t *testing.T, event mb.Event, info utils.ClusterInfo, transactionId string) {

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cat_shards_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cat_shards_test.go
@@ -191,7 +191,7 @@ func Test500FailedToResolveIndexesWhileFetching(t *testing.T) {
 		require.Equal(t, "GET", errorField.HTTPMethod)
 		require.Equal(t, 500, errorField.HTTPStatusCode)
 		require.Equal(t, "Server Error", errorField.HTTPResponse) // checking the HTTP response body
-		require.Equal(t, "test-resource-id", event.RootFields["orchestrator.resource.id"])
+		require.Equal(t, "test-resource-id", auto_ops_testing.GetObjectValue(event.RootFields, "orchestrator.resource.id"))
 	})
 }
 
@@ -217,7 +217,7 @@ func Test404FailedToResolveIndexesWhileFetching(t *testing.T) {
 		require.Equal(t, "cat_shards", errorField.MetricSet)
 		require.Equal(t, "GET", errorField.HTTPMethod)
 		require.Equal(t, 404, errorField.HTTPStatusCode)
-		require.Equal(t, "test-resource-id", event.RootFields["orchestrator.resource.id"])
+		require.Equal(t, "test-resource-id", auto_ops_testing.GetObjectValue(event.RootFields, "orchestrator.resource.id"))
 		// avoiding the HTTP response body check on purpose, as the error response is a JSON string, and it's already tested
 	})
 }
@@ -244,7 +244,7 @@ func Test405FailedToResolveIndexesWhileFetching(t *testing.T) {
 		require.Equal(t, "cat_shards", errorField.MetricSet)
 		require.Equal(t, "GET", errorField.HTTPMethod)
 		require.Equal(t, 405, errorField.HTTPStatusCode)
-		require.Equal(t, "test-resource-id", event.RootFields["orchestrator.resource.id"])
+		require.Equal(t, "test-resource-id", auto_ops_testing.GetObjectValue(event.RootFields, "orchestrator.resource.id"))
 		// avoiding the HTTP response body check on purpose, as the error response is a JSON string, and it's already tested
 	})
 }
@@ -271,7 +271,7 @@ func Test500FailedToResolveIndexesWhileFetchingEmptyResponse(t *testing.T) {
 		require.Equal(t, "cat_shards", errorField.MetricSet)
 		require.Equal(t, "GET", errorField.HTTPMethod)
 		require.Equal(t, 500, errorField.HTTPStatusCode)
-		require.Equal(t, "test-resource-id", event.RootFields["orchestrator.resource.id"])
+		require.Equal(t, "test-resource-id", auto_ops_testing.GetObjectValue(event.RootFields, "orchestrator.resource.id"))
 		// avoiding the HTTP response body check on purpose, as the error response is a JSON string, and it's already tested
 	})
 }

--- a/x-pack/metricbeat/module/autoops_es/events/events.go
+++ b/x-pack/metricbeat/module/autoops_es/events/events.go
@@ -5,7 +5,6 @@
 package events
 
 import (
-	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/autoops_es/utils"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -29,10 +28,11 @@ func CreateEvent(info *utils.ClusterInfo, metricSetFields mapstr.M, transactionI
 			"transactionId": transactionId,
 		},
 		RootFields: mapstr.M{
-			"service.name":             "autoops_es",
-			"metricbeatVersion":        version.GetDefaultVersion(),
-			"commit":                   version.Commit(),
-			"orchestrator.resource.id": utils.GetResourceID(),
+			"orchestrator": mapstr.M{
+				"resource": mapstr.M{
+					"id": utils.GetResourceID(),
+				},
+			},
 		},
 	}
 }

--- a/x-pack/metricbeat/module/autoops_es/events/events_test.go
+++ b/x-pack/metricbeat/module/autoops_es/events/events_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/autoops_es/auto_ops_testing"
+	"github.com/elastic/beats/v7/x-pack/metricbeat/module/autoops_es/utils"
 
 	"github.com/stretchr/testify/require"
 
@@ -37,6 +38,10 @@ func TestCreateEventWithRandomTransactionId(t *testing.T) {
 }
 
 func TestCreateEvent(t *testing.T) {
+	t.Cleanup(utils.ClearResourceID)
+
+	utils.SetResourceID("resource-id")
+
 	info := auto_ops_testing.CreateClusterInfo("8.15.3")
 	metricSetFields := mapstr.M{
 		"field1":      "value1",
@@ -54,4 +59,7 @@ func TestCreateEvent(t *testing.T) {
 	require.Equal(t, "value1", auto_ops_testing.GetObjectValue(event.MetricSetFields, "field1"))
 	require.Equal(t, "value2", auto_ops_testing.GetObjectValue(event.MetricSetFields, "obj1.field1"))
 	require.Equal(t, "value3", auto_ops_testing.GetObjectValue(event.MetricSetFields, "obj2.field1"))
+
+	// orchestrator
+	require.Equal(t, "resource-id", auto_ops_testing.GetObjectValue(event.RootFields, "orchestrator.resource.id"))
 }

--- a/x-pack/metricbeat/module/autoops_es/metricset/cluster_info_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/cluster_info_test.go
@@ -59,7 +59,7 @@ func TestNestedFailedClusterInfoNoId(t *testing.T) {
 		require.Equal(t, "test_nested_metricset", errorField.MetricSet)
 		require.Equal(t, http.MethodGet, errorField.HTTPMethod)
 		require.Equal(t, 0, errorField.HTTPStatusCode) // status code vary based on the server response for cluster not ready
-		require.Equal(t, "test-resource-id", event.RootFields["orchestrator.resource.id"])
+		require.Equal(t, "test-resource-id", auto_ops_testing.GetObjectValue(event.RootFields, "orchestrator.resource.id"))
 	})
 }
 
@@ -82,6 +82,6 @@ func TestNestedFailedClusterInfoNAId(t *testing.T) {
 		require.Equal(t, "", errorField.ClusterID)
 		require.Equal(t, "/", errorField.URLPath)
 		require.Equal(t, "test_metricset", errorField.MetricSet)
-		require.Equal(t, "test-resource-id", event.RootFields["orchestrator.resource.id"])
+		require.Equal(t, "test-resource-id", auto_ops_testing.GetObjectValue(event.RootFields, "orchestrator.resource.id"))
 	})
 }


### PR DESCRIPTION
This drops custom fields that duplicate fields coming from Metricbeat through OTel in ECS format.

## Proposed commit message

Deduplicate the reported fields.

## Disruptive User Impact

None. This is an unreleased feature.

## Author's Checklist

- [ ] Confirm that operations still work.

## How to test this PR locally

Run this within the Elastic Agent via OTel and push to the dev service to ensure that fields are still properly parsed.