### PR TITLE
feat(heartbeat): remove deprecated certificate fields

### DIFF
--- a/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta.go
+++ b/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta.go
@@ -75,9 +75,7 @@ func CertFields(hostCert *x509.Certificate, verifiedChains [][]*x509.Certificate
 	_, _ = x509Fields.Put("signature_algorithm", hostCert.SignatureAlgorithm.String())
 	_, _ = x509Fields.Put("public_key_algorithm", hostCert.PublicKeyAlgorithm.String())
 	_, _ = x509Fields.Put("not_before", hostCert.NotBefore)
-	_, _ = tlsFields.Put("certificate_not_valid_before", hostCert.NotBefore)
 	_, _ = x509Fields.Put("not_after", hostCert.NotAfter)
-	_, _ = tlsFields.Put("certificate_not_valid_after", hostCert.NotAfter)
 	if rsaKey, ok := hostCert.PublicKey.(*rsa.PublicKey); ok {
 		sizeInBits := rsaKey.Size() * 8
 		_, _ = x509Fields.Put("public_key_size", sizeInBits)
@@ -115,12 +113,8 @@ func CertFields(hostCert *x509.Certificate, verifiedChains [][]*x509.Certificate
 			latestChainExpiration = *chainNotAfter
 		}
 
-		// Legacy non-ECS field
-		_, _ = tlsFields.Put("certificate_not_valid_before", chainNotBefore)
 		_, _ = x509Fields.Put("not_before", chainNotBefore)
 		if chainNotAfter != nil {
-			// Legacy non-ECS field
-			_, _ = tlsFields.Put("certificate_not_valid_after", *chainNotAfter)
 			_, _ = x509Fields.Put("not_after", *chainNotAfter)
 		}
 	}

--- a/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta_test.go
+++ b/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta_test.go
@@ -114,8 +114,6 @@ func TestCertFields(t *testing.T) {
 	require.NoError(t, err)
 
 	elasticCertFields := lookslike.Strict(lookslike.MustCompile(map[string]interface{}{
-		"certificate_not_valid_after":  certNotAfter,
-		"certificate_not_valid_before": certNotBefore,
 		"server": mapstr.M{
 			"hash": mapstr.M{
 				"sha1":   "b7b4b89ef0d0caf39d223736f0fdbb03c7b426f1",
@@ -145,8 +143,6 @@ func TestCertFields(t *testing.T) {
 
 	letsEncryptCertFields := func(notBefore time.Time, notAfter time.Time) validator.Validator {
 		return lookslike.Strict(lookslike.MustCompile(map[string]interface{}{
-			"certificate_not_valid_before": notBefore,
-			"certificate_not_valid_after":  notAfter,
 			"server": mapstr.M{
 				"hash": mapstr.M{
 					"sha1":   "98d7ca35e3608b0ee7accc9ec665babdbdc6e39c",


### PR DESCRIPTION
## Proposed commit message

The tls.certificate_not_valid_before and tls.certificate_not_valid_after fields have been deprecated since 7.8.0

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Closes https://github.com/elastic/beats/issues/35814

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
