### PR TITLE
[beats receivers] Don't return unsupported error for ssl.curve_types and ssl.renegotiation.

### DIFF
--- a/libbeat/otelbeat/oteltranslate/tls_otel.go
+++ b/libbeat/otelbeat/oteltranslate/tls_otel.go
@@ -43,12 +43,6 @@ var tlsVersions = map[uint16]string{
 func validateUnsupportedConfig(output *config.C) error {
 
 	if sslConfig, err := output.Child("ssl", -1); err == nil {
-		if sslConfig.HasField("curve_type") {
-			return fmt.Errorf("ssl.curve_types is currently not supported: %w", errors.ErrUnsupported)
-		} else if sslConfig.HasField("renegotiation") {
-			return fmt.Errorf("ssl.renegotiation is currently not supported: %w", errors.ErrUnsupported)
-		}
-
 		if reloadCfg, err := sslConfig.Child("restart_on_cert_change", -1); err == nil {
 			if reloadCfg.HasField("enabled") {
 				return fmt.Errorf("ssl.restart_on_cert_change.enabled is currently not supported: %w", errors.ErrUnsupported)

--- a/libbeat/otelbeat/oteltranslate/tls_otel_test.go
+++ b/libbeat/otelbeat/oteltranslate/tls_otel_test.go
@@ -78,19 +78,6 @@ ssl:
 
 	})
 
-	t.Run("when unsupported configuration  renegotiation is used", func(t *testing.T) {
-		input := `
-ssl:
-  verification_mode: none
-  renegotiation: never
-`
-		cfg := config.MustNewConfigFrom(input)
-		_, err := TLSCommonToOTel(cfg, logger)
-		require.Error(t, err)
-		require.ErrorIs(t, err, errors.ErrUnsupported)
-
-	})
-
 	t.Run("when unsupported configuration restart_on_cert_change.enabled is used", func(t *testing.T) {
 		input := `
 ssl:
@@ -108,7 +95,7 @@ ssl:
 		input := `
 ssl:
   verification_mode: none
-  supported_protocols: 
+  supported_protocols:
    - TLSv1.4
 `
 		cfg := config.MustNewConfigFrom(input)


### PR DESCRIPTION
- Relates https://github.com/elastic/beats/pull/46428

When we brought in the beatsauth extension in https://github.com/elastic/beats/pull/46428 we missed removing the unsupported error for `ssl.curve_types` and `ssl.renegotiation` which are now supported via elastic-agent-libs as they were before.