### PR TITLE
Improve documentation about Windows install script

### DIFF
--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -101,9 +101,10 @@ If script execution is disabled on your system, you need to set the execution po
 :::
 
 :::{important}
-```{applies_to}
-stack: ga 9.0.6
-```
+This was introduced on:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
+
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for
 state and logs) is now `C:\Program Files\Auditbeat-Data`.

--- a/docs/reference/auditbeat/auditbeat-installation-script.md
+++ b/docs/reference/auditbeat/auditbeat-installation-script.md
@@ -1,13 +1,15 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/auditbeat/current/auditbeat-installation-script.html
-applies_to:
-  stack: ga 9.0.6
 ---
+
+This page applies to:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
 
 # Installation script
 The installation script, `install-service-auditbeat.ps1` is responsible
-for creating the Windows Service for Auditbeat. Starting in 9.0.6, the
+for creating the Windows Service for Auditbeat. The
 base folder has changed from `C:\ProgramData\` to  `C:\Program Files\`
 because the latter has stricter permissions, therefore the home path
 (base for state and logs) is now `C:\Program Files\Auditbeat-Data`.
@@ -33,3 +35,7 @@ If there is a permission error when the installation script is moving
 the folder, ensure the user running the script has enough permissions
 to do so. If the problem persists, the folder can be moved manually,
 then the installation script can be executed again.
+
+If the script still cannot move the files, you can manually move
+`C:\ProgramData\auditbeat` to `C:\Program Files\Auditbeat-Data`
+and run the install script again.

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -100,9 +100,10 @@ If script execution is disabled on your system, you need to set the execution po
 :::
 
 :::{important}
-```{applies_to}
-stack: ga 9.0.6
-```
+This was introduced on:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
+
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for
 state and logs) is now `C:\Program Files\Filebeat-Data`.

--- a/docs/reference/filebeat/filebeat-installation-script.md
+++ b/docs/reference/filebeat/filebeat-installation-script.md
@@ -1,13 +1,15 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-script.html
-applies_to:
-  stack: ga 9.0.6
 ---
+
+This page applies to:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
 
 # Installation script
 The installation script, `install-service-filebeat.ps1` is responsible
-for creating the Windows Service for Filebeat. Starting in 9.0.6, the
+for creating the Windows Service for Filebeat. The
 base folder has changed from `C:\ProgramData\` to  `C:\Program Files\`
 because the latter has stricter permissions, therefore the home path
 (base for state and logs) is now `C:\Program Files\Filebeat-Data`.
@@ -33,3 +35,7 @@ If there is a permission error when the installation script is moving
 the folder, ensure the user running the script has enough permissions
 to do so. If the problem persists, the folder can be moved manually,
 then the installation script can be executed again.
+
+If the script still cannot move the files, you can manually move
+`C:\ProgramData\filebeat` to `C:\Program Files\Filebeat-Data`
+and run the install script again.

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -102,9 +102,10 @@ If script execution is disabled on your system, you need to set the execution po
 :::
 
 :::{important}
-```{applies_to}
-stack: ga 9.0.6
-```
+This was introduced on:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
+
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for
 state and logs) is now `C:\Program Files\Heartbeat-Data`.

--- a/docs/reference/heartbeat/heartbeat-installation-script.md
+++ b/docs/reference/heartbeat/heartbeat-installation-script.md
@@ -1,13 +1,15 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/heartbeat/current/heartbeat-installation-script.html
-applies_to:
-  stack: ga 9.0.6
 ---
+
+This page applies to:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
 
 # Installation script
 The installation script, `install-service-heartbeat.ps1` is responsible
-for creating the Windows Service for Heartbeat. Starting in 9.0.6, the
+for creating the Windows Service for Heartbeat. The
 base folder has changed from `C:\ProgramData\` to  `C:\Program Files\`
 because the latter has stricter permissions, therefore the home path
 (base for state and logs) is now `C:\Program Files\Heartbeat-Data`.
@@ -33,3 +35,7 @@ If there is a permission error when the installation script is moving
 the folder, ensure the user running the script has enough permissions
 to do so. If the problem persists, the folder can be moved manually,
 then the installation script can be executed again.
+
+If the script still cannot move the files, you can manually move
+`C:\ProgramData\heartbeat` to `C:\Program Files\heartbeat-Data`
+and run the install script again.

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -104,9 +104,10 @@ If script execution is disabled on your system, you need to set the execution po
 :::
 
 :::{important}
-```{applies_to}
-stack: ga 9.0.6
-```
+This was introduced on:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
+
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for
 state and logs) is now `C:\Program Files\Metricbeat-Data`.

--- a/docs/reference/metricbeat/metricbeat-installation-script.md
+++ b/docs/reference/metricbeat/metricbeat-installation-script.md
@@ -1,13 +1,15 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-installation-script.html
-applies_to:
-  stack: ga 9.0.6
 ---
+
+This page applies to:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
 
 # Installation script
 The installation script, `install-service-metricbeat.ps1` is responsible
-for creating the Windows Service for Metricbeat. Starting in 9.0.6, the
+for creating the Windows Service for Metricbeat. The
 base folder has changed from `C:\ProgramData\` to  `C:\Program Files\`
 because the latter has stricter permissions, therefore the home path
 (base for state and logs) is now `C:\Program Files\Metricbeat-Data`.
@@ -33,3 +35,7 @@ If there is a permission error when the installation script is moving
 the folder, ensure the user running the script has enough permissions
 to do so. If the problem persists, the folder can be moved manually,
 then the installation script can be executed again.
+
+If the script still cannot move the files, you can manually move
+`C:\ProgramData\metricbeat` to `C:\Program Files\Metricbeat-Data`
+and run the install script again.

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -141,9 +141,10 @@ If script execution is disabled on your system, you need to set the execution po
 :::
 
 :::{important}
-```{applies_to}
-stack: ga 9.0.6
-```
+This was introduced on:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
+
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for
 state and logs) is now `C:\Program Files\Packetbeat-Data`.

--- a/docs/reference/packetbeat/packetbeat-installation-script.md
+++ b/docs/reference/packetbeat/packetbeat-installation-script.md
@@ -1,13 +1,15 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/packetbeat/current/packetbeat-installation-script.html
-applies_to:
-  stack: ga 9.0.6
 ---
+
+This page applies to:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
 
 # Installation script
 The installation script, `install-service-packetbeat.ps1` is responsible
-for creating the Windows Service for Packetbeat. Starting in 9.0.6, the
+for creating the Windows Service for Packetbeat. The
 base folder has changed from `C:\ProgramData\` to  `C:\Program Files\`
 because the latter has stricter permissions, therefore the home path
 (base for state and logs) is now `C:\Program Files\Packetbeat-Data`.
@@ -33,3 +35,7 @@ If there is a permission error when the installation script is moving
 the folder, ensure the user running the script has enough permissions
 to do so. If the problem persists, the folder can be moved manually,
 then the installation script can be executed again.
+
+If the script still cannot move the files, you can manually move
+`C:\ProgramData\packetbeat` to `C:\Program Files\Packetbeat-Data`
+and run the install script again.

--- a/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
@@ -73,9 +73,10 @@ To use a local non-Administrator account to run Winlogbeat, follow [these additi
 :::
 
 :::{important}
-```{applies_to}
-stack: ga 9.0.6
-```
+This was introduced on:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
+
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for
 state and logs) is now `C:\Program Files\Winlogbeat-Data`.

--- a/docs/reference/winlogbeat/winlogbeat-installation-script.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-script.md
@@ -1,13 +1,15 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/winlogbeat/current/winlogbeat-installation-script.html
-applies_to:
-  stack: ga 9.0.6
 ---
+
+This page applies to:
+ - 9.0.6 for versions >= 9.0.0 and < 9.1.0.
+ - 9.1.0 for versions >= 9.1.0.
 
 # Installation script
 The installation script, `install-service-winlogbeat.ps1` is responsible
-for creating the Windows Service for Winlogbeat. Starting in 9.0.6, the
+for creating the Windows Service for Winlogbeat. The
 base folder has changed from `C:\ProgramData\` to  `C:\Program Files\`
 because the latter has stricter permissions, therefore the home path
 (base for state and logs) is now `C:\Program Files\Winlogbeat-Data`.
@@ -33,3 +35,7 @@ If there is a permission error when the installation script is moving
 the folder, ensure the user running the script has enough permissions
 to do so. If the problem persists, the folder can be moved manually,
 then the installation script can be executed again.
+
+If the script still cannot move the files, you can manually move
+`C:\ProgramData\winlogbeat` to `C:\Program Files\Winlogbeat-Data`
+and run the install script again.


### PR DESCRIPTION
## Proposed commit message

```
This commit updates the documentation to clarify which versions have the new install script that uses `C:\Program Files-Data` as the base path for Beats.
```

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~
## How to test this PR locally
1. Build the docs: `docs-builder serve`
2. For each Beat check (example links for Filebeat)
    - http://localhost:3000/reference/filebeat/filebeat-installation-script
    - http://localhost:3000/reference/filebeat/filebeat-installation-configuration - Go to "Step 1", then click on "Windows" tab.

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

