### PR TITLE
Add missing dash in add-cloud-metadata documentation

### DIFF
--- a/docs/reference/filebeat/add-cloud-metadata.md
+++ b/docs/reference/filebeat/add-cloud-metadata.md
@@ -66,7 +66,7 @@ For example, configuration below only utilize `aws` metadata retrival mechanism,
 processors:
   - add_cloud_metadata:
       providers:
-        aws
+        - aws
 ```
 
 The third optional configuration setting is `overwrite`. When `overwrite` is `true`, `add_cloud_metadata` overwrites existing `cloud.*` fields (`false` by default).


### PR DESCRIPTION
## Proposed commit message

Add missing dash in add-cloud-metadata documentation

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
