### PR TITLE
ci: tentative fix for agent lost in x-pack otel check pipeline

### DIFF
--- a/.buildkite/x-pack/pipeline.xpack.otel.yml
+++ b/.buildkite/x-pack/pipeline.xpack.otel.yml
@@ -33,7 +33,7 @@ steps:
         agents:
           image: "${IMAGE_BEATS_WITH_HOOKS_LATEST}"
           cpu: "4000m"
-          memory: "8Gi"
+          memory: "12Gi"
           # 10GB storage was not enough for check/update.
           ephemeralStorage: "50G"
           useCustomGlobalHooks: true


### PR DESCRIPTION
## Proposed commit message

PR https://github.com/elastic/beats/pull/47873 moved some code to x-pack/otel, which increased the amount of code and dependencies required for the mage check call. After it was merged, we saw an increase in agent lost -1 errors from Buildkite agents, likely due to OOM conditions. This PR increases the amount of memory available to the agent for this stage.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

- Relates to https://github.com/elastic/ingest-dev/issues/6207.
- Relates to https://github.com/elastic/beats/pull/47873.