### PR TITLE
[osquerybeat] Implement encoding package in extension

### DIFF
--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding.go
@@ -13,13 +13,10 @@ import (
 type EncodingFlag int
 
 const (
-	// EncodingFlagParseUnexported enables parsing of unexported (private) struct fields.
-	// When set, fields that start with lowercase letters will be included in the output.
-	EncodingFlagParseUnexported EncodingFlag = 1 << iota
 	// EncodingFlagUseNumbersZeroValues forces numeric zero values to be rendered as "0"
 	// instead of empty strings. By default, zero values for int, uint, and float types
 	// are converted to empty strings, but this flag preserves them as "0".
-	EncodingFlagUseNumbersZeroValues
+	EncodingFlagUseNumbersZeroValues EncodingFlag = 1 << iota
 )
 
 func (f EncodingFlag) has(option EncodingFlag) bool {
@@ -76,7 +73,7 @@ func MarshalToMapWithFlags(in any, flags EncodingFlag) (map[string]string, error
 		fieldValue := v.Field(i)
 		fieldType := t.Field(i)
 
-		if !flags.has(EncodingFlagParseUnexported) && !fieldType.IsExported() {
+		if !fieldType.IsExported() {
 			continue
 		}
 

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding_test.go
@@ -15,11 +15,7 @@ func TestEncodingFlagHas(t *testing.T) {
 		option   EncodingFlag
 		expected bool
 	}{
-		{EncodingFlagParseUnexported, EncodingFlagParseUnexported, true},
-		{EncodingFlagParseUnexported, EncodingFlagUseNumbersZeroValues, false},
 		{EncodingFlagUseNumbersZeroValues, EncodingFlagUseNumbersZeroValues, true},
-		{EncodingFlagParseUnexported | EncodingFlagUseNumbersZeroValues, EncodingFlagParseUnexported, true},
-		{EncodingFlagParseUnexported | EncodingFlagUseNumbersZeroValues, EncodingFlagUseNumbersZeroValues, true},
 	}
 
 	for _, test := range tests {
@@ -55,14 +51,6 @@ func TestMarshalToMapWithFlags(t *testing.T) {
 			input:    map[string]any{"key1": "value1", "key2": "value2", "key3": 1},
 			flags:    0,
 			expected: map[string]string{"key1": "value1", "key2": "value2", "key3": "1"},
-			err:      false,
-		},
-		{
-			input: &struct {
-				age int `osquery:"Age"`
-			}{age: 30},
-			flags:    EncodingFlagParseUnexported,
-			expected: map[string]string{"Age": "30"},
 			err:      false,
 		},
 		{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Adds a custom osquery encoder for the extension to standardize expected osquery type conversions

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~
