### PR TITLE
[filebeat] fix running on kubernets docs

### DIFF
--- a/docs/reference/filebeat/running-on-kubernetes.md
+++ b/docs/reference/filebeat/running-on-kubernetes.md
@@ -34,7 +34,8 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/{{ version.stack | M.
 
 To support runtime environments different from Docker, like CRI-O or containerd, configure the `paths` as follows:
 
- - if using a single filestream input for all container logs:
+### A single filestream input for all container logs
+
 ```yaml
 filebeat.inputs:
 - type: filestream
@@ -55,7 +56,8 @@ filebeat.inputs:
 2. Container logs use symlinks, so they need to be enabled.
 3. Path for all container logs.
 
- - if using autodiscover to create one filestream input per container:
+### One filestream input per container using autodiscover:
+
 ```yaml
  filebeat.autodiscover:
    providers:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
[filebeat] adjust running on kubernetes docs

Adjust the docs to correct the inputs configuration snippets:
 - remove them from the OpenShift section as they are valid for k8s and OpenSHift
 - fix the issues on the snippets
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`]~~(https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

N/A

## How to test this PR locally

N/A
But if you want to test the configs, you can follow the steps from [this PR](https://github.com/elastic/beats/pull/47384) but use the config from the docs here.

## Related issues

- Closes https://github.com/elastic/beats/issues/47598

## Use cases

Running filebeat on kubernetes
