### PR TITLE
[aws]Change aws.cloudwatch.* fields to nested object

### DIFF
--- a/x-pack/filebeat/input/awscloudwatch/input_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/input_test.go
@@ -34,10 +34,12 @@ func TestCreateEvent(t *testing.T) {
 				"path": "logGroup1" + "/" + *logEvent.LogStreamName,
 			},
 		},
-		"aws.cloudwatch": mapstr.M{
-			"log_group":      "logGroup1",
-			"log_stream":     *logEvent.LogStreamName,
-			"ingestion_time": time.Unix(*logEvent.IngestionTime/1000, 0),
+		"aws": mapstr.M{
+			"cloudwatch": mapstr.M{
+				"log_group":      "logGroup1",
+				"log_stream":     *logEvent.LogStreamName,
+				"ingestion_time": time.Unix(*logEvent.IngestionTime/1000, 0),
+			},
 		},
 		"cloud": mapstr.M{
 			"provider": "aws",

--- a/x-pack/filebeat/input/awscloudwatch/processor.go
+++ b/x-pack/filebeat/input/awscloudwatch/processor.go
@@ -54,10 +54,12 @@ func createEvent(logEvent types.FilteredLogEvent, logGroupId string, regionName 
 				"id":       *logEvent.EventId,
 				"ingested": time.Now(),
 			},
-			"aws.cloudwatch": mapstr.M{
-				"log_group":      logGroupId,
-				"log_stream":     *logEvent.LogStreamName,
-				"ingestion_time": time.UnixMilli(*logEvent.IngestionTime),
+			"aws": mapstr.M{
+				"cloudwatch": mapstr.M{
+					"log_group":      logGroupId,
+					"log_stream":     *logEvent.LogStreamName,
+					"ingestion_time": time.UnixMilli(*logEvent.IngestionTime),
+				},
 			},
 			"cloud": mapstr.M{
 				"provider": "aws",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This PR changes `aws.cloudwatch.*` fields in `awscloudwatch` input from dotted fields to nested objects. Similar to what we did for `log.file.path` field in https://github.com/elastic/beats/pull/41099.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact
Same concern as the previous PR, which is around users have ingest pipelines or logstash filters. For example in ingest pipeline, `ctx[aws.cloudwatch.*]` needs to be changed to `ctx.aws?.cloudwatch.*`.

## Related issues

- Relates https://github.com/elastic/integrations/issues/5156