### PR TITLE
[docs] Adds `applies_to` to changes from #44761

### DIFF
--- a/docs/reference/filebeat/filebeat-input-entity-analytics.md
+++ b/docs/reference/filebeat/filebeat-input-entity-analytics.md
@@ -2,6 +2,8 @@
 navigation_title: "Entity Analytics"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-entity-analytics.html
+applies_to:
+  stack: preview
 ---
 
 # Entity Analytics Input [filebeat-input-entity-analytics]
@@ -468,7 +470,7 @@ filebeat.inputs:
   client_id: "CLIENT_ID"
   tenant_id: "TENANT_ID"
   secret: "SECRET"
-  expand:
+  expand: <1>
     users:
       manager:
         - displayName
@@ -476,6 +478,7 @@ filebeat.inputs:
       directReports:
         - id
 ```
+1. {applies_to}`stack: preview 9.1.0`
 
 The `azure-ad` provider supports the following configuration:
 
@@ -537,15 +540,27 @@ Override the default [device query selections](https://learn.microsoft.com/en-us
 
 #### `expand.users` [_expand_users]
 
+```{applies_to}
+stack: preview 9.1.0
+```
+
 Add [user query relationship expansions](https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#relationships). This is a map of relationship names to attribute lists. By default this is not set. If an empty relationship list is given, the relationship expansion is the same as the users query.
 
 
 #### `expand.groups` [_expand_groups]
 
+```{applies_to}
+stack: preview 9.1.0
+```
+
 Add [group query relationship expansions](https://learn.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-1.0#relationships). This is a map of relationship names to attribute lists. By default this is not set. If an empty relationship list is given, the relationship expansion is the same as the groups query.
 
 
 #### `expand.devices` [_expand_devices]
+
+```{applies_to}
+stack: preview 9.1.0
+```
 
 Add [device query relationship expansions](https://learn.microsoft.com/en-us/graph/api/resources/device?view=graph-rest-1.0#relationships). This is a map of relationship names to attribute lists. By default this is not set. If an empty relationship list is given, the relationship expansion is the same as the devices query.
 


### PR DESCRIPTION
>[!NOTE]
>Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

In https://github.com/elastic/beats/pull/44761, @efd6 added support for `expand` in the azure-ad provider. The 9.0 backport was closed without merging, but it is in 9.1 so I _think_ we should add 9.1.0 `applies_to` labels to the new options in `docs/reference/filebeat/filebeat-input-entity-analytics.md`.

Note for @elastic/ingest-docs: For the [code block callout](https://elastic.github.io/docs-builder/syntax/code/#code-callouts), I couldn't come up with language that would make sense alongside the `applies_to` label both when it is rendered as `Planned` before the release and a specific version number after the release. Do you think it's ok to just add the label on its own? Do you have any suggestions for language that would make sense? 

<img width="859" height="494" alt="Screenshot 2025-07-24 at 4 22 11 PM" src="https://github.com/user-attachments/assets/94c79329-e518-4024-93cd-a50358e5b372" />
