### PR TITLE
filebeat: deploy k8s: use `compression` instead of `gzip_experimental`

### DIFF
--- a/changelog/fragments/1765780037-filebeat-deploy-k8s-use-compression.yaml
+++ b/changelog/fragments/1765780037-filebeat-deploy-k8s-use-compression.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Filebeat deploy on kubernetes examples use `compression` instead of `gzip_experimental`.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: filebeat
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/48079
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/47882

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -136,7 +136,7 @@ data:
           ##    - container metadata isn't available when collecting logs from /var/log/pods/. Refer to add_kubernetes_metadata docs for details: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata#_logs_path
           #- type: filestream
           #  id: kubernetes-container-logs
-          #  gzip_experimental: true # BETA: enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
+          #  compression: auto # enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
           #  parsers:
           #    - container: ~
           #  paths:
@@ -171,7 +171,7 @@ data:
     #        - /var/log/containers/*-${data.kubernetes.container.id}.log
     # # To enable collection of rotated logs, use the following configuration instead. WARNING: It might cause data re-ingestion for existing deployments. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/running-on-kubernetes#ingesting-rotated-log-files
     # #         id: kubernetes-container-logs-${data.kubernetes.pod.uid}-${data.kubernetes.container.name}
-    # #         gzip_experimental: true # BETA: enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
+    # #         compression: auto # enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
     # #         paths:
     # #           - /var/log/pods/${data.kubernetes.namespace}_${data.kubernetes.pod.name}_${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log*
 

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -32,7 +32,7 @@ data:
           ##    - container metadata isn't available when collecting logs from /var/log/pods/. Refer to add_kubernetes_metadata docs for details: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata#_logs_path
           #- type: filestream
           #  id: kubernetes-container-logs
-          #  gzip_experimental: true # BETA: enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
+          #  compression: auto # enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
           #  parsers:
           #    - container: ~
           #  paths:
@@ -67,7 +67,7 @@ data:
     #        - /var/log/containers/*-${data.kubernetes.container.id}.log
     # # To enable collection of rotated logs, use the following configuration instead. WARNING: It might cause data re-ingestion for existing deployments. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/running-on-kubernetes#ingesting-rotated-log-files
     # #         id: kubernetes-container-logs-${data.kubernetes.pod.uid}-${data.kubernetes.container.name}
-    # #         gzip_experimental: true # BETA: enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
+    # #         compression: auto # enable gzip decompression. Refer to the docs for details: https://www.elastic.co/docs/reference/beats/filebeat/filebeat-input-filestream#reading-gzip-files
     # #         paths:
     # #           - /var/log/pods/${data.kubernetes.namespace}_${data.kubernetes.pod.name}_${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log*
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
filebeat: deploy k8s: use `compression` instead of `gzip_experimental`
```

the docs will be updated on https://github.com/elastic/beats/issues/47881
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`]~~(https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

If users are using `gzip_experimental`, they will need to change it to `compression: auto`


## How to test this PR locally

Use a filebeat with includes https://github.com/elastic/beats/pull/47893
As this PR is just a config change, you can use the config from here directly on https://github.com/elastic/beats/pull/47893

You can follow the sames steps as https://github.com/elastic/beats/pull/47384. But you just need to check the gzip logs are ingested. No need to check again the edge-case when a container crashes.

## Related issues

- Closes https://github.com/elastic/beats/issues/47882

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
