### PR TITLE
[metricbeat] [sql] query_integration_test.go: add !requirefips

### DIFF
--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -301,7 +301,7 @@ func assertFieldContainsFloat64(field string, limit float64) func(t *testing.T, 
 	return func(t *testing.T, event beat.Event) {
 		value, err := event.GetValue("sql.metrics.hit_ratio")
 		assert.NoError(t, err)
-		require.GreaterOrEqual(t, value.(float64), limit)
+		require.GreaterOrEqual(t, value.(float64), limit) //nolint:errcheck // ignore
 	}
 }
 


### PR DESCRIPTION
Adding `!requirefips` to query_integration_test.go of sql package: all sql's go source files have `go:build !requirefips` directive except the integration test.

Backporting only to 9.2, as 8.19-9.1 will have that line added in https://github.com/elastic/beats/pull/47261 https://github.com/elastic/beats/pull/47262 https://github.com/elastic/beats/pull/47263