### PR TITLE
x-pack/filebeat/input/o365audit: trim redundant BOM prefix

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -265,6 +265,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Added missing "text/csv" content-type filter support in GCS input. {issue}44922[44922] {pull}44923[44923]
 - Fix a panic in the winlog input that prevented it from starting. {issue}45693[45693] {pull}45730[45730]
 - Fix error handling in ABS input when both root level `max_workers` and `batch_size` are empty. {issue}45680[45680] {pull}45743[45743]
+- Fix handling of unnecessary BOM in UTF-8 text received by o365audit input. {issue}44327[44327] {pull}45739[45739]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/o365audit/listblobs.go
+++ b/x-pack/filebeat/input/o365audit/listblobs.go
@@ -5,6 +5,7 @@
 package o365audit
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -281,6 +282,9 @@ func readJSONBody(response *http.Response, dest interface{}) error {
 	if err != nil {
 		return fmt.Errorf("reading body failed: %w", err)
 	}
+	// Remove the BOM ("\uFEFF") prefix if it exists.
+	// https://unicode.org/faq/utf_bom.html#bom5
+	body = bytes.TrimPrefix(body, []byte("\uFEFF"))
 	if err = json.Unmarshal(body, dest); err != nil {
 		return fmt.Errorf("decoding json failed: %w", err)
 	}

--- a/x-pack/filebeat/input/o365audit/listblobs_test.go
+++ b/x-pack/filebeat/input/o365audit/listblobs_test.go
@@ -107,7 +107,7 @@ func (f *fakePoll) deliverResult(t testing.TB, pl poll.Transaction, msg interfac
 	}
 	response := &http.Response{
 		StatusCode:    200,
-		Body:          io.NopCloser(bytes.NewReader(js)),
+		Body:          io.NopCloser(io.MultiReader(strings.NewReader("\xef\xbb\xbf"), bytes.NewReader(js))),
 		ContentLength: int64(len(js)),
 	}
 	if nextUrl != "" {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/o365audit: trim redundant BOM prefix

Despite it being advised against, the O365 data source prefixes UTF-8
text with a BOM. Remove it before attempting to unmarshal the JSON.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #44327

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
