### PR TITLE
[8.19](backport #47815) [Metricbeat ] Change calculation of CPU/Memory to allocatable values

### DIFF
--- a/changelog/fragments/1764864570-k8s_container_allocatable.yaml
+++ b/changelog/fragments/1764864570-k8s_container_allocatable.yaml
@@ -16,10 +16,10 @@ summary: k8s_container_allocatable
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
-#description:
+description: Updates kubernetes cpu and memory metrics to use allocatable values instead of capacity values.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
-component:
+component: metricbeat
 
 # PR URL; optional; the PR number that added the changeset.
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.


### PR DESCRIPTION
- Enhancement

## Proposed commit message

- WHAT: Updates kubernetes cpu and memory metrics to use allocatable values instead of capacity values.
- WHY:  https://github.com/elastic/beats/issues/40701

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

- Follow instructions of doc [here](https://github.com/elastic/beats/tree/main/metricbeat/module/kubernetes/_meta/test/docs)
- Build your new metricbeat and run your local stack 
- Open local kibana dashboard
- Create a dataview with `metricbeat-*` filter
- Filter for `kubernetes.container.cpu.usage.node.pct: * or kubernetes.container.memory.usage.node.pct: *`

## Related issues

- Closes #https://github.com/elastic/beats/issues/39906
- Closes #https://github.com/elastic/beats/issues/40701

## Screenshots

<img width="1711" height="887" alt="Screenshot 2025-11-28 at 10 40 57 AM" src="https://github.com/user-attachments/assets/e4b8b4aa-c6b1-43c8-9eb9-de2c54cc4820" />

