### PR TITLE
Change package name for fips-enabled deb packages

### DIFF
--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -742,6 +743,18 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 		return err
 	}
 
+	packageName := spec.ServiceName
+	fipsPackageName := packageName + "-fips"
+	var conflicts []string
+	if spec.FIPS {
+		// add the non-FIPS package as conflict
+		conflicts = append(conflicts, packageName)
+		// change the package name to distinguish it from the non-FIPS variant
+		packageName = fipsPackageName
+	} else if slices.Contains(FIPSConfig.Beats, BeatName) {
+		// the beat is enabled for FIPS capable build, we are add the FIPS package as conflict
+		conflicts = append(conflicts, fipsPackageName)
+	}
 	args = append(args,
 		"--rm",
 		"-w", "/app",
@@ -750,9 +763,13 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 		"fpm", "--force",
 		"--input-type", "tar",
 		"--output-type", fpmPackageType,
-		"--name", spec.ServiceName,
+		"--name", packageName,
 		"--architecture", spec.Arch,
 	)
+	for _, conflict := range conflicts {
+		args = append(args, "--conflicts", conflict)
+	}
+
 	if packageType == RPM {
 		args = append(args,
 			"--rpm-rpmbuild-define", "_build_id_links none",

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -743,6 +743,11 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 		return err
 	}
 
+	// this snippet handles the package name metadata for the beats .deb or .rpm specs.
+	// If the FIPS-enabled spec is being built, add `-fips` suffix to the package name and list the non-FIPS package
+	// as a conflict in order to prevent having both packages installed at the same time.
+	// If a non FIPS-enabled spec is built but a FIPS-enabled package can be produced for the same beat, list the
+	// FIPS-enabled package as conflict as well.
 	packageName := spec.ServiceName
 	fipsPackageName := packageName + "-fips"
 	var conflicts []string
@@ -752,7 +757,7 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 		// change the package name to distinguish it from the non-FIPS variant
 		packageName = fipsPackageName
 	} else if slices.Contains(FIPSConfig.Beats, BeatName) {
-		// the beat is enabled for FIPS capable build, we are add the FIPS package as conflict
+		// the beat is enabled for FIPS capable build, add the FIPS package as conflict
 		conflicts = append(conflicts, fipsPackageName)
 	}
 	args = append(args,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Set a different package name for FIPS-enabled `.deb`  packages. This will allow to choose between FIPS and non-FIPS enabled version of the same beat by package name.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

### Create and inspect packages

- Build a FIPS-enabled beat .deb package:
  ```shell
  FIPS=true SNAPSHOT=true PACKAGES="deb" PLATFORMS="linux/amd64" mage -v package
  ```
- Have a look at the package metadata
  ```shell
  dpkg --info build/distributions/metricbeat-fips-9.2.0-SNAPSHOT-amd64.deb
  new Debian package, version 2.0.
  size 67598384 bytes: control archive=40435 bytes.
      3497 bytes,    75 lines      conffiles
      319 bytes,    12 lines      control
    135154 bytes,  1180 lines      md5sums
        65 bytes,     4 lines   *  postinst             #!/usr/bin/env
  Package: metricbeat-fips
  Version: 9.2.0
  License: Elastic-License
  Vendor: Elastic
  Architecture: amd64
  Maintainer: <@aa18a0fbc118>
  Installed-Size: 264684
  Conflicts: metricbeat
  Section: default
  Priority: extra
  Homepage: https://www.elastic.co/beats/metricbeat
  Description: Metricbeat is a lightweight shipper for metrics.
  ```

  Notice how `Package` is now `*-fips` and `Conflicts` lists the non FIPS-enabled package

### Test using a deb source

- Move all the relevant FIPS and non-FIPS enabled .deb in a directory (in the following commands `/vagrant/distributions` and `metricbeat` is used
  ```shell
  vagrant@elastic-agent-dev:/vagrant/distributions$ ll /vagrant/distributions/
  total 136776
  drwxr-xr-x 1 vagrant vagrant     4096 Jul 30 06:24 ./
  drwxr-xr-x 1 vagrant vagrant     4096 Jul 30 06:09 ../
  -rw-r--r-- 1 vagrant vagrant 72431808 Jul 30 06:05 metricbeat-9.2.0-SNAPSHOT-amd64.deb
  -rw-r--r-- 1 vagrant vagrant      165 Jul 30 06:05 metricbeat-9.2.0-SNAPSHOT-amd64.deb.sha512
  -rw-r--r-- 1 vagrant vagrant 67598384 Jul 30 06:05 metricbeat-fips-9.2.0-SNAPSHOT-amd64.deb
  -rw-r--r-- 1 vagrant vagrant      170 Jul 30 06:05 metricbeat-fips-9.2.0-SNAPSHOT-amd64.deb.sha512
  ```
- Install `dpkg-dev` package and scan the packages in the directory
  ```shell
  sudo apt-install dpkg-dev
  cd /vagrant/distributions
  dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
  ```
- Check that the `Packages.gz` file has been created correctly
  ```shell
  vagrant@elastic-agent-dev:/vagrant/distributions$ dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
  dpkg-scanpackages: warning: Packages in archive but missing from override file:
  dpkg-scanpackages: warning:   metricbeat metricbeat-fips
  dpkg-scanpackages: info: Wrote 2 entries to output Packages file.
  vagrant@elastic-agent-dev:/vagrant/distributions$ ls -lah /vagrant/distributions/
  total 134M
  drwxr-xr-x 1 vagrant vagrant 4.0K Jul 30 06:25 .
  drwxr-xr-x 1 vagrant vagrant 4.0K Jul 30 06:09 ..
  -rw-r--r-- 1 vagrant vagrant  525 Jul 30 06:25 Packages.gz
  -rw-r--r-- 1 vagrant vagrant  70M Jul 30 06:05 metricbeat-9.2.0-SNAPSHOT-amd64.deb
  -rw-r--r-- 1 vagrant vagrant  165 Jul 30 06:05 metricbeat-9.2.0-SNAPSHOT-amd64.deb.sha512
  -rw-r--r-- 1 vagrant vagrant  65M Jul 30 06:05 metricbeat-fips-9.2.0-SNAPSHOT-amd64.deb
  -rw-r--r-- 1 vagrant vagrant  170 Jul 30 06:05 metricbeat-fips-9.2.0-SNAPSHOT-amd64.deb.sha512
  ```
- Add the directory as a deb source in `/etc/apt/sources.list`
  ```shell
  #Local DEB archive
  deb [trusted=yes] file:/vagrant/distributions ./
  ```
- Update the list of packages
  ```shell
  vagrant@elastic-agent-dev:/vagrant/distributions$ sudo apt-get update
  Get:1 file:/vagrant/distributions ./ InRelease
  Ign:1 file:/vagrant/distributions ./ InRelease
  Get:2 file:/vagrant/distributions ./ Release
  Ign:2 file:/vagrant/distributions ./ Release
  Get:3 file:/vagrant/distributions ./ Packages
  Ign:3 file:/vagrant/distributions ./ Packages
  Get:4 file:/vagrant/distributions ./ Translation-en
  Ign:4 file:/vagrant/distributions ./ Translation-en
  Get:3 file:/vagrant/distributions ./ Packages
  Ign:3 file:/vagrant/distributions ./ Packages
  Get:4 file:/vagrant/distributions ./ Translation-en
  Ign:4 file:/vagrant/distributions ./ Translation-en
  Get:3 file:/vagrant/distributions ./ Packages
  Ign:3 file:/vagrant/distributions ./ Packages
  Get:4 file:/vagrant/distributions ./ Translation-en
  Ign:4 file:/vagrant/distributions ./ Translation-en
  Get:3 file:/vagrant/distributions ./ Packages [525 B]
  Get:4 file:/vagrant/distributions ./ Translation-en
  Err:4 file:/vagrant/distributions ./ Translation-en
    File not found - /vagrant/distributions/./en.gz (2: No such file or directory)
  Get:4 file:/vagrant/distributions ./ Translation-en
  Err:4 file:/vagrant/distributions ./ Translation-en
    File not found - /vagrant/distributions/./en.lz4 (2: No such file or directory)
  Get:4 file:/vagrant/distributions ./ Translation-en
  Err:4 file:/vagrant/distributions ./ Translation-en
    File not found - /vagrant/distributions/./en.zst (2: No such file or directory)
  Get:4 file:/vagrant/distributions ./ Translation-en
  Ign:4 file:/vagrant/distributions ./ Translation-en
  Hit:5 http://archive.ubuntu.com/ubuntu jammy InRelease
  Hit:6 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
  Hit:7 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
  Hit:8 http://security.ubuntu.com/ubuntu jammy-security InRelease
  Reading package lists... Done
  ```
- Install `metricbeat` (non-FIPS) first 
  ```shell
  vagrant@elastic-agent-dev:/vagrant/distributions$ sudo apt install metricbeat
  Reading package lists... Done
  Building dependency tree... Done
  Reading state information... Done
  The following NEW packages will be installed:
    metricbeat
  0 upgraded, 1 newly installed, 0 to remove and 12 not upgraded.
  Need to get 0 B/72.4 MB of archives.
  After this operation, 287 MB of additional disk space will be used.
  Get:1 file:/vagrant/distributions ./ metricbeat 9.2.0 [72.4 MB]
  Selecting previously unselected package metricbeat.
  (Reading database ... 99690 files and directories currently installed.)
  Preparing to unpack .../metricbeat-9.2.0-SNAPSHOT-amd64.deb ...
  Unpacking metricbeat (9.2.0) ...
  Setting up metricbeat (9.2.0) ...
  Scanning processes...
  Scanning candidates...
  Scanning linux images...

  Restarting services...
  systemctl restart packagekit.service

  No containers need to be restarted.

  No user sessions are running outdated binaries.

  No VM guests are running outdated hypervisor (qemu) binaries on this host.
  vagrant@elastic-agent-dev:/vagrant/distributions$ metricbeat version
  metricbeat version 9.2.0 (amd64), libbeat 9.2.0 [77cd2393e723daf5d935eb4d0da5323c152cd767 built 2025-07-29 15:28:00 +0000 UTC] (FIPS-distribution: false)
  vagrant@elastic-agent-dev:/vagrant/distributions$
  ```
  As we can see in the `metricbeat version` output, the non-FIPS version has been installed
- Install `metricbeat-fips`
  ```shell
  vagrant@elastic-agent-dev:/vagrant/distributions$ sudo apt install metricbeat-fips
  Reading package lists... Done
  Building dependency tree... Done
  Reading state information... Done
  The following packages will be REMOVED:
    metricbeat
  The following NEW packages will be installed:
    metricbeat-fips
  0 upgraded, 1 newly installed, 1 to remove and 12 not upgraded.
  Need to get 0 B/67.6 MB of archives.
  After this operation, 15.6 MB disk space will be freed.
  Do you want to continue? [Y/n] y
  Get:1 file:/vagrant/distributions ./ metricbeat-fips 9.2.0 [67.6 MB]
  (Reading database ... 100960 files and directories currently installed.)
  Removing metricbeat (9.2.0) ...
  Selecting previously unselected package metricbeat-fips.
  (Reading database ... 99767 files and directories currently installed.)
  Preparing to unpack .../metricbeat-fips-9.2.0-SNAPSHOT-amd64.deb ...
  Unpacking metricbeat-fips (9.2.0) ...
  Setting up metricbeat-fips (9.2.0) ...
  Scanning processes...
  Scanning linux images...

  No services need to be restarted.

  No containers need to be restarted.

  No user sessions are running outdated binaries.

  No VM guests are running outdated hypervisor (qemu) binaries on this host.
  vagrant@elastic-agent-dev:/vagrant/distributions$ metricbeat version
  panic: opensslcrypto: FIPS mode requested (requirefips tag set) but not available in OpenSSL 3.0.2 15 Mar 2022

  goroutine 1 [running]:
  crypto/internal/backend.init.1()
          crypto/internal/backend/openssl_linux.go:40 +0x9f
  vagrant@elastic-agent-dev:/vagrant/distributions$
  ```
  As we can see, `metricbeat-fips` replaces `metricbeat` (as they are listed as conflicts) and it installs (with **the same executable name**) FIPS-enabled metricbeat (which then panics when running the version command as the VM I am using is not enabled for FIPS)

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
