### PR TITLE
otel: handle compression_level 0 correctly in config translation

### DIFF
--- a/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
+++ b/libbeat/otelbeat/oteltranslate/outputs/elasticsearch/config_otel.go
@@ -143,11 +143,15 @@ func ToOTelConfig(output *config.C, logger *logp.Logger) (map[string]any, error)
 		"mapping": map[string]any{
 			"mode": "bodymap",
 		},
+	}
 
-		"compression": "gzip",
-		"compression_params": map[string]any{
+	// Compression
+	otelYAMLCfg["compression"] = "none"
+	if escfg.CompressionLevel > 0 {
+		otelYAMLCfg["compression"] = "gzip"
+		otelYAMLCfg["compression_params"] = map[string]any{
 			"level": escfg.CompressionLevel,
-		},
+		}
 	}
 
 	// Authentication


### PR DESCRIPTION
## Proposed commit message

If the Elasticsearch output has compression_level set to 0, the generated elasticsearchexporter config ends up with compression: gzip and compression_params.level: 0. This still applies compression instead of sending plain requests. Translate it to compression: none instead.

See https://www.elastic.co/docs/reference/beats/filebeat/elasticsearch-output#compression-level-option.


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
