### PR TITLE
Update docs for #43995 backports

### DIFF
--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -258,6 +258,7 @@ Auditbeat comes with predefined assets for parsing, indexing, and visualizing yo
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Auditbeat-Data\logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Auditbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\auditbeat\Logs`
 
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to {{es}} and deploys the sample dashboards for visualizing the data in {{kib}}.
@@ -329,6 +330,7 @@ PS C:\Program Files\auditbeat> Start-Service auditbeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Auditbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Auditbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\auditbeat\Logs`
 ::::::
 

--- a/docs/reference/auditbeat/auditbeat-starting.md
+++ b/docs/reference/auditbeat/auditbeat-starting.md
@@ -60,6 +60,7 @@ PS C:\Program Files\auditbeat> Start-Service auditbeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Auditbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Auditbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\auditbeat\Logs`
 ::::::
 

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -359,6 +359,7 @@ visualizing your data. To load these assets:
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Filebeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Filebeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\filebeat\Logs`
 
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to {{es}} and deploys the sample dashboards for visualizing the data in {{kib}}.
@@ -443,6 +444,7 @@ PS C:\Program Files\filebeat> Start-Service filebeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Filebeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Filebeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\filebeat\Logs`
 ::::::
 

--- a/docs/reference/filebeat/filebeat-starting.md
+++ b/docs/reference/filebeat/filebeat-starting.md
@@ -70,6 +70,7 @@ PS C:\Program Files\filebeat> Start-Service filebeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Filebeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Filebeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\filebeat\Logs`
 ::::::
 

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -367,6 +367,7 @@ PS C:\Program Files\heartbeat> Start-Service heartbeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Heartbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Heartbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\heartbeat\Logs`
 
 Heartbeat is now ready to check the status of your services and send events to your defined output.

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -333,6 +333,7 @@ Metricbeat comes with predefined assets for parsing, indexing, and visualizing y
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Metricbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Metricbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\metricbeat\Logs`
 
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to Elasticsearch and deploys the sample dashboards for visualizing the data in Kibana.
@@ -408,6 +409,7 @@ PS C:\Program Files\metricbeat> Start-Service metricbeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Metricbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Metricbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\metricbeat\Logs`
 
 For versions lower than 9.1.0, logs are stored by default under `C:\ProgramData\metricbeat\Logs`.

--- a/docs/reference/metricbeat/metricbeat-starting.md
+++ b/docs/reference/metricbeat/metricbeat-starting.md
@@ -70,6 +70,7 @@ PS C:\Program Files\metricbeat> Start-Service metricbeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Metricbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Metricbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\metricbeat\Logs`
 
 ::::{note}

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -389,6 +389,7 @@ Packetbeat comes with predefined assets for parsing, indexing, and visualizing y
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Packetbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Packetbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\packetbeat\Logs`
 
 This step loads the recommended [index template](docs-content://manage-data/data-store/templates.md) for writing to Elasticsearch and deploys the sample dashboards for visualizing the data in Kibana.
@@ -462,6 +463,7 @@ PS C:\Program Files\packetbeat> Start-Service packetbeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Packetbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Packetbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\packetbeat\Logs`
 ::::::
 

--- a/docs/reference/packetbeat/packetbeat-starting.md
+++ b/docs/reference/packetbeat/packetbeat-starting.md
@@ -68,6 +68,7 @@ PS C:\Program Files\packetbeat> Start-Service packetbeat
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Packetbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Packetbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\packetbeat\Logs`
 ::::::
 

--- a/docs/reference/winlogbeat/configuration-logging.md
+++ b/docs/reference/winlogbeat/configuration-logging.md
@@ -21,7 +21,8 @@ logging.files:
   permissions: 0640
 ```
 
-1. {applies_to}`stack: ga 9.1` Default path changed from `C:\ProgramData\winlogbeat\Logs` to `C:\Program Files\winlogbeat-Data\Logs`.
+1. {applies_to}`stack: ga 9.1` Default path changed from `C:\ProgramData\winlogbeat\Logs` to `C:\Program Files\Winlogbeat-Data\Logs`.
+1. {applies_to}`stack: ga 9.0.6` Default path changed from `C:\ProgramData\winlogbeat\Logs` to `C:\Program Files\Winlogbeat-Data\Logs`.
 
 ::::{tip}
 In addition to setting logging options in the config file, you can modify the logging output configuration from the command line. See [Command reference](/reference/winlogbeat/command-line-options.md).

--- a/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
@@ -156,6 +156,7 @@ In `winlogbeat.yml`, configure the event logs that you want to monitor.
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Winlogbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Winlogbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\winlogbeat\Logs`
 
 3. After you save your configuration file, test it with the following command.
@@ -211,6 +212,7 @@ Winlogbeat should now be running. If you used the logging configuration describe
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Winlogbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Winlogbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\winlogbeat\Logs`
 
 You can view the status of the service and control it from the Services management console in Windows. To launch the management console, run this command:

--- a/docs/reference/winlogbeat/winlogbeat-starting.md
+++ b/docs/reference/winlogbeat/winlogbeat-starting.md
@@ -23,6 +23,7 @@ Winlogbeat should now be running. If you used the logging configuration describe
 
 The default location where Windows log files are stored varies:
 * {applies_to}`stack: ga 9.1` `C:\Program Files\Winlogbeat-Data\Logs`
+* {applies_to}`stack: ga 9.0.6` `C:\Program Files\Winlogbeat-Data\Logs`
 * {applies_to}`stack: ga 9.0` `C:\ProgramData\winlogbeat\Logs`
 
 You can view the status of the service and control it from the Services management console in Windows. To launch the management console, run this command:

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -30,7 +30,6 @@ Users relying on specific user agents could be impacted.
 For more information, check [#45251]({{beats-pull}}45251).
 ::::
 
-## 9.0.1 [beats-9.0.1-breaking-changes]
 
 ::::{dropdown} The default data and logs path for the Windows service installation has changed.
 The base folder has changed from `C:\ProgramData\` to `C:\Program
@@ -47,6 +46,32 @@ In a PowerShell prompt, can use `Get-Help install-service-<Beat Name>.ps1
 
 ::::
 
+## 9.0.6 [beats-9.0.6-breaking-changes]
+
+::::{dropdown} The default data and logs path for the Windows service installation has changed.
+The base folder has changed from `C:\ProgramData\` to `C:\Program
+Files\` because the latter has stricter permissions. The state
+and logs are now stored in `C:\Program Files\<Beat Name>-Data`.
+
+When the installation script runs, it looks for the previous default
+data path. If the path is found, data is moved to the new path.
+The installation script accepts the parameter `-UseLegacyPath` to
+force using the legacy data path.
+
+In a PowerShell prompt, can use `Get-Help install-service-<Beat Name>.ps1
+-detailed` to get detailed help.
+
+::::
+
+## 9.0.4 [beats-9.0.4-breaking-changes]
+
+**Metricbeat**
+
+::::{dropdown} Change index summary metricset to use `_nodes/stats` API instead of `_stats` API to avoid data gaps.
+For more information, check  [#45049]({{beats-pull}}45049).
+::::
+
+## 9.0.1 [beats-9.0.1-breaking-changes]
 
 ::::{dropdown} 'close.on_state_change.removed' defaults to `true` on Windows and `false` on the rest of the platforms.
 To keep the previous behaviour, add `close.on_state_change.removed:
@@ -58,14 +83,6 @@ inactivity. See [`close.on_state_change.inactive`](https://www.elastic.co/docs/r
 for more details.
 
 For more information, check [#38523](https://github.com/elastic/beats/issues/38523)
-::::
-
-## 9.0.4 [beats-9.0.4-breaking-changes]
-
-**Metricbeat**
-
-::::{dropdown} Change index summary metricset to use `_nodes/stats` API instead of `_stats` API to avoid data gaps.
-For more information, check  [#45049]({{beats-pull}}45049).
 ::::
 
 ## 9.0.0 [beats-9.0.0-breaking-changes]


### PR DESCRIPTION
## Proposed commit message

```
43995 has been backported to 9.0 and should be published in 9.0.6, this PR updates the docs to reflect that the changes from #43995 affect:
 - >= 9.0.6, for 9.0.x series
 - >= 9.1.0 for 9.1.x series
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~
~~## How to test this PR locally~~
## Related issues
- Docs update for https://github.com/elastic/beats/pull/43995 backports

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
