### PR TITLE
Add string method to `AuthType`

### DIFF
--- a/libbeat/common/transport/kerberos/config.go
+++ b/libbeat/common/transport/kerberos/config.go
@@ -39,6 +39,11 @@ var (
 		authPasswordStr: authPassword,
 		authKeytabStr:   authKeytab,
 	}
+
+	authTypeInverse = map[AuthType]string{
+		authPassword: authPasswordStr,
+		authKeytab:   authKeytabStr,
+	}
 )
 
 type Config struct {
@@ -68,4 +73,8 @@ func (t *AuthType) Unpack(value string) error {
 	*t = authT
 
 	return nil
+}
+
+func (t *AuthType) String() string {
+	return authTypeInverse[*t]
 }

--- a/x-pack/otel/extension/beatsauthextension/authenticator.go
+++ b/x-pack/otel/extension/beatsauthextension/authenticator.go
@@ -126,7 +126,7 @@ func getHttpClient(a *authenticator) (roundTripperProvider, error) {
 		return nil, fmt.Errorf("failed creating config: %w", err)
 	}
 
-	beatAuthConfig := esAuthConfig{}
+	beatAuthConfig := BeatsAuthConfig{}
 	err = parsedCfg.Unpack(&beatAuthConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed unpacking config: %w", err)

--- a/x-pack/otel/extension/beatsauthextension/config.go
+++ b/x-pack/otel/extension/beatsauthextension/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	ContinueOnError bool                   `mapstructure:"continue_on_error"`
 }
 
-type esAuthConfig struct {
+type BeatsAuthConfig struct {
 	Kerberos  *kerberos.Config                 `config:"kerberos"`
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This PR adds a `String()` method to `AuthType` in kerberos package

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->
None


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/issues/46749
- Preceeds https://github.com/elastic/beats/pull/47687

## Use cases
This is required for beat-beatreceiver config translation logic

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

