### PR TITLE
[Chore][Backport] Replace global logger with local loggers in mb modules #5 

### DIFF
--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/docker"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func init() {
@@ -73,7 +72,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if config.SkipMajor == nil {
 		config.SkipMajor = defaultMajorDev
 	}
-	logp.L().Debugf("Skipping major devices: %v", config.SkipMajor)
+	base.Logger().Debugf("Skipping major devices: %v", config.SkipMajor)
 	client, err := docker.NewDockerClient(base.HostData().URI, docker.Config{TLS: config.TLS, DeDot: config.DeDot})
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/docker/diskio/diskio_integration_test.go
+++ b/metricbeat/module/docker/diskio/diskio_integration_test.go
@@ -23,11 +23,9 @@ import (
 	"testing"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestData(t *testing.T) {
-	logp.DevelopmentSetup()
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 	if err := mbtest.WriteEventsReporterV2Error(f, t, ""); err != nil {
 		t.Fatal("write", err)

--- a/metricbeat/module/docker/event/event.go
+++ b/metricbeat/module/docker/event/event.go
@@ -73,7 +73,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		BaseMetricSet: base,
 		dockerClient:  client,
 		dedot:         config.DeDot,
-		logger:        logp.NewLogger("docker"),
+		logger:        base.Logger().Named("docker"),
 	}, nil
 }
 

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -49,7 +49,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker memory MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logger := logp.NewLogger("docker.memory")
+	logger := base.Logger().Named("docker.memory")
 	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err

--- a/metricbeat/module/jolokia/jmx/config.go
+++ b/metricbeat/module/jolokia/jmx/config.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 

--- a/metricbeat/module/jolokia/jmx/config.go
+++ b/metricbeat/module/jolokia/jmx/config.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 

--- a/metricbeat/module/kubernetes/event/event_test.go
+++ b/metricbeat/module/kubernetes/event/event_test.go
@@ -24,12 +24,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 func TestGenerateMapStrFromEvent(t *testing.T) {
-	logger := logp.NewLogger("kubernetes.event")
+	logger := logptest.NewTestingLogger(t, "kubernetes.event")
 
 	labels := map[string]string{
 		"app.kubernetes.io/name":      "mysql",

--- a/metricbeat/module/kubernetes/util/kubernetes_test.go
+++ b/metricbeat/module/kubernetes/util/kubernetes_test.go
@@ -40,6 +40,8 @@ import (
 	kubernetes2 "github.com/elastic/beats/v7/libbeat/autodiscover/providers/kubernetes"
 	"github.com/elastic/elastic-agent-autodiscover/kubernetes/metadata"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	"github.com/stretchr/testify/require"
@@ -47,11 +49,10 @@ import (
 	k8smetafake "k8s.io/client-go/metadata/fake"
 
 	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestWatchOptions(t *testing.T) {
-	log := logp.NewLogger("test")
+	log := logptest.NewTestingLogger(t, "test")
 
 	client := k8sfake.NewSimpleClientset()
 	config := &kubernetesConfig{
@@ -82,7 +83,7 @@ func TestCreateWatcher(t *testing.T) {
 		SyncPeriod: time.Minute,
 		Node:       "test-node",
 	}
-	log := logp.NewLogger("test")
+	log := logptest.NewTestingLogger(t, "test")
 
 	options, err := getWatchOptions(config, false, client, log)
 	require.NoError(t, err)
@@ -154,7 +155,7 @@ func TestAddToMetricsetsUsing(t *testing.T) {
 		SyncPeriod: time.Minute,
 		Node:       "test-node",
 	}
-	log := logp.NewLogger("test")
+	log := logptest.NewTestingLogger(t, "test")
 
 	options, err := getWatchOptions(config, false, client, log)
 	require.NoError(t, err)
@@ -201,7 +202,7 @@ func TestRemoveFromMetricsetsUsing(t *testing.T) {
 		SyncPeriod: time.Minute,
 		Node:       "test-node",
 	}
-	log := logp.NewLogger("test")
+	log := logptest.NewTestingLogger(t, "test")
 
 	options, err := getWatchOptions(config, false, client, log)
 	require.NoError(t, err)
@@ -388,7 +389,7 @@ func TestCreateAllWatchers(t *testing.T) {
 			Deployment: true,
 		},
 	}
-	log := logp.NewLogger("test")
+	log := logptest.NewTestingLogger(t, "test")
 
 	// Start watchers based on a resource that does not exist should cause an error
 	err := createAllWatchers(
@@ -439,7 +440,8 @@ func TestCreateMetaGen(t *testing.T) {
 	commonConfig, err := conf.NewConfigFrom(&commonMetaConfig)
 	require.NoError(t, err)
 
-	log := logp.NewLogger("test")
+	log := logptest.NewTestingLogger(t, "test")
+
 	config := &kubernetesConfig{
 		Namespace:  "test-ns",
 		SyncPeriod: time.Minute,
@@ -483,7 +485,7 @@ func TestCreateMetaGenSpecific(t *testing.T) {
 	commonConfig, err := conf.NewConfigFrom(&commonMetaConfig)
 	require.NoError(t, err)
 
-	log := logp.NewLogger("test")
+	log := logptest.NewTestingLogger(t, "test")
 
 	namespaceConfig, err := conf.NewConfigFrom(map[string]interface{}{
 		"enabled": true,
@@ -586,7 +588,7 @@ func TestBuildMetadataEnricher_Start_Stop(t *testing.T) {
 		},
 	}
 
-	log := logp.NewLogger(selector)
+	log := logptest.NewTestingLogger(t, selector)
 
 	enricherNamespace := buildMetadataEnricher(
 		metricsetNamespace,
@@ -669,7 +671,7 @@ func TestBuildMetadataEnricher_Start_Stop_SameResources(t *testing.T) {
 		},
 	}
 
-	log := logp.NewLogger(selector)
+	log := logptest.NewTestingLogger(t, selector)
 	enricherPod := buildMetadataEnricher(metricsetPod, PodResource, resourceWatchers, config,
 		funcs.update, funcs.delete, funcs.index, log)
 	resourceWatchers.lock.Lock()
@@ -746,7 +748,7 @@ func TestBuildMetadataEnricher_EventHandler(t *testing.T) {
 	}
 
 	metricset := "pod"
-	log := logp.NewLogger(selector)
+	log := logptest.NewTestingLogger(t, selector)
 
 	enricher := buildMetadataEnricher(metricset, PodResource, resourceWatchers, config,
 		funcs.update, funcs.delete, funcs.index, log)
@@ -879,7 +881,7 @@ func TestBuildMetadataEnricher_PartialMetadata(t *testing.T) {
 	}
 
 	metricset := "replicaset"
-	log := logp.NewLogger(selector)
+	log := logptest.NewTestingLogger(t, selector)
 
 	commonMetaConfig := metadata.Config{}
 	commonConfig, _ := conf.NewConfigFrom(&commonMetaConfig)

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
 	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -39,8 +38,6 @@ var (
 		DefaultScheme: defaultScheme,
 		DefaultPath:   defaultPath,
 	}.Build()
-
-	logger = logp.NewLogger("kubernetes.volume")
 )
 
 // init registers the MetricSet with the central registry.
@@ -95,7 +92,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		return fmt.Errorf("error doing HTTP request to fetch 'volume' Metricset data: %w", err)
 	}
 
-	events, err := eventMapping(body, logger)
+	events, err := eventMapping(body, m.Logger().Named("kubernetes.volume"))
 	if err != nil {
 		return err
 	}

--- a/metricbeat/module/kubernetes/volume/volume_test.go
+++ b/metricbeat/module/kubernetes/volume/volume_test.go
@@ -27,14 +27,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
-	logger := logp.NewLogger("kubernetes.volume")
+	logger := logptest.NewTestingLogger(t, "kubernetes.volume")
 
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)


### PR DESCRIPTION
This is a follow up backport PR of https://github.com/elastic/beats/pull/44775

The base PR had to be split because currently CI fails on 8.19 if the PR includes changes for K8's and docker modules at the same time 