### PR TITLE
[windows/perfmon] - Add match_by_parent_instance to the documenation

### DIFF
--- a/docs/reference/metricbeat/metricbeat-metricset-windows-perfmon.md
+++ b/docs/reference/metricbeat/metricbeat-metricset-windows-perfmon.md
@@ -52,8 +52,8 @@ You must configure queries for the Windows performance counters that you wish to
 :   A boolean option to refresh the counter list at each fetch. By default, the counter list will be retrieved at the starting time, to refresh the list at each fetch, users will have to enable this setting.
 
 **`match_by_parent_instance`**
-:   A boolean option that allows instances of the same parent to have a common instance value. In the above example, this will cause metrics for `svchost`, `svchost#1`, etc. to have an `instance`
-value of `svchost`. If set to `false` they will keep the original values (`svchost`, `svchost#1`, etc.). It defaults to `true`.
+:   A boolean option that causes all instances of the same parent to have the same instance value. In the previous example, this causes metrics for `svchost`, `svchost#1`, and so on to have an `instance`
+value of `svchost`. If set to `false` they keep the original values (`svchost`, `svchost#1`, and so on). Defaults to `true`.
 
 
 ### Query Configuration [_query_configuration]

--- a/metricbeat/module/windows/perfmon/_meta/docs.md
+++ b/metricbeat/module/windows/perfmon/_meta/docs.md
@@ -41,8 +41,8 @@ You must configure queries for the Windows performance counters that you wish to
 :   A boolean option to refresh the counter list at each fetch. By default, the counter list will be retrieved at the starting time, to refresh the list at each fetch, users will have to enable this setting.
 
 **`match_by_parent_instance`**
-:   A boolean option that causes all instances of the same parent to have the same instance value. In the above example, this will cause metrics for `svchost`, `svchost#1`, etc. to have an `instance`
-value of `svchost`. If set to `false` they will keep the original values (`svchost`, `svchost#1`, etc.). It defaults to `true`.
+:   A boolean option that causes all instances of the same parent to have the same instance value. In the previous example, this causes metrics for `svchost`, `svchost#1`, and so on to have an `instance`
+value of `svchost`. If set to `false` they keep the original values (`svchost`, `svchost#1`, and so on). Defaults to `true`.
 
 
 ### Query Configuration [_query_configuration]


### PR DESCRIPTION
Add `match_by_parent_instance` to the documentation. It was missing from markdown documentation,