### PR TITLE
Add more tests for the ndjson parser behavior

### DIFF
--- a/libbeat/reader/readjson/json_test.go
+++ b/libbeat/reader/readjson/json_test.go
@@ -391,6 +391,21 @@ func TestMergeJSONFields(t *testing.T) {
 				},
 			},
 		},
+		"key collision with overwrite": {
+			Data: mapstr.M{
+				"log.level": "info",
+				"log": mapstr.M{
+					"logger": "agent_component.cli",
+				},
+			},
+			JSONConfig: Config{OverwriteKeys: true, AddErrorKey: true, IgnoreDecodingError: true},
+			ExpectedItems: mapstr.M{
+				"log.level": "info",
+				"log": mapstr.M{
+					"logger": "agent_component.cli",
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Tests for troubleshooting a bug discovered by @straistaru 

When parsing JSON objects with duplicated keys it was not clear how our parser behaves.
These tests are to clarify the behavior which should help with the future debugging efforts.