### PR TITLE
[Docs][Elasticsearch] Fix formatting `/` -> `.`

### DIFF
--- a/docs/reference/metricbeat/metricbeat-module-elasticsearch.md
+++ b/docs/reference/metricbeat/metricbeat-module-elasticsearch.md
@@ -59,7 +59,7 @@ Also like some other modules, the `elasticsearch` module accepts either a `usern
 When used, the `api_key`  configuration can be specified as:
 
 * {applies_to}`stack: ga 9.1.4` The unencoded `id:api_key` format (`api_key: "foo:bar"`) or the Base64-encoded `id:api_key` format (`api_key: "Zm9vOmJhcgo="`).
-* All earlier releases can only use the unencoded `id:api_key` format (`api_key: "foo:bar"`)/
+* All earlier releases can only use the unencoded `id:api_key` format (`api_key: "foo:bar"`).
 
 
 ## Example configuration [_example_configuration]

--- a/metricbeat/module/elasticsearch/_meta/docs.md
+++ b/metricbeat/module/elasticsearch/_meta/docs.md
@@ -50,4 +50,4 @@ Also like some other modules, the `elasticsearch` module accepts either a `usern
 When used, the `api_key`  configuration can be specified as:
 
 * {applies_to}`stack: ga 9.1.4` The unencoded `id:api_key` format (`api_key: "foo:bar"`) or the Base64-encoded `id:api_key` format (`api_key: "Zm9vOmJhcgo="`).
-* All earlier releases can only use the unencoded `id:api_key` format (`api_key: "foo:bar"`)/
+* All earlier releases can only use the unencoded `id:api_key` format (`api_key: "foo:bar"`).


### PR DESCRIPTION
This changes a trailing `/` that was typoed to a `.`.