### PR TITLE
Match prometheus version with upstream prometheusreceivers'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/otiai10/copy v1.12.0
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/pkg/xattr v0.4.9
-	github.com/prometheus/prometheus v0.305.0
+	github.com/prometheus/prometheus v0.304.3-0.20250703114031-419d436a447a
 	github.com/shirou/gopsutil/v4 v4.25.6
 	github.com/teambition/rrule-go v1.8.2
 	github.com/tklauser/go-sysconf v0.3.12

--- a/go.sum
+++ b/go.sum
@@ -901,8 +901,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/prometheus/prometheus v0.305.0 h1:UO/LsM32/E9yBDtvQj8tN+WwhbyWKR10lO35vmFLx0U=
-github.com/prometheus/prometheus v0.305.0/go.mod h1:JG+jKIDUJ9Bn97anZiCjwCxRyAx+lpcEQ0QnZlUlbwY=
+github.com/prometheus/prometheus v0.304.3-0.20250703114031-419d436a447a h1:g/nRTrO18wB/VeyJfU2DMAbwWh7Pt/wJ/FcbDlMZb+A=
+github.com/prometheus/prometheus v0.304.3-0.20250703114031-419d436a447a/go.mod h1:L4c564sBwcHLfk60S2IRO2QjLKxPCdy/vxT9tw/T2Jk=
 github.com/prometheus/sigv4 v0.2.0 h1:qDFKnHYFswJxdzGeRP63c4HlH3Vbn1Yf/Ao2zabtVXk=
 github.com/prometheus/sigv4 v0.2.0/go.mod h1:D04rqmAaPPEUkjRQxGqjoxdyJuyCh6E0M18fZr0zBiE=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
Match the `prometheus/prometheus` version used by upstream `prometheusreceiver` to avoid dependency conflict in `elastic-agent`

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


### Why is it required

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Currently, `prometheusreceiver` uses an unreleased version of `prometheus/prometheus`

```go
	github.com/prometheus/prometheus v0.304.3-0.20250703114031-419d436a447a
	github.com/stretchr/testify v1.10.0
```

which uses the latest version of `oteltranslator` ( reverted in the `v0.305.0` release https://github.com/prometheus/prometheus/commit/3253ba63107ee5db50f98d3dc418f25a829d1a7b )


This mismatch is causing dependency conflict when updating otel collector dependencies in elastic-agent

Compilation error as follows

```
> build: Building elastic-agent
# github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite
../pkg/mod/github.com/prometheus/prometheus@v0.305.0/storage/remote/otlptranslator/prometheusremotewrite/helper.go:155:30: undefined: otlptranslator.NormalizeLabel
../pkg/mod/github.com/prometheus/prometheus@v0.305.0/storage/remote/otlptranslator/prometheusremotewrite/helper.go:167:32: undefined: otlptranslator.NormalizeLabel
../pkg/mod/github.com/prometheus/prometheus@v0.305.0/storage/remote/otlptranslator/prometheusremotewrite/helper.go:207:26: undefined: otlptranslator.NormalizeLabel
Error: running "go build -o build/elastic-agent -buildmode pie -trimpath -ldflags -s -X github.com/elastic/elastic-agent/version.buildTime=2025-08-08T15:33:17Z -X github.com/elastic/elastic-agent/version.commit=7e374e8177f915f9c2a9bd806ab43fe0c9f121f7 -X github.com/elastic/elastic-agent/internal/pkg/release.snapshot=" failed with exit code 1
```







