### PR TITLE
[oteltest][fbreceiver]: skip TestMultipleReceivers

### DIFF
--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -158,6 +158,7 @@ func BenchmarkFactory(b *testing.B) {
 }
 
 func TestMultipleReceivers(t *testing.T) {
+	t.Skip("flaky test, see https://github.com/elastic/beats/issues/43832")
 	// This test verifies that multiple receivers can be instantiated
 	// in isolation, started, and can ingest logs without interfering
 	// with each other.


### PR DESCRIPTION

## Proposed commit message

This test is flaking for a while with a high failure rate. We have an integration test that covers the same scenario added by https://github.com/elastic/beats/pull/45093. Skip this test for now.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- For https://github.com/elastic/beats/issues/43832