### PR TITLE
Add latency_delta histogram to monitoring.metrics.libbeat.output.write metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -343,6 +343,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Publish cloud.availability_zone by add_cloud_metadata processor in azure environments {issue}42601[42601] {pull}43618[43618]
 - Added the `now` processor, which will populate the specified target field with the current timestamp. {pull}44795[44795]
 - Improve trimming of BOM from UTF-8 data in the libbeat reader/readfile.EncoderReader. {pull}45742[45742]
+- The following output latency_delta metrics are now included when `logging.metrics` is enabled: `output.latency_delta.{count, max, median, min, p99}`. This only includes data since the last internal metrics was logged. {pull}45749[45749]
 
 *Auditbeat*
 

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.7.0
 	github.com/elastic/elastic-agent-autodiscover v0.10.0
-	github.com/elastic/elastic-agent-libs v0.21.5
+	github.com/elastic/elastic-agent-libs v0.22.0
 	github.com/elastic/elastic-agent-system-metrics v0.11.11
 	github.com/elastic/go-elasticsearch/v8 v8.18.1
 	github.com/elastic/go-freelru v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,8 @@ github.com/elastic/elastic-agent-autodiscover v0.10.0 h1:WJ4zl9uSfk1kHmn2B/0byQB
 github.com/elastic/elastic-agent-autodiscover v0.10.0/go.mod h1:Nf3zh9FcJ9nTTswTwDTUAqXmvQllOrNliM6xmORSxwE=
 github.com/elastic/elastic-agent-client/v7 v7.15.0 h1:nDB7v8TBoNuD6IIzC3z7Q0y+7bMgXoT2DsHfolO2CHE=
 github.com/elastic/elastic-agent-client/v7 v7.15.0/go.mod h1:6h+f9QdIr3GO2ODC0Y8+aEXRwzbA5W4eV4dd/67z7nI=
-github.com/elastic/elastic-agent-libs v0.21.5 h1:YTMwaBPgOPvQnxBPv7fLpUqjw2HgY3ymC9TwdzdOD8U=
-github.com/elastic/elastic-agent-libs v0.21.5/go.mod h1:xSeIP3NtOIT4N2pPS4EyURmS1Q8mK0lWZ8Wd1Du6q3w=
+github.com/elastic/elastic-agent-libs v0.22.0 h1:36OSYIJ340kzNxwH8bkpSgt3fLbyAPGMj1zD6hcoSok=
+github.com/elastic/elastic-agent-libs v0.22.0/go.mod h1:xSeIP3NtOIT4N2pPS4EyURmS1Q8mK0lWZ8Wd1Du6q3w=
 github.com/elastic/elastic-agent-system-metrics v0.11.11 h1:Qjh3Zef23PfGlG91AF+9ciNLNQf/8cDJ4CalnLZtV3g=
 github.com/elastic/elastic-agent-system-metrics v0.11.11/go.mod h1:GNqmKfvOt8PwORjbS6GllNdMfkLpOWyTa7P8oQq4E5o=
 github.com/elastic/elastic-transport-go/v8 v8.7.0 h1:OgTneVuXP2uip4BA658Xi6Hfw+PeIOod2rY3GVMGoVE=


### PR DESCRIPTION
## Proposed commit message

This PR adds a new histogram (`latency_delta`) to the `.monitoring.metrics.libbeat.output.write` metrics.  This histogram is cleared every time it is visited (read).  This is useful because the existing histogram (`latency`) is for the lifetime of the output.  If you have a long running process it becomes very difficult to see short term changes in the lifetime histogram.  The original `latency` histogram is unchanged.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

This does add 6 new fields to the monitoring output.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run a beat and look at the "30 sec" metrics output

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes elastic/ingest-dev#5882

## Use cases



## Screenshots

## Logs

### Original

```
jq 'select (.message == "Non-zero metrics in the last 30s") |.monitoring.metrics.libbeat.output.write' *.ndjson
{
  "bytes": 2866,
  "latency": {
    "histogram": {
      "count": 33,
      "max": 7,
      "mean": 2.212121212121212,
      "median": 2,
      "min": 1,
      "p75": 2,
      "p95": 4.899999999999995,
      "p99": 7,
      "p999": 7,
      "stddev": 1.0374086526438604
    }
  }
}
```

### With new `latency_delta` histogram

```
jq 'select (.message == "Non-zero metrics in the last 30s") | .monitoring.metrics.libbeat.output.write' *.ndjson
{
  "bytes": 2806,
  "latency": {
    "histogram": {
      "count": 42,
      "max": 4,
      "mean": 1.6904761904761905,
      "median": 2,
      "min": 1,
      "p75": 2,
      "p95": 3.849999999999998,
      "p99": 4,
      "p999": 4,
      "stddev": 0.8014301276050875
    }
  },
  "latency_delta": {
    "histogram": {
      "count": 3,
      "max": 2,
      "median": 1,
      "min": 1,
      "p99": 2
    }
  }
}
```


