### PR TITLE
filebeat: improve gzip_experimental deprecation warning

### DIFF
--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -259,9 +259,15 @@ func (c config) checkUnsupportedParams(logger *logp.Logger) {
 				"highly discouraged.")
 	}
 	if c.GZIPExperimental != nil {
-		logger.Named("filestream").Warn(cfgwarn.Deprecate(
-			"",
-			"'gzip_experimental' is deprecated and ignored, set 'compression' instead"))
+		if c.Compression != CompressionNone {
+			logger.Named("filestream").Warn(cfgwarn.Deprecate(
+				"",
+				"'gzip_experimental' is deprecated and ignored. 'compression' is set, using it instead"))
+		} else {
+			logger.Named("filestream").Warn(cfgwarn.Deprecate(
+				"",
+				"'gzip_experimental' is deprecated and ignored, set 'compression' instead"))
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
filebeat: improve gzip_experimental deprecation warning
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None

## How to test this PR locally

Just like the test `TestFilestreamGZIP/GzipExperimentalDeprecationWarningWithCompressionSet`, run filestream with `gzip_experimental: true` and `compression: auto`. Then look for the log
`'gzip_experimental' is deprecated and ignored. 'compression' is set, using it instead`

## Related issues

- Relates https://github.com/elastic/integrations/issues/16219

~~## Use cases~~

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

~~## Screenshots~~

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

~~## Logs~~

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
