### PR TITLE
feat: add `add_fields` processor to OTel Beat processor

### DIFF
--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -986,6 +986,9 @@ processors:
     processors:
       - add_cloud_metadata:
       - add_docker_metadata:
+      - add_fields:
+          fields:
+            custom_field: "CustomValue"
       - add_host_metadata:
 exporters:
   debug:
@@ -1043,6 +1046,9 @@ receivers:
     processors:
       - add_cloud_metadata:
       - add_docker_metadata:
+      - add_fields:
+          fields:
+            custom_field: "CustomValue"
       - add_host_metadata:
     logging:
       level: info

--- a/x-pack/otel/processor/beatprocessor/README.md
+++ b/x-pack/otel/processor/beatprocessor/README.md
@@ -18,6 +18,7 @@ Here are the currently supported processors:
 
 - [add_cloud_metadata]
 - [add_docker_metadata]
+- [add_fields]
 - [add_host_metadata]
 - [add_kubernetes_metadata]
 
@@ -144,6 +145,21 @@ processors:
 
 You can configure the Docker metadata enrichment using the options supported by the [add_docker_metadata] processor.
 
+## Using the `add_fields` processor
+
+To use the [add_fields] processor, configure the processor as follows:
+
+```yaml
+processors:
+  beat:
+    processors:
+      - add_fields:
+          fields:
+            custom_field: custom-value
+```
+
+You can configure the processor using the options supported by the [add_fields] processor.
+
 ## Using the `add_host_metadata` processor
 
 To use the [add_host_metadata] processor, configure the processor as follows:
@@ -182,6 +198,7 @@ In the example above, the `container` indexer and the `logs_path` matcher are co
 [Metricbeat receiver]: https://github.com/elastic/beats/tree/main/x-pack/metricbeat/mbreceiver
 [add_cloud_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-cloud-metadata
 [add_docker_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-docker-metadata
+[add_fields]: https://www.elastic.co/docs/reference/beats/filebeat/add-fields
 [add_host_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-host-metadata
 [add_kubernetes_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata
 [indexers]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata#_indexers

--- a/x-pack/otel/processor/beatprocessor/processor.go
+++ b/x-pack/otel/processor/beatprocessor/processor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/otelbeat/otelmap"
+	"github.com/elastic/beats/v7/libbeat/processors/actions/addfields"
 	"github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata"
 	"github.com/elastic/beats/v7/libbeat/processors/add_docker_metadata"
 	"github.com/elastic/beats/v7/libbeat/processors/add_host_metadata"
@@ -87,6 +88,8 @@ func createProcessor(processorNameAndConfig map[string]any, logpLogger *logp.Log
 			processorInstance, createProcessorError = add_cloud_metadata.New(processorConfig, logpLogger)
 		case "add_docker_metadata":
 			processorInstance, createProcessorError = add_docker_metadata.New(processorConfig, logpLogger)
+		case "add_fields":
+			processorInstance, createProcessorError = addfields.CreateAddFields(processorConfig, logpLogger)
 		case "add_host_metadata":
 			processorInstance, createProcessorError = add_host_metadata.New(processorConfig, logpLogger)
 		case "add_kubernetes_metadata":

--- a/x-pack/otel/processor/beatprocessor/processor_test.go
+++ b/x-pack/otel/processor/beatprocessor/processor_test.go
@@ -114,6 +114,19 @@ func TestCreateProcessor(t *testing.T) {
 		assert.Equal(t, "add_docker_metadata", processor.String()[:len("add_docker_metadata")])
 	})
 
+	t.Run("valid add_fields processor config returns processor", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{
+			"add_fields": map[string]any{
+				"fields": map[string]any{
+					"env": "staging",
+				},
+			},
+		}, testLogger())
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		assert.Equal(t, "add_fields", processor.String()[:len("add_fields")])
+	})
+
 	t.Run("valid add_host_metadata processor config returns processor", func(t *testing.T) {
 		processor, err := createProcessor(map[string]any{
 			"add_host_metadata": map[string]any{},


### PR DESCRIPTION
## Proposed commit message

Add `add_fields` processor to the OTel Beat processor.

This allows users to use the `add_fields` processor outside of the Filebeat receiver anywhere in the EDOT Collector pipeline.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

1. Include the processor in Elastic Agent by adding it to https://github.com/elastic/elastic-agent/blob/89e0e9a5b0ebb376773de813a1fd2c0b2f30e74a/internal/pkg/otel/components.go.
2. Build the Elastic Agent binary.
3. Run the Agent with an OTel config that includes the Beat processor.

Example OTel config:

```yaml
service:
  pipelines:
    logs:
      receivers:
        - filebeatreceiver
      processors:
        - beat
      exporters:
        - debug
receivers:
  filebeatreceiver:
    filebeat:
      inputs:
        - type: filestream
          id: logs-from-host
          paths:
            - /var/log/*.log
    processors: []
    path.data: /tmp/1217/data
    path.logs: /tmp/1217/logs
    queue.mem:
      flush.timeout: 0
processors:
  beat:
    processors:
      - add_fields:
          fields:
            custom_field: custom-value
exporters:
  debug:
    use_internal_logger: false
    verbosity: normal
```
