### PR TITLE
dependabot: Add Windows dependencies to allow list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,10 @@ updates:
       - dependency-name: github.com/lib/pq
       - dependency-name: github.com/godror/godror
       - dependency-name: github.com/microsoft/go-mssqldb
+      # Windows dependencies
+      - dependency-name: "github.com/microsoft/wmi"
+      - dependency-name: "github.com/go-ole/go-ole"
+      - dependency-name: "github.com/StackExchange/wmi"
     groups:
       windows:
         patterns:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Add the Windows-related dependencies to the 'allow' list so that it works. In one of the previous PRs, entries were made only to the groups list, but now the 'allow' list and hence Dependabot was not creating the PRs.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->