### PR TITLE
fix: change source for Noto-CJK font

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -172,9 +172,9 @@ RUN for iter in {1..10}; do \
     dbus-glib libicu mesa-libGL unzip \
     findutils shadow-utils ca-certificates gawk libcap xz tar -y && \
     mkdir -p /usr/share/fonts/google-noto && \
-    curl -LO https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip && \
-    unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/google-noto && \
-    rm -f NotoSansCJKjp-hinted.zip && \
+    curl -L -o NotoSansCJKjp.zip https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip && \
+    unzip NotoSansCJKjp.zip -d /usr/share/fonts/google-noto && \
+    rm -f NotoSansCJKjp.zip && \
     microdnf -y remove unzip && \
     curl -LO https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf && \
     mv NotoSans-Regular.ttf /usr/share/fonts/google-noto && \


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

The source we were using to download the Noto CJK font stopped working.
Switch to the github's repository releases to find the required font.


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I've tested the solution using the fix on elastic-agent. Copying the steps here in case it's useful:

1. Build elastic-agent locally

> DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 PACKAGES=docker EXTERNAL=true mage package

2. Create a fleet agent policy

Go to fleet > Agent policies > Create agent policies

3. Add an agent to the agent policy

Policy options > add agent

Follow steps to run elastic-agent locally. Example:

> docker run --name elastic-agent --rm --env FLEET_ENROLL=1 --env FLEET_URL=<url> --env FLEET_ENROLLMENT_TOKEN="<token>" local/elastic-agent:latest

4. Create a synthetics private location

Go to Synthetics > Settings > Private Locations > Create location

Assign the agent policy to the location

5. Create a browser monitor that uses the private location.

> step("first", async () => {
>     await page.goto('https://zh.wikipedia.org/wiki/%E7%BB%B4%E5%9F%BA%E7%99%BE%E7%A7%91', { waitUntil: 'networkidle' });
> });


Result is correct:

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/a293f167-ce29-4cd9-92f4-2edd05d2be35" />

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
