### PR TITLE
[9.0](backport #47324) [Filebeat/Journald] Use --boot=all

### DIFF
--- a/filebeat/input/journald/environment_test.go
+++ b/filebeat/input/journald/environment_test.go
@@ -108,9 +108,7 @@ func (e *inputTestingEnvironment) startInput(ctx context.Context, inp v2.Input) 
 				return
 			}
 
-			cleanTestName := strings.Replace(t.Name(), "\\", "_", -1)
-
-			f, err := os.CreateTemp(folder, cleanTestName+"-*")
+			f, err := os.CreateTemp(folder, "Filebeat-Test-Journald"+"-*")
 			if err != nil {
 				t.Logf("cannot create file for error logs: %s", err)
 				return

--- a/filebeat/input/journald/input_test.go
+++ b/filebeat/input/journald/input_test.go
@@ -475,18 +475,7 @@ func TestDoubleStarCanBeUsed(t *testing.T) {
 	}
 
 	env.startInput(ctx, inp)
-	// Wait for at least 11 events, this means more than one journal file
-	// has been read and ingested.
-	//
-	// When many small journal files are ingested, the journalctl process
-	// may exit before the input has fully read its stdout, which makes us
-	// discard the last few lines/entries.
-	//
-	// We still correctly track the cursor of events published to the output,
-	// however the cursor returned by journalctl on this set of handcrafted
-	// journal files leads to us skipping some events.
-	// See https://github.com/elastic/beats/issues/46904.
-	env.waitUntilEventsPublished(11)
+	env.waitUntilEventCount(len(srcFiles) * 10)
 }
 
 func decompress(t *testing.T, namegz string) string {

--- a/filebeat/input/journald/pkg/journalctl/jctlmock_test.go
+++ b/filebeat/input/journald/pkg/journalctl/jctlmock_test.go
@@ -41,7 +41,7 @@ var _ Jctl = &JctlMock{}
 //			KillFunc: func() error {
 //				panic("mock out the Kill method")
 //			},
-//			NextFunc: func(canceler input.Canceler) ([]byte, bool, error) {
+//			NextFunc: func(canceler input.Canceler) ([]byte, error) {
 //				panic("mock out the Next method")
 //			},
 //		}
@@ -55,7 +55,7 @@ type JctlMock struct {
 	KillFunc func() error
 
 	// NextFunc mocks the Next method.
-	NextFunc func(canceler input.Canceler) ([]byte, bool, error)
+	NextFunc func(canceler input.Canceler) ([]byte, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -100,7 +100,7 @@ func (mock *JctlMock) KillCalls() []struct {
 }
 
 // Next calls NextFunc.
-func (mock *JctlMock) Next(canceler input.Canceler) ([]byte, bool, error) {
+func (mock *JctlMock) Next(canceler input.Canceler) ([]byte, error) {
 	if mock.NextFunc == nil {
 		panic("JctlMock.NextFunc: method is nil but Jctl.Next was just called")
 	}

--- a/filebeat/input/journald/pkg/journalctl/journalctl.go
+++ b/filebeat/input/journald/pkg/journalctl/journalctl.go
@@ -169,24 +169,20 @@ func (j *journalctl) Kill() error {
 // journalctl finished returning all data and exited successfully, if journalctl
 // exited unexpectedly, then `err` is non-nil, `finished` is false and an empty
 // byte array is returned.
-func (j *journalctl) Next(cancel input.Canceler) ([]byte, bool, error) {
+func (j *journalctl) Next(cancel input.Canceler) ([]byte, error) {
 	select {
 	case <-cancel.Done():
-		return []byte{}, false, ErrCancelled
+		return []byte{}, ErrCancelled
 	case d, open := <-j.dataChan:
 		if !open {
 			// Wait for the process to exit, so we can read the exit code.
 			j.waitDone.Wait()
-			if j.cmd.ProcessState.ExitCode() == 0 {
-				return []byte{}, true, nil
-			}
 			return []byte{},
-				false,
 				fmt.Errorf(
 					"no more data to read, journalctl exited unexpectedly, exit code: %d",
 					j.cmd.ProcessState.ExitCode())
 		}
 
-		return d, false, nil
+		return d, nil
 	}
 }

--- a/filebeat/input/journald/pkg/journalctl/reader_test.go
+++ b/filebeat/input/journald/pkg/journalctl/reader_test.go
@@ -50,8 +50,8 @@ func TestEventWithNonStringData(t *testing.T) {
 	for idx, rawEvent := range testCases {
 		t.Run(fmt.Sprintf("test %d", idx), func(t *testing.T) {
 			mock := JctlMock{
-				NextFunc: func(canceler input.Canceler) ([]byte, bool, error) {
-					return rawEvent, false, nil
+				NextFunc: func(canceler input.Canceler) ([]byte, error) {
+					return rawEvent, nil
 				},
 			}
 			r := Reader{
@@ -75,8 +75,8 @@ func TestRestartsJournalctlOnError(t *testing.T) {
 	ctx := context.Background()
 
 	mock := JctlMock{
-		NextFunc: func(canceler input.Canceler) ([]byte, bool, error) {
-			return jdEvent, false, errors.New("journalctl exited with code 42")
+		NextFunc: func(canceler input.Canceler) ([]byte, error) {
+			return jdEvent, errors.New("journalctl exited with code 42")
 		},
 	}
 
@@ -93,8 +93,8 @@ func TestRestartsJournalctlOnError(t *testing.T) {
 
 		// If calls have been made, change the Next function to always succeed
 		// and return it
-		mock.NextFunc = func(canceler input.Canceler) ([]byte, bool, error) {
-			return jdEvent, false, nil
+		mock.NextFunc = func(canceler input.Canceler) ([]byte, error) {
+			return jdEvent, nil
 		}
 
 		return &mock, nil

--- a/filebeat/tests/integration/journald_test.go
+++ b/filebeat/tests/integration/journald_test.go
@@ -53,9 +53,6 @@ func TestJournaldInputRunsAndRecoversFromJournalctlFailures(t *testing.T) {
 
 	filebeat.WriteConfigFile(yamlCfg)
 	filebeat.Start()
-	// On a normal execution we run journalclt twice, the first time to read all messages from the
-	// previous boot until 'now' and the second one with the --follow flag that should keep on running.
-	filebeat.WaitForLogs("journalctl started with PID", 10*time.Second, "journalctl did not start")
 	filebeat.WaitForLogs("journalctl started with PID", 10*time.Second, "journalctl did not start")
 
 	pidLine := filebeat.GetLastLogLine("journalctl started with PID")
@@ -98,9 +95,6 @@ func TestJournaldInputDoesNotDuplicateData(t *testing.T) {
 
 	filebeat.WriteConfigFile(yamlCfg)
 	filebeat.Start()
-	// On a normal execution we run journalclt twice, the first time to read all messages from the
-	// previous boot until 'now' and the second one with the --follow flag that should keep on running.
-	filebeat.WaitForLogs("journalctl started with PID", 10*time.Second, "journalctl did not start")
 	filebeat.WaitForLogs("journalctl started with PID", 10*time.Second, "journalctl did not start")
 
 	pidLine := filebeat.GetLastLogLine("journalctl started with PID")

--- a/libbeat/tests/integration/framework.go
+++ b/libbeat/tests/integration/framework.go
@@ -919,7 +919,7 @@ func readLastNBytes(filename string, numBytes int64) ([]byte, error) {
 }
 
 func reportErrors(t *testing.T, tempDir string, beatName string) {
-	var maxlen int64 = 100 * 1024 // 100 KiB
+	var maxlen int64 = 1024
 	stderr, err := readLastNBytes(filepath.Join(tempDir, "stderr"), maxlen)
 	if err != nil {
 		t.Logf("error reading stderr: %s", err)


### PR DESCRIPTION
## Proposed commit message

```
This commit uses the --boot=all argument instead of the workaround of
running journalctl twice:
- The first time without --follow to read all boots
- Then restarting it with --follow + cursor to follow the new messages
```

## Checklist



- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~


~~## Author's Checklist~~


- [ ] Closes https://github.com/elastic/beats/issues/46933

## How to test this PR locally

### Run all Journald tests
```
cd filebeat
go test -count=1 -v ./input/journald/...
mage buildSystemTestBinary
go test -count=1 -v -tags=integration -run=TestJournald ./tests/integration
```

### Manual tests
You will need a Linux machine (or VM) with multiple boots on its journal, to check you can run:
```
journalctl --boot=-1
journalctl --boot=-2
```
And ensure the first few log lines have different timestamps.

For this test you can use any output that allows you to inspect the data, for this example I'll use Elasticsearch deployed using elastic-package.

1. Get Elasticsearch and Kibana up and running
    ```
    elastic-package stack up -d
    ```
2.  Deploy Filebeat with the following configuration
    <details><summary>filebeat.yaml</summary>
    <p>
    
    ```yaml
    filebeat.inputs:
      - type: journald
        id: foo
    
    output.elasticsearch:
      hosts:
        - https://localhost:9200
      ssl.verification_mode: none
      username: elastic
      password: changeme
    
    logging:
      to_stderr: true
    ```
    
    </p>
    </details>

3. Go to Kibana and open Dev Tools
4. Run the following query
    ```
    POST /filebeat-*/_search
    {
      "size": 0,
      "aggs": {
        "boot_id_aggregation": {
          "terms": {
            "field": "journald.host.boot_id"
          }
        }
      }
    }
    ```
    Once enough data is ingested, you should have multiple buckets
    returned.
5. Look at the logs and ensure there is only one log entry from when
   `journalctl` is started, it looks like:
   ```json
   {
     "@timestamp": "2025-10-24T16:25:35.368-0400",
     "ecs.version": "1.6.0",
     "id": "1479199F3BEFB739",
     "input_id": "",
     "input_source": "LOCAL_SYSTEM_JOURNAL",
     "log.level": "info",
     "log.logger": "input.journald.reader.journalctl-runner",
     "log.origin": {
       "file.line": 146,
       "file.name": "journalctl/journalctl.go",
       "function": "github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalctl.Factory"
     },
     "message": "journalctl started with PID 3135917",
     "path": "LOCAL_SYSTEM_JOURNAL",
     "service.name": "filebeat"
   }
   ```


## Related issues

- Fixes https://github.com/elastic/beats/issues/46933

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
<hr>This is an manual backport of pull request #47324 done by @belimawr 