### PR TITLE
fix(libbeat): fix race between Send and Close in Logstash output

### DIFF
--- a/changelog/fragments/1759848602-fix-prevent-panic-in-logstash-output.yaml
+++ b/changelog/fragments/1759848602-fix-prevent-panic-in-logstash-output.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Prevent panic in logstash output when trying to send events while shutting down
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: all
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/libbeat/outputs/logstash/async_test.go
+++ b/libbeat/outputs/logstash/async_test.go
@@ -25,10 +25,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common/transport/transptest"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/outest"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/transport"
+	"github.com/stretchr/testify/require"
 )
 
 type testAsyncDriver struct {
@@ -63,6 +67,43 @@ func makeAsyncTestClient(conn *transport.Client) testClientDriver {
 		panic(err)
 	}
 	return newAsyncTestDriver(client)
+}
+
+func TestClientSendCloseDoesNotPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		for i := 0; i < 10; i++ {
+			testClientSendCloseDoesNotPanic(t)
+		}
+	})
+}
+
+func testClientSendCloseDoesNotPanic(t *testing.T) {
+	server := transptest.NewMockServerTCP(t, 50*time.Millisecond, "", nil)
+	defer server.Close()
+	transp, err := server.Connect()
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer transp.Close()
+	config := DefaultConfig()
+	logger, err := logp.NewDevelopmentLogger("")
+	if err != nil {
+		t.Fatalf("Failed to create logger: %v", err)
+	}
+	asyncClient, err := newAsyncClient(logger, "beat_version", transp, outputs.NewNilObserver(), &config)
+	if err != nil {
+		t.Fatalf("Failed to create async client: %v", err)
+	}
+	event := beat.Event{
+		Fields: mapstr.M{
+			"message": "test event",
+		},
+	}
+	batch := outest.NewBatch(event)
+	go func() {
+		_ = asyncClient.Close()
+	}()
+	_ = asyncClient.Publish(t.Context(), batch)
 }
 
 func newAsyncTestDriver(client outputs.NetworkClient) *testAsyncDriver {


### PR DESCRIPTION
## Proposed commit message

Close and Send could run in parallel, causing a panic when Send tried to use a client already shutting down. Use an RWMutex so multiple Sends can run in parallel while Connect/Close hold an exclusive lock. Add a test to make sure Send+Close no longer panic.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Run the following test. When run against the main branch, it panics. With this fix applied, it no longer panics.

```bash
$ ./script/stresstest.sh ./libbeat/outputs/logstash ^TestClientSendCloseDoesNotPanic$
1m0s: 26356 runs so far, 0 failures, 32 active

$ go test -run ^TestClientSendCloseDoesNotPanic$ ./libbeat/outputs/logstash -v -count=1
```

## Related issues

- Closes https://github.com/elastic/beats/issues/46889