### PR TITLE
otel: skip flaky test TestMetricbeatOTelMultipleReceiversE2E

### DIFF
--- a/x-pack/metricbeat/tests/integration/otel_test.go
+++ b/x-pack/metricbeat/tests/integration/otel_test.go
@@ -294,6 +294,7 @@ processors:
 }
 
 func TestMetricbeatOTelMultipleReceiversE2E(t *testing.T) {
+	t.Skip("Flaky test, see https://github.com/elastic/beats/issues/45631")
 	integration.EnsureESIsRunning(t)
 
 	host := integration.GetESURL(t, "http")


### PR DESCRIPTION
## Proposed commit message

This test is flaking with a high failure rate. I suspect it has to do with running multiple receivers on the same process, since the single receiver version of this test (TestMetricbeatOTelReceiverE2E) is not flaking.

This test was introduced by https://github.com/elastic/beats/pull/45427.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

```
$ cd x-pack/metricbeat/
$ go test -c -tags otelbeat
$ mage docker:composeUp
$ go test -tags "integration" -run 'TestMetricbeatOTelMultipleReceiversE2E' ./tests/integration -v -count=1

=== RUN   TestMetricbeatOTelMultipleReceiversE2E
    otel_test.go:297: Flaky test, see https://github.com/elastic/beats/issues/45631
--- SKIP: TestMetricbeatOTelMultipleReceiversE2E (0.00s)
PASS
ok      github.com/elastic/beats/v7/x-pack/metricbeat/tests/integration 0.005s
```

## Related issues

- For https://github.com/elastic/beats/issues/45631.