### PR TITLE
[docs] Use version variables

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -14,7 +14,6 @@ toc:
   - toc: release-notes
   - toc: extend
 subs:
-  version: "9.0.0"
   beats-ref:   "https://www.elastic.co/guide/en/beats/libbeat/current"
   ecloud:   "Elastic Cloud"
   ess:   "Elasticsearch Service"
@@ -46,8 +45,5 @@ subs:
   elastic-sec:   "Elastic Security"
   monitoring:   "X-Pack monitoring"
   monitor-features:   "monitoring features"
-  stack-version: "9.0.0"
-  major-version: "9.0"
-  major-release: "9.x"
   beats-pull: "https://github.com/elastic/beats/pull/"
   beats-issue: "https://github.com/elastic/beats/issues/"

--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -48,38 +48,38 @@ To download and install Auditbeat, use the commands that work with your system:
 ::::::{tab-item} DEB
 :sync: deb
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-amd64.deb
-sudo dpkg -i auditbeat-{{stack-version}}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{version.stack}}-amd64.deb
+sudo dpkg -i auditbeat-{{version.stack}}-amd64.deb
 ```
 ::::::
 
 ::::::{tab-item} RPM
 :sync: rpm
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-x86_64.rpm
-sudo rpm -vi auditbeat-{{stack-version}}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{version.stack}}-x86_64.rpm
+sudo rpm -vi auditbeat-{{version.stack}}-x86_64.rpm
 ```
 ::::::
 
 ::::::{tab-item} MacOS
 :sync: macos
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-darwin-x86_64.tar.gz
-tar xzvf auditbeat-{{stack-version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{version.stack}}-darwin-x86_64.tar.gz
+tar xzvf auditbeat-{{version.stack}}-darwin-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Linux
 :sync: linux
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-linux-x86_64.tar.gz
-tar xzvf auditbeat-{{stack-version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{version.stack}}-linux-x86_64.tar.gz
+tar xzvf auditbeat-{{version.stack}}-linux-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Windows
 :sync: windows
-1. Download the [Auditbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{stack-version}}-windows-x86_64.zip).
+1. Download the [Auditbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-{{version.stack}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
 

--- a/docs/reference/auditbeat/auditbeat-template.md
+++ b/docs/reference/auditbeat/auditbeat-template.md
@@ -97,7 +97,7 @@ auditbeat setup --index-management -E output.logstash.enabled=false -E 'output.e
 **docker:**
 
 ```sh subs=true
-docker run --rm docker.elastic.co/beats/auditbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+docker run --rm docker.elastic.co/beats/auditbeat:{{version.stack}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -171,7 +171,7 @@ auditbeat export template > auditbeat.template.json
 **win:**
 
 ```sh subs=true
-PS > .\auditbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 auditbeat.template.json
+PS > .\auditbeat.exe export template --es.version {{version.stack}} | Out-File -Encoding UTF8 auditbeat.template.json
 ```
 
 To install the template, run:
@@ -179,50 +179,50 @@ To install the template, run:
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{stack-version}} -d@auditbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{version.stack}} -d@auditbeat.template.json
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{stack-version}} -d@auditbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{version.stack}} -d@auditbeat.template.json
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{stack-version}} -d@auditbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/auditbeat-{{version.stack}} -d@auditbeat.template.json
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile auditbeat.template.json -Uri http://localhost:9200/_index_template/auditbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile auditbeat.template.json -Uri http://localhost:9200/_index_template/auditbeat-{{version.stack}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on auditbeat-{{stack-version}} index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on auditbeat-{{version.stack}} index.
 
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{version.stack}}
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{version.stack}}
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/auditbeat-{{version.stack}}
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/auditbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/auditbeat-{{version.stack}}
 ```
 

--- a/docs/reference/auditbeat/command-line-options.md
+++ b/docs/reference/auditbeat/command-line-options.md
@@ -91,7 +91,7 @@ Also see [Global flags](#global-flags).
 
 ```sh subs=true
 auditbeat export config
-auditbeat export template --es.version {{stack-version}}
+auditbeat export template --es.version {{version.stack}}
 auditbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/auditbeat/http-endpoint.md
+++ b/docs/reference/auditbeat/http-endpoint.md
@@ -66,7 +66,7 @@ curl -XGET 'localhost:5066/?pretty'
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "{{stack-version}}"
+  "version": "{{version.stack}}"
 }
 ```
 

--- a/docs/reference/auditbeat/load-kibana-dashboards.md
+++ b/docs/reference/auditbeat/load-kibana-dashboards.md
@@ -44,7 +44,7 @@ auditbeat setup --dashboards
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/auditbeat:{{stack-version}} setup --dashboards
+docker run --rm --net="host" docker.elastic.co/beats/auditbeat:{{version.stack}} setup --dashboards
 ```
 ::::::
 
@@ -120,7 +120,7 @@ auditbeat setup -e \
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/auditbeat:{{stack-version}} setup -e \
+docker run --rm --net="host" docker.elastic.co/beats/auditbeat:{{version.stack}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=auditbeat_internal \

--- a/docs/reference/auditbeat/logstash-output.md
+++ b/docs/reference/auditbeat/logstash-output.md
@@ -38,7 +38,7 @@ Every event sent to {{ls}} contains the following metadata fields that you can u
     ...
     "@metadata": { <1>
       "beat": "auditbeat", <2>
-      "version": "{{stack-version}}" <3>
+      "version": "{{version.stack}}" <3>
     }
 }
 ```

--- a/docs/reference/auditbeat/running-on-docker.md
+++ b/docs/reference/auditbeat/running-on-docker.md
@@ -16,12 +16,12 @@ These images are free to use under the Elastic license. They contain open source
 Obtaining Auditbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
 % ::::{warning} subs=true
-% Version {{stack-version}} of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat {{stack-version}}.
+% Version {{version.stack}} of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
-docker pull docker.elastic.co/beats/auditbeat:{{stack-version}}
+docker pull docker.elastic.co/beats/auditbeat:{{version.stack}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
@@ -29,7 +29,7 @@ Alternatively, you can download other Docker images that contain only features a
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
 ```bash subs=true
-docker pull docker.elastic.co/beats/auditbeat-wolfi:{{stack-version}}
+docker pull docker.elastic.co/beats/auditbeat-wolfi:{{version.stack}}
 ```
 
 
@@ -38,19 +38,19 @@ docker pull docker.elastic.co/beats/auditbeat-wolfi:{{stack-version}}
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Auditbeat Docker image signature.
 
 % ::::{warning} subs=true
-% Version {{stack-version}} of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat {{stack-version}}.
+% Version {{version.stack}} of Auditbeat has not yet been released. No Docker image is currently available for Auditbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/auditbeat:{{stack-version}}
+cosign verify --key cosign.pub docker.elastic.co/beats/auditbeat:{{version.stack}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
 ```sh subs=true
-Verification for docker.elastic.co/beats/auditbeat:{{stack-version}} --
+Verification for docker.elastic.co/beats/auditbeat:{{version.stack}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -71,7 +71,7 @@ Running Auditbeat with the setup command will create the index pattern and load 
 docker run --rm \
   --cap-add="AUDIT_CONTROL" \
   --cap-add="AUDIT_READ" \
-  docker.elastic.co/beats/auditbeat:{{stack-version}} \
+  docker.elastic.co/beats/auditbeat:{{version.stack}} \
   setup -E setup.kibana.host=kibana:5601 \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -96,7 +96,7 @@ For example:
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/auditbeat/data \
   --read-only \
-  docker.elastic.co/beats/auditbeat:{{stack-version}}
+  docker.elastic.co/beats/auditbeat:{{version.stack}}
 ```
 
 
@@ -109,7 +109,7 @@ The Docker image provides several methods for configuring Auditbeat. The convent
 Download this example configuration file as a starting point:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/auditbeat.docker.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/docker/auditbeat.docker.yml
 ```
 
 
@@ -125,7 +125,7 @@ docker run -d \
   --cap-add="AUDIT_CONTROL" \
   --cap-add="AUDIT_READ" \
   --pid=host \
-  docker.elastic.co/beats/auditbeat:{{stack-version}} -e \
+  docker.elastic.co/beats/auditbeat:{{version.stack}} -e \
   --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -145,7 +145,7 @@ The `auditbeat.docker.yml` downloaded earlier should be customized for your envi
 It’s possible to embed your Auditbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
 ```dockerfile subs=true
-FROM docker.elastic.co/beats/auditbeat:{{stack-version}}
+FROM docker.elastic.co/beats/auditbeat:{{version.stack}}
 COPY auditbeat.yml /usr/share/auditbeat/auditbeat.yml
 ```
 
@@ -158,7 +158,7 @@ Under Docker, Auditbeat runs as a non-root user, but requires some privileged ca
 It is also essential to run Auditbeat in the host PID namespace.
 
 ```sh subs=true
-docker run --cap-add=AUDIT_CONTROL --cap-add=AUDIT_READ --user=root --pid=host docker.elastic.co/beats/auditbeat:{{stack-version}}
+docker run --cap-add=AUDIT_CONTROL --cap-add=AUDIT_READ --user=root --pid=host docker.elastic.co/beats/auditbeat:{{version.stack}}
 ```
 
 

--- a/docs/reference/auditbeat/running-on-kubernetes.md
+++ b/docs/reference/auditbeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-% However, version {{stack-version}} of Auditbeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{version.stack}} of Auditbeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests for Auditbeat [_kubernetes_deploy_manifests]
@@ -24,7 +24,7 @@ Everything is deployed under `kube-system` namespace, you can change that by upd
 To get the manifests just run:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/auditbeat-kubernetes.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/kubernetes/auditbeat-kubernetes.yaml
 ```
 
 ::::{warning}

--- a/docs/reference/auditbeat/setup-repositories.md
+++ b/docs/reference/auditbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
     :::
 
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-release}}]
-    name=Elastic repository for {{major-release}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
+    [elastic-{{ version.stack | M.x }}]
+    name=Elastic repository for {{ version.stack | M.x }} packages
+    baseurl=https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/yum
     ```
     :::
 

--- a/docs/reference/filebeat/command-line-options.md
+++ b/docs/reference/filebeat/command-line-options.md
@@ -92,7 +92,7 @@ Also see [Global flags](#global-flags).
 
 ```sh subs=true
 filebeat export config
-filebeat export template --es.version {{stack-version}}
+filebeat export template --es.version {{version.stack}}
 filebeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -47,38 +47,38 @@ To download and install Filebeat, use the commands that work with your system:
 ::::::{tab-item} DEB
 :sync: deb
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-amd64.deb
-sudo dpkg -i filebeat-{{stack-version}}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version.stack}}-amd64.deb
+sudo dpkg -i filebeat-{{version.stack}}-amd64.deb
 ```
 ::::::
 
 ::::::{tab-item} RPM
 :sync: rpm
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-x86_64.rpm
-sudo rpm -vi filebeat-{{stack-version}}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version.stack}}-x86_64.rpm
+sudo rpm -vi filebeat-{{version.stack}}-x86_64.rpm
 ```
 ::::::
 
 ::::::{tab-item} MacOS
 :sync: macos
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-darwin-x86_64.tar.gz
-tar xzvf filebeat-{{stack-version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version.stack}}-darwin-x86_64.tar.gz
+tar xzvf filebeat-{{version.stack}}-darwin-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Linux
 :sync: linux
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-linux-x86_64.tar.gz
-tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version.stack}}-linux-x86_64.tar.gz
+tar xzvf filebeat-{{version.stack}}-linux-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Windows
 :sync: windows
-1. Download the [Filebeat Windows zip file](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-windows-x86_64.zip).
+1. Download the [Filebeat Windows zip file](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version.stack}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
 
@@ -160,7 +160,7 @@ cloud.auth: "filebeat_setup:YOUR_PASSWORD" <1>
 
     1. The hostname and port of the machine where {{kib}} is running, for example, `mykibanahost:5601`. If you specify a path after the port number, include the scheme and port: `http://mykibanahost:5601/path`.
     2. The `username` and `password` settings for {{kib}} are optional. If you don’t specify credentials for {{kib}}, Filebeat uses the `username` and `password` specified for the {{es}} output.
-    
+
         To use the pre-built {{kib}} dashboards, this user must be authorized to view dashboards or have the `kibana_admin` [built-in role](elasticsearch://reference/elasticsearch/roles.md).
 ::::::
 

--- a/docs/reference/filebeat/filebeat-template.md
+++ b/docs/reference/filebeat/filebeat-template.md
@@ -97,7 +97,7 @@ filebeat setup --index-management -E output.logstash.enabled=false -E 'output.el
 **docker:**
 
 ```sh subs=true
-docker run --rm docker.elastic.co/beats/filebeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+docker run --rm docker.elastic.co/beats/filebeat:{{version.stack}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -171,7 +171,7 @@ filebeat export template > filebeat.template.json
 **win:**
 
 ```sh subs=true
-PS > .\filebeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 filebeat.template.json
+PS > .\filebeat.exe export template --es.version {{version.stack}} | Out-File -Encoding UTF8 filebeat.template.json
 ```
 
 To install the template, run:
@@ -179,50 +179,50 @@ To install the template, run:
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{stack-version}} -d@filebeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{version.stack}} -d@filebeat.template.json
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{stack-version}} -d@filebeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{version.stack}} -d@filebeat.template.json
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{stack-version}} -d@filebeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/filebeat-{{version.stack}} -d@filebeat.template.json
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile filebeat.template.json -Uri http://localhost:9200/_index_template/filebeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile filebeat.template.json -Uri http://localhost:9200/_index_template/filebeat-{{version.stack}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on filebeat-{{stack-version}} index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on filebeat-{{version.stack}} index.
 
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/filebeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/filebeat-{{version.stack}}
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/filebeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/filebeat-{{version.stack}}
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/filebeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/filebeat-{{version.stack}}
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/filebeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/filebeat-{{version.stack}}
 ```
 

--- a/docs/reference/filebeat/filtering-enhancing-data.md
+++ b/docs/reference/filebeat/filtering-enhancing-data.md
@@ -91,7 +91,7 @@ The resulting output looks something like this:
   "beat": {
     "hostname": "host.example.com",
     "name": "host.example.com",
-    "version": "{{stack-version}}"
+    "version": "{{version.stack}}"
   },
   "inner": {
     "data": "value"

--- a/docs/reference/filebeat/http-endpoint.md
+++ b/docs/reference/filebeat/http-endpoint.md
@@ -66,7 +66,7 @@ curl -XGET 'localhost:5066/?pretty'
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "{{stack-version}}"
+  "version": "{{version.stack}}"
 }
 ```
 

--- a/docs/reference/filebeat/load-kibana-dashboards.md
+++ b/docs/reference/filebeat/load-kibana-dashboards.md
@@ -49,7 +49,7 @@ filebeat setup --dashboards
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/filebeat:{{stack-version}} setup --dashboards
+docker run --rm --net="host" docker.elastic.co/beats/filebeat:{{version.stack}} setup --dashboards
 ```
 ::::::
 
@@ -124,7 +124,7 @@ filebeat setup -e \
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/filebeat:{{stack-version}} setup -e \
+docker run --rm --net="host" docker.elastic.co/beats/filebeat:{{version.stack}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=filebeat_internal \

--- a/docs/reference/filebeat/logstash-output.md
+++ b/docs/reference/filebeat/logstash-output.md
@@ -40,7 +40,7 @@ Every event sent to {{ls}} contains the following metadata fields that you can u
     ...
     "@metadata": { <1>
       "beat": "filebeat", <2>
-      "version": "{{stack-version}}" <3>
+      "version": "{{version.stack}}" <3>
     }
 }
 ```

--- a/docs/reference/filebeat/running-on-cloudfoundry.md
+++ b/docs/reference/filebeat/running-on-cloudfoundry.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 You can use Filebeat on Cloud Foundry to retrieve and ship logs.
 
-% However, version {{stack-version}} of Filebeat has not yet been released, no build is currently available for this version.
+% However, version {{version.stack}} of Filebeat has not yet been released, no build is currently available for this version.
 
 ## Create Cloud Foundry credentials [_create_cloud_foundry_credentials]
 
@@ -31,11 +31,11 @@ You deploy Filebeat as an application with no route.
 Cloud Foundry requires that 3 files exist inside of a directory to allow Filebeat to be pushed. The commands below provide the basic steps for getting it up and running.
 
 ```sh subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-linux-x86_64.tar.gz
-tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
-cd filebeat-{{stack-version}}-linux-x86_64
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/filebeat/filebeat.yml
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/filebeat/manifest.yml
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version.stack}}-linux-x86_64.tar.gz
+tar xzvf filebeat-{{version.stack}}-linux-x86_64.tar.gz
+cd filebeat-{{version.stack}}-linux-x86_64
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/cloudfoundry/filebeat/filebeat.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/cloudfoundry/filebeat/manifest.yml
 ```
 
 You need to modify the `filebeat.yml` file to set the `api_address`, `client_id` and `client_secret`.

--- a/docs/reference/filebeat/running-on-docker.md
+++ b/docs/reference/filebeat/running-on-docker.md
@@ -16,12 +16,12 @@ These images are free to use under the Elastic license. They contain open source
 Obtaining Filebeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
 % ::::{warning}
-% Version {{stack-version}} of Filebeat has not yet been released. No Docker image is currently available for Filebeat {{stack-version}}.
+% Version {{version.stack}} of Filebeat has not yet been released. No Docker image is currently available for Filebeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
-docker pull docker.elastic.co/beats/filebeat:{{stack-version}}
+docker pull docker.elastic.co/beats/filebeat:{{version.stack}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
@@ -29,7 +29,7 @@ Alternatively, you can download other Docker images that contain only features a
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
 ```bash subs=true
-docker pull docker.elastic.co/beats/filebeat-wolfi:{{stack-version}}
+docker pull docker.elastic.co/beats/filebeat-wolfi:{{version.stack}}
 ```
 
 
@@ -38,19 +38,19 @@ docker pull docker.elastic.co/beats/filebeat-wolfi:{{stack-version}}
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Filebeat Docker image signature.
 
 % ::::{warning}
-% Version {{stack-version}} of Filebeat has not yet been released. No Docker image is currently available for Filebeat {{stack-version}}.
+% Version {{version.stack}} of Filebeat has not yet been released. No Docker image is currently available for Filebeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/filebeat:{{stack-version}}
+cosign verify --key cosign.pub docker.elastic.co/beats/filebeat:{{version.stack}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
 ```sh subs=true
-Verification for docker.elastic.co/beats/filebeat:{{stack-version}} --
+Verification for docker.elastic.co/beats/filebeat:{{version.stack}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -69,7 +69,7 @@ Running Filebeat with the setup command will create the index pattern and load v
 
 ```sh subs=true
 docker run --rm \
-docker.elastic.co/beats/filebeat:{{stack-version}} \
+docker.elastic.co/beats/filebeat:{{version.stack}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -94,7 +94,7 @@ For example:
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/filebeat/data \
   --read-only \
-  docker.elastic.co/beats/filebeat:{{stack-version}}
+  docker.elastic.co/beats/filebeat:{{version.stack}}
 ```
 
 
@@ -107,7 +107,7 @@ The Docker image provides several methods for configuring Filebeat. The conventi
 Download this example configuration file as a starting point:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/filebeat.docker.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/docker/filebeat.docker.yml
 ```
 
 
@@ -123,7 +123,7 @@ docker run -d \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
   --volume="registry:/usr/share/filebeat/data:rw" \
-  docker.elastic.co/beats/filebeat:{{stack-version}} filebeat -e --strict.perms=false \
+  docker.elastic.co/beats/filebeat:{{version.stack}} filebeat -e --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
 
@@ -156,7 +156,7 @@ docker run \
 It’s possible to embed your Filebeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
 ```dockerfile subs=true
-FROM docker.elastic.co/beats/filebeat:{{stack-version}}
+FROM docker.elastic.co/beats/filebeat:{{version.stack}}
 COPY --chown=root:filebeat filebeat.yml /usr/share/filebeat/filebeat.yml
 ```
 

--- a/docs/reference/filebeat/running-on-kubernetes.md
+++ b/docs/reference/filebeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-% However, version {{stack-version}} of Filebeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{version.stack}} of Filebeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests for Filebeat [_kubernetes_deploy_manifests]
@@ -26,7 +26,7 @@ Everything is deployed under the `kube-system` namespace by default. To change t
 To download the manifest file, run:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/filebeat-kubernetes.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/kubernetes/filebeat-kubernetes.yaml
 ```
 
 ::::{warning}

--- a/docs/reference/filebeat/setup-repositories.md
+++ b/docs/reference/filebeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
     :::
 
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-release}}]
-    name=Elastic repository for {{major-release}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
+    [elastic-{{ version.stack | M.x }}]
+    name=Elastic repository for {{ version.stack | M.x }} packages
+    baseurl=https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/yum
     ```
     :::
 

--- a/docs/reference/heartbeat/command-line-options.md
+++ b/docs/reference/heartbeat/command-line-options.md
@@ -74,7 +74,7 @@ Also see [Global flags](#global-flags).
 
 ```sh subs=true
 heartbeat export config
-heartbeat export template --es.version {{stack-version}}
+heartbeat export template --es.version {{version.stack}}
 ```
 
 

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -49,38 +49,38 @@ To download and install Heartbeat, use the commands that work with your system:
 ::::::{tab-item} DEB
 :sync: deb
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-amd64.deb
-sudo dpkg -i heartbeat-{{stack-version}}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{version.stack}}-amd64.deb
+sudo dpkg -i heartbeat-{{version.stack}}-amd64.deb
 ```
 ::::::
 
 ::::::{tab-item} RPM
 :sync: rpm
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-x86_64.rpm
-sudo rpm -vi heartbeat-{{stack-version}}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{version.stack}}-x86_64.rpm
+sudo rpm -vi heartbeat-{{version.stack}}-x86_64.rpm
 ```
 ::::::
 
 ::::::{tab-item} MacOS
 :sync: macos
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-darwin-x86_64.tar.gz
-tar xzvf heartbeat-{{stack-version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{version.stack}}-darwin-x86_64.tar.gz
+tar xzvf heartbeat-{{version.stack}}-darwin-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Linux
 :sync: linux
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-linux-x86_64.tar.gz
-tar xzvf heartbeat-{{stack-version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{version.stack}}-linux-x86_64.tar.gz
+tar xzvf heartbeat-{{version.stack}}-linux-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Windows
 :sync: windows
-1. Download the [Heartbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{stack-version}}-windows-x86_64.zip).
+1. Download the [Heartbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/heartbeat/heartbeat-{{version.stack}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
 

--- a/docs/reference/heartbeat/heartbeat-template.md
+++ b/docs/reference/heartbeat/heartbeat-template.md
@@ -97,7 +97,7 @@ heartbeat setup --index-management -E output.logstash.enabled=false -E 'output.e
 **docker:**
 
 ```sh subs=true
-docker run --rm docker.elastic.co/beats/heartbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+docker run --rm docker.elastic.co/beats/heartbeat:{{version.stack}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -171,7 +171,7 @@ heartbeat export template > heartbeat.template.json
 **win:**
 
 ```sh subs=true
-PS > .\heartbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 heartbeat.template.json
+PS > .\heartbeat.exe export template --es.version {{version.stack}} | Out-File -Encoding UTF8 heartbeat.template.json
 ```
 
 To install the template, run:
@@ -179,50 +179,50 @@ To install the template, run:
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{stack-version}} -d@heartbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{version.stack}} -d@heartbeat.template.json
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{stack-version}} -d@heartbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{version.stack}} -d@heartbeat.template.json
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{stack-version}} -d@heartbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/heartbeat-{{version.stack}} -d@heartbeat.template.json
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile heartbeat.template.json -Uri http://localhost:9200/_index_template/heartbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile heartbeat.template.json -Uri http://localhost:9200/_index_template/heartbeat-{{version.stack}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on heartbeat-{{stack-version}} index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on heartbeat-{{version.stack}} index.
 
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{version.stack}}
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{version.stack}}
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/heartbeat-{{version.stack}}
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/heartbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/heartbeat-{{version.stack}}
 ```
 

--- a/docs/reference/heartbeat/http-endpoint.md
+++ b/docs/reference/heartbeat/http-endpoint.md
@@ -66,7 +66,7 @@ curl -XGET 'localhost:5066/?pretty'
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "{{stack-version}}"
+  "version": "{{version.stack}}"
 }
 ```
 

--- a/docs/reference/heartbeat/logstash-output.md
+++ b/docs/reference/heartbeat/logstash-output.md
@@ -38,7 +38,7 @@ Every event sent to {{ls}} contains the following metadata fields that you can u
     ...
     "@metadata": { <1>
       "beat": "heartbeat", <2>
-      "version": "{{stack-version}}" <3>
+      "version": "{{version.stack}}" <3>
     }
 }
 ```

--- a/docs/reference/heartbeat/running-on-docker.md
+++ b/docs/reference/heartbeat/running-on-docker.md
@@ -16,12 +16,12 @@ These images are free to use under the Elastic license. They contain open source
 Obtaining Heartbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
 % ::::{warning} subs=true
-% Version {{stack-version}} of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat {{stack-version}}.
+% Version {{version.stack}} of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
-docker pull docker.elastic.co/beats/heartbeat:{{stack-version}}
+docker pull docker.elastic.co/beats/heartbeat:{{version.stack}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
@@ -29,7 +29,7 @@ Alternatively, you can download other Docker images that contain only features a
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
 ```bash subs=true
-docker pull docker.elastic.co/beats/heartbeat-wolfi:{{stack-version}}
+docker pull docker.elastic.co/beats/heartbeat-wolfi:{{version.stack}}
 ```
 
 
@@ -38,19 +38,19 @@ docker pull docker.elastic.co/beats/heartbeat-wolfi:{{stack-version}}
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Heartbeat Docker image signature.
 
 % ::::{warning} subs=true
-% Version {{stack-version}} of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat {{stack-version}}.
+% Version {{version.stack}} of Heartbeat has not yet been released. No Docker image is currently available for Heartbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/heartbeat:{{stack-version}}
+cosign verify --key cosign.pub docker.elastic.co/beats/heartbeat:{{version.stack}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
 ```sh subs=true
-Verification for docker.elastic.co/beats/heartbeat:{{stack-version}} --
+Verification for docker.elastic.co/beats/heartbeat:{{version.stack}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -70,7 +70,7 @@ Running Heartbeat with the setup command will create the index pattern and load 
 ```sh subs=true
 docker run --rm \
 --cap-add=NET_RAW \
-docker.elastic.co/beats/heartbeat:{{stack-version}} \
+docker.elastic.co/beats/heartbeat:{{version.stack}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -95,7 +95,7 @@ For example:
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/heartbeat/data \
   --read-only \
-  docker.elastic.co/beats/heartbeat:{{stack-version}}
+  docker.elastic.co/beats/heartbeat:{{version.stack}}
 ```
 
 
@@ -108,7 +108,7 @@ The Docker image provides several methods for configuring Heartbeat. The convent
 Download this example configuration file as a starting point:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/heartbeat.docker.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/docker/heartbeat.docker.yml
 ```
 
 
@@ -122,7 +122,7 @@ docker run -d \
   --user=heartbeat \
   --volume="$(pwd)/heartbeat.docker.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --cap-add=NET_RAW \
-  docker.elastic.co/beats/heartbeat:{{stack-version}} \
+  docker.elastic.co/beats/heartbeat:{{version.stack}} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -142,7 +142,7 @@ The `heartbeat.docker.yml` downloaded earlier should be customized for your envi
 It’s possible to embed your Heartbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
 ```dockerfile subs=true
-FROM docker.elastic.co/beats/heartbeat:{{stack-version}}
+FROM docker.elastic.co/beats/heartbeat:{{version.stack}}
 COPY --chown=root:heartbeat heartbeat.yml /usr/share/heartbeat/heartbeat.yml
 ```
 
@@ -152,7 +152,7 @@ COPY --chown=root:heartbeat heartbeat.yml /usr/share/heartbeat/heartbeat.yml
 Under Docker, Heartbeat runs as a non-root user, but requires some privileged network capabilities to operate correctly. Ensure that the `NET_RAW` capability is available to the container.
 
 ```sh subs=true
-docker run --cap-add=NET_RAW docker.elastic.co/beats/heartbeat:{{stack-version}}
+docker run --cap-add=NET_RAW docker.elastic.co/beats/heartbeat:{{version.stack}}
 ```
 
 

--- a/docs/reference/heartbeat/running-on-kubernetes.md
+++ b/docs/reference/heartbeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-% However, version {{stack-version}} of Heartbeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{version.stack}} of Heartbeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests for Heartbeat [_kubernetes_deploy_manifests]
@@ -24,7 +24,7 @@ Everything is deployed under `kube-system` namespace, you can change that by upd
 To get the manifests just run:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/heartbeat-kubernetes.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/kubernetes/heartbeat-kubernetes.yaml
 ```
 
 ::::{warning}
@@ -75,7 +75,7 @@ Under Kubernetes, Heartbeat can run as a non-root user, but requires some privil
 ```yaml subs=true
 containers:
 - name: heartbeat
-  image: docker.elastic.co/beats/heartbeat:{{stack-version}}
+  image: docker.elastic.co/beats/heartbeat:{{version.stack}}
   securityContext:
     runAsUser: 1000
     runAsGroup: 1000

--- a/docs/reference/heartbeat/setup-repositories.md
+++ b/docs/reference/heartbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
     :::
 
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-release}}]
-    name=Elastic repository for {{major-release}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
+    [elastic-{{ version.stack | M.x }}]
+    name=Elastic repository for {{ version.stack | M.x }} packages
+    baseurl=https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/yum
     ```
     :::
 

--- a/docs/reference/loggingplugin/log-driver-configuration.md
+++ b/docs/reference/loggingplugin/log-driver-configuration.md
@@ -18,7 +18,7 @@ Use the following options to configure the Elastic Logging Plugin for Docker. Yo
 To set configuration options when you start a container:
 
 ```sh subs=true
-docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
+docker run --log-driver=elastic/elastic-logging-plugin:{{version.stack}} \
            --log-opt hosts="https://myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -29,7 +29,7 @@ To set configuration options for all containers in the `daemon.json` file:
 
 ```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
+  "log-driver" : "elastic/elastic-logging-plugin:{{version.stack}}",
   "log-opts" : {
     "hosts" : "https://myhost:9200",
     "user" : "myusername",
@@ -74,26 +74,26 @@ This plugin fully supports `docker logs`, and it maintains a local copy of logs 
 1. Disable the plugin:
 
     ```sh subs=true
-    docker plugin disable elastic/elastic-logging-plugin:{{stack-version}}
+    docker plugin disable elastic/elastic-logging-plugin:{{version.stack}}
     ```
 
 2. Set the bindmount directory:
 
     ```sh subs=true
-    docker plugin set elastic/elastic-logging-plugin:{{stack-version}} LOG_DIR.source=NEW_LOG_LOCATION
+    docker plugin set elastic/elastic-logging-plugin:{{version.stack}} LOG_DIR.source=NEW_LOG_LOCATION
     ```
 
 3. Enable the plugin:
 
     ```sh subs=true
-    docker plugin enable elastic/elastic-logging-plugin:{{stack-version}}
+    docker plugin enable elastic/elastic-logging-plugin:{{version.stack}}
     ```
 
 
 The local log also supports the `max-file`, `max-size` and `compress` options that are [a part of the Docker default file logger](https://docs.docker.com/config/containers/logging/json-file/#options). For example:
 
 ```sh subs=true
-docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
+docker run --log-driver=elastic/elastic-logging-plugin:{{version.stack}} \
            --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -108,19 +108,19 @@ In situations where logs can’t be easily managed, for example, you can also co
 1. Disable the plugin:
 
     ```sh subs=true
-    docker plugin disable elastic/elastic-logging-plugin:{{stack-version}}
+    docker plugin disable elastic/elastic-logging-plugin:{{version.stack}}
     ```
 
 2. Enable log removal:
 
     ```sh subs=true
-    docker plugin set elastic/elastic-logging-plugin:{{stack-version}} DESTROY_LOGS_ON_STOP=true
+    docker plugin set elastic/elastic-logging-plugin:{{version.stack}} DESTROY_LOGS_ON_STOP=true
     ```
 
 3. Enable the plugin:
 
     ```sh subs=true
-    docker plugin enable elastic/elastic-logging-plugin:{{stack-version}}
+    docker plugin enable elastic/elastic-logging-plugin:{{version.stack}}
     ```
 
 

--- a/docs/reference/loggingplugin/log-driver-installation.md
+++ b/docs/reference/loggingplugin/log-driver-installation.md
@@ -23,7 +23,7 @@ Make sure your system meets the following prerequisites:
     **To install from the Docker store:**
 
     ```sh subs=true
-    docker plugin install elastic/elastic-logging-plugin:{{stack-version}}
+    docker plugin install elastic/elastic-logging-plugin:{{version.stack}}
     ```
 
     **To build and install from source:**
@@ -38,7 +38,7 @@ Make sure your system meets the following prerequisites:
 2. If necessary, enable the plugin:
 
     ```sh subs=true
-    docker plugin enable elastic/elastic-logging-plugin:{{stack-version}}
+    docker plugin enable elastic/elastic-logging-plugin:{{version.stack}}
     ```
 
 3. Verify that the plugin is installed and enabled:
@@ -51,7 +51,7 @@ Make sure your system meets the following prerequisites:
 
     ```sh subs=true
     ID                  NAME                                   DESCRIPTION              ENABLED
-    c2ff9d2cf090        elastic/elastic-logging-plugin:{{stack-version}}   A beat for docker logs   true
+    c2ff9d2cf090        elastic/elastic-logging-plugin:{{version.stack}}   A beat for docker logs   true
     ```
 
 
@@ -65,7 +65,7 @@ You can set configuration options for a single container, or for all containers 
 Pass configuration options at run time when you start the container. For example:
 
 ```sh subs=true
-docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
+docker run --log-driver=elastic/elastic-logging-plugin:{{version.stack}} \
            --log-opt hosts="https://myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -78,7 +78,7 @@ Set configuration options in the Docker `daemon.json` configuration file. For ex
 
 ```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
+  "log-driver" : "elastic/elastic-logging-plugin:{{version.stack}}",
   "log-opts" : {
     "hosts" : "https://myhost:9200",
     "user" : "myusername",

--- a/docs/reference/loggingplugin/log-driver-usage-examples.md
+++ b/docs/reference/loggingplugin/log-driver-usage-examples.md
@@ -15,7 +15,7 @@ The following examples show common configurations for the Elastic Logging Plugin
 **Docker run command:**
 
 ```sh subs=true
-docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
+docker run --log-driver=elastic/elastic-logging-plugin:{{version.stack}} \
            --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -26,7 +26,7 @@ docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
 
 ```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
+  "log-driver" : "elastic/elastic-logging-plugin:{{version.stack}}",
   "log-opts" : {
     "hosts" : "myhost:9200",
     "user" : "myusername",
@@ -41,7 +41,7 @@ docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
 **Docker run command:**
 
 ```sh subs=true
-docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
+docker run --log-driver=elastic/elastic-logging-plugin:{{version.stack}} \
            --log-opt cloud_id="MyElasticStack:daMbY2VudHJhbDekZ2NwLmN4b3VkLmVzLmliJDVkYmQwtGJiYjs0NTRiN4Q5ODJmNGUwm1IxZmFkNjM5JDFiNjdkMDE4MTgxMTQzNTM5ZGFiYWJjZmY0OWIyYWE5" \
            --log-opt cloud_auth="myusername:mypassword" \
            -it debian:jessie /bin/bash
@@ -51,7 +51,7 @@ docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
 
 ```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
+  "log-driver" : "elastic/elastic-logging-plugin:{{version.stack}}",
   "log-opts" : {
     "cloud_id" : "MyElasticStack:daMbY2VudHJhbDekZ2NwLmN4b3VkLmVzLmliJDVkYmQwtGJiYjs0NTRiN4Q5ODJmNGUwm1IxZmFkNjM5JDFiNjdkMDE4MTgxMTQzNTM5ZGFiYWJjZmY0OWIyYWE5",
     "cloud_auth" : "myusername:mypassword",
@@ -66,7 +66,7 @@ docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
 **Docker run command:**
 
 ```sh subs=true
-docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
+docker run --log-driver=elastic/elastic-logging-plugin:{{version.stack}} \
            --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
@@ -78,7 +78,7 @@ docker run --log-driver=elastic/elastic-logging-plugin:{{stack-version}} \
 
 ```json subs=true
 {
-  "log-driver" : "elastic/elastic-logging-plugin:{{stack-version}}",
+  "log-driver" : "elastic/elastic-logging-plugin:{{version.stack}}",
   "log-opts" : {
     "hosts" : "myhost:9200",
     "user" : "myusername",

--- a/docs/reference/metricbeat/command-line-options.md
+++ b/docs/reference/metricbeat/command-line-options.md
@@ -92,7 +92,7 @@ Also see [Global flags](#global-flags).
 
 ```sh subs=true
 metricbeat export config
-metricbeat export template --es.version {{stack-version}}
+metricbeat export template --es.version {{version.stack}}
 metricbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/metricbeat/http-endpoint.md
+++ b/docs/reference/metricbeat/http-endpoint.md
@@ -66,7 +66,7 @@ curl -XGET 'localhost:5066/?pretty'
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "{{stack-version}}"
+  "version": "{{version.stack}}"
 }
 ```
 

--- a/docs/reference/metricbeat/load-kibana-dashboards.md
+++ b/docs/reference/metricbeat/load-kibana-dashboards.md
@@ -49,7 +49,7 @@ metricbeat setup --dashboards
 
 ::::::{tab-item} Docker
 ```sh  subs=true
-docker run --rm --net="host" docker.elastic.co/beats/metricbeat:{{stack-version}} setup --dashboards
+docker run --rm --net="host" docker.elastic.co/beats/metricbeat:{{version.stack}} setup --dashboards
 ```
 ::::::
 
@@ -125,7 +125,7 @@ metricbeat setup -e \
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/metricbeat:{{stack-version}} setup -e \
+docker run --rm --net="host" docker.elastic.co/beats/metricbeat:{{version.stack}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=metricbeat_internal \

--- a/docs/reference/metricbeat/logstash-output.md
+++ b/docs/reference/metricbeat/logstash-output.md
@@ -38,7 +38,7 @@ Every event sent to {{ls}} contains the following metadata fields that you can u
     ...
     "@metadata": { <1>
       "beat": "metricbeat", <2>
-      "version": "{{stack-version}}" <3>
+      "version": "{{version.stack}}" <3>
     }
 }
 ```

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -51,38 +51,38 @@ To download and install Metricbeat, use the commands that work with your system:
 ::::::{tab-item} DEB
 :sync: deb
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-amd64.deb
-sudo dpkg -i metricbeat-{{stack-version}}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{version.stack}}-amd64.deb
+sudo dpkg -i metricbeat-{{version.stack}}-amd64.deb
 ```
 ::::::
 
 ::::::{tab-item} RPM
 :sync: rpm
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-x86_64.rpm
-sudo rpm -vi metricbeat-{{stack-version}}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{version.stack}}-x86_64.rpm
+sudo rpm -vi metricbeat-{{version.stack}}-x86_64.rpm
 ```
 ::::::
 
 ::::::{tab-item} MacOS
 :sync: macos
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-darwin-x86_64.tar.gz
-tar xzvf metricbeat-{{stack-version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{version.stack}}-darwin-x86_64.tar.gz
+tar xzvf metricbeat-{{version.stack}}-darwin-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Linux
 :sync: linux
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-linux-x86_64.tar.gz
-tar xzvf metricbeat-{{stack-version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{version.stack}}-linux-x86_64.tar.gz
+tar xzvf metricbeat-{{version.stack}}-linux-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Windows
 :sync: windows
-1. Download the [Metricbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-windows-x86_64.zip).
+1. Download the [Metricbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{version.stack}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
 

--- a/docs/reference/metricbeat/metricbeat-template.md
+++ b/docs/reference/metricbeat/metricbeat-template.md
@@ -97,7 +97,7 @@ metricbeat setup --index-management -E output.logstash.enabled=false -E 'output.
 **docker:**
 
 ```sh subs=true
-docker run --rm docker.elastic.co/beats/metricbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+docker run --rm docker.elastic.co/beats/metricbeat:{{version.stack}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -171,7 +171,7 @@ metricbeat export template > metricbeat.template.json
 **win:**
 
 ```sh subs=true
-PS > .\metricbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 metricbeat.template.json
+PS > .\metricbeat.exe export template --es.version {{version.stack}} | Out-File -Encoding UTF8 metricbeat.template.json
 ```
 
 To install the template, run:
@@ -179,50 +179,50 @@ To install the template, run:
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{stack-version}} -d@metricbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{version.stack}} -d@metricbeat.template.json
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{stack-version}} -d@metricbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{version.stack}} -d@metricbeat.template.json
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{stack-version}} -d@metricbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/metricbeat-{{version.stack}} -d@metricbeat.template.json
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile metricbeat.template.json -Uri http://localhost:9200/_index_template/metricbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile metricbeat.template.json -Uri http://localhost:9200/_index_template/metricbeat-{{version.stack}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on metricbeat-{{stack-version}} index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on metricbeat-{{version.stack}} index.
 
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{version.stack}}
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{version.stack}}
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/metricbeat-{{version.stack}}
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/metricbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/metricbeat-{{version.stack}}
 ```
 

--- a/docs/reference/metricbeat/running-on-cloudfoundry.md
+++ b/docs/reference/metricbeat/running-on-cloudfoundry.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 You can use Metricbeat on Cloud Foundry to retrieve and ship metrics.
 
-% However, version {{stack-version}} of Metricbeat has not yet been released, no build is currently available for this version.
+% However, version {{version.stack}} of Metricbeat has not yet been released, no build is currently available for this version.
 
 ## Create Cloud Foundry credentials [_create_cloud_foundry_credentials]
 
@@ -31,11 +31,11 @@ You deploy Metricbeat as an application with no route.
 Cloud Foundry requires that 3 files exist inside of a directory to allow Metricbeat to be pushed. The commands below provide the basic steps for getting it up and running.
 
 ```sh subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{stack-version}}-linux-x86_64.tar.gz
-tar xzvf metricbeat-{{stack-version}}-linux-x86_64.tar.gz
-cd metricbeat-{{stack-version}}-linux-x86_64
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/metricbeat/metricbeat.yml
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/cloudfoundry/metricbeat/manifest.yml
+curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{{version.stack}}-linux-x86_64.tar.gz
+tar xzvf metricbeat-{{version.stack}}-linux-x86_64.tar.gz
+cd metricbeat-{{version.stack}}-linux-x86_64
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/cloudfoundry/metricbeat/metricbeat.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/cloudfoundry/metricbeat/manifest.yml
 ```
 
 You need to modify the `metricbeat.yml` file to set the `api_address`, `client_id` and `client_secret`.

--- a/docs/reference/metricbeat/running-on-docker.md
+++ b/docs/reference/metricbeat/running-on-docker.md
@@ -16,12 +16,12 @@ These images are free to use under the Elastic license. They contain open source
 Obtaining Metricbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
 % ::::{warning} subs=true
-% Version {{stack-version}} of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat {{stack-version}}.
+% Version {{version.stack}} of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
-docker pull docker.elastic.co/beats/metricbeat:{{stack-version}}
+docker pull docker.elastic.co/beats/metricbeat:{{version.stack}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
@@ -29,7 +29,7 @@ Alternatively, you can download other Docker images that contain only features a
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
 ```bash subs=true
-docker pull docker.elastic.co/beats/metricbeat-wolfi:{{stack-version}}
+docker pull docker.elastic.co/beats/metricbeat-wolfi:{{version.stack}}
 ```
 
 
@@ -38,19 +38,19 @@ docker pull docker.elastic.co/beats/metricbeat-wolfi:{{stack-version}}
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Metricbeat Docker image signature.
 
 % ::::{warning}
-% Version {{stack-version}} of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat {{stack-version}}.
+% Version {{version.stack}} of Metricbeat has not yet been released. No Docker image is currently available for Metricbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/metricbeat:{{stack-version}}
+cosign verify --key cosign.pub docker.elastic.co/beats/metricbeat:{{version.stack}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
 ```sh subs=true
-Verification for docker.elastic.co/beats/metricbeat:{{stack-version}} --
+Verification for docker.elastic.co/beats/metricbeat:{{version.stack}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -69,7 +69,7 @@ Running Metricbeat with the setup command will create the index pattern and load
 
 ```sh subs=true
 docker run --rm \
-docker.elastic.co/beats/metricbeat:{{stack-version}} \
+docker.elastic.co/beats/metricbeat:{{version.stack}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -94,7 +94,7 @@ For example:
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/metricbeat/data \
   --read-only \
-  docker.elastic.co/beats/metricbeat:{{stack-version}}
+  docker.elastic.co/beats/metricbeat:{{version.stack}}
 ```
 
 
@@ -107,7 +107,7 @@ The Docker image provides several methods for configuring Metricbeat. The conven
 Download this example configuration file as a starting point:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/metricbeat.docker.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/docker/metricbeat.docker.yml
 ```
 
 
@@ -124,7 +124,7 @@ docker run -d \
   --volume="/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro" \
   --volume="/proc:/hostfs/proc:ro" \
   --volume="/:/hostfs:ro" \
-  docker.elastic.co/beats/metricbeat:{{stack-version}} metricbeat -e \
+  docker.elastic.co/beats/metricbeat:{{version.stack}} metricbeat -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
 
@@ -157,7 +157,7 @@ docker run \
 It’s possible to embed your Metricbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
 ```dockerfile subs=true
-FROM docker.elastic.co/beats/metricbeat:{{stack-version}}
+FROM docker.elastic.co/beats/metricbeat:{{version.stack}}
 COPY --chown=root:metricbeat metricbeat.yml /usr/share/metricbeat/metricbeat.yml
 ```
 
@@ -177,7 +177,7 @@ docker run \
   --env DBUS_SYSTEM_BUS_ADDRESS='unix:path=/hostfs/var/run/dbus/system_bus_socket' \ <4>
   --net=host \ <5>
   --cgroupns=host \ <6>
-  docker.elastic.co/beats/metricbeat:{{stack-version}} -e --system.hostfs=/hostfs
+  docker.elastic.co/beats/metricbeat:{{version.stack}} -e --system.hostfs=/hostfs
 ```
 
 1. Metricbeat’s [system module](/reference/metricbeat/metricbeat-module-system.md) collects much of its data through the Linux proc filesystem, which is normally located at `/proc`. Because containers are isolated as much as possible from the host, the data inside of the container’s `/proc` is different than the host’s `/proc`. To account for this, you can mount the host’s `/proc` filesystem inside of the container and tell Metricbeat to look inside the `/hostfs` directory when looking for `/proc` by using the `hostfs=/hostfs` config value.
@@ -208,7 +208,7 @@ Next, let’s look at an example of monitoring a containerized service from a Me
 docker run \
   --network=mysqlnet \ <1>
   -e MYSQL_PASSWORD=secret \ <2>
-  docker.elastic.co/beats/metricbeat:{{stack-version}}
+  docker.elastic.co/beats/metricbeat:{{version.stack}}
 ```
 
 1. Placing the Metricbeat and MySQL containers on the same Docker network allows Metricbeat access to the exposed ports of the MySQL container, and makes the hostname `mysql` resolvable to Metricbeat.

--- a/docs/reference/metricbeat/running-on-kubernetes.md
+++ b/docs/reference/metricbeat/running-on-kubernetes.md
@@ -12,7 +12,7 @@ Running {{ecloud}} on Kubernetes? See [Run {{beats}} on ECK](docs-content://depl
 ::::
 
 
-% However, version {{stack-version}} of Metricbeat has not yet been released, so no Docker image is currently available for this version.
+% However, version {{version.stack}} of Metricbeat has not yet been released, so no Docker image is currently available for this version.
 
 
 ## Kubernetes deploy manifests for Metricbeat [_kubernetes_deploy_manifests]
@@ -28,7 +28,7 @@ Everything is deployed under the `kube-system` namespace by default. To change t
 To download the manifest file, run:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/kubernetes/metricbeat-kubernetes.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/kubernetes/metricbeat-kubernetes.yaml
 ```
 
 ::::{warning}

--- a/docs/reference/metricbeat/setup-repositories.md
+++ b/docs/reference/metricbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
     :::
 
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-release}}]
-    name=Elastic repository for {{major-release}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
+    [elastic-{{ version.stack | M.x }}]
+    name=Elastic repository for {{ version.stack | M.x }} packages
+    baseurl=https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/yum
     ```
     :::
 

--- a/docs/reference/packetbeat/command-line-options.md
+++ b/docs/reference/packetbeat/command-line-options.md
@@ -91,7 +91,7 @@ Also see [Global flags](#global-flags).
 
 ```sh subs=true
 packetbeat export config
-packetbeat export template --es.version {{stack-version}}
+packetbeat export template --es.version {{version.stack}}
 packetbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/packetbeat/configuration-flows.md
+++ b/docs/reference/packetbeat/configuration-flows.md
@@ -33,7 +33,7 @@ Here’s an example of a flow information sent by Packetbeat. See [*Flow Event f
   "agent": {
     "hostname": "host.example.com",
     "name": "host.example.com",
-    "version": "{{stack-version}}"
+    "version": "{{version.stack}}"
   },
   "destination": {
     "bytes": 460,

--- a/docs/reference/packetbeat/http-endpoint.md
+++ b/docs/reference/packetbeat/http-endpoint.md
@@ -66,7 +66,7 @@ curl -XGET 'localhost:5066/?pretty'
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "{{stack-version}}"
+  "version": "{{version.stack}}"
 }
 ```
 

--- a/docs/reference/packetbeat/load-kibana-dashboards.md
+++ b/docs/reference/packetbeat/load-kibana-dashboards.md
@@ -49,7 +49,7 @@ packetbeat setup --dashboards
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/packetbeat:{{stack-version}} setup --dashboards
+docker run --rm --net="host" docker.elastic.co/beats/packetbeat:{{version.stack}} setup --dashboards
 ```
 ::::::
 
@@ -125,7 +125,7 @@ packetbeat setup -e \
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/packetbeat:{{stack-version}} setup -e \
+docker run --rm --net="host" docker.elastic.co/beats/packetbeat:{{version.stack}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=packetbeat_internal \

--- a/docs/reference/packetbeat/logstash-output.md
+++ b/docs/reference/packetbeat/logstash-output.md
@@ -38,7 +38,7 @@ Every event sent to {{ls}} contains the following metadata fields that you can u
     ...
     "@metadata": { <1>
       "beat": "packetbeat", <2>
-      "version": "{{stack-version}}" <3>
+      "version": "{{version.stack}}" <3>
     }
 }
 ```

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -88,38 +88,38 @@ This guide describes how to get started quickly with network packets analytics. 
 ::::::{tab-item} DEB
 :sync: deb
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-amd64.deb
-sudo dpkg -i packetbeat-{{stack-version}}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{version.stack}}-amd64.deb
+sudo dpkg -i packetbeat-{{version.stack}}-amd64.deb
 ```
 ::::::
 
 ::::::{tab-item} RPM
 :sync: rpm
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-x86_64.rpm
-sudo rpm -vi packetbeat-{{stack-version}}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{version.stack}}-x86_64.rpm
+sudo rpm -vi packetbeat-{{version.stack}}-x86_64.rpm
 ```
 ::::::
 
 ::::::{tab-item} MacOS
 :sync: macos
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-darwin-x86_64.tar.gz
-tar xzvf packetbeat-{{stack-version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{version.stack}}-darwin-x86_64.tar.gz
+tar xzvf packetbeat-{{version.stack}}-darwin-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Linux
 :sync: linux
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-linux-x86_64.tar.gz
-tar xzvf packetbeat-{{stack-version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{version.stack}}-linux-x86_64.tar.gz
+tar xzvf packetbeat-{{version.stack}}-linux-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Windows
 :sync: windows
-1. Download the [Packetbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{stack-version}}-windows-x86_64.zip).
+1. Download the [Packetbeat Windows zip file](https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{{version.stack}}-windows-x86_64.zip).
 
 2. Extract the contents of the zip file into `C:\Program Files`.
 

--- a/docs/reference/packetbeat/packetbeat-template.md
+++ b/docs/reference/packetbeat/packetbeat-template.md
@@ -102,7 +102,7 @@ packetbeat setup --index-management -E output.logstash.enabled=false -E 'output.
 **docker:**
 
 ```sh subs=true
-docker run --rm docker.elastic.co/beats/packetbeat:{{stack-version}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
+docker run --rm docker.elastic.co/beats/packetbeat:{{version.stack}} setup --index-management -E output.logstash.enabled=false -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ```
 
 **win:**
@@ -176,7 +176,7 @@ packetbeat export template > packetbeat.template.json
 **win:**
 
 ```sh subs=true
-PS > .\packetbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 packetbeat.template.json
+PS > .\packetbeat.exe export template --es.version {{version.stack}} | Out-File -Encoding UTF8 packetbeat.template.json
 ```
 
 To install the template, run:
@@ -184,50 +184,50 @@ To install the template, run:
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{stack-version}} -d@packetbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{version.stack}} -d@packetbeat.template.json
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{stack-version}} -d@packetbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{version.stack}} -d@packetbeat.template.json
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{stack-version}} -d@packetbeat.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/packetbeat-{{version.stack}} -d@packetbeat.template.json
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile packetbeat.template.json -Uri http://localhost:9200/_index_template/packetbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile packetbeat.template.json -Uri http://localhost:9200/_index_template/packetbeat-{{version.stack}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on packetbeat-{{stack-version}} index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on packetbeat-{{version.stack}} index.
 
 **deb and rpm:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{version.stack}}
 ```
 
 **mac:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{version.stack}}
 ```
 
 **linux:**
 
 ```sh subs=true
-curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
+curl -XPUT http://localhost:9200/_data_stream/packetbeat-{{version.stack}}
 ```
 
 **win:**
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/packetbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/packetbeat-{{version.stack}}
 ```
 

--- a/docs/reference/packetbeat/running-on-docker.md
+++ b/docs/reference/packetbeat/running-on-docker.md
@@ -16,12 +16,12 @@ These images are free to use under the Elastic license. They contain open source
 Obtaining Packetbeat for Docker is as simple as issuing a `docker pull` command against the Elastic Docker registry.
 
 % ::::{warning} subs=true
-% Version {{stack-version}} of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat {{stack-version}}.
+% Version {{version.stack}} of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
-docker pull docker.elastic.co/beats/packetbeat:{{stack-version}}
+docker pull docker.elastic.co/beats/packetbeat:{{version.stack}}
 ```
 
 Alternatively, you can download other Docker images that contain only features available under the Apache 2.0 license. To download the images, go to [www.docker.elastic.co](https://www.docker.elastic.co).
@@ -29,7 +29,7 @@ Alternatively, you can download other Docker images that contain only features a
 As another option, you can use the hardened [Wolfi](https://wolfi.dev/) image. Using Wolfi images requires Docker version 20.10.10 or higher. For details about why the Wolfi images have been introduced, refer to our article [Reducing CVEs in Elastic container images](https://www.elastic.co/blog/reducing-cves-in-elastic-container-images).
 
 ```bash subs=true
-docker pull docker.elastic.co/beats/packetbeat-wolfi:{{stack-version}}
+docker pull docker.elastic.co/beats/packetbeat-wolfi:{{version.stack}}
 ```
 
 
@@ -38,19 +38,19 @@ docker pull docker.elastic.co/beats/packetbeat-wolfi:{{stack-version}}
 You can use the [Cosign application](https://docs.sigstore.dev/cosign/installation/) to verify the Packetbeat Docker image signature.
 
 % ::::{warning} subs=true
-% Version {{stack-version}} of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat {{stack-version}}.
+% Version {{version.stack}} of Packetbeat has not yet been released. No Docker image is currently available for Packetbeat {{version.stack}}.
 % ::::
 
 
 ```sh subs=true
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub docker.elastic.co/beats/packetbeat:{{stack-version}}
+cosign verify --key cosign.pub docker.elastic.co/beats/packetbeat:{{version.stack}}
 ```
 
 The `cosign` command prints the check results and the signature payload in JSON format:
 
 ```sh subs=true
-Verification for docker.elastic.co/beats/packetbeat:{{stack-version}} --
+Verification for docker.elastic.co/beats/packetbeat:{{version.stack}} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -70,7 +70,7 @@ Running Packetbeat with the setup command will create the index pattern and load
 ```sh subs=true
 docker run --rm \
 --cap-add=NET_ADMIN \
-docker.elastic.co/beats/packetbeat:{{stack-version}} \
+docker.elastic.co/beats/packetbeat:{{version.stack}} \
 setup -E setup.kibana.host=kibana:5601 \
 -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -95,7 +95,7 @@ For example:
 docker run --rm \
   --mount type=bind,source=$(pwd)/data,destination=/usr/share/packetbeat/data \
   --read-only \
-  docker.elastic.co/beats/packetbeat:{{stack-version}}
+  docker.elastic.co/beats/packetbeat:{{version.stack}}
 ```
 
 
@@ -108,7 +108,7 @@ The Docker image provides several methods for configuring Packetbeat. The conven
 Download this example configuration file as a starting point:
 
 ```sh subs=true
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{{major-version}}/deploy/docker/packetbeat.docker.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.M }}/deploy/docker/packetbeat.docker.yml
 ```
 
 
@@ -124,7 +124,7 @@ docker run -d \
   --cap-add="NET_RAW" \
   --cap-add="NET_ADMIN" \
   --network=host \
-  docker.elastic.co/beats/packetbeat:{{stack-version}} \
+  docker.elastic.co/beats/packetbeat:{{version.stack}} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -144,7 +144,7 @@ The `packetbeat.docker.yml` downloaded earlier should be customized for your env
 It’s possible to embed your Packetbeat configuration in a custom image. Here is an example Dockerfile to achieve this:
 
 ```dockerfile subs=true
-FROM docker.elastic.co/beats/packetbeat:{{stack-version}}
+FROM docker.elastic.co/beats/packetbeat:{{version.stack}}
 COPY --chown=root:packetbeat packetbeat.yml /usr/share/packetbeat/packetbeat.yml
 ```
 
@@ -154,7 +154,7 @@ COPY --chown=root:packetbeat packetbeat.yml /usr/share/packetbeat/packetbeat.yml
 Under Docker, Packetbeat runs as a non-root user, but requires some privileged network capabilities to operate correctly. Ensure that the `NET_ADMIN` capability is available to the container.
 
 ```sh subs=true
-docker run --cap-add=NET_ADMIN docker.elastic.co/beats/packetbeat:{{stack-version}}
+docker run --cap-add=NET_ADMIN docker.elastic.co/beats/packetbeat:{{version.stack}}
 ```
 
 
@@ -163,7 +163,7 @@ docker run --cap-add=NET_ADMIN docker.elastic.co/beats/packetbeat:{{stack-versio
 By default, Docker networking will connect the Packetbeat container to an isolated virtual network, with a limited view of network traffic. You may wish to connect the container directly to the host network in order to see traffic destined for, and originating from, the host system. With `docker run`, this can be achieved by specifying `--network=host`.
 
 ```sh subs=true
-docker run --cap-add=NET_ADMIN --network=host docker.elastic.co/beats/packetbeat:{{stack-version}}
+docker run --cap-add=NET_ADMIN --network=host docker.elastic.co/beats/packetbeat:{{version.stack}}
 ```
 
 ::::{note}

--- a/docs/reference/packetbeat/setup-repositories.md
+++ b/docs/reference/packetbeat/setup-repositories.md
@@ -31,17 +31,17 @@ To add the Beats repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{major-release}}.list_:
+3. Save the repository definition to _/etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list_:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
 
     :::{note}
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following sources list:
 
     ```shell subs=true
-    echo "deb https://artifacts.elastic.co/packages/oss-{{major-release}}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{major-release}}.list
+    echo "deb https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{ version.stack | M.x }}.list
     ```
     :::
 
@@ -83,9 +83,9 @@ To add the Beats repository for YUM:
 2. Create a file with a `.repo` extension (for example, `elastic.repo`) in your `/etc/yum.repos.d/` directory and add the following lines:
 
     ```shell subs=true
-    [elastic-{{major-release}}]
-    name=Elastic repository for {{major-release}} packages
-    baseurl=https://artifacts.elastic.co/packages/{{major-release}}/yum
+    [elastic-{{ version.stack | M.x }}]
+    name=Elastic repository for {{ version.stack | M.x }} packages
+    baseurl=https://artifacts.elastic.co/packages/{{ version.stack | M.x }}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -97,7 +97,7 @@ To add the Beats repository for YUM:
     The package is free to use under the Elastic license. An alternative package which contains only features that are available under the Apache 2.0 license is also available. To install it, use the following `baseurl` in your `.repo` file:
 
     ```shell subs=true
-    baseurl=https://artifacts.elastic.co/packages/oss-{{major-release}}/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-{{ version.stack | M.x }}/yum
     ```
     :::
 

--- a/docs/reference/winlogbeat/command-line-options.md
+++ b/docs/reference/winlogbeat/command-line-options.md
@@ -87,7 +87,7 @@ Also see [Global flags](#global-flags).
 
 ```sh subs=true
 winlogbeat export config
-winlogbeat export template --es.version {{stack-version}}
+winlogbeat export template --es.version {{version.stack}}
 winlogbeat export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 ```
 

--- a/docs/reference/winlogbeat/http-endpoint.md
+++ b/docs/reference/winlogbeat/http-endpoint.md
@@ -66,7 +66,7 @@ curl -XGET 'localhost:5066/?pretty'
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",
-  "version": "{{stack-version}}"
+  "version": "{{version.stack}}"
 }
 ```
 

--- a/docs/reference/winlogbeat/load-kibana-dashboards.md
+++ b/docs/reference/winlogbeat/load-kibana-dashboards.md
@@ -44,7 +44,7 @@ winlogbeat setup --dashboards
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:{{stack-version}} setup --dashboards
+docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:{{version.stack}} setup --dashboards
 ```
 ::::::
 
@@ -120,7 +120,7 @@ winlogbeat setup -e \
 
 ::::::{tab-item} Docker
 ```sh subs=true
-docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:{{stack-version}} setup -e \
+docker run --rm --net="host" docker.elastic.co/beats/winlogbeat:{{version.stack}} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username=winlogbeat_internal \

--- a/docs/reference/winlogbeat/logstash-output.md
+++ b/docs/reference/winlogbeat/logstash-output.md
@@ -38,7 +38,7 @@ Every event sent to {{ls}} contains the following metadata fields that you can u
     ...
     "@metadata": { <1>
       "beat": "winlogbeat", <2>
-      "version": "{{stack-version}}" <3>
+      "version": "{{version.stack}}" <3>
     }
 }
 ```

--- a/docs/reference/winlogbeat/winlogbeat-template.md
+++ b/docs/reference/winlogbeat/winlogbeat-template.md
@@ -105,18 +105,18 @@ If the host running Winlogbeat does not have direct connectivity to {{es}}, you 
 To export the index template, run:
 
 ```sh subs=true
-PS > .\winlogbeat.exe export template --es.version {{stack-version}} | Out-File -Encoding UTF8 winlogbeat.template.json
+PS > .\winlogbeat.exe export template --es.version {{version.stack}} | Out-File -Encoding UTF8 winlogbeat.template.json
 ```
 
 To install the template, run:
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile winlogbeat.template.json -Uri http://localhost:9200/_index_template/winlogbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile winlogbeat.template.json -Uri http://localhost:9200/_index_template/winlogbeat-{{version.stack}}
 ```
 
-Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on winlogbeat-{{stack-version}} index.
+Once you have loaded the index template, load the data stream as well. If you do not load it, you have to give the publisher user `manage` permission on winlogbeat-{{version.stack}} index.
 
 ```sh subs=true
-PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/winlogbeat-{{stack-version}}
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/winlogbeat-{{version.stack}}
 ```
 


### PR DESCRIPTION
Use [version variables](https://elastic.github.io/docs-builder/syntax/version-variables/) from the central configuration instead of relying on docset-level version-related `subs` so we don't have to update those values in this repo for every release.

Note: This is currently blocked by https://github.com/elastic/docs-builder/issues/1605.