### PR TITLE
Enable Otel support in BuildSystemTestBinary

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -116,6 +116,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Removed direct dependency on Azure/go-autorest/autorest/adal, which is deprecated. {issue}41463[41463] {pull}42959[42959]
 - Fixed flaky zookeeper integration tests. {pull}43638[43638]
 - Fixed Fileebat GCP Pub/Sub input integration tests. {pull}45150[45150]
+- `mage BuildSystemTestBinary` now build Otel enabled binaries for Filebeat and Metricbeat {pull}45824[45824]
 
 ==== Added
 

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -50,7 +50,7 @@ func BuildOTel() error {
 
 // BuildSystemTestBinary builds a binary instrumented for use with Python system tests.
 func BuildSystemTestBinary() error {
-	return devtools.BuildSystemTestBinary()
+	return devtools.BuildSystemTestOTelBinary()
 }
 
 // GolangCrossBuild builds the Beat binary inside of the golang-builder.

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -123,6 +123,7 @@ func BuildSystemTestBinary() error {
 	args := []string{
 		"test", "-c",
 		"-o", binArgs.Name + ".test",
+		"-tags", "otelbeat",
 	}
 
 	// On Windows 7 32-bit we run out of memory if we enable coverage and DWARF


### PR DESCRIPTION


## Proposed commit message

See title

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

```
cd x-pack/filebeat
mage -v buildSystemTestBinary # Ensure -tags otelbeat is in the command
./filebeat.test --systemTest otel
# The otel receiver should start.
# stop it CTRL+c

cd ../metricbeat
mage -v buildSystemTestBinary # Ensure -tags otelbeat is in the command
./metricbeat.test --systemTest otel
# The otel receiver should start.
# stop it CTRL+c
```

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
