### PR TITLE
[Osquerybeat] Unit test fix nil dereference in osquerybeat_status_test.go

### DIFF
--- a/x-pack/osquerybeat/beater/osquerybeat_status_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_status_test.go
@@ -278,7 +278,8 @@ func TestOsquerybeatStatusReporting_ManagerStartFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Inject mock osqueryd that works fine
-	ob := beater.(*osquerybeat)
+	ob, ok := beater.(*osquerybeat)
+	require.True(t, ok)
 	ob.osquerydFactory = func(socketPath string, opts ...osqd.Option) (osqd.Runner, error) {
 		return &mockOsqueryd{
 			checkErr: nil,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Fixes a panic in a unit test due to nil dereference

```
=== FAIL: x-pack/osquerybeat/beater TestOsquerybeatStatusReporting_Lifecycle (unknown)
--
  | panic: runtime error: invalid memory address or nil pointer dereference
  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe985c3]
  |  
  | goroutine 501 [running]:
  | github.com/elastic/elastic-agent-libs/monitoring.(*Registry).getOrCreateRegistry(0x0, {0xc000112930, 0x1, 0x1}, {0x0, 0x0, 0x0})
  | /opt/buildkite-agent/.asdf/installs/golang/1.24.9/packages/pkg/mod/github.com/elastic/elastic-agent-libs@v0.26.0/monitoring/registry.go:157 +0x83
  | github.com/elastic/elastic-agent-libs/monitoring.(*Registry).GetOrCreateRegistry(0x0, {0x16c701a?, 0xc000100008?}, {0x0, 0x0, 0x0})
  | /opt/buildkite-agent/.asdf/installs/golang/1.24.9/packages/pkg/mod/github.com/elastic/elastic-agent-libs@v0.26.0/monitoring/registry.go:149 +0x6a
  | github.com/elastic/beats/v7/x-pack/osquerybeat/beater.newOsquerydMetrics(0x184dab0?, 0xc000590078)
  | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1762452447968064219/elastic/beats-xpack-osquerybeat/x-pack/osquerybeat/beater/osqueryd_metrics.go:65 +0x79
  | github.com/elastic/beats/v7/x-pack/osquerybeat/beater.(*osquerybeat).Run(0xc000488050, 0xc00048a1c0)
  | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1762452447968064219/elastic/beats-xpack-osquerybeat/x-pack/osquerybeat/beater/osquerybeat.go:181 +0x3c5
  | github.com/elastic/beats/v7/x-pack/osquerybeat/beater.TestOsquerybeatStatusReporting_Lifecycle.func2()
  | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1762452447968064219/elastic/beats-xpack-osquerybeat/x-pack/osquerybeat/beater/osquerybeat_status_test.go:113 +0x29
  | created by github.com/elastic/beats/v7/x-pack/osquerybeat/beater.TestOsquerybeatStatusReporting_Lifecycle in goroutine 500
  | /opt/buildkite-agent/builds/bk-agent-prod-gcp-1762452447968064219/elastic/beats-xpack-osquerybeat/x-pack/osquerybeat/beater/osquerybeat_status_test.go:112 +0x268
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
