### PR TITLE
[docs] Adds `applies_to` to changes from #43655

### DIFF
--- a/docs/reference/filebeat/filebeat-input-entity-analytics.md
+++ b/docs/reference/filebeat/filebeat-input-entity-analytics.md
@@ -2,6 +2,8 @@
 navigation_title: "Entity Analytics"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-entity-analytics.html
+applies_to:
+  stack: preview
 ---
 
 # Entity Analytics Input [filebeat-input-entity-analytics]
@@ -972,6 +974,10 @@ The time between Okta API rate limit resets. Expressed as a duration string (e.g
 
 
 #### `batch_size` [_batch_size]
+
+```{applies_to}
+stack: preview 9.0.1
+```
 
 The pagination batch size for requests. If it is zero or negative, the API default is used. The default is 200.
 


### PR DESCRIPTION
>[!NOTE]
>Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

In https://github.com/elastic/beats/pull/43655, @efd6 added support for pagination batch size. According to the [release notes](https://www.elastic.co/docs/release-notes/beats#beats-9.0.1-release-notes), this was added in 9.0.1. This PR adds a 9.0.1 `applies_to` label to the `batch_size` heading in  `docs/reference/filebeat/filebeat-input-entity-analytics.md`.