### PR TITLE
Use logp.NewNopLogger to avoid panic on test

### DIFF
--- a/filebeat/channel/runner_test.go
+++ b/filebeat/channel/runner_test.go
@@ -246,7 +246,7 @@ index: "%{[fields.log_type]}-%{[agent.version]}-%{+yyyy.MM.dd}"
 	cfg, err := conf.NewConfigWithYAML([]byte(configYAML), configYAML)
 	require.NoError(t, err)
 
-	b := beat.Info{Logger: logptest.NewTestingLogger(t, "")} // not important for the test
+	b := beat.Info{Logger: logp.NewNopLogger()} // not important for the test
 	rf := &runnerFactoryMock{
 		clientCount: 3, // we will create 3 clients from the wrapped pipeline
 	}


### PR DESCRIPTION
## Proposed commit message

```
Use logp.NewNopLogger on TestRunnerFactoryWithCommonInputSettings to avoid panic: "
Log in goroutine after TestRunnerFactoryWithCommonInputSettings has completed"
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~


## How to test this PR locally

```
go test -v -count=1 -run=TestRunnerFactoryWithCommonInputSettings ./filebeat/channel
```

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
