### PR TITLE
[docs] Set `subsections` to `true` in `config.changelog.yaml`

### DIFF
--- a/config.changelog.yaml
+++ b/config.changelog.yaml
@@ -2,3 +2,4 @@ owner: elastic
 repo: beats
 rendered_changelog_destination: docs/release-notes/_snippets
 file_type: markdown
+subsections: true


### PR DESCRIPTION
Related to https://github.com/elastic/elastic-agent-changelog-tool/pull/221

Set `subsections` to `true` in `config.changelog.yaml` to add subsections to release notes for each `component` (for example, `filebeat`, `auditbeat`, etc) when generated. This illustrates what changes when `subsections` is set to `false` (before) vs. `true` (after): https://github.com/elastic/beats/pull/47278/commits/a7bea88ca9df1b4da5d3089fad9bc25a0a3772bb.  


