### PR TITLE
Fix TestDataAddedAfterCloseInactive integration test

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -210,6 +210,7 @@ func startHarvester(
 		// until a slot is available. Without this early check, repeated file events
 		// would spawn goroutines that wait on the semaphore only to discover (after
 		// acquiring it) that a harvester is already running, causing a goroutine leak.
+		ctx.Logger.Debug("Harvester already running")
 		return nil
 	}
 


### PR DESCRIPTION
## Proposed commit message
The test waits for the "Harvester already running" that is not reachable anymore. Broken after https://github.com/elastic/beats/pull/48445.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~