### PR TITLE
[beatreceiver] - add pprof extension

### DIFF
--- a/libbeat/otelbeat/beatconverter/beatconverter.go
+++ b/libbeat/otelbeat/beatconverter/beatconverter.go
@@ -189,6 +189,10 @@ func (c Converter) Convert(_ context.Context, conf *confmap.Conf) error {
 		if err != nil {
 			return err
 		}
+
+		if err := injectPprofExtension(conf); err != nil {
+			return fmt.Errorf("error injecting pprof extension: %w", err)
+		}
 	}
 
 	return nil
@@ -286,4 +290,20 @@ func getBeatsAuthExtensionConfig(cfg *config.C) (map[string]any, error) {
 	}
 
 	return newMap, nil
+}
+
+func injectPprofExtension(conf *confmap.Conf) error {
+	extensions, ok := conf.Get("service::extensions").([]any)
+	if !ok {
+		extensions = []any{}
+	}
+	extensions = append(extensions, "pprof")
+	out := map[string]any{
+		"service::extensions": extensions,
+		"extensions": map[string]any{
+			"pprof": nil,
+		},
+	}
+
+	return conf.Merge(confmap.NewFromStringMap(out))
 }

--- a/libbeat/otelbeat/beatconverter/beatconverter_test.go
+++ b/libbeat/otelbeat/beatconverter/beatconverter_test.go
@@ -35,6 +35,7 @@ extensions:
     proxy_disable: false
     proxy_url: https://tikugfk.example
     timeout: 1m30s
+  pprof: 
 exporters:
   elasticsearch:
     endpoints:
@@ -117,6 +118,7 @@ receivers:
 service:
   extensions:
     - beatsauth
+    - pprof
   pipelines:
     logs:
       exporters:
@@ -190,6 +192,7 @@ service:
 `
 		var expectedOutput = `
 extensions:
+  pprof:
   beatsauth:
     idle_connection_timeout: 3s
     proxy_disable: false
@@ -243,6 +246,7 @@ receivers:
 service:
   extensions:
     - beatsauth
+    - pprof
   pipelines:
     logs:
       exporters:
@@ -299,6 +303,7 @@ receivers:
 service:
   extensions:
     - beatsauth
+    - pprof
   pipelines:
     logs:
       exporters:
@@ -371,6 +376,8 @@ receivers:
   filebeatreceiver:
     output:
       otelconsumer: null
+extensions:
+  pprof:
 service:
   pipelines:
     logs:
@@ -378,6 +385,8 @@ service:
         - logstash
       receivers:
         - filebeatreceiver
+  extensions:
+    - pprof
 `
 		input := newFromYamlString(t, supportedInput)
 		err := c.Convert(context.Background(), input)
@@ -438,6 +447,8 @@ receivers:
           timeout: 10s
     output:
       otelconsumer: null
+extensions:
+  pprof:
 service:
   pipelines:
     logs:
@@ -445,6 +456,8 @@ service:
         - logstash
       receivers:
         - filebeatreceiver
+  extensions:
+    - pprof
 `
 		input := newFromYamlString(t, supportedInput)
 		err := c.Convert(context.Background(), input)
@@ -474,13 +487,18 @@ receivers:
   filebeatreceiver:
     output:
       otelconsumer: null
+extensions:
+  pprof:
 service:
   pipelines:
     logs:
       receivers:
         - filebeatreceiver
+  extensions:
+    - pprof
 `
 		input := newFromYamlString(t, supportedInput)
+		fmt.Println(input.ToStringMap())
 		err := c.Convert(context.Background(), input)
 		require.NoError(t, err, "error converting beats logstash-output config")
 
@@ -643,6 +661,7 @@ exporters:
 service:
   extensions:
     - beatsauth
+    - pprof
   pipelines:
     logs:
       exporters:


### PR DESCRIPTION
This PR injects pprof extension while doing config translation. By default, it is being run on port `1777`. 
Pprof extension is useful to debug the otel mode while testing against benchmarks.