### PR TITLE
Add host processor to beat processor

### DIFF
--- a/x-pack/otel/processor/beatprocessor/README.md
+++ b/x-pack/otel/processor/beatprocessor/README.md
@@ -7,17 +7,21 @@
 [development]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#development
 
 > [!NOTE]
-> This component is currently in development and no functionality is implemented.
-> Including it in a pipeline is a no-op.
-> The documentation describes the intended state after the functionality is implemented.
+> This component is currently in development and functionality is limited.
 
 The Beat processor (`beat`) is an OpenTelemetry Collector processor that wraps the [Beat processors].
-This allows you to use Beat processorss like e.g. [add_host_metadata] anywhere in the OpenTelemetry Collector's pipeline, independently of Beat receivers.
+This allows you to use Beat processors like e.g. [add_host_metadata] anywhere in the OpenTelemetry Collector's pipeline, independently of Beat receivers.
 
 > [!NOTE]
 > This component is only expected to work correctly with data from the Beat receivers: [Filebeat receiver], [Metricbeat receiver].
 > This is because it relies on the specific structure of telemetry emitted by those components.
 > Using it with data coming from other components is not recommended and may result in unexpected behavior.
+
+The processor enriches the telemetry with host metadata by using the [add_host_metadata] processor under the hood.
+Note that configuration is limited at this stage.
+Host metadata is added unconditionally and cannot be disabled.
+You can configure the host metadata enrichment using the options that the [add_host_metadata] processor allows.
+The only exception is that the option `replace_fields` is always set to `true` and setting it to `false` has no effect.
 
 ## Example
 
@@ -33,7 +37,9 @@ receivers:
           paths:
             - /var/log/*.log
     processors:
-      - add_host_metadata: ~
+      - add_host_metadata:
+          netinfo:
+            enabled: false
     output:
       otelconsumer:
 ```
@@ -55,7 +61,9 @@ receivers:
 processors:
   beat:
     processors:
-      - add_host_metadata: ~
+      - add_host_metadata:
+          netinfo:
+            enabled: false
 ```
 
 [Beat processors]: https://www.elastic.co/docs/reference/beats/filebeat/filtering-enhancing-data#using-processors

--- a/x-pack/otel/processor/beatprocessor/config.go
+++ b/x-pack/otel/processor/beatprocessor/config.go
@@ -4,4 +4,6 @@
 
 package beatprocessor
 
-type Config struct{}
+type Config struct {
+	Processors []map[string]any `mapstructure:"processors"`
+}

--- a/x-pack/otel/processor/beatprocessor/factory.go
+++ b/x-pack/otel/processor/beatprocessor/factory.go
@@ -6,10 +6,10 @@ package beatprocessor
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
@@ -36,14 +36,19 @@ func createLogsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (processor.Logs, error) {
+	beatProcessorConfig, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast component config to Beat processor config")
+	}
+	beatProcessor, err := newBeatProcessor(set, beatProcessorConfig)
+	if err != nil {
+		return nil, err
+	}
 	return processorhelper.NewLogs(
 		ctx,
 		set,
 		cfg,
 		nextConsumer,
-		func(_ context.Context, logs plog.Logs) (plog.Logs, error) {
-			// This is a placeholder for the actual processing logic.
-			return logs, nil
-		},
+		beatProcessor.ConsumeLogs,
 	)
 }

--- a/x-pack/otel/processor/beatprocessor/processor.go
+++ b/x-pack/otel/processor/beatprocessor/processor.go
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beatprocessor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors/add_host_metadata"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+)
+
+type beatProcessor struct {
+	logger     *zap.Logger
+	processors []beat.Processor
+}
+
+func newBeatProcessor(set processor.Settings, cfg *Config) (*beatProcessor, error) {
+	bp := &beatProcessor{
+		logger:     set.Logger,
+		processors: []beat.Processor{},
+	}
+
+	for _, processorConfig := range cfg.Processors {
+		processor, err := createProcessor(processorConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create processor: %w", err)
+		}
+		if processor != nil {
+			bp.processors = append(bp.processors, processor)
+		}
+	}
+
+	return bp, nil
+}
+
+func createProcessor(cfg map[string]any) (beat.Processor, error) {
+	if len(cfg) == 0 {
+		return nil, nil
+	}
+	if len(cfg) > 1 {
+		if len(cfg) < 10 {
+			configKeys := make([]string, 0, len(cfg))
+			for k := range cfg {
+				configKeys = append(configKeys, k)
+			}
+			return nil, fmt.Errorf("expected single processor name but got %v: %v", len(cfg), configKeys)
+		}
+		return nil, fmt.Errorf("expected single processor name but got %v", len(cfg))
+	}
+	for processorName, processorConfig := range cfg {
+		switch processorName {
+		case "add_host_metadata":
+			return createAddHostMetadataProcessor(processorConfig)
+		default:
+			return nil, fmt.Errorf("invalid processor name '%s'", processorName)
+		}
+	}
+	return nil, errors.New("malformed processor config")
+}
+
+func createAddHostMetadataProcessor(cfg any) (beat.Processor, error) {
+	addHostMetadataConfig, err := config.NewConfigFrom(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create add_host_metadata processor config: %w", err)
+	}
+	addHostMetadataProcessor, err := add_host_metadata.New(addHostMetadataConfig, logp.NewLogger("beatprocessor"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create add_host_metadata processor: %w", err)
+	}
+	return addHostMetadataProcessor, nil
+}
+
+func (p *beatProcessor) ConsumeLogs(_ context.Context, logs plog.Logs) (plog.Logs, error) {
+	if len(p.processors) == 0 {
+		return logs, nil
+	}
+
+	for _, hostProcessor := range p.processors {
+		dummyEvent := &beat.Event{}
+		dummyEvent.Fields = mapstr.M{}
+		dummyEvent.Meta = mapstr.M{}
+		dummyEventWithHostMetadata, err := hostProcessor.Run(dummyEvent)
+		if err != nil {
+			p.logger.Error("error processing host metadata", zap.Error(err))
+			continue
+		}
+		hostMap, ok := dummyEventWithHostMetadata.Fields["host"].(mapstr.M)
+		if !ok {
+			p.logger.Error("error casting host metadata to mapstr.M", zap.Error(err))
+			continue
+		}
+		otelMap, err := toOtelMap(&hostMap)
+		if err != nil {
+			p.logger.Error("error converting host metadata", zap.Error(err))
+			continue
+		}
+		for _, resourceLogs := range logs.ResourceLogs().All() {
+			for _, scopeLogs := range resourceLogs.ScopeLogs().All() {
+				for _, logRecord := range scopeLogs.LogRecords().All() {
+					bodyMap := logRecord.Body().Map().PutEmptyMap("host")
+					otelMap.CopyTo(bodyMap)
+				}
+			}
+		}
+	}
+
+	return logs, nil
+}
+
+func toOtelMap(m *mapstr.M) (pcommon.Map, error) {
+	otelMap := pcommon.NewMap()
+	for key, value := range *m {
+		switch typedValue := value.(type) {
+		case mapstr.M:
+			subMap, err := toOtelMap(&typedValue)
+			if err != nil {
+				return pcommon.Map{}, fmt.Errorf("failed to convert map for key '%s': %w", key, err)
+			}
+			otelSubMap := otelMap.PutEmptyMap(key)
+			subMap.MoveTo(otelSubMap)
+		case []string:
+			otelValue := otelMap.PutEmptySlice(key)
+			for _, item := range typedValue {
+				otelValue.AppendEmpty().SetStr(item)
+			}
+		default:
+			otelValue := otelMap.PutEmpty(key)
+			err := otelValue.FromRaw(typedValue)
+			if err != nil {
+				return pcommon.Map{}, fmt.Errorf("failed to convert value for key '%s': %w", key, err)
+			}
+		}
+	}
+	return otelMap, nil
+}

--- a/x-pack/otel/processor/beatprocessor/processor_test.go
+++ b/x-pack/otel/processor/beatprocessor/processor_test.go
@@ -1,0 +1,78 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beatprocessor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+)
+
+func TestConsumeLogs(t *testing.T) {
+	// Arrange
+	beatProcessor := &beatProcessor{
+		logger: zap.NewNop(),
+		processors: []beat.Processor{
+			mockProcessor{
+				runFunc: func(event *beat.Event) (*beat.Event, error) {
+					event.Fields["host"] = mapstr.M{"name": "test-host"}
+					return event, nil
+				},
+			},
+		},
+	}
+
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	for i := range 2 {
+		logRecord := scopeLogs.LogRecords().AppendEmpty()
+		logRecord.Body().SetEmptyMap()
+		logRecord.Body().Map().PutStr("message", fmt.Sprintf("test log message %v", i))
+	}
+
+	// Act
+	processedLogs, err := beatProcessor.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	// Assert
+	for _, resourceLogs := range processedLogs.ResourceLogs().All() {
+		for _, scopeLogs := range resourceLogs.ScopeLogs().All() {
+			for i, logRecord := range scopeLogs.LogRecords().All() {
+				// Verify that the original contents of the log is unchanged.
+				messageAttribute, found := logRecord.Body().Map().Get("message")
+				assert.True(t, found)
+				assert.Equal(t, fmt.Sprintf("test log message %v", i), messageAttribute.Str())
+
+				// Verify that the host attribute is added.
+				hostAttribute, found := logRecord.Body().Map().Get("host")
+				assert.True(t, found)
+				nameAttribute, found := hostAttribute.Map().Get("name")
+				assert.True(t, found)
+				assert.Equal(t, "test-host", nameAttribute.Str())
+			}
+		}
+	}
+}
+
+type mockProcessor struct {
+	runFunc func(event *beat.Event) (*beat.Event, error)
+}
+
+func (m mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	return m.runFunc(event)
+}
+
+func (m mockProcessor) String() string {
+	return "mockProcessor"
+}


### PR DESCRIPTION
## Proposed commit message

Add OpenTelemetry Beat processor

This processors allows to use the global Beat processors like `add_host_metadata` in an OTel pipeline separately from Beat receivers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
  - I didn't add a changelog entry as the processor is not ready for public use

## How to test this PR locally

1. Include the processor in Elastic Agent by adding it to https://github.com/elastic/elastic-agent/blob/89e0e9a5b0ebb376773de813a1fd2c0b2f30e74a/internal/pkg/otel/components.go.
2. Build the Elastic Agent
3. Run the Agent with an OTel config that includes the Beat processor.

Example OTel config:

```yaml
service:
  pipelines:
    logs:
      receivers:
        - filebeatreceiver
      processors:
        - beat
      exporters:
        - debug

receivers:
  filebeatreceiver:
    filebeat:
      inputs:
        - type: filestream
          paths:
            - /tmp/logs-1k.log
    processors:
      # Configure a processor to prevent enabling default processors
      - add_fields:
          fields:
            custom_field: "custom_value"
    output:
      otelconsumer:
    path.data: /tmp/0819/data
    path.logs: /tmp/0819/logs
    queue.mem:
      flush.timeout: 0

processors:
  beat:
    processors:
      - add_host_metadata:
          netinfo:
            enabled: false

exporters:
  debug:
    use_internal_logger: false
    verbosity: normal
```
