### PR TITLE
stresstest.sh takes optional go build flags

### DIFF
--- a/script/stresstest.sh
+++ b/script/stresstest.sh
@@ -5,18 +5,33 @@
 set -e
 
 function usage() {
-  echo "Usage: $0 [package_path] TestName [stress options...]"
+  echo "Usage: $0 [--tags tag1,tag2,...] [package_path] TestName [stress options...]"
   echo ""
+  echo "--tags: Optional comma-separated list of build tags"
   echo "package_path: Path to the Go package containing the tests."
   echo "TestName: Regular expression to match the test to run, equivalent to -test.run."
   echo "[stress options]: Options to pass to the stress command."
   echo ""
-  echo "Example: $0 ./libbeat/common/backoff ^TestBackoff$ -p 32"
+  echo "Examples:"
+  echo "  $0 ./libbeat/common/backoff ^TestBackoff$ -p 32"
+  echo "  $0 --tags integration ./libbeat/common/backoff ^TestBackoff$ -p 32"
 }
 
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
   usage
   exit 0
+fi
+
+# Parse optional --tags parameter
+build_tags=""
+if [[ "$1" == "--tags" ]]; then
+  if [[ $# -lt 2 ]]; then
+    echo "Error: --tags requires a value."
+    usage
+    exit 1
+  fi
+  build_tags="$2"
+  shift 2
 fi
 
 if [[ $# -lt 2 ]]; then
@@ -32,12 +47,16 @@ if [ ! -d "$1" ]; then
 fi
 
 test_package_path=${1}
-test_exec_file="$(basename $test_package_path).test"
+test_exec_file="$(basename "$test_package_path").test"
 test_regex=${2}
 stress_options=("${@:3}")
 
 cd "$test_package_path"
 rm "$test_exec_file" 2>/dev/null || true
-go test -c -o "./$test_exec_file"
+if [[ -n "$build_tags" ]]; then
+  go test -tags "$build_tags" -c -o "./$test_exec_file"
+else
+  go test -c -o "./$test_exec_file"
+fi
 trap 'rm "./$test_exec_file" 2>/dev/null || true' EXIT INT TERM
 go run golang.org/x/tools/cmd/stress@latest "${stress_options[@]}" "./$test_exec_file" -test.run "$test_regex" -test.v


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
stresstest.sh takes optional go build flags
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

 - N/A

## How to test this PR locally

use `stresstest.sh` to stress test an integration test
```
cd filebeat
../script/stresstest.sh --tags integration ./testing/integration/ TestFilebeat -p 1
```

## Related issues
 - N/A

## Use cases

use `stresstest.sh` with integration tests

## Logs

```
❯ ../script/stresstest.sh --tags integration ./testing/integration/ TestFilebeat -p 1
5s: 0 runs so far, 0 failures, 1 active
10s: 0 runs so far, 0 failures, 1 active
15s: 0 runs so far, 0 failures, 1 active
20s: 0 runs so far, 0 failures, 1 active
25s: 0 runs so far, 0 failures, 1 active
30s: 0 runs so far, 0 failures, 1 active
35s: 1 runs so far, 0 failures, 1 active
40s: 1 runs so far, 0 failures, 1 active
45s: 1 runs so far, 0 failures, 1 active
50s: 1 runs so far, 0 failures, 1 active
55s: 1 runs so far, 0 failures, 1 active
1m0s: 1 runs so far, 0 failures, 1 active
1m5s: 2 runs so far, 0 failures, 1 active
1m10s: 2 runs so far, 0 failures, 1 active
1m15s: 2 runs so far, 0 failures, 1 active
1m20s: 2 runs so far, 0 failures, 1 active
1m25s: 2 runs so far, 0 failures, 1 active
1m30s: 3 runs so far, 0 failures, 1 active
1m35s: 3 runs so far, 0 failures, 1 active
```
