### PR TITLE
Temporarily have FIPS integration tests spin up deployments in Production CFT environment

### DIFF
--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -214,10 +214,11 @@ steps:
           ASDF_PYTHON_VERSION: "3.9.13" # Not needed by ECH tests, but needed by VM
 # We are temporarily using the Production CFT environment instead of the Staging GovCloud
 # one.  This is being done until issues with creating deployments in Staging GovCloud are
-# fixed. Once this happens, uncomment the lines below.
+# fixed. Once this happens, uncomment the lines below and delete the gcp-us-west2 line.
 #          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
 #          TF_VAR_ech_region: "us-gov-east-1"
 #          TF_VAR_deployment_template_id: "aws-general-purpose"
+          TF_VAR_ech_region: "gcp-us-west2"
         command: |
           .buildkite/scripts/custom_fips_ech_test.sh x-pack/filebeat
         retry:

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -251,10 +251,11 @@ steps:
           ASDF_PYTHON_VERSION: "3.9.13" # Not needed by ECH tests, but needed by VM
 # We are temporarily using the Production CFT environment instead of the Staging GovCloud
 # one.  This is being done until issues with creating deployments in Staging GovCloud are
-# fixed. Once this happens, uncomment the lines below.
+# fixed. Once this happens, uncomment the lines below and delete the gcp-us-west2 line.
 #          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
 #          TF_VAR_ech_region: "us-gov-east-1"
 #          TF_VAR_deployment_template_id: "aws-general-purpose"
+          TF_VAR_ech_region: "gcp-us-west2"
         command: |
           .buildkite/scripts/custom_fips_ech_test.sh x-pack/metricbeat
         retry:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR temporarily creates ECH deployments for the FIPS integration testing Buildkite pipeline in the Production CFT ESS environment (as opposed to the Staging GovCloud ESS environment).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The FIPS integration tests pipeline is currently failing because the step where it provisions deployments in GovCloud Staging is consistently failing.  
