### PR TITLE
metricbeat: Remove global paths

### DIFF
--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -50,6 +50,7 @@ type Metricbeat struct {
 	stopOnce                 sync.Once     // wraps the Stop() method
 	config                   Config
 	registry                 *mb.Register
+	paths                    *paths.Path
 	autodiscover             *autodiscover.Autodiscover
 	dynamicCfgEnabled        bool
 	otelStatusFactoryWrapper func(cfgfile.RunnerFactory) cfgfile.RunnerFactory
@@ -74,7 +75,7 @@ func WithModuleOptions(options ...module.Option) Option {
 // WithLightModules enables light modules support
 func WithLightModules() Option {
 	return func(m *Metricbeat) {
-		path := paths.Resolve(paths.Home, "module")
+		path := m.paths.Resolve(paths.Home, "module")
 		mb.Registry.SetSecondarySource(mb.NewLightModulesSource(m.logger, path))
 	}
 }
@@ -156,6 +157,7 @@ func newMetricbeat(b *beat.Beat, c *conf.C, registry *mb.Register, options ...Op
 		done:              make(chan struct{}),
 		config:            config,
 		registry:          registry,
+		paths:             b.Paths,
 		logger:            b.Info.Logger,
 		dynamicCfgEnabled: dynamicCfgEnabled,
 	}


### PR DESCRIPTION
## Proposed commit message

Re-use already available beat.Paths to properly initialize light modules directory.

Closes https://github.com/elastic/beats/issues/46990

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

### 1. Prepare the light module
```sh
mkdir -p /tmp/metricbeat/module/custommodule/lightmetricset

cat >/tmp/metricbeat/module/custommodule/module.yml <<'EOF'
name: custommodule
metricsets:
  - lightmetricset
EOF

cat >/tmp/metricbeat/module/custommodule/lightmetricset/manifest.yml <<'EOF'
default: true
input:
  module: http
  metricset: json
  defaults:
    hosts: ["http://localhost:8080"]
EOF
```

### 2. Run dummy python server
```sh
python - <<'PY'
import http.server, json, socketserver
PORT = 8080
class Handler(http.server.BaseHTTPRequestHandler):
    def do_GET(self):
        data = {"u": self.path}
        body = json.dumps(data).encode()
        self.send_response(200)
        self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        self.wfile.write(body)
with socketserver.TCPServer(("", PORT), Handler) as httpd:
    print(f"Serving dummy JSON on http://localhost:{PORT}")
    httpd.serve_forever()
PY
```

### 3. Minimal Metricbeat config
```yaml
path.home: /tmp/metricbeat
path.data: ${path.home}/data
path.logs: ${path.home}/logs

metricbeat.modules:
  - module: custommodule
    metricsets: ["lightmetricset"]
    hosts: ["http://localhost:8080"]
    namespace: "custommodule"
    period: 5s

output.console:
  pretty: true
```

### 4. Run
```sh
x-pack/metricbeat/metricbeat -e -c metricbeat-paths.yaml
```

See also https://www.elastic.co/blog/introducing-metricbeat-light-modules

## Related issues

- Closes https://github.com/elastic/beats/issues/46990