### PR TITLE
Skip flaky tests TestStateContinuity, TestBrowserSummaries

### DIFF
--- a/x-pack/heartbeat/scenarios/browserbasics_test.go
+++ b/x-pack/heartbeat/scenarios/browserbasics_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestBrowserSummaries(t *testing.T) {
+	t.Skip("Skipping flaky test https://github.com/elastic/beats/issues/47159")
 	t.Parallel()
 	scenarioDB.RunTagWithSeparateTwists(t, "browser", StdAttemptTwists, func(t *testing.T, mtr *framework.MonitorTestRun, err error) {
 		all := mtr.Events()

--- a/x-pack/heartbeat/scenarios/stateloader_test.go
+++ b/x-pack/heartbeat/scenarios/stateloader_test.go
@@ -18,6 +18,7 @@ const numRuns = 2
 var esIntegTwists = framework.MultiTwist(TwistAddRunFrom, TwistMultiRun(numRuns))
 
 func TestStateContinuity(t *testing.T) {
+	t.Skip("Skipping flaky test https://github.com/elastic/beats/issues/47193")
 	t.Parallel()
 	scenarioDB.RunAllWithATwist(t, esIntegTwists, func(t *testing.T, mtr *framework.MonitorTestRun, err error) {
 		events := mtr.Events()


### PR DESCRIPTION
Skip flaky heartbeat tests (https://github.com/elastic/beats/issues/47193, https://github.com/elastic/beats/issues/47159)
