### PR TITLE
[docs] Adds applies_to to changes from #43368

### DIFF
--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -626,6 +626,10 @@ file_identity.inode_marker.path: /logs/.filebeat-marker
 
 ## Removing fully ingested files [filebeat-input-filestream-delete-options]
 
+```{applies_to}
+stack: ga 9.2.0
+```
+
 By default, Filestream input doesn't delete files. If option is turned
 on, Filestream input can delete files when those conditions are met:
  - The reader is closed. The default is 5 minutes of inactivity.


### PR DESCRIPTION
>[!NOTE]
>Starting with v9.0, there is no longer a new documentation set published with every minor release: the same page stays valid over time and shows version-related evolutions. Read more in [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).

In #43368, @belimawr added information on deleting ingested log files. Because the initial PR was not backported, I guessed that these changes are planned for 9.2.0. If it is being added to a different version, please adjust the `applies_to` annotations.

Note: We already added a page-level `applies_to` annotation to the new [Removing files after ingestion](https://docs-v3-preview.elastic.dev/elastic/beats/pull/46097/reference/filebeat/delete-file-guide) page in https://github.com/elastic/beats/pull/45542 so this just adds a heading-level annotation to filestream input doc.