### PR TITLE
Update post-dependabot.yml to add a team as a reviewer

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -49,17 +49,16 @@ jobs:
     steps:
       - name: Add reviewers (obs-infraobs-integrations) if PR has Team:Obs-InfraObs label
         run: |
-          PR_NUMBER=$(gh pr list --head ${{ github.ref_name }} --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --head ${{ github.ref_name }} --json number --jq '.[0].number')
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
-            HAS_LABEL=$(gh pr view $PR_NUMBER --json labels --jq '.labels[] | select(.name == "Team:Obs-InfraObs") | .name')
+            HAS_LABEL=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json labels --jq '.labels[] | select(.name == "Team:Obs-InfraObs") | .name')
             
             if [ -n "$HAS_LABEL" ]; then
               echo "PR #$PR_NUMBER has Team:Obs-InfraObs label, adding reviewer obs-infraobs-integrations" >> $GITHUB_OUTPUT
-              gh pr edit $PR_NUMBER --add-reviewer obs-infraobs-integrations
+              gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer obs-infraobs-integrations
             fi
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       # Allow job to write to the branch.
       contents: write
+      # Allow job to add reviewers to PRs
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,3 +43,26 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git commit -m "Update NOTICE.txt"
           git push
+
+      - name: Get PR number
+        id: get-pr
+        run: |
+          PR_NUMBER=$(gh pr list --head ${{ github.ref_name }} --json number --jq '.[0].number')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if PR has Team:Obs-InfraObs label
+        id: check-label
+        run: |
+          HAS_LABEL=$(gh pr view ${{ steps.get-pr.outputs.pr_number }} --json labels --jq '.labels[] | select(.name == "Team:Obs-InfraObs") | .name')
+          echo "has_obs_infraobs_label=$(if [ -n "$HAS_LABEL" ]; then echo "true"; else echo "false"; fi)" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add obs-infraobs-integrations team as reviewers
+        if: steps.check-label.outputs.has_obs_infraobs_label == 'true'
+        run: |
+          gh pr edit ${{ steps.get-pr.outputs.pr_number }} --add-reviewer obs-infraobs-integrations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -17,8 +17,6 @@ jobs:
     permissions:
       # Allow job to write to the branch.
       contents: write
-      # Allow job to add reviewers to PRs
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,25 +42,24 @@ jobs:
           git commit -m "Update NOTICE.txt"
           git push
 
-      - name: Get PR number
-        id: get-pr
+  manage-pr-reviewers:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reviewers (obs-infraobs-integrations) if PR has Team:Obs-InfraObs label
         run: |
           PR_NUMBER=$(gh pr list --head ${{ github.ref_name }} --json number --jq '.[0].number')
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            HAS_LABEL=$(gh pr view $PR_NUMBER --json labels --jq '.labels[] | select(.name == "Team:Obs-InfraObs") | .name')
+            
+            if [ -n "$HAS_LABEL" ]; then
+              echo "PR #$PR_NUMBER has Team:Obs-InfraObs label, adding reviewer obs-infraobs-integrations" >> $GITHUB_OUTPUT
+              gh pr edit $PR_NUMBER --add-reviewer obs-infraobs-integrations
+            fi
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check if PR has Team:Obs-InfraObs label
-        id: check-label
-        run: |
-          HAS_LABEL=$(gh pr view ${{ steps.get-pr.outputs.pr_number }} --json labels --jq '.labels[] | select(.name == "Team:Obs-InfraObs") | .name')
-          echo "has_obs_infraobs_label=$(if [ -n "$HAS_LABEL" ]; then echo "true"; else echo "false"; fi)" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add obs-infraobs-integrations team as reviewers
-        if: steps.check-label.outputs.has_obs_infraobs_label == 'true'
-        run: |
-          gh pr edit ${{ steps.get-pr.outputs.pr_number }} --add-reviewer obs-infraobs-integrations
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -50,13 +50,13 @@ jobs:
       - name: Add reviewers (obs-infraobs-integrations) if PR has Team:Obs-InfraObs label
         run: |
           PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --head ${{ github.ref_name }} --json number --jq '.[0].number')
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            echo "Found PR #$PR_NUMBER"
             HAS_LABEL=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json labels --jq '.labels[] | select(.name == "Team:Obs-InfraObs") | .name')
             
             if [ -n "$HAS_LABEL" ]; then
-              echo "PR #$PR_NUMBER has Team:Obs-InfraObs label, adding reviewer obs-infraobs-integrations" >> $GITHUB_OUTPUT
+              echo "PR #$PR_NUMBER has Team:Obs-InfraObs label, adding reviewer obs-infraobs-integrations"
               gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer obs-infraobs-integrations
             fi
           fi


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This change enhances our post-dependabot workflow by automatically requesting a review from the obs-infraobs-integrations team whenever a Dependabot‐generated Go module PR is scoped to the Obs-InfraObs team.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

