### PR TITLE
github-actions: macos-13 sunset

### DIFF
--- a/.github/workflows/auditbeat-macos-unit-tests.yml
+++ b/.github/workflows/auditbeat-macos-unit-tests.yml
@@ -38,9 +38,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-branch:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -48,21 +47,6 @@ jobs:
         # TODO uncomment for testing or once solved
         os: [macos-15-intel] #, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    # Disabled due to: https://github.com/elastic/beats/issues/43482
-    # TODO: remove the `if: false` and uncomment `if: github.event_name == 'pull_request'`for testing or once solved
-    if: false
-#    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/filebeat-macos-unit-tests.yml
+++ b/.github/workflows/filebeat-macos-unit-tests.yml
@@ -38,26 +38,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/heartbeat-macos-unit-tests.yml
+++ b/.github/workflows/heartbeat-macos-unit-tests.yml
@@ -39,26 +39,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/metricbeat-macos-unit-tests.yml
+++ b/.github/workflows/metricbeat-macos-unit-tests.yml
@@ -38,9 +38,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -48,21 +47,6 @@ jobs:
         # TODO uncomment for testing or once solved
         os: [macos-15-intel] #, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    # Disabled due to: https://github.com/elastic/beats/issues/43658
-    # TODO: remove the `if: false` and uncomment `if: github.event_name == 'pull_request'`for testing or once solved
-    if: false
-    # if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/packetbeat-macos-unit-tests.yml
+++ b/.github/workflows/packetbeat-macos-unit-tests.yml
@@ -38,26 +38,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/xpack-auditbeat-macos-unit-tests.yml
+++ b/.github/workflows/xpack-auditbeat-macos-unit-tests.yml
@@ -44,26 +44,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/xpack-filebeat-macos-unit-tests.yml
+++ b/.github/workflows/xpack-filebeat-macos-unit-tests.yml
@@ -44,9 +44,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -59,15 +58,3 @@ jobs:
       - uses: ./.github/actions/unit-test
         with:
           beat:  ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macOS 15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}

--- a/.github/workflows/xpack-heartbeat-macos-unit-tests.yml
+++ b/.github/workflows/xpack-heartbeat-macos-unit-tests.yml
@@ -43,32 +43,14 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       max-parallel: 10
       matrix:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODEJS_VERSION }}
-
-      - run: npm i -g @elastic/synthetics
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat:  ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [ macos-15 ]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/xpack-metricbeat-macos-unit-tests.yml
+++ b/.github/workflows/xpack-metricbeat-macos-unit-tests.yml
@@ -40,9 +40,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -51,20 +50,6 @@ jobs:
         os: [ macos-15-intel ] #, macos-15]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    # Disabled due to: https://github.com/elastic/beats/issues/40496
-    # TODO: remove the `if: false` and uncomment `if: github.event_name == 'pull_request'`for testing or once solved
-    if: false
-    # if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/xpack-osquerybeat-macos-unit-tests.yml
+++ b/.github/workflows/xpack-osquerybeat-macos-unit-tests.yml
@@ -40,27 +40,14 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       max-parallel: 10
       matrix:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/xpack-packetbeat-macos-unit-tests.yml
+++ b/.github/workflows/xpack-packetbeat-macos-unit-tests.yml
@@ -42,9 +42,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  unit-tests-push:
+  unit-tests:
     name: Unit tests ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -52,17 +51,6 @@ jobs:
         os: [macos-15-intel, macos-15]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: ./.github/actions/unit-test
-        with:
-          beat: ${{ env.BEAT }}
-
-  unit-tests-pr:
-    name: Unit tests macos-15
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: [macos-15]
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Proposed commit message

* Refactor jobs and use only one (for pushes and pull requests)
* `macos-13` sunset by `December 4th, 2025`, see https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

```
The macOS 13 runner image will be retired by December 4th, 2025. To raise awareness of the upcoming removal, jobs using macOS 13 will temporarily fail during the scheduled brownout time periods defined below:

November 4, 14:00 UTC to November 5, 00:00 UTC
November 11, 14:00 UTC to November 12, 00:00 UTC
November 18, 14:00 UTC to November 19, 00:00 UTC
November 25, 14:00 UTC to November 26, 00:00 UTC
This deprecation includes the following labels:
– macos-13
– macos-13-large
– macos-13-xlarge

[What you need to do](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#what-you-need-to-do)
(Recommended) If your workflow is architecture agnostic, you can migrate to any of our arm64 labels:
– macos-15 or macos-latest
– macos-14
– macos-14-xlarge
– macos-latest-xlarge or macos-15-xlarge

For users that require the x86_64 (Intel) architecture, we have added a new label to support standard runner users. Jobs can be migrated to one of the following labels:
– macos-15-intel (new)
– macos-14-large
```


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
