### PR TITLE
Make data updates in add_host_metadata processor synchronous

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,6 +155,7 @@ otherwise no tag is added. {issue}42208[42208] {pull}42403[42403]
 - Update Go version to 1.24.7 {pull}46070[46070].
 - Update github.com/go-viper/mapstructure/v2 to v2.4.0 {pull}46335[46335]
 - Update github.com/docker/docker to v28.3.3 {pull}46334[46334]
+- Make data updates in add_host_metadata processor synchronous {pull}46546[46546]
 
 *Auditbeat*
 

--- a/go.mod
+++ b/go.mod
@@ -187,7 +187,6 @@ require (
 	github.com/elastic/sarama v1.19.1-0.20250603175145-7672917f26b6
 	github.com/elastic/tk-btf v0.2.0
 	github.com/elastic/toutoumomoma v0.0.0-20240626215117-76e39db18dfb
-	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15
 	github.com/go-ldap/ldap/v3 v3.4.6
 	github.com/go-ole/go-ole v1.3.0
 	github.com/go-resty/resty/v2 v2.16.5

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,6 @@ github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e h1:2jjYsG
 github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e/go.mod h1:uAyTlAUxchYuiFjTHmuIEJ4nGSm7iOPaGcAyA81fJ80=
 github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006 h1:50sW4r0PcvlpG4PV8tYh2RVCapszJgaOLRCS2subvV4=
 github.com/foxboron/swtpm_test v0.0.0-20230726224112-46aaafdf7006/go.mod h1:eIXCMsMYCaqq9m1KSSxXwQG11krpuNPGP3k0uaWrbas=
-github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
-github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
@@ -774,7 +772,6 @@ github.com/microsoft/go-mssqldb v1.9.2 h1:nY8TmFMQOHpm2qVWo6y4I2mAmVdZqlGiMGAYt6
 github.com/microsoft/go-mssqldb v1.9.2/go.mod h1:GBbW9ASTiDC+mpgWDGKdm3FnFLTUsLYN3iFL90lQ+PA=
 github.com/microsoft/wmi v0.25.1 h1:sQv9hCEHtW5K6yEVL78T6XGRMGxk4aTpcJwCiB5rLN0=
 github.com/microsoft/wmi v0.25.1/go.mod h1:1zbdSF0A+5OwTUII5p3hN7/K6KF2m3o27pSG6Y51VU8=
-github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.66 h1:FeZXOS3VCVsKnEAd+wBkjMC3D2K+ww66Cq3VnCINuJE=
 github.com/miekg/dns v1.1.66/go.mod h1:jGFzBsSNbJw6z1HYut1RKBKHA9PBdxeHrZG8J+gC2WE=
 github.com/mileusna/useragent v1.3.4 h1:MiuRRuvGjEie1+yZHO88UBYg8YBC/ddF6T7F56i3PCk=
@@ -1240,7 +1237,6 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -1280,7 +1276,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1328,8 +1323,6 @@ golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1391,7 +1384,6 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -170,6 +170,7 @@ func (p *addHostMetadata) loadData(useFQDN bool) (mapstr.M, error) {
 	data := cache.data.Get()
 	var err error
 	if data == nil || timestampExpired(cache.lastUpdate, p.config.CacheTTL) {
+		// Data is absent or expired, refresh it.
 		data, err = p.fetchData(useFQDN)
 		if err == nil {
 			cache.data.Set(data)

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -158,7 +158,7 @@ func timestampExpired(timestamp time.Time, ttl time.Duration) bool {
 	if ttl <= 0 {
 		return true
 	}
-	return timestamp.Add(ttl).Before((time.Now()))
+	return timestamp.Add(ttl).Before(time.Now())
 }
 
 // loadData update's the processor's associated host metadata

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -717,15 +717,17 @@ func newWithHostInfoFactory(cfg *conf.C, log *logp.Logger, factory hostInfoFacto
 
 	p := &addHostMetadata{
 		config: c,
-		data:   mapstr.NewPointer(nil),
+		caches: [2]hostMetadataCache{
+			{data: mapstr.NewPointer(nil)},
+			{data: mapstr.NewPointer(nil)},
+		},
 		logger: log.Named(logName),
 		metrics: metrics{
 			FQDNLookupFailed: monitoring.NewInt(reg, "fqdn_lookup_failed"),
 		},
 		hostInfoFactory: factory,
 	}
-	p.useFQDN.Store(features.FQDN())
-	if err := p.loadData(true); err != nil {
+	if _, err := p.loadData(features.FQDN()); err != nil {
 		return nil, fmt.Errorf("failed to load data: %w", err)
 	}
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -18,16 +18,19 @@
 package add_host_metadata
 
 import (
+	"errors"
 	"fmt"
-	"net"
-	"os"
 	"runtime"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+
+	"github.com/elastic/beats/v7/libbeat/processors/util"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/features"
@@ -35,8 +38,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/go-sysinfo/types"
-
-	"github.com/foxcpp/go-mockdns"
 )
 
 var (
@@ -476,32 +477,29 @@ func TestSkipAddingHostMetadata(t *testing.T) {
 }
 
 func TestFQDNEventSync(t *testing.T) {
-	hostname, err := os.Hostname()
-	require.NoError(t, err)
-	srv, _ := mockdns.NewServer(map[string]mockdns.Zone{
-		hostname + ".": {
-			CNAME: "foo.bar.baz.",
-		},
-		"foo.bar.baz.": {
-			A: []string{"1.1.1.1"},
-		},
-	}, false)
-	defer srv.Close()
-
-	srv.PatchNet(net.DefaultResolver)
-	defer mockdns.UnpatchNet(net.DefaultResolver)
+	hostname := "hostname"
+	fqdn := "fqdn"
 
 	testConfig := conf.MustNewConfigFrom(map[string]interface{}{
 		"cache.ttl": "5m",
 	})
 
 	// Start with FQDN off
-	err = features.UpdateFromConfig(conf.MustNewConfigFrom(map[string]interface{}{
+	err := features.UpdateFromConfig(conf.MustNewConfigFrom(map[string]interface{}{
 		"features.fqdn.enabled": false,
 	}))
 	require.NoError(t, err)
 
 	p, err := New(testConfig, logptest.NewTestingLogger(t, ""))
+	typedProc, ok := p.(*addHostMetadata)
+	require.True(t, ok)
+	typedProc.hostInfoFactory = func() (hostInfo, error) {
+		return &mockHostInfo{
+			Hostname: hostname,
+			FQDN:     fqdn,
+		}, nil
+	}
+
 	require.NoError(t, err)
 
 	// update
@@ -513,40 +511,31 @@ func TestFQDNEventSync(t *testing.T) {
 	t.Logf("updated FQDN")
 
 	// run a number of events, make sure none have wrong hostname.
-	checkWait := sync.WaitGroup{}
-	for i := 0; i < 10; i++ {
-		checkWait.Add(1)
-		go func() {
-			resp, err := p.Run(&beat.Event{
-				Fields: mapstr.M{},
-			})
-			require.NoError(t, err)
-			name, err := resp.Fields.GetValue("host.name")
-			require.NoError(t, err)
-			require.Equal(t, "foo.bar.baz", name)
-			checkWait.Done()
-		}()
-	}
-	t.Logf("Waiting for runners to return...")
-	checkWait.Wait()
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		resp, err := p.Run(&beat.Event{
+			Fields: mapstr.M{},
+		})
+		require.NoError(collect, err)
+		name, err := resp.Fields.GetValue("host.name")
+		require.NoError(collect, err)
+		assert.Equal(collect, fqdn, name)
+	}, time.Second*3600, time.Millisecond*10)
 }
 
 func TestFQDNLookup(t *testing.T) {
-	hostname, err := os.Hostname()
-	require.NoError(t, err)
+	hostname := "placeholder"
 
 	tests := map[string]struct {
-		cnameLookupResult             string
+		fqdnLookupResult              string
 		expectedHostName              string
 		expectedFQDNLookupFailedCount int64
 	}{
 		"lookup_succeeds": {
-			cnameLookupResult:             "example.com.",
+			fqdnLookupResult:              "example.com",
 			expectedHostName:              "example.com",
 			expectedFQDNLookupFailedCount: 0,
 		},
 		"lookup_fails": {
-			cnameLookupResult:             "",
 			expectedHostName:              hostname,
 			expectedFQDNLookupFailedCount: 1,
 		},
@@ -554,22 +543,8 @@ func TestFQDNLookup(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Mock CNAME resolution
-			srv, _ := mockdns.NewServer(map[string]mockdns.Zone{
-				hostname + ".": {
-					CNAME: test.cnameLookupResult,
-				},
-				test.cnameLookupResult: {
-					A: []string{"1.1.1.1"},
-				},
-			}, false)
-			defer srv.Close()
-
-			srv.PatchNet(net.DefaultResolver)
-			defer mockdns.UnpatchNet(net.DefaultResolver)
-
 			// Enable FQDN feature flag
-			err = features.UpdateFromConfig(fqdnFeatureFlagConfig(true))
+			err := features.UpdateFromConfig(fqdnFeatureFlagConfig(true))
 			require.NoError(t, err)
 			defer func() {
 				err = features.UpdateFromConfig(fqdnFeatureFlagConfig(true))
@@ -580,7 +555,18 @@ func TestFQDNLookup(t *testing.T) {
 			testConfig, err := conf.NewConfigFrom(map[string]interface{}{})
 			require.NoError(t, err)
 
-			p, err := New(testConfig, logptest.NewTestingLogger(t, ""))
+			factory := func() (hostInfo, error) {
+				var fqdnError error
+				if test.expectedFQDNLookupFailedCount > 0 {
+					fqdnError = errors.New("hostname lookup failed")
+				}
+				return &mockHostInfo{
+					Hostname: hostname,
+					FQDN:     test.fqdnLookupResult,
+					FQDNErr:  fqdnError,
+				}, nil
+			}
+			p, err := newWithHostInfoFactory(testConfig, logptest.NewTestingLogger(t, ""), factory)
 			require.NoError(t, err)
 
 			addHostMetadataP, ok := p.(*addHostMetadata)
@@ -609,4 +595,58 @@ func fqdnFeatureFlagConfig(fqdnEnabled bool) *conf.C {
 	return conf.MustNewConfigFrom(map[string]interface{}{
 		"features.fqdn.enabled": fqdnEnabled,
 	})
+}
+
+type mockHostInfo struct {
+	FQDN     string
+	Hostname string
+	FQDNErr  error
+}
+
+var _ hostInfo = &mockHostInfo{}
+
+func (m *mockHostInfo) Info() types.HostInfo {
+	return types.HostInfo{
+		Hostname: m.Hostname,
+		OS:       &types.OSInfo{},
+	}
+}
+
+func (m *mockHostInfo) FQDNWithContext(_ context.Context) (string, error) {
+	if m.FQDNErr != nil {
+		return "", m.FQDNErr
+	}
+	return m.FQDN, nil
+}
+
+// New constructs a new add_host_metadata processor with a custom host info factory
+func newWithHostInfoFactory(cfg *conf.C, log *logp.Logger, factory hostInfoFactory) (beat.Processor, error) {
+	c := defaultConfig()
+	if err := cfg.Unpack(&c); err != nil {
+		return nil, fmt.Errorf("fail to unpack the %v configuration: %w", processorName, err)
+	}
+
+	p := &addHostMetadata{
+		config: c,
+		data:   mapstr.NewPointer(nil),
+		logger: log.Named(logName),
+		metrics: metrics{
+			FQDNLookupFailed: monitoring.NewInt(reg, "fqdn_lookup_failed"),
+		},
+		useFQDN:         features.FQDN(),
+		hostInfoFactory: factory,
+	}
+	if err := p.loadData(true); err != nil {
+		return nil, fmt.Errorf("failed to load data: %w", err)
+	}
+
+	if c.Geo != nil {
+		geoFields, err := util.GeoConfigToMap(*c.Geo)
+		if err != nil {
+			return nil, err
+		}
+		p.geoData = mapstr.M{"host": mapstr.M{"geo": geoFields}}
+	}
+
+	return p, nil
 }

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -633,9 +633,9 @@ func newWithHostInfoFactory(cfg *conf.C, log *logp.Logger, factory hostInfoFacto
 		metrics: metrics{
 			FQDNLookupFailed: monitoring.NewInt(reg, "fqdn_lookup_failed"),
 		},
-		useFQDN:         features.FQDN(),
 		hostInfoFactory: factory,
 	}
+	p.useFQDN.Store(features.FQDN())
 	if err := p.loadData(true); err != nil {
 		return nil, fmt.Errorf("failed to load data: %w", err)
 	}


### PR DESCRIPTION
This PR is based on https://github.com/elastic/beats/pull/46546, with some changes to fix concurrency issues.

### Original description (@swiatekm):

Make data updates in add_host_metadata processor synchronous.

Right now, the add_host_metadata processor adds a callback tracking changes to the value of the FQDN feature flag. This callback is never cleaned up, and adding a Close method to the processor is a breaking change. This change gets rid of the callback and instead just checks whenever it processes an event.

We reload the data synchronously now, during event processing. The asynchronous updates intentionally blocked processing anyway by taking the expiration lock, so in practice this shouldn't change much. Synchronous updates happen on every cache expiration regardless.

I've also made it possible to substitute real hostname and fqdn fetching with a mock, making our unit tests not rely on injecting a DNS server into the default resolver.

### Additional changes

Instead of making FQDN config part of the global processor state, keep two caches, one for FQDN and one for non-FQDN, so there is never contention between the cases when the settings change. This simplifies the caching logic and also makes it possible (in a followup PR) to share this cache between all Beats receivers in the same process, instead of running the same (relatively expensive) FQDN lookup independently in each of them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

