### PR TITLE
[Filbeat/Journald] Restore support for paths like /foo/*/*

### DIFF
--- a/filebeat/input/journald/pkg/journalctl/reader.go
+++ b/filebeat/input/journald/pkg/journalctl/reader.go
@@ -187,15 +187,17 @@ func New(
 	args := []string{"--utc", "--output=json", "--no-pager", "--all"}
 
 	if file != "" && file != localSystemJournalID {
+
 		st, err := os.Stat(file)
 		if err != nil {
-			return nil, fmt.Errorf("cannot stat path: %w", err)
-		}
-
-		if st.IsDir() {
-			args = append(args, "--directory", file)
-		} else {
+			logger.Debugf("cannot stat file: %s. Using '--file %s'", err, file)
 			args = append(args, "--file", file)
+		} else {
+			if st.IsDir() {
+				args = append(args, "--directory", file)
+			} else {
+				args = append(args, "--file", file)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Proposed commit message

```
When the --directory option was introduced we broke the behaviour of supporting globs like /foo/*/*, this commit restores it.

If there is any error when trying to stat the path to check whether it is directory, we log at debug level and default to the previous behaviour of using `--path`.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~


## How to test this PR locally

1. Create the necessary folder structure with journal files
    ```sh
    cd filebeat/input/journald/testdata
    mkdir -p /tmp/journaltest/001
    cp journal?.journal.gz /tmp/journaltest/001
    cd /tmp/journaltest/001
    gunzip *
    ```
2. Start Filebeat with the following configuration
     <details><summary>filebeat.yaml</summary>
     <p>
     
     ```
     filebeat.inputs:
       - type: journald
         id: foo
         paths:
           - /tmp/journaltest/*/*
     
     queue.mem:
       flush.timeout: 0
     
     output.discard:
       enabled: true
     
     http.enabled: true
     http.host: localhost
     http.port: 5066
     ```
     
     </p>
     </details>
3. Start monitoring the stats endpoint for published events
    ```
    watch -c 'curl -s http://localhost:5066/stats|jq '.filebeat.events''
    ```
    Wait until you have 30 events published, the JSON will look like this
    ```json
    {
      "active": 0,
      "added": 30,
      "done": 30
    }    
    ```


~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
