### PR TITLE
[docs][elasticsearch] - add a warning regarding multiple clusters

### DIFF
--- a/docs/reference/auditbeat/elasticsearch-output.md
+++ b/docs/reference/auditbeat/elasticsearch-output.md
@@ -81,6 +81,10 @@ The list of Elasticsearch nodes to connect to. The events are distributed to the
 When a node is defined as an `IP:PORT`, the *scheme* and *path* are taken from the [`protocol`](#protocol-option) and [`path`](#path-option) config options.
 ::::
 
+::::{warning}
+All configured hosts must belong to the same Elasticsearch cluster; using nodes from different clusters may result in split or inconsistent data.
+::::
+
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/filebeat/elasticsearch-output.md
+++ b/docs/reference/filebeat/elasticsearch-output.md
@@ -81,6 +81,10 @@ The list of Elasticsearch nodes to connect to. The events are distributed to the
 When a node is defined as an `IP:PORT`, the *scheme* and *path* are taken from the [`protocol`](#protocol-option) and [`path`](#path-option) config options.
 ::::
 
+::::{warning}
+All configured hosts must belong to the same Elasticsearch cluster; using nodes from different clusters may result in split or inconsistent data.
+::::
+
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/heartbeat/elasticsearch-output.md
+++ b/docs/reference/heartbeat/elasticsearch-output.md
@@ -81,6 +81,10 @@ The list of Elasticsearch nodes to connect to. The events are distributed to the
 When a node is defined as an `IP:PORT`, the *scheme* and *path* are taken from the [`protocol`](#protocol-option) and [`path`](#path-option) config options.
 ::::
 
+::::{warning}
+All configured hosts must belong to the same Elasticsearch cluster; using nodes from different clusters may result in split or inconsistent data.
+::::
+
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/metricbeat/elasticsearch-output.md
+++ b/docs/reference/metricbeat/elasticsearch-output.md
@@ -81,6 +81,10 @@ The list of Elasticsearch nodes to connect to. The events are distributed to the
 When a node is defined as an `IP:PORT`, the *scheme* and *path* are taken from the [`protocol`](#protocol-option) and [`path`](#path-option) config options.
 ::::
 
+::::{warning}
+All configured hosts must belong to the same Elasticsearch cluster; using nodes from different clusters may result in split or inconsistent data.
+::::
+
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/packetbeat/elasticsearch-output.md
+++ b/docs/reference/packetbeat/elasticsearch-output.md
@@ -81,6 +81,10 @@ The list of Elasticsearch nodes to connect to. The events are distributed to the
 When a node is defined as an `IP:PORT`, the *scheme* and *path* are taken from the [`protocol`](#protocol-option) and [`path`](#path-option) config options.
 ::::
 
+::::{warning}
+All configured hosts must belong to the same Elasticsearch cluster; using nodes from different clusters may result in split or inconsistent data.
+::::
+
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/winlogbeat/elasticsearch-output.md
+++ b/docs/reference/winlogbeat/elasticsearch-output.md
@@ -81,6 +81,10 @@ The list of Elasticsearch nodes to connect to. The events are distributed to the
 When a node is defined as an `IP:PORT`, the *scheme* and *path* are taken from the [`protocol`](#protocol-option) and [`path`](#path-option) config options.
 ::::
 
+::::{warning}
+All configured hosts must belong to the same Elasticsearch cluster; using nodes from different clusters may result in split or inconsistent data.
+::::
+
 
 ```yaml
 output.elasticsearch:


### PR DESCRIPTION
## Proposed commit message

Adds a warning to the Elasticsearch output docs stating that all hosts must be part of the same cluster.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Screenshot

<img width="936" height="408" alt="Screenshot 2025-11-26 at 2 39 20 PM" src="https://github.com/user-attachments/assets/4192c381-8979-4cba-a082-45c8a9f2e6f3" />

