### PR TITLE
docs/reference/filebeat/filebeat-input-{cel,streaming}.md: Improve explanation of `state` option

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -489,6 +489,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Add support for generalized token authentication to CEL input. {pull}45359[45359]
 - Log CEL single object evaluation results as ECS compliant documents where possible. {issue}45254[45254] {pull}45399[45399]
 - Add status update functionality to Salesforce input. {issue}44653[44653] {pull}45227[45227]
+- Improve CEL and Streaming input documentation of the `state` option. {pull}45616[45616]
 
 *Auditbeat*
 

--- a/docs/reference/filebeat/filebeat-input-cel.md
+++ b/docs/reference/filebeat/filebeat-input-cel.md
@@ -381,7 +381,7 @@ The CEL program that is executed each polling period. This field is required.
 
 ### `state` [state-cel]
 
-`state` is an optional object that is passed to the CEL program on the first execution. It is available to the executing program as the `state` variable. It is made available to subsequent executions of the program during the life of input as the returned value of the previous execution, but with the `state.events` field removed. Except for the `state.cursor` field, `state` does not persist over restarts.
+`state` is an optional object that is passed to the CEL program as the `state` variable on the first execution. Subsequent executions of the program during the life of the input will populate the `state` variable with the return value of the previous execution, but with the `state.events` field removed. Except for the `state.cursor` field, returned `state` data does not persist over restarts.
 
 
 ### `state.cursor` [cursor-cel]

--- a/docs/reference/filebeat/filebeat-input-streaming.md
+++ b/docs/reference/filebeat/filebeat-input-streaming.md
@@ -280,7 +280,7 @@ program: |
 
 ### `state` [state-streaming]
 
-`state` is an optional object that is passed to the CEL program on the first execution. It is available to the executing program as the `state` variable. Except for the `state.cursor` field, `state` does not persist over restarts.
+`state` is an optional object that is passed to the CEL program as the `state` variable on the first execution. Subsequent executions of the program during the life of the input will populate the `state` variable with the return value of the previous execution, but with the `state.events` field removed. Except for the `state.cursor` field, returned `state` data does not persist over restarts.
 
 
 ### `state.cursor` [cursor-streaming]


### PR DESCRIPTION
## Proposed commit message

```
docs/reference/filebeat/filebeat-input-{cel,streaming}.md: Improve explanation of `state` option

Improved to make it clear that the configuration option only sets the
initial value and that CEL program return values will be used after
that.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.