### PR TITLE
[docs] Add 9.0.6 release notes in Markdown

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -33,8 +33,8 @@ For more information, check [#45251]({{beats-pull}}45251).
 **All Beats**
 
 ::::{dropdown} The default data and logs path for the Windows service installation has changed.
-The base folder has changed from `C:\ProgramData\` to `C:\Program
-Files\` because the latter has stricter permissions. The state
+The base folder has changed from `C:\ProgramData\` to `C:\ProgramFiles\`
+because the latter has stricter permissions. The state
 and logs are now stored in `C:\Program Files\<Beat Name>-Data`.
 
 When the installation script runs, it looks for the previous default
@@ -62,6 +62,28 @@ inactivity. See [`close.on_state_change.inactive`](https://www.elastic.co/docs/r
 for more details.
 
 For more information, check [#38523](https://github.com/elastic/beats/issues/38523)
+::::
+
+## 9.0.6 [beats-9.0.6-breaking-changes]
+
+**All Beats**
+
+::::{dropdown} The default data and logs path for the Windows service installation has changed.
+The base folder has changed from `C:\ProgramData\` to
+`C:\ProgramFiles\` because the latter has stricter permissions. The state
+and logs are now stored in `C:\Program Files\<Beat Name>-Data`.
+
+When the installation script runs, it looks for the previous default
+data path. If the path is found, data is moved to the new path.
+The installation script accepts the parameter `-ForceLegacyPath` to
+force using the legacy data path.
+
+In a PowerShell prompt, use `Get-Help install-service-<Beat Name>.ps1
+-detailed` to get detailed help.
+
+See 'Quick start -> Installation script' from each Beat for more
+details.
+
 ::::
 
 ## 9.0.4 [beats-9.0.4-breaking-changes]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -113,6 +113,37 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 - Added maintenance windows support for Heartbeat. [41508]({{beats-pull}}41508)
 
+## 9.0.6 [beats-9.0.6-release-notes]
+
+### Features and enhancements [beats-9.0.6-features-enhancements]
+
+**Affecting all Beats**
+
+- Update Go version to 1.24.5. [45403]({{beats-pull}}45403)
+
+**Filebeat**
+
+- Add mechanism to allow HTTP JSON templates to terminate without logging an error. [45664]({{beats-issue}}45664) [45810]({{beats-pull}}45810)
+
+**Winlogbeat**
+
+- Render data values in xml renderer. [44132]({{beats-pull}}44132)
+
+### Fixes [beats-9.0.6-fixes]
+
+**Filebeat**
+
+- Fix handling of unnecessary BOM in UTF-8 text received by o365audit input. [44327]({{beats-issue}}44327) [45739]({{beats-pull}}45739)
+- Fix reading journald messages with more than 4kb. [45511]({{beats-issue}}45511) [46017]({{beats-pull}}46017)
+- Restore the Streaming input on Windows. [46031]({{beats-pull}}46031)
+- Fix termination of input on API errors. [45999]({{beats-pull}}45999)
+- Fix filestream registry entries being prematurely removed, which could cause files to be re-ingested after Filebeat restarts. [46007]({{beats-issue}}46007) [46032]({{beats-pull}}46032)
+
+**Metricbeat**
+
+- Changed Kafka protocol version from 3.6.0 to 2.1.0 to fix compatibility with Kafka 2.x brokers. [45761]({{beats-pull}}45761)
+- Enhance behavior of sanitizeError: replace sensitive info even if it is escaped and add pattern-based sanitization [45857]({{beats-pull}}45857)
+
 ## 9.0.5 [beats-9.0.5-release-notes]
 
 ### Features and enhancements [beats-9.0.5-features-enhancements]


### PR DESCRIPTION
Ports release notes from https://github.com/elastic/beats/pull/46223 to Markdown.