### PR TITLE
Feat/support kafka bulk config

### DIFF
--- a/docs/reference/filebeat/filebeat-reference-yml.md
+++ b/docs/reference/filebeat/filebeat-reference-yml.md
@@ -2052,6 +2052,14 @@ output.elasticsearch:
   # is 0.
   #bulk_flush_frequency: 0s
 
+  # The best-effort number of bytes needed to trigger a flush. If the batch reaches 
+  # this size, it will be sent immediately. 0 means disabled. The default is 0.
+  #bulk_flush_bytes: 0
+
+  # The best-effort number of messages needed to trigger a flush. If the batch reaches
+  # this count, it will be sent immediately. 0 means disabled. The default is 0.
+  #bulk_flush_messages: 0
+
   # The number of seconds to wait for responses from the Kafka brokers before
   # timing out. The default is 30s.
   #timeout: 30s

--- a/docs/reference/filebeat/kafka-output.md
+++ b/docs/reference/filebeat/kafka-output.md
@@ -276,6 +276,13 @@ The maximum number of events to bulk in a single Kafka request. The default is 2
 
 Duration to wait before sending bulk Kafka request. 0 is no delay. The default is 0.
 
+### `bulk_flush_bytes` [_bulk_flush_bytes]
+
+The best-effort number of bytes needed to trigger a flush. If the batch reaches this size, it will be sent immediately. 0 means disabled. The default is 0.
+
+### `bulk_flush_messages` [bulk_flush_messages]
+
+The best-effort number of messages needed to trigger a flush. If the batch reaches this count, it will be sent immediately. 0 means disabled. The default is 0.
 
 ### `timeout` [_timeout_4]
 

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -59,6 +59,8 @@ type kafkaConfig struct {
 	Partition          map[string]*config.C      `config:"partition"`
 	KeepAlive          time.Duration             `config:"keep_alive"          validate:"min=0"`
 	MaxMessageBytes    *int                      `config:"max_message_bytes"   validate:"min=1"`
+	BulkFlushBytes     int                       `config:"bulk_flush_bytes"`
+	BulkFlushMessages  int                       `config:"bulk_flush_messages"`
 	RequiredACKs       *int                      `config:"required_acks"       validate:"min=-1"`
 	BrokerTimeout      time.Duration             `config:"broker_timeout"      validate:"min=1"`
 	Compression        string                    `config:"compression"`
@@ -298,6 +300,13 @@ func newSaramaConfig(log *logp.Logger, config *kafkaConfig) (*sarama.Config, err
 	if config.BulkFlushFrequency > 0 {
 		k.Producer.Flush.Frequency = config.BulkFlushFrequency
 	}
+	if config.BulkFlushBytes > 0 {
+		k.Producer.Flush.Bytes = config.BulkFlushBytes
+	}
+	if config.BulkFlushMessages > 0 {
+		k.Producer.Flush.Messages = config.BulkFlushMessages
+	}
+
 
 	// configure client ID
 	k.ClientID = config.ClientID

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -281,6 +281,14 @@ The maximum number of events to bulk in a single Kafka request. The default is 2
 
 Duration to wait before sending bulk Kafka request. 0 is no delay. The default is 0.
 
+===== `bulk_flush_bytes`
+
+The best-effort number of bytes needed to trigger a flush. If the batch reaches this size, it will be sent immediately. 0 means disabled. The default is 0.
+
+===== `bulk_flush_messages`
+
+The best-effort number of messages needed to trigger a flush. If the batch reaches this count, it will be sent immediately. 0 means disabled. The default is 0.
+
 ===== `timeout`
 
 The number of seconds to wait for responses from the Kafka brokers before timing


### PR DESCRIPTION
Type of change:
- Enhancement

## Proposed commit message

Just add two Kafka output configurations to control bulk behavior. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
   - no need, just leave it empty to use default
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
    - no need, just add a configuration for third party kafka sdk (sarama)
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

NO disruption by default.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes  #48503

