### PR TITLE
Remove the data plane team as the changelog fragment owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 # as a reviewer every time a change to files they do not own also adds a changelog entry.
 # https://github.community/t/codeowners-file-with-a-not-file-type-condition/1423/9
 CHANGELOG*
+changelog/fragments/
 
 # Top-level files ownership
 /catalog-info.yaml @elastic/observablt-ci @elastic/observablt-ci-contractors


### PR DESCRIPTION
Prevents data plane code owner review being requested when it shouldn't be needed.