### PR TITLE
Fix flaky test TestFilestreamDelete

### DIFF
--- a/filebeat/tests/integration/filestream_delete_test.go
+++ b/filebeat/tests/integration/filestream_delete_test.go
@@ -236,8 +236,16 @@ func testGracePeriod(
 			filebeat.WaitLogsContains(changedMsg, time.Second, "filestream did detect the file change")
 
 			// Make sure the harvester is closed
-			filebeat.WaitLogsContains("Stopped harvester for file", time.Second, "harvester was not closed")
-			filebeat.WaitLogsContains("Closing reader of filestream", time.Second, "reader was not closed")
+			// These two messages are logged at essentially the same time, so
+			// their order in the log file is non-deterministic. Use
+			// WaitLogsContainsAnyOrder to check for both without relying on order.
+			filebeat.WaitLogsContainsAnyOrder(
+				[]string{
+					"Closing reader of filestream",
+					"Stopped harvester for file",
+				},
+				5*time.Second,
+				"harvester/reader was not closed")
 		})
 	}
 


### PR DESCRIPTION
## Proposed commit message

The two log messages are logged from different goroutines that race:

- "Closing reader of filestream" is logged from a background goroutine spawned by ctxtool.WithFunc when streamCancel() triggers cancellation
- "Stopped harvester for file" is logged from the main harvester goroutine via a defer in harvester.go

When streamCancel() executes, it closes a channel that wakes the background goroutine to log "Closing reader", while the main goroutine continues and logs "Stopped harvester". These two goroutines race to write to the log file, making the order non-deterministic.

The original test used sequential WaitLogsContains calls which track file offset - when messages appeared in the "wrong" order, the first check would advance the offset past both messages, causing the second to fail.

Changed to WaitLogsContainsAnyOrder which checks for both messages without relying on order.

Closes #47784 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

1. Start the integration test containers:
   ```bash
   cd filebeat && mage docker:composeUp
   ```

2. Build the test binary:
   ```bash
   mage buildSystemTestBinary
   ```

3. Run the specific test with FIPS mode (reproduces original failure without fix):
   ```bash
   GODEBUG=fips140=only \
   ES_HOST=localhost ES_USER=beats ES_PASS=testing \
   ES_SUPERUSER_USER=admin ES_SUPERUSER_PASS=testing \
   go test -v -failfast -tags "integration,requirefips" \
     -run "TestFilestreamDelete/Inactive_resource_not_finished_and_data_added_during_grace_period" \
     ./tests/integration/ -count=20
   ```

4. Clean up:
   ```bash
   mage docker:composeDown
   ```

## Related issues

- Closes #47784