### PR TITLE
chore(github): mention stresstest script in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,7 @@ List here all the items you have verified BEFORE sending this PR. Please DO NOT 
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have made corresponding change to the default configuration files
-- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the `stresstest.sh` script to run them under stress conditions and race detector to verify their stability.
+- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
 - [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
 
 ## Disruptive User Impact


### PR DESCRIPTION
## Proposed commit message

Flaky tests are a common challenge in our codebase. Some tests pass during development or when run a few times but can intermittently fail on CI, sometimes requiring several runs to reproduce. We have a stresstest script that can be used to run a specific test or a group of tests under stress, helping uncover race conditions and flakiness before merging the changes.

Update the pull request template to mention it.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).