### PR TITLE
Remove all remaining NewRegistry method calls

### DIFF
--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -65,7 +65,7 @@ const (
 )
 
 var (
-	auditdMetrics         = monitoring.Default.NewRegistry(moduleName)
+	auditdMetrics         = monitoring.Default.GetOrCreateRegistry(moduleName)
 	reassemblerGapsMetric = monitoring.NewInt(auditdMetrics, "reassembler_seq_gaps")
 	kernelLostMetric      = monitoring.NewInt(auditdMetrics, "kernel_lost")
 	userspaceLostMetric   = monitoring.NewInt(auditdMetrics, "userspace_lost")

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -60,7 +60,7 @@ import (
 )
 
 var (
-	harvesterMetrics = monitoring.Default.NewRegistry("filebeat.harvester")
+	harvesterMetrics = monitoring.Default.GetOrCreateRegistry("filebeat.harvester")
 	filesMetrics     = monitoring.GetNamespace("dataset").GetRegistry()
 
 	harvesterStarted   = monitoring.NewInt(harvesterMetrics, "started")
@@ -219,7 +219,7 @@ func (h *Harvester) Setup() error {
 }
 
 func newHarvesterProgressMetrics(id string) *harvesterProgressMetrics {
-	r := filesMetrics.NewRegistry(id)
+	r := filesMetrics.GetOrCreateRegistry(id)
 	return &harvesterProgressMetrics{
 		metricsRegistry:             r,
 		filename:                    monitoring.NewString(r, "name"),

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -180,7 +180,7 @@ func (h *Harvester) open() error {
 	case harvester.LogType, harvester.DockerType, harvester.ContainerType:
 		return h.openFile()
 	default:
-		return fmt.Errorf("Invalid harvester type: %+v", h.config)
+		return fmt.Errorf("invalid harvester type: %+v", h.config)
 	}
 }
 
@@ -446,7 +446,7 @@ func (h *Harvester) onMessage(
 	// Check if json fields exist
 	var jsonFields mapstr.M
 	if f, ok := fields["json"]; ok {
-		jsonFields = f.(mapstr.M)
+		jsonFields, _ = f.(mapstr.M)
 	}
 
 	var meta mapstr.M

--- a/heartbeat/hbregistry/hbregistry.go
+++ b/heartbeat/hbregistry/hbregistry.go
@@ -20,10 +20,10 @@ package hbregistry
 import "github.com/elastic/elastic-agent-libs/monitoring"
 
 // StatsRegistry contains a singleton instance of the heartbeat stats registry
-var StatsRegistry = monitoring.Default.NewRegistry("heartbeat")
+var StatsRegistry = monitoring.Default.GetOrCreateRegistry("heartbeat")
 
 // SchedulerRegistry holds scheduler stats
-var SchedulerRegistry = StatsRegistry.NewRegistry("scheduler")
+var SchedulerRegistry = StatsRegistry.GetOrCreateRegistry("scheduler")
 
 // TelemetryRegistry contains a singleton instance of the heartbeat telemetry registry
-var TelemetryRegistry = monitoring.GetNamespace("state").GetRegistry().NewRegistry("heartbeat")
+var TelemetryRegistry = monitoring.GetNamespace("state").GetRegistry().GetOrCreateRegistry("heartbeat")

--- a/heartbeat/monitors/plugin/regrecord.go
+++ b/heartbeat/monitors/plugin/regrecord.go
@@ -53,7 +53,7 @@ type CountersRecorder struct {
 }
 
 func NewPluginCountersRecorder(pluginName string, rootRegistry *monitoring.Registry) RegistryRecorder {
-	pluginRegistry := rootRegistry.NewRegistry(pluginName)
+	pluginRegistry := rootRegistry.GetOrCreateRegistry(pluginName)
 	return CountersRecorder{
 		monitoring.NewInt(pluginRegistry, "monitor_starts"),
 		monitoring.NewInt(pluginRegistry, "monitor_stops"),
@@ -87,7 +87,7 @@ func newRootGaugeRecorder(r *monitoring.Registry) RegistryRecorder {
 }
 
 func newPluginGaugeRecorder(pluginName string, rootRegistry *monitoring.Registry) RegistryRecorder {
-	pluginRegistry := rootRegistry.NewRegistry(pluginName)
+	pluginRegistry := rootRegistry.GetOrCreateRegistry(pluginName)
 	return newRootGaugeRecorder(pluginRegistry)
 }
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -351,7 +351,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	}
 
 	// Report central management state
-	mgmt := b.Monitoring.StateRegistry().NewRegistry("management")
+	mgmt := b.Monitoring.StateRegistry().GetOrCreateRegistry("management")
 	monitoring.NewBool(mgmt, "enabled").Set(b.Manager.Enabled())
 
 	log.Debug("Initializing output plugins")
@@ -1281,7 +1281,7 @@ func (b *Beat) registerClusterUUIDFetching() {
 
 // Build and return a callback to fetch the Elasticsearch cluster_uuid for monitoring
 func (b *Beat) clusterUUIDFetchingCallback() elasticsearch.ConnectCallback {
-	elasticsearchRegistry := b.Monitoring.StateRegistry().NewRegistry("outputs.elasticsearch")
+	elasticsearchRegistry := b.Monitoring.StateRegistry().GetOrCreateRegistry("outputs.elasticsearch")
 	clusterUUIDRegVar := monitoring.NewString(elasticsearchRegistry, "cluster_uuid")
 
 	callback := func(esClient *eslegclient.Connection, _ *logp.Logger) error {
@@ -1318,7 +1318,7 @@ func (b *Beat) setupMonitoring(settings Settings) (report.Reporter, error) {
 
 	// Expose monitoring.cluster_uuid in state API
 	if monitoringClusterUUID != "" {
-		monitoringRegistry := b.Monitoring.StateRegistry().NewRegistry("monitoring")
+		monitoringRegistry := b.Monitoring.StateRegistry().GetOrCreateRegistry("monitoring")
 		clusterUUIDRegVar := monitoring.NewString(monitoringRegistry, "cluster_uuid")
 		clusterUUIDRegVar.Set(monitoringClusterUUID)
 	}

--- a/libbeat/monitoring/inputmon/httphandler_test.go
+++ b/libbeat/monitoring/inputmon/httphandler_test.go
@@ -60,7 +60,7 @@ func TestHandler(t *testing.T) {
 
 	// Register legacy metrics without id or input. This must be ignored.
 	{
-		legacy := parent.NewRegistry("f49c0680-fc5f-4b78-bd98-7b16628f9a77")
+		legacy := parent.GetOrCreateRegistry("f49c0680-fc5f-4b78-bd98-7b16628f9a77")
 		monitoring.NewString(legacy, "name").Set("/var/log/wifi.log")
 		monitoring.NewTimestamp(legacy, "last_event_published_time").Set(time.Now())
 	}

--- a/libbeat/monitoring/inputmon/input.go
+++ b/libbeat/monitoring/inputmon/input.go
@@ -78,7 +78,7 @@ func NewDeprecatedMetricsRegistry(inputType, inputID string, optionalParent *mon
 	// that isn't at the top-level.
 	reg = findInputRegistryWithID(parentRegistry, inputID)
 	if reg == nil {
-		reg = parentRegistry.NewRegistry(registryID)
+		reg = parentRegistry.GetOrCreateRegistry(registryID)
 	} else {
 		log.Warnw(fmt.Sprintf(
 			"parent metrics registry already contains a %q registry, reusing it",
@@ -154,7 +154,15 @@ func NewMetricsRegistry(
 	registryID := sanitizeID(inputID)
 	reg := parent.GetRegistry(registryID)
 	if reg == nil {
-		reg = parent.NewRegistry(registryID)
+		// Technically this is a race: the previous GetRegistry is not atomic with
+		// this GetOrCreateRegistry, so if someone else is adding the same id at this
+		// exact moment we might take this branch inappropriately. However, the
+		// consequences in that case are metrics for two inputs with the same id
+		// being inappropriately reported under the same registry, whereas the
+		// consequences if we called NewRegistry here are a panic.
+		// (We should also never have two inputs with the same id in the first
+		// place, but it's worth being cautious.)
+		reg = parent.GetOrCreateRegistry(registryID)
 	} else {
 		// Null route metrics for duplicated ID.
 		reg = monitoring.NewRegistry()

--- a/libbeat/monitoring/inputmon/input_test.go
+++ b/libbeat/monitoring/inputmon/input_test.go
@@ -105,7 +105,7 @@ func TestMetricSnapshotJSON(t *testing.T) {
 	monitoring.NewInt(reg, "events_pipeline_total").Set(10)
 
 	// simulate a duplicated ID in the local and global namespace.
-	reg = globalRegistry().NewRegistry(inputID)
+	reg = globalRegistry().GetOrCreateRegistry(inputID)
 	monitoring.NewString(reg, MetricKeyID).Set(inputID)
 	monitoring.NewString(reg, MetricKeyInput).Set(inputType)
 	monitoring.NewBool(reg, "should_be_overwritten").Set(true)
@@ -139,12 +139,12 @@ func TestMetricSnapshotJSON(t *testing.T) {
 
 	// ==== registries in the global registries which aren't input metrics ===
 	// unrelated registry in the global namespace, should be ignored.
-	reg = globalRegistry().NewRegistry("another-registry")
+	reg = globalRegistry().GetOrCreateRegistry("another-registry")
 	monitoring.NewInt(reg, "foo3_total").Set(100)
 	defer globalRegistry().Remove("another-registry")
 
 	// another input registry missing required information.
-	reg = globalRegistry().NewRegistry("yet-another-registry")
+	reg = globalRegistry().GetOrCreateRegistry("yet-another-registry")
 	monitoring.NewString(reg, MetricKeyID).Set("some-id")
 	monitoring.NewInt(reg, "foo3_total").Set(100)
 	defer globalRegistry().Remove("yet-another-registry")
@@ -339,7 +339,7 @@ func TestCancelMetricsRegistry(t *testing.T) {
 	inputID := "input-ID"
 	inputType := "input-type"
 
-	_ = parent.NewRegistry(inputID)
+	_ = parent.GetOrCreateRegistry(inputID)
 	got := parent.GetRegistry(inputID)
 	require.NotNil(t, got, "metrics registry not found on parent")
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -50,7 +50,7 @@ func init() {
 	processors.RegisterPlugin(processorName, New)
 	jsprocessor.RegisterPlugin("AddHostMetadata", New)
 
-	reg = monitoring.Default.NewRegistry(logName, monitoring.DoNotReport)
+	reg = monitoring.Default.GetOrCreateRegistry(logName, monitoring.DoNotReport)
 }
 
 type metrics struct {

--- a/libbeat/processors/dns/dns.go
+++ b/libbeat/processors/dns/dns.go
@@ -59,7 +59,7 @@ func New(cfg *conf.C, log *logp.Logger) (beat.Processor, error) {
 	// Logging and metrics (each processor instance has a unique ID).
 	var (
 		id      = int(instanceID.Add(1))
-		metrics = monitoring.Default.NewRegistry(logName+"."+strconv.Itoa(id), monitoring.DoNotReport)
+		metrics = monitoring.Default.GetOrCreateRegistry(logName+"."+strconv.Itoa(id), monitoring.DoNotReport)
 	)
 
 	log = log.Named(logName).With("instance_id", id)
@@ -69,7 +69,7 @@ func New(cfg *conf.C, log *logp.Logger) (beat.Processor, error) {
 		return nil, err
 	}
 
-	cache, err := newLookupCache(metrics.NewRegistry("cache"), c.cacheConfig, resolver)
+	cache, err := newLookupCache(metrics.GetOrCreateRegistry("cache"), c.cacheConfig, resolver)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -241,7 +241,7 @@ func (res *miekgResolver) getOrCreateNameserverStats(ns string) *nameserverStats
 	}
 
 	// Create stats for the nameserver.
-	reg := res.registry.NewRegistry(strings.Replace(ns, ".", "_", -1))
+	reg := res.registry.GetOrCreateRegistry(strings.Replace(ns, ".", "_", -1))
 	stats = &nameserverStats{
 		success:         monitoring.NewInt(reg, "success"),
 		failure:         monitoring.NewInt(reg, "failure"),

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -38,7 +38,7 @@ func TestNewMiekgResolverWithIPv6(t *testing.T) {
 	const addr = `fe80::1%en0` // Example IPv6 address with zone index.
 
 	reg := monitoring.NewRegistry()
-	_, err := newMiekgResolver(reg.NewRegistry(logName), 0, "udp", addr)
+	_, err := newMiekgResolver(reg.GetOrCreateRegistry(logName), 0, "udp", addr)
 	assert.NoError(t, err)
 }
 
@@ -52,7 +52,7 @@ func TestMiekgResolverLookupPTR(t *testing.T) {
 	}()
 
 	reg := monitoring.NewRegistry()
-	res, err := newMiekgResolver(reg.NewRegistry(logName), 0, "udp", addr)
+	res, err := newMiekgResolver(reg.GetOrCreateRegistry(logName), 0, "udp", addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestMiekgResolverLookupPTRTLS(t *testing.T) {
 
 	reg := monitoring.NewRegistry()
 
-	res, err := newMiekgResolver(reg.NewRegistry(logName), 0, "tls", addr)
+	res, err := newMiekgResolver(reg.GetOrCreateRegistry(logName), 0, "tls", addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/ratelimit/rate_limit.go
+++ b/libbeat/processors/ratelimit/rate_limit.go
@@ -80,7 +80,7 @@ func new(cfg *c.C, log *logp.Logger) (beat.Processor, error) {
 	// Logging and metrics (each processor instance has a unique ID).
 	var (
 		id  = int(instanceID.Add(1))
-		reg = monitoring.Default.NewRegistry(logName+"."+strconv.Itoa(id), monitoring.DoNotReport)
+		reg = monitoring.Default.GetOrCreateRegistry(logName+"."+strconv.Itoa(id), monitoring.DoNotReport)
 	)
 
 	log = log.Named(logName).With("instance_id", id)

--- a/libbeat/processors/script/javascript/javascript.go
+++ b/libbeat/processors/script/javascript/javascript.go
@@ -222,7 +222,7 @@ func getStats(id string, reg *monitoring.Registry) *processorStats {
 		// If a module is reloaded then the namespace could already exist.
 		_ = processorReg.Clear()
 	} else {
-		processorReg = reg.NewRegistry(namespace, monitoring.DoNotReport)
+		processorReg = reg.GetOrCreateRegistry(namespace, monitoring.DoNotReport)
 	}
 
 	stats := &processorStats{

--- a/libbeat/processors/syslog/syslog.go
+++ b/libbeat/processors/syslog/syslog.go
@@ -122,7 +122,7 @@ func New(c *conf.C, log *logp.Logger) (beat.Processor, error) {
 		log = log.With("tag", cfg.Tag)
 		registryName = logName + "." + cfg.Tag + "-" + strconv.Itoa(id)
 	}
-	registry := monitoring.Default.NewRegistry(registryName, monitoring.DoNotReport)
+	registry := monitoring.Default.GetOrCreateRegistry(registryName, monitoring.DoNotReport)
 
 	return &processor{
 		config: cfg,

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -264,10 +264,7 @@ func (c *outputController) createQueueIfNeeded(outGrp outputs.Group) {
 	// Queue metrics are reported under the pipeline namespace
 	var pipelineMetrics *monitoring.Registry
 	if c.monitors.Metrics != nil {
-		pipelineMetrics = c.monitors.Metrics.GetRegistry("pipeline")
-		if pipelineMetrics == nil {
-			pipelineMetrics = c.monitors.Metrics.NewRegistry("pipeline")
-		}
+		pipelineMetrics = c.monitors.Metrics.GetOrCreateRegistry("pipeline")
 	}
 	queueObserver := queue.NewQueueObserver(pipelineMetrics)
 
@@ -280,7 +277,7 @@ func (c *outputController) createQueueIfNeeded(outGrp outputs.Group) {
 	c.queue = queue
 
 	if c.monitors.Telemetry != nil {
-		queueReg := c.monitors.Telemetry.NewRegistry("queue")
+		queueReg := c.monitors.Telemetry.GetOrCreateRegistry("queue")
 		monitoring.NewString(queueReg, "name").Set(c.queue.QueueType())
 	}
 

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -131,7 +131,7 @@ func loadOutput(
 			}
 
 		} else {
-			metrics = monitors.Metrics.NewRegistry("output")
+			metrics = monitors.Metrics.GetOrCreateRegistry("output")
 		}
 		outStats = outputs.NewStats(metrics)
 	}
@@ -152,7 +152,7 @@ func loadOutput(
 				return outputs.Group{}, err
 			}
 		} else {
-			telemetry = monitors.Telemetry.NewRegistry("output")
+			telemetry = monitors.Telemetry.GetOrCreateRegistry("output")
 		}
 		monitoring.NewString(telemetry, "name").Set(outName)
 		monitoring.NewInt(telemetry, "batch_size").Set(int64(out.BatchSize))

--- a/libbeat/publisher/pipeline/monitoring.go
+++ b/libbeat/publisher/pipeline/monitoring.go
@@ -78,10 +78,7 @@ type metricsObserverVars struct {
 }
 
 func newMetricsObserver(metrics *monitoring.Registry) *metricsObserver {
-	reg := metrics.GetRegistry("pipeline")
-	if reg == nil {
-		reg = metrics.NewRegistry("pipeline")
-	}
+	reg := metrics.GetOrCreateRegistry("pipeline")
 
 	return &metricsObserver{
 		metrics: metrics,

--- a/libbeat/publisher/queue/monitoring.go
+++ b/libbeat/publisher/queue/monitoring.go
@@ -75,7 +75,7 @@ func NewQueueObserver(metrics *monitoring.Registry) Observer {
 			return nilObserver{}
 		}
 	} else {
-		queueMetrics = metrics.NewRegistry("queue")
+		queueMetrics = metrics.GetOrCreateRegistry("queue")
 	}
 
 	ob := &queueObserver{

--- a/libbeat/publisher/queue/monitoring.go
+++ b/libbeat/publisher/queue/monitoring.go
@@ -100,16 +100,24 @@ func NewQueueObserver(metrics *monitoring.Registry) Observer {
 }
 
 func (ob *queueObserver) MaxEvents(value int) {
-	ob.maxEvents.Set(uint64(value))
+	if value >= 0 {
+		ob.maxEvents.Set(uint64(value))
+	}
 }
 
 func (ob *queueObserver) MaxBytes(value int) {
-	ob.maxBytes.Set(uint64(value))
+	if value >= 0 {
+		ob.maxBytes.Set(uint64(value))
+	}
 }
 
 func (ob *queueObserver) Restore(eventCount int, byteCount int) {
-	ob.filledEvents.Set(uint64(eventCount))
-	ob.filledBytes.Set(uint64(byteCount))
+	if eventCount >= 0 {
+		ob.filledEvents.Set(uint64(eventCount))
+	}
+	if byteCount >= 0 {
+		ob.filledBytes.Set(uint64(byteCount))
+	}
 	ob.updateFilledPct()
 }
 

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -462,7 +462,7 @@ func getMetricSetStats(mon beat.Monitoring, module, name string) *stats {
 		return s
 	}
 
-	reg := mon.StatsRegistry().NewRegistry(key)
+	reg := mon.StatsRegistry().GetOrCreateRegistry(key)
 	s := &stats{
 		key:                 key,
 		ref:                 1,

--- a/x-pack/auditbeat/module/system/process/quark_provider_linux.go
+++ b/x-pack/auditbeat/module/system/process/quark_provider_linux.go
@@ -32,7 +32,7 @@ var quarkMetrics = struct {
 }{}
 
 func init() {
-	reg := monitoring.Default.NewRegistry("process@quark")
+	reg := monitoring.Default.GetOrCreateRegistry("process@quark")
 	quarkMetrics.insertions = monitoring.NewUint(reg, "insertions")
 	quarkMetrics.removals = monitoring.NewUint(reg, "removals")
 	quarkMetrics.aggregations = monitoring.NewUint(reg, "aggregations")

--- a/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
+++ b/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
@@ -77,7 +77,7 @@ func genRegistry(reg *monitoring.Registry, base string) *monitoring.Registry {
 		regName = fmt.Sprintf("%s.%d", base, id)
 	}
 
-	metricsReg := reg.NewRegistry(regName)
+	metricsReg := reg.GetOrCreateRegistry(regName)
 	return metricsReg
 }
 


### PR DESCRIPTION
The `NewRegistry` method in `elastic-agent-libs` is inherently unsafe, especially in concurrent code: calling `NewRegistry` on a name that already exists causes a panic, but checking whether the name exists first is not atomic. The recently added `GetOrCreateRegistry` method is a safe alternative that checks the name's existence and initializes it atomically, and never panics. This PR replaces all remaining `NewRegistry` calls with `GetOrCreateRegistry`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas