### PR TITLE
[9.1] [docs] Add 9.1.3 release notes in Markdown

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,6 +12,20 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 % Description and impact of the breaking change.
 % For more information, check [PR #](PR link).
 
+## 9.1.3 [beats-9.1.3-breaking-changes]
+
+**Metricbeat**
+
+::::{dropdown} API used by index summary metricset changed.
+Changed index summary metricset to use `_nodes/stats` API instead of `_stats` API to avoid data gaps.
+
+% **Impact**<br>Add a description of the impact.
+
+% **Action**<br>Add a description of what action to take.
+
+For more information, check [#45049]({{beats-pull}}45049).
+::::
+
 ## 9.1.1 [beats-9.1.1-breaking-changes]
 
 **All Beats**

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -17,6 +17,38 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % ### Fixes [beats-versionext-fixes]
 
+## 9.1.3 [beats-9.1.3-release-notes]
+
+### Features and enhancements [beats-9.1.3-features-enhancements]
+
+**Affecting all Beats**
+
+- Update Go version to 1.24.5. [45403]({{beats-pull}}45403)
+- Improve trimming of BOM from UTF-8 data in the libbeat `reader/readfile.EncoderReader`. [45742]({{beats-pull}}45742)
+
+**Filebeat**
+
+- Add mechanism to allow HTTP JSON templates to terminate without logging an error. [45664]({{beats-issue}}45664) [45810]({{beats-pull}}45810)
+- Add status reporting support for AWS S3 input. [45748]({{beats-pull}}45748)
+
+### Fixes [beats-9.1.3-fixes]
+
+**Affecting all Beats**
+
+- Fixed case where Beats would silently fail due to invalid input configuration, now the error is correctly reported. [43118]({{beats-issue}}43118) [45733]({{beats-pull}}45733)
+
+**Filebeat**
+
+- Fix handling of unnecessary BOM in UTF-8 text received by o365audit input. [44327]({{beats-issue}}44327) [45739]({{beats-pull}}45739)
+- Fix reading journald messages with more than 4kb. [45511]({{beats-issue}}45511) [46017]({{beats-pull}}46017)
+- Restore the Streaming input on Windows. [46031]({{beats-pull}}46031)
+- Fix termination of input on API errors. [45999]({{beats-pull}}45999)
+
+**Metricbeat**
+
+- Changed Kafka protocol version from 3.6.0 to 2.1.0 to fix compatibility with Kafka 2.x brokers. [45761]({{beats-pull}}45761)
+- Enhance behavior of `sanitizeError`: replace sensitive info even if it is escaped and add pattern-based sanitization. [45857]({{beats-pull}}45857)
+
 ## 9.1.2 [beats-9.1.2-release-notes]
 
 ### Features and enhancements [beats-9.1.2-features-enhancements]


### PR DESCRIPTION
Ports release notes from https://github.com/elastic/beats/pull/46224 to Markdown.