### PR TITLE
test(integration): fix sredis container image

### DIFF
--- a/testing/environments/docker/sredis/Dockerfile
+++ b/testing/environments/docker/sredis/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.22
 
 RUN apk add --no-cache stunnel
 


### PR DESCRIPTION
The [sredis](https://github.com/elastic/beats/blob/24b4bbb264441979d6bcbb78f03ab5560bb217a6/testing/environments/docker/sredis/Dockerfile) image started [failing](https://buildkite.com/elastic/beats-libbeat/builds/18388/steps/canvas?jid=01982be6-e632-4799-aabc-423446ef5c20) to run in recent days with:

```
$ docker logs libbeat_9_2_0_7b2b3aa2d9-snapshot-sredis-1
Error relocating /usr/bin/stunnel: OSSL_PROVIDER_add_conf_parameter: symbol not found
```

Switching to stable base Alpine image for more stability.