### PR TITLE
[filebeat][abs] - Improve error handling when both root level "max_workers" and "batch_size" are empty

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -263,6 +263,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fixed issue for "Root level readerConfig no longer respected" in azureblobstorage input. {issue}44812[44812] {pull}44873[44873]
 - Added missing "text/csv" content-type filter support in GCS input. {issue}44922[44922] {pull}44923[44923]
 - Fix a panic in the winlog input that prevented it from starting. {issue}45693[45693] {pull}45730[45730]
+- Fix error handling in ABS input when both root level `max_workers` and `batch_size` are empty. {issue}45680[45680] {pull}45743[45743]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/azureblobstorage/config.go
+++ b/x-pack/filebeat/input/azureblobstorage/config.go
@@ -43,7 +43,7 @@ type config struct {
 	BatchSize int `config:"batch_size"`
 	// MaxWorkers defines the maximum number of concurrent workers for processing blobs.
 	// It can be set globally or overridden at the container level.
-	MaxWorkers *int `config:"max_workers" validate:"max=5000"`
+	MaxWorkers int `config:"max_workers" validate:"max=5000"`
 	// Poll enables or disables polling for new blobs in the storage account.
 	// It can be set globally or overridden at the container level.
 	Poll *bool `config:"poll"`

--- a/x-pack/filebeat/input/azureblobstorage/input.go
+++ b/x-pack/filebeat/input/azureblobstorage/input.go
@@ -62,7 +62,7 @@ func configure(cfg *conf.C, _ *logp.Logger) ([]cursor.Source, cursor.Input, erro
 	var sources []cursor.Source
 	// This is to maintain backward compatibility with the old config.
 	if config.BatchSize == 0 {
-		config.BatchSize = *config.MaxWorkers
+		config.BatchSize = config.MaxWorkers
 	}
 	for _, c := range config.Containers {
 		container := tryOverrideOrDefault(config, c)
@@ -102,8 +102,8 @@ func configure(cfg *conf.C, _ *logp.Logger) ([]cursor.Source, cursor.Input, erro
 func tryOverrideOrDefault(cfg config, c container) container {
 	if c.MaxWorkers == nil {
 		maxWorkers := 1
-		if cfg.MaxWorkers != nil {
-			maxWorkers = *cfg.MaxWorkers
+		if cfg.MaxWorkers != 0 {
+			maxWorkers = cfg.MaxWorkers
 		}
 		c.MaxWorkers = &maxWorkers
 	}


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
 Improve error handling when both root level "max_workers" and "batch_size" are empty.
```
**NOTE:** Having a mandatory validation would go against the philosophy of the design here were it would be then required
to have a max_worker or batch_size value present at the root level. This fix allows the default container level "max_worker" to get configured without errors and this would eventually trickle down to the "batch_size" if both root level attributes are missing.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/beats/issues/45680
- Relates https://github.com/elastic/beats/pull/44992


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
