### PR TITLE
[fbreceiver] partial fix for global paths

### DIFF
--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -34,6 +34,7 @@ import (
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 const (
@@ -68,7 +69,7 @@ func NewLogHints(cfg *conf.C, logger *logp.Logger) (autodiscover.Builder, error)
 		return nil, fmt.Errorf("unable to unpack hints config due to error: %w", err)
 	}
 
-	moduleRegistry, err := fileset.NewModuleRegistry(nil, beat.Info{Logger: logger}, false, fileset.FilesetOverrides{})
+	moduleRegistry, err := fileset.NewModuleRegistry(nil, beat.Info{Logger: logger}, false, fileset.FilesetOverrides{}, paths.Paths)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,6 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*conf
 			} else {
 				shouldPut(tempCfg, json, jsonOpts, l.log)
 			}
-
 		}
 		// Merge config template with the configs from the annotations
 		// AppendValues option is used to append arrays from annotations to existing arrays while merging

--- a/filebeat/beater/diagnostics.go
+++ b/filebeat/beater/diagnostics.go
@@ -39,12 +39,12 @@ func getRegexpsForRegistryFiles() ([]*regexp.Regexp, error) {
 
 	registryFileRegExps := []*regexp.Regexp{}
 	preFilesList := [][]string{
-		[]string{"^registry$"},
-		[]string{"^registry", "filebeat$"},
-		[]string{"^registry", "filebeat", "meta\\.json$"},
-		[]string{"^registry", "filebeat", "log\\.json$"},
-		[]string{"^registry", "filebeat", "active\\.dat$"},
-		[]string{"^registry", "filebeat", "[[:digit:]]*\\.json$"},
+		{"^registry$"},
+		{"^registry", "filebeat$"},
+		{"^registry", "filebeat", "meta\\.json$"},
+		{"^registry", "filebeat", "log\\.json$"},
+		{"^registry", "filebeat", "active\\.dat$"},
+		{"^registry", "filebeat", "[[:digit:]]*\\.json$"},
 	}
 
 	for _, lst := range preFilesList {
@@ -70,12 +70,12 @@ func getRegexpsForRegistryFiles() ([]*regexp.Regexp, error) {
 	return registryFileRegExps, nil
 }
 
-func gzipRegistry(logger *logp.Logger) func() []byte {
+func gzipRegistry(logger *logp.Logger, beatPaths *paths.Path) func() []byte {
 	logger = logger.Named("diagnostics")
 
 	return func() []byte {
 		buf := bytes.Buffer{}
-		dataPath := paths.Resolve(paths.Data, "")
+		dataPath := beatPaths.Resolve(paths.Data, "")
 		registryPath := filepath.Join(dataPath, "registry")
 		f, err := os.CreateTemp("", "filebeat-registry-*.tar")
 		if err != nil {

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -110,7 +110,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 		EnableAllFilesets:         enableAllFilesets,
 		ForceEnableModuleFilesets: forceEnableModuleFilesets,
 	}
-	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Info, true, filesetOverrides)
+	moduleRegistry, err := fileset.NewModuleRegistry(config.Modules, b.Info, true, filesetOverrides, b.Paths)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (fb *Filebeat) setupPipelineLoaderCallback(b *beat.Beat) error {
 			ForceEnableModuleFilesets: forceEnableModuleFilesets,
 		}
 
-		modulesFactory := fileset.NewSetupFactory(b.Info, pipelineLoaderFactory, filesetOverrides)
+		modulesFactory := fileset.NewSetupFactory(b.Info, pipelineLoaderFactory, filesetOverrides, b.Paths)
 		if fb.config.ConfigModules.Enabled() {
 			if enableAllFilesets {
 				// All module configs need to be loaded to enable all the filesets
@@ -204,7 +204,7 @@ func (fb *Filebeat) setupPipelineLoaderCallback(b *beat.Beat) error {
 				newPath := strings.TrimSuffix(origPath, ".yml")
 				_ = fb.config.ConfigModules.SetString("path", -1, newPath)
 			}
-			modulesLoader := cfgfile.NewReloader(fb.logger.Named("module.reloader"), fb.pipeline, fb.config.ConfigModules)
+			modulesLoader := cfgfile.NewReloader(fb.logger.Named("module.reloader"), fb.pipeline, fb.config.ConfigModules, b.Paths)
 			modulesLoader.Load(modulesFactory)
 		}
 
@@ -263,7 +263,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 			"Filebeat's registry",
 			"registry.tar.gz",
 			"application/octet-stream",
-			gzipRegistry(b.Info.Logger))
+			gzipRegistry(b.Info.Logger, b.Paths))
 	}
 
 	if !fb.moduleRegistry.Empty() {
@@ -285,7 +285,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 	finishedLogger := newFinishedLogger(wgEvents)
 
-	registryMigrator := registrar.NewMigrator(config.Registry, fb.logger)
+	registryMigrator := registrar.NewMigrator(config.Registry, fb.logger, b.Paths)
 	if err := registryMigrator.Run(); err != nil {
 		fb.logger.Errorf("Failed to migrate registry file: %+v", err)
 		return err
@@ -298,7 +298,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 		cn()
 	}()
 
-	stateStore, err := openStateStore(ctx, b.Info, fb.logger.Named("filebeat"), config.Registry)
+	stateStore, err := openStateStore(ctx, b.Info, fb.logger.Named("filebeat"), config.Registry, b.Paths)
 	if err != nil {
 		fb.logger.Errorf("Failed to open state store: %+v", err)
 		return err
@@ -364,7 +364,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	pipelineConnector := channel.NewOutletFactory(outDone).Create
 
 	inputsLogger := fb.logger.Named("input")
-	v2Inputs := fb.pluginFactory(b.Info, inputsLogger, stateStore, paths.Paths)
+	v2Inputs := fb.pluginFactory(b.Info, inputsLogger, stateStore, b.Paths)
 	v2InputLoader, err := v2.NewLoader(inputsLogger, v2Inputs, "type", cfg.DefaultType)
 	if err != nil {
 		panic(err) // loader detected invalid state.
@@ -406,8 +406,8 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 			fb.logger.Warn(pipelinesWarning)
 		}
 	}
-	moduleLoader := fileset.NewFactory(inputLoader, b.Info, pipelineLoaderFactory, config.OverwritePipelines)
-	crawler, err := newCrawler(inputLoader, moduleLoader, config.Inputs, fb.done, *once, fb.logger)
+	moduleLoader := fileset.NewFactory(inputLoader, b.Info, pipelineLoaderFactory, config.OverwritePipelines, b.Paths)
+	crawler, err := newCrawler(inputLoader, moduleLoader, config.Inputs, fb.done, *once, fb.logger, b.Paths)
 	if err != nil {
 		fb.logger.Errorf("Could not init crawler: %v", err)
 		return err

--- a/filebeat/beater/store.go
+++ b/filebeat/beater/store.go
@@ -46,7 +46,7 @@ type filebeatStore struct {
 	notifier *es.Notifier
 }
 
-func openStateStore(ctx context.Context, info beat.Info, logger *logp.Logger, cfg config.Registry) (*filebeatStore, error) {
+func openStateStore(ctx context.Context, info beat.Info, logger *logp.Logger, cfg config.Registry, beatPaths *paths.Path) (*filebeatStore, error) {
 	var (
 		reg backend.Registry
 		err error
@@ -61,7 +61,7 @@ func openStateStore(ctx context.Context, info beat.Info, logger *logp.Logger, cf
 	}
 
 	reg, err = memlog.New(logger, memlog.Settings{
-		Root:     paths.Resolve(paths.Data, cfg.Path),
+		Root:     beatPaths.Resolve(paths.Data, cfg.Path),
 		FileMode: cfg.Permissions,
 	})
 	if err != nil {

--- a/filebeat/fileset/config.go
+++ b/filebeat/fileset/config.go
@@ -60,10 +60,10 @@ func NewFilesetConfig(cfg *conf.C) (*FilesetConfig, error) {
 // mergePathDefaults returns a copy of c containing the path variables that must
 // be available for variable expansion in module configuration (e.g. it enables
 // the use of ${path.config} in module config).
-func mergePathDefaults(c *conf.C) (*conf.C, error) {
+func mergePathDefaults(c *conf.C, beatPaths *paths.Path) (*conf.C, error) {
 	defaults := conf.MustNewConfigFrom(map[string]interface{}{
 		"path": map[string]interface{}{
-			"home":   paths.Paths.Home,
+			"home":   beatPaths.Home,
 			"config": "${path.home}",
 			"data":   filepath.Join("${path.home}", "data"),
 			"logs":   filepath.Join("${path.home}", "logs"),

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -40,6 +40,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/version"
 )
 
@@ -58,6 +59,7 @@ type Fileset struct {
 	vars        map[string]interface{}
 	pipelineIDs []string
 	logger      *logp.Logger
+	beatPaths   *paths.Path
 }
 
 type pipeline struct {
@@ -77,6 +79,7 @@ func New(
 	mname string,
 	fcfg *FilesetConfig,
 	logger *logp.Logger,
+	beatPaths *paths.Path,
 ) (*Fileset, error,
 ) {
 	modulePath := filepath.Join(modulesPath, mname)
@@ -90,6 +93,7 @@ func New(
 		fcfg:       fcfg,
 		modulePath: modulePath,
 		logger:     logger,
+		beatPaths:  beatPaths,
 	}, nil
 }
 
@@ -178,7 +182,7 @@ func (fs *Fileset) evaluateVars(info beat.Info) (map[string]interface{}, error) 
 		var exists bool
 		name, exists := vals["name"].(string)
 		if !exists {
-			return nil, fmt.Errorf("Variable doesn't have a string 'name' key")
+			return nil, fmt.Errorf("variable doesn't have a string 'name' key")
 		}
 
 		// Variables are not required to have a default. Templates should
@@ -217,28 +221,31 @@ func (fs *Fileset) turnOffElasticsearchVars(vars map[string]interface{}, esVersi
 	}
 
 	if !esVersion.IsValid() {
-		return vars, errors.New("Unknown Elasticsearch version")
+		return vars, errors.New("unknown Elasticsearch version")
 	}
 
 	for _, vals := range fs.manifest.Vars {
 		var ok bool
 		name, ok := vals["name"].(string)
 		if !ok {
-			return nil, fmt.Errorf("Variable doesn't have a string 'name' key")
+			return nil, fmt.Errorf("variable doesn't have a string 'name' key")
 		}
 
 		minESVersion, ok := vals["min_elasticsearch_version"].(map[string]interface{})
 		if ok {
-			minVersion, err := version.New(minESVersion["version"].(string))
-			if err != nil {
-				return vars, fmt.Errorf("Error parsing version %s: %w", minESVersion["version"].(string), err)
-			}
+			versionString, ok := minESVersion["version"].(string)
+			if ok {
+				minVersion, err := version.New(versionString)
+				if err != nil {
+					return vars, fmt.Errorf("Error parsing version %s: %w", versionString, err)
+				}
 
-			fs.logger.Named("fileset").Debugf("Comparing ES version %s with requirement of %s", esVersion.String(), minVersion)
+				fs.logger.Named("fileset").Debugf("Comparing ES version %s with requirement of %s", esVersion.String(), minVersion)
 
-			if esVersion.LessThan(minVersion) {
-				retVars[name] = minESVersion["value"]
-				fs.logger.Infof("Setting var %s (%s) to %v because Elasticsearch version is %s", name, fs, minESVersion["value"], esVersion.String())
+				if esVersion.LessThan(minVersion) {
+					retVars[name] = minESVersion["value"]
+					fs.logger.Infof("Setting var %s (%s) to %v because Elasticsearch version is %s", name, fs, minESVersion["value"], esVersion.String())
+				}
 			}
 		}
 	}
@@ -322,11 +329,11 @@ func getTemplateFunctions(vars map[string]interface{}) (template.FuncMap, error)
 		},
 		"IngestPipeline": func(shortID string) string {
 			return FormatPipelineID(
-				builtinVars["prefix"].(string),
-				builtinVars["module"].(string),
-				builtinVars["fileset"].(string),
+				builtinVars["prefix"].(string),  //nolint:errcheck //keep behavior for now
+				builtinVars["module"].(string),  //nolint:errcheck //keep behavior for now
+				builtinVars["fileset"].(string), //nolint:errcheck //keep behavior for now
 				shortID,
-				builtinVars["beatVersion"].(string),
+				builtinVars["beatVersion"].(string), //nolint:errcheck //keep behavior for now
 			)
 		},
 	}, nil
@@ -378,7 +385,7 @@ func (fs *Fileset) getInputConfig() (*conf.C, error) {
 		return nil, fmt.Errorf("Error reading input config: %w", err)
 	}
 
-	cfg, err = mergePathDefaults(cfg)
+	cfg, err = mergePathDefaults(cfg, fs.beatPaths)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +478,7 @@ func (fs *Fileset) GetPipelines(esVersion version.V) (pipelines []pipeline, err 
 			}
 			newContent, err := FixYAMLMaps(content)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to sanitize the YAML pipeline file: %s: %w", path, err)
+				return nil, fmt.Errorf("failed to sanitize the YAML pipeline file: %s: %w", path, err)
 			}
 			var ok bool
 			content, ok = newContent.(map[string]interface{})
@@ -479,7 +486,7 @@ func (fs *Fileset) GetPipelines(esVersion version.V) (pipelines []pipeline, err 
 				return nil, errors.New("cannot convert newContent to map[string]interface{}")
 			}
 		default:
-			return nil, fmt.Errorf("Unsupported extension '%s' for pipeline file: %s", extension, path)
+			return nil, fmt.Errorf("unsupported extension '%s' for pipeline file: %s", extension, path)
 		}
 
 		pipelineID := fs.pipelineIDs[idx]

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -37,8 +37,9 @@ import (
 const logName = "modules"
 
 type ModuleRegistry struct {
-	registry []Module // []Module -> []Fileset
-	log      *logp.Logger
+	registry  []Module // []Module -> []Fileset
+	log       *logp.Logger
+	beatPaths *paths.Path
 }
 
 type Module struct {
@@ -57,10 +58,12 @@ func newModuleRegistry(modulesPath string,
 	overrides *ModuleOverrides,
 	beatInfo beat.Info,
 	filesetOverrides FilesetOverrides,
+	beatPaths *paths.Path,
 ) (*ModuleRegistry, error) {
 	reg := ModuleRegistry{
-		registry: []Module{},
-		log:      beatInfo.Logger.Named(logName),
+		registry:  []Module{},
+		log:       beatInfo.Logger.Named(logName),
+		beatPaths: beatPaths,
 	}
 
 	for _, mcfg := range moduleConfigs {
@@ -120,7 +123,7 @@ func newModuleRegistry(modulesPath string,
 				return nil, fmt.Errorf("fileset %s/%s is configured but doesn't exist", mcfg.Module, filesetName)
 			}
 
-			fileset, err := New(modulesPath, filesetName, mcfg.Module, fcfg, beatInfo.Logger)
+			fileset, err := New(modulesPath, filesetName, mcfg.Module, fcfg, beatInfo.Logger, beatPaths)
 			if err != nil {
 				return nil, err
 			}
@@ -143,8 +146,8 @@ func newModuleRegistry(modulesPath string,
 }
 
 // NewModuleRegistry reads and loads the configured module into the registry.
-func NewModuleRegistry(moduleConfigs []*conf.C, beatInfo beat.Info, init bool, filesetOverrides FilesetOverrides) (*ModuleRegistry, error) {
-	modulesPath := paths.Resolve(paths.Home, "module")
+func NewModuleRegistry(moduleConfigs []*conf.C, beatInfo beat.Info, init bool, filesetOverrides FilesetOverrides, beatPaths *paths.Path) (*ModuleRegistry, error) {
+	modulesPath := beatPaths.Resolve(paths.Home, "module")
 
 	stat, err := os.Stat(modulesPath)
 	if err != nil || !stat.IsDir() {
@@ -153,7 +156,7 @@ func NewModuleRegistry(moduleConfigs []*conf.C, beatInfo beat.Info, init bool, f
 			// When run under agent via agentbeat there is no modules directory and this is expected.
 			log.Errorf("Not loading modules. Module directory not found: %s", modulesPath)
 		}
-		return &ModuleRegistry{log: log}, nil
+		return &ModuleRegistry{log: log, beatPaths: beatPaths}, nil
 	}
 
 	var modulesCLIList []string
@@ -166,7 +169,7 @@ func NewModuleRegistry(moduleConfigs []*conf.C, beatInfo beat.Info, init bool, f
 	}
 	var mcfgs []*ModuleConfig //nolint:prealloc  //breaks tests
 	for _, cfg := range moduleConfigs {
-		cfg, err = mergePathDefaults(cfg)
+		cfg, err = mergePathDefaults(cfg, beatPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +187,7 @@ func NewModuleRegistry(moduleConfigs []*conf.C, beatInfo beat.Info, init bool, f
 	}
 
 	enableFilesetsFromOverrides(mcfgs, modulesOverrides)
-	return newModuleRegistry(modulesPath, mcfgs, modulesOverrides, beatInfo, filesetOverrides)
+	return newModuleRegistry(modulesPath, mcfgs, modulesOverrides, beatInfo, filesetOverrides, beatPaths)
 }
 
 // enableFilesetsFromOverrides enables in mcfgs the filesets mentioned in overrides,
@@ -461,7 +464,7 @@ func (reg *ModuleRegistry) ModuleNames() []string {
 // ModuleAvailableFilesets return the list of available filesets for the given module
 // it returns an empty list if the module doesn't exist
 func (reg *ModuleRegistry) ModuleAvailableFilesets(module string) ([]string, error) {
-	modulesPath := paths.Resolve(paths.Home, "module")
+	modulesPath := reg.beatPaths.Resolve(paths.Home, "module")
 	return getModuleFilesets(modulesPath, module)
 }
 

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegtest"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 func makeTestInfo(version string) beat.Info {
@@ -118,7 +119,12 @@ func TestSetupNginx(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("5.2.0"), FilesetOverrides{})
+	beatPaths := paths.New()
+	beatPaths.Home = t.TempDir()
+	if err := beatPaths.InitPaths(beatPaths); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("5.2.0"), FilesetOverrides{}, beatPaths)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +203,12 @@ func TestLoadMultiplePipelines(t *testing.T) {
 		{"foo", &enabled, filesetConfigs},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"), FilesetOverrides{})
+	beatPaths := paths.New()
+	beatPaths.Home = t.TempDir()
+	if err := beatPaths.InitPaths(beatPaths); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"), FilesetOverrides{}, beatPaths)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +253,13 @@ func TestLoadMultiplePipelinesWithRollback(t *testing.T) {
 		{"foo", &enabled, filesetConfigs},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"), FilesetOverrides{})
+	beatPaths := paths.New()
+	beatPaths.Home = t.TempDir()
+	if err := beatPaths.InitPaths(beatPaths); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"), FilesetOverrides{}, beatPaths)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -83,7 +83,11 @@ func TestNewModuleRegistry(t *testing.T) {
 	}
 
 	logger := logptest.NewTestingLogger(t, "")
-	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{})
+	beatPaths := paths.New()
+	beatPaths.Home = t.TempDir()
+	err = beatPaths.InitPaths(beatPaths)
+	require.NoError(t, err)
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{}, beatPaths)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -151,7 +155,11 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 	}
 
 	logger := logptest.NewTestingLogger(t, "")
-	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{})
+	beatPaths := paths.New()
+	beatPaths.Home = t.TempDir()
+	err = beatPaths.InitPaths(beatPaths)
+	require.NoError(t, err)
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{}, beatPaths)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -178,7 +186,11 @@ func TestMovedModule(t *testing.T) {
 	}
 
 	logger := logptest.NewTestingLogger(t, "")
-	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{})
+	beatPaths := paths.New()
+	beatPaths.Home = t.TempDir()
+	err = beatPaths.InitPaths(beatPaths)
+	require.NoError(t, err)
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0", Logger: logger}, FilesetOverrides{}, beatPaths)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 }
@@ -441,16 +453,15 @@ func TestMcfgFromConfig(t *testing.T) {
 }
 
 func TestMissingModuleFolder(t *testing.T) {
-	home := paths.Paths.Home
-	paths.Paths.Home = "/no/such/path"
-	defer func() { paths.Paths.Home = home }()
+	p := paths.New()
+	p.Home = "/no/such/path"
 
 	configs := []*conf.C{
 		load(t, map[string]interface{}{"module": "nginx"}),
 	}
 
 	logger := logptest.NewTestingLogger(t, "")
-	reg, err := NewModuleRegistry(configs, beat.Info{Version: "5.2.0", Logger: logger}, true, FilesetOverrides{})
+	reg, err := NewModuleRegistry(configs, beat.Info{Version: "5.2.0", Logger: logger}, true, FilesetOverrides{}, p)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 

--- a/filebeat/fileset/setup.go
+++ b/filebeat/fileset/setup.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	pubpipeline "github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 // SetupFactory is for loading module assets when running setup subcommand.
@@ -30,21 +31,23 @@ type SetupFactory struct {
 	pipelineLoaderFactory PipelineLoaderFactory
 	overwritePipelines    bool
 	filesetOverrides      FilesetOverrides
+	beatPaths             *paths.Path
 }
 
 // NewSetupFactory creates a SetupFactory
-func NewSetupFactory(beatInfo beat.Info, pipelineLoaderFactory PipelineLoaderFactory, filesetOverrides FilesetOverrides) *SetupFactory {
+func NewSetupFactory(beatInfo beat.Info, pipelineLoaderFactory PipelineLoaderFactory, filesetOverrides FilesetOverrides, beatPaths *paths.Path) *SetupFactory {
 	return &SetupFactory{
 		beatInfo:              beatInfo,
 		pipelineLoaderFactory: pipelineLoaderFactory,
 		overwritePipelines:    true,
 		filesetOverrides:      filesetOverrides,
+		beatPaths:             beatPaths,
 	}
 }
 
 // Create creates a new SetupCfgRunner to setup module configuration.
 func (sf *SetupFactory) Create(_ beat.PipelineConnector, c *conf.C) (cfgfile.Runner, error) {
-	m, err := NewModuleRegistry([]*conf.C{c}, sf.beatInfo, false, sf.filesetOverrides)
+	m, err := NewModuleRegistry([]*conf.C{c}, sf.beatInfo, false, sf.filesetOverrides, sf.beatPaths)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/registrar/migrate.go
+++ b/filebeat/registrar/migrate.go
@@ -49,11 +49,11 @@ type Migrator struct {
 	logger      *logp.Logger
 }
 
-func NewMigrator(cfg config.Registry, logger *logp.Logger) *Migrator {
-	path := paths.Resolve(paths.Data, cfg.Path)
+func NewMigrator(cfg config.Registry, logger *logp.Logger, beatPaths *paths.Path) *Migrator {
+	path := beatPaths.Resolve(paths.Data, cfg.Path)
 	migrateFile := cfg.MigrateFile
 	if migrateFile != "" {
-		migrateFile = paths.Resolve(paths.Data, migrateFile)
+		migrateFile = beatPaths.Resolve(paths.Data, migrateFile)
 	}
 
 	return &Migrator{

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-
 	"syscall"
 	"time"
 
@@ -184,7 +183,7 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 	}
 
 	if bt.config.ConfigMonitors.Enabled() {
-		bt.monitorReloader = cfgfile.NewReloader(b.Info.Logger.Named("module.reload"), b.Publisher, bt.config.ConfigMonitors)
+		bt.monitorReloader = cfgfile.NewReloader(b.Info.Logger.Named("module.reload"), b.Publisher, bt.config.ConfigMonitors, b.Paths)
 		defer bt.monitorReloader.Stop()
 
 		err := bt.RunReloadableMonitors()

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/keystore"
+	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/useragent"
 )
 
@@ -88,6 +89,7 @@ type Beat struct {
 
 	API      *api.Server      // API server. This is nil unless the http endpoint is enabled.
 	Registry *reload.Registry // input, & output registry for configuration manager, should be instantiated in NewBeat
+	Paths    *paths.Path      // per beat paths definition
 }
 
 func (beat *Beat) userAgentMode() useragent.AgentManagementMode {

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -103,13 +103,13 @@ type Reloader struct {
 }
 
 // NewReloader creates new Reloader instance for the given config
-func NewReloader(logger *logp.Logger, pipeline beat.PipelineConnector, cfg *config.C) *Reloader {
+func NewReloader(logger *logp.Logger, pipeline beat.PipelineConnector, cfg *config.C, beatPaths *paths.Path) *Reloader {
 	conf := DefaultDynamicConfig
 	_ = cfg.Unpack(&conf)
 
 	path := conf.Path
 	if !filepath.IsAbs(path) {
-		path = paths.Resolve(paths.Config, path)
+		path = beatPaths.Resolve(paths.Config, path)
 	}
 
 	return &Reloader{

--- a/libbeat/cfgfile/reload_integration_test.go
+++ b/libbeat/cfgfile/reload_integration_test.go
@@ -32,6 +32,7 @@ import (
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 func TestReloader(t *testing.T) {
@@ -59,7 +60,7 @@ func TestReloader(t *testing.T) {
 	})
 	// config.C{}
 
-	reloader := NewReloader(logptest.NewTestingLogger(t, "cfgfile-test.reload"), nil, config)
+	reloader := NewReloader(logptest.NewTestingLogger(t, "cfgfile-test.reload"), nil, config, paths.Paths)
 	retryCount := 10
 
 	go reloader.Run(nil)
@@ -90,7 +91,7 @@ func TestReloader(t *testing.T) {
 
 	// Write a file to the reloader path to trigger a real reload
 	content := []byte("test\n")
-	err = os.WriteFile(filepath.Join(dir, "config1.yml"), content, 0644)
+	err = os.WriteFile(filepath.Join(dir, "config1.yml"), content, 0o644)
 	assert.NoError(t, err)
 
 	// Wait for the number of scans to increase at least twice. This is somewhat

--- a/libbeat/cmd/export/ilm_policy.go
+++ b/libbeat/cmd/export/ilm_policy.go
@@ -45,7 +45,7 @@ func GenGetILMPolicyCmd(settings instance.Settings) *cobra.Command {
 			// the way this works, we decide to export ILM or DSL based on the user's config.
 			// This means that if a user has no index management config, we'll default to ILM, regardless of what the user
 			// is connected to. Might not be a problem since a user who doesn't have any custom lifecycle config has nothing to export?
-			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Config.LifecycleConfig)
+			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Paths, b.Config.LifecycleConfig)
 			if err != nil {
 				fatalf("error creating file handler: %s", err)
 			}

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -47,7 +47,7 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 				fatalfInitCmd(err)
 			}
 
-			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Config.LifecycleConfig)
+			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Paths, b.Config.LifecycleConfig)
 			if err != nil {
 				fatalf("error creating file handler: %s", err)
 			}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -248,11 +248,12 @@ func NewBeat(name, indexPrefix, v string, elasticLicensed bool, initFuncs []func
 			ID:               id,
 			FirstStart:       time.Now(),
 			StartTime:        time.Now(),
-			EphemeralID:      metricreport.EphemeralID(),
+			EphemeralID:      metricreport.EphemeralID(), //nolint:staticcheck //keep behavior for now
 			FIPSDistribution: version.FIPSDistribution,
 		},
 		Fields:   fields,
 		Registry: reload.NewRegistry(),
+		Paths:    paths.New(),
 	}
 
 	return &Beat{Beat: b}, nil
@@ -344,7 +345,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 
 	reg := b.Monitoring.StatsRegistry().GetOrCreateRegistry("libbeat")
 
-	err = metricreport.SetupMetrics(b.Info.Logger.Named("metrics"), b.Info.Beat, version.GetDefaultVersion())
+	err = metricreport.SetupMetrics(b.Info.Logger.Named("metrics"), b.Info.Beat, version.GetDefaultVersion()) //nolint:staticcheck //keep behavior for now
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +420,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	// Try to acquire exclusive lock on data path to prevent another beat instance
 	// sharing same data path. This is disabled under elastic-agent.
 	if !management.UnderAgent() {
-		bl := locks.New(b.Info)
+		bl := locks.New(b.Info, b.Paths)
 		err := bl.Lock()
 		if err != nil {
 			return err
@@ -683,7 +684,7 @@ func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) er
 				loadILM = idxmgmt.LoadModeEnabled
 			}
 
-			mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Config.LifecycleConfig)
+			mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Paths, b.Config.LifecycleConfig)
 			if err != nil {
 				return fmt.Errorf("error creating index management handler: %w", err)
 			}
@@ -759,10 +760,11 @@ func (b *Beat) configure(settings Settings) error {
 	if err := InitPaths(cfg); err != nil {
 		return err
 	}
+	b.Paths = paths.Paths
 
 	// We have to initialize the keystore before any unpack or merging the cloud
 	// options.
-	store, err := LoadKeystore(cfg, b.Info.Beat)
+	store, err := LoadKeystore(cfg, b.Info.Beat, b.Paths)
 	if err != nil {
 		return fmt.Errorf("could not initialize the keystore: %w", err)
 	}
@@ -822,9 +824,9 @@ func (b *Beat) configure(settings Settings) error {
 	b.Instrumentation = instrumentation
 
 	// log paths values to help with troubleshooting
-	logger.Infof("%s", paths.Paths.String())
+	logger.Infof("%s", b.Paths.String())
 
-	metaPath := paths.Resolve(paths.Data, "meta.json")
+	metaPath := b.Paths.Resolve(paths.Data, "meta.json")
 	err = b.LoadMeta(metaPath)
 	if err != nil {
 		return err
@@ -1061,7 +1063,7 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 			return fmt.Errorf("error generating index pattern: %w", err)
 		}
 
-		err = dashboards.ImportDashboards(ctx, b.Info, paths.Resolve(paths.Home, ""),
+		err = dashboards.ImportDashboards(ctx, b.Info, b.Paths.Resolve(paths.Home, ""),
 			kibanaConfig, b.Config.Dashboards, nil, pattern)
 		if err != nil {
 			return fmt.Errorf("error importing Kibana dashboards: %w", err)
@@ -1127,7 +1129,7 @@ func (b *Beat) registerESIndexManagement() error {
 
 func (b *Beat) indexSetupCallback() elasticsearch.ConnectCallback {
 	return func(esClient *eslegclient.Connection, _ *logp.Logger) error {
-		mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Config.LifecycleConfig)
+		mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Paths, b.Config.LifecycleConfig)
 		if err != nil {
 			return fmt.Errorf("error creating index management handler: %w", err)
 		}
@@ -1374,10 +1376,10 @@ func (b *Beat) logSystemInfo(log *logp.Logger) {
 		"type": b.Info.Beat,
 		"uuid": b.Info.ID,
 		"path": mapstr.M{
-			"config": paths.Resolve(paths.Config, ""),
-			"data":   paths.Resolve(paths.Data, ""),
-			"home":   paths.Resolve(paths.Home, ""),
-			"logs":   paths.Resolve(paths.Logs, ""),
+			"config": b.Paths.Resolve(paths.Config, ""),
+			"data":   b.Paths.Resolve(paths.Data, ""),
+			"home":   b.Paths.Resolve(paths.Home, ""),
+			"logs":   b.Paths.Resolve(paths.Logs, ""),
 		},
 	}
 	log.Infow("Beat info", "beat", beat)

--- a/libbeat/cmd/instance/keystore_fips.go
+++ b/libbeat/cmd/instance/keystore_fips.go
@@ -22,9 +22,10 @@ package instance
 import (
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/keystore"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 // LoadKeystore returns nil in FIPS mode
-func LoadKeystore(cfg *config.C, name string) (keystore.Keystore, error) {
+func LoadKeystore(cfg *config.C, name string, beatPaths *paths.Path) (keystore.Keystore, error) {
 	return nil, nil
 }

--- a/libbeat/cmd/instance/keystore_fips_test.go
+++ b/libbeat/cmd/instance/keystore_fips_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 func TestLoadKeystore(t *testing.T) {
-	ks, err := LoadKeystore(config.NewConfig(), "test")
+	ks, err := LoadKeystore(config.NewConfig(), "test", paths.New())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/libbeat/cmd/instance/keystore_nofips.go
+++ b/libbeat/cmd/instance/keystore_nofips.go
@@ -29,8 +29,8 @@ import (
 )
 
 // LoadKeystore returns the appropriate keystore based on the configuration.
-func LoadKeystore(cfg *config.C, name string) (keystore.Keystore, error) {
+func LoadKeystore(cfg *config.C, name string, beatPaths *paths.Path) (keystore.Keystore, error) {
 	keystoreCfg, _ := cfg.Child("keystore", -1)
-	defaultPathConfig := paths.Resolve(paths.Data, fmt.Sprintf("%s.keystore", name))
+	defaultPathConfig := beatPaths.Resolve(paths.Data, fmt.Sprintf("%s.keystore", name))
 	return keystore.Factory(keystoreCfg, defaultPathConfig, common.IsStrictPerms())
 }

--- a/libbeat/cmd/instance/locks/lock.go
+++ b/libbeat/cmd/instance/locks/lock.go
@@ -36,21 +36,19 @@ type Locker struct {
 	logger     *logp.Logger
 }
 
-var (
-	// ErrAlreadyLocked is returned when a lock on the data path is attempted but
-	// unsuccessful because another Beat instance already has the lock on the same
-	// data path.
-	ErrAlreadyLocked = fmt.Errorf("data path already locked by another beat. Please make sure that multiple beats are not sharing the same data path (path.data)")
-)
+// ErrAlreadyLocked is returned when a lock on the data path is attempted but
+// unsuccessful because another Beat instance already has the lock on the same
+// data path.
+var ErrAlreadyLocked = fmt.Errorf("data path already locked by another beat. Please make sure that multiple beats are not sharing the same data path (path.data)")
 
 // New returns a new file locker
-func New(beatInfo beat.Info) *Locker {
-	return NewWithRetry(beatInfo, 4, time.Millisecond*400)
+func New(beatInfo beat.Info, beatPaths *paths.Path) *Locker {
+	return NewWithRetry(beatInfo, beatPaths, 4, time.Millisecond*400)
 }
 
 // NewWithRetry returns a new file locker with the given settings
-func NewWithRetry(beatInfo beat.Info, retryCount int, retrySleep time.Duration) *Locker {
-	lockfilePath := paths.Resolve(paths.Data, beatInfo.Beat+".lock")
+func NewWithRetry(beatInfo beat.Info, beatPaths *paths.Path, retryCount int, retrySleep time.Duration) *Locker {
+	lockfilePath := beatPaths.Resolve(paths.Data, beatInfo.Beat+".lock")
 	return &Locker{
 		fileLock:   flock.New(lockfilePath),
 		retryCount: retryCount,

--- a/libbeat/idxmgmt/client_handler.go
+++ b/libbeat/idxmgmt/client_handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle"
 	"github.com/elastic/beats/v7/libbeat/template"
+	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/version"
 )
 
@@ -59,12 +60,12 @@ func NewClientHandler(ilm lifecycle.ClientHandler, template template.Loader) Cli
 
 // NewESClientHandler returns a new ESLoader instance,
 // initialized with an ilm and template client handler based on the passed in client.
-func NewESClientHandler(client ESClient, info beat.Info, cfg lifecycle.RawConfig) (ClientHandler, error) {
+func NewESClientHandler(client ESClient, info beat.Info, beatPaths *paths.Path, cfg lifecycle.RawConfig) (ClientHandler, error) {
 	esHandler, err := lifecycle.NewESClientHandler(client, info, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ES handler: %w", err)
 	}
-	loader, err := template.NewESLoader(client, esHandler, info.Logger)
+	loader, err := template.NewESLoader(client, esHandler, info.Logger, beatPaths)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ES loader: %w", err)
 	}
@@ -73,10 +74,10 @@ func NewESClientHandler(client ESClient, info beat.Info, cfg lifecycle.RawConfig
 
 // NewFileClientHandler returns a new ESLoader instance,
 // initialized with an ilm and template client handler based on the passed in client.
-func NewFileClientHandler(client FileClient, info beat.Info, cfg lifecycle.RawConfig) (ClientHandler, error) {
+func NewFileClientHandler(client FileClient, info beat.Info, beatPaths *paths.Path, cfg lifecycle.RawConfig) (ClientHandler, error) {
 	mgmt, err := lifecycle.NewFileClientHandler(client, info, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating client handler: %w", err)
 	}
-	return NewClientHandler(mgmt, template.NewFileLoader(client, mgmt.Mode() == lifecycle.DSL, info.Logger)), nil
+	return NewClientHandler(mgmt, template.NewFileLoader(client, mgmt.Mode() == lifecycle.DSL, info.Logger, beatPaths)), nil
 }

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
@@ -71,7 +72,7 @@ func newTestSetup(t *testing.T, cfg TemplateConfig) *testSetup {
 	}
 	handler := &mockClientHandler{serverless: false, mode: lifecycle.ILM}
 	logger := logptest.NewTestingLogger(t, "")
-	loader, err := NewESLoader(client, handler, logger)
+	loader, err := NewESLoader(client, handler, logger, paths.New())
 	require.NoError(t, err)
 	s := testSetup{t: t, client: client, loader: loader, config: cfg}
 	// don't care if the cleanup fails, since they might just return a 404
@@ -89,7 +90,7 @@ func newTestSetupWithESClient(t *testing.T, client ESClient, cfg TemplateConfig)
 	}
 	handler := &mockClientHandler{serverless: false, mode: lifecycle.ILM}
 	logger := logptest.NewTestingLogger(t, "")
-	loader, err := NewESLoader(client, handler, logger)
+	loader, err := NewESLoader(client, handler, logger, paths.New())
 	require.NoError(t, err)
 	return &testSetup{t: t, client: client, loader: loader, config: cfg}
 }
@@ -482,7 +483,6 @@ func TestTemplateWithData(t *testing.T) {
 		_, _, err := esClient.Index(setup.config.Name, "_doc", "", nil, test.data)
 		if test.error {
 			assert.Error(t, err)
-
 		} else {
 			assert.NoError(t, err)
 		}

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -287,7 +287,7 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 
 	// Dynamic file based modules (metricbeat.config.modules)
 	if bt.config.ConfigModules.Enabled() {
-		moduleReloader := cfgfile.NewReloader(bt.logger.Named("module.reload"), b.Publisher, bt.config.ConfigModules)
+		moduleReloader := cfgfile.NewReloader(bt.logger.Named("module.reload"), b.Publisher, bt.config.ConfigModules, b.Paths)
 
 		if err := moduleReloader.Check(factory); err != nil {
 			return err
@@ -329,7 +329,6 @@ func (bt *Metricbeat) WithOtelFactoryWrapper(wrapper cfgfile.FactoryWrapper) {
 // result in undefined behavior.
 func (bt *Metricbeat) Stop() {
 	bt.stopOnce.Do(func() { close(bt.done) })
-
 }
 
 // Modules return a list of all configured modules.

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -291,19 +291,24 @@ func TestMultipleReceivers(t *testing.T) {
 				return getFromSocket(t, &lastError, monitorSocket2, "inputs")
 			}, "failed to connect to monitoring socket2, inputs endpoint, last error was: %s", &lastError)
 
+			ingest1Json, err := json.Marshal(ingest1)
+			require.NoError(c, err)
+			ingest2Json, err := json.Marshal(ingest2)
+			require.NoError(c, err)
+
 			reg1Path := filepath.Join(dir1, "/data/registry/filebeat/log.json")
 			require.FileExists(c, reg1Path, "receiver 1 filebeat registry should exist")
 			reg1Data, err := os.ReadFile(reg1Path)
 			require.NoError(c, err)
-			require.Containsf(c, string(reg1Data), ingest1, "receiver 1 registry should contain '%s', but was: %s", ingest1, string(reg1Data))
-			require.NotContainsf(c, string(reg1Data), ingest2, "receiver 1 registry should not contain '%s', but was: %s", ingest2, string(reg1Data))
+			require.Containsf(c, string(reg1Data), string(ingest1Json), "receiver 1 registry should contain '%s', but was: %s", string(ingest1Json), string(reg1Data))
+			require.NotContainsf(c, string(reg1Data), string(ingest2Json), "receiver 1 registry should not contain '%s', but was: %s", string(ingest2Json), string(reg1Data))
 
 			reg2Path := filepath.Join(dir2, "/data/registry/filebeat/log.json")
 			require.FileExists(c, reg2Path, "receiver 2 filebeat registry should exist")
 			reg2Data, err := os.ReadFile(reg2Path)
 			require.NoError(c, err)
-			require.Containsf(c, string(reg2Data), ingest2, "receiver 2 registry should contain '%s', but was: %s", ingest2, string(reg2Data))
-			require.NotContainsf(c, string(reg2Data), ingest1, "receiver 2 registry should not contain '%s', but was: %s", ingest1, string(reg2Data))
+			require.Containsf(c, string(reg2Data), string(ingest2Json), "receiver 2 registry should contain '%s', but was: %s", string(ingest2Json), string(reg2Data))
+			require.NotContainsf(c, string(reg2Data), string(ingest1Json), "receiver 2 registry should not contain '%s', but was: %s", string(ingest1Json), string(reg2Data))
 		},
 	})
 }

--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -71,13 +71,29 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 	}
 
 	cfg := (*config.C)(tmp)
-	if err := instance.InitPaths(cfg); err != nil {
-		return nil, fmt.Errorf("error initializing paths: %w", err)
+	if settings.Name == "filebeat" {
+		partialConfig := struct {
+			Path paths.Path `config:"path"`
+		}{}
+
+		if err := cfg.Unpack(&partialConfig); err != nil {
+			return nil, fmt.Errorf("error extracting default paths: %w", err)
+		}
+		p := paths.New()
+		if err := p.InitPaths(&partialConfig.Path); err != nil {
+			return nil, fmt.Errorf("error initializing default paths: %w", err)
+		}
+		b.Paths = p
+	} else {
+		if err := instance.InitPaths(cfg); err != nil {
+			return nil, fmt.Errorf("error initializing paths: %w", err)
+		}
+		b.Paths = paths.Paths
 	}
 
 	// We have to initialize the keystore before any unpack or merging the cloud
 	// options.
-	store, err := instance.LoadKeystore(cfg, b.Info.Beat)
+	store, err := instance.LoadKeystore(cfg, b.Info.Beat, b.Paths)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize the keystore: %w", err)
 	}
@@ -159,9 +175,9 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 	}
 
 	// log paths values to help with troubleshooting
-	logger.Infof("%s", paths.Paths.String())
+	logger.Infof("%s", b.Paths.String())
 
-	metaPath := paths.Resolve(paths.Data, "meta.json")
+	metaPath := b.Paths.Resolve(paths.Data, "meta.json")
 	err = b.LoadMeta(metaPath)
 	if err != nil {
 		return nil, fmt.Errorf("error loading meta data: %w", err)


### PR DESCRIPTION
## Proposed commit message

** For filebeatreceiver only **

Add a unique per filebeat receiver path variable.  All other beats will use the global `paths.Paths` provided by `elastic-agent-libs/paths`

This is necessary for each filebeat receiver to have it's own registry in a separate directory.

This is not a complete fix for #44903 .  The following paths still need to migrated to use the unique per beat path variable.

- `auditbeat/datastore/datastore.go`
- `filebeat/autodiscover/builder/hints/logs.go`
- `filebeat/cmd/generate.go`
- `libbeat/processors/cache/cache.go`
- `libbeat/processors/cache/file_store.go`
- `libbeat/processors/script/javascript/javascript.go`
- `libbeat/publisher/queue/diskqueue/config.go`
- `metricbeat/beater/metricbeat.go`
- `winlogbeat/beater/winlogbeat.go`
- `x-pack/libbeat/persistentcache/persistentcache.go`
- `x-pack/metricbeat/module/openai/usage/usage.go`


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

### Unit Test

```shell
cd x-pack/filebeat/fbreceiver
go test . -run TestMultipleReceivers -count 1
```

### By hand

1. Build elastic-agent with this PR for beats dependency
2. configure multiple filebeat receivers with different `path.home`
3. restart multiple times
4. verify that each filebeat receiver has it's own registry

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #44903

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
