### PR TITLE
fix(ci): restore agentbeat pipeline in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1034,6 +1034,55 @@ spec:
         everyone:
           access_level: BUILD_AND_READ
 
+# TODO: Remove the following pipeline once agentbeat is no longer required by any supported version.
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-beats-xpack-agentbeat
+  description: "Beats x-pack agentbeat pipeline"
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/beats-xpack-agentbeat
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: platform-ingest
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: beats-xpack-agentbeat
+      description: "Beats x-pack agentbeat pipeline"
+    spec:
+      # branch_configuration: "main 8.*"         #TODO: uncomment after tests
+      pipeline_file: ".buildkite/x-pack/pipeline.xpack.agentbeat.yml"
+      maximum_timeout_in_minutes: 120
+      provider_settings:
+        trigger_mode: none # don't trigger jobs from github activity
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_tags: true
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/beats
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: "!main !8.* !9.*"
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: "!main !8.* !9.*"
+      env:
+        # TODO set to true once https://github.com/elastic/ingest-dev/issues/3001 has been resolved
+        ELASTIC_PR_COMMENTS_ENABLED: "false"
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+
+
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
## Proposed commit message

This pipeline was removed as part of https://github.com/elastic/beats/pull/48147. Agentbeat is intended to be removed from 9.3 onwards, but the other supported version branches still rely on it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

- Relates to https://github.com/elastic/beats/pull/48147