### PR TITLE
[AutoOps] Allow `AUTOOPS_ES_` prefix for environment variables

### DIFF
--- a/docs/reference/metricbeat/metricbeat-module-elasticsearch.md
+++ b/docs/reference/metricbeat/metricbeat-module-elasticsearch.md
@@ -85,6 +85,14 @@ metricbeat.modules:
   #scope: node
 ```
 
+You cannot specify the `username`/`password` settings _and_ `api_key` at the same time.
+
+When used, the `api_key`  configuration can be specified as:
+
+* {applies_to}`stack: ga 9.2.0` The unencoded `id:api_key` format (`api_key: "foo:bar"`) or the Base64-encoded `id:api_key` format (`api_key: "Zm9vOmJhcgo="`)
+* {applies_to}`stack: ga 9.1.4` The unencoded `id:api_key` format (`api_key: "foo:bar"`) or the Base64-encoded `id:api_key` format (`api_key: "Zm9vOmJhcgo="`)
+* All earlier releases can only use the unencoded `id:api_key` format (`api_key: "foo:bar"`)
+
 This module supports TLS connections when using `ssl` config field, as described in [SSL](/reference/metricbeat/configuration-ssl.md). It also supports the options described in [Standard HTTP config options](/reference/metricbeat/configuration-metricbeat.md#module-http-config-options).
 
 

--- a/metricbeat/module/elasticsearch/metricset_test.go
+++ b/metricbeat/module/elasticsearch/metricset_test.go
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !integration
+
+package elasticsearch
+
+import (
+	"testing"
+)
+
+func TestGetEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		backupKey string
+		expected  string
+		useBackup bool
+	}{
+		{"both set", "TEST_KEY", "BACKUP_KEY", "test_value", false},
+		{"only key set", "TEST_KEY", "BACKUP_KEY", "test_value", false},
+		{"only backup key set", "NOT_SET", "BACKUP_KEY", "backup_value", true},
+		{"neither set", "NOT_SET", "BACKUP_KEY", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.useBackup {
+				t.Setenv(tt.backupKey, tt.expected)
+			} else if tt.expected != "" {
+				t.Setenv(tt.key, tt.expected)
+			}
+
+			result := getEnv(tt.key, tt.backupKey)
+
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for three _expected_ environment variables to be supplied by service usage of AutoOps wrapping the Elasticsearch metricset.

This adds support for these in addition to the existing key

- `AUTOOPS_ES_USERNAME` (or `ELASTICSEARCH_READ_USERNAME`)
- `AUTOOPS_ES_PASSWORD` (or `ELASTICSEARCH_READ_PASSWORD`)
- `AUTOOPS_ES_API_KEY` (or `ELASTICSEARCH_API_KEY`)

This also adds support for the API Key to be supplied as a Base64 encoded value, which will be used directly. This is detected by looking for the `:` that separates the existing `id:key` value, then encoding it if it detects that and, otherwise, using it directly.

## Proposed commit message

Add expected support for `AUTOOPS_ES_USERNAME`, `AUTOOPS_ES_PASSWORD`, and `AUTOOPS_ES_API_KEY`. Support base64-encoded API Keys without re-encoding them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Disruptive User Impact

None. This retains backward compatibility while expanding compatibility.

## How to test this PR locally

Attempt to use the environment variables specified to connect to Elasticsearch. When using the API Key, try to use both the Base64-encoded value and the non-Base64 encoded value.

## Related issues

Relates https://github.com/elastic/elastic-agent/pull/9363

## Use cases

Allow users to copy/paste the API Key that is provided in most scenarios (Base64 encoded) and allow AutoOps to specify more appropriately named environment variables.
