### PR TITLE
libbeat/reader/readfile: improve performance and clarity of BOM prefix removal

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -337,6 +337,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Replace Ubuntu 20.04 with 24.04 for Docker base images {issue}40743[40743] {pull}40942[40942]
 - Publish cloud.availability_zone by add_cloud_metadata processor in azure environments {issue}42601[42601] {pull}43618[43618]
 - Added the `now` processor, which will populate the specified target field with the current timestamp. {pull}44795[44795]
+- Improve trimming of BOM from UTF-8 data in the libbeat reader/readfile.EncoderReader. {pull}45742[45742]
 
 *Auditbeat*
 

--- a/libbeat/reader/readfile/encode.go
+++ b/libbeat/reader/readfile/encode.go
@@ -57,13 +57,17 @@ func NewEncodeReader(r io.ReadCloser, config Config, logger *logp.Logger) (Encod
 }
 
 // Next reads the next line from it's initial io.Reader
-// This converts a io.Reader to a reader.reader
+// This converts a io.Reader to a reader.reader.
+//
+// Lines that have a [BOM] ("\uFEFF") prefix will have that prefix removed.
+//
+// [BOM]: https://unicode.org/faq/utf_bom.html#bom5
 func (r EncoderReader) Next() (reader.Message, error) {
 	c, sz, err := r.reader.Next()
 	// Creating message object
 	return reader.Message{
 		Ts:      time.Now(),
-		Content: bytes.Trim(c, "\xef\xbb\xbf"),
+		Content: bytes.TrimPrefix(c, []byte("\uFEFF")),
 		Bytes:   sz,
 		Fields:  mapstr.M{},
 	}, err

--- a/libbeat/reader/readfile/encode_test.go
+++ b/libbeat/reader/readfile/encode_test.go
@@ -33,11 +33,23 @@ func TestEncodeLines(t *testing.T) {
 		Input  []byte
 		Output []string
 	}{
-		"simple":            {[]byte("testing simple line\n"), []string{"testing simple line\n"}},
-		"multiline":         {[]byte("testing\nmultiline\n"), []string{"testing\n", "multiline\n"}},
-		"bom-on-first":      {[]byte("\xef\xbb\xbftesting simple line\n"), []string{"testing simple line\n"}},
-		"bom-on-each":       {[]byte("\xef\xbb\xbftesting\n\xef\xbb\xbfmultiline\n"), []string{"testing\n", "multiline\n"}},
-		"bom-in-the-middle": {[]byte("testing simple \xef\xbb\xbfline\n"), []string{"testing simple \xef\xbb\xbfline\n"}},
+		"simple":                  {[]byte("testing simple line\n"), []string{"testing simple line\n"}},
+		"multiline":               {[]byte("testing\nmultiline\n"), []string{"testing\n", "multiline\n"}},
+		"bom-on-first-bytes":      {[]byte("\xef\xbb\xbftesting simple line\n"), []string{"testing simple line\n"}},
+		"bom-on-each-bytes":       {[]byte("\xef\xbb\xbftesting\n\xef\xbb\xbfmultiline\n"), []string{"testing\n", "multiline\n"}},
+		"bom-in-the-middle-bytes": {[]byte("testing simple \xef\xbb\xbfline\n"), []string{"testing simple \xef\xbb\xbfline\n"}},
+		"not-a-bom-bytes":         {[]byte("\xef\xbf\xbbtesting simple line\n"), []string{"\xef\xbf\xbbtesting simple line\n"}},
+		"bom-on-first-rune":       {[]byte("\uFEFFtesting simple line\n"), []string{"testing simple line\n"}},
+		"bom-on-each-rune":        {[]byte("\uFEFFtesting\n\uFEFFmultiline\n"), []string{"testing\n", "multiline\n"}},
+		"bom-in-the-middle-rune":  {[]byte("testing simple \uFEFFline\n"), []string{"testing simple \uFEFFline\n"}},
+		"not-a-bom-rune":          {[]byte("\uFFEFtesting simple line\n"), []string{"\uFFEFtesting simple line\n"}},
+		// This final test is included for completeness. It is never possible for
+		// a line obtained in the Next method to have a BOM suffix since all
+		// lines are new-line terminated, thus the new-line blocks the BOM
+		// from being identified as a suffix even in the case that is was
+		// actively looked for.
+		"not-a-prefix-bytes": {[]byte("testing simple line\xef\xbf\xbb\n"), []string{"testing simple line\xef\xbf\xbb\n"}},
+		"not-a-prefix-rune":  {[]byte("testing simple line\uFEFF\n"), []string{"testing simple line\uFEFF\n"}},
 	}
 
 	bufferSize := 1000


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
libbeat/reader/readfile: improve performance and clarity of BOM prefix removal

The EncoderReader.Next uses bytes.Trim to trim unnecessary BOM prefixes
from the reader's data, but this requires unnecessary work examining the
suffix of the []byte data. Also express the BOM as its code point rather
than the byte sequence.
```
> [!NOTE]
> Identified while working on #44327.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
