### PR TITLE
Add `applies_to` tags to mark version-related changes

### DIFF
--- a/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
+++ b/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
@@ -39,13 +39,12 @@ filebeat.inputs:
     poll: true
     poll_interval: 10s
   - name: container_2
-    batch_size: 50 <2>
+    batch_size: 50 <1>
     max_workers: 3
     poll: true
     poll_interval: 10s
 ```
 1. {applies_to}`stack: ga 9.1.0`
-2. {applies_to}`stack: ga 9.1.0`
 
 **Explanation :** This `configuration` given above describes a basic blob storage config having two containers named `container_1` and `container_2`. Each of these containers have their own attributes such as `name`, `batch_size` {applies_to}`stack: ga 9.1.0`, `max_workers`, `poll` and `poll_interval`. These attributes have detailed explanations given [below](#supported-attributes). For now lets try to understand how this config works.
 


### PR DESCRIPTION
Type of change:
- Docs

## Proposed commit message

- Added `applies_to` tags to the version-related changes in `docs/reference/filebeat/filebeat-input-azure-blob-storage.md`
- Reason for change: Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - added `applies_to` version tags
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.