### PR TITLE
[beatreceivers] skip caller by one in beats auth extension

### DIFF
--- a/x-pack/libbeat/outputs/otelconsumer/otelconsumer.go
+++ b/x-pack/libbeat/outputs/otelconsumer/otelconsumer.go
@@ -187,7 +187,7 @@ func (out *otelConsumer) logsPublish(ctx context.Context, batch publisher.Batch)
 			batch.Retry()
 		}
 
-		out.log.Errorf("failed to send batch events to otel collector: %v", err)
+		out.log.Errorf("failed to publish batch events to otel collector pipeline: %v", err)
 		return nil
 	}
 

--- a/x-pack/otel/extension/beatsauthextension/authenticator.go
+++ b/x-pack/otel/extension/beatsauthextension/authenticator.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensionauth"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/kerberos"
@@ -50,7 +51,7 @@ type authenticator struct {
 
 func newAuthenticator(cfg *Config, telemetry component.TelemetrySettings) (*authenticator, error) {
 	// logp.NewZapLogger essentially never returns an error; look within the implementation
-	logger, err := logp.NewZapLogger(telemetry.Logger)
+	logger, err := logp.NewZapLogger(telemetry.Logger.WithOptions(zap.AddCallerSkip(1)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This PR skips log caller by 1. 
 Logs before this change looked like this
 ```
{"log.level":"error","@timestamp":"2025-12-05T15:07:32.959+0530","message":"Error dialing dial tcp 127.0.0.1:9200: connect: connection refused","log.origin":{"file.line":251,"file.name":"logp/logger.go","function":"github.com/elastic/elastic-agent-libs/logp.(*Logger).Errorf"},...
 ```

