### PR TITLE
Update CODEOWNERS entry for release note docs files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@ changelog/fragments/
 /dev-tools/ @elastic/elastic-agent-data-plane
 /dev-tools/kubernetes @elastic/elastic-agent-data-plane @elastic/elastic-agent-control-plane
 /docs/ @elastic/ingest-docs
+/docs/release-notes @elastic/ingest-docs @elastic/elastic-agent-data-plane
 /filebeat @elastic/elastic-agent-data-plane
 /filebeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /filebeat/input/syslog/ @elastic/integration-experience


### PR DESCRIPTION
@pierrehilbert @ebeahan how do you feel about co-owning the release notes docs files to remove friction when approving/merging backports and forwardports on release day (like [this one](https://github.com/elastic/beats/pull/47867) and [this one](https://github.com/elastic/beats/pull/47866))? If the initial PR was approved by the docs team and the doc preview builds successfully, you should be able to merge backports/forwardports.

cc @karenzone 