### PR TITLE
[Stack Monitoring] Trim Trailing `/` After Host URI

### DIFF
--- a/changelog/fragments/1768435100-stack-monitoring-trim-host-trailing-slash.yaml
+++ b/changelog/fragments/1768435100-stack-monitoring-trim-host-trailing-slash.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Stack Monitoring now trims trailing slashes from host URLs for simplicity
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/48426

--- a/metricbeat/module/elasticsearch/node/node_test.go
+++ b/metricbeat/module/elasticsearch/node/node_test.go
@@ -21,10 +21,11 @@ package node
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestFetch(t *testing.T) {
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
-			response, err := ioutil.ReadFile(f)
+			response, err := os.ReadFile(f)
 			require.NoError(t, err)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -128,10 +129,17 @@ func TestFetch(t *testing.T) {
 				}))
 				defer server.Close()
 
+				serverURL := server.URL
+
+				// for an arbitrary request, try configuring with an extra trailing slash
+				if strings.HasPrefix(tt.name, "from config") {
+					serverURL = server.URL + "/"
+				}
+
 				config := map[string]any{
 					"module":     "elasticsearch",
 					"metricsets": []string{"node"},
-					"hosts":      []string{server.URL},
+					"hosts":      []string{serverURL},
 				}
 
 				apiKey := base64.StdEncoding.EncodeToString([]byte(tt.apiKey))


### PR DESCRIPTION
This removes any trailing slash to simplify configuration of both Stack Monitoring and AutoOps hostnames.

If the user accidentally adds the `/`, then historically some requests would succeed and some would fail and, depending on the error handling, the error may not be made clear. This bypasses the whole issue.

## Proposed commit message

Remove trailing `/`s from Stack Monitoring and AutoOps host URIs to avoid accidental and confusing misconfigurations.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

If there is a proxy out there that requires _extra_ trailing `/`s, then this would break it. But obviously the solution is to fix the proxy's misconfiguration.

## How to test this PR locally

Run either Stack Monitoring or AutoOps with a configured host trailing with `/`. AutoOps uses Stack Monitoring to talk to Elasticsearch, so both benefit from this same change.

## Related issues

- Closes https://github.com/elastic/beats/issues/48426

## Use cases

Particularly with Cloud Connected clusters, users have had an accidental habit of typing `http[s]://[host]:9200/`, which triggers unexpected failures for AutoOps for Self-managed.

## Logs

Example of the warning log in the test that I added:

> 2026-01-14T16:51:25.794-0700      WARN    elasticsearch.node      host URI should not have a trailing slash, updated from http://127.0.0.1:60182/ to http://127.0.0.1:60182