### PR TITLE
x-pack/filebeat/input/httpjson: allow template termination without logging error

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -499,6 +499,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Enhanced HTTPJSON input error logging with structured error metadata conforming to Elastic Common Schema (ECS) conventions. {pull}45653[45653]
 - Clarify behavior in logging for starting periodic evaluations and for exceeding the maximum execution budget. {pull}45633[45633]
 - Add status reporting support for AWS CloudWatch input. {pull}45679[45679]
+- Add mechanism to allow HTTP JSON templates to terminate without logging an error. {issue}45664[45664] {pull}45810[45810]
 
 *Auditbeat*
 

--- a/docs/reference/filebeat/filebeat-input-httpjson.md
+++ b/docs/reference/filebeat/filebeat-input-httpjson.md
@@ -221,6 +221,7 @@ Some built-in helper functions are provided to work with the input state inside 
 * `parseTimestamp`: parses a timestamp in seconds and returns a `time.Time` in UTC. Example: `[[parseTimestamp 1604582732]]` returns `2020-11-05 13:25:32 +0000 UTC`.
 * `replaceAll(old, new, s)`: replaces all non-overlapping instances of `old` with `new` in `s`. Example: `[[ replaceAll "some" "my" "some value" ]]` returns `my value`.
 * `sprintf`: formats according to a format specifier and returns the resulting string. Refer to [the Go docs](https://pkg.go.dev/fmt#Sprintf) for usage. Example: `[[sprintf "%d:%q" 34 "quote this"]]`
+* `terminate`: exits the template without falling back to the default value and without causing an error. It takes a single string argument that is logged in debug logging.
 * `toInt`: converts a value of any type to an integer when possible. Returns 0 if the conversion fails.
 * `toJSON`: converts a value to a JSON string. This can be used with `value_type: json` to create an object from a template. Example: `[[ toJSON .last_response.body.pagingIdentifiers ]]`.
 * `urlEncode`: URL encodes the supplied string. Example `[[urlEncode "string1"]]`. Example `[[urlEncode "<string1>"]]` will return `%3Cstring1%3E`.

--- a/docs/reference/filebeat/filebeat-input-httpjson.md
+++ b/docs/reference/filebeat/filebeat-input-httpjson.md
@@ -221,7 +221,7 @@ Some built-in helper functions are provided to work with the input state inside 
 * `parseTimestamp`: parses a timestamp in seconds and returns a `time.Time` in UTC. Example: `[[parseTimestamp 1604582732]]` returns `2020-11-05 13:25:32 +0000 UTC`.
 * `replaceAll(old, new, s)`: replaces all non-overlapping instances of `old` with `new` in `s`. Example: `[[ replaceAll "some" "my" "some value" ]]` returns `my value`.
 * `sprintf`: formats according to a format specifier and returns the resulting string. Refer to [the Go docs](https://pkg.go.dev/fmt#Sprintf) for usage. Example: `[[sprintf "%d:%q" 34 "quote this"]]`
-* `terminate`: exits the template without falling back to the default value and without causing an error. It takes a single string argument that is logged in debug logging.
+* `terminate`: exits the template without falling back to the default value and without causing an error. It takes a single string argument that is logged in debug logging. {applies_to}`stack: ga 8.18.6, ga 8.19.2, ga 9.1.2, ga 9.0.6`
 * `toInt`: converts a value of any type to an integer when possible. Returns 0 if the conversion fails.
 * `toJSON`: converts a value to a JSON string. This can be used with `value_type: json` to create an object from a template. Example: `[[ toJSON .last_response.body.pagingIdentifiers ]]`.
 * `urlEncode`: URL encodes the supplied string. Example `[[urlEncode "string1"]]`. Example `[[urlEncode "<string1>"]]` will return `%3Cstring1%3E`.

--- a/docs/reference/filebeat/filebeat-input-httpjson.md
+++ b/docs/reference/filebeat/filebeat-input-httpjson.md
@@ -221,7 +221,7 @@ Some built-in helper functions are provided to work with the input state inside 
 * `parseTimestamp`: parses a timestamp in seconds and returns a `time.Time` in UTC. Example: `[[parseTimestamp 1604582732]]` returns `2020-11-05 13:25:32 +0000 UTC`.
 * `replaceAll(old, new, s)`: replaces all non-overlapping instances of `old` with `new` in `s`. Example: `[[ replaceAll "some" "my" "some value" ]]` returns `my value`.
 * `sprintf`: formats according to a format specifier and returns the resulting string. Refer to [the Go docs](https://pkg.go.dev/fmt#Sprintf) for usage. Example: `[[sprintf "%d:%q" 34 "quote this"]]`
-* `terminate`: exits the template without falling back to the default value and without causing an error. It takes a single string argument that is logged in debug logging. {applies_to}`stack: ga 8.18.6, ga 8.19.2, ga 9.1.2, ga 9.0.6`
+* `terminate`: exits the template without falling back to the default value and without causing an error. It takes a single string argument that is logged in debug logging. {applies_to}`stack: ga 9.1.2, ga 9.0.6, ga 8.19.2, ga 8.18.6`
 * `toInt`: converts a value of any type to an integer when possible. Returns 0 if the conversion fails.
 * `toJSON`: converts a value to a JSON string. This can be used with `value_type: json` to create an object from a template. Example: `[[ toJSON .last_response.body.pagingIdentifiers ]]`.
 * `urlEncode`: URL encodes the supplied string. Example `[[urlEncode "string1"]]`. Example `[[urlEncode "<string1>"]]` will return `%3Cstring1%3E`.

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -414,8 +414,10 @@ func evaluateResponse(expression *valueTpl, data []byte, stat status.StatusRepor
 
 	val, err := expression.Execute(paramCtx, tr, "response_evaluation", nil, stat, log)
 	if err != nil {
-
 		return false, fmt.Errorf("error while evaluating expression: %w", err)
+	}
+	if val == "" {
+		return false, nil
 	}
 	result, err := strconv.ParseBool(val)
 	if err != nil {

--- a/x-pack/filebeat/input/httpjson/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl.go
@@ -83,6 +83,7 @@ func (t *valueTpl) Unpack(in string) error {
 			"urlEncode":           urlEncode,
 			"userAgent":           userAgentString,
 			"uuid":                uuidString,
+			"terminate":           func(s string) (any, error) { return nil, &errTerminate{s} },
 		}).
 		Delims(leftDelim, rightDelim).
 		Parse(in)
@@ -93,6 +94,17 @@ func (t *valueTpl) Unpack(in string) error {
 	*t = valueTpl{Template: tpl}
 
 	return nil
+}
+
+type errTerminate struct {
+	Reason string
+}
+
+func (e *errTerminate) Error() string {
+	if e.Reason != "" {
+		return "terminated template: " + e.Reason
+	}
+	return "terminated template"
 }
 
 func (t *valueTpl) Execute(trCtx *transformContext, tr transformable, targetName string, defaultVal *valueTpl, stat status.StatusReporter, log *logp.Logger) (val string, err error) {
@@ -134,6 +146,11 @@ func (t *valueTpl) Execute(trCtx *transformContext, tr transformable, targetName
 	}
 
 	if err := t.Template.Execute(buf, data); err != nil {
+		var termErr *errTerminate
+		if errors.As(err, &termErr) {
+			log.Debugw("template execution terminated", "target", targetName, "reason", termErr.Reason)
+			return "", nil
+		}
 		return fallback(err)
 	}
 

--- a/x-pack/filebeat/input/httpjson/value_tpl_test.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl_test.go
@@ -76,6 +76,14 @@ func TestValueTpl(t *testing.T) {
 			expectedVal: "25",
 		},
 		{
+			name:        "terminate",
+			value:       `[[if false]]ok[[else]][[terminate "because reasons"]][[end]]`,
+			paramCtx:    emptyTransformContext(),
+			paramTr:     transformable{},
+			paramDefVal: "this should not be seen",
+			expectedVal: "",
+		},
+		{
 			name:          "returns error if result is empty and no default is set",
 			value:         "",
 			paramCtx:      emptyTransformContext(),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/httpjson: allow template termination without logging error

This adds a terminate helper that can be used to signal that a template
should terminate without an error. The termination can (should) be used
to report the reason for the termination which will be logged at DEBUG
level, but otherwise ignored.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #45664

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
