### PR TITLE
[OTel] Add logstash exporter logic

### DIFF
--- a/x-pack/otel/exporter/logstashexporter/config.go
+++ b/x-pack/otel/exporter/logstashexporter/config.go
@@ -4,4 +4,36 @@
 
 package logstashexporter
 
+import (
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/outputs/logstash"
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
 type Config map[string]any
+
+func createDefaultConfig() component.Config {
+	return &Config{}
+}
+
+type logstashOutputConfig struct {
+	outputs.HostWorkerCfg `config:",inline"`
+	logstash.Config       `config:",inline"`
+}
+
+func parseLogstashConfig(cfg *component.Config) (*config.C, *logstashOutputConfig, error) {
+	rawConfig, err := config.NewConfigFrom(&cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	parsedConfig := logstashOutputConfig{}
+	err = rawConfig.Unpack(&parsedConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rawConfig, &parsedConfig, nil
+}

--- a/x-pack/otel/exporter/logstashexporter/config_test.go
+++ b/x-pack/otel/exporter/logstashexporter/config_test.go
@@ -1,0 +1,98 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package logstashexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/elastic/go-ucfg"
+
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	_, ok := createDefaultConfig().(*Config)
+	require.True(t, ok)
+}
+
+func TestParseLogstashConfig(t *testing.T) {
+	testingConfig := newTestConfig(t)
+	expectedRawConfig, err := config.NewConfigFrom(testingConfig)
+	require.NoError(t, err)
+
+	expectedLogstashConfig := logstashOutputConfig{}
+	require.NoError(t, expectedRawConfig.Unpack(&expectedLogstashConfig))
+
+	rawConfig, logstashConfig, err := parseLogstashConfig(testingConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedRawConfig, rawConfig)
+	assert.Equal(t, expectedLogstashConfig, *logstashConfig)
+}
+
+func TestParseLogstashConfigInvalidConfig(t *testing.T) {
+	invalidConfig := component.Config("invalid") // fail config.NewConfigFrom
+	rawConfig, logstashConfig, err := parseLogstashConfig(&invalidConfig)
+
+	assert.Error(t, err)
+	var ucfgErr ucfg.Error
+	require.ErrorAs(t, err, &ucfgErr)
+	assert.Equal(t, ucfg.ErrTypeMismatch, ucfgErr.Reason())
+	assert.Nil(t, rawConfig)
+	assert.Nil(t, logstashConfig)
+}
+
+func newTestConfig(t *testing.T) *component.Config {
+	defaultConfig := createDefaultConfig()
+	var cfg Config
+	if c, ok := defaultConfig.(*Config); ok {
+		cfg = *c
+	} else {
+		t.Fatal("default config is not of type *Config")
+	}
+	cfg["hosts"] = []string{"localhost:5044"}
+	cfg["workers"] = 1
+	cfg["index"] = "test-index"
+	cfg["loadbalance"] = true
+	cfg["bulk_max_size"] = 100
+	cfg["slow_start"] = true
+	cfg["timeout"] = time.Second * 5
+	cfg["ttl"] = time.Second * 10
+	cfg["pipelining"] = 4
+	cfg["compression_level"] = 5
+	cfg["max_retries"] = 7
+	cfg["escape_html"] = true
+	cfg["backoff"] = map[string]any{
+		"init": "2s",
+		"max":  "1m",
+	}
+	cfg["ssl"] = map[string]any{
+		"enabled":             false,
+		"verification_mode":   "none",
+		"supported_protocols": []string{"TLSv1.3"},
+		"cipher_suites":       []string{"ECDHE-ECDSA-AES-128-CBC-SHA"},
+		"certificate_authorities": []string{
+			"/path/to/ca1",
+			"/path/to/ca2",
+		},
+		"certificate":            "/path/to/cert",
+		"key":                    "/path/to/key",
+		"key_passphrase":         "passphrase",
+		"key_passphrase_path":    "/path/to/key.pass",
+		"curve_types":            []string{"P-256"},
+		"renegotiation":          "never",
+		"ca_sha256":              []string{"abc", "def"},
+		"ca_trusted_fingerprint": "12:34:56:78:90:ab:cd:ef:12:34:56:78:90:ab:cd:ef:12:34:56:78",
+	}
+	cfg["proxy_url"] = "socks5://proxy:3128"
+	cfg["proxy_use_local_resolver"] = false
+	cfg["queue"] = map[string]any{}
+	return &defaultConfig
+}

--- a/x-pack/otel/exporter/logstashexporter/exporter.go
+++ b/x-pack/otel/exporter/logstashexporter/exporter.go
@@ -1,0 +1,290 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package logstashexporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/elastic/beats/v7/libbeat/outputs"
+
+	"github.com/elastic/beats/v7/libbeat/otelbeat/otelctx"
+	"github.com/elastic/beats/v7/libbeat/outputs/logstash"
+	"github.com/elastic/beats/v7/x-pack/otel/exporter/logstashexporter/internal"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/transport"
+)
+
+const (
+	defaultDeadlockTimeout = 5 * time.Minute
+)
+
+type logstashExporter struct {
+	config    *logstashOutputConfig
+	rawConfig *config.C
+	logger    *logp.Logger
+	workers   []internal.Worker
+	workQueue chan *internal.Work
+	settings  exporter.Settings
+	mu        sync.RWMutex
+}
+
+func newLogstashExporter(settings exporter.Settings, cfg component.Config) (*logstashExporter, error) {
+	rawConfig, logstashConfig, err := parseLogstashConfig(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	logger, err := logp.ConfigureWithCoreLocal(logp.Config{}, settings.Logger.Core())
+	if err != nil {
+		return nil, err
+	}
+
+	// Same as the number of outputs.Client created by the otelconsumer
+	workQueueSize := runtime.NumCPU()
+
+	return &logstashExporter{
+		config:    logstashConfig,
+		rawConfig: rawConfig,
+		logger:    logger,
+		workQueue: make(chan *internal.Work, workQueueSize),
+		settings:  settings,
+	}, nil
+}
+
+func (*logstashExporter) Start(context.Context, component.Host) error {
+	// Clients are initialized on the first ConsumeLogs call and not here on purpose.
+	// The context passed to Start doesn't have the necessary values to create
+	// the Logstash clients.
+	return nil
+}
+
+func (l *logstashExporter) Shutdown(context.Context) error {
+	return l.shutdownLogstashWorkers()
+}
+
+func (l *logstashExporter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (l *logstashExporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	_, err := l.makeLogstashWorkers(ctx)
+	if err != nil {
+		return err
+	}
+
+	batch, err := internal.NewLogBatch(ctx, ld)
+	if err != nil {
+		return err
+	}
+
+	work := internal.NewWork(batch)
+	if err := l.enqueueWork(ctx, work); err != nil {
+		return consumererror.NewLogs(err, ld)
+	}
+
+	return l.processWorkResult(ctx, ld, work, batch)
+}
+
+func (l *logstashExporter) enqueueWork(ctx context.Context, w *internal.Work) error {
+	backoff := 5 * time.Millisecond
+	maxBackoff := 250 * time.Millisecond
+	attempts := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case l.workQueue <- w:
+			return nil
+
+		default:
+			attempts++
+			l.logger.Debugf("Work queue is full, retrying enqueue (attempt %d, backoff %v)", attempts, backoff)
+			time.Sleep(backoff)
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		}
+	}
+}
+
+func (l *logstashExporter) processWorkResult(
+	ctx context.Context,
+	ld plog.Logs,
+	work *internal.Work,
+	batch *internal.LogBatch,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return consumererror.NewLogs(ctx.Err(), ld)
+
+		case workRes := <-work.Result():
+			complete, res := l.processBatchResult(ctx, workRes, ld, batch, work)
+			if complete {
+				return res
+			}
+
+		case <-time.After(defaultDeadlockTimeout):
+			// See logstash.deadlockListener for reasoning behind this log.
+			l.logger.Warnf("Logstash worker hasn't complete processing in the last %v", defaultDeadlockTimeout)
+		}
+	}
+}
+
+func (l *logstashExporter) processBatchResult(
+	ctx context.Context,
+	workRes error,
+	ld plog.Logs,
+	batch *internal.LogBatch,
+	work *internal.Work,
+) (bool, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return true, consumererror.NewLogs(ctx.Err(), ld)
+
+		case batchRes := <-batch.Result():
+			return l.handleBatchResult(ctx, batchRes, workRes, ld, batch, work)
+
+		case <-time.After(defaultDeadlockTimeout):
+			// See logstash.deadlockListener for reasoning behind this log.
+			l.logger.Warnf("Logstash batch hasn't complete processing in the last %v.", defaultDeadlockTimeout)
+		}
+	}
+}
+
+func (l *logstashExporter) handleBatchResult(
+	ctx context.Context,
+	batchRes internal.LogBatchResult,
+	workRes error,
+	ld plog.Logs,
+	batch *internal.LogBatch,
+	work *internal.Work,
+) (bool, error) {
+	switch batchRes {
+	case internal.LogBatchResultACK:
+		// Batch was acknowledged, processing complete
+		return true, nil
+
+	case internal.LogBatchResultDrop:
+		// Batch was explicitly dropped, report permanent error
+		return true, consumererror.NewPermanent(fmt.Errorf("batch was dropped: %w", workRes))
+
+	case internal.LogBatchResultCancelled:
+		if err := l.enqueueWork(ctx, work); err != nil {
+			return true, consumererror.NewLogs(fmt.Errorf("failed to requeue cancelled batch: %w", err), ld)
+		}
+		return false, nil
+
+	case internal.LogBatchResultRetry:
+		return l.handleRetry(ctx, workRes, ld, batch, work)
+
+	default:
+		return true, consumererror.NewPermanent(fmt.Errorf("unexpected batch result: %v", batchRes))
+	}
+}
+
+func (l *logstashExporter) handleRetry(
+	ctx context.Context,
+	workRes error,
+	ld plog.Logs,
+	batch *internal.LogBatch,
+	work *internal.Work,
+) (bool, error) {
+	// Connection errors don't count against retry limit. The Logstash clients might close
+	// the connection for different reasons, and workers don't have access to the internal
+	// client's state to properly determined when the connection was closed.
+	if workRes != nil && errors.Is(workRes, transport.ErrNotConnected) {
+		batch.AddRetry(-1)
+		if err := l.enqueueWork(ctx, work); err != nil {
+			return true, consumererror.NewLogs(fmt.Errorf("failed to requeue batch after connection error: %w", err), ld)
+		}
+		return false, nil
+	}
+
+	//nolint:gosec //G115: MaxRetries is positive.
+	if l.config.MaxRetries > 0 && batch.NumRetries() >= uint64(l.config.MaxRetries) {
+		return true, consumererror.NewLogs(
+			fmt.Errorf("max number of retries exceeded: %d", l.config.MaxRetries),
+			ld,
+		)
+	}
+
+	l.logger.Debugf("Attempt %d of %d to publish events", batch.NumRetries()+1, l.config.MaxRetries)
+	if err := l.enqueueWork(ctx, work); err != nil {
+		return true, consumererror.NewLogs(fmt.Errorf("failed to requeue batch for retry: %w", err), ld)
+	}
+
+	return false, nil
+}
+
+func (l *logstashExporter) makeLogstashWorkers(ctx context.Context) ([]internal.Worker, error) {
+	if w := l.getWorkers(); w != nil {
+		return w, nil
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Re-check after acquiring write lock
+	if l.workers != nil {
+		return l.workers, nil
+	}
+
+	beatVersion := otelctx.GetBeatVersion(ctx)
+	beatIndexPrefix := otelctx.GetBeatIndexPrefix(ctx)
+	group, err := logstash.MakeLogstashClients(beatVersion, l.logger, outputs.NewNilObserver(), l.rawConfig, beatIndexPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	workers := make([]internal.Worker, 0, len(group.Clients))
+	for _, cli := range group.Clients {
+		workers = append(workers, internal.MakeClientWorker(l.workQueue, cli, *l.logger))
+	}
+
+	l.workers = workers
+	return workers, nil
+}
+
+func (l *logstashExporter) getWorkers() []internal.Worker {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.workers
+}
+
+func (l *logstashExporter) shutdownLogstashWorkers() error {
+	l.mu.Lock()
+	closingWorkers := l.workers
+	l.workers = nil
+	l.mu.Unlock()
+
+	var errs error
+	for _, cw := range closingWorkers {
+		err := cw.Close()
+		if err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	return errs
+}

--- a/x-pack/otel/exporter/logstashexporter/exporter_test.go
+++ b/x-pack/otel/exporter/logstashexporter/exporter_test.go
@@ -1,0 +1,499 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package logstashexporter
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/otelbeat/otelctx"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/x-pack/otel/exporter/logstashexporter/internal"
+	"github.com/elastic/elastic-agent-libs/transport"
+)
+
+const (
+	exporterTestDefaultTimeout = 10 * time.Second
+)
+
+func TestNewLogstashExporterCreatesValidInstance(t *testing.T) {
+	exp := newExporterWithDefaults(t)
+	assert.NotNil(t, exp)
+	assert.NotNil(t, exp.config)
+	assert.NotNil(t, exp.rawConfig)
+	assert.NotNil(t, exp.logger)
+	assert.Empty(t, exp.workers)
+	assert.NotNil(t, exp.workQueue)
+	assert.NotNil(t, exp.settings)
+	assert.Equal(t, runtime.NumCPU(), cap(exp.workQueue))
+}
+
+func TestNewLogstashExporterReturnsErrorOnInvalidConfig(t *testing.T) {
+	settings := exporter.Settings{}
+
+	// missing required "hosts" field
+	invalidCfg := map[string]any{}
+
+	_, err := newLogstashExporter(settings, invalidCfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required field")
+}
+
+func TestCapabilitiesReturnsMutatesDataFalse(t *testing.T) {
+	exp := newExporterWithDefaults(t)
+	assert.False(t, exp.Capabilities().MutatesData)
+}
+
+func TestConsumeLogs(t *testing.T) {
+	exp := newExporterWithDefaults(t)
+	tests := []struct {
+		name              string
+		wantEnqueued      int
+		wantErrPermanent  bool
+		wantErrRetryable  bool
+		wantErrContaining string
+		wantBatchRetries  uint64
+		publishFn         func(publishCall int, batch publisher.Batch) error
+	}{
+		{
+			name: "ACK",
+			publishFn: func(_ int, batch publisher.Batch) error {
+				batch.ACK()
+				return nil
+			},
+			wantEnqueued: 1,
+		},
+		{
+			name: "Drop",
+			publishFn: func(_ int, batch publisher.Batch) error {
+				batch.Drop()
+				return nil
+			},
+			wantEnqueued:      1,
+			wantErrPermanent:  true,
+			wantErrContaining: "batch was dropped",
+		},
+		{
+			name: "Retry",
+			publishFn: func(publishCall int, batch publisher.Batch) error {
+				if publishCall == 1 {
+					batch.Retry()
+				} else {
+					batch.ACK()
+				}
+				return nil
+			},
+			wantEnqueued:     2,
+			wantBatchRetries: 1,
+		},
+		{
+			name: "Retry with max retries exceeded",
+			publishFn: func(publishCall int, batch publisher.Batch) error {
+				batch.Retry()
+				return nil
+			},
+			wantEnqueued:      10,
+			wantBatchRetries:  10,
+			wantErrContaining: "max number of retries exceeded",
+			wantErrRetryable:  true,
+		},
+		{
+			name: "Retry with ErrNotConnected error",
+			publishFn: func(publishCall int, batch publisher.Batch) error {
+				switch publishCall {
+				case 1, 3:
+					batch.Retry()
+					return errors.New("some error")
+				case 2, 4:
+					batch.Retry()
+					return transport.ErrNotConnected
+				default:
+					batch.ACK()
+					return nil
+				}
+			},
+			wantEnqueued:     5,
+			wantBatchRetries: 2, // ErrNotConnected does not count against retries
+		},
+		{
+			name: "Retry specific events",
+			publishFn: func(publishCall int, batch publisher.Batch) error {
+				if publishCall == 1 {
+					batch.RetryEvents([]publisher.Event{})
+				} else {
+					batch.ACK()
+				}
+				return nil
+			},
+			wantEnqueued:     2,
+			wantBatchRetries: 1,
+		},
+		{
+			name: "Cancelled",
+			publishFn: func(publishCall int, batch publisher.Batch) error {
+				if publishCall == 5 {
+					batch.ACK()
+				} else {
+					batch.Cancelled()
+				}
+				return nil
+			},
+			wantEnqueued: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var publishCallCount atomic.Int32
+			worker := &mockClientWorker{
+				PublishFn: func(ctx context.Context, batch publisher.Batch) error {
+					return tt.publishFn(int(publishCallCount.Add(1)), batch)
+				},
+			}
+
+			clientCtx := newTestBeatsClientContext(t.Context())
+			exp.workers = append(exp.workers, worker)
+
+			workerCtx, workerCtxCancel := context.WithCancel(t.Context())
+			t.Cleanup(workerCtxCancel)
+			worker.run(workerCtx, exp)
+
+			logs := newTestLogs()
+			ok, err := runWithTimeout(clientCtx, func(timeoutCtx context.Context) error {
+				return exp.ConsumeLogs(timeoutCtx, logs)
+			})
+
+			require.True(t, ok, "test timed out")
+			assert.Len(t, worker.Enqueued, tt.wantEnqueued)
+
+			if tt.wantEnqueued > 0 {
+				// All enqueued batch should be the same instance
+				lb, ok := worker.Enqueued[len(worker.Enqueued)-1].Batch().(*internal.LogBatch)
+				require.True(t, ok, "expected batch to be of type *internal.LogBatch")
+				assert.Equal(t, tt.wantBatchRetries, lb.NumRetries())
+			}
+
+			if tt.wantErrRetryable || tt.wantErrPermanent || tt.wantErrContaining != "" {
+				require.Error(t, err)
+				if tt.wantErrContaining != "" {
+					assert.Contains(t, err.Error(), tt.wantErrContaining)
+				}
+				if tt.wantErrPermanent {
+					assert.True(t, consumererror.IsPermanent(err))
+				}
+				if tt.wantErrRetryable {
+					assert.False(t, consumererror.IsPermanent(err))
+					var retryableErr consumererror.Logs
+					if assert.ErrorAs(t, err, &retryableErr) {
+						assert.Equal(t, logs, retryableErr.Data())
+					}
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConsumeLogsWithInvalidLogs(t *testing.T) {
+	clientCtx := newTestBeatsClientContext(t.Context())
+	exp := newExporterWithDefaults(t)
+	exp.workers = append(exp.workers, &mockClientWorker{})
+
+	logs := newTestLogs()
+	invalidRecord := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().AppendEmpty()
+	invalidRecord.Body().SetStr("invalid") // body must be a map
+
+	ok, err := runWithTimeout(clientCtx, func(timeoutCtx context.Context) error {
+		return exp.ConsumeLogs(timeoutCtx, logs)
+	})
+
+	require.True(t, ok, "test timed out")
+	require.Error(t, err)
+	assert.True(t, consumererror.IsPermanent(err))
+	assert.ErrorContains(t, err, "invalid beats event body")
+}
+
+func TestConsumeLogsHandlesCancelledContext(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(newTestBeatsClientContext(t.Context()))
+	cancel()
+
+	exp := newExporterWithDefaults(t)
+	exp.workers = append(exp.workers, &mockClientWorker{})
+
+	logs := newTestLogs()
+	ok, err := runWithTimeout(t.Context(), func(context.Context) error {
+		return exp.ConsumeLogs(cancelledCtx, logs)
+	})
+
+	require.True(t, ok, "test timed out")
+	require.Error(t, err)
+	assert.False(t, consumererror.IsPermanent(err))
+	var retryableErr consumererror.Logs
+	if assert.ErrorAs(t, err, &retryableErr) {
+		assert.Equal(t, logs, retryableErr.Data())
+		assert.ErrorIs(t, retryableErr, context.Canceled)
+	}
+}
+
+func TestGetWorkersReturnsNilWhenNotInitialized(t *testing.T) {
+	exp := newExporterWithDefaults(t)
+	assert.Nil(t, exp.getWorkers())
+}
+
+func TestHasWorkersForReturnsWorkersAfterCreation(t *testing.T) {
+	expectedWorkers := []internal.Worker{&mockClientWorker{}}
+	exp := newExporterWithDefaults(t)
+	exp.workers = expectedWorkers
+	assert.Equal(t, expectedWorkers, exp.getWorkers())
+}
+
+func TestShutdownClosesWorkers(t *testing.T) {
+	exp := newExporterWithDefaults(t)
+	worker := &mockClientWorker{CloseErr: errors.New("close error")}
+	worker2 := &mockClientWorker{}
+	exp.workers = append(exp.workers, worker, worker2)
+
+	_ = exp.Shutdown(t.Context())
+	assert.Empty(t, exp.workers)
+	assert.True(t, worker.Closed)
+	assert.True(t, worker2.Closed)
+}
+
+func TestHandleBatchResultReturnsErrorForUnexpectedResult(t *testing.T) {
+	exp := newExporterWithDefaults(t)
+
+	done, err := exp.handleBatchResult(
+		t.Context(),
+		999, // Invalid/unexpected result value
+		nil,
+		plog.NewLogs(),
+		nil,
+		nil,
+	)
+
+	require.True(t, done)
+	require.Error(t, err)
+	assert.True(t, consumererror.IsPermanent(err))
+	assert.ErrorContains(t, err, "unexpected batch result")
+}
+
+func TestMakeLogstashWorkers(t *testing.T) {
+	exp := newExporterWithDefaultsWith(t, map[string]any{
+		"loadbalance": true,
+		"hosts":       []string{"localhost:9999", "localhost:8888"},
+	})
+	t.Cleanup(func() { _ = exp.Shutdown(t.Context()) })
+	clientCtx := newTestBeatsClientContext(t.Context())
+
+	// Initial worker creation
+	initialWorkers, err := exp.makeLogstashWorkers(clientCtx)
+	require.NoError(t, err)
+	assert.Len(t, initialWorkers, 2)
+	assert.Equal(t, initialWorkers, exp.getWorkers())
+
+	// Call it again and verify if it returns initial workers
+	workers2, err := exp.makeLogstashWorkers(clientCtx)
+	require.NoError(t, err)
+	assert.Equal(t, initialWorkers, workers2)
+
+	// Test if concurrent calls don't create duplicates
+	var wg sync.WaitGroup
+	results := make([][]internal.Worker, 10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ws, err := exp.makeLogstashWorkers(clientCtx)
+			require.NoError(t, err)
+			results[idx] = ws
+		}(i)
+	}
+	wg.Wait()
+
+	// All results should be the same
+	for i := 1; i < len(results); i++ {
+		assert.Equal(t, initialWorkers, results[i])
+	}
+}
+
+func TestConsumeLogsConcurrency(t *testing.T) {
+	exp := newExporterWithDefaults(t)
+	clientCtx := newTestBeatsClientContext(t.Context())
+	worker := &mockClientWorker{
+		PublishFn: func(ctx context.Context, batch publisher.Batch) error {
+			time.Sleep(10 * time.Millisecond)
+			batch.ACK()
+			return nil
+		},
+	}
+	exp.workers = append(exp.workers, worker)
+	workerCtx, workerCtxCancel := context.WithCancel(t.Context())
+	t.Cleanup(workerCtxCancel)
+	worker.run(workerCtx, exp)
+
+	// Run multiple ConsumeLogs calls concurrently
+	var wg sync.WaitGroup
+	const numConsumers = 10
+	errsChan := make(chan error, numConsumers)
+	for i := 0; i < numConsumers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			logs := newTestLogs()
+			ok, err := runWithTimeout(clientCtx, func(timeoutCtx context.Context) error {
+				return exp.ConsumeLogs(timeoutCtx, logs)
+			})
+			if !ok {
+				errsChan <- errors.New("test timed out")
+			} else {
+				errsChan <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errsChan)
+
+	for err := range errsChan {
+		assert.NoError(t, err)
+	}
+
+	assert.Len(t, worker.Enqueued, numConsumers)
+}
+
+func TestProcessBatchResultHandlesCancelledContext(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(newTestBeatsClientContext(t.Context()))
+	cancel()
+
+	exp := newExporterWithDefaults(t)
+	logs := newTestLogs()
+	batch, err := internal.NewLogBatch(cancelledCtx, logs)
+	require.NoError(t, err)
+
+	ok, err := runWithTimeout(t.Context(), func(context.Context) error {
+		_, err := exp.processBatchResult(cancelledCtx, nil, logs, batch, nil)
+		return err
+	})
+
+	require.True(t, ok, "test timed out")
+	assert.False(t, consumererror.IsPermanent(err))
+	var retryableErr consumererror.Logs
+	if assert.ErrorAs(t, err, &retryableErr) {
+		assert.Equal(t, logs, retryableErr.Data())
+		assert.ErrorIs(t, retryableErr, context.Canceled)
+	}
+}
+
+func newExporterWithDefaults(t *testing.T) *logstashExporter {
+	return newExporterWithDefaultsWith(t, nil)
+}
+
+func newExporterWithDefaultsWith(t *testing.T, extraConfig map[string]any) *logstashExporter {
+	settings := exportertest.NewNopSettings(Type)
+	defaultConfig := createDefaultConfig()
+	var cfg Config
+	if c, ok := defaultConfig.(*Config); ok {
+		cfg = *c
+	} else {
+		t.Fatal("default config is not of type *Config")
+	}
+	cfg["hosts"] = []string{"localhost:9999"}
+	cfg["max_retries"] = 10
+
+	for k, v := range extraConfig {
+		cfg[k] = v
+	}
+
+	exp, err := newLogstashExporter(settings, defaultConfig)
+	require.NoError(t, err)
+	return exp
+}
+
+func newTestLogs() plog.Logs {
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	logRecord := scopeLogs.LogRecords().AppendEmpty()
+	logBody := logRecord.Body().SetEmptyMap()
+	logBody.PutStr("value", "test log message")
+	return logs
+}
+
+func newTestBeatsClientContext(ctx context.Context) context.Context {
+	return otelctx.NewConsumerContext(ctx, beat.Info{
+		Beat:        "test-beat",
+		Version:     "1.0.0",
+		IndexPrefix: "test-index",
+	})
+}
+
+func runWithTimeout(ctx context.Context, fn func(context.Context) error) (bool, error) {
+	result := make(chan error, 1)
+	timeoutCtx, cancel := context.WithTimeout(ctx, exporterTestDefaultTimeout)
+	defer cancel()
+
+	go func() {
+		result <- fn(timeoutCtx)
+	}()
+
+	select {
+	case <-timeoutCtx.Done():
+		return false, errors.New("timed out")
+	case err := <-result:
+		return true, err
+	}
+}
+
+type mockClientWorker struct {
+	Closed     bool
+	Enqueued   []*internal.Work
+	EnqueueErr error
+	CloseErr   error
+	PublishFn  func(ctx context.Context, batch publisher.Batch) error
+}
+
+func (m *mockClientWorker) Publish(ctx context.Context, batch publisher.Batch) error {
+	if m.PublishFn != nil {
+		return m.PublishFn(ctx, batch)
+	}
+	return nil
+}
+
+func (m *mockClientWorker) String() string {
+	return "mockClientWorker"
+}
+
+func (m *mockClientWorker) run(ctx context.Context, exp *logstashExporter) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case work := <-exp.workQueue:
+				m.Enqueued = append(m.Enqueued, work)
+				work.Result() <- m.Publish(ctx, work.Batch())
+			}
+		}
+	}()
+}
+
+func (m *mockClientWorker) Close() error {
+	m.Closed = true
+	return m.CloseErr
+}

--- a/x-pack/otel/exporter/logstashexporter/factory.go
+++ b/x-pack/otel/exporter/logstashexporter/factory.go
@@ -8,77 +8,22 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.opentelemetry.io/collector/pdata/plog"
-
-	"github.com/elastic/beats/v7/libbeat/outputs"
-	"github.com/elastic/beats/v7/libbeat/outputs/logstash"
-	"github.com/elastic/beats/v7/x-pack/otel/exporter/logstashexporter/internal"
-	"github.com/elastic/elastic-agent-libs/config"
 )
 
 var (
-	Name              = "logstash"
+	Type              = component.MustNewType("logstash")
 	LogStabilityLevel = component.StabilityLevelDevelopment
 )
 
-type logstashOutputConfig struct {
-	outputs.HostWorkerCfg `config:",inline"`
-	logstash.Config       `config:",inline"`
-}
-
-type logstashExporter struct {
-	config *logstashOutputConfig
-}
-
 func NewFactory() exporter.Factory {
 	return exporter.NewFactory(
-		component.MustNewType(Name),
+		Type,
 		createDefaultConfig,
-		exporter.WithLogs(createLogsExporter, LogStabilityLevel),
+		exporter.WithLogs(createLogExporter, LogStabilityLevel),
 	)
 }
 
-func createDefaultConfig() component.Config {
-	return &Config{}
-}
-
-func createLogsExporter(
-	ctx context.Context,
-	settings exporter.Settings,
-	cfg component.Config,
-) (exporter.Logs, error) {
-	parsedCfg, err := config.NewConfigFrom(&cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	lsOutputCfg := logstashOutputConfig{}
-	err = parsedCfg.Unpack(&lsOutputCfg)
-	if err != nil {
-		return nil, err
-	}
-
-	exp := logstashExporter{
-		config: &lsOutputCfg,
-	}
-
-	return exporterhelper.NewLogs(
-		ctx,
-		settings,
-		cfg,
-		exp.pushLogData,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-	)
-}
-
-func (l *logstashExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
-	_, err := internal.NewLogBatch(ctx, ld)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func createLogExporter(_ context.Context, settings exporter.Settings, cfg component.Config) (exporter.Logs, error) {
+	return newLogstashExporter(settings, cfg)
 }

--- a/x-pack/otel/exporter/logstashexporter/factory_test.go
+++ b/x-pack/otel/exporter/logstashexporter/factory_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 
 	"github.com/elastic/beats/v7/libbeat/outputs"
@@ -24,7 +23,7 @@ func TestCreateExporter(t *testing.T) {
 			Hosts: []string{"localhost:5044"},
 		},
 	}
-	params := exportertest.NewNopSettings(component.MustNewType(Name))
+	params := exportertest.NewNopSettings(Type)
 	exporter, err := factory.CreateLogs(context.Background(), params, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exporter)

--- a/x-pack/otel/exporter/logstashexporter/internal/worker.go
+++ b/x-pack/otel/exporter/logstashexporter/internal/worker.go
@@ -25,6 +25,10 @@ func NewWork(batch publisher.Batch) *Work {
 	}
 }
 
+func (w *Work) Batch() publisher.Batch {
+	return w.batch
+}
+
 func (w *Work) Result() chan error {
 	return w.result
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR implements the logstash exporter logic, which includes:

-  Batch creation from the plog data.
-  Feed the logstash client workers queue.
-  Wait and process the batch results, handling client retries (re-submitting the batch to the workers queue, as the backoff delay is already applied by the clients).
- Return a proper result to [otelconsumer](https://github.com/edmocosta/beats/blob/logstash-exporter-draft/x-pack/libbeat/outputs/otelconsumer/otelconsumer.go#L169).

A few considerations:

- The exporter's `ConsumeLogs` response is sync, and it returns to the actual batch processing results, so the `otelconsumer` outcome is correct.
- The workers queue is sized as the the number of `outputs.Client` created by the `otelconsumer`, which given the sync `ConsumeLogs` nature, should be enough. A few adjusts might be necessary after benchmarking it, but it's not an issue at the moment. 
- When the batch is dropped internally on the exporter, it returns a `consumererror.NewPermanent`, which leads the `otelconsumer` to also drop the batch on the beats side. Besides that, all other flow errors are being wrapped into `consumererror.NewLogs`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run am agent `filebeat` in OTel mode, adding on the pipeline a `logstash` output configuration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
