### PR TITLE
Fix TestContainerInput and `testing/integrataion` framework 

### DIFF
--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -188,6 +188,7 @@ func DefaultGoTestIntegrationArgs() GoTestArgs {
 	// Use the non-cachable -count=1 flag to disable test caching when running integration tests.
 	// There are reasons to re-run tests even if the code is unchanged (e.g. Dockerfile changes).
 	args.ExtraFlags = append(args.ExtraFlags, "-count=1")
+	args.ExtraFlags = append(args.ExtraFlags, "-timeout=15m")
 	return args
 }
 

--- a/filebeat/testing/integration/helper.go
+++ b/filebeat/testing/integration/helper.go
@@ -28,25 +28,29 @@ import (
 )
 
 // AssertLastOffset takes path of the regsitry file and the expected offset
-// and asserts if the expected offset exists on regisry
-func AssertLastOffset(t *testing.T, path string, offset int) {
-	t.Helper()
+// and returns true if the expected offset exists on registry. Otherwise
+// false is returned. It will fail the test on any error reading/parsing
+// the registry file.
+func AssertLastOffset(t *testing.T, path string, offset int) bool {
 	entries, _ := readFilestreamRegistryLog(t, path)
 	lastEntry := entries[len(entries)-1]
 	if lastEntry.Offset != offset {
 		t.Errorf("expecting offset %d got %d instead", offset, lastEntry.Offset)
 		t.Log("last registry entries:")
 
+		l := len(entries)
 		max := len(entries)
 		if max > 10 {
 			max = 10
 		}
-		for _, e := range entries[:max] {
+		for _, e := range entries[l-max:] {
 			t.Logf("%+v\n", e)
 		}
 
-		t.FailNow()
+		return false
 	}
+
+	return true
 }
 
 type registryEntry struct {

--- a/filebeat/testing/integration/helper.go
+++ b/filebeat/testing/integration/helper.go
@@ -27,7 +27,7 @@ import (
 	"time"
 )
 
-// AssertLastOffset takes path of the regsitry file and the expected offset
+// AssertLastOffset takes path of the registry file and the expected offset
 // and returns true if the expected offset exists on registry. Otherwise
 // false is returned. It will fail the test on any error reading/parsing
 // the registry file.

--- a/libbeat/testing/integration/run_beat.go
+++ b/libbeat/testing/integration/run_beat.go
@@ -51,6 +51,7 @@ type RunningBeat struct {
 	outputDone  chan struct{}
 	watcher     OutputWatcher
 	keepRunning bool
+	t           *testing.T
 }
 
 // CollectOutput returns the last `limit` lines of the currently
@@ -123,7 +124,7 @@ func (b *RunningBeat) writeOutputLine(line string) {
 	if b.watcher.Observed() {
 		if !b.keepRunning {
 			if err := proc.StopCmd(b.c.Process); err != nil {
-				fmt.Printf("Cannot stop Beat: %s\n", err)
+				b.t.Logf("Cannot stop Beat: %s\n", err)
 			}
 		}
 		b.watcher = nil
@@ -200,6 +201,7 @@ func RunBeat(ctx context.Context, t *testing.T, opts RunBeatOptions, watcher Out
 		watcher:     watcher,
 		keepRunning: opts.KeepRunning,
 		outputDone:  make(chan struct{}),
+		t:           t,
 	}
 
 	var wg sync.WaitGroup

--- a/libbeat/testing/integration/run_beat.go
+++ b/libbeat/testing/integration/run_beat.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
 	"github.com/elastic/beats/v7/libbeat/common/proc"
 )
 

--- a/libbeat/testing/integration/run_beat.go
+++ b/libbeat/testing/integration/run_beat.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"github.com/elastic/beats/v7/libbeat/common/proc"
 )
 
 var (
@@ -120,7 +121,7 @@ func (b *RunningBeat) writeOutputLine(line string) {
 	b.watcher.Inspect(line)
 	if b.watcher.Observed() {
 		if !b.keepRunning {
-			_ = b.c.Process.Kill()
+			_ = proc.StopCmd(b.c.Process)
 		}
 		b.watcher = nil
 	}

--- a/libbeat/testing/integration/run_beat.go
+++ b/libbeat/testing/integration/run_beat.go
@@ -121,7 +121,9 @@ func (b *RunningBeat) writeOutputLine(line string) {
 	b.watcher.Inspect(line)
 	if b.watcher.Observed() {
 		if !b.keepRunning {
-			_ = proc.StopCmd(b.c.Process)
+			if err := proc.StopCmd(b.c.Process); err != nil {
+				fmt.Printf("Cannot stop Beat: %s\n", err)
+			}
 		}
 		b.watcher = nil
 	}
@@ -176,6 +178,7 @@ func RunBeat(ctx context.Context, t *testing.T, opts RunBeatOptions, watcher Out
 
 	t.Logf("running %s %s", binaryFilename, strings.Join(execArgs, " "))
 	c := exec.CommandContext(ctx, binaryFilename, execArgs...)
+	c.SysProcAttr = proc.GetSysProcAttr()
 
 	// we must use 2 pipes since writes are not aligned by lines
 	// part of the stdout output can end up in the middle of the stderr line

--- a/x-pack/filebeat/tests/integration/windows/inputs_windows_test.go
+++ b/x-pack/filebeat/tests/integration/windows/inputs_windows_test.go
@@ -21,7 +21,7 @@ import (
 func TestWinInputs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	lbint.EnsureCompiled(ctx, t, "filebeat")
+	fbint.EnsureCompiled(ctx, t)
 
 	reportOptions := lbint.ReportOptions{
 		PrintLinesOnFail:  10,
@@ -73,7 +73,7 @@ output.console:
 		}
 		for name, tc := range tcs {
 			t.Run(name, func(t *testing.T) {
-				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+				ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 				defer cancel()
 
 				test := fbint.NewTest(t, fbint.TestOptions{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
This commit fixes the process handling for Windows in `testing/integrataion` that was causing `mage goWindowsIntegTest` to fail in CI as well as `TestWinInputs` to fail when run manually.

`TestContainerInput` is also fixed. The `time.Sleep` is replaced by `require.Eventually` and a Filestream input ID is added to the configuration.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~
## How to test this PR locally
### 1. Run the integration tests from `filebeat/testing/integration`
```sh
cd filebeat
go test -tags=integration -count=1 ./testing/integration
```
### 2. Run the Windows integration tests
```
cd x-pack/filebeat
mage goWindowsIntegTest
```

## Related issues

- Fixes https://github.com/elastic/beats/issues/46100
- Fixes https://github.com/elastic/beats/issues/46126 

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~