### PR TITLE
dev-tools: Refactor DocsDir to use git root directory

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -899,13 +899,12 @@ func IsUpToDate(dst string, sources ...string) bool {
 	return err == nil && !execute
 }
 
-func DocsDir() string {
-	cwd := CWD()
-	// Check if we need to correct ossDir because it's in x-pack.
-	if parentDir := filepath.Base(filepath.Dir(cwd)); parentDir == "x-pack" {
-		return filepath.Join(cwd, "../..", "docs")
+func DocsDir() (string, error) {
+	repoInfo, err := GetProjectRepoInfo()
+	if err != nil {
+		return "", fmt.Errorf("failed to get project repo info: %w", err)
 	}
-	return filepath.Join(cwd, "..", "docs")
+	return filepath.Join(repoInfo.RootDir, "docs"), nil
 }
 
 // OSSBeatDir returns the OSS beat directory. You can pass paths and they will

--- a/dev-tools/mage/docs.go
+++ b/dev-tools/mage/docs.go
@@ -84,7 +84,12 @@ func (docsBuilder) FieldDocs(fieldsYML string) error {
 		return err
 	}
 
-	outputPath := filepath.Join(DocsDir(), "reference", BeatName)
+	docsDir, err := DocsDir()
+	if err != nil {
+		return err
+	}
+
+	outputPath := filepath.Join(docsDir, "reference", BeatName)
 
 	// TODO: Port this script to Go.
 	log.Println(">> Generating exported-fields.md for", BeatName)

--- a/metricbeat/scripts/mage/docs_collector.go
+++ b/metricbeat/scripts/mage/docs_collector.go
@@ -435,8 +435,12 @@ func gatherData(modules []string) ([]moduleData, error) {
 
 // writeModuleDocs writes the module-level docs
 func writeModuleDocs(modules []moduleData, t *template.Template) error {
+	docsDir, err := mage.DocsDir()
+	if err != nil {
+		return err
+	}
 	for _, mod := range modules {
-		filename := filepath.Join(mage.DocsDir(), "reference", "metricbeat", fmt.Sprintf("metricbeat-module-%s.md", mod.Base))
+		filename := filepath.Join(docsDir, "reference", "metricbeat", fmt.Sprintf("metricbeat-module-%s.md", mod.Base))
 		err := writeTemplate(filename, t.Lookup("moduleDoc.tmpl"), mod)
 		if err != nil {
 			return err
@@ -447,6 +451,10 @@ func writeModuleDocs(modules []moduleData, t *template.Template) error {
 
 // writeMetricsetDocs writes the metricset-level docs
 func writeMetricsetDocs(modules []moduleData, t *template.Template) error {
+	docsDir, err := mage.DocsDir()
+	if err != nil {
+		return err
+	}
 	for _, mod := range modules {
 		for _, metricset := range mod.Metricsets {
 			modData := struct {
@@ -456,7 +464,7 @@ func writeMetricsetDocs(modules []moduleData, t *template.Template) error {
 				mod,
 				metricset,
 			}
-			filename := filepath.Join(mage.DocsDir(), "reference", "metricbeat", fmt.Sprintf("metricbeat-metricset-%s-%s.md", mod.Base, metricset.Title))
+			filename := filepath.Join(docsDir, "reference", "metricbeat", fmt.Sprintf("metricbeat-metricset-%s-%s.md", mod.Base, metricset.Title))
 
 			err := writeTemplate(filename, t.Lookup("metricsetDoc.tmpl"), modData)
 			if err != nil {
@@ -469,6 +477,10 @@ func writeMetricsetDocs(modules []moduleData, t *template.Template) error {
 
 // writeModuleList writes the module linked list
 func writeModuleList(modules []moduleData, t *template.Template) error {
+	docsDir, err := mage.DocsDir()
+	if err != nil {
+		return err
+	}
 	// Turn the map into a sorted list
 	//Normally the glob functions would do this sorting for us,
 	//but because we mix the regular and x-pack dirs we have to sort them again.
@@ -476,7 +488,7 @@ func writeModuleList(modules []moduleData, t *template.Template) error {
 		return modules[i].Base < modules[j].Base
 	})
 	//write and execute the template
-	filepath := filepath.Join(mage.DocsDir(), "reference", "metricbeat", "metricbeat-modules.md")
+	filepath := filepath.Join(docsDir, "reference", "metricbeat", "metricbeat-modules.md")
 	return writeTemplate(filepath, t.Lookup("moduleList.tmpl"), modules)
 
 }

--- a/winlogbeat/scripts/mage/docs.go
+++ b/winlogbeat/scripts/mage/docs.go
@@ -47,6 +47,11 @@ func moduleDocs() error {
 		return fmt.Errorf("No modules found matching %v", searchPath)
 	}
 
+	docsDir, err := mage.DocsDir()
+	if err != nil {
+		return err
+	}
+
 	// Extract module name from path and copy the file.
 	var names []string
 	for _, f := range files {
@@ -59,12 +64,12 @@ func moduleDocs() error {
 		modulesListTmpl += fmt.Sprintf("* [%s](/reference/winlogbeat/winlogbeat-module-%s.md)\n", strings.Title(name), name)
 
 		// Copy to the docs dirs.
-		dest := filepath.Join(mage.DocsDir(), "reference", "winlogbeat", fmt.Sprintf("winlogbeat-module-%s.md", name))
+		dest := filepath.Join(docsDir, "reference", "winlogbeat", fmt.Sprintf("winlogbeat-module-%s.md", name))
 		if err = mage.Copy(f, mage.CreateDir(dest)); err != nil {
 			return err
 		}
 	}
 
 	fmt.Printf(">> update:moduleDocs: Collecting module documentation for %v.\n", strings.Join(names, ", "))
-	return os.WriteFile(filepath.Join(mage.DocsDir(), "reference", "winlogbeat", "winlogbeat-modules.md"), []byte(modulesListTmpl), 0o644)
+	return os.WriteFile(filepath.Join(docsDir, "reference", "winlogbeat", "winlogbeat-modules.md"), []byte(modulesListTmpl), 0o644)
 }


### PR DESCRIPTION
## Proposed commit message
This fixes packaging errors in cloudbeat: https://github.com/elastic/cloudbeat/pull/3567 by removing the assumption that we're following elastic/beats' structure.

Changes DocsDir() signature to return (string, error).

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

- Relates https://github.com/elastic/cloudbeat/pull/3567
- Relates https://github.com/elastic/beats/pull/44638