### PR TITLE
[AutoOps] Cleanup Version Mismatch Error

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/events/error_event.go
+++ b/x-pack/metricbeat/module/autoops_es/events/error_event.go
@@ -106,5 +106,10 @@ func getHTTPResponseBodyInfo(err error) (int, string, string) {
 		return 0, "CLUSTER_NOT_READY", clusterErr.Message
 	}
 
+	var versionErr *utils.VersionMismatchError
+	if errors.As(err, &versionErr) {
+		return 0, "VERSION_MISMATCH", fmt.Sprintf("expected %s, got %s", versionErr.ExpectedVersion, versionErr.ActualVersion)
+	}
+
 	return 0, "UNKNOWN_ERROR", ""
 }

--- a/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
+++ b/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
@@ -90,6 +90,16 @@ func TestGetHTTPResponseBodyInfo(t *testing.T) {
 			expectedBody:   "Cluster not ready",
 		},
 		{
+			name: "Error is of type VersionMismatchError",
+			inputError: &utils.VersionMismatchError{
+				ExpectedVersion: "7.10.0",
+				ActualVersion:   "7.9.3",
+			},
+			expectedStatus: 0,
+			expectedCode:   "VERSION_MISMATCH",
+			expectedBody:   "expected 7.10.0, got 7.9.3",
+		},
+		{
 			name:           "Error is not of a known type",
 			inputError:     errors.New("some other error"),
 			expectedStatus: 0,

--- a/x-pack/metricbeat/module/autoops_es/metricset/cluster_info.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/cluster_info.go
@@ -5,7 +5,6 @@
 package metricset
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -46,7 +45,10 @@ func GetInfo(m *elasticsearch.MetricSet) (*utils.ClusterInfo, error) {
 func checkEsVersion(esVersion *libversion.V, errChan chan error) error {
 	if esVersion.LessThan(minVersion) {
 		isVersionChecked = true
-		err := fmt.Errorf("version %s is less than the minimum required version %s", esVersion.String(), minVersion)
+		err := &utils.VersionMismatchError{
+			ExpectedVersion: minVersion.String(),
+			ActualVersion:   esVersion.String(),
+		}
 		errChan <- err
 		return err
 	}

--- a/x-pack/metricbeat/module/autoops_es/utils/version.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/version.go
@@ -1,0 +1,18 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package utils
+
+import (
+	"fmt"
+)
+
+type VersionMismatchError struct {
+	ExpectedVersion string
+	ActualVersion   string
+}
+
+func (e *VersionMismatchError) Error() string {
+	return fmt.Sprintf("version mismatch: expected %s, got %s", e.ExpectedVersion, e.ActualVersion)
+}


### PR DESCRIPTION
This improves the Version Mismatch error to make it easier to debug.

## Proposed commit message

Improve debug support for unsupported versions.
