### PR TITLE
Unpin stack version on `9.1` branch

### DIFF
--- a/.buildkite/scripts/custom_fips_ech_test.sh
+++ b/.buildkite/scripts/custom_fips_ech_test.sh
@@ -7,13 +7,7 @@ BEAT_PATH=${1:?"Error: Specify the beat path: custom_fips_ech_test.sh [beat_path
 
 trap 'ech_down' EXIT
 
-# We manually override the stack version during the period when we need to bump
-# the Beats version in `libbeat/version/version.go` but new artifacts with that bumped version
-# haven't been published yet and are, therefore, not yet available in ECH.
-# Once artifacts matching the version in `libbeat/version/version.go` are available in ECH, the
-# following line should be removed and the line after that should be uncommented.
-STACK_VERSION="9.1.1-SNAPSHOT"
-# STACK_VERSION="$(./dev-tools/get_version)-SNAPSHOT"
+STACK_VERSION="$(./dev-tools/get_version)-SNAPSHOT"
 
 ech_up $STACK_VERSION
 


### PR DESCRIPTION
Follow up to https://github.com/elastic/beats/pull/45784, which was bumping up the version of Beats to `9.1.2`.  In that PR, we had to pin the stack version used in integration tests that spin up ECH deployments to `9.1.1` because artifacts of version `9.1.2-SNAPSHOT` are not yet available in the ECH CFT region.  

This PR here removes the pinning.  It should be merged once CI goes green, which should happen once artifacts of version `9.1.2-SNAPSHOT` are available in the ECH CFT region.