### PR TITLE
[Streaming] Restore the Streaming input on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -267,6 +267,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fix wrongly emitted missing input ID warning {issue}42969[42969] {pull}45747[45747]
 - Fix error handling in ABS input when both root level `max_workers` and `batch_size` are empty. {issue}45680[45680] {pull}45743[45743]
 - Fix handling of unnecessary BOM in UTF-8 text received by o365audit input. {issue}44327[44327] {pull}45739[45739]
+- Restore the Streaming input on Windows. {pull}46031[46031]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/default-inputs/inputs_windows.go
+++ b/x-pack/filebeat/input/default-inputs/inputs_windows.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/netflow"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/o365audit"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/salesforce"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/streaming"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -44,6 +45,8 @@ func xpackInputs(info beat.Info, log *logp.Logger, store statestore.States) []v2
 		awscloudwatch.Plugin(log, store),
 		lumberjack.Plugin(log),
 		etw.Plugin(),
+		streaming.Plugin(log, store),
+		streaming.PluginWebsocketAlias(log, store),
 		netflow.Plugin(log),
 		salesforce.Plugin(log, store),
 		benchmark.Plugin(),


### PR DESCRIPTION
## Proposed commit message

```
[Streaming] Restore the Streaming input on Windows

It was originally named the Websocket input and was added everywhere
except AIX. It was accidentally removed from Windows in #36915.
```

## Discussion

This does the same thing for the Streaming (previously Websocket) input as was done for the Netflow input in #39024.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
