### PR TITLE
Improve documentation about Windows install script

### DIFF
--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -102,7 +102,7 @@ If script execution is disabled on your system, you need to set the execution po
 
 :::{important}
 ```{applies_to}
-stack: ga 9.0.6
+stack: ga 9.1.0, ga 9.0.6
 ```
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for

--- a/docs/reference/auditbeat/auditbeat-installation-script.md
+++ b/docs/reference/auditbeat/auditbeat-installation-script.md
@@ -2,7 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/auditbeat/current/auditbeat-installation-script.html
 applies_to:
-  stack: ga 9.0.6
+  stack: ga 9.1.0, ga 9.0.6
 ---
 
 # Installation script

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -101,7 +101,7 @@ If script execution is disabled on your system, you need to set the execution po
 
 :::{important}
 ```{applies_to}
-stack: ga 9.0.6
+stack: ga 9.1.0, ga 9.0.6
 ```
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for

--- a/docs/reference/filebeat/filebeat-installation-script.md
+++ b/docs/reference/filebeat/filebeat-installation-script.md
@@ -2,7 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-script.html
 applies_to:
-  stack: ga 9.0.6
+  stack: ga 9.1.0, ga 9.0.6
 ---
 
 # Installation script

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -103,7 +103,7 @@ If script execution is disabled on your system, you need to set the execution po
 
 :::{important}
 ```{applies_to}
-stack: ga 9.0.6
+stack: ga 9.1.0, ga 9.0.6
 ```
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for

--- a/docs/reference/heartbeat/heartbeat-installation-script.md
+++ b/docs/reference/heartbeat/heartbeat-installation-script.md
@@ -2,7 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/heartbeat/current/heartbeat-installation-script.html
 applies_to:
-  stack: ga 9.0.6
+  stack: ga 9.1.0, ga 9.0.6
 ---
 
 # Installation script

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -105,7 +105,7 @@ If script execution is disabled on your system, you need to set the execution po
 
 :::{important}
 ```{applies_to}
-stack: ga 9.0.6
+stack: ga 9.1.0, ga 9.0.6
 ```
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for

--- a/docs/reference/metricbeat/metricbeat-installation-script.md
+++ b/docs/reference/metricbeat/metricbeat-installation-script.md
@@ -2,7 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-installation-script.html
 applies_to:
-  stack: ga 9.0.6
+  stack: ga 9.1.0, ga 9.0.6
 ---
 
 # Installation script

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -142,7 +142,7 @@ If script execution is disabled on your system, you need to set the execution po
 
 :::{important}
 ```{applies_to}
-stack: ga 9.0.6
+stack: ga 9.1.0, ga 9.0.6
 ```
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for

--- a/docs/reference/packetbeat/packetbeat-installation-script.md
+++ b/docs/reference/packetbeat/packetbeat-installation-script.md
@@ -2,7 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/packetbeat/current/packetbeat-installation-script.html
 applies_to:
-  stack: ga 9.0.6
+  stack: ga 9.1.0, ga 9.0.6
 ---
 
 # Installation script

--- a/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
@@ -74,7 +74,7 @@ To use a local non-Administrator account to run Winlogbeat, follow [these additi
 
 :::{important}
 ```{applies_to}
-stack: ga 9.0.6
+stack: ga 9.1.0, ga 9.0.6
 ```
 The base folder has changed from `C:\ProgramData\` to `C:\Program Files\`
 because the latter has stricter permissions. The home path (base for

--- a/docs/reference/winlogbeat/winlogbeat-installation-script.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-script.md
@@ -2,7 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/winlogbeat/current/winlogbeat-installation-script.html
 applies_to:
-  stack: ga 9.0.6
+  stack: ga 9.1.0, ga 9.0.6
 ---
 
 # Installation script


### PR DESCRIPTION
## Proposed commit message

```
This commit updates the documentation to clarify which versions have the new install script that uses `C:\Program Files-Data` as the base path for Beats.
```

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~
## How to test this PR locally
1. Build the docs: `docs-builder serve`
2. For each Beat check (example links for Filebeat)
    - http://localhost:3000/reference/filebeat/filebeat-installation-script
    - http://localhost:3000/reference/filebeat/filebeat-installation-configuration - Go to "Step 1", then click on "Windows" tab.

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

