### PR TITLE
[AutoOps] Flatten Cluster Settings

### DIFF
--- a/changelog/fragments/1768602570-autoops-flatten-settings.yaml
+++ b/changelog/fragments/1768602570-autoops-flatten-settings.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Flatten AutoOps Cluster Settings to avoid unnecessary nesting and information
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/48453

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.7.17.0.json
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.7.17.0.json
@@ -9,6 +9,7 @@
                     "enable": "true"
                 }
             },
+            "max_shards_per_node": "2000",
             "metadata": {
                 "display_name": "my-cluster"
             }
@@ -17,6 +18,9 @@
     "transient": {
         "action": {
             "auto_create_index": "false"
+        },
+        "cluster": {
+            "max_shards_per_node": "4000"
         }
     },
     "defaults": {
@@ -196,6 +200,11 @@
             "default_keep_alive": "5m",
             "aggs": {
                 "rewrite_to_filter_by_filter": "true"
+            }
+        },
+        "serverless": {
+            "search": {
+                "search_power_min": "3"
             }
         },
         "path": {

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.8.15.3.json
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.8.15.3.json
@@ -12,7 +12,7 @@
                 }
             },
             "metadata": {
-                "display_name": "my-cluster"
+                "display_name": "my-overridden-cluster-name"
             },
             "max_shards_per_node": "4000"
         },
@@ -23,11 +23,21 @@
         },
         "action": {
             "auto_create_index": ".ent-search-*-logs-*,-.ent-search-*,+*"
+        },
+        "serverless": {
+            "search": {
+                "search_power_min": "3"
+            }
         }
     },
     "transient": {
         "action": {
             "auto_create_index": ".ent-search-*-logs-*,-.ent-search-*,+*"
+        },
+        "cluster": {
+            "metadata": {
+                "display_name": "my-cluster"
+            }
         }
     },
     "defaults": {

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
@@ -29,13 +29,15 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]i
 
 	// metrics exist
 	require.True(t, len(*event.MetricSetFields.FlattenKeys()) > 3)
-	require.NotNil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "defaults"))
 
 	// filename includes the "display_name" as the second part
 	displayName := strings.Split(data.File, ".")[1]
 
-	require.Equal(t, displayName, auto_ops_testing.GetObjectValue(event.MetricSetFields, "persistent.cluster.metadata.display_name"))
-	require.ElementsMatch(t, []string{"/app/data"}, auto_ops_testing.GetObjectValue(event.MetricSetFields, "defaults.path.data"))
+	// Settings are flattened with precedence: transient > persistent > defaults
+	require.Equal(t, "4000", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.max_shards_per_node"))
+	require.Equal(t, displayName, auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.metadata.display_name"))
+	require.ElementsMatch(t, []string{"/app/data"}, auto_ops_testing.GetObjectValue(event.MetricSetFields, "path.data"))
+	require.Equal(t, "3", auto_ops_testing.GetObjectValue(event.MetricSetFields, "serverless.search.search_power_min"))
 
 	// schema is expected to drop this field if it appears (it does in one file)
 	require.Nil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "ignored_field"))


### PR DESCRIPTION
This removes the unnecessary exporting of `cluster_settings` by only sending the settings _that apply_. For instance, if a setting is both set as a transient and persistent setting, then only the transient value matters.

## Proposed commit message

Flatten the cluster settings to avoid wasting bandwidth sending unnecessary information that is unused.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

Flattening the data actually forces it into the state that we store it as, which allows us to stop doing that work.

## How to test this PR locally

- Observe the test configurations.
- Run it against a cluster with cluster settings that override `defaults`, `persistent`, and use `transient` to ensure order is used properly (which can be observed in the tests that use the example files).

## Related issues

- Closes https://github.com/elastic/beats/issues/48453

## Use cases

Ensure the comparison of settings exclusively relies on the _relevant_ settings and ignore anything else.