### PR TITLE
Do not show 'ingest pipeline' warning when managed by Elastic Agent

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -239,7 +239,9 @@ func (fb *Filebeat) WithOtelFactoryWrapper(wrapper cfgfile.FactoryWrapper) {
 // setup.
 func (fb *Filebeat) loadModulesPipelines(b *beat.Beat) error {
 	if b.Config.Output.Name() != "elasticsearch" {
-		fb.logger.Warn(pipelinesWarning)
+		if !b.Manager.Enabled() {
+			fb.logger.Warn(pipelinesWarning)
+		}
 		return nil
 	}
 
@@ -399,7 +401,9 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	if b.Config.Output.Name() == "elasticsearch" {
 		pipelineLoaderFactory = newPipelineLoaderFactory(pipelineFactoryCtx, b.Config.Output.Config(), fb.logger)
 	} else {
-		fb.logger.Warn(pipelinesWarning)
+		if !b.Manager.Enabled() {
+			fb.logger.Warn(pipelinesWarning)
+		}
 	}
 	moduleLoader := fileset.NewFactory(inputLoader, b.Info, pipelineLoaderFactory, config.OverwritePipelines)
 	crawler, err := newCrawler(inputLoader, moduleLoader, config.Inputs, fb.done, *once, fb.logger)


### PR DESCRIPTION
## Proposed commit message

See title

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally
### Ensuring the warning is not printed under Elastic Agent
1. Build Agentbeat
    ```
    cd x-pack/agentbeat
    go build .
    ```
2. Download the Elastic Agent 9.2.0-SNAPSHOT
 - Linux: https://snapshots.elastic.co/9.2.0-f3caf25b/downloads/beats/elastic-agent/elastic-agent-9.2.0-SNAPSHOT-linux-x86_64.tar.gz
 - Darwin ARM: https://snapshots.elastic.co/9.2.0-f3caf25b/downloads/beats/elastic-agent/elastic-agent-9.2.0-SNAPSHOT-darwin-aarch64.tar.gz

3. Extract it and replace the agentbeat binary by the one you compiled
4. Start Elasticsearch (run it from `x-pack/filebeat`): `mage docker:ComposeUp`
5. Start the Elastic Agent
    Use the following configuration
    ```yaml
    outputs:
      default:
        type: elasticsearch
        hosts:
          - http://localhost:9200
        username: "admin"
        password: "testing"
    
    inputs:
      - type: filestream
        id: filestream-input-id
        streams:
          - id: filestream-stream-id
            data_stream:
              dataset: generic
            paths:
              - /var/log/*.log
    
    agent.monitoring:
      enabled: false
    
    agent.logging.to_stderr: true
    
    agent.grpc:
      port: 5050
    ```

    Start the Elastic Agent:
    ```
    ./elastic-agent 2>&1 | jq '{"ts": ."@timestamp", "lvl": ."log.level", "component": .component.id, "m": .message}' -c
    ```
6. Ensure the following warning is **not** printed by `filestream-default`
> Filebeat is unable to load the ingest pipelines for the configured modules because the Elasticsearch output is not configured/enabled. If you have already loaded the ingest pipelines or are using Logstash pipelines, you can ignore this warning.


### Ensuring the warning are still printed by a standalone Filebeat
1. Package Filebeat
    ```
    cd x-pack/filebeat
    # Adjust the platforms according to your OS
    DEV=true SNAPSHOT=true PACKAGES="tar.gz" PLATFORMS=linux/amd64 mage -v package
    ```

2. Enable a module
    ```
    ./filebeat modules enable nginx
    ```

3. Edit `modules.d/nginx.yml` and enable at least one fileset
4. Start Filebeat
    ```
    ./filebeat -e
    ```
5. Ensure the following warning is printed twice
> Filebeat is unable to load the ingest pipelines for the configured modules because the Elasticsearch output is not configured/enabled. If you have already loaded the ingest pipelines or are using Logstash pipelines, you can ignore this warning.

## Related issues

- Closes #45803


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
