### PR TITLE
[Flaky test] skip x-pack/filebeat/fbreceiver/TestReceiverDegraded on linux/arm64

### DIFF
--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -265,6 +265,9 @@ func TestMultipleReceivers(t *testing.T) {
 }
 
 func TestReceiverDegraded(t *testing.T) {
+	if runtime.GOARCH == "arm64" && runtime.GOOS == "linux" {
+		t.Skip("flaky test on Ubuntu arm64, see https://github.com/elastic/beats/issues/46437")
+	}
 	testCases := []struct {
 		name            string
 		status          oteltest.ExpectedStatus


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
skip x-pack/filebeat/fbreceiver/TestReceiverDegraded on linux/arm64

it's failing due a goroutine leak now goleak was enabled, see https://github.com/elastic/beats/issues/46437#issuecomment-3280096244 for more details
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Disruptive User Impact

N/a


## How to test this PR locally

try to run it on Ubuntu arm64. Without the skip the test should fail.

## Related issues

- Relates https://github.com/elastic/beats/issues/46437
