### PR TITLE
[docs] Add 9.1.2 release notes in Markdown

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -17,6 +17,24 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % ### Fixes [beats-versionext-fixes]
 
+## 9.1.2 [beats-9.1.2-release-notes]
+
+### Features and enhancements [beats-9.1.2-features-enhancements]
+
+**Filebeat**
+
+- Add status reporting support for AWS CloudWatch input. [45679]({{beats-pull}}45679)
+
+**Winlogbeat**
+
+- Render data values in xml renderer. [44132]({{beats-pull}}44132)
+
+### Fixes [beats-9.1.2-fixes]
+
+**Filebeat**
+
+- Fix error handling in ABS input when both root level `max_workers` and `batch_size` are empty. [45680]({{beats-issue}}45680) [45743]({{beats-pull}}45743)
+
 ## 9.1.1 [beats-9.1.1-release-notes]
 
 ### Features and enhancements [beats-9.1.1-features-enhancements]


### PR DESCRIPTION
Ports release notes from https://github.com/elastic/beats/pull/45917 to Markdown. 