### PR TITLE
[AutoOps] Include Missing Total Size

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/node_stats/data.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data.go
@@ -37,7 +37,8 @@ var (
 				"count": c.Int("count", s.IgnoreAllErrors),
 			}, c.DictOptional),
 			"store": c.Dict("store", s.Schema{
-				"size_in_bytes": c.Int("size_in_bytes", s.IgnoreAllErrors),
+				"size_in_bytes":                c.Int("size_in_bytes", s.IgnoreAllErrors),
+				"total_data_set_size_in_bytes": c.Int("total_data_set_size_in_bytes", s.IgnoreAllErrors),
 			}, c.DictOptional),
 			"indexing": c.Dict("indexing", s.Schema{
 				"index_total":             c.Int("index_total", s.IgnoreAllErrors),

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
@@ -89,6 +89,7 @@ func expectValidParsedDetailed(t *testing.T, data metricset.FetcherData[NodesSta
 		require.ElementsMatch(t, []string{"data_content", "data_hot", "ingest", "master", "remote_cluster_client", "transform"}, node1MetricSet["roles"])
 		require.EqualValues(t, 2337, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.docs.count"))
 		require.EqualValues(t, 45203023, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.store.size_in_bytes"))
+		require.EqualValues(t, 45203023, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.store.total_data_set_size_in_bytes"))
 		require.EqualValues(t, 1390859, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.indexing.index_total"))
 		require.EqualValues(t, 942011, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.indexing.index_time_in_millis"))
 		require.EqualValues(t, 164, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.indexing.index_failed"))
@@ -128,7 +129,6 @@ func expectValidParsedDetailed(t *testing.T, data metricset.FetcherData[NodesSta
 
 	// some ignored values
 	require.Nil(t, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.shard_stats"))
-	require.Nil(t, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.store.total_data_set_size_in_bytes"))
 }
 
 func expectValidParsedDetailedWithNoCache(t *testing.T, data metricset.FetcherData[NodesStats]) {


### PR DESCRIPTION
This includes the 'total' data set size in addition to just the size in bytes.

## Proposed commit message

Send the missing `total_data_set_size_in_bytes` alongside the `size_in_bytes`.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None. Unreleased code.

## Author's Checklist

- [ ] Node stats should produce `size_in_bytes` with `total_data_set_size_in_bytes`

## How to test this PR locally

Run the `node_stats` metricset and verify the `total_data_set_size_in_bytes` is included in the documents.