### PR TITLE
Use correct team name for post-dependabot

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -56,8 +56,8 @@ jobs:
             HAS_LABEL=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json labels --jq '.labels[] | select(.name == "Team:Obs-InfraObs") | .name')
             
             if [ -n "$HAS_LABEL" ]; then
-              echo "PR #$PR_NUMBER has Team:Obs-InfraObs label, adding reviewer obs-infraobs-integrations"
-              gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer obs-infraobs-integrations
+              echo "PR #$PR_NUMBER has Team:Obs-InfraObs label, adding reviewer elastic/obs-infraobs-integrations"
+              gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer elastic/obs-infraobs-integrations
             fi
           fi
         env:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Error logs:

```
Found PR #45184
PR #45184 has Team:Obs-InfraObs label, adding reviewer obs-infraobs-integrations
error fetching organization teams: GraphQL: Resource not accessible by integration (organization.teams)
```

I did not use the correct team name; as you can see we can correct debug messages. Only the last command failed. I have renamed the team name here.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
