### PR TITLE
otel: increase goleak coverage in receiver tests

### DIFF
--- a/x-pack/filebeat/fbreceiver/receiver_leak_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_leak_test.go
@@ -11,23 +11,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
-	"go.uber.org/goleak"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestLeak(t *testing.T) {
-	// opencensus goroutine comes from init in cloud.google.com/go/pubsub and filebeat/input/gcppubsub
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreAnyFunction("github.com/Microsoft/go-winio.getQueuedCompletionStatus"),
-		goleak.IgnoreAnyFunction("go.opencensus.io/stats/view.(*worker).start"))
+	defer oteltest.VerifyNoLeaks(t)
 
 	monitorSocket := genSocketPath()
 	var monitorHost string

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -461,6 +461,8 @@ func (g *logGenerator) Generate() []receivertest.UniqueIDAttrVal {
 // - Random permanent error. We expect the batch to be dropped.
 // - Random error. We expect the batch to be retried or dropped based on the error type.
 func TestConsumeContract(t *testing.T) {
+	defer oteltest.VerifyNoLeaks(t)
+
 	tmpDir := t.TempDir()
 	const logsPerTest = 100
 

--- a/x-pack/metricbeat/mbreceiver/receiver_leak_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_leak_test.go
@@ -11,23 +11,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
-	"go.uber.org/goleak"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestLeak(t *testing.T) {
-	// opencensus goroutine comes from init in cloud.google.com/go/pubsub and filebeat/input/gcppubsub
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreAnyFunction("github.com/Microsoft/go-winio.getQueuedCompletionStatus"),
-		goleak.IgnoreAnyFunction("go.opencensus.io/stats/view.(*worker).start"))
+	defer oteltest.VerifyNoLeaks(t)
 
 	monitorSocket := genSocketPath()
 	var monitorHost string


### PR DESCRIPTION
## Proposed commit message

This commit improves goleak coverage in the receiver tests. By instrumenting `oteltest.CheckReceivers`, we achieve broader coverage of receiver use cases. It also adds references to the known leaks that are allowed and why.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
go test ./x-pack/filebeat/fbreceiver ./x-pack/metricbeat/mbreceiver -v
```

## Related issues

- Relates https://github.com/elastic/beats/pull/46305