### PR TITLE
Set ulimit for aerospike container so it runs

### DIFF
--- a/metricbeat/module/aerospike/docker-compose.yml
+++ b/metricbeat/module/aerospike/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   aerospike:
     image: docker.elastic.co/integrations-ci/beats-aerospike:${AEROSPIKE_VERSION:-7.2.0.1}-1
+    ulimits:
+      nofile:
+        soft: 20000
+        hard: 20000
     build:
       context: ./_meta
       args:


### PR DESCRIPTION

## Proposed commit message

```
The aerospike container used for testing was failing with:

  CRITICAL (config): (cfg.c:4387) 1024 system file descriptors not
  enough, config specified 15000

This commit fixes it by setting the ulimit to 20000

```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~


## How to test this PR locally
Run the tests
```
cd metricbeat/module/aerospike
go test -tags=integration -v -count=1 ./...
```

Or, try running the container:
```
docker compose up
```
## Related issues

- Closes #47681

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~