### PR TITLE
fix(metricbeat): report correct number of entries in conntrack metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -301,6 +301,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Upgrade `go.mongodb.org/mongo-driver` from `v1.14.0` to `v1.17.4` to fix connection leaks in MongoDB module {pull}44769[44769]
 - Fix histogram values of zero are filtered out on non-amd64 platforms for openmetrics and prometheus {pull}44750[44750]
 - Changed Kafka protocol version from 3.6.0 to 2.1.0 to fix compatibility with Kafka 2.x brokers. {pull}45761[45761]
+- Fix an issue where the conntrack metricset entries field reported an inflated count because it was multiplied by the number of CPU cores. {issue}00000[00000] {pull}00000[00000]
 
 *Osquerybeat*
 

--- a/metricbeat/module/linux/conntrack/conntrack.go
+++ b/metricbeat/module/linux/conntrack/conntrack.go
@@ -79,8 +79,11 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	}
 
 	summedEvents := procfs.ConntrackStatEntry{}
-	for _, conn := range conntrackStats {
-		summedEvents.Entries += conn.Entries
+	for i, conn := range conntrackStats {
+		// Entries is the total connections in the conntrack table and is repeated per-cpu.
+		if i == 0 {
+			summedEvents.Entries += conn.Entries
+		}
 		summedEvents.Found += conn.Found
 		summedEvents.Invalid += conn.Invalid
 		summedEvents.Ignore += conn.Ignore

--- a/metricbeat/module/linux/conntrack/conntrack_test.go
+++ b/metricbeat/module/linux/conntrack/conntrack_test.go
@@ -52,7 +52,7 @@ func TestFetch(t *testing.T) {
 	testConn := mapstr.M{
 		"drop":           uint64(0),
 		"early_drop":     uint64(0),
-		"entries":        uint64(16),
+		"entries":        uint64(4),
 		"found":          uint64(0),
 		"ignore":         uint64(3271028),
 		"insert_failed":  uint64(0),


### PR DESCRIPTION
## Proposed commit message

The conntrack metricset was summing the `entries` value across all CPUs, but this field is identical on each line of `/proc/net/stat/nf_conntrack`. As a result, the reported count was inflated by a factor of the number of
CPU cores. 

This fixes the issue by reading the entries value only once.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Fixes https://github.com/elastic/beats/issues/46138