### PR TITLE
feat: add status reporting to CloudWatch

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -495,6 +495,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Improve CEL and Streaming input documentation of the `state` option. {pull}45616[45616]
 - Enhanced HTTPJSON input error logging with structured error metadata conforming to Elastic Common Schema (ECS) conventions. {pull}45653[45653]
 - Clarify behavior in logging for starting periodic evaluations and for exceeding the maximum execution budget. {pull}45633[45633]
+- Add status reporting support for AWS CloudWatch input. {pull}45679[45679]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
@@ -72,7 +72,7 @@ func (p *cloudwatchPoller) startWorkers(ctx context.Context, svc *cloudwatchlogs
 	for i := 0; i < p.config.NumberOfWorkers; i++ {
 		worker, err := newCWWorker(p.config, p.region, p.metrics, p.status, svc, pipeline, p.log)
 		if err != nil {
-			return fmt.Errorf("failed to create worker %d: %v", i, err)
+			return fmt.Errorf("failed to create worker %d: %w", i, err)
 		}
 		p.workerWg.Add(1)
 		go func(wrk *cwWorker) {

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch.go
@@ -6,12 +6,14 @@ package awscloudwatch
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -21,6 +23,7 @@ type cloudwatchPoller struct {
 	log          *logp.Logger
 	metrics      *inputMetrics
 	stateHandler *stateHandler
+	status       status.StatusReporter
 
 	workersListingMap    *sync.Map
 	workersProcessingMap *sync.Map
@@ -41,8 +44,7 @@ type workResponse struct {
 	startTime, endTime time.Time
 }
 
-func newCloudwatchPoller(log *logp.Logger, metrics *inputMetrics,
-	awsRegion string, config config, stateHandler *stateHandler) *cloudwatchPoller {
+func newCloudwatchPoller(log *logp.Logger, metrics *inputMetrics, awsRegion string, config config, stateHandler *stateHandler, reporter status.StatusReporter) *cloudwatchPoller {
 	if metrics == nil {
 		metrics = newInputMetrics("", nil)
 	}
@@ -53,6 +55,7 @@ func newCloudwatchPoller(log *logp.Logger, metrics *inputMetrics,
 		region:               awsRegion,
 		config:               config,
 		stateHandler:         stateHandler,
+		status:               reporter,
 		workersListingMap:    new(sync.Map),
 		workersProcessingMap: new(sync.Map),
 		// workRequestChan is unbuffered to guarantee that
@@ -65,20 +68,20 @@ func newCloudwatchPoller(log *logp.Logger, metrics *inputMetrics,
 	}
 }
 
-func (p *cloudwatchPoller) startWorkers(ctx context.Context, svc *cloudwatchlogs.Client, pipeline beat.Pipeline) {
+func (p *cloudwatchPoller) startWorkers(ctx context.Context, svc *cloudwatchlogs.Client, pipeline beat.Pipeline) error {
 	for i := 0; i < p.config.NumberOfWorkers; i++ {
+		worker, err := newCWWorker(p.config, p.region, p.metrics, p.status, svc, pipeline, p.log)
+		if err != nil {
+			return fmt.Errorf("failed to create worker %d: %v", i, err)
+		}
 		p.workerWg.Add(1)
-		go func() {
+		go func(wrk *cwWorker) {
 			defer p.workerWg.Done()
-
-			worker, err := newCWWorker(p.config, p.region, p.metrics, svc, pipeline, p.log)
-			if err != nil {
-				p.log.Error("Error creating CloudWatch worker: ", err)
-				return
-			}
-			worker.Start(ctx, p.workRequestChan, p.workResponseChan, p.stateHandler)
-		}()
+			wrk.Start(ctx, p.workRequestChan, p.workResponseChan, p.stateHandler)
+		}(worker)
 	}
+
+	return nil
 }
 
 // receive implements the main run loop that distributes tasks to the worker

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker.go
@@ -113,6 +113,10 @@ func (w *cwWorker) run(ctx context.Context, logGroupId string, startTime, endTim
 		}
 	}
 
+	if err == nil {
+		w.status.UpdateStatus(status.Running, "Input is running")
+	}
+
 	return count
 }
 

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -101,7 +101,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 
 	handler, err := newStateHandler(log, in.config, in.store)
 	if err != nil {
-		in.status.UpdateStatus(status.Failed, "State registry creation failure")
+		in.status.UpdateStatus(status.Failed, fmt.Sprintf("State registry creation failure: %s", err.Error()))
 		return fmt.Errorf("failed to create state handler: %w", err)
 	}
 	defer handler.Close()
@@ -110,7 +110,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	var logGroupIDs []string
 	logGroupIDs, region, err := fromConfig(in.config, in.awsConfig)
 	if err != nil {
-		in.status.UpdateStatus(status.Failed, "Configuration loading error")
+		in.status.UpdateStatus(status.Failed, fmt.Sprintf("Configuration loading error: %s", err.Error()))
 		return fmt.Errorf("error processing configurations: %w", err)
 	}
 
@@ -126,7 +126,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 		// now fallback to provided LogGroupNamePrefix and use derived service client to derive logGroupIDs
 		logGroupIDs, err = getLogGroupNames(svc, in.config.LogGroupNamePrefix, in.config.IncludeLinkedAccountsForPrefixMode)
 		if err != nil {
-			in.status.UpdateStatus(status.Failed, "Configuration loading error")
+			in.status.UpdateStatus(status.Failed, fmt.Sprintf("Configuration loading error: %s", err.Error()))
 			return fmt.Errorf("failed to get log group names from LogGroupNamePrefix: %w", err)
 		}
 	}
@@ -146,7 +146,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	cwPoller.metrics.logGroupsTotal.Add(uint64(len(logGroupIDs)))
 	err = cwPoller.startWorkers(ctx, svc, pipeline)
 	if err != nil {
-		in.status.UpdateStatus(status.Failed, "Error starting input processors")
+		in.status.UpdateStatus(status.Failed, fmt.Sprintf("Error starting input processors: %s", err.Error()))
 		return err
 	}
 

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -94,10 +94,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	log := inputContext.Logger
 
 	// setup status reporter
-	in.status = inputContext.StatusReporter
-	if in.status == nil {
-		in.status = &debugCWStatusReporter{log}
-	}
+	in.status = newCWStateReporter(inputContext, log)
 
 	defer in.status.UpdateStatus(status.Stopped, "Input stopped")
 	in.status.UpdateStatus(status.Starting, "Input starting")
@@ -158,15 +155,6 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	log.Debugf("Config api_sleep = %f", cwPoller.config.APISleep)
 	cwPoller.receive(ctx, logGroupIDs, time.Now)
 	return nil
-}
-
-// debugCWStatusReporter with debugging logs. This is typically used when running in standalone mode.
-type debugCWStatusReporter struct {
-	log *logp.Logger
-}
-
-func (n *debugCWStatusReporter) UpdateStatus(status status.Status, msg string) {
-	n.log.Debugf("CloudWatch input status updated: status: %s, message: %s", status, msg)
 }
 
 // fromConfig is a helper to parse input configurations and derive logGroupIDs & aws region

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -96,7 +96,7 @@ func (in *cloudwatchInput) Run(inputContext v2.Context, pipeline beat.Pipeline) 
 	// setup status reporter
 	in.status = newCWStateReporter(inputContext, log)
 
-	defer in.status.UpdateStatus(status.Stopped, "Input stopped")
+	defer in.status.UpdateStatus(status.Stopped, "")
 	in.status.UpdateStatus(status.Starting, "Input starting")
 
 	handler, err := newStateHandler(log, in.config, in.store)

--- a/x-pack/filebeat/input/awscloudwatch/state_reporter.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_reporter.go
@@ -5,6 +5,8 @@
 package awscloudwatch
 
 import (
+	"sync"
+
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -13,6 +15,8 @@ import (
 type cwStateReporter struct {
 	current  status.Status
 	reporter status.StatusReporter
+
+	sync sync.Mutex
 }
 
 func newCWStateReporter(ctx v2.Context, log *logp.Logger) *cwStateReporter {
@@ -29,6 +33,9 @@ func newCWStateReporter(ctx v2.Context, log *logp.Logger) *cwStateReporter {
 }
 
 func (c *cwStateReporter) UpdateStatus(status status.Status, msg string) {
+	c.sync.Lock()
+	defer c.sync.Unlock()
+
 	// proxy the update only on a state change
 	if c.current != status {
 		c.current = status

--- a/x-pack/filebeat/input/awscloudwatch/state_reporter.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_reporter.go
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awscloudwatch
+
+import (
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+type cwStateReporter struct {
+	current  status.Status
+	reporter status.StatusReporter
+}
+
+func newCWStateReporter(ctx v2.Context, log *logp.Logger) *cwStateReporter {
+	rep := &cwStateReporter{
+		current:  status.Unknown,
+		reporter: &debugCWStatusReporter{log: log},
+	}
+
+	if ctx.StatusReporter != nil {
+		rep.reporter = ctx.StatusReporter
+	}
+
+	return rep
+}
+
+func (c *cwStateReporter) UpdateStatus(status status.Status, msg string) {
+	// proxy the update only on a state change
+	if c.current != status {
+		c.current = status
+		c.reporter.UpdateStatus(c.current, msg)
+	}
+}
+
+// debugCWStatusReporter with debugging logs.
+// This is typically used when running in standalone mode where injected reporter is nil.
+type debugCWStatusReporter struct {
+	log *logp.Logger
+}
+
+func (n *debugCWStatusReporter) UpdateStatus(status status.Status, msg string) {
+	n.log.Debugf("CloudWatch input status updated: status: %s, message: %s", status, msg)
+}

--- a/x-pack/filebeat/input/awscloudwatch/state_reporter_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_reporter_test.go
@@ -20,6 +20,7 @@ func Test_constructor(t *testing.T) {
 		require.NotNil(t, reporter)
 
 		require.IsType(t, &cwStateReporter{}, reporter)
+		require.IsType(t, &debugCWStatusReporter{}, reporter.reporter)
 	})
 }
 
@@ -42,6 +43,10 @@ func Test_cwStateReporterStatus(t *testing.T) {
 	require.Equal(t, status.Running, reporter.current)
 	require.Equal(t, 1, counterReporter.count)
 
+	// check for change of status
+	reporter.UpdateStatus(status.Stopped, "")
+	require.Equal(t, status.Stopped, reporter.current)
+	require.Equal(t, 2, counterReporter.count)
 }
 
 // countedReporter helps with testing to track proxying count

--- a/x-pack/filebeat/input/awscloudwatch/state_reporter_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_reporter_test.go
@@ -1,0 +1,54 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awscloudwatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func Test_constructor(t *testing.T) {
+	t.Run("Nil context reporter results in reporter with debug reporter", func(t *testing.T) {
+		reporter := newCWStateReporter(v2.Context{}, logp.NewNopLogger())
+		require.NotNil(t, reporter)
+
+		require.IsType(t, &cwStateReporter{}, reporter)
+	})
+}
+
+func Test_cwStateReporterStatus(t *testing.T) {
+	reporter := newCWStateReporter(v2.Context{StatusReporter: &countedReporter{}}, logp.NewNopLogger())
+	require.IsType(t, &countedReporter{}, reporter.reporter)
+
+	counterReporter, ok := reporter.reporter.(*countedReporter)
+	require.True(t, ok)
+
+	// check initials
+	require.Equal(t, status.Unknown, reporter.current)
+	require.Equal(t, 0, counterReporter.count)
+
+	// update status multiple times
+	reporter.UpdateStatus(status.Running, "some message")
+	reporter.UpdateStatus(status.Running, "some message")
+
+	// check for proxying only the necessary
+	require.Equal(t, status.Running, reporter.current)
+	require.Equal(t, 1, counterReporter.count)
+
+}
+
+// countedReporter helps with testing to track proxying count
+type countedReporter struct {
+	count int
+}
+
+func (c *countedReporter) UpdateStatus(status status.Status, msg string) {
+	c.count++
+}


### PR DESCRIPTION
## Proposed commit message

Adds Status reporting for AWS CloudWatch input. I have introduced following,

- `cwStateReporter` : This proxy the status to the actual status reporter. Validate status change from current before conveying status to internal reporter.
- `debugCWStatusReporter`: Performs debug logging when context-bound reporter is missing. For example, this happens in standalone mode

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

None - Status reports are utilized by the Agent. In standalone mode, logs are added in Debug level

## How to test this PR locally

- Run standalone filebeat with CloudWatch input & debug logs
- Observe debug logs with `CloudWatch input status updated:` prefix for status changes 

See below log entries from a standalone run,

#### Startup and configuration

<img width="1400" height="134" alt="image" src="https://github.com/user-attachments/assets/c1ba99e9-7b4a-47bb-b427-cd40d11cf651" />


#### Degraded - network connectivity issue

<img width="2215" height="30" alt="image" src="https://github.com/user-attachments/assets/ba82debf-8a50-4983-bbc5-c9955ded4cfb" />

#### Back to running status

<img width="1402" height="30" alt="image" src="https://github.com/user-attachments/assets/b5710cba-2fd6-4486-834f-5673b7c17f4e" />

### Related issues

Fixes https://github.com/elastic/beats/issues/44648 