### PR TITLE
[8.19](backport #45315) Docs: Fix wrong host reference in add_kubernetes_metadata

### DIFF
--- a/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
+++ b/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
@@ -79,7 +79,7 @@ the Kubernetes node.
 -------------------------------------------------------------------------------
 processors:
   - add_kubernetes_metadata:
-      host: <hostname>
+      node: <kubernetes_node_name>
       # If kube_config is not set, KUBECONFIG environment variable will be checked
       # and if not present it will fall back to InCluster
       kube_config: ${HOME}/.kube/config
@@ -102,7 +102,7 @@ enables ones that the user is interested in.
 -------------------------------------------------------------------------------
 processors:
   - add_kubernetes_metadata:
-      host: <hostname>
+      node: <kubernetes_node_name>
       # If kube_config is not set, KUBECONFIG environment variable will be checked
       # and if not present it will fall back to InCluster
       kube_config: ~/.kube/config
@@ -119,7 +119,7 @@ processors:
 
 The `add_kubernetes_metadata` processor has the following configuration settings:
 
-`host`:: (Optional) Specify the node to scope {beatname_lc} to in case it
+`node`:: (Optional) Specify the node to scope {beatname_lc} to in case it
 cannot be accurately detected, as when running {beatname_lc} in host network
 mode.
 `scope`:: (Optional) Specify if the processor should have visibility at the node level or at the entire cluster


### PR DESCRIPTION
This is a manual backport of https://github.com/elastic/beats/pull/45315 

---

- Docs

## Proposed commit message

Fix the `host` reference on `add_kubernetes_metadata` with correct param `node`.
Rif commit that brake this: https://github.com/elastic/beats/commit/c1d4f28ff30e28429efed51c817cd02d46633aac
Rif current spec: https://github.com/elastic/beats/blob/main/libbeat/autodiscover/providers/kubernetes/config.go#L47

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.