### PR TITLE
osquerybeat: remove go.uber.org/multierr leftovers

### DIFF
--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/browserhistory.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/browserhistory.go
@@ -6,13 +6,13 @@ package browserhistory
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/osquery/osquery-go/plugin/table"
-	"go.uber.org/multierr"
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
@@ -59,7 +59,7 @@ func GetTableRows(ctx context.Context, queryContext table.QueryContext, log *log
 		for _, parser := range parsers {
 			visits, err := parser.parse(ctx, queryContext, filters)
 			if err != nil {
-				merr = multierr.Append(merr, err)
+				merr = errors.Join(merr, err)
 			}
 			if len(visits) == 0 {
 				continue
@@ -68,7 +68,7 @@ func GetTableRows(ctx context.Context, queryContext table.QueryContext, log *log
 			for i, visit := range visits {
 				mvisit, err := encoding.MarshalToMap(visit)
 				if err != nil {
-					merr = multierr.Append(merr, err)
+					merr = errors.Join(merr, err)
 					continue
 				}
 				rows[i] = mvisit

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/chromium.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/chromium.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/osquery/osquery-go/plugin/table"
-	"go.uber.org/multierr"
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 )
@@ -66,7 +66,7 @@ func (parser *chromiumParser) parse(ctx context.Context, queryContext table.Quer
 		}
 		vs, err := parser.parseProfile(ctx, queryContext, profile)
 		if err != nil {
-			merr = multierr.Append(merr, err)
+			merr = errors.Join(merr, err)
 			continue
 		}
 		visits = append(visits, vs...)

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/firefox.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/firefox.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/osquery/osquery-go/plugin/table"
-	"go.uber.org/multierr"
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 )
@@ -87,7 +87,7 @@ func (parser *firefoxParser) parse(ctx context.Context, queryContext table.Query
 		}
 		vs, err := parser.parseProfile(ctx, queryContext, profile)
 		if err != nil {
-			merr = multierr.Append(merr, err)
+			merr = errors.Join(merr, err)
 			continue
 		}
 		visits = append(visits, vs...)

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/safari.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/safari.go
@@ -7,13 +7,13 @@ package browserhistory
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/osquery/osquery-go/plugin/table"
-	"go.uber.org/multierr"
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 )
@@ -65,7 +65,7 @@ func (parser *safariParser) parse(ctx context.Context, queryContext table.QueryC
 		}
 		vs, err := parser.parseProfile(ctx, queryContext, profile)
 		if err != nil {
-			merr = multierr.Append(merr, err)
+			merr = errors.Join(merr, err)
 			continue
 		}
 		visits = append(visits, vs...)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

osquerybeat: remove go.uber.org/multierr leftovers

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

N/A

## How to test this PR locally

It's a drop in replacement, there isn't a specific test. All should keep working just as it did before.


## Related PR

- Relates https://github.com/elastic/beats/pull/45275
