### PR TITLE
[DOCS] Update API key link

### DIFF
--- a/docs/reference/serverless/beats.md
+++ b/docs/reference/serverless/beats.md
@@ -21,7 +21,7 @@ mapped_pages:
 ::::{admonition} Authenticating with {{es}}
 :class: note
 
-When you use {{beats}} to export data to an {{es-serverless}} project, the {{beats}} require an API key to authenticate with {{es}}. Refer to [Create API key](docs-content://solutions/search/search-connection-details.md#create-an-api-key-serverless) for the steps to set up your API key, and to [Grant access using API keys](https://www.elastic.co/guide/en/beats/filebeat/current/beats-api-keys.md) in the Filebeat documentation for an example of how to configure your {{beats}} to use the key.
+When you use {{beats}} to export data to an {{es-serverless}} project, the {{beats}} require an API key to authenticate with {{es}}. Refer to [Create API key](docs-content://solutions/search/search-connection-details.md#create-an-api-key-serverless) for the steps to set up your API key, and to [Grant access using API keys](/reference/filebeat/beats-api-keys.md) in the Filebeat documentation for an example of how to configure your {{beats}} to use the key.
 
 ::::
 


### PR DESCRIPTION
Updates the `Create API key` docs link so it no longer 404s.