### PR TITLE
[AutoOps] Avoid Environment Collision by prefixing with AUTOOPS_

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cat_shards_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cat_shards_test.go
@@ -170,7 +170,7 @@ func TestFailedCatShardsFetch(t *testing.T) {
 // Integration tests to check the error handling when the server returns different error types
 // TestElasticSearchError tests the error handling when an Elasticsearch simple error is returned
 func Test500FailedToResolveIndexesWhileFetching(t *testing.T) {
-	t.Setenv("DEPLOYMENT_ID", "test-resource-id")
+	t.Setenv("AUTOOPS_DEPLOYMENT_ID", "test-resource-id")
 	utils.GetAndSetResourceID()
 
 	t.Cleanup(utils.ClearResourceID)
@@ -197,7 +197,7 @@ func Test500FailedToResolveIndexesWhileFetching(t *testing.T) {
 
 // TestElasticSearchError tests the error handling when an elasticsearch is returned
 func Test404FailedToResolveIndexesWhileFetching(t *testing.T) {
-	t.Setenv("RESOURCE_ID", "test-resource-id")
+	t.Setenv("AUTOOPS_RESOURCE_ID", "test-resource-id")
 	utils.GetAndSetResourceID()
 
 	t.Cleanup(utils.ClearResourceID)
@@ -224,7 +224,7 @@ func Test404FailedToResolveIndexesWhileFetching(t *testing.T) {
 
 // TestElasticSearchError tests the error handling when an elasticsearch is returned
 func Test405FailedToResolveIndexesWhileFetching(t *testing.T) {
-	t.Setenv("PROJECT_ID", "test-resource-id")
+	t.Setenv("AUTOOPS_PROJECT_ID", "test-resource-id")
 	utils.GetAndSetResourceID()
 
 	t.Cleanup(utils.ClearResourceID)
@@ -251,7 +251,7 @@ func Test405FailedToResolveIndexesWhileFetching(t *testing.T) {
 
 // TestElasticSearchError tests the error handling when an error different from Elasticsearch is returned (proxy error, etc.)
 func Test500FailedToResolveIndexesWhileFetchingEmptyResponse(t *testing.T) {
-	t.Setenv("DEPLOYMENT_ID", "test-resource-id")
+	t.Setenv("AUTOOPS_DEPLOYMENT_ID", "test-resource-id")
 	utils.GetAndSetResourceID()
 
 	t.Cleanup(utils.ClearResourceID)

--- a/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
+++ b/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
@@ -133,32 +133,32 @@ func TestGetResourceID(t *testing.T) {
 		expectedValue string
 	}{
 		{
-			name: "DEPLOYMENT_ID is set",
+			name: "AUTOOPS_DEPLOYMENT_ID is set",
 			envVars: map[string]string{
-				"DEPLOYMENT_ID": "deployment-123",
+				"AUTOOPS_DEPLOYMENT_ID": "deployment-123",
 			},
 			expectedValue: "deployment-123",
 		},
 		{
-			name: "PROJECT_ID is set",
+			name: "AUTOOPS_PROJECT_ID is set",
 			envVars: map[string]string{
-				"PROJECT_ID": "project-456",
+				"AUTOOPS_PROJECT_ID": "project-456",
 			},
 			expectedValue: "project-456",
 		},
 		{
-			name: "RESOURCE_ID is set",
+			name: "AUTOOPS_RESOURCE_ID is set",
 			envVars: map[string]string{
-				"RESOURCE_ID": "resource-789",
+				"AUTOOPS_RESOURCE_ID": "resource-789",
 			},
 			expectedValue: "resource-789",
 		},
 		{
 			name: "No environment variables are set",
 			envVars: map[string]string{
-				"DEPLOYMENT_ID": "",
-				"PROJECT_ID":    "",
-				"RESOURCE_ID":   "",
+				"AUTOOPS_DEPLOYMENT_ID": "",
+				"AUTOOPS_PROJECT_ID":    "",
+				"AUTOOPS_RESOURCE_ID":   "",
 			},
 			expectedValue: "",
 		},

--- a/x-pack/metricbeat/module/autoops_es/metricset/cluster_info_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/cluster_info_test.go
@@ -39,7 +39,7 @@ func setupClusterInfoFromFile(filename string) auto_ops_testing.SetupServerCallb
 }
 
 func TestNestedFailedClusterInfoNoId(t *testing.T) {
-	t.Setenv("DEPLOYMENT_ID", "test-resource-id")
+	t.Setenv("AUTOOPS_DEPLOYMENT_ID", "test-resource-id")
 	utils.GetAndSetResourceID()
 
 	t.Cleanup(utils.ClearResourceID)
@@ -64,7 +64,7 @@ func TestNestedFailedClusterInfoNoId(t *testing.T) {
 }
 
 func TestNestedFailedClusterInfoNAId(t *testing.T) {
-	t.Setenv("RESOURCE_ID", "test-resource-id")
+	t.Setenv("AUTOOPS_RESOURCE_ID", "test-resource-id")
 	utils.GetAndSetResourceID()
 
 	t.Cleanup(utils.ClearResourceID)

--- a/x-pack/metricbeat/module/autoops_es/utils/resource.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/resource.go
@@ -21,13 +21,13 @@ func GetAndSetResourceID() string {
 		return resourceID
 	}
 
-	if deploymentID := os.Getenv("DEPLOYMENT_ID"); deploymentID != "" {
+	if deploymentID := os.Getenv("AUTOOPS_DEPLOYMENT_ID"); deploymentID != "" {
 		SetResourceID(deploymentID)
 		return deploymentID
-	} else if projectID := os.Getenv("PROJECT_ID"); projectID != "" {
+	} else if projectID := os.Getenv("AUTOOPS_PROJECT_ID"); projectID != "" {
 		SetResourceID(projectID)
 		return projectID
-	} else if resourceID := os.Getenv("RESOURCE_ID"); resourceID != "" {
+	} else if resourceID := os.Getenv("AUTOOPS_RESOURCE_ID"); resourceID != "" {
 		SetResourceID(resourceID)
 		return resourceID
 	}

--- a/x-pack/metricbeat/module/autoops_es/utils/resource_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/resource_test.go
@@ -57,28 +57,28 @@ func TestGetAndSetResourceID(t *testing.T) {
 		{
 			name:               "resourceID already set",
 			initialResourceID:  "pre-existing-id",
-			envVars:            map[string]string{"DEPLOYMENT_ID": "env-dep-id"}, // This env var should not be used
+			envVars:            map[string]string{"AUTOOPS_DEPLOYMENT_ID": "env-dep-id"}, // This env var should not be used
 			expectedResourceID: "pre-existing-id",
 			expectedFinalID:    "pre-existing-id",
 		},
 		{
-			name:               "resourceID empty, DEPLOYMENT_ID set",
+			name:               "resourceID empty, AUTOOPS_DEPLOYMENT_ID set",
 			initialResourceID:  "",
-			envVars:            map[string]string{"DEPLOYMENT_ID": "env-dep-id"},
+			envVars:            map[string]string{"AUTOOPS_DEPLOYMENT_ID": "env-dep-id"},
 			expectedResourceID: "env-dep-id",
 			expectedFinalID:    "env-dep-id",
 		},
 		{
-			name:               "resourceID empty, DEPLOYMENT_ID empty, PROJECT_ID set",
+			name:               "resourceID empty, AUTOOPS_DEPLOYMENT_ID empty, AUTOOPS_PROJECT_ID set",
 			initialResourceID:  "",
-			envVars:            map[string]string{"PROJECT_ID": "env-proj-id"},
+			envVars:            map[string]string{"AUTOOPS_PROJECT_ID": "env-proj-id"},
 			expectedResourceID: "env-proj-id",
 			expectedFinalID:    "env-proj-id",
 		},
 		{
-			name:               "resourceID empty, DEPLOYMENT_ID empty, PROJECT_ID empty, RESOURCE_ID (env) set",
+			name:               "resourceID empty, AUTOOPS_DEPLOYMENT_ID empty, AUTOOPS_PROJECT_ID empty, AUTOOPS_RESOURCE_ID (env) set",
 			initialResourceID:  "",
-			envVars:            map[string]string{"RESOURCE_ID": "env-res-id"},
+			envVars:            map[string]string{"AUTOOPS_RESOURCE_ID": "env-res-id"},
 			expectedResourceID: "env-res-id",
 			expectedFinalID:    "env-res-id",
 		},
@@ -90,16 +90,16 @@ func TestGetAndSetResourceID(t *testing.T) {
 			expectedFinalID:    "",
 		},
 		{
-			name:               "precedence: DEPLOYMENT_ID > PROJECT_ID > RESOURCE_ID (env)",
+			name:               "precedence: AUTOOPS_DEPLOYMENT_ID > AUTOOPS_PROJECT_ID > AUTOOPS_RESOURCE_ID (env)",
 			initialResourceID:  "",
-			envVars:            map[string]string{"DEPLOYMENT_ID": "env-dep-id-prec", "PROJECT_ID": "env-proj-id-prec", "RESOURCE_ID": "env-res-id-prec"},
+			envVars:            map[string]string{"AUTOOPS_DEPLOYMENT_ID": "env-dep-id-prec", "AUTOOPS_PROJECT_ID": "env-proj-id-prec", "AUTOOPS_RESOURCE_ID": "env-res-id-prec"},
 			expectedResourceID: "env-dep-id-prec",
 			expectedFinalID:    "env-dep-id-prec",
 		},
 		{
-			name:               "precedence: PROJECT_ID > RESOURCE_ID (env), DEPLOYMENT_ID empty",
+			name:               "precedence: AUTOOPS_PROJECT_ID > AUTOOPS_RESOURCE_ID (env), AUTOOPS_DEPLOYMENT_ID empty",
 			initialResourceID:  "",
-			envVars:            map[string]string{"DEPLOYMENT_ID": "", "PROJECT_ID": "env-proj-id-prec2", "RESOURCE_ID": "env-res-id-prec2"},
+			envVars:            map[string]string{"AUTOOPS_DEPLOYMENT_ID": "", "AUTOOPS_PROJECT_ID": "env-proj-id-prec2", "AUTOOPS_RESOURCE_ID": "env-res-id-prec2"},
 			expectedResourceID: "env-proj-id-prec2",
 			expectedFinalID:    "env-proj-id-prec2",
 		},
@@ -117,7 +117,7 @@ func TestGetAndSetResourceID(t *testing.T) {
 			// Set environment variables for this specific sub-test.
 			// t.Setenv handles cleanup (restoring original value) for each variable at the end of the sub-test.
 			// Ensure all relevant keys are explicitly set (even to "") for the test's context.
-			relevantKeys := []string{"DEPLOYMENT_ID", "PROJECT_ID", "RESOURCE_ID"}
+			relevantKeys := []string{"AUTOOPS_DEPLOYMENT_ID", "AUTOOPS_PROJECT_ID", "AUTOOPS_RESOURCE_ID"}
 			for _, key := range relevantKeys {
 				if val, ok := tt.envVars[key]; ok {
 					t.Setenv(key, val)


### PR DESCRIPTION
This adds a `AUTOOPS_` to ensure resource IDs are intended for AutoOps rather than some other system property.

We do not want to accidentally consume an unrelated ID.