### PR TITLE
[docs] Update contributing docs with versioning information

### DIFF
--- a/docs/extend/community-beats.md
+++ b/docs/extend/community-beats.md
@@ -19,7 +19,7 @@ This page lists some of the {{beats}} developed by the open source community.
 
 Have a question about developing a community Beat? You can post questions and discuss issues in the [{{beats}} discussion forum](https://discuss.elastic.co/tags/c/elastic-stack/beats/28/beats-development).
 
-Have you created a Beat that’s not listed? Add the name and description of your Beat to the source document for [Community {{beats}}](https://github.com/elastic/beats/blob/main/libbeat/docs/communitybeats.asciidoc) and [open a pull request](https://help.github.com/articles/using-pull-requests) in the [{{beats}} GitHub repository](https://github.com/elastic/beats) to get your change merged. When you’re ready, go ahead and [announce](https://discuss.elastic.co/c/announcements) your new Beat in the Elastic discussion forum.
+Have you created a Beat that’s not listed? Add the name and description of your Beat to the source document for [Community {{beats}}](https://github.com/elastic/beats/blob/main/docs/extend/community-beats.md) and [open a pull request](https://help.github.com/articles/using-pull-requests) in the [{{beats}} GitHub repository](https://github.com/elastic/beats) to get your change merged. When you’re ready, go ahead and [announce](https://discuss.elastic.co/c/announcements) your new Beat in the Elastic discussion forum.
 
 ::::{note}
 Elastic provides no warranty or support for community-sourced {{beats}}.

--- a/docs/extend/contributing-docs.md
+++ b/docs/extend/contributing-docs.md
@@ -7,48 +7,92 @@ applies_to:
 
 # Contributing to the docs
 
-The Beats documentation is written in Markdown and is built using [elastic/docs-builder](https://github.com/elastic/docs-builder). Most Markdown files should be edited directly, but some Markdown files are generated.
+The Beats documentation is written in Markdown and is built using [elastic/docs-builder](https://github.com/elastic/docs-builder).
+
+## Cumulative docs [cumulative-docs]
+
+Starting with Elastic Stack version 9.0.0 we no longer publish a new documentation set for every minor release.
+This means that a single page should stay valid over time and use version-related tags to illustrate how the product has evolved.
+
+For information on labeling manually maintained content with product lifecycle and versioning information, refer to [Write cumulative documentation](https://elastic.github.io/docs-builder/contribute/cumulative-docs/).
+
+For generated content, read more below in [Update `fields.yml`](#update-fields).
 
 ## Generated docs [generated-docs]
 
-After updating `docs.md` files in `_meta` directories, you must run the doc collector scripts to regenerate the docs.
+Many Markdown files in the Beats repo should be edited directly, but some are generated including:
 
-Make sure you [set up your Beats development environment](./index.md#setting-up-dev-environment) and use the correct Go version. The Go version is listed in the `version.asciidoc` file for the branch you want to update.
+* Exported fields (for example, [AWS fields](https://www.elastic.co/docs/reference/beats/metricbeat/exported-fields-aws))
+* Module docs (for example, [AWS module](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-module-aws))
+* Metricset and dataset docs (for example, [AWS billing metricset](https://www.elastic.co/docs/reference/beats/metricbeat/metricbeat-metricset-aws-billing))
 
-To run the docs collector scripts, change to the beats directory and run:
+:::{tip}
+Every Markdown file that is generated includes a code comment at the top of the content that states `% This file is generated!`.
+:::
 
-`make update`
+### Update `fields.yml` [update-fields]
 
-::::{warning}
-The `make update` command overwrites files in the `docs` directories **without warning**. If you accidentally update a generated file and run `make update`, your changes will be overwritten.
-::::
+The `fields.yml` files in `_meta` directories across individual beats contain descriptions of fields available in the module, dataset, fileset, or metricset. Here are some tips for optimizing `fields.yml` for generating docs:
 
-To format your files, you might also need to run this command:
+* The `title` is used as a page title in the docs, so it’s best to capitalize it.
+* The `description` at all levels should be written in full sentences and include punctuation.
+* The `version` at all levels is used to label docs with product lifecycle and version-related
+  information that illustrates how the product has evolved over time, which is important to
+  [writing docs cumulatively](#cumulative-docs). Some tips for using `version`:
 
-`make fmt`
+  * Supported product lifecycles include `preview`, `beta`, `ga`, and `deprecated`.
+  * Multiple product lifecycles can exist for the same module or field to illustrate how it changed over time.
+  * The version number can be in major, minor, or patch format, but the resulting rendered label will always resolve to the patch level.
+  * Here's an example of `version` for a field that went through all product lifecycles:
+    ```yaml
+    version:
+      preview: 9.0.0
+      beta: 9.1.0
+      ga: 9.2.0
+      deprecated: 9.3.0
+    ```
 
-The make command calls the following scripts to generate the docs:
+### Update `docs.md`
 
-[auditbeat/scripts/docs_collector.py](https://github.com/elastic/beats/blob/main/auditbeat/scripts/docs_collector.py) generates:
+The `docs.md` files in `_meta` directories is used for generated module documentation.
 
-* `docs/reference/auditbeat/auditbeat-modules.md`
-* `docs/reference/auditbeat/auditbeat-module-*.md`
+### Generate the docs
 
-[filebeat/scripts/docs_collector.py](https://github.com/elastic/beats/blob/main/filebeat/scripts/docs_collector.py) generates:
+After updating `fields.md` and `docs.md` files in `_meta` directories,
+you must run the doc collector scripts to regenerate the docs:
 
-* `docs/reference/filebeat/filebeat-modules.md`
-* `docs/reference/filebeat/filebeat-module-*.md`
+1. Make sure you [set up your Beats development environment](./index.md#setting-up-dev-environment)
+  and use the correct Go version.
+    * The Go version is listed in the `version.asciidoc` file for the branch you want to update.
+1. Change to the beats directory.
+1. Run `make update` to run the docs collector scripts.
 
-[metricbeat/scripts/mage/docs_collector.go](https://github.com/elastic/beats/blob/main/metricbeat/scripts/mage/docs_collector.go) generates:
+    ::::{warning}
+    The `make update` command overwrites files in the `docs` directories **without warning**. If you accidentally update a generated file and run `make update`, your changes will be overwritten.
+    ::::
 
-* `docs/reference/metricbeat/metricbeat-modules.md`
-* `docs/reference/metricbeat/metricbeat-module-*.md`
+    The `make` command calls the following scripts to generate the docs:
 
-[libbeat/scripts/generate_fields_docs.py](https://github.com/elastic/beats/blob/main/libbeat/scripts/generate_fields_docs.py) generates:
+    * [**`auditbeat/scripts/docs_collector.py`**](https://github.com/elastic/beats/blob/main/auditbeat/scripts/docs_collector.py) generates:
+        * `docs/reference/auditbeat/auditbeat-modules.md`
+        * `docs/reference/auditbeat/auditbeat-module-*.md`
+    * [**`filebeat/scripts/docs_collector.py`**](https://github.com/elastic/beats/blob/main/filebeat/scripts/docs_collector.py) generates:
+      * `docs/reference/filebeat/filebeat-modules.md`
+      * `docs/reference/filebeat/filebeat-module-*.md`
+    * [**`metricbeat/scripts/mage/docs_collector.go`**](https://github.com/elastic/beats/blob/main/metricbeat/scripts/mage/docs_collector.go) generates:
+      * `docs/reference/metricbeat/metricbeat-modules.md`
+      * `docs/reference/metricbeat/metricbeat-module-*.md`
+    * [**`libbeat/scripts/generate_fields_docs.py`**](https://github.com/elastic/beats/blob/main/libbeat/scripts/generate_fields_docs.py) generates:
+      * `docs/reference/auditbeat/exported-fields.md`
+      * `docs/reference/filebeat/exported-fields.md`
+      * `docs/reference/heartbeat/exported-fields.md`
+      * `docs/reference/metricbeat/exported-fields.md`
+      * `docs/reference/packetbeat/exported-fields.md`
+      * `docs/reference/winlogbeat/exported-fields.md`
 
-* `docs/reference/auditbeat/exported-fields.md`
-* `docs/reference/filebeat/exported-fields.md`
-* `docs/reference/heartbeat/exported-fields.md`
-* `docs/reference/metricbeat/exported-fields.md`
-* `docs/reference/packetbeat/exported-fields.md`
-* `docs/reference/winlogbeat/exported-fields.md`
+1. (Optional) To format your files, you might also need to run this command:
+    ```sh
+    make fmt
+    ```
+
+

--- a/docs/extend/creating-metricbeat-module.md
+++ b/docs/extend/creating-metricbeat-module.md
@@ -13,7 +13,7 @@ It’s important to complete the configuration and documentation files for a mod
 ## Module Files [_module_files]
 
 * `config.yml` and `config.reference.yml`
-* `docs.asciidoc`
+* `docs.md`
 * `fields.yml`
 
 After updating any of these files, make sure you run `make update` in your beat directory so all generated files are updated.
@@ -40,11 +40,11 @@ It contains the module name, your metricset, and the default period. If you have
 The `full.config.yml` file is optional and by default has the same content as the `config.yml`. It is used to add and document more advanced configuration options that should not be part of the minimal config file shipped by default.
 
 
-### docs.asciidoc [_docs_asciidoc]
+### docs.md [_docs_md]
 
-The `docs.asciidoc` file contains the documentation about your module. During generation of the documentation, the default config file will be appended to the docs. Use this file to describe your module in more detail and to document specific configuration options.
+The `docs.md` file contains the documentation about your module. During generation of the documentation, the default config file will be appended to the docs. Use this file to describe your module in more detail and to document specific configuration options.
 
-```asciidoc
+```md
 This is the {module} module.
 ```
 
@@ -58,18 +58,30 @@ The default file looks like this:
 ```yaml
 - key: {module}
   title: "{module}"
-  release: beta
   description: >
     {module} module
   fields:
     - name: {module}
       type: group
-      description: >
+      description:
       fields:
 ```
 
-Make sure that you update at least the description of the module.
+After the default file is created, make sure to:
 
+* Update the `description` of the module and each field.
+* Add a `version` property with information about the product lifecycle and version in which the module is being added.
+  For example, if a module is being added in Elastic Stack version 9.1.0 in beta:
+  ```yaml
+  - key: {module}
+    title: "{module}"
+    version:
+      beta: 9.1.0
+    description: >
+      {module} module
+  ```
+
+For more tips on fine-tuning the `fields.yml` file for generating documentation, refer to [](/extend/contributing-docs.md#update-fields).
 
 ## Testing [_testing_2]
 

--- a/docs/extend/creating-metricsets.md
+++ b/docs/extend/creating-metricsets.md
@@ -50,7 +50,7 @@ To create a new metricset:
 After running the mage commands, you’ll find the metricset, along with its generated files, under `module/{{module}}/{metricset}`. This directory contains the following files:
 
 * `\{{metricset}}.go`
-* `_meta/docs.asciidoc`
+* `_meta/docs.md`
 * `_meta/data.json`
 * `_meta/fields.yml`
 

--- a/docs/extend/filebeat-modules-devguide.md
+++ b/docs/extend/filebeat-modules-devguide.md
@@ -39,7 +39,7 @@ After running the `make create-module` command, you’ll find the module, along 
 module/{module}
 ├── module.yml
 └── _meta
-    └── docs.asciidoc
+    └── docs.md
     └── fields.yml
     └── kibana
 ```
@@ -52,14 +52,30 @@ Let’s look at these files one by one.
 This file contains list of all the dashboards available for the module and used by `export_dashboards.go` script for exporting dashboards. Each dashboard is defined by an id and the name of json file where the dashboard is saved locally. At generation new fileset this file will be automatically updated with "default" dashboard settings for new fileset. Please ensure that this settings are correct.
 
 
-### _meta/docs.asciidoc [_metadocs_asciidoc]
+### _meta/docs.md [_metadocs_md]
 
 This file contains module-specific documentation. You should include information about which versions of the service were tested and the variables that are defined in each fileset.
 
 
 ### _meta/fields.yml [_metafields_yml]
 
-The module level `fields.yml` contains descriptions for the module-level fields. Please review and update the title and the descriptions in this file. The title is used as a title in the docs, so it’s best to capitalize it.
+The module level `fields.yml` contains descriptions for the module-level fields.
+
+After the default file is created, make sure to:
+
+* Update the `description` of the module and each field.
+* Add a `version` property with information about the product lifecycle and version in which the module is being added.
+  For example, if a module is being added in Elastic Stack version 9.1.0 in beta:
+  ```yaml
+  - key: {module}
+    title: "{module}"
+    version:
+      beta: 9.1.0
+    description: >
+      {module} module
+  ```
+
+For more tips on fine-tuning the `fields.yml` file for generating documentation, refer to [](/extend/contributing-docs.md#update-fields).
 
 
 ### _meta/kibana [_metakibana]

--- a/docs/extend/metricset-details.md
+++ b/docs/extend/metricset-details.md
@@ -78,6 +78,9 @@ You can find up to 3 different types of files named `fields.yml` in the beats re
         MySQL server status metrics collected from MySQL.
       short_config: false
       release: ga
+      version: <1>
+        beta: 9.0.0
+        ga: 9.1.0
       fields:
         - name: mysql
           type: group
@@ -86,6 +89,9 @@ You can find up to 3 different types of files named `fields.yml` in the beats re
             query.
           fields:
     ```
+    1. This is used to add product lifecycle and version related tags to illustrate how the product has evolved.
+       In this example, the module was added in beta in 9.0.0 and went GA in 9.1.0.
+       Read more in [](/extend/contributing-docs.md#cumulative-docs).
 
 * `metricbeat/module/{{module}}/{metricset}/_meta/fields.yml`: Contains all fields definitions retrieved by the metricset. As field types, each field must have a core data type [supported by elasticsearch](elasticsearch://reference/elasticsearch/mapping-reference/field-data-types.md#_core_datatypes). Here’s a very basic example that shows one group from the MySQL `status` metricset:
 
@@ -94,6 +100,8 @@ You can find up to 3 different types of files named `fields.yml` in the beats re
       type: group
       description: >
         `status` contains the metrics that were obtained by the status SQL query.
+      version:
+        ga: 9.0.0 <1>
       fields:
         - name: aborted
           type: group
@@ -106,9 +114,15 @@ You can find up to 3 different types of files named `fields.yml` in the beats re
 
             - name: connects
               type: integer
+              version:
+                beta: 9.1.0 <2>
               description: >
                 The number of failed attempts to connect to the MySQL server.
     ```
+    1. This is used to add product lifecycle and version related tags to illustrate how the product has evolved.
+       In this example, the metricset was added in GA in version 9.0.0.
+       Read more in [](/extend/contributing-docs.md#cumulative-docs).
+    2. And this illustrates that a new field was added to the existing metricset in beta in version 9.1.0.
 
 
 
@@ -253,5 +267,4 @@ MODULE=apache mage integTest
 
 ## Documentation [_documentation]
 
-Each module must be documented. The documentation is based on asciidoc and is in the file `module/{{module}}/_meta/docs.asciidoc` for the module and in `module/{{module}}/{metricset}/_meta/docs.asciidoc` for the metricset. Basic documentation with the config file and an example output is automatically generated. Use these files to document specific configuration options or usage examples.
-
+Each module must be documented. The documentation is based on Markdown and is in the file `module/{{module}}/_meta/docs.md` for the module and in `module/{{module}}/{metricset}/_meta/docs.md` for the metricset. Basic documentation with the config file and an example output is automatically generated. Use these files to document specific configuration options or usage examples.


### PR DESCRIPTION
Related to https://github.com/elastic/beats/pull/45772, https://github.com/elastic/beats/pull/45837, https://github.com/elastic/beats/pull/45890, https://github.com/elastic/beats/pull/45896

Update contributing docs to include information about writing cumulative documentation including using `version` in `fields.yml` files to add `applies_to` labels to generated docs.