### PR TITLE
feat(conntrack): add fallback to fetch metrics using netlink

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -238,6 +238,7 @@ require (
 )
 
 require (
+	github.com/ti-mo/conntrack v0.5.2
 	go.opentelemetry.io/collector/client v1.36.0
 	go.opentelemetry.io/collector/pipeline v0.130.0
 	go.opentelemetry.io/collector/processor v1.36.0
@@ -360,6 +361,7 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/josharian/native v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
@@ -375,6 +377,8 @@ require (
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mdlayher/netlink v1.7.2 // indirect
+	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mileusna/useragent v1.3.4 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
@@ -411,6 +415,7 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/ti-mo/netfilter v0.5.3 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -967,6 +967,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/teambition/rrule-go v1.8.2 h1:lIjpjvWTj9fFUZCmuoVDrKVOtdiyzbzc93qTmRVe/J8=
 github.com/teambition/rrule-go v1.8.2/go.mod h1:Ieq5AbrKGciP1V//Wq8ktsTXwSwJHDD5mD/wLBGl3p4=
+github.com/ti-mo/conntrack v0.5.2 h1:PQ7MCdFjniEiTJT+qsAysREUsT5iH62/VNyhkB06HOI=
+github.com/ti-mo/conntrack v0.5.2/go.mod h1:4HZrFQQLOSuBzgQNid3H/wYyyp1kfGXUYxueXjIGibo=
+github.com/ti-mo/netfilter v0.5.3 h1:ikzduvnaUMwre5bhbNwWOd6bjqLMVb33vv0XXbK0xGQ=
+github.com/ti-mo/netfilter v0.5.3/go.mod h1:08SyBCg6hu1qyQk4s3DjjJKNrm3RTb32nm6AzyT972E=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/metricbeat/module/linux/conntrack/conntrack_integration_test.go
+++ b/metricbeat/module/linux/conntrack/conntrack_integration_test.go
@@ -1,0 +1,103 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration && linux
+
+package conntrack
+
+import (
+	"maps"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
+	_ "github.com/elastic/beats/v7/metricbeat/module/linux"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+func BenchmarkFetchNetlink(b *testing.B) {
+	if os.Geteuid() != 0 {
+		b.Skip("This benchmark requires CAP_NET_ADMIN capability (run as root)")
+	}
+
+	cfg := getConfig()
+	cfg["hostfs"] = b.TempDir()
+	f := mbtest.NewReportingMetricSetV2Error(b, cfg)
+	for range b.N {
+		_, errs := mbtest.ReportingFetchV2Error(f)
+		require.Empty(b, errs, "fetch should not return an error")
+	}
+}
+
+func TestFetchNetlink(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("This test requires CAP_NET_ADMIN capability (run as root)")
+	}
+
+	// hide /proc/net/stat/nf_conntrack file so it uses netlink
+	cfg := getConfig()
+	cfg["hostfs"] = t.TempDir()
+
+	f := mbtest.NewReportingMetricSetV2Error(t, cfg)
+	events, errs := mbtest.ReportingFetchV2Error(f)
+	require.Empty(t, errs, "fetch should not return an error")
+
+	require.NotEmpty(t, events)
+	rawEvent := events[0].BeatEvent("linux", "conntrack").Fields["linux"].(mapstr.M)["conntrack"].(mapstr.M)["summary"].(mapstr.M)
+	keys := slices.Collect(maps.Keys(rawEvent))
+	assert.Contains(t, keys, "entries")
+	assert.Greater(t, rawEvent["entries"], uint64(0), "entries should be greater than 0")
+	assert.Contains(t, keys, "drop")
+	assert.Contains(t, keys, "early_drop")
+	assert.Contains(t, keys, "found")
+	assert.Contains(t, keys, "ignore")
+	assert.Contains(t, keys, "insert_failed")
+	assert.Contains(t, keys, "invalid")
+	assert.Contains(t, keys, "search_restart")
+}
+
+func TestFetchABTest(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("This test requires CAP_NET_ADMIN capability (run as root)")
+	}
+
+	cfg := getConfig()
+	cfg["hostfs"] = "/"
+
+	// procfs
+	f := mbtest.NewReportingMetricSetV2Error(t, cfg)
+	events, errs := mbtest.ReportingFetchV2Error(f)
+	require.Empty(t, errs, "fetch should not return an error")
+	require.NotEmpty(t, events)
+	procfsEvent := events[0].BeatEvent("linux", "conntrack").Fields["linux"].(mapstr.M)["conntrack"].(mapstr.M)["summary"].(mapstr.M)
+
+	// netlink
+	cfg["hostfs"] = t.TempDir()
+
+	f = mbtest.NewReportingMetricSetV2Error(t, cfg)
+	events, errs = mbtest.ReportingFetchV2Error(f)
+	require.Empty(t, errs, "fetch should not return an error")
+
+	require.NotEmpty(t, events)
+	netlinkEvent := events[0].BeatEvent("linux", "conntrack").Fields["linux"].(mapstr.M)["conntrack"].(mapstr.M)["summary"].(mapstr.M)
+
+	assert.Equal(t, procfsEvent, netlinkEvent, "events should be equal")
+}


### PR DESCRIPTION
## Proposed commit message

Currently, metrics are fetched from the /proc/net/stat/nf_conntrack provided by the nf_conntrack kernel module.
In newer kernels and distributions, this file is not present which prevents users from reading those metrics.

Add a fallback to netlink(7), which is present by default on kernels since 2.6.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/45719.