### PR TITLE
Update user agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.7.0
 	github.com/elastic/elastic-agent-autodiscover v0.9.2
-	github.com/elastic/elastic-agent-libs v0.20.0
+	github.com/elastic/elastic-agent-libs v0.21.1
 	github.com/elastic/elastic-agent-system-metrics v0.11.11
 	github.com/elastic/go-elasticsearch/v8 v8.18.1
 	github.com/elastic/go-freelru v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/elastic/elastic-agent-client/v7 v7.15.0 h1:nDB7v8TBoNuD6IIzC3z7Q0y+7b
 github.com/elastic/elastic-agent-client/v7 v7.15.0/go.mod h1:6h+f9QdIr3GO2ODC0Y8+aEXRwzbA5W4eV4dd/67z7nI=
 github.com/elastic/elastic-agent-libs v0.20.0 h1:MPjenwuEr+QfMeQRV4BK817ZbiNS38SXJE7QGHDwhUs=
 github.com/elastic/elastic-agent-libs v0.20.0/go.mod h1:1HNxREH8C27kGrJCtKZh/ot8pV8joH8VREP21+FrH5s=
+github.com/elastic/elastic-agent-libs v0.21.1 h1:DKp+LC+e0THUN8Cs5lfSzK8jcry/KBqBmfGvTt3fM78=
+github.com/elastic/elastic-agent-libs v0.21.1/go.mod h1:xSeIP3NtOIT4N2pPS4EyURmS1Q8mK0lWZ8Wd1Du6q3w=
 github.com/elastic/elastic-agent-system-metrics v0.11.11 h1:Qjh3Zef23PfGlG91AF+9ciNLNQf/8cDJ4CalnLZtV3g=
 github.com/elastic/elastic-agent-system-metrics v0.11.11/go.mod h1:GNqmKfvOt8PwORjbS6GllNdMfkLpOWyTa7P8oQq4E5o=
 github.com/elastic/elastic-transport-go/v8 v8.7.0 h1:OgTneVuXP2uip4BA658Xi6Hfw+PeIOod2rY3GVMGoVE=

--- a/libbeat/beat/beat_test.go
+++ b/libbeat/beat/beat_test.go
@@ -81,6 +81,18 @@ func TestUserAgentString(t *testing.T) {
 				Manager: testManager{isEnabled: true, isUnpriv: true, mgmtMode: proto.AgentManagedMode_STANDALONE}},
 			expectedComments: []string{"Standalone", "Unprivileged"},
 		},
+		{
+			name: "management-disabled",
+			beat: &Beat{Info: Info{Beat: "testbeat"},
+				Manager: testManager{isEnabled: false}},
+			expectedComments: []string{"Unmanaged"},
+		},
+		{
+			name: "no-management",
+			beat: &Beat{Info: Info{Beat: "testbeat"},
+				Manager: nil},
+			expectedComments: []string{},
+		},
 	}
 
 	// User-Agent will take the form of
@@ -107,11 +119,4 @@ func TestUserAgentString(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGenerateUserAgentNilManagerPanics(t *testing.T) {
-    b := &Beat{Info: Info{Beat: "testbeat"}, Manager: nil}
-    require.Panics(t, func() {
-        b.GenerateUserAgent()
-    })
 }

--- a/libbeat/beat/beat_test.go
+++ b/libbeat/beat/beat_test.go
@@ -81,12 +81,6 @@ func TestUserAgentString(t *testing.T) {
 				Manager: testManager{isEnabled: true, isUnpriv: true, mgmtMode: proto.AgentManagedMode_STANDALONE}},
 			expectedComments: []string{"Standalone", "Unprivileged"},
 		},
-		{
-			name: "management-disabled",
-			beat: &Beat{Info: Info{Beat: "testbeat"},
-				Manager: testManager{isEnabled: false}},
-			expectedComments: []string{},
-		},
 	}
 
 	// User-Agent will take the form of

--- a/libbeat/beat/beat_test.go
+++ b/libbeat/beat/beat_test.go
@@ -84,7 +84,7 @@ func TestUserAgentString(t *testing.T) {
 	}
 
 	// User-Agent will take the form of
-	// Elastic-testbeat/8.15.0 (linux; amd64; unknown; 0001-01-01 00:00:00 +0000 UTC; Standalone; Unprivileged)
+	// Elastic-testbeat/9.2.0 (linux; arm64; Managed; Unprivileged)
 	// the RFC (https://www.rfc-editor.org/rfc/rfc9110#name-user-agent) says the comment field can basically be anything,
 	// but we put metadata in it, delimited by '; '
 	uaReg := regexp.MustCompile(`Elastic-testbeat/([\d.]+) \(([\w-:+; ]+)\)`)
@@ -107,4 +107,11 @@ func TestUserAgentString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateUserAgentNilManagerPanics(t *testing.T) {
+    b := &Beat{Info: Info{Beat: "testbeat"}, Manager: nil}
+    require.Panics(t, func() {
+        b.GenerateUserAgent()
+    })
 }


### PR DESCRIPTION
## Proposed commit message

Update default user agent to distinguish between all beat modes:

* managed - under agent and using fleet
* standalone - under agent and not using fleet
* unmanaged - not under agent

privilege mode information is only exposed under agent

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

Users relying on specific user agents could be impacted.  We've made no guarantees of stability for those and the only parts that changes are in the comments section.

## Author's Checklist

- [ ] running in each mode

This will remain in draft until the corresponding changes in elastic-agent-libs are accepted - https://github.com/elastic/elastic-agent-libs/pull/328
