### PR TITLE
Fix TCP & UDP input metricsets for ports > 32767

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -278,6 +278,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fix termination of input on API errors. {pull}45999[45999]
 - Fix race condition that could cause Filebeat to hang during shutdown after failing to startup {issue}45034[45034] {pull}46331[46331]
 - Fixed hints autodiscover for Docker when the configuration is only `hints.enabled: true`. {issue}45156[45156] {pull}45864[45864]
+- Fix metrics from TCP & UDP inputs when the port number is > 32767 {pull}46486[46486]
 
 *Heartbeat*
 

--- a/filebeat/input/netmetrics/netmetrics.go
+++ b/filebeat/input/netmetrics/netmetrics.go
@@ -48,7 +48,7 @@ func addrs(addr string, log *logp.Logger) (addr4, addr6 []string, err error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get address for %s: %w", addr, err)
 	}
-	pn, err := strconv.ParseInt(port, 10, 16)
+	pn, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get port for %s: %w", addr, err)
 	}

--- a/filebeat/input/netmetrics/netmetrics_test.go
+++ b/filebeat/input/netmetrics/netmetrics_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestAddrs(t *testing.T) {
 	t.Run("ipv4", func(t *testing.T) {
-		addr4, addr6, err := addrs("0.0.0.0:9001", logptest.NewTestingLogger(t, ""))
+		addr4, addr6, err := addrs("0.0.0.0:65535", logptest.NewTestingLogger(t, ""))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
## Proposed commit message

```
When parsing the port to collect metrics, the TCP & UDP inputs were
parsing the port as a int16, which limited the maximum port to
32767. This commit fixes it by parsing the port as uint16.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally
1. Start Filebeat with the following configuration:
    ```yaml
    filebeat.inputs:
      - type: udp
        host: 127.0.0.1:42000
    
    output.discard:
      enabled: true
    
    logging:
      to_stderr: true
      level: warning

    http.enabled: true
    ```

2. Ensure the following waring is **not** in the logs:
    ```json
    {
      "log.level": "warn",
      "@timestamp": "2025-09-09T18:02:06.893-0400",
      "log.logger": "input.udp",
      "log.origin": {
        "function": "github.com/elastic/beats/v7/filebeat/input/netmetrics.NewUDP",
        "file.name": "netmetrics/udp.go",
        "file.line": 65
      },
      "message": "failed to get port for 127.0.0.1:42000: strconv.ParseInt: parsing \"42000\": value out of range",
      "service.name": "filebeat",
      "id": "8C542040A200BF6D",
      "host": "127.0.0.1:42000",
      "ecs.version": "1.6.0"
    }
    ```

3. Start sending some data in the UDP port
    ```
    docker run -it --rm mingrammer/flog -l | nc -vu localhost 42000 
    ```

4. Get the input metrics from `http://localhost:5066/inputs/` and ensure `receive_queue_length` is populated.
    ```
    curl http://localhost:5066/inputs/ -s|jq '.[].receive_queue_length'
    ```
    You might have to call `curl` multiple times, as the value some times is zero.

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
