### PR TITLE
Fix data race in measuring event retry count

### DIFF
--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -162,8 +162,7 @@ outerLoop:
 		case outputChan <- active:
 			// Successfully sent a batch to the output workers
 			if len(retryBatches) > 0 {
-				// This was a retry, report it to the observer
-				c.retryObserver.eventsRetry(len(active.Events()))
+				// This was a retry, advance the retry batch list
 				retryBatches = retryBatches[1:]
 			} else {
 				// This was directly from the queue, clear the value so we can
@@ -182,8 +181,10 @@ outerLoop:
 
 				alive := req.batch.reduceTTL()
 
+				// Report retried vs dropped event count to the observer
 				countDropped := countFailed - len(req.batch.Events())
 				c.retryObserver.eventsDropped(countDropped)
+				c.retryObserver.eventsRetry(len(req.batch.Events()))
 
 				if !alive {
 					log.Info("Drop batch")


### PR DESCRIPTION
Fix a small data race in measuring the number of retried events in the event consumer. The previous code counted retried events immediately after they were sent to an output worker, but the output worker owns the events list once the batch is handed off, and the event consumer checking the event count was technically concurrent with the output's clearing the event list after full publication. The new code instead increments the event retry count when the event consumer receives a batch retry request and decides how many events will be retried.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Fixes https://github.com/elastic/beats/issues/45643