### PR TITLE
otel: update filebeat integration tests to run in isolation

### DIFF
--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -61,6 +61,9 @@ http.host: localhost
 http.port: %d
 `
 
+	namespace := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
+	fbOtelIndex := "logs-integration-" + namespace
+	fbIndex := "logs-filebeat-" + namespace
 	// start filebeat in otel mode
 	filebeatOTel := integration.NewBeat(
 		t,
@@ -70,7 +73,7 @@ http.port: %d
 	)
 
 	logFilePath := filepath.Join(filebeatOTel.TempDir(), "log.log")
-	filebeatOTel.WriteConfigFile(fmt.Sprintf(beatsCfgFile, logFilePath, "logs-integration-default", 5066))
+	filebeatOTel.WriteConfigFile(fmt.Sprintf(beatsCfgFile, logFilePath, fbOtelIndex, 5066))
 	writeEventsToLogFile(t, logFilePath, numEvents)
 	filebeatOTel.Start()
 	defer filebeatOTel.Stop()
@@ -83,7 +86,7 @@ http.port: %d
 	)
 	logFilePath = filepath.Join(filebeat.TempDir(), "log.log")
 	writeEventsToLogFile(t, logFilePath, numEvents)
-	s := fmt.Sprintf(beatsCfgFile, logFilePath, "logs-filebeat-default", 5067)
+	s := fmt.Sprintf(beatsCfgFile, logFilePath, fbIndex, 5067)
 
 	filebeat.WriteConfigFile(s)
 	filebeat.Start()
@@ -102,10 +105,10 @@ http.port: %d
 			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer findCancel()
 
-			otelDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-integration-default*")
+			otelDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+fbOtelIndex+"*")
 			require.NoError(t, err)
 
-			filebeatDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-filebeat-default*")
+			filebeatDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+fbIndex+"*")
 			require.NoError(t, err)
 
 			return otelDocs.Hits.Total.Value >= numEvents && filebeatDocs.Hits.Total.Value >= numEvents
@@ -315,13 +318,17 @@ func TestFilebeatOTelReceiverE2E(t *testing.T) {
 		"otel",
 	)
 
+	namespace := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
+	fbReceiverIndex := "logs-integration-" + namespace
+	filebeatIndex := "logs-filebeat-" + namespace
+
 	otelConfig := struct {
 		Index          string
 		MonitoringPort int
 		InputFile      string
 		PathHome       string
 	}{
-		Index:          "logs-integration-default",
+		Index:          fbReceiverIndex,
 		MonitoringPort: 5066,
 		InputFile:      filepath.Join(filebeatOTel.TempDir(), "log.log"),
 		PathHome:       filebeatOTel.TempDir(),
@@ -427,7 +434,7 @@ http.port: %d
 `
 	logFilePath := filepath.Join(filebeat.TempDir(), "log.log")
 	writeEventsToLogFile(t, logFilePath, wantEvents)
-	s := fmt.Sprintf(beatsCfgFile, logFilePath, "logs-filebeat-default", 5067)
+	s := fmt.Sprintf(beatsCfgFile, logFilePath, filebeatIndex, 5067)
 	filebeat.WriteConfigFile(s)
 	filebeat.Start()
 	defer filebeat.Stop()
@@ -444,10 +451,10 @@ http.port: %d
 			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer findCancel()
 
-			otelDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-integration-default*")
+			otelDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+fbReceiverIndex+"*")
 			require.NoError(t, err)
 
-			filebeatDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-filebeat-default*")
+			filebeatDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+filebeatIndex+"*")
 			require.NoError(t, err)
 
 			return otelDocs.Hits.Total.Value >= wantEvents && filebeatDocs.Hits.Total.Value >= wantEvents
@@ -492,21 +499,22 @@ func TestFilebeatOTelMultipleReceiversE2E(t *testing.T) {
 		PathHome       string
 	}
 
+	namespace := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
 	otelConfig := struct {
 		Index     string
 		Receivers []receiverConfig
 	}{
-		Index: "logs-integration-default",
+		Index: "logs-integration-" + namespace,
 		Receivers: []receiverConfig{
 			{
 				MonitoringPort: 5066,
 				InputFile:      logFilePath,
-				PathHome:       filebeatOTel.TempDir(),
+				PathHome:       filepath.Join(filebeatOTel.TempDir(), "r1"),
 			},
 			{
 				MonitoringPort: 5067,
 				InputFile:      logFilePath,
-				PathHome:       filebeatOTel.TempDir(),
+				PathHome:       filepath.Join(filebeatOTel.TempDir(), "r2"),
 			},
 		},
 	}
@@ -592,7 +600,7 @@ service:
 			findCtx, findCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer findCancel()
 
-			otelDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-logs-integration-default*")
+			otelDocs, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+otelConfig.Index+"*")
 			require.NoError(t, err)
 
 			return otelDocs.Hits.Total.Value >= wantTotalLogs


### PR DESCRIPTION
## Proposed commit message

As a leftover from https://github.com/elastic/beats/pull/45093, the tests added reuse the index names which may cause issues when running the tests in sequence without cleaning up first.

Adjusted the existing tests to use unique indexes.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/pull/45093
- Relates https://github.com/elastic/beats/pull/45242
