### PR TITLE
[Docs] Add `applies_to` to changes from #43251

### DIFF
--- a/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
+++ b/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
@@ -83,7 +83,7 @@ A string to filter the results to include only log events from log streams that 
 
 * `beginning`: Read messages starting from the beginning of the log group (default).
 * `end`: Read messages starting from the current time minus `scan_frequency`.
-* `lastSync`: Read messages starting from the last known sync time, if available. If there is no last known sync, then
+* `lastSync` {applies_to}`stack: ga 9.1.0`: Read messages starting from the last known sync time, if available. If there is no last known sync, then
   fall back to the default mode (`beginning`). This value is stored in the registry, so it persists across restarts.
 
 For example, in the case where `scan_frequency: 30s` and the current timestamp is `2020-06-24 12:00:00`:
@@ -98,7 +98,7 @@ For example, in the case where `scan_frequency: 30s` and the current timestamp i
     * First read: `startTime=2020-06-24 11:59:30`, `endTime=2020-06-24 12:00:00`
     * Next read: `startTime=2020-06-24 12:00:00`, `endTime=2020-06-24 12:00:30`
 
-* If `start_position: lastSync`, reading starts from the last known sync timestamp. Assuming the last sync timestamp stored in the registry is `2020-06-23 12:00:00`:
+* If `start_position: lastSync` {applies_to}`stack: ga 9.1.0`, reading starts from the last known sync timestamp. Assuming the last sync timestamp stored in the registry is `2020-06-23 12:00:00`:
 
     * First read: `startTime=2020-06-23 12:00:00`, `endTime=2020-06-24 12:00:00`
     * Next read: `startTime=2020-06-24 12:00:00`, `endTime=2020-06-24 12:00:30`


### PR DESCRIPTION
### Proposed commit message

Adds `applies_to` tags to changes in the documentation introduced with https://github.com/elastic/beats/pull/43251 

### Reason for change

>[!NOTE]
>Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

In https://github.com/elastic/beats/pull/43251, @Kavindu-Dodan introduced `lastSync` option to AWS CloudWatch input's `start_position` configuration. Based on [this comment](https://github.com/elastic/beats/pull/43251#issuecomment-2956087030), we should add 9.1 `applies_to` labels to `docs/reference/filebeat/filebeat-input-aws-cloudwatch.md`.