### PR TITLE
[aws] Fix missing cloudwatch metrics with linked accounts and same dimensions

### DIFF
--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -579,7 +579,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 					continue
 				}
 
-				identifierValue := labels[aws.LabelConst.IdentifierValueIdx] + fmt.Sprint("-", valI)
+				identifierValue := labels[aws.LabelConst.AccountIdIdx] + "-" + labels[aws.LabelConst.IdentifierValueIdx] + fmt.Sprint("-", valI)
 				if _, ok := events[identifierValue]; !ok {
 					events[identifierValue] = aws.InitEvent(regionName, labels[aws.LabelConst.AccountLabelIdx], labels[aws.LabelConst.AccountIdIdx], metricDataResult.Timestamps[valI], labels[aws.LabelConst.PeriodLabelIdx])
 				}
@@ -640,7 +640,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 				}
 
 				identifierValue := labels[aws.LabelConst.IdentifierValueIdx]
-				uniqueIdentifierValue := identifierValue + fmt.Sprint("-", valI)
+				uniqueIdentifierValue := labels[aws.LabelConst.AccountIdIdx] + "-" + identifierValue + fmt.Sprint("-", valI)
 
 				// add tags to event based on identifierValue
 				// Check if identifier includes dimensionSeparator (comma in this case),

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -36,11 +36,11 @@ var (
 
 	id1    = "cpu"
 	value1 = 0.25
-	label1 = " | |CPUUtilization|AWS/EC2|Average|300|InstanceId|i-1"
+	label1 = "123456789012|${PROP('AccountLabel')}|CPUUtilization|AWS/EC2|Average|300|InstanceId|i-1"
 
 	id2    = "disk"
 	value2 = 5.0
-	label2 = " | |DiskReadOps|AWS/EC2|Average|300|InstanceId|i-1"
+	label2 = "123456789012|${PROP('AccountLabel')}|DiskReadOps|AWS/EC2|Average|300|InstanceId|i-1"
 
 	label3 = " | |CPUUtilization|AWS/EC2|Average|300"
 	label4 = " | |DiskReadOps|AWS/EC2|Average|300"
@@ -1068,7 +1068,17 @@ func TestFilterListMetricsOutput(t *testing.T) {
 			},
 			[]metricsWithStatistics{
 				{
-					listMetric1,
+					aws.MetricWithID{
+						Metric: cloudwatchtypes.Metric{
+							Dimensions: []cloudwatchtypes.Dimension{{
+								Name:  awssdk.String("InstanceId"),
+								Value: awssdk.String("i-1"),
+							}},
+							MetricName: awssdk.String("CPUUtilization"),
+							Namespace:  awssdk.String("AWS/EC2"),
+						},
+						// No AccountID - matches the input metric
+					},
 					[]string{"Average"},
 				},
 			},
@@ -1287,11 +1297,12 @@ func TestCreateEventsWithIdentifier(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(events))
 
-	metricValue, err := events["i-1-0"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
+	expectedKey := accountID + "-i-1-0"
+	metricValue, err := events[expectedKey].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
 	assert.NoError(t, err)
 	assert.Equal(t, value1, metricValue)
 
-	dimension, err := events["i-1-0"].RootFields.GetValue("aws.dimensions.InstanceId")
+	dimension, err := events[expectedKey].RootFields.GetValue("aws.dimensions.InstanceId")
 	assert.NoError(t, err)
 	assert.Equal(t, instanceID1, dimension)
 }
@@ -1593,4 +1604,78 @@ func TestGetStartTimeEndTime(t *testing.T) {
 	var previousEndTime time.Time
 	startTime, endTime := aws.GetStartTimeEndTime(time.Now(), m.MetricSet.Period, m.MetricSet.Latency, previousEndTime)
 	assert.Equal(t, 5*time.Minute, endTime.Sub(startTime))
+}
+
+// MockCloudWatchClientLinkedAccounts simulates the linked accounts deduplication issue
+type MockCloudWatchClientLinkedAccounts struct{}
+
+func (m *MockCloudWatchClientLinkedAccounts) GetMetricData(context.Context, *cloudwatch.GetMetricDataInput, ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
+	emptyString := ""
+	deliveryStreamName := "test-stream"
+
+	// Two accounts with the same DeliveryStreamName
+	label1 := "123456789012|${PROP('AccountLabel')}|IncomingRecords|AWS/KinesisFirehose|Sum|${PROP('Period')}|DeliveryStreamName|" + deliveryStreamName
+	label2 := "678901234567|${PROP('AccountLabel')}|IncomingRecords|AWS/KinesisFirehose|Sum|${PROP('Period')}|DeliveryStreamName|" + deliveryStreamName
+
+	return &cloudwatch.GetMetricDataOutput{
+		MetricDataResults: []cloudwatchtypes.MetricDataResult{
+			{Id: awssdk.String("m1"), Label: &label1, Values: []float64{100}, Timestamps: []time.Time{timestamp}},
+			{Id: awssdk.String("m2"), Label: &label2, Values: []float64{200}, Timestamps: []time.Time{timestamp}},
+		},
+		NextToken: &emptyString,
+	}, nil
+}
+
+func TestLinkedAccountsDeduplicationFix(t *testing.T) {
+	m := MetricSet{}
+	m.CloudwatchConfigs = []Config{{Statistic: []string{"Sum"}}}
+	m.MetricSet = &aws.MetricSet{Period: 5, MonitoringAccountID: "123456789012"}
+	m.logger = logptest.NewTestingLogger(t, "test")
+
+	mockCloudwatchSvc := &MockCloudWatchClientLinkedAccounts{}
+	mockTaggingSvc := &MockResourceGroupsTaggingClient{}
+
+	deliveryStreamName := "test-stream"
+	listMetricWithStatsTotal := []metricsWithStatistics{
+		{
+			cloudwatchMetric: aws.MetricWithID{
+				Metric: cloudwatchtypes.Metric{
+					Dimensions: []cloudwatchtypes.Dimension{{Name: awssdk.String("DeliveryStreamName"), Value: awssdk.String(deliveryStreamName)}},
+					MetricName: awssdk.String("IncomingRecords"), Namespace: awssdk.String("AWS/KinesisFirehose"),
+				},
+				AccountID: "123456789012",
+			},
+			statistic: []string{"Sum"},
+		},
+		{
+			cloudwatchMetric: aws.MetricWithID{
+				Metric: cloudwatchtypes.Metric{
+					Dimensions: []cloudwatchtypes.Dimension{{Name: awssdk.String("DeliveryStreamName"), Value: awssdk.String(deliveryStreamName)}},
+					MetricName: awssdk.String("IncomingRecords"), Namespace: awssdk.String("AWS/KinesisFirehose"),
+				},
+				AccountID: "678901234567",
+			},
+			statistic: []string{"Sum"},
+		},
+	}
+
+	var previousEndTime time.Time
+	startTime, endTime := aws.GetStartTimeEndTime(time.Now(), m.MetricSet.Period, m.MetricSet.Latency, previousEndTime)
+
+	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, map[string][]aws.Tag{}, make(map[string]string), regionName, startTime, endTime)
+	assert.NoError(t, err)
+
+	// The fix ensures we get 2 events instead of 1 (no incorrect deduplication)
+	assert.Equal(t, 2, len(events), "Should have 2 distinct events for same dimension across different accounts")
+
+	// Verify both accounts are present
+	foundAccounts := make(map[string]bool)
+	for _, event := range events {
+		accountID, _ := event.RootFields.GetValue("cloud.account.id")
+		if accountID != nil {
+			foundAccounts[accountID.(string)] = true
+		}
+	}
+	assert.True(t, foundAccounts["123456789012"], "Should find events for account 123456789012")
+	assert.True(t, foundAccounts["678901234567"], "Should find events for account 678901234567")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Problem: 
The AWS Cloudwatch metrics input is not correctly accounting for the unique combination of cloud account ID and dimensions. With `include_linked_accounts` enabled by default, users might run into issues of losing cloudwatch metrics when data points from CloudWatch are from different linked accounts but with the same dimensions. 

This PR is to fix this issue by simply adding the account IDs into the unique identifier.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->
This is internal logic when processing metrics with same dimensions but different account IDs, so it shouldn't cause any disruption to existing users.

## Related issues

- Closes https://github.com/elastic/integrations/issues/15362
