### PR TITLE
Doc: Use current Logstash SSL settings for beats

### DIFF
--- a/docs/reference/auditbeat/configuring-ssl-logstash.md
+++ b/docs/reference/auditbeat/configuring-ssl-logstash.md
@@ -38,7 +38,7 @@ To use SSL mutual authentication:
 
     * `ssl`. When set to true, enables Logstash to use SSL/TLS.
     * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_certificate` and `ssl_key`. Specifies the certificate and key that Logstash uses to authenticate with the client.
     * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Auditbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:

--- a/docs/reference/auditbeat/ssl-client-fails.md
+++ b/docs/reference/auditbeat/ssl-client-fails.md
@@ -23,7 +23,7 @@ The host running {{ls}} might be unreachable or the certificate may not be valid
     ::::
 
 * Use OpenSSL to test connectivity to the {{ls}} server and diagnose problems. See the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man1/openssl-s_client.md) for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
+* Make sure that you have enabled SSL (set `ssl_enabled => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
 
 ## Common SSL-Related Errors and Resolutions [_common_ssl_related_errors_and_resolutions]
 

--- a/docs/reference/filebeat/configuring-ssl-logstash.md
+++ b/docs/reference/filebeat/configuring-ssl-logstash.md
@@ -17,10 +17,10 @@ To use SSL mutual authentication:
     If you are using {{security-features}}, you can use the [elasticsearch-certutil tool](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md) to generate certificates.
     ::::
 
-2. Configure Filebeat to use SSL. In the `filebeat.yml` config file, specify the following settings under `ssl`:
+2. Configure Filebeat to use SSL. In the `filebeat.yml` config file, specify these settings under `ssl`:
 
-    * `certificate_authorities`: Configures Filebeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
-    * `certificate` and `key`: Specifies the certificate and key that Filebeat uses to authenticate with Logstash.
+    * `certificate_authorities`. Configures Filebeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
+    * `certificate` and `key`. Specifies the certificate and key that Filebeat uses to authenticate with Logstash.
 
         For example:
 
@@ -34,12 +34,12 @@ To use SSL mutual authentication:
 
         For more information about these configuration options, see [SSL](/reference/filebeat/configuration-ssl.md).
 
-3. Configure Logstash to use SSL. In the Logstash config file, specify the following settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
+3. Configure Logstash to use SSL. In the Logstash config file, specify these settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
 
-    * `ssl`: When set to true, enables Logstash to use SSL/TLS.
-    * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
-    * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you specify `force_peer`, and Filebeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+    * `ssl`. When set to true, enables Logstash to use SSL/TLS.
+    * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
+    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Filebeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:
 
@@ -47,11 +47,11 @@ To use SSL mutual authentication:
         input {
           beats {
             port => 5044
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => ["/etc/ca.crt"]
             ssl_certificate => "/etc/server.crt"
             ssl_key => "/etc/server.key"
-            ssl_verify_mode => "force_peer"
+            ssl_client_authentication => "required"
           }
         }
         ```
@@ -74,7 +74,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 * Rebuilt URL to: https://logs.example.com:5044/
 *   Trying 192.168.99.100...
 * Connected to logs.example.com (192.168.99.100) port 5044 (#0)
-* TLS 1.2 connection using TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
 * Server certificate: logs.example.com
 * Server certificate: example.com
 > GET / HTTP/1.1
@@ -87,7 +87,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 curl: (52) Empty reply from server
 ```
 
-The following example uses the IP address rather than the hostname to validate the certificate:
+This example uses the IP address rather than the hostname to validate the certificate:
 
 ```shell
 curl -v --cacert ca.crt https://192.168.99.100:5044

--- a/docs/reference/filebeat/configuring-ssl-logstash.md
+++ b/docs/reference/filebeat/configuring-ssl-logstash.md
@@ -38,7 +38,7 @@ To use SSL mutual authentication:
 
     * `ssl`. When set to true, enables Logstash to use SSL/TLS.
     * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_certificate` and `ssl_key`. Specifies the certificate and key that Logstash uses to authenticate with the client.
     * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Filebeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:

--- a/docs/reference/filebeat/ssl-client-fails.md
+++ b/docs/reference/filebeat/ssl-client-fails.md
@@ -23,7 +23,7 @@ The host running {{ls}} might be unreachable or the certificate may not be valid
     ::::
 
 * Use OpenSSL to test connectivity to the {{ls}} server and diagnose problems. See the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man1/openssl-s_client.md) for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
+* Make sure that you have enabled SSL (set `ssl_enabled => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
 
 ## Common SSL-Related Errors and Resolutions [_common_ssl_related_errors_and_resolutions]
 

--- a/docs/reference/heartbeat/configuring-ssl-logstash.md
+++ b/docs/reference/heartbeat/configuring-ssl-logstash.md
@@ -17,10 +17,10 @@ To use SSL mutual authentication:
     If you are using {{security-features}}, you can use the [elasticsearch-certutil tool](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md) to generate certificates.
     ::::
 
-2. Configure Heartbeat to use SSL. In the `heartbeat.yml` config file, specify the following settings under `ssl`:
+2. Configure Heartbeat to use SSL. In the `heartbeat.yml` config file, specify these settings under `ssl`:
 
-    * `certificate_authorities`: Configures Heartbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
-    * `certificate` and `key`: Specifies the certificate and key that Heartbeat uses to authenticate with Logstash.
+    * `certificate_authorities`. Configures Heartbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
+    * `certificate` and `key`. Specifies the certificate and key that Heartbeat uses to authenticate with Logstash.
 
         For example:
 
@@ -34,12 +34,12 @@ To use SSL mutual authentication:
 
         For more information about these configuration options, see [SSL](/reference/heartbeat/configuration-ssl.md).
 
-3. Configure Logstash to use SSL. In the Logstash config file, specify the following settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
+3. Configure Logstash to use SSL. In the Logstash config file, specify these settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
 
-    * `ssl`: When set to true, enables Logstash to use SSL/TLS.
-    * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
-    * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you specify `force_peer`, and Heartbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+    * `ssl`. When set to true, enables Logstash to use SSL/TLS.
+    * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
+    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Heartbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:
 
@@ -47,11 +47,11 @@ To use SSL mutual authentication:
         input {
           beats {
             port => 5044
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => ["/etc/ca.crt"]
             ssl_certificate => "/etc/server.crt"
             ssl_key => "/etc/server.key"
-            ssl_verify_mode => "force_peer"
+            ssl_client_authentication => "required"
           }
         }
         ```
@@ -74,7 +74,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 * Rebuilt URL to: https://logs.example.com:5044/
 *   Trying 192.168.99.100...
 * Connected to logs.example.com (192.168.99.100) port 5044 (#0)
-* TLS 1.2 connection using TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
 * Server certificate: logs.example.com
 * Server certificate: example.com
 > GET / HTTP/1.1
@@ -87,7 +87,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 curl: (52) Empty reply from server
 ```
 
-The following example uses the IP address rather than the hostname to validate the certificate:
+This example uses the IP address rather than the hostname to validate the certificate:
 
 ```shell
 curl -v --cacert ca.crt https://192.168.99.100:5044

--- a/docs/reference/heartbeat/configuring-ssl-logstash.md
+++ b/docs/reference/heartbeat/configuring-ssl-logstash.md
@@ -38,7 +38,7 @@ To use SSL mutual authentication:
 
     * `ssl`. When set to true, enables Logstash to use SSL/TLS.
     * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_certificate` and `ssl_key`. Specifies the certificate and key that Logstash uses to authenticate with the client.
     * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Heartbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:

--- a/docs/reference/heartbeat/ssl-client-fails.md
+++ b/docs/reference/heartbeat/ssl-client-fails.md
@@ -23,7 +23,7 @@ The host running {{ls}} might be unreachable or the certificate may not be valid
     ::::
 
 * Use OpenSSL to test connectivity to the {{ls}} server and diagnose problems. See the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man1/openssl-s_client.md) for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
+* Make sure that you have enabled SSL (set `ssl_enabled => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
 
 ## Common SSL-Related Errors and Resolutions [_common_ssl_related_errors_and_resolutions]
 

--- a/docs/reference/metricbeat/configuring-ssl-logstash.md
+++ b/docs/reference/metricbeat/configuring-ssl-logstash.md
@@ -17,10 +17,10 @@ To use SSL mutual authentication:
     If you are using {{security-features}}, you can use the [elasticsearch-certutil tool](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md) to generate certificates.
     ::::
 
-2. Configure Metricbeat to use SSL. In the `metricbeat.yml` config file, specify the following settings under `ssl`:
+2. Configure Metricbeat to use SSL. In the `metricbeat.yml` config file, specify these settings under `ssl`:
 
-    * `certificate_authorities`: Configures Metricbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
-    * `certificate` and `key`: Specifies the certificate and key that Metricbeat uses to authenticate with Logstash.
+    * `certificate_authorities`. Configures Metricbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
+    * `certificate` and `key`. Specifies the certificate and key that Metricbeat uses to authenticate with Logstash.
 
         For example:
 
@@ -34,12 +34,12 @@ To use SSL mutual authentication:
 
         For more information about these configuration options, see [SSL](/reference/metricbeat/configuration-ssl.md).
 
-3. Configure Logstash to use SSL. In the Logstash config file, specify the following settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
+3. Configure Logstash to use SSL. In the Logstash config file, specify these settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
 
-    * `ssl`: When set to true, enables Logstash to use SSL/TLS.
-    * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
-    * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you specify `force_peer`, and Metricbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+    * `ssl`. When set to true, enables Logstash to use SSL/TLS.
+    * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
+    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Metricbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:
 
@@ -47,11 +47,11 @@ To use SSL mutual authentication:
         input {
           beats {
             port => 5044
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => ["/etc/ca.crt"]
             ssl_certificate => "/etc/server.crt"
             ssl_key => "/etc/server.key"
-            ssl_verify_mode => "force_peer"
+            ssl_client_authentication => "required"
           }
         }
         ```
@@ -74,7 +74,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 * Rebuilt URL to: https://logs.example.com:5044/
 *   Trying 192.168.99.100...
 * Connected to logs.example.com (192.168.99.100) port 5044 (#0)
-* TLS 1.2 connection using TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
 * Server certificate: logs.example.com
 * Server certificate: example.com
 > GET / HTTP/1.1
@@ -87,7 +87,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 curl: (52) Empty reply from server
 ```
 
-The following example uses the IP address rather than the hostname to validate the certificate:
+This example uses the IP address rather than the hostname to validate the certificate:
 
 ```shell
 curl -v --cacert ca.crt https://192.168.99.100:5044

--- a/docs/reference/metricbeat/configuring-ssl-logstash.md
+++ b/docs/reference/metricbeat/configuring-ssl-logstash.md
@@ -38,7 +38,7 @@ To use SSL mutual authentication:
 
     * `ssl`. When set to true, enables Logstash to use SSL/TLS.
     * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_certificate` and `ssl_key`. Specifies the certificate and key that Logstash uses to authenticate with the client.
     * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Metricbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:

--- a/docs/reference/metricbeat/ssl-client-fails.md
+++ b/docs/reference/metricbeat/ssl-client-fails.md
@@ -23,7 +23,7 @@ The host running {{ls}} might be unreachable or the certificate may not be valid
     ::::
 
 * Use OpenSSL to test connectivity to the {{ls}} server and diagnose problems. See the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man1/openssl-s_client.md) for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
+* Make sure that you have enabled SSL (set `ssl_enabled => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
 
 ## Common SSL-Related Errors and Resolutions [_common_ssl_related_errors_and_resolutions]
 

--- a/docs/reference/packetbeat/configuring-ssl-logstash.md
+++ b/docs/reference/packetbeat/configuring-ssl-logstash.md
@@ -38,7 +38,7 @@ To use SSL mutual authentication:
 
     * `ssl`. When set to true, enables Logstash to use SSL/TLS.
     * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_certificate` and `ssl_key`. Specifies the certificate and key that Logstash uses to authenticate with the client.
     * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Packetbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:

--- a/docs/reference/packetbeat/configuring-ssl-logstash.md
+++ b/docs/reference/packetbeat/configuring-ssl-logstash.md
@@ -17,10 +17,10 @@ To use SSL mutual authentication:
     If you are using {{security-features}}, you can use the [elasticsearch-certutil tool](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md) to generate certificates.
     ::::
 
-2. Configure Packetbeat to use SSL. In the `packetbeat.yml` config file, specify the following settings under `ssl`:
+2. Configure Packetbeat to use SSL. In the `packetbeat.yml` config file, specify these settings under `ssl`:
 
-    * `certificate_authorities`: Configures Packetbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
-    * `certificate` and `key`: Specifies the certificate and key that Packetbeat uses to authenticate with Logstash.
+    * `certificate_authorities`. Configures Packetbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
+    * `certificate` and `key`. Specifies the certificate and key that Packetbeat uses to authenticate with Logstash.
 
         For example:
 
@@ -34,12 +34,12 @@ To use SSL mutual authentication:
 
         For more information about these configuration options, see [SSL](/reference/packetbeat/configuration-ssl.md).
 
-3. Configure Logstash to use SSL. In the Logstash config file, specify the following settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
+3. Configure Logstash to use SSL. In the Logstash config file, specify these settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
 
-    * `ssl`: When set to true, enables Logstash to use SSL/TLS.
-    * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
-    * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you specify `force_peer`, and Packetbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+    * `ssl`. When set to true, enables Logstash to use SSL/TLS.
+    * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
+    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Packetbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:
 
@@ -47,11 +47,11 @@ To use SSL mutual authentication:
         input {
           beats {
             port => 5044
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => ["/etc/ca.crt"]
             ssl_certificate => "/etc/server.crt"
             ssl_key => "/etc/server.key"
-            ssl_verify_mode => "force_peer"
+            ssl_client_authentication => "required"
           }
         }
         ```
@@ -74,7 +74,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 * Rebuilt URL to: https://logs.example.com:5044/
 *   Trying 192.168.99.100...
 * Connected to logs.example.com (192.168.99.100) port 5044 (#0)
-* TLS 1.2 connection using TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
 * Server certificate: logs.example.com
 * Server certificate: example.com
 > GET / HTTP/1.1
@@ -87,7 +87,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 curl: (52) Empty reply from server
 ```
 
-The following example uses the IP address rather than the hostname to validate the certificate:
+This example uses the IP address rather than the hostname to validate the certificate:
 
 ```shell
 curl -v --cacert ca.crt https://192.168.99.100:5044

--- a/docs/reference/packetbeat/ssl-client-fails.md
+++ b/docs/reference/packetbeat/ssl-client-fails.md
@@ -23,7 +23,7 @@ The host running {{ls}} might be unreachable or the certificate may not be valid
     ::::
 
 * Use OpenSSL to test connectivity to the {{ls}} server and diagnose problems. See the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man1/openssl-s_client.md) for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
+* Make sure that you have enabled SSL (set `ssl_enabled => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
 
 ## Common SSL-Related Errors and Resolutions [_common_ssl_related_errors_and_resolutions]
 

--- a/docs/reference/winlogbeat/configuring-ssl-logstash.md
+++ b/docs/reference/winlogbeat/configuring-ssl-logstash.md
@@ -38,7 +38,7 @@ To use SSL mutual authentication:
 
     * `ssl`. When set to true, enables Logstash to use SSL/TLS.
     * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_certificate` and `ssl_key`. Specifies the certificate and key that Logstash uses to authenticate with the client.
     * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Winlogbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:

--- a/docs/reference/winlogbeat/configuring-ssl-logstash.md
+++ b/docs/reference/winlogbeat/configuring-ssl-logstash.md
@@ -17,10 +17,10 @@ To use SSL mutual authentication:
     If you are using {{security-features}}, you can use the [elasticsearch-certutil tool](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md) to generate certificates.
     ::::
 
-2. Configure Winlogbeat to use SSL. In the `winlogbeat.yml` config file, specify the following settings under `ssl`:
+2. Configure Winlogbeat to use SSL. In the `winlogbeat.yml` config file, specify these settings under `ssl`:
 
-    * `certificate_authorities`: Configures Winlogbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
-    * `certificate` and `key`: Specifies the certificate and key that Winlogbeat uses to authenticate with Logstash.
+    * `certificate_authorities`. Configures Winlogbeat to trust any certificates signed by the specified CA. If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
+    * `certificate` and `key`. Specifies the certificate and key that Winlogbeat uses to authenticate with Logstash.
 
         For example:
 
@@ -34,12 +34,12 @@ To use SSL mutual authentication:
 
         For more information about these configuration options, see [SSL](/reference/winlogbeat/configuration-ssl.md).
 
-3. Configure Logstash to use SSL. In the Logstash config file, specify the following settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
+3. Configure Logstash to use SSL. In the Logstash config file, specify these settings for the [Beats input plugin for Logstash](logstash-docs-md://lsr/plugins-inputs-beats.md):
 
-    * `ssl`: When set to true, enables Logstash to use SSL/TLS.
-    * `ssl_certificate_authorities`: Configures Logstash to trust any certificates signed by the specified CA.
-    * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
-    * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you specify `force_peer`, and Winlogbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+    * `ssl`. When set to true, enables Logstash to use SSL/TLS.
+    * `ssl_certificate_authorities`. Configures Logstash to trust any certificates signed by the specified CA.
+    * `ssl_certificate` and `ssl_key`. Specify the certificate and key that Logstash uses to authenticate with the client.
+    * `ssl_client_authentication`. Specifies whether the Logstash server verifies the client certificate against the CA. You need to specify either `required` or `optional` to make the server ask for the certificate and validate it. If you specify `required`, and Winlogbeat doesn’t provide a certificate, the Logstash connection will be closed. If you choose not to use [certutil](elasticsearch://reference/elasticsearch/command-line-tools/certutil.md), the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 
         For example:
 
@@ -47,11 +47,11 @@ To use SSL mutual authentication:
         input {
           beats {
             port => 5044
-            ssl => true
+            ssl_enabled => true
             ssl_certificate_authorities => ["/etc/ca.crt"]
             ssl_certificate => "/etc/server.crt"
             ssl_key => "/etc/server.key"
-            ssl_verify_mode => "force_peer"
+            ssl_client_authentication => "required"
           }
         }
         ```
@@ -74,7 +74,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 * Rebuilt URL to: https://logs.example.com:5044/
 *   Trying 192.168.99.100...
 * Connected to logs.example.com (192.168.99.100) port 5044 (#0)
-* TLS 1.2 connection using TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
 * Server certificate: logs.example.com
 * Server certificate: example.com
 > GET / HTTP/1.1
@@ -87,7 +87,7 @@ If the test is successful, you’ll receive an empty response error. Here's an e
 curl: (52) Empty reply from server
 ```
 
-The following example uses the IP address rather than the hostname to validate the certificate:
+This example uses the IP address rather than the hostname to validate the certificate:
 
 ```shell
 curl -v --cacert ca.crt https://192.168.99.100:5044

--- a/docs/reference/winlogbeat/ssl-client-fails.md
+++ b/docs/reference/winlogbeat/ssl-client-fails.md
@@ -23,7 +23,7 @@ The host running {{ls}} might be unreachable or the certificate may not be valid
     ::::
 
 * Use OpenSSL to test connectivity to the {{ls}} server and diagnose problems. See the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man1/openssl-s_client.md) for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
+* Make sure that you have enabled SSL (set `ssl_enabled => true`) when configuring the [Beats input plugin for {{ls}}](logstash-docs-md://lsr/plugins-inputs-beats.md).
 
 ## Common SSL-Related Errors and Resolutions [_common_ssl_related_errors_and_resolutions]
 


### PR DESCRIPTION
Closes: https://github.com/elastic/docs-content/issues/2821

- [x] Auditbeat
- [x] Filebeat
- [x] Heartbeat
- [x] Metricbeat
- [x] Packetbeat
- [x] Winlogbeat

Propagates changes established in https://github.com/elastic/beats/pull/46457 to other Beats. 
Also corrects a setting in troubleshooting topics that was not included in the original PR.
