### PR TITLE
[docs] Add 9.1.1 release notes in Markdown

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,6 +12,24 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 % Description and impact of the breaking change.
 % For more information, check [PR #](PR link).
 
+## 9.1.1 [beats-9.1.1-breaking-changes]
+
+::::{dropdown} Update user agent used by Beats HTTP clients.
+
+% Description
+The default user agent was updated to distinguish between all beat modes:
+
+* **Standalone** indicates that the beat is not running under agent.
+* **Unmanaged** indicates that the beat is running under agent but not managed by Fleet.
+* **Managed** indicates that the beat is running under agent and managed by Fleet.
+
+% Impact
+% TO DO: Add more details
+Users relying on specific user agents could be impacted.
+
+For more information, check [#45251]({{beats-pull}}45251).
+::::
+
 ## 9.0.1 [beats-9.0.1-breaking-changes]
 
 ::::{dropdown} The default data and logs path for the Windows service installation has changed.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -17,6 +17,26 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % ### Fixes [beats-versionext-fixes]
 
+## 9.1.1 [beats-9.1.1-release-notes]
+
+### Features and enhancements [beats-9.1.1-features-enhancements]
+
+**Filebeat**
+
+- Log CEL single object evaluation results as ECS compliant documents where possible. [45254]({{beats-issue}}45254) [45399]({{beats-pull}}45399)
+- Enhanced HTTPJSON input error logging with structured error metadata conforming to Elastic Common Schema (ECS) conventions. [45653]({{beats-pull}}45653)
+
+### Fixes [beats-9.1.1-fixes]
+
+**Filebeat**
+
+- Fix a panic in the winlog input that prevented it from starting. [45693]({{beats-issue}}45693) [45730]({{beats-pull}}45730)
+
+**Metricbeat**
+
+- Improve error messages in AWS Health [45408]({{beats-pull}}45408)
+- Fix URL construction to handle query parameters properly in GET requests for Jolokia [45620]({{beats-pull}}45620)
+
 ## 9.1.0 [beats-9.1.0-release-notes]
 
 ### Features and enhancements [beats-9.1.0-features-enhancements]


### PR DESCRIPTION
Ports release notes from https://github.com/elastic/beats/pull/45771 to Markdown. 

Notes:
* I added the first item from #45771 in breaking changes. If the outcome of [this thread](https://github.com/elastic/beats/pull/45771#pullrequestreview-3093340158) is to make this an enhancement instead, it will need to be moved.
* I'm doing this in a separate PR so I can target `main` and backport to `9.1` (to avoid having [to do this](https://github.com/elastic/beats/pull/45609)).
