### PR TITLE
[Docs] Convert asciidoc lifecycle markers into Docs V3 syntax

### DIFF
--- a/docs/reference/auditbeat/configuration-logging.md
+++ b/docs/reference/auditbeat/configuration-logging.md
@@ -172,7 +172,10 @@ Enable log file rotation on time intervals in addition to size-based rotation. I
 If the log file already exists on startup, immediately rotate it and start writing to a new file instead of appending to the existing one. Defaults to true.
 
 
-### `logging.files.redirect_stderr` [preview] [_logging_files_redirect_stderr]
+### `logging.files.redirect_stderr` [_logging_files_redirect_stderr]
+```{applies_to}
+stack: preview
+```
 
 When true, diagnostic messages printed to Auditbeat’s standard error output will also be logged to the log file. This can be helpful in situations were Auditbeat terminates unexpectedly because an error has been detected by Go’s runtime but diagnostic information is not present in the log file. This feature is only available when logging to files (`logging.to_files` is true). Disabled by default.
 

--- a/docs/reference/filebeat/configuration-logging.md
+++ b/docs/reference/filebeat/configuration-logging.md
@@ -172,7 +172,10 @@ Enable log file rotation on time intervals in addition to size-based rotation. I
 If the log file already exists on startup, immediately rotate it and start writing to a new file instead of appending to the existing one. Defaults to true.
 
 
-### `logging.files.redirect_stderr` [preview] [_logging_files_redirect_stderr]
+### `logging.files.redirect_stderr` [_logging_files_redirect_stderr]
+```{applies_to}
+stack: preview
+```
 
 When true, diagnostic messages printed to Filebeat’s standard error output will also be logged to the log file. This can be helpful in situations were Filebeat terminates unexpectedly because an error has been detected by Go’s runtime but diagnostic information is not present in the log file. This feature is only available when logging to files (`logging.to_files` is true). Disabled by default.
 


### PR DESCRIPTION
There are some leftover asciidoc markers for identifying preview, beta, and deprecated features. This PR converts those into the syntax now expected by the markdown documentation system.

Rel: https://github.com/elastic/docs-content/issues/2951