### PR TITLE
Fix rendering of code snippet annotation in Filebeat quick start

### DIFF
--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -154,13 +154,14 @@ cloud.auth: "filebeat_setup:YOUR_PASSWORD" <1>
     ```yaml
       setup.kibana:
         host: "mykibanahost:5601" <1>
-        username: "my_kibana_user" <2> <3>
+        username: "my_kibana_user" <2>
         password: "YOUR_PASSWORD"
     ```
 
     1. The hostname and port of the machine where {{kib}} is running, for example, `mykibanahost:5601`. If you specify a path after the port number, include the scheme and port: `http://mykibanahost:5601/path`.
     2. The `username` and `password` settings for {{kib}} are optional. If you don’t specify credentials for {{kib}}, Filebeat uses the `username` and `password` specified for the {{es}} output.
-    3. To use the pre-built {{kib}} dashboards, this user must be authorized to view dashboards or have the `kibana_admin` [built-in role](elasticsearch://reference/elasticsearch/roles.md).
+    
+        To use the pre-built {{kib}} dashboards, this user must be authorized to view dashboards or have the `kibana_admin` [built-in role](elasticsearch://reference/elasticsearch/roles.md).
 ::::::
 
 :::::::


### PR DESCRIPTION
This PR fixes the rendering issue of a code snippet annotation in the "Filebeat quick start" doc.

### Preview

https://docs-v3-preview.elastic.dev/elastic/beats/pull/45121/reference/filebeat/filebeat-installation-configuration#set-connection