### PR TITLE
Fix hints default config for logs to match Kubernetes and Docker

### DIFF
--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -29,7 +29,7 @@ type config struct {
 func defaultConfig() config {
 	defaultCfgRaw := map[string]interface{}{
 		"type": "filestream",
-		"id":   "kubernetes-container-logs-${data.kubernetes.container.id}",
+		"id":   "container-logs-${data.container.id}",
 		"prospector": map[string]interface{}{
 			"scanner": map[string]interface{}{
 				"fingerprint.enabled": true,
@@ -46,7 +46,8 @@ func defaultConfig() config {
 			},
 		},
 		"paths": []string{
-			"/var/log/containers/*-${data.kubernetes.container.id}.log",
+			"/var/log/containers/*-${data.container.id}.log",             // Kubernetes
+			"/var/lib/docker/containers/${data.container.id}/*-json.log", // Docker
 		},
 	}
 	defaultCfg, _ := conf.NewConfigFrom(defaultCfgRaw)


### PR DESCRIPTION


## Proposed commit message

```
The hints default config template was using
`${data.kubernetes.container.id}`, however it only works with the Kubernetes provider.

To also support the Docker provided the template is updated to use `${data.container.id}` that is supported by both providers.

The paths is also updated to include the Kubernetes and Docker log paths.

```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/beats/issues/45864
- Closes https://github.com/elastic/beats/issues/45156

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
