### PR TITLE
test: update integration test Dockerfiles with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,7 @@ updates:
 
   - package-ecosystem: gomod
     directory: /
-    # Workaround to satisfy Dependabot's unique constraint (needs unique 'package-ecosystem', 'directory', 'target-branch' tuples) 
+    # Workaround to satisfy Dependabot's unique constraint (needs unique 'package-ecosystem', 'directory', 'target-branch' tuples)
     # for duplicate package-ecosystem configurations: https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
     target-branch: main
     schedule:
@@ -92,6 +92,19 @@ updates:
           - "github.com/go-ole/go-ole"
           - "github.com/StackExchange/wmi"
     open-pull-requests-limit: 5
+
+  # Update integration test container images
+  - package-ecosystem: "docker"
+    directories:
+      # Starting with the sredis image, we might want to add other images later.
+      - '/testing/environments/docker/sredis'
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "23:29"
+    labels:
+      - automation
+      - dependabot
 
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
After https://github.com/elastic/beats/pull/45496 is merged, let's make sure that Alpine base image is kept up-to-date by Dependabot.