### PR TITLE
[Chore][Backport] Updates elastic-agent-autodiscover to v0.10.0

### DIFF
--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -88,7 +88,7 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*conf
 
 	// Hint must be explicitly enabled when default_config sets enabled=false.
 	if !l.config.DefaultConfig.Enabled() && !utils.IsEnabled(hints, l.config.Key) ||
-		utils.IsDisabled(hints, l.config.Key) {
+		utils.IsDisabled(hints, l.config.Key, l.log) {
 		l.log.Debugw("Hints config is not enabled.", "autodiscover.event", event)
 		return nil
 	}
@@ -224,11 +224,11 @@ func (l *logHints) getModule(hints mapstr.M) string {
 }
 
 func (l *logHints) getInputsConfigs(hints mapstr.M) []mapstr.M {
-	return utils.GetHintAsConfigs(hints, l.config.Key)
+	return utils.GetHintAsConfigs(hints, l.config.Key, l.log)
 }
 
 func (l *logHints) getProcessors(hints mapstr.M) []mapstr.M {
-	return utils.GetProcessors(hints, l.config.Key)
+	return utils.GetProcessors(hints, l.config.Key, l.log)
 }
 
 func (l *logHints) getPipeline(hints mapstr.M) string {

--- a/filebeat/tests/integration/translate_ldap_attribute_test.go
+++ b/filebeat/tests/integration/translate_ldap_attribute_test.go
@@ -129,7 +129,7 @@ func TestTranslateGUIDWithLDAP(t *testing.T) {
 
 func startOpenldapContainer(t *testing.T) {
 	ctx := context.Background()
-	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil, logp.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.6.0
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.7.0
-	github.com/elastic/elastic-agent-autodiscover v0.9.2
+	github.com/elastic/elastic-agent-autodiscover v0.10.0
 	github.com/elastic/elastic-agent-libs v0.21.2
 	github.com/elastic/elastic-agent-system-metrics v0.11.11
 	github.com/elastic/go-elasticsearch/v8 v8.18.1

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 h1:lnDkqiRFKm0rxdljqr
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3/go.mod h1:aPqzac6AYkipvp4hufTyMj5PDIphF3+At8zr7r51xjY=
 github.com/elastic/ebpfevents v0.7.0 h1:25VVhkUdXp0Am9Gk60ae+lMHFd1DNGbhOjullDbSkLc=
 github.com/elastic/ebpfevents v0.7.0/go.mod h1:ESG9gw7N+n5yCCMgdg1IIJENKWSmX7+X0Fi9GUs9nvU=
-github.com/elastic/elastic-agent-autodiscover v0.9.2 h1:eBmru2v66HRRHOFf89rDl9OZUr7VsPoT4+ZNYHW6e9I=
-github.com/elastic/elastic-agent-autodiscover v0.9.2/go.mod h1:RNaHnOTYfNptSTQUyZYnjypxmrR5AaE6BIap/175F5c=
+github.com/elastic/elastic-agent-autodiscover v0.10.0 h1:WJ4zl9uSfk1kHmn2B/0byQBLIL607Zt4LNfOgV7+XN0=
+github.com/elastic/elastic-agent-autodiscover v0.10.0/go.mod h1:Nf3zh9FcJ9nTTswTwDTUAqXmvQllOrNliM6xmORSxwE=
 github.com/elastic/elastic-agent-client/v7 v7.15.0 h1:nDB7v8TBoNuD6IIzC3z7Q0y+7bMgXoT2DsHfolO2CHE=
 github.com/elastic/elastic-agent-client/v7 v7.15.0/go.mod h1:6h+f9QdIr3GO2ODC0Y8+aEXRwzbA5W4eV4dd/67z7nI=
 github.com/elastic/elastic-agent-libs v0.21.2 h1:r4Tokxx8OvFUVw28foiZT/WHwGUM7JFdlb4TVJ25v9M=

--- a/heartbeat/autodiscover/builder/hints/monitors.go
+++ b/heartbeat/autodiscover/builder/hints/monitors.go
@@ -81,7 +81,7 @@ func (hb *heartbeatHints) CreateConfig(event bus.Event, options ...ucfg.Option) 
 	monitorConfig := hb.getRawConfigs(hints)
 
 	// If explicty disabled, return nothing
-	if utils.IsDisabled(hints, hb.config.Key) {
+	if utils.IsDisabled(hints, hb.config.Key, hb.logger) {
 		hb.logger.Warnf("heartbeat config disabled by hint: %+v", event)
 		return []*conf.C{}
 	}
@@ -144,7 +144,7 @@ func (hb *heartbeatHints) CreateConfig(event bus.Event, options ...ucfg.Option) 
 }
 
 func (hb *heartbeatHints) getRawConfigs(hints mapstr.M) []mapstr.M {
-	return utils.GetHintAsConfigs(hints, hb.config.Key)
+	return utils.GetHintAsConfigs(hints, hb.config.Key, hb.logger)
 }
 
 func (hb *heartbeatHints) getProcessors(hints mapstr.M) []mapstr.M {

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -87,7 +87,7 @@ func NewNodeEventer(
 		Node:         config.Node,
 		IsUpdated:    isUpdated,
 		HonorReSyncs: true,
-	}, nil)
+	}, nil, logger)
 
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create watcher for %T due to error %w", &kubernetes.Node{}, err)

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -99,7 +99,7 @@ func NewPodEventer(
 		Node:         config.Node,
 		Namespace:    config.Namespace,
 		HonorReSyncs: true,
-	}, nil)
+	}, nil, logger)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create watcher for %T due to error %w", &kubernetes.Pod{}, err)
 	}
@@ -121,7 +121,7 @@ func NewPodEventer(
 			Node:         config.Node,
 			HonorReSyncs: true,
 		}
-		nodeWatcher, err = kubernetes.NewNamedWatcher("node", client, &kubernetes.Node{}, options, nil)
+		nodeWatcher, err = kubernetes.NewNamedWatcher("node", client, &kubernetes.Node{}, options, nil, logger)
 		if err != nil {
 			logger.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Node{}, err)
 		}
@@ -132,7 +132,7 @@ func NewPodEventer(
 			SyncTimeout:  config.SyncPeriod,
 			Namespace:    config.Namespace,
 			HonorReSyncs: true,
-		}, nil)
+		}, nil, logger)
 		if err != nil {
 			logger.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Namespace{}, err)
 		}
@@ -159,6 +159,7 @@ func NewPodEventer(
 			},
 			nil,
 			metadata.RemoveUnnecessaryReplicaSetData,
+			logger,
 		)
 		if err != nil {
 			logger.Errorf("Error creating watcher for %T due to error %+v", &kubernetes.ReplicaSet{}, err)
@@ -169,7 +170,7 @@ func NewPodEventer(
 			SyncTimeout:  config.SyncPeriod,
 			Namespace:    config.Namespace,
 			HonorReSyncs: true,
-		}, nil)
+		}, nil, logger)
 		if err != nil {
 			logger.Errorf("Error creating watcher for %T due to error %+v", &kubernetes.Job{}, err)
 		}

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -67,7 +67,7 @@ func NewServiceEventer(
 		SyncTimeout:  config.SyncPeriod,
 		Namespace:    config.Namespace,
 		HonorReSyncs: true,
-	}, nil)
+	}, nil, logger)
 
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create watcher for %T due to error %w", &kubernetes.Service{}, err)
@@ -88,7 +88,7 @@ func NewServiceEventer(
 			SyncTimeout:  config.SyncPeriod,
 			Namespace:    config.Namespace,
 			HonorReSyncs: true,
-		}, nil)
+		}, nil, logger)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create watcher for %T due to error %w", &kubernetes.Namespace{}, err)
 		}

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_integration_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_integration_test.go
@@ -40,7 +40,7 @@ func TestAddDockerMetadata(t *testing.T) {
 	goroutines := resources.NewGoroutinesChecker()
 	defer goroutines.Check(t)
 
-	client, err := docker.NewClient(defaultConfig().Host, nil, nil)
+	client, err := docker.NewClient(defaultConfig().Host, nil, nil, logp.NewNopLogger())
 	require.NoError(t, err)
 
 	// Docker clients can affect the goroutines checker because they keep

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -202,7 +202,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *config.C) {
 			Node:         config.Node,
 			Namespace:    config.Namespace,
 			HonorReSyncs: true,
-		}, nil)
+		}, nil, k.log)
 		if err != nil {
 			k.log.Errorf("Couldn't create kubernetes watcher for %T", &kubernetes.Pod{})
 			return
@@ -215,7 +215,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *config.C) {
 				SyncTimeout:  config.SyncPeriod,
 				Node:         config.Node,
 				HonorReSyncs: true,
-			}, nil)
+			}, nil, k.log)
 			if err != nil {
 				k.log.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Node{}, err)
 			}
@@ -226,7 +226,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *config.C) {
 				SyncTimeout:  config.SyncPeriod,
 				Namespace:    config.Namespace,
 				HonorReSyncs: true,
-			}, nil)
+			}, nil, k.log)
 			if err != nil {
 				k.log.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Namespace{}, err)
 			}
@@ -253,6 +253,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *config.C) {
 				},
 				nil,
 				metadata.RemoveUnnecessaryReplicaSetData,
+				k.log,
 			)
 			if err != nil {
 				k.log.Errorf("Error creating watcher for %T due to error %+v", &kubernetes.ReplicaSet{}, err)
@@ -264,7 +265,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *config.C) {
 				SyncTimeout:  config.SyncPeriod,
 				Namespace:    config.Namespace,
 				HonorReSyncs: true,
-			}, nil)
+			}, nil, k.log)
 			if err != nil {
 				k.log.Errorf("Error creating watcher for %T due to error %+v", &kubernetes.Job{}, err)
 			}

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -56,7 +56,7 @@ type wrapperDriver struct {
 }
 
 func newWrapperDriver() (*wrapperDriver, error) {
-	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil, logp.NewNopLogger())
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/tests/docker/docker.go
+++ b/libbeat/tests/docker/docker.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 
 	"github.com/elastic/elastic-agent-autodiscover/docker"
+	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
@@ -37,7 +38,7 @@ type Client struct {
 
 // NewClient builds and returns a docker Client
 func NewClient() (Client, error) {
-	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil, logp.NewNopLogger())
 	return Client{cli: c}, err
 }
 

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -322,11 +322,11 @@ func (m *metricHints) getMetricsFilters(hints mapstr.M) mapstr.M {
 }
 
 func (m *metricHints) getModuleConfigs(hints mapstr.M) []mapstr.M {
-	return utils.GetHintAsConfigs(hints, m.Key)
+	return utils.GetHintAsConfigs(hints, m.Key, m.logger)
 }
 
 func (m *metricHints) getProcessors(hints mapstr.M) []mapstr.M {
-	return utils.GetProcessors(hints, m.Key)
+	return utils.GetProcessors(hints, m.Key, m.logger)
 
 }
 

--- a/metricbeat/module/docker/docker.go
+++ b/metricbeat/module/docker/docker.go
@@ -82,7 +82,7 @@ func NewDockerClient(endpoint string, config Config) (*client.Client, error) {
 		}
 	}
 
-	client, err := docker.NewClient(endpoint, httpClient, nil)
+	client, err := docker.NewClient(endpoint, httpClient, nil, logp.NewNopLogger())
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/docker/event/event_integration_test.go
+++ b/metricbeat/module/docker/event/event_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/elastic-agent-autodiscover/docker"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestData(t *testing.T) {
@@ -70,7 +71,7 @@ func assertNoErrors(t *testing.T, events []mb.Event) {
 }
 
 func createEvent(t *testing.T) {
-	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil)
+	c, err := docker.NewClient(client.DefaultDockerHost, nil, nil, logp.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -79,7 +79,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		Namespace:   config.Namespace,
 	}
 
-	watcher, err := kubernetes.NewNamedWatcher("event", client, &kubernetes.Event{}, watchOptions, nil)
+	watcher, err := kubernetes.NewNamedWatcher("event", client, &kubernetes.Event{}, watchOptions, nil, base.Logger())
 	if err != nil {
 		return nil, fmt.Errorf("fail to init kubernetes watcher: %w", err)
 	}

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -353,7 +353,7 @@ func createWatcher(
 			if isNamespaced(resourceName) {
 				options.Namespace = namespace
 			}
-			restartWatcher, err := kubernetes.NewNamedWatcher(resourceName, client, resource, options, nil)
+			restartWatcher, err := kubernetes.NewNamedWatcher(resourceName, client, resource, options, nil, logp.NewNopLogger())
 			if err != nil {
 				return false, err
 			}
@@ -385,9 +385,10 @@ func createWatcher(
 			options,
 			nil,
 			transformReplicaSetMetadata,
+			logp.NewNopLogger(),
 		)
 	default:
-		watcher, err = kubernetes.NewNamedWatcher(resourceName, client, resource, options, nil)
+		watcher, err = kubernetes.NewNamedWatcher(resourceName, client, resource, options, nil, logp.NewNopLogger())
 	}
 	if err != nil {
 		return false, fmt.Errorf("error creating watcher for %T: %w", resource, err)


### PR DESCRIPTION
This PR is part of https://github.com/elastic/beats/pull/45692

It has to be backported to 9.1 because that include version update to `elastic-agent-autodiscover`