### PR TITLE
filebeat/filestream: Use gzip.Reader.Reset instead of Close+NewReader

### DIFF
--- a/filebeat/input/filestream/file.go
+++ b/filebeat/input/filestream/file.go
@@ -157,13 +157,10 @@ func (r *gzipSeekerReader) Seek(offset int64, whence int) (int64, error) {
 				"gzipSeekerReader: could not seek to 0: %w", err)
 		}
 
-		// it'll create a new reader, so this error can be safely ignored
-		_ = r.gzr.Close()
-
-		r.gzr, err = gzip.NewReader(r.f)
+		err = r.gzr.Reset(r.f)
 		if err != nil {
 			return n, fmt.Errorf(
-				"gzipSeekerReader: could not create new gzip reader: %w", err)
+				"gzipSeekerReader: could not reset gzip reader: %w", err)
 		}
 		r.offset = 0
 


### PR DESCRIPTION
## Proposed commit message

filebeat/filestream: Use gzip.Reader.Reset instead of Close+NewReader

Replace the pattern of closing the gzip reader and creating a new one with a call to gzip.Reader.Reset() in gzipSeekerReader.Seek().

`Reset()` is the idiomatic way to reuse a gzip reader when switching to a new underlying reader. It:
- Reuses internal buffers instead of allocating new ones, reducing memory pressure and GC overhead
- Is semantically equivalent to creating a new reader (discards current state and reinitializes)
- Eliminates the unnecessary `Close()` call whose error was being ignored anyway

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

Run the gzip-related unit and integration tests

## Related issues

- I discovered this while reviewing https://github.com/elastic/beats/pull/48506. However, if I am not mistaken, it does not lead to less `open` syscalls.