### PR TITLE
improve: use SetupMetricsOptions instead of SetupMetrics

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -345,7 +345,18 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 
 	reg := b.Monitoring.StatsRegistry().GetOrCreateRegistry("libbeat")
 
-	err = metricreport.SetupMetrics(b.Info.Logger.Named("metrics"), b.Info.Beat, version.GetDefaultVersion())
+	ephemeralID, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	err = metricreport.SetupMetricsOptions(metricreport.MetricOptions{
+		Name:           b.Info.Beat,
+		Version:        version.GetDefaultVersion(),
+		EphemeralID:    ephemeralID.String(),
+		Logger:         b.Info.Logger.Named("metrics"),
+		SystemMetrics:  monitoring.Default.GetOrCreateRegistry("system"),
+		ProcessMetrics: monitoring.Default.GetOrCreateRegistry("beat"),
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Proposed commit message

The problem is that `SetupMetrics` in `elastic-agent-system-metrics` is conditionally compiled and only available when the build tags `(darwin && cgo) || (freebsd && cgo) || linux || windows` are satisfied. If you build on Darwin without cgo, it won't be compiled, hence the undefined symbol.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


