### PR TITLE
[8.18](backport #46253) docs/refrence/filebeat/filebeat-input-cel.md Explain application of auth configuration (fix)

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-cel.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-cel.asciidoc
@@ -253,7 +253,7 @@ The CEL environment enables the https://pkg.go.dev/github.com/google/cel-go/cel#
 
 Additionally, it supports authentication via Basic Authentication, Digest Authentication or OAuth2.
 
-As described in Mito's [HTTP]({{mito_docs}}/lib#HTTP) documentation, configuration for Basic Authentication will only affect direct HEAD, GET and POST method calls, not explicity constructed requests run with `.do_request()`. Configuration for Digest Authentication or OAuth2 will be used for all requests made from CEL.
+As described in Mito's {mito_docs}/lib#HTTP[HTTP] documentation, configuration for Basic Authentication will only affect direct HEAD, GET and POST method calls, not explicity constructed requests run with `.do_request()`. Configuration for Digest Authentication or OAuth2 will be used for all requests made from CEL.
 
 Example configurations with authentication:
 
@@ -457,7 +457,7 @@ NOTE: Basic auth settings are disabled if either `enabled` is set to `false` or
 the `auth.basic` section is missing.
 
 NOTE: Basic auth settings do not affect requests run with `.do_request()`, as
-explained in [HTTP]({{mito_docs}}/lib#HTTP).
+explained in {mito_docs}/lib#HTTP[HTTP].
 
 [float]
 ==== `auth.basic.user`


### PR DESCRIPTION
## Proposed commit message

```
[8.18](backport #46253) docs/refrence/filebeat/filebeat-input-cel.md Explain application of auth configuration (fix) #

Fixes the backport done in #46408 by using asciidoc links instead of markdown.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #46408
