### PR TITLE
Add applies_to tag to mark version-related changes

### DIFF
--- a/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
+++ b/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
@@ -499,6 +499,10 @@ filebeat.inputs:
 **Explanation :** In this configuration even though we have specified `max_workers = 10`, `poll = true` and `poll_interval = 15s` at the root level, both the containers will override these values with their own respective values which are defined as part of their sub attibutes.
 
 ## Metrics [_metrics]
+```{applies_to}
+  stack: ga 9.0.4
+```
+
 This input exposes metrics under the [HTTP monitoring endpoint](/reference/filebeat/http-endpoint.md).
 These metrics are exposed under the `/inputs` path. They can be used to
 observe the activity of the input.


### PR DESCRIPTION
Type of change:
- Docs

## Proposed commit message

- Added `applies_to` tag to the Metrics heading in `docs/reference/filebeat/filebeat-input-azure-blob-storage.md`
- Reason for change: Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - added `applies_to` version tag
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
