### PR TITLE
Add a FIPS ECH integration test for filebeat

### DIFF
--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -10,6 +10,7 @@ env:
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
   IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
+  MAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips"
   IMAGE_WIN_10: "family/platform-ingest-beats-windows-10"
   IMAGE_WIN_11: "family/platform-ingest-beats-windows-11"
   IMAGE_WIN_2016: "family/platform-ingest-beats-windows-2016"
@@ -316,6 +317,36 @@ steps:
         notify:
           - github_commit_status:
               context: "filebeat: Win 2022 Unit Tests"
+
+      - label: ":ubuntu: Filebeat: FIPS ECH Integration Tests"
+        command: |
+          .buildkite/scripts/custom_fips_ech_test.sh filebeat
+        retry:
+          automatic:
+            - limit: 1
+        agents:
+          provider: "aws"
+          imagePrefix: "${IMAGE_UBUNTU_X86_64_FIPS}"
+          instanceType: "m5.xlarge"
+        artifact_paths:
+          - "filebeat/build/*.xml"
+          - "filebeat/build/*.json"
+          - "filebeat/build/integration-tests/*"
+          - "filebeat/build/integration-tests/Test*/*"
+          - "filebeat/build/integration-tests/Test*/data/**/*"
+        plugins:
+          - test-collector#v1.10.2:
+              files: "filebeat/build/TEST-*.xml"
+              format: "junit"
+              branches: "main"
+              debug: true
+          - elastic/vault-secrets#v0.1.0:
+              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
+              field: "apiKey"
+              env_var: "EC_API_KEY"
+        notify:
+          - github_commit_status:
+              context: "filebeat: FIPS ECH Integration Tests / Ubuntu x86_64"
 
   - group: "Extended Tests"
     key: "filebeat-extended-tests"

--- a/.buildkite/scripts/custom_fips_ech_test.sh
+++ b/.buildkite/scripts/custom_fips_ech_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source .buildkite/scripts/ech.sh
+
+BEAT_PATH=$1
+
+if [ -z "$BEAT_PATH" ]; then
+    echo "Error: Specify the beat path: custom_fips_ech_test.sh [beat_path]" >&2
+    exit 1
+fi
+
+# TODO ensure terraform is on host?
+
+STACK_VERSION="$(./dev-tools/get_version)-SNAPSHOT"
+
+trap 'ech_down' EXIT
+
+ech_up $STACK_VERSION
+
+echo "~~~ Running custom FIPS ECH tests"
+
+cd $BEAT_PATH
+SNAPSHOT=true FIPS=true mage fipsECHTest

--- a/.buildkite/scripts/ech.sh
+++ b/.buildkite/scripts/ech.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function ech_up() {
+  echo "~~~ Starting ECH Stack"
+  local WORKSPACE=$(git rev-parse --show-toplevel)
+  local TF_DIR="${WORKSPACE}/testing/terraform-ech/"
+  local STACK_VERSION=$1
+  local ECH_REGION=${2:-"gcp-us-west2"}
+
+  if [ -z "$STACK_VERSION" ]; then
+    echo "Error: Specify stack version: ech_up [stack_version]" >&2
+    return 1
+  fi
+
+  BUILDKITE_BUILD_CREATOR="${BUILDKITE_BUILD_CREATOR:-"$(get_git_user_email)"}"
+  BUILDKITE_BUILD_NUMBER="${BUILDKITE_BUILD_NUMBER:-"0"}"
+  BUILDKITE_PIPELINE_SLUG="${BUILDKITE_PIPELINE_SLUG:-"beat-fips-ech-tests"}"
+
+  pushd "${TF_DIR}"
+  terraform init
+  terraform apply \
+    -auto-approve \
+    -var="stack_version=${STACK_VERSION}" \
+    -var="ech_region=${ECH_REGION}" \
+    -var="creator=${BUILDKITE_BUILD_CREATOR}" \
+    -var="buildkite_id=${BUILDKITE_BUILD_NUMBER}" \
+    -var="pipeline=${BUILDKITE_PIPELINE_SLUG}"
+
+  export ES_HOST=$(terraform output -raw es_host)
+  export ES_USER=$(terraform output -raw es_username)
+  export ES_PASS=$(terraform output -raw es_password)
+  export KIBANA_HOST=$(terraform output -raw kibana_endpoint)
+  export KIBANA_USER=$ES_USER
+  export KIBANA_PASS=$ES_PASS
+  popd
+}
+
+function ech_down() {
+  echo "~~~ Tearing down the ECH Stack"
+  local WORKSPACE=$(git rev-parse --show-toplevel)
+  local TF_DIR="${WORKSPACE}/testing/terraform-ech/"
+
+  pushd "${TF_DIR}"
+  terraform init
+  terraform destroy -auto-approve
+  popd
+}
+
+function get_git_user_email() {
+  if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "unknown"
+    return
+  fi
+
+  local email
+  email=$(git config --get user.email)
+
+  if [ -z "$email" ]; then
+    echo "unknown"
+  else
+    echo "$email"
+  fi
+}

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -210,3 +210,12 @@ func PythonIntegTest(ctx context.Context) error {
 	mg.Deps(Fields, Dashboards, devtools.BuildSystemTestBinary)
 	return devtools.PythonIntegTestFromHost(devtools.DefaultPythonTestIntegrationFromHostArgs())
 }
+
+// FipsECH test runs a smoke test using the FIPS enabled binary targetting an ECH deployment.
+func FipsECHTest(ctx context.Context) error {
+	mg.Deps(Build)
+	args := devtools.DefaultGoTestIntegrationArgs()
+	args.Packages = []string{"testing/fips-ech"} // TODO does this work or should we change the working directory?
+	return devtools.GoTest(ctx, args)
+	return nil
+}

--- a/filebeat/testing/fips-ech/filebeat_test.go
+++ b/filebeat/testing/fips-ech/filebeat_test.go
@@ -1,0 +1,93 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package fips
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+	"github.com/elastic/go-elasticsearch/v8"
+)
+
+const filebeatFIPSConfig = `
+filebeat.inputs:
+  - type: filestream
+    id: "test-filebeat-fips"
+    paths:
+      - %s
+path.home: %s
+output:
+  elasticsearch:
+    hosts:
+      - %s
+    protocol: https
+    username: %s
+    password: %s
+`
+
+// TestFilebeatFIPSSmoke starts a FIPS compatible binary and ensures that data ends up in an (https) ES cluster.
+func TestFilebeatFIPSSmoke(t *testing.T) {
+	// use vars directly instead of integration.GetESURL as the integration package makes assumptions about the ports and username/password.
+	esHost := os.Getenv("ES_HOST")
+	require.NotEmpty(t, esHost, "Expected env var ES_HOST to be not-empty.")
+	esUser := os.Getenc("ES_USER")
+	require.NotEmpty(t, esUser, "Expected env var ES_USER to be not-empty.")
+	esPass := os.Getenc("ES_PASS")
+	require.NotEmpty(t, esPass, "Expected env var ES_PASS to be not-empty.")
+
+	filebeat := integration.NewBeat(
+		t,
+		"filebeat",
+		"../../filebeat",
+	)
+	filebeat.RemoveAllCLIArgs()
+
+	// 1. Generate the log file path, but do not write data to it
+	tempDir := filebeat.TempDir()
+	logFilePath := path.Join(tempDir, "log.log")
+
+	// 2. Create the log file
+	integration.GenerateLogFile(t, logFilePath, 10, false)
+
+	// 3. Write configuration file and start Filebeat
+	filebeat.WriteConfigFile(fmt.Sprintf(filebeatFIPSConfig, logFilePath, tempDir, esHost, esUser, esPass))
+	filebeat.Start()
+
+	es, err := elasticsearch.NewTypedClient(elasticsearch.Config{
+		Addresses: []string{esHost},
+		Username:  esUser,
+		Password:  esPass,
+	})
+	require.NoError(t, err, "unable to create elasticsearch client")
+
+	// 4. Ensure data ends up in ES
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := es.Search().Index("logs-*").Do(t.Context())
+		require.NoError(c, err, "search request for index failed.")
+		require.Equal(t, int64(10), resp.Hits.Total.Value, "expected to find 10 hits within ES.")
+	}, time.Minute, time.Second, "filebeat logs are not detected within the elasticsearch deployment")
+}

--- a/testing/terraform-ech/.gitignore
+++ b/testing/terraform-ech/.gitignore
@@ -1,0 +1,4 @@
+.terraform
+terraform.tfstate
+terraform.tfstate.backup
+.terraform.lock.hcl

--- a/testing/terraform-ech/ech.tf
+++ b/testing/terraform-ech/ech.tf
@@ -1,0 +1,73 @@
+variable "stack_version" {
+  type        = string
+  default     = "latest"
+  description = "the stack version to use"
+}
+
+variable "ech_region" {
+  type        = string
+  default     = ""
+  description = "The region to use"
+}
+
+variable "creator" {
+  type        = string
+  default     = ""
+  description = "This is the name who created this deployment"
+}
+
+variable "buildkite_id" {
+  type        = string
+  default     = ""
+  description = "The buildkite build id associated with this deployment"
+}
+
+variable "pipeline" {
+  type        = string
+  default     = ""
+  description = "The buildkite pipeline slug, useful for in combination with the build id to trace back to the pipeline"
+}
+
+variable "deployment_template_id" {
+  type        = string
+  default     = ""
+  description = "The deployment template to use"
+}
+
+resource "random_uuid" "deployment_suffix" {
+}
+
+# If we have defined a stack version, validate that this version exists on that region and return it.
+data "ec_stack" "latest" {
+  version_regex = var.stack_version
+  region        = local.region
+}
+
+locals {
+  deployment_name    = join("-", ["beats-ci", substr("${random_uuid.deployment_suffix.result}", 0, 8)])
+  deployment_version = data.ec_stack.latest.version
+
+  region                 = coalesce(var.ech_region, "gcp-us-east1")
+  deployment_template_id = coalesce(var.deployment_template_id, "gcp-storage-optimized")
+}
+
+resource "ec_deployment" "default" {
+  name                   = local.deployment_name
+  alias                  = local.deployment_name
+  region                 = local.region
+  deployment_template_id = local.deployment_template_id
+  version                = local.deployment_version
+
+  elasticsearch = {
+    hot = {
+      autoscaling = {}
+      size        = "8g"
+      zone_count  = 2
+    }
+  }
+
+  kibana = {
+    size       = "1g"
+    zone_count = 1
+  }
+}

--- a/testing/terraform-ech/output.tf
+++ b/testing/terraform-ech/output.tf
@@ -1,0 +1,25 @@
+output "cloud_id" {
+  value       = ec_deployment.default.elasticsearch.cloud_id
+  description = "Cloud ID (cloud_id)"
+}
+
+output "es_password" {
+  value       = ec_deployment.default.elasticsearch_password
+  description = "Password (cloud_id)"
+  sensitive   = true
+}
+
+output "es_username" {
+  value       = ec_deployment.default.elasticsearch_username
+  description = "Password (cloud_id)"
+  sensitive   = true
+}
+
+output "es_host" {
+  value       = ec_deployment.default.elasticsearch.https_endpoint
+  description = ""
+}
+
+output "kibana_endpoint" {
+  value = ec_deployment.default.kibana.https_endpoint
+}

--- a/testing/terraform-ech/terraform.tf
+++ b/testing/terraform-ech/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.2.7"
+
+  required_providers {
+    ec = {
+      source  = "elastic/ec"
+      version = ">= 0.12.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}


### PR DESCRIPTION
## Proposed commit message

Add an integration test that provisions an ECH deployment, builds a FIPS enabled binary and ensures that data reaches the deployment.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

N/A
