### PR TITLE
test: add benchmark for OTel Beat processor

### DIFF
--- a/x-pack/otel/processor/beatprocessor/benchmark_test.go
+++ b/x-pack/otel/processor/beatprocessor/benchmark_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
@@ -102,7 +103,7 @@ func benchmarkBeatProcessor(b *testing.B, logCount int, tc testCase) {
 		}
 
 		for b.Loop() {
-			beatProcessor.ConsumeLogs(context.Background(), logs)
+			_, _ = beatProcessor.ConsumeLogs(context.Background(), logs)
 		}
 	})
 }


### PR DESCRIPTION
## Proposed commit message

Adds a microbenchmark to measure the overhead of the OTel Beat processor.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

```bash
cd x-pack/otel/processor/beatprocessor/
go test -benchmem . -run ^$ -bench=BenchmarkBeatProcessor
```

Results from my machine:

```console
goos: darwin
goarch: arm64
pkg: github.com/elastic/beats/v7/x-pack/otel/processor/beatprocessor
cpu: Apple M2 Pro
BenchmarkBeatProcessor/empty_log_record/0_logs-12               338138461                3.519 ns/op           0 B/op          0 allocs/op
BenchmarkBeatProcessor/empty_log_record/1_logs-12               10082673               116.0 ns/op           208 B/op          4 allocs/op
BenchmarkBeatProcessor/empty_log_record/1000_logs-12               10000            111746 ns/op          208001 B/op       4000 allocs/op
BenchmarkBeatProcessor/message/1_logs-12                         2766692               429.6 ns/op           848 B/op          9 allocs/op
BenchmarkBeatProcessor/message/1000_logs-12                         2744            431760 ns/op          848006 B/op       9000 allocs/op
BenchmarkBeatProcessor/Kubernetes_log/1_logs-12                  2112459               565.0 ns/op           976 B/op         13 allocs/op
BenchmarkBeatProcessor/Kubernetes_log/1000_logs-12                  2005            578497 ns/op          976006 B/op      13000 allocs/op
BenchmarkBeatProcessor/Nginx_access_log/1_logs-12                 628468              1814 ns/op            2200 B/op         35 allocs/op
BenchmarkBeatProcessor/Nginx_access_log/1000_logs-12                 637           1847566 ns/op         2200017 B/op      35000 allocs/op
PASS
ok      github.com/elastic/beats/v7/x-pack/otel/processor/beatprocessor 11.602s
```
