### PR TITLE
[Metricbeat] Fix CPU/disk/network visualizations in EC2 overview dashboard

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/15818fd0-f7f9-11e8-af03-c999c9dea608-ecs.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/15818fd0-f7f9-11e8-af03-c999c9dea608-ecs.json
@@ -35,13 +35,13 @@
                         "color": "rgba(104,188,0,1)",
                         "fill": "0",
                         "filter": "",
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 Network In Bytes",
                         "line_width": "2",
                         "metrics": [
                             {
-                                "field": "aws.ec2.network.in.bytes",
+                                "field": "host.network.ingress.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/233b3400-f7f9-11e8-af03-c999c9dea608-ecs.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/233b3400-f7f9-11e8-af03-c999c9dea608-ecs.json
@@ -35,13 +35,13 @@
                         "color": "rgba(104,188,0,1)",
                         "fill": "0",
                         "filter": "",
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 Network Out Bytes",
                         "line_width": "2",
                         "metrics": [
                             {
-                                "field": "aws.ec2.network.out.bytes",
+                                "field": "host.network.egress.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/be8828d0-f7f6-11e8-af03-c999c9dea608-ecs.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/be8828d0-f7f6-11e8-af03-c999c9dea608-ecs.json
@@ -40,7 +40,7 @@
                         "line_width": 1,
                         "metrics": [
                             {
-                                "field": "aws.ec2.cpu.total.pct",
+                                "field": "host.cpu.usage",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/be8828d0-f7f6-11e8-af03-c999c9dea608-ecs.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/be8828d0-f7f6-11e8-af03-c999c9dea608-ecs.json
@@ -54,7 +54,7 @@
                         "steps": 0,
                         "terms_field": "cloud.instance.id",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "5"
+                        "terms_size": "10"
                     }
                 ],
                 "show_grid": 1,

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/f1db6ec0-f7f8-11e8-af03-c999c9dea608-ecs.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/f1db6ec0-f7f8-11e8-af03-c999c9dea608-ecs.json
@@ -38,13 +38,13 @@
                             "language": "kuery",
                             "query": ""
                         },
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 DiskIO Read Bytes",
                         "line_width": "2",
                         "metrics": [
                             {
-                                "field": "aws.ec2.diskio.read.bytes",
+                                "field": "host.disk.read.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/fed59380-f7f8-11e8-af03-c999c9dea608-ecs.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/visualization/fed59380-f7f8-11e8-af03-c999c9dea608-ecs.json
@@ -35,13 +35,13 @@
                         "color": "rgba(104,188,0,1)",
                         "fill": "0",
                         "filter": "",
-                        "formatter": "number",
+                        "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "AWS EC2 DiskIO Write Bytes",
                         "line_width": "2",
                         "metrics": [
                             {
-                                "field": "aws.ec2.diskio.write.bytes",
+                                "field": "host.disk.write.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
                                 "type": "avg"
                             }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Updates the CPU/disk/network metric field names in the "[Metricbeat AWS] EC2 Overview" dashboard.

The "[Metricbeat AWS] EC2 Overview" dashboard that comes with the AWS modules was still using the old metric field names that are no longer in use, resulting in a dashboard with multiple empty visualizations.

Here are the current changes:


| Old                          | New                          | Formatter |
| ---------------------------- | ---------------------------- | --------- |
| `aws.ec2.cpu.total.pct`      | `host.cpu.usage`             | `percent` |
| `aws.ec2.diskio.read.bytes`  | `host.disk.read.bytes`       | `bytes`   |
| `aws.ec2.diskio.write.bytes` | `host.disk.write.bytes`      | `bytes`   |
| `aws.ec2.network.in.bytes`   | `host.network.ingress.bytes` | `bytes`   |
| `aws.ec2.network.out.bytes`  | `host.network.egress.bytes`  | `bytes`   |


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

<!--
## Disruptive User Impact

Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Update the CPU usage visualization
- [x] Update the disk visualization
- [x] Update the network visualization

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Build Metricbeat

```sh
cd x-pack/metricbeat/

mage build
```

Enable AWS module 

```sh
./metricbeat modules enable aws
```

And update `modules.d/aws.yml` to only collect EC2 metrics.

Set up `cloud.id` and `cloud.auth` to access Elastic Cloud, and deploy the dashboards

```sh
./metricbeat setup -E setup.dashboards.directory=build/kibana
```

Start Metricbeat to collect metric values to visualize in the dashboard.

### Missing `host.disk.*.bytes` values?

If the disk read|write visualizations are empty, it means there are not EC2 instances with instance store volumes running, so we're not getting the fields `host.disk.read.bytes` and `host.disk.write.bytes`.

If you need to set up an EC2 instance for getting, you have to:

1. Launch and EC2 instance with an instance store volume (I used an m5d.large, see https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html#gp_instance-store for more options.
2. SSH into the EC2 instance
3. Identify, format and mount the disk.
4. Write and read data.

Here's what I did following https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/making-instance-stores-available-on-your-instances.html


```sh
$ lsblk
NAME          MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
nvme1n1       259:0    0 69.8G  0 disk
nvme0n1       259:1    0    8G  0 disk
├─nvme0n1p1   259:2    0    8G  0 part /
├─nvme0n1p127 259:3    0    1M  0 part
└─nvme0n1p128 259:4    0   10M  0 part /boot/efi

sudo mkfs -t xfs /dev/nvme1n1
sudo mkdir /data
sudo mount /dev/nvme1n1 /data
```

```sh
# Generate many small files
for i in {1..1000}; do
    echo "Test data $i" > /data/file_$i.txt
done

# Read them back
cat /data/file_* > /dev/null
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A


<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

Here are the CPU usage, disk, network visualization displaying data.

![CleanShot 2025-07-08 at 22 46 36@2x](https://github.com/user-attachments/assets/e8ccd7b6-97f8-4169-ae77-9cb25df20df2)



<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
