### PR TITLE
[AutoOps] Fix Bad Auto-merge

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/metricset/register.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/register.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/autoops_es/utils"


### PR DESCRIPTION
This fixes a bad auto-merge that merged out of order: one removed and re-added slices. As a result of the out-of-order merge, it only got removed.