### PR TITLE
Fix error handling from BeatV2Manager reload

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -148,6 +148,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fix an issue where the Kafka output could get stuck if a proxied connection to the Kafka cluster was reset. {issue}44606[44606]
 - Use Debian 11 to build linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31. {issue}44816[44816]
 - The Elasticsearch output now correctly applies exponential backoff when being throttled by 429s ("too many requests") from Elasticsarch. {issue}36926[36926] {pull}45073[45073]
+- Fixed case where Beats would silently fail due to invalid input configuration, now the error is correctly reported. {issue}43118[43118] {pull}45733[45733]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/tests/integration/managerV2_test.go
+++ b/x-pack/filebeat/tests/integration/managerV2_test.go
@@ -95,9 +95,9 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 					Type: "elasticsearch",
 					Name: "elasticsearch",
 					Source: integration.RequireNewStruct(t,
-						map[string]interface{}{
+						map[string]any{
 							"type":                 "elasticsearch",
-							"hosts":                []interface{}{"http://localhost:9200"},
+							"hosts":                []any{"http://localhost:9200"},
 							"username":             "admin",
 							"password":             "testing",
 							"protocol":             "http",
@@ -119,10 +119,10 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 					Streams: []*proto.Stream{
 						{
 							Id: "log-input-1",
-							Source: integration.RequireNewStruct(t, map[string]interface{}{
+							Source: integration.RequireNewStruct(t, map[string]any{
 								"enabled": true,
 								"type":    "log",
-								"paths":   []interface{}{logFilePath},
+								"paths":   []any{logFilePath},
 							}),
 						},
 					},
@@ -141,9 +141,9 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 					Type: "elasticsearch",
 					Name: "elasticsearch",
 					Source: integration.RequireNewStruct(t,
-						map[string]interface{}{
+						map[string]any{
 							"type":                 "elasticsearch",
-							"hosts":                []interface{}{"http://localhost:9200"},
+							"hosts":                []any{"http://localhost:9200"},
 							"username":             "admin",
 							"password":             "testing",
 							"protocol":             "http",
@@ -165,10 +165,10 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 					Streams: []*proto.Stream{
 						{
 							Id: "log-input-2",
-							Source: integration.RequireNewStruct(t, map[string]interface{}{
+							Source: integration.RequireNewStruct(t, map[string]any{
 								"enabled": true,
 								"type":    "log",
-								"paths":   []interface{}{logFilePath},
+								"paths":   []any{logFilePath},
 							}),
 						},
 					},
@@ -274,7 +274,7 @@ func TestFailedOutputReportsUnhealthy(t *testing.T) {
 				Type: "logstash",
 				Name: "logstash",
 				Source: integration.RequireNewStruct(t,
-					map[string]interface{}{
+					map[string]any{
 						"type":    "logstash",
 						"invalid": "configuration",
 					}),
@@ -295,7 +295,7 @@ func TestFailedOutputReportsUnhealthy(t *testing.T) {
 				Streams: []*proto.Stream{
 					{
 						Id: "log-input",
-						Source: integration.RequireNewStruct(t, map[string]interface{}{
+						Source: integration.RequireNewStruct(t, map[string]any{
 							"enabled": true,
 							"type":    "log",
 							"paths":   "/tmp/foo",
@@ -363,7 +363,7 @@ func TestRecoverFromInvalidOutputConfiguration(t *testing.T) {
 			Streams: []*proto.Stream{
 				{
 					Id: "filestream-input-id",
-					Source: integration.RequireNewStruct(t, map[string]interface{}{
+					Source: integration.RequireNewStruct(t, map[string]any{
 						"id":      "filestream-stream-input-id",
 						"enabled": true,
 						"type":    "filestream",
@@ -387,7 +387,7 @@ func TestRecoverFromInvalidOutputConfiguration(t *testing.T) {
 			Streams: []*proto.Stream{
 				{
 					Id: "filestream-input-id",
-					Source: integration.RequireNewStruct(t, map[string]interface{}{
+					Source: integration.RequireNewStruct(t, map[string]any{
 						"id":      "filestream-stream-input-id",
 						"enabled": true,
 						"type":    "filestream",
@@ -409,9 +409,9 @@ func TestRecoverFromInvalidOutputConfiguration(t *testing.T) {
 			Type: "elasticsearch",
 			Name: "elasticsearch",
 			Source: integration.RequireNewStruct(t,
-				map[string]interface{}{
+				map[string]any{
 					"type":     "elasticsearch",
-					"hosts":    []interface{}{"http://localhost:9200"},
+					"hosts":    []any{"http://localhost:9200"},
 					"username": "admin",
 					"password": "testing",
 					"protocol": "http",
@@ -431,7 +431,7 @@ func TestRecoverFromInvalidOutputConfiguration(t *testing.T) {
 			Type: "logstash",
 			Name: "logstash",
 			Source: integration.RequireNewStruct(t,
-				map[string]interface{}{
+				map[string]any{
 					"type":    "logstash",
 					"invalid": "configuration",
 				}),
@@ -534,7 +534,7 @@ func TestAgentPackageVersionOnStartUpInfo(t *testing.T) {
 				Type: "file",
 				Name: "events-to-file",
 				Source: integration.RequireNewStruct(t,
-					map[string]interface{}{
+					map[string]any{
 						"name": "events-to-file",
 						"type": "file",
 						"path": eventsDir,
@@ -554,10 +554,10 @@ func TestAgentPackageVersionOnStartUpInfo(t *testing.T) {
 				Streams: []*proto.Stream{
 					{
 						Id: "log-input-1",
-						Source: integration.RequireNewStruct(t, map[string]interface{}{
+						Source: integration.RequireNewStruct(t, map[string]any{
 							"enabled": true,
 							"type":    "log",
-							"paths":   []interface{}{logFilePath},
+							"paths":   []any{logFilePath},
 						}),
 					},
 				},
@@ -1060,9 +1060,9 @@ func outputUnitES(t *testing.T, id int) *proto.UnitExpected {
 			Type: "elasticsearch",
 			Name: fmt.Sprintf("elasticsearch-%d", id),
 			Source: integration.RequireNewStruct(t,
-				map[string]interface{}{
+				map[string]any{
 					"type":                 "elasticsearch",
-					"hosts":                []interface{}{"http://localhost:9200"},
+					"hosts":                []any{"http://localhost:9200"},
 					"username":             "admin",
 					"password":             "testing",
 					"protocol":             "http",

--- a/x-pack/filebeat/tests/integration/managerV2_test.go
+++ b/x-pack/filebeat/tests/integration/managerV2_test.go
@@ -1078,7 +1078,7 @@ func TestReloadErrorHandling(t *testing.T) {
 	finalStateReached := atomic.Bool{}
 
 	output := proto.UnitExpected{
-		Id:             "output-unit-borken",
+		Id:             "output-unit",
 		Type:           proto.UnitType_OUTPUT,
 		ConfigStateIdx: 1,
 		State:          proto.State_FAILED,

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -693,7 +693,7 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*agentUnit) {
 			Unwrap() error
 		}
 
-		//nolint:errorlint // That's a custom logic based on how reloadInputs builds the error
+		//nolint:errorlint // Custom error wrapping, not suitable for errors.As
 		switch e := err.(type) {
 		// cfgfile.UnitError implements errWrapper, but we don't want to unwrap
 		// it, so we keep it as the first case
@@ -718,7 +718,8 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*agentUnit) {
 			// error we need to call Unwrap and ensure it is an error list.
 			// Then we can finally access each individual error
 			e2 := errors.Unwrap(err)
-			switch e3 := e2.(type) { //nolint:errorlint // Handling specific error wrapping
+			//nolint:errorlint // Custom error wrapping, not suitable for errors.As
+			switch e3 := e2.(type) {
 			case errList:
 				for _, err := range e3.Unwrap() {
 					unitErr := cfgfile.UnitError{}

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -855,7 +855,7 @@ func (cm *BeatV2Manager) reloadInputs(inputUnits []*agentUnit) error {
 		if err != nil {
 			return cfgfile.UnitError{
 				UnitID: unit.ID(),
-				Err:    fmt.Errorf("failed to generate configuration for unit %s: %w", unit.ID(), err),
+				Err:    fmt.Errorf("failed to generate configuration for unit %q: %w", unit.ID(), err),
 			}
 		}
 		// add diag callbacks for unit

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -116,7 +116,6 @@ type BeatV2Manager struct {
 	// trying to reload the configuration after an input not finished error
 	// happens
 	forceReloadDebounce time.Duration
-	wg                  sync.WaitGroup
 }
 
 // ================================
@@ -466,8 +465,8 @@ func (cm *BeatV2Manager) watchErrChan(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case err := <-cm.client.Errors():
-			// Don't print the context canceled errors that happen normally during shutdown, restart, etc
-			if !errors.Is(context.Canceled, err) {
+			// Don't print the context cancelled errors that happen normally during shutdown, restart, etc
+			if !errors.Is(err, context.Canceled) {
 				cm.logger.Errorf("elastic-agent-client error: %s", err)
 			}
 

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -702,7 +702,7 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*agentUnit) {
 			// the inputs to reload was not possible. So we set the error for
 			// the failed unit, set the whole Beat as failed and return
 			unitErrors[e.UnitID] = append(unitErrors[e.UnitID], e.Err)
-			cm.UpdateStatus(status.Failed, fmt.Sprintf("cannot process %q configuration: %s", e.UnitID, e.Unwrap()))
+			cm.UpdateStatus(status.Failed, fmt.Sprintf("cannot process %q configuration: %s", e.UnitID, e.Error()))
 			return
 
 		case errWrapper:
@@ -848,7 +848,7 @@ func (cm *BeatV2Manager) reloadInputs(inputUnits []*agentUnit) error {
 			// should not happen; hard stop
 			return cfgfile.UnitError{
 				UnitID: unit.ID(),
-				Err:    fmt.Errorf("input unit %s has no config", unit.ID()),
+				Err:    fmt.Errorf("input unit %q has no config", unit.ID()),
 			}
 		}
 

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -693,6 +693,7 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*agentUnit) {
 			Unwrap() error
 		}
 
+		//nolint:errorlint // That's a custom logic based on how reloadInputs builds the error
 		switch e := err.(type) {
 		// cfgfile.UnitError implements errWrapper, but we don't want to unwrap
 		// it, so we keep it as the first case
@@ -717,7 +718,7 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*agentUnit) {
 			// error we need to call Unwrap and ensure it is an error list.
 			// Then we can finally access each individual error
 			e2 := errors.Unwrap(err)
-			switch e3 := e2.(type) {
+			switch e3 := e2.(type) { //nolint:errorlint // Handling specific error wrapping
 			case errList:
 				for _, err := range e3.Unwrap() {
 					unitErr := cfgfile.UnitError{}
@@ -892,7 +893,7 @@ func (cm *BeatV2Manager) reloadInputs(inputUnits []*agentUnit) error {
 		type unwrapList interface {
 			Unwrap() []error
 		}
-		errList, isErrList := err.(unwrapList) //nolint:errorlint // see the comment above
+		errList, isErrList := err.(unwrapList)
 		if isErrList {
 			for _, err := range errList.Unwrap() {
 				causeErr := errors.Unwrap(err)

--- a/x-pack/libbeat/management/simple_input_config_test.go
+++ b/x-pack/libbeat/management/simple_input_config_test.go
@@ -53,7 +53,7 @@ func TestSimpleInputConfig(t *testing.T) {
 				Type: "mock",
 				Name: "mock",
 				Source: integration.RequireNewStruct(t,
-					map[string]interface{}{
+					map[string]any{
 						"Is":        "this",
 						"required?": "Yes!",
 					}),
@@ -70,7 +70,8 @@ func TestSimpleInputConfig(t *testing.T) {
 				Type: "filestream",
 				// All fields get repeated here, including ID.
 				Source: integration.RequireNewStruct(t,
-					map[string]interface{}{
+					map[string]any{
+						"type": "filestream",
 						"paths": []any{
 							"/tmp/logfile.log",
 						},
@@ -92,7 +93,7 @@ func TestSimpleInputConfig(t *testing.T) {
 				Type: "filestream",
 				Name: "mock",
 				Source: integration.RequireNewStruct(t,
-					map[string]interface{}{
+					map[string]any{
 						"this":     "is",
 						"required": true,
 					}),
@@ -118,6 +119,7 @@ func TestSimpleInputConfig(t *testing.T) {
 			if DoesStateMatch(observed, desiredState, 0) {
 				stateReached.Store(true)
 			}
+
 			return &proto.CheckinExpected{
 				Units: units,
 			}


### PR DESCRIPTION
## Proposed commit message
```
BeatV2Manager `reload` method calls `reloadInputs`, however it did not
handle the errors returned correctly. This commit fixes it by making
`reloadInputs`, whenever possible, use a cfgfile.UnitError to indicate
the failed unit and `reload` now handles any unexpected error case/type.

Multiple lint warnings are fixed, including:
 - An unused wait group is removed
 - The parameters order in a `errors.Is` call is fixed
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes https://github.com/elastic/beats/issues/43118

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
