### PR TITLE
Doc: Add applies_to label for 9.1 content

### DIFF
--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -422,8 +422,8 @@ the file open to make sure the harvester has completed. If this
 setting results in files that are not completely read because they are
 removed from disk too early, disable this option.
 
-This option is enabled by default on Windows and disabled by default
-on all other OSes.
+{applies_to}`stack: ga 9.1` This option is enabled by default on Windows and disabled by default
+on all other operating systems.
 
 ::::{warning}
 If your Windows log rotation system shows errors because it


### PR DESCRIPTION
Related: https://github.com/elastic/docs-content-internal/issues/68
Closes: https://github.com/elastic/docs-content-internal/issues/83

The column-wrapped changes in https://github.com/elastic/beats/pull/43978/files made this one look like a lot more changed than actually did.  Here's what it boils down to: 

<img width="853" height="249" alt="Screenshot 2025-07-28 at 5 45 07 PM" src="https://github.com/user-attachments/assets/841db8e5-f169-4885-b245-e43b4f9345d0" />
