### PR TITLE
[otelbeat]: warning should not be logged if allow_older_versions field is absent

### DIFF
--- a/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
+++ b/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
@@ -190,7 +190,7 @@ func checkUnsupportedConfig(cfg *config.C, logger *logp.Logger) error {
 		logger.Warn("parameters is currently not supported")
 	} else if cfg.HasField("proxy_headers") {
 		logger.Warn("proxy_headers is currently not supported")
-	} else if value, _ := cfg.Bool("allow_older_versions", -1); !value {
+	} else if value, err := cfg.Bool("allow_older_versions", -1); err == nil && !value {
 		logger.Warn("allow_older_versions:false is currently not supported")
 	}
 	return nil


### PR DESCRIPTION
The `allow_older_versions` warning should not be logged if field is absent or if it is set to true. 