### PR TITLE
Use logp.NewNopLogger for TestGenerateProcessorList

### DIFF
--- a/libbeat/publisher/processing/default_test.go
+++ b/libbeat/publisher/processing/default_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/processors/actions/addfields"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	_ "github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata"
@@ -52,7 +51,7 @@ func TestGenerateProcessorList(t *testing.T) {
 	plugins, err := processors.NewPluginConfigFromList(inputCfg)
 	require.NoError(t, err)
 
-	processors, err := processors.New(plugins, logptest.NewTestingLogger(t, ""))
+	processors, err := processors.New(plugins, logp.NewNopLogger())
 	require.NoError(t, err)
 	// make sure the processor init got the config formatted in a way it expected
 	require.Equal(t, 4, len(processors.List))


### PR DESCRIPTION
## Proposed commit message

```
Because logptest.NewTestingLogger uses the testing.T as the output for the logger, it could happen that the processors would log after the test had ended, leading to a panic.

This commit fixes it by using a no-op logger instead.

```

Example of the test failing: https://buildkite.com/elastic/beats-libbeat/builds/22486/steps/canvas?jid=019a1301-63ab-498b-b294-88e04f93bd9d#019a1301-63ab-498b-b294-88e04f93bd9d/210-617

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally
```
cd libbeat/publisher/processing
go test -v -count=1 -run=TestGenerateProcessorList .
```

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
