### PR TITLE
test(TestDurationIsAddedToEvent): wait for worker to shutdown

### DIFF
--- a/metricbeat/mb/module/wrapper_test.go
+++ b/metricbeat/mb/module/wrapper_test.go
@@ -224,8 +224,6 @@ func TestDurationIsAddedToEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan struct{})
-	defer close(done)
-
 	output := m.Start(done)
 
 	event := <-output
@@ -233,6 +231,13 @@ func TestDurationIsAddedToEvent(t *testing.T) {
 	fields := event.Fields.Flatten()
 	assert.Contains(t, fields, "event.duration", "event.duration should be present in event")
 	assert.Greater(t, fields["event.duration"], time.Duration(0), "event.duration should be greater than 0")
+
+	// stop worker
+	close(done)
+
+	// wait for shutdown to prevent logging after test completes
+	event, ok := <-output
+	assert.Falsef(t, ok, "received unexpected event: %+v", event)
 }
 
 func TestNewWrapperForMetricSet(t *testing.T) {


### PR DESCRIPTION
## Proposed commit message
metricbeat wrapper is leaking a goroutine causing the test to fail because it's logging a message after the test is over.

Wait for worker to shutdown before returning.

Similar to #47660 which fixed the same issue for TestPeriodIsAddedToEvent.
Similar to #47663 which fixed the same issue for TestGenerateProcessorList.

Closes #47776

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

```sh
go test -v -count=1000 -run "TestDurationIsAddedToEvent" ./metricbeat/mb/module/
```

## Related issues
- Related #47660
- Related #47663
- Closes #47776