### PR TITLE
Revert "Temporarily have FIPS integration tests spin up deployments in Production CFT environment"

### DIFF
--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -212,13 +212,9 @@ steps:
         env:
           ASDF_TERRAFORM_VERSION: "1.9.3"
           ASDF_PYTHON_VERSION: "3.9.13" # Not needed by ECH tests, but needed by VM
-# We are temporarily using the Production CFT environment instead of the Staging GovCloud
-# one.  This is being done until issues with creating deployments in Staging GovCloud are
-# fixed. Once this happens, uncomment the lines below and delete the gcp-us-west2 line.
-#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-#          TF_VAR_ech_region: "us-gov-east-1"
-#          TF_VAR_deployment_template_id: "aws-general-purpose"
-          TF_VAR_ech_region: "gcp-us-west2"
+          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+          TF_VAR_ech_region: "us-gov-east-1"
+          TF_VAR_deployment_template_id: "aws-general-purpose"
         command: |
           .buildkite/scripts/custom_fips_ech_test.sh x-pack/filebeat
         retry:
@@ -241,12 +237,7 @@ steps:
               branches: "main"
               debug: true
           - elastic/vault-secrets#v0.1.0:
-# We are temporarily using the Production CFT environment API key instead of the
-# Staging GovCloud one.  This is being done until issues with creating deployments in
-# Staging GovCloud are fixed. Once this happens, uncomment the line below and delete
-# the vault_ec_key_prod line.
-#              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
-              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
+              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
               field: "apiKey"
               env_var: "EC_API_KEY"
         notify:

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -249,13 +249,9 @@ steps:
         env:
           ASDF_TERRAFORM_VERSION: "1.9.3"
           ASDF_PYTHON_VERSION: "3.9.13" # Not needed by ECH tests, but needed by VM
-# We are temporarily using the Production CFT environment instead of the Staging GovCloud
-# one.  This is being done until issues with creating deployments in Staging GovCloud are
-# fixed. Once this happens, uncomment the lines below and delete the gcp-us-west2 line.
-#          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
-#          TF_VAR_ech_region: "us-gov-east-1"
-#          TF_VAR_deployment_template_id: "aws-general-purpose"
-          TF_VAR_ech_region: "gcp-us-west2"
+          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+          TF_VAR_ech_region: "us-gov-east-1"
+          TF_VAR_deployment_template_id: "aws-general-purpose"
         command: |
           .buildkite/scripts/custom_fips_ech_test.sh x-pack/metricbeat
         retry:
@@ -278,12 +274,7 @@ steps:
               branches: "main"
               debug: true
           - elastic/vault-secrets#v0.1.0:
-# We are temporarily using the Production CFT environment API key instead of the
-# Staging GovCloud one.  This is being done until issues with creating deployments in
-# Staging GovCloud are fixed. Once this happens, uncomment the line below and delete
-# the vault_ec_key_prod line.
-#              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
-              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
+              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
               field: "apiKey"
               env_var: "EC_API_KEY"
         notify:


### PR DESCRIPTION
Reverts elastic/beats#46698

I was able to successfully create a `9.2.0-SNAPSHOT` deployment in the GovCloud Staging region so I'm putting up this PR to direct FIPS integration tests back to that environment.  Let's make sure it passes CI a few times (at least 3?) before we merge it.