### PR TITLE
[9.2](backport #46112) Add host processor to Beat processor

### DIFF
--- a/x-pack/libbeat/common/otelbeat/otel.go
+++ b/x-pack/libbeat/common/otelbeat/otel.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/beats/v7/x-pack/filebeat/fbreceiver"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/mbreceiver"
+	"github.com/elastic/beats/v7/x-pack/otel/processor/beatprocessor"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -67,6 +68,13 @@ func getComponent() (otelcol.Factories, error) {
 		return otelcol.Factories{}, nil //nolint:nilerr //ignoring this error
 	}
 
+	processors, err := otelcol.MakeFactoryMap(
+		beatprocessor.NewFactory(),
+	)
+	if err != nil {
+		return otelcol.Factories{}, nil //nolint:nilerr //ignoring this error
+	}
+
 	exporters, err := otelcol.MakeFactoryMap(
 		debugexporter.NewFactory(),
 		elasticsearchexporter.NewFactory(),
@@ -76,8 +84,9 @@ func getComponent() (otelcol.Factories, error) {
 	}
 
 	return otelcol.Factories{
-		Receivers: receivers,
-		Exporters: exporters,
+		Receivers:  receivers,
+		Processors: processors,
+		Exporters:  exporters,
 	}, nil
 
 }

--- a/x-pack/otel/processor/beatprocessor/README.md
+++ b/x-pack/otel/processor/beatprocessor/README.md
@@ -7,17 +7,63 @@
 [development]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#development
 
 > [!NOTE]
-> This component is currently in development and no functionality is implemented.
-> Including it in a pipeline is a no-op.
-> The documentation describes the intended state after the functionality is implemented.
+> This component is currently in development and functionality is limited.
 
 The Beat processor (`beat`) is an OpenTelemetry Collector processor that wraps the [Beat processors].
-This allows you to use Beat processorss like e.g. [add_host_metadata] anywhere in the OpenTelemetry Collector's pipeline, independently of Beat receivers.
+This allows you to use Beat processors like e.g. [add_host_metadata] anywhere in the OpenTelemetry Collector's pipeline, independently of Beat receivers.
 
 > [!NOTE]
 > This component is only expected to work correctly with data from the Beat receivers: [Filebeat receiver], [Metricbeat receiver].
 > This is because it relies on the specific structure of telemetry emitted by those components.
 > Using it with data coming from other components is not recommended and may result in unexpected behavior.
+
+The processor enriches the telemetry with host metadata by using the [add_host_metadata] processor under the hood.
+Note that configuration is limited at this stage.
+Host metadata is added unconditionally and cannot be disabled.
+You can configure the host metadata enrichment using the options that the [add_host_metadata] processor allows.
+The only exception is that the option `replace_fields` is always set to `true` and setting it to `false` has no effect.
+
+## Default processors in Beat receivers
+
+The Beat receivers have a set of default processors that are included when the `processors` option is not specified.
+These processors are: [add_cloud_metadata], [add_docker_metadata], [add_host_metadata], [add_kubernetes_metadata].
+To disable them, explicitly specify the `processors` configuration option of the Beat receiver.
+The list of processors can be an empty list or an arbitrary list of processors.
+
+For example:
+
+```yaml
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: host-logs
+          paths:
+            - /var/log/*.log
+    output:
+      otelconsumer:
+```
+
+The above Filebeat receiver configuration does not explicitly specify the `processors` option.
+In this case, the four processors listed above are included and ran as part of the Filebeat receiver.
+
+```yaml
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: host-logs
+          paths:
+            - /var/log/*.log
+    processors: []
+    output:
+      otelconsumer:
+```
+
+The above Filebeat receiver configuration specifies an empty list of processors.
+In this case, none of the default processors are ran as part of the Filebeat receiver.
 
 ## Example
 
@@ -33,7 +79,9 @@ receivers:
           paths:
             - /var/log/*.log
     processors:
-      - add_host_metadata: ~
+      - add_host_metadata:
+          netinfo:
+            enabled: false
     output:
       otelconsumer:
 ```
@@ -49,16 +97,22 @@ receivers:
           id: host-logs
           paths:
             - /var/log/*.log
+    processors: []
     output:
       otelconsumer:
 
 processors:
   beat:
     processors:
-      - add_host_metadata: ~
+      - add_host_metadata:
+          netinfo:
+            enabled: false
 ```
 
 [Beat processors]: https://www.elastic.co/docs/reference/beats/filebeat/filtering-enhancing-data#using-processors
 [Filebeat receiver]: https://github.com/elastic/beats/tree/main/x-pack/filebeat/fbreceiver
 [Metricbeat receiver]: https://github.com/elastic/beats/tree/main/x-pack/metricbeat/mbreceiver
+[add_cloud_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-cloud-metadata
+[add_docker_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-docker-metadata
 [add_host_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-host-metadata
+[add_kubernetes_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata

--- a/x-pack/otel/processor/beatprocessor/config.go
+++ b/x-pack/otel/processor/beatprocessor/config.go
@@ -4,4 +4,6 @@
 
 package beatprocessor
 
-type Config struct{}
+type Config struct {
+	Processors []map[string]any `mapstructure:"processors"`
+}

--- a/x-pack/otel/processor/beatprocessor/factory.go
+++ b/x-pack/otel/processor/beatprocessor/factory.go
@@ -6,10 +6,10 @@ package beatprocessor
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
@@ -36,14 +36,19 @@ func createLogsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (processor.Logs, error) {
+	beatProcessorConfig, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast component config to Beat processor config")
+	}
+	beatProcessor, err := newBeatProcessor(set, beatProcessorConfig)
+	if err != nil {
+		return nil, err
+	}
 	return processorhelper.NewLogs(
 		ctx,
 		set,
 		cfg,
 		nextConsumer,
-		func(_ context.Context, logs plog.Logs) (plog.Logs, error) {
-			// This is a placeholder for the actual processing logic.
-			return logs, nil
-		},
+		beatProcessor.ConsumeLogs,
 	)
 }

--- a/x-pack/otel/processor/beatprocessor/integration_test.go
+++ b/x-pack/otel/processor/beatprocessor/integration_test.go
@@ -1,0 +1,261 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build integration
+
+package beatprocessor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/otelbeat/oteltest"
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+	"github.com/elastic/elastic-agent-libs/testing/estools"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOtelBeatProcessorE2E(t *testing.T) {
+	integration.EnsureESIsRunning(t)
+	wantEvents := 1
+
+	// Start Filebeat receiver with Beat processors in a separate OTel processor
+	processorFilebeat := integration.NewBeat(
+		t,
+		"filebeat-otel",
+		"../../../filebeat/filebeat.test",
+		"otel",
+	)
+
+	namespace := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
+	processorIndex := "logs-processor-" + namespace
+	receiverIndex := "logs-receiver-" + namespace
+
+	configParameters := struct {
+		Index     string
+		InputFile string
+		PathHome  string
+	}{
+		Index:     processorIndex,
+		InputFile: filepath.Join(processorFilebeat.TempDir(), "log.log"),
+		PathHome:  processorFilebeat.TempDir(),
+	}
+
+	configTemplate := `
+service:
+  pipelines:
+    logs:
+      receivers:
+        - filebeatreceiver
+      processors:
+        - beat
+      exporters:
+        - elasticsearch/log
+        - debug
+  telemetry:
+    metrics:
+      level: none # Disable collector's own metrics to prevent conflict on port 8888. We don't use those metrics anyway.
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: filestream-fbreceiver
+          enabled: true
+          paths:
+            - {{.InputFile}}
+          prospector.scanner.fingerprint.enabled: false
+          file_identity.native: ~
+    output:
+      otelconsumer:
+    processors:
+      # Configure a processor to prevent enabling default processors
+      - add_fields:
+          fields:
+            custom_field: "custom_value"
+    logging:
+      level: info
+      selectors:
+        - '*'
+    queue.mem.flush.timeout: 0s
+    path.home: {{.PathHome}}
+processors:
+  beat:
+    processors:
+      - add_host_metadata:
+exporters:
+  debug:
+    use_internal_logger: false
+    verbosity: detailed
+  elasticsearch/log:
+    endpoints:
+      - http://localhost:9200
+    compression: none
+    user: admin
+    password: testing
+    logs_index: {{.Index}}
+    batcher:
+      enabled: true
+      flush_timeout: 1s
+    mapping:
+      mode: bodymap
+`
+	var renderedConfig bytes.Buffer
+	require.NoError(t, template.Must(template.New("config").Parse(configTemplate)).Execute(&renderedConfig, configParameters))
+	configContents := renderedConfig.Bytes()
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("Processor config:\n%s", configContents)
+		}
+	})
+
+	processorFilebeat.WriteConfigFile(string(configContents))
+	writeEventsToLogFile(t, configParameters.InputFile, wantEvents)
+	processorFilebeat.Start()
+	defer processorFilebeat.Stop()
+
+	// start Filebeat receiver with processors embedded in receiver's configuration
+	filebeatWithReceiver := integration.NewBeat(
+		t,
+		"filebeat-otel",
+		"../../../filebeat/filebeat.test",
+		"otel",
+	)
+
+	receiverConfig := `
+service:
+  pipelines:
+    logs:
+      receivers:
+        - filebeatreceiver
+      exporters:
+        - elasticsearch/log
+        - debug
+  telemetry:
+    metrics:
+      level: none # Disable collector's own metrics to prevent conflict on port 8888. We don't use those metrics anyway.
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: filestream-fbreceiver
+          enabled: true
+          paths:
+            - %s
+          prospector.scanner.fingerprint.enabled: false
+          file_identity.native: ~
+    processors:
+      - add_fields:
+          fields:
+            custom_field: "custom_value"
+      - add_host_metadata:
+    output:
+      otelconsumer:
+    logging:
+      level: info
+      selectors:
+        - '*'
+    queue.mem.flush.timeout: 0s
+    path.home: %s
+exporters:
+  debug:
+    use_internal_logger: false
+    verbosity: detailed
+  elasticsearch/log:
+    endpoints:
+      - http://localhost:9200
+    compression: none
+    user: admin
+    password: testing
+    logs_index: %s
+    batcher:
+      enabled: true
+      flush_timeout: 1s
+    mapping:
+      mode: bodymap
+`
+	logFilePath := filepath.Join(filebeatWithReceiver.TempDir(), "log.log")
+	writeEventsToLogFile(t, logFilePath, wantEvents)
+	receiverRenderedConfig := fmt.Sprintf(receiverConfig,
+		logFilePath,
+		filebeatWithReceiver.TempDir(),
+		receiverIndex,
+	)
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("Receiver config:\n%s", receiverRenderedConfig)
+		}
+	})
+	filebeatWithReceiver.WriteConfigFile(receiverRenderedConfig)
+	filebeatWithReceiver.Start()
+	defer filebeatWithReceiver.Stop()
+
+	es := integration.GetESClient(t, "http")
+
+	var processorDocuments estools.Documents
+	var receiverDocuments estools.Documents
+	var err error
+
+	// wait for logs to be published
+	require.EventuallyWithTf(t,
+		func(ct *assert.CollectT) {
+			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer findCancel()
+
+			processorDocuments, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+processorIndex+"*")
+			assert.NoError(ct, err)
+
+			receiverDocuments, err = estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+receiverIndex+"*")
+			assert.NoError(ct, err)
+
+			assert.GreaterOrEqual(ct, processorDocuments.Hits.Total.Value, wantEvents, "expected at least %d otel events, got %d", wantEvents, processorDocuments.Hits.Total.Value)
+			assert.GreaterOrEqual(ct, receiverDocuments.Hits.Total.Value, wantEvents, "expected at least %d filebeat events, got %d", wantEvents, receiverDocuments.Hits.Total.Value)
+		},
+		2*time.Minute, 1*time.Second, "expected at least %d events for both filebeat and otel", wantEvents)
+
+	processorDoc := processorDocuments.Hits.Hits[0].Source
+	receiverDoc := receiverDocuments.Hits.Hits[0].Source
+	ignoredFields := []string{
+		// Expected to change between the agents
+		"@timestamp",
+		"agent.ephemeral_id",
+		"agent.id",
+		"log.file.inode",
+		"log.file.path",
+	}
+
+	oteltest.AssertMapsEqual(t, receiverDoc, processorDoc, ignoredFields, "expected documents to be equal")
+}
+
+func writeEventsToLogFile(t *testing.T, filename string, numEvents int) {
+	t.Helper()
+	logFile, err := os.Create(filename)
+	if err != nil {
+		t.Fatalf("could not create file '%s': %s", filename, err)
+	}
+	// write events to log file
+	for i := 0; i < numEvents; i++ {
+		msg := fmt.Sprintf("Line %d", i)
+		_, err = logFile.Write([]byte(msg + "\n"))
+		require.NoErrorf(t, err, "failed to write line %d to temp file", i)
+	}
+
+	if err := logFile.Sync(); err != nil {
+		t.Fatalf("could not sync log file '%s': %s", filename, err)
+	}
+	if err := logFile.Close(); err != nil {
+		t.Fatalf("could not close log file '%s': %s", filename, err)
+	}
+}

--- a/x-pack/otel/processor/beatprocessor/processor.go
+++ b/x-pack/otel/processor/beatprocessor/processor.go
@@ -1,0 +1,147 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beatprocessor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors/add_host_metadata"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+)
+
+type beatProcessor struct {
+	logger     *zap.Logger
+	processors []beat.Processor
+}
+
+func newBeatProcessor(set processor.Settings, cfg *Config) (*beatProcessor, error) {
+	bp := &beatProcessor{
+		logger:     set.Logger,
+		processors: []beat.Processor{},
+	}
+
+	for _, processorConfig := range cfg.Processors {
+		processor, err := createProcessor(processorConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create processor: %w", err)
+		}
+		if processor != nil {
+			bp.processors = append(bp.processors, processor)
+		}
+	}
+
+	return bp, nil
+}
+
+func createProcessor(cfg map[string]any) (beat.Processor, error) {
+	if len(cfg) == 0 {
+		return nil, nil
+	}
+	if len(cfg) > 1 {
+		if len(cfg) < 10 {
+			configKeys := make([]string, 0, len(cfg))
+			for k := range cfg {
+				configKeys = append(configKeys, k)
+			}
+			return nil, fmt.Errorf("expected single processor name but got %v: %v", len(cfg), configKeys)
+		}
+		return nil, fmt.Errorf("expected single processor name but got %v", len(cfg))
+	}
+	for processorName, processorConfig := range cfg {
+		switch processorName {
+		case "add_host_metadata":
+			return createAddHostMetadataProcessor(processorConfig)
+		default:
+			return nil, fmt.Errorf("invalid processor name '%s'", processorName)
+		}
+	}
+	return nil, errors.New("malformed processor config")
+}
+
+func createAddHostMetadataProcessor(cfg any) (beat.Processor, error) {
+	addHostMetadataConfig, err := config.NewConfigFrom(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create add_host_metadata processor config: %w", err)
+	}
+	addHostMetadataProcessor, err := add_host_metadata.New(addHostMetadataConfig, logp.NewLogger("beatprocessor"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create add_host_metadata processor: %w", err)
+	}
+	return addHostMetadataProcessor, nil
+}
+
+func (p *beatProcessor) ConsumeLogs(_ context.Context, logs plog.Logs) (plog.Logs, error) {
+	if len(p.processors) == 0 {
+		return logs, nil
+	}
+
+	for _, hostProcessor := range p.processors {
+		dummyEvent := &beat.Event{}
+		dummyEvent.Fields = mapstr.M{}
+		dummyEvent.Meta = mapstr.M{}
+		dummyEventWithHostMetadata, err := hostProcessor.Run(dummyEvent)
+		if err != nil {
+			p.logger.Error("error processing host metadata", zap.Error(err))
+			continue
+		}
+		hostMap, ok := dummyEventWithHostMetadata.Fields["host"].(mapstr.M)
+		if !ok {
+			p.logger.Error("error casting host metadata to mapstr.M", zap.Error(err))
+			continue
+		}
+		otelMap, err := toOtelMap(&hostMap)
+		if err != nil {
+			p.logger.Error("error converting host metadata", zap.Error(err))
+			continue
+		}
+		for _, resourceLogs := range logs.ResourceLogs().All() {
+			for _, scopeLogs := range resourceLogs.ScopeLogs().All() {
+				for _, logRecord := range scopeLogs.LogRecords().All() {
+					bodyMap := logRecord.Body().Map().PutEmptyMap("host")
+					otelMap.CopyTo(bodyMap)
+				}
+			}
+		}
+	}
+
+	return logs, nil
+}
+
+func toOtelMap(m *mapstr.M) (pcommon.Map, error) {
+	otelMap := pcommon.NewMap()
+	for key, value := range *m {
+		switch typedValue := value.(type) {
+		case mapstr.M:
+			subMap, err := toOtelMap(&typedValue)
+			if err != nil {
+				return pcommon.Map{}, fmt.Errorf("failed to convert map for key '%s': %w", key, err)
+			}
+			otelSubMap := otelMap.PutEmptyMap(key)
+			subMap.MoveTo(otelSubMap)
+		case []string:
+			otelValue := otelMap.PutEmptySlice(key)
+			for _, item := range typedValue {
+				otelValue.AppendEmpty().SetStr(item)
+			}
+		default:
+			otelValue := otelMap.PutEmpty(key)
+			err := otelValue.FromRaw(typedValue)
+			if err != nil {
+				return pcommon.Map{}, fmt.Errorf("failed to convert value for key '%s': %w", key, err)
+			}
+		}
+	}
+	return otelMap, nil
+}

--- a/x-pack/otel/processor/beatprocessor/processor_test.go
+++ b/x-pack/otel/processor/beatprocessor/processor_test.go
@@ -1,0 +1,118 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beatprocessor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+)
+
+func TestConsumeLogs(t *testing.T) {
+	// Arrange
+	beatProcessor := &beatProcessor{
+		logger: zap.NewNop(),
+		processors: []beat.Processor{
+			mockProcessor{
+				runFunc: func(event *beat.Event) (*beat.Event, error) {
+					event.Fields["host"] = mapstr.M{"name": "test-host"}
+					return event, nil
+				},
+			},
+		},
+	}
+
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	for i := range 2 {
+		logRecord := scopeLogs.LogRecords().AppendEmpty()
+		logRecord.Body().SetEmptyMap()
+		logRecord.Body().Map().PutStr("message", fmt.Sprintf("test log message %v", i))
+	}
+
+	// Act
+	processedLogs, err := beatProcessor.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	// Assert
+	for _, resourceLogs := range processedLogs.ResourceLogs().All() {
+		for _, scopeLogs := range resourceLogs.ScopeLogs().All() {
+			for i, logRecord := range scopeLogs.LogRecords().All() {
+				// Verify that the original contents of the log is unchanged.
+				messageAttribute, found := logRecord.Body().Map().Get("message")
+				assert.True(t, found, "'message' not found in log record")
+				assert.Equal(t, fmt.Sprintf("test log message %v", i), messageAttribute.Str())
+
+				// Verify that the host attribute is added.
+				hostAttribute, found := logRecord.Body().Map().Get("host")
+				assert.True(t, found, "'host' not found in log record")
+				nameAttribute, found := hostAttribute.Map().Get("name")
+				assert.True(t, found, "'name' not found in 'host' attribute")
+				assert.Equal(t, "test-host", nameAttribute.Str())
+			}
+		}
+	}
+}
+
+func TestCreateProcessor(t *testing.T) {
+	t.Run("nil config returns nil processor", func(t *testing.T) {
+		processor, err := createProcessor(nil)
+		require.NoError(t, err)
+		assert.Nil(t, processor)
+	})
+
+	t.Run("empty config returns nil processor", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{})
+		require.NoError(t, err)
+		assert.Nil(t, processor)
+	})
+
+	t.Run("multiple processor names in config returns error", func(t *testing.T) {
+		_, err := createProcessor(map[string]any{
+			"add_host_metadata": map[string]any{},
+			"another_key":       map[string]any{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected single processor name")
+	})
+
+	t.Run("unknown processor returns error", func(t *testing.T) {
+		_, err := createProcessor(map[string]any{
+			"unknown_processor": map[string]any{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid processor name 'unknown_processor'")
+	})
+
+	t.Run("valid add_host_metadata processor config returns processor", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{
+			"add_host_metadata": map[string]any{},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		assert.Equal(t, "add_host_metadata", processor.String()[:len("add_host_metadata")])
+	})
+}
+
+type mockProcessor struct {
+	runFunc func(event *beat.Event) (*beat.Event, error)
+}
+
+func (m mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	return m.runFunc(event)
+}
+
+func (m mockProcessor) String() string {
+	return "mockProcessor"
+}


### PR DESCRIPTION
## Proposed commit message

Add add_host_metadata processor to the OpenTelemetry Beat processor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
  - I didn't add a changelog entry as the processor is not ready for public use

## How to test this PR locally

1. Include the processor in Elastic Agent by adding it to https://github.com/elastic/elastic-agent/blob/89e0e9a5b0ebb376773de813a1fd2c0b2f30e74a/internal/pkg/otel/components.go.
2. Build the Elastic Agent
3. Run the Agent with an OTel config that includes the Beat processor.

Example OTel config:

```yaml
service:
  pipelines:
    logs:
      receivers:
        - filebeatreceiver
      processors:
        - beat
      exporters:
        - debug

receivers:
  filebeatreceiver:
    filebeat:
      inputs:
        - type: filestream
          paths:
            - /tmp/logs-1k.log
    processors:
      # Configure a processor to prevent enabling default processors
      - add_fields:
          fields:
            custom_field: "custom_value"
    output:
      otelconsumer:
    path.data: /tmp/0819/data
    path.logs: /tmp/0819/logs
    queue.mem:
      flush.timeout: 0

processors:
  beat:
    processors:
      - add_host_metadata:
          netinfo:
            enabled: false

exporters:
  debug:
    use_internal_logger: false
    verbosity: normal
```

<hr>This is a manual backport of pull request #46112 done by @andrzej-stencel