### PR TITLE
[x-pack/metricbeat/{sql,oracle}] fix flaky test: remove 5500 port in oracle's docker-compose.yml

### DIFF
--- a/x-pack/metricbeat/module/oracle/docker-compose.yml
+++ b/x-pack/metricbeat/module/oracle/docker-compose.yml
@@ -7,4 +7,3 @@ services:
         ORACLE_VERSION: ${ORACLE_VERSION:-12.2.0.1}
     ports:
       - 1521:1521
-      - 5500:5500


### PR DESCRIPTION
Oracle’s Docker compose file exposes two ports:

**1521** - the Oracle listener port used for actual database connections.

**5500** - the HTTPS UI for Oracle Enterprise Manager Express (EM Express).

Only 1521 is relevant for integration tests, because it is the port through which SQL connections are established.
Port 5500 is not a database readiness indicator and may be enabled or started at a completely different time.

The [integration test](https://github.com/elastic/beats/blob/main/x-pack/metricbeat/module/sql/query/query_integration_test.go#L229) uses the following code to start the database and wait for its readiness to accept connections:
```
	service := compose.EnsureUp(t, "oracle")
	host, port, _ := net.SplitHostPort(service.Host())
	waitForOracleConnection(t, host, port)
```
The issue is that `service.Host()` does not guarantee that the returned port is 1521.
Depending on the order exposed ports are returned, **sometimes the test receives 5500 instead of 1521.**

When that happens, the readiness check waits for 5500 to open - but that port is unrelated to database readiness. As soon as EM Express becomes reachable, the test proceeds and immediately fails because the database is still not fully started.

This produces failures such as:
```
 query_integration_test.go:256: ... cannot open connection: ... ORA-12547: TNS:lost contact
```
And logs like:
```
    query_integration_test.go:385: Oracle not ready yet (attempt 1/30), waiting 2s: dial tcp 172.18.0.4:5500: connect: connection refused
    ...
    query_integration_test.go:385: Oracle not ready yet (attempt 6/30), waiting 30s: dial tcp 172.18.0.4:5500: connect: connection refused
```

(Example: https://buildkite.com/elastic/beats-xpack-metricbeat/builds/24156#019a27e3-7dc0-4d86-ae9a-84d5171ce21c/172-1422)

Here, 6 out of 30 retries failed against port 5500, meaning the 7th retry finally connected - but to EM Express, not the database.
Since the database was still initializing, the very first SQL query failed with ORA-12547 (lost contact).

The port `5500` is not used anywhere, hence **removing** it from `ports` in `docker-compose.yml`

## Proposed commit message

See title.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/issues/45424

