### PR TITLE
CODEOWNERS: add /metricbeat/helper/sql @elastic/obs-infraobs-integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,6 +78,7 @@ CHANGELOG*
 /metricbeat/ @elastic/elastic-agent-data-plane
 /metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /metricbeat/helper/kubernetes @elastic/obs-ds-hosted-services
+/metricbeat/helper/sql @elastic/obs-infraobs-integrations
 /metricbeat/module/aerospike @elastic/obs-infraobs-integrations
 /metricbeat/module/apache @elastic/obs-infraobs-integrations
 /metricbeat/module/beat/ @elastic/stack-monitoring


### PR DESCRIPTION
Marks metricbeats's SQL helper as owned by infraobs-integrations team