### PR TITLE
harvester_test: Fix flakiness issues

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester_test.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -43,6 +42,23 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
+
+const (
+	eventuallyTimeout  = 5 * time.Second
+	eventuallyInterval = 10 * time.Millisecond
+)
+
+// requireEventually wraps require.Eventually with consistent timeout and polling interval.
+func requireEventually(t *testing.T, condition func() bool, msgAndArgs ...any) {
+	t.Helper()
+	require.Eventually(t, condition, eventuallyTimeout, eventuallyInterval, msgAndArgs...)
+}
+
+// requireEventuallyWithT wraps require.EventuallyWithT with consistent timeout and polling interval.
+func requireEventuallyWithT(t *testing.T, condition func(c *assert.CollectT), msgAndArgs ...any) {
+	t.Helper()
+	require.EventuallyWithT(t, condition, eventuallyTimeout, eventuallyInterval, msgAndArgs...)
+}
 
 func TestReaderGroup(t *testing.T) {
 	requireGroupSuccess := func(t *testing.T, ctx context.Context, cf context.CancelFunc, err error) {
@@ -101,19 +117,11 @@ func TestReaderGroup(t *testing.T) {
 func TestDefaultHarvesterGroup(t *testing.T) {
 	source := &testSource{name: "/path/to/test"}
 
-	requireSourceAddedToBookkeeper := func(t *testing.T, hg *defaultHarvesterGroup, s Source) {
-		require.True(t, hg.readers.hasID(hg.identifier.ID(s)))
-	}
-
-	requireSourceRemovedFromBookkeeper := func(t *testing.T, hg *defaultHarvesterGroup, s Source) {
-		require.False(t, hg.readers.hasID(hg.identifier.ID(s)))
-	}
-
 	t.Run("assert a harvester is started in a goroutine", func(t *testing.T) {
 		var wg sync.WaitGroup
 
 		mockHarvester := &mockHarvester{onRun: correctOnRun, wg: &wg}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
 		defer goroutinesChecker.WaitUntilOriginalCount()
@@ -129,7 +137,10 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 
 		require.Equal(t, 1, mockHarvester.getRunCount())
 
-		requireSourceRemovedFromBookkeeper(t, hg, source)
+		// Wait for source to be removed from bookkeeper.
+		requireEventually(t,
+			func() bool { return !hg.readers.hasID(hg.identifier.ID(source)) },
+			"source should be removed from bookkeeper")
 		// stopped source can be stopped
 		require.Nil(t, hg.StopHarvesters())
 	})
@@ -162,8 +173,7 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 			onRun: harvesterRun,
 			wg:    &wg,
 		}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
-		hg.tg = task.NewGroup(1, time.Second, logptest.NewTestingLogger(t, ""), "")
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 1)
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
 		defer goroutinesChecker.WaitUntilOriginalCount()
@@ -210,8 +220,13 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 
 		require.Equal(t, 2, mockHarvester.getRunCount())
 
-		requireSourceRemovedFromBookkeeper(t, hg, source1)
-		requireSourceRemovedFromBookkeeper(t, hg, source2)
+		// Wait for sources to be removed from bookkeeper.
+		requireEventually(t,
+			func() bool {
+				return !hg.readers.hasID(hg.identifier.ID(source1)) &&
+					!hg.readers.hasID(hg.identifier.ID(source2))
+			},
+			"sources should be removed from bookkeeper")
 
 		// stopped source can be stopped
 		require.Nil(t, hg.StopHarvesters())
@@ -219,44 +234,70 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 
 	t.Run("assert a harvester can be stopped and removed from bookkeeper", func(t *testing.T) {
 		mockHarvester := &mockHarvester{onRun: blockUntilCancelOnRun}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
+		defer goroutinesChecker.WaitUntilOriginalCount()
 
 		ctx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
 		hg.Start(ctx, source)
 
-		goroutinesChecker.WaitUntilIncreased(1)
-		// wait until harvester is started
-		require.Eventually(t,
-			func() bool { return mockHarvester.getRunCount() == 1 },
-			5*time.Second,
-			10*time.Millisecond,
-			"run count must equal one")
-		requireSourceAddedToBookkeeper(t, hg, source)
+		// Wait until harvester is started and registered in bookkeeper.
+		requireEventually(t,
+			func() bool {
+				return mockHarvester.getRunCount() == 1 && hg.readers.hasID(hg.identifier.ID(source))
+			},
+			"harvester should be running and registered")
 		// after started, stop it
 		hg.Stop(source)
-		_, err := goroutinesChecker.WaitUntilOriginalCount()
-		require.NoError(t, err)
-		requireSourceRemovedFromBookkeeper(t, hg, source)
+		// Wait for source to be removed from bookkeeper.
+		requireEventually(t,
+			func() bool { return !hg.readers.hasID(hg.identifier.ID(source)) },
+			"source should be removed from bookkeeper")
+		// StopHarvesters waits for all goroutines to fully complete, including deferred logging.
+		require.NoError(t, hg.StopHarvesters())
 	})
 
-	t.Run("assert a harvester for same source cannot be started", func(t *testing.T) {
+	sameSourceTest := func(t *testing.T, limit uint64) {
 		mockHarvester := &mockHarvester{onRun: blockUntilCancelOnRun}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
+		hg := testDefaultHarvesterGroup(t, mockHarvester, limit)
 		inputCtx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
 		defer goroutinesChecker.WaitUntilOriginalCount()
 
+		// Start first harvester and wait for it to be registered
 		hg.Start(inputCtx, source)
-		hg.Start(inputCtx, source)
+		requireEventually(t,
+			func() bool { return hg.readers.hasID(hg.identifier.ID(source)) },
+			"first harvester should be registered")
+		// To avoid any kind of race, wait for the mock harvester to be running as well since that happens _after_ the
+		// source ID is registered
+		requireEventuallyWithT(t,
+			func(c *assert.CollectT) {
+				assert.Equal(c, 1, mockHarvester.getRunCount())
+			},
+			"one mock harvester should be running")
 
-		goroutinesChecker.WaitUntilIncreased(2)
-		// error is expected as a harvester group was expected to start twice for the same source
-		for !hg.readers.hasID(hg.identifier.ID(source)) {
+		// Repeatedly try to start additional harvesters for the same source
+		// None of them should succeed because one is already running
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for range 20 {
+				hg.Start(inputCtx, source)
+				time.Sleep(time.Millisecond / 4)
+			}
+		}()
+
+		// Verify runCount stays at 1 while we start new harvesters
+		for { // Check at least once
+			assert.Equal(t, 1, mockHarvester.getRunCount())
+			if isClosed(done) {
+				break
+			}
+			time.Sleep(time.Millisecond / 10) // tiny sleep to not monopolize the CPU
 		}
-		time.Sleep(3 * time.Millisecond)
 
 		hg.Stop(source)
 
@@ -264,11 +305,18 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, 1, mockHarvester.getRunCount())
+	}
+	t.Run("assert a harvester for same source cannot be started", func(t *testing.T) {
+		for _, limit := range []uint64{0, 1, 100} {
+			t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+				sameSourceTest(t, limit)
+			})
+		}
 	})
 
 	t.Run("assert a harvester panic is handled", func(t *testing.T) {
 		mockHarvester := &mockHarvester{onRun: panicOnRun}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
 		defer func() {
 			if v := recover(); v != nil {
 				t.Errorf("did not recover from harvester panic in defaultHarvesterGroup")
@@ -276,16 +324,21 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 		}()
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
+		defer goroutinesChecker.WaitUntilOriginalCount()
 
 		ctx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
 		hg.Start(ctx, source)
 
-		// wait until harvester is stopped
-		goroutinesChecker.WaitUntilOriginalCount()
+		// First wait for the harvester to run (runCount increases when Run is called,
+		// before the panic occurs).
+		requireEventually(t,
+			func() bool { return mockHarvester.getRunCount() == 1 },
+			"harvester should have run once")
 
-		// make sure harvester had run once
-		require.Equal(t, 1, mockHarvester.getRunCount())
-		requireSourceRemovedFromBookkeeper(t, hg, source)
+		// Then wait for source to be removed from bookkeeper after panic recovery.
+		requireEventually(t,
+			func() bool { return !hg.readers.hasID(hg.identifier.ID(source)) },
+			"source should be removed from bookkeeper after panic")
 
 		require.Nil(t, hg.StopHarvesters())
 	})
@@ -293,8 +346,7 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 	t.Run("assert a harvester error is handled", func(t *testing.T) {
 		testLog := &testLogger{}
 		mockHarvester := &mockHarvester{onRun: errorOnRun}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
-		hg.tg = task.NewGroup(0, 100*time.Millisecond, testLog, "")
+		hg := testDefaultHarvesterGroupWithLogger(t, mockHarvester, 0, testLog)
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
 		defer goroutinesChecker.WaitUntilOriginalCount()
@@ -302,9 +354,10 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 		ctx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
 		hg.Start(ctx, source)
 
-		goroutinesChecker.WaitUntilOriginalCount()
-
-		requireSourceRemovedFromBookkeeper(t, hg, source)
+		// Wait for the harvester to be removed from the bookkeeper after the error.
+		requireEventually(t,
+			func() bool { return !hg.readers.hasID(hg.identifier.ID(source)) },
+			"source should be removed from bookkeeper after error")
 
 		err := hg.StopHarvesters()
 		assert.NoError(t, err)
@@ -315,7 +368,7 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 	t.Run("assert already locked resource has to wait", func(t *testing.T) {
 		var wg sync.WaitGroup
 		mockHarvester := &mockHarvester{onRun: correctOnRun, wg: &wg}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
 		inputCtx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
 
 		r, err := lock(inputCtx, hg.store, hg.identifier.ID(source))
@@ -328,15 +381,11 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 		wg.Add(1)
 		hg.Start(inputCtx, source)
 
-		goroutinesChecker.WaitUntilIncreased(1)
-		ok := false
-		for !ok {
-			// wait until harvester is added to the bookeeper
-			ok = hg.readers.hasID(hg.identifier.ID(source))
-			if ok {
-				releaseResource(r)
-			}
-		}
+		// Wait until harvester is added to the bookkeeper.
+		requireEventually(t,
+			func() bool { return hg.readers.hasID(hg.identifier.ID(source)) },
+			"harvester should be registered in readers table")
+		releaseResource(r)
 
 		// wait until harvester.Run is done
 		wg.Wait()
@@ -349,8 +398,7 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 	t.Run("assert already locked resource has no problem when harvestergroup is cancelled", func(t *testing.T) {
 		testLog := &testLogger{}
 		mockHarvester := &mockHarvester{onRun: correctOnRun}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
-		hg.tg = task.NewGroup(0, 50*time.Millisecond, testLog, "")
+		hg := testDefaultHarvesterGroupWithLogger(t, mockHarvester, 0, testLog)
 		inputCtx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
@@ -364,7 +412,11 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 
 		hg.Start(inputCtx, source)
 
-		goroutinesChecker.WaitUntilIncreased(1)
+		// Wait for the harvester to be registered in the readers table.
+		requireEventually(t,
+			func() bool { return hg.readers.hasID(hg.identifier.ID(source)) },
+			"harvester should be registered in readers table")
+
 		assert.NoError(t, hg.StopHarvesters())
 
 		assert.Equal(t, 0, mockHarvester.getRunCount())
@@ -373,7 +425,7 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 	t.Run("assert harvester can be restarted", func(t *testing.T) {
 		var wg sync.WaitGroup
 		mockHarvester := &mockHarvester{onRun: blockUntilCancelOnRun, wg: &wg}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
 		inputCtx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
 
 		goroutinesChecker := resources.NewGoroutinesChecker()
@@ -395,60 +447,6 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 		wg.Wait()
 
 		require.Equal(t, 2, mockHarvester.getRunCount())
-	})
-
-	t.Run("assert repeated start for same source does not leak goroutines with harvester_limit", func(t *testing.T) {
-		mockHarvester := &mockHarvester{onRun: blockUntilCancelOnRun}
-		hg := testDefaultHarvesterGroup(t, mockHarvester)
-		// Set harvester_limit to 1 - this creates the semaphore that caused the leak
-		hg.tg = task.NewGroup(1, time.Second, logptest.NewTestingLogger(t, ""), "")
-		inputCtx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
-
-		goroutinesChecker := resources.NewGoroutinesChecker()
-
-		// Start the first harvester - this should spawn exactly 1 goroutine
-		hg.Start(inputCtx, source)
-
-		// Wait for the harvester to be running
-		require.EventuallyWithT(t,
-			func(c *assert.CollectT) {
-				assert.Equal(c, 1, mockHarvester.getRunCount())
-			},
-			5*time.Second,
-			10*time.Millisecond,
-			"harvester should be running")
-
-		// Record goroutine count after first harvester starts
-		goroutinesChecker.WaitUntilIncreased(1)
-		afterFirstStart := runtime.NumGoroutine()
-
-		// Simulate repeated file events by calling Start multiple times
-		const repeatCount = 10
-		for range repeatCount {
-			hg.Start(inputCtx, source)
-		}
-
-		// Give time for any leaked goroutines to be spawned
-		// Check that goroutine count hasn't grown significantly
-		// With the fix: should still be ~afterFirstStart (no new goroutines)
-		// Without the fix: would be afterFirstStart + repeatCount (goroutines waiting on semaphore)
-		assert.Never(t, func() bool {
-			currentGoroutines := runtime.NumGoroutine()
-			goroutineGrowth := currentGoroutines - afterFirstStart
-			return goroutineGrowth > 2
-		}, 50*time.Millisecond, 10*time.Millisecond, "goroutine count should not grow significantly after repeated Start calls")
-
-		// Cleanup
-		hg.Stop(source)
-		require.NoError(t, hg.StopHarvesters())
-
-		// Verify only 1 harvester actually ran
-		require.Equal(t, 1, mockHarvester.getRunCount(),
-			"only one harvester should have run despite multiple Start calls")
-
-		// Ensure all goroutines are cleaned up
-		_, err := goroutinesChecker.WaitUntilOriginalCount()
-		require.NoError(t, err, "all goroutines should be cleaned up")
 	})
 }
 
@@ -479,7 +477,7 @@ func TestCursorAllEventsPublished(t *testing.T) {
 
 	var cursor Cursor
 	mockHarvester := &mockHarvester{onRun: runFn, wg: &wg}
-	hg := testDefaultHarvesterGroup(t, mockHarvester)
+	hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
 	hg.pipeline = &MockPipeline{
 		// Define the callback that will be called before each event is
 		// published/acknowledged, when this callback is called, the
@@ -581,14 +579,18 @@ func TestCursorAllEventsPublished(t *testing.T) {
 		"once the harvester is done, the resource must be unlocked, 'pending' must be 0")
 }
 
-func testDefaultHarvesterGroup(t *testing.T, mockHarvester Harvester) *defaultHarvesterGroup {
+func testDefaultHarvesterGroup(t *testing.T, mockHarvester Harvester, limit uint64) *defaultHarvesterGroup {
+	return testDefaultHarvesterGroupWithLogger(t, mockHarvester, limit, logptest.NewTestingLogger(t, ""))
+}
+
+func testDefaultHarvesterGroupWithLogger(t *testing.T, mockHarvester Harvester, limit uint64, logger task.Logger) *defaultHarvesterGroup {
 	return &defaultHarvesterGroup{
 		readers:    newReaderGroup(),
 		pipeline:   &MockPipeline{},
 		harvester:  mockHarvester,
 		store:      testOpenStore(t, "test", nil),
 		identifier: &SourceIdentifier{"filestream::.global::"},
-		tg:         task.NewGroup(0, time.Second, logptest.NewTestingLogger(t, ""), ""),
+		tg:         task.NewGroup(limit, 5*time.Second, logger, ""),
 	}
 }
 
@@ -745,4 +747,13 @@ type mockStatusReporter struct{}
 
 // UpdateStatus is a no-op
 func (m mockStatusReporter) UpdateStatus(status status.Status, msg string) {
+}
+
+func isClosed(done chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+	}
+	return false
 }

--- a/libbeat/tests/resources/goroutines.go
+++ b/libbeat/tests/resources/goroutines.go
@@ -102,11 +102,3 @@ func (c *GoroutinesChecker) WaitUntilOriginalCount() (int, error) {
 	}
 	return after, ErrTimeout
 }
-
-// WaitUntilIncreased waits till the number of goroutines is n plus the number
-// before creating the checker.
-func (c *GoroutinesChecker) WaitUntilIncreased(n int) {
-	for runtime.NumGoroutine() < c.before+n {
-		time.Sleep(10 * time.Millisecond)
-	}
-}


### PR DESCRIPTION
## Proposed commit message
- Fix "assert a harvester for same source cannot be started" test which was race-y, especially after #48445. The improved test correctly waits first for the harvester to be started and then starts multiple harvesters to assert they don't run despite the existing one.
- `WaitUntilIncreased` is unreliable and race-y. It can miss a goroutine starting before its invocation and it can have other edge cases as well, for example GC goroutines. I've completely deleted the function to avoid the foot gun.
- Fix multiple other synchronization failures discovered via the stresstest script.
- Some refactoring to use consistent timeouts, helper functions etc.
- Test "assert repeated start for same source does not leak goroutines with harvester_limit" is now merged with "assert a harvester for same source cannot be started"

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

With the stress test script. I run significantly stressful tests on an c7a.8xlarge EC2 instance (32 CPUs):
```shell
+ script/stresstest.sh ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 10 -count 10000
...
2m41s: 10000 runs total, 0 failures
+ script/stresstest.sh --race ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 10 -count 1000
...
1m59s: 1000 runs total, 0 failures
+ script/stresstest.sh ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 30 -count 30000
...
2m41s: 30000 runs total, 0 failures
+ script/stresstest.sh --race ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 30 -count 3000
...
1m59s: 3000 runs total, 0 failures
+ script/stresstest.sh ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 100 -count 100000
...
2m42s: 100000 runs total, 0 failures
+ script/stresstest.sh --race ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 100 -count 10000
...
1m59s: 10000 runs total, 0 failures
+ script/stresstest.sh ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 1000 -count 2000000
...
16m55s: 2000000 runs total, 0 failures
+ script/stresstest.sh --race ./filebeat/input/filestream/internal/input-logfile TestDefaultHarvesterGroup -p 1000 -count 200000
...
6m22s: 200000 runs total, 0 failures
```

## Related issues

- Closes #45906
- Relates #48445
