### PR TITLE
fbreceiver: close file in writeFile to fix Windows test

### DIFF
--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -604,6 +604,7 @@ func hostFromSocket(socket string) string {
 func writeFile(t require.TestingT, path string, data string) {
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	require.NoErrorf(t, err, "Could not open file %s", path)
+	defer f.Close()
 	_, err = f.WriteString(data + "\n")
 	require.NoErrorf(t, err, "Could not write %s to file %s", data, path)
 }


### PR DESCRIPTION
On Windows, open file handles prevent t.TempDir() cleanup. Add defer f.Close() to properly release the file handle.

Fixes test failure introduced in #47969.
Fixes #48009

## Proposed commit message

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~