### PR TITLE
otel: unskip TestFilebeatOTelMultipleReceiversE2E integration test

### DIFF
--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -592,7 +592,6 @@ http.port: %d
 }
 
 func TestFilebeatOTelMultipleReceiversE2E(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/45631")
 	integration.EnsureESIsRunning(t)
 	wantEvents := 100
 


### PR DESCRIPTION
## Proposed commit message

The integration test `TestFilebeatOTelMultipleReceiversE2E` seems stable again, so enable it. The metricbeat version of this test is working great for a while now.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

```bash
(cd x-pack/filebeat; mage docker:composeUp)
go test -tags integration -run ^TestFilebeatOTelMultipleReceiversE2E$ ./x-pack/filebeat/tests/integration -v -count=1

./script/stresstest.sh --tags integration ./x-pack/filebeat/tests/integration ^TestFilebeatOTelMultipleReceiversE2E$ -p 1
```

## Related issues

- Fixes https://github.com/elastic/beats/issues/43832.