### PR TITLE
[filebeat] update changelog: add fix panic when registering metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,7 +21,6 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - The Beats logger and file output rotate files when necessary. The beat now forces a file rotation when unexpectedly writing to a file through a symbolic link.
 - Allow faccessat(2) in seccomp. {pull}43322[43322]
 - Update user agent used by beats http clients {pull}45251[45251]
-- Fix a race condition during metrics initialization which could cause a panic. {issue}45822[45822] {pull}45967[45967]
 
 *Auditbeat*
 
@@ -150,6 +149,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Use Debian 11 to build linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31. {issue}44816[44816]
 - The Elasticsearch output now correctly applies exponential backoff when being throttled by 429s ("too many requests") from Elasticsarch. {issue}36926[36926] {pull}45073[45073]
 - Fixed case where Beats would silently fail due to invalid input configuration, now the error is correctly reported. {issue}43118[43118] {pull}45733[45733]
+- Fix a race condition during metrics initialization which could cause a panic. {issue}45822[45822] {pull}46054[46054]
 
 *Auditbeat*
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
update elastic-agent-libs to fix panic when registering metrics

A race condition on elastic-agent-libs (https://github.com/elastic/elastic-agent-libs/issues/319)
could cause filestream to panic when registering its metrics (https://github.com/elastic/beats/issues/45822).
elastic-agent-libs was updated to v0.23.0 by commit https://github.com/elastic/beats/commit/a601b44f74cfdae6f0d63e05dc3b2f4c478206b0, which has the issue fixed.
This commit updates the chancgelog
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

- N/A


## How to test this PR locally

Follow the steps on #45822 to ensure the panic does not happen

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues


- Closes #45822