### PR TITLE
[9.1] Remove hardcoded `STACK_VERSION` for FIPS ECH testing

### DIFF
--- a/.buildkite/scripts/custom_fips_ech_test.sh
+++ b/.buildkite/scripts/custom_fips_ech_test.sh
@@ -12,8 +12,7 @@ trap 'ech_down' EXIT
 # haven't been published yet and are, therefore, not yet available in ECH.
 # Once artifacts matching the version in `libbeat/version/version.go` are available in ECH, the
 # following line should be removed and the line after that should be uncommented.
-# STACK_VERSION="$(./dev-tools/get_version)-SNAPSHOT"
-STACK_VERSION="9.1.6-SNAPSHOT"
+STACK_VERSION="$(./dev-tools/get_version)-SNAPSHOT"
 
 ech_up $STACK_VERSION
 


### PR DESCRIPTION
Undos the workaround added in b3e5b61a8387c65ae1a0cf527b21f7be75a75b9e that pinned the `9.1` branch to use the `9.1.6-SNAPSHOT` until `9.1.7-SNAPSHOT` was created.