### PR TITLE
[ci] Restore dynamic image setting for FIPS `STACK_VERSION`

### DIFF
--- a/.buildkite/scripts/custom_fips_ech_test.sh
+++ b/.buildkite/scripts/custom_fips_ech_test.sh
@@ -7,9 +7,7 @@ BEAT_PATH=${1:?"Error: Specify the beat path: custom_fips_ech_test.sh [beat_path
 
 trap 'ech_down' EXIT
 
-# TEMPORARY FIX: Use a fixed snapshot version until the snapshot versioning is fixed.
-STACK_VERSION="9.2.0-SNAPSHOT"
-# STACK_VERSION="$(./dev-tools/get_version)-SNAPSHOT"
+STACK_VERSION="$(./dev-tools/get_version)-SNAPSHOT"
 
 ech_up $STACK_VERSION
 


### PR DESCRIPTION
Removes workaround added for `9.2` in https://github.com/elastic/beats/pull/46871/commits/1aa273541fb6499bff404aeeb42923350390b4a2