### PR TITLE
[docs] Add missing components in changelog fragments.

### DIFF
--- a/changelog/fragments/1764715501-encoding_timestamps.yaml
+++ b/changelog/fragments/1764715501-encoding_timestamps.yaml
@@ -28,7 +28,7 @@ summary: fixes zero time encoding for unix timestamps
 
 # REQUIRED for all kinds
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
-component:
+component: osquerybeat
 
 # AUTOMATED
 # OPTIONAL to manually add other PR URLs

--- a/changelog/fragments/1765279149-ipfrag2.yaml
+++ b/changelog/fragments/1765279149-ipfrag2.yaml
@@ -28,7 +28,7 @@ summary: ipfrag2
 
 # REQUIRED for all kinds
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
-component:
+component: packetbeat
 
 # AUTOMATED
 # OPTIONAL to manually add other PR URLs


### PR DESCRIPTION
A couple of changelog fragments are missing a `component` and causing the [release notes](https://github.com/elastic/beats/blob/main/.github/workflows/release-notes.yml) action to fail.