### PR TITLE
filestream: make gzip a beta feature

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -69,7 +69,7 @@ already present as `container.id` and `container.log.tag` is dropped because it 
 otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Fixed race conditions in the global ratelimit processor that could drop events or apply rate limiting incorrectly.
 - Fixed password authentication for ACL users in the Redis input of Filebeat. {pull}44137[44137]
-- Add experimental GZIP file ingestion in filestream. {pull}45301[45301]
+- Add beta GZIP file ingestion in filestream. {pull}45301[45301]
 -Change aws.cloudwatch.* field in awscloudwatch input to nested object. {pull}46357[46357]
 
 

--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -26,7 +26,7 @@ Use the `filestream` input to read lines from log files. It is the improved alte
 * Only the most recent updates are serialized to the registry. In contrast, the `log` input has to serialize the complete registry on each ACK from the outputs. This makes the registry updates much quicker with this input.
 * The input ensures that only offsets updates are written to the registry append only log. The `log` writes the complete file state.
 * Stale entries can be removed from the registry, even if there is no active input.
-* {applies_to}`stack: preview 9.2.0` As a technical preview feature, it can read GZIP files.
+* {applies_to}`stack: beta 9.2.0` As a beta feature, it can read GZIP files.
 
 
 To configure this input, specify a list of glob-based [`paths`](#filestream-input-paths) that must be crawled to locate and fetch the log lines.
@@ -72,14 +72,14 @@ filebeat.inputs:
 ## Reading GZIP files
 
 ```{applies_to}
-stack: preview 9.2.0
+stack: beta 9.2.0
 ```
 
 ::::{warning}
-This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
 ::::
 
-The `filestream` input can ingest GZIP files as a **technical preview** feature.
+The `filestream` input can ingest GZIP files as a **beta** feature.
 A GZIP file is treated like any other file, with the same guarantees `filestream`
 offers. This includes offset tracking and resuming from partially read files.
 

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -44,7 +44,7 @@ type config struct {
 	FileWatcher  *conf.Namespace `config:"prospector"`
 	FileIdentity *conf.Namespace `config:"file_identity"`
 
-	// GZIPExperimental enables tech-preview support for ingesting GZIP files.
+	// GZIPExperimental enables beta support for ingesting GZIP files.
 	// When set to true the input will transparently stream-decompress GZIP files.
 	// This feature is experimental and subject to change.
 	GZIPExperimental bool `config:"gzip_experimental"`
@@ -205,8 +205,8 @@ func (c config) checkUnsupportedParams(logger *logp.Logger) {
 				"highly discouraged.")
 	}
 	if c.GZIPExperimental {
-		logger.Named("filestream").Warn(cfgwarn.Experimental(
-			"filestream: experimental gzip support enabled"))
+		logger.Named("filestream").Warn(cfgwarn.Beta(
+			"filestream: beta gzip support enabled"))
 	}
 }
 

--- a/filebeat/testing/integration/filestream_gzip_test.go
+++ b/filebeat/testing/integration/filestream_gzip_test.go
@@ -127,7 +127,7 @@ output.file:
 		}
 	})
 
-	t.Run("TechPreviewWarning", func(t *testing.T) {
+	t.Run("BetaWarning", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -162,8 +162,9 @@ output.console:
 			WithReportOptions(reportOptions).
 			ExpectStart().
 			ExpectOutput(
-				"EXPERIMENTAL: filestream: experimental gzip support enabled").
-			Start(ctx).Wait()
+				"BETA: filestream: beta gzip support enabled").
+			Start(ctx).
+			Wait()
 	})
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
filestream: make gzip a beta feature
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

n/a


## How to test this PR locally

run filebeat with the following config:

```yaml
filebeat.inputs:
  - type: filestream
    id: "test-filestream"
    paths:
      - /tmp/log.log
    gzip_experimental: true
output.console:
  enabled: true
```

you should see a log containing:

```
BETA: filestream: beta gzip support enabled
```

check the docs mention gzip ingestion is a beta feature

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- n/a
