### PR TITLE
[docs] Adds `applies_to` to changes from #44892 

### DIFF
--- a/docs/reference/filebeat/filebeat-input-gcp-pubsub.md
+++ b/docs/reference/filebeat/filebeat-input-gcp-pubsub.md
@@ -71,6 +71,10 @@ JSON blob containing the credentials and key used to subscribe. This can be as a
 
 ### `proxy_url` [_proxy_url]
 
+```{applies_to}
+stack: ga 9.1.0
+```
+
 This specifies proxy configuration in the form of `http[s]://<user>:<password>@<server name/ip>:<port>`. Proxy headers may be configured using the `resource.proxy_headers` field which accepts a set of key/value pairs.
 
 ```yaml


### PR DESCRIPTION
>[!NOTE]
>Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

In https://github.com/elastic/beats/pull/44892, @efd6 added proxy support to GCP Pub/Sub input and it was confirmed that this is going into 9.1.0. We should add 9.1.0 `applies_to` labels to `docs/reference/filebeat/filebeat-input-gcp-pubsub.md`.