### PR TITLE
Remove direct access to v2.Context.StatusReporter in Filestream

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -210,7 +210,7 @@ func startHarvester(
 
 			// Report any harvester error as a degraded state for the input
 			if err != nil {
-				ctx.StatusReporter.UpdateStatus(
+				ctx.UpdateStatus(
 					status.Degraded,
 					fmt.Sprintf("Harvester for Filestream input %q failed: %s", inputID, err),
 				)

--- a/filebeat/input/v2/input.go
+++ b/filebeat/input/v2/input.go
@@ -109,6 +109,8 @@ type Context struct {
 	// StatusReporter provides a method to update the status of the underlying unit
 	// that maps to the config. Note: Under standalone execution of Filebeat this is
 	// expected to be nil.
+	// Deprecated: Direct access to StatusReporter is deprecated because it
+	// can be nil, use the UpdateStatus method instead
 	StatusReporter status.StatusReporter
 
 	// MetricsRegistry is the registry collecting metrics for the input using


### PR DESCRIPTION
## Proposed commit message

```
v2.Context.StatusReporter can be nil when Filebeat runs standalone. The direct access to this field is replaced in Filestream by the UpdateStatus method. A deprecation notice is added is added to the StatusReporter field.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

### 1. Create a log file

```
docker run -it --rm mingrammer/flog -n 50 > /tmp/flog.ndjson
```

### 2. Run Filebeat with the following configuration

<details><summary>filebeat.yml</summary>
<p>

```yaml
filebeat.inputs:
  - type: filestream
    id: filestream-input-id
    paths:
      - /tmp/flog.log
    processors:
      - add_fields:
          INVALID_CONFIG_KEY: true
          fields:
            labels:
              foo: bar

logging:
  to_stderr: true

output.discard:
  enabled: true
```

</p>
</details> 

It should not panic

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

