### PR TITLE
Fix linter errors, overflows in mysql parser

### DIFF
--- a/changelog/fragments/1769464841-clean-up-mysql-parsers.yaml
+++ b/changelog/fragments/1769464841-clean-up-mysql-parsers.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Clean int overloads and array access in mysql parsers
+summary: Clean int overflows and array access in mysql parsers
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -222,9 +222,12 @@ func (mysql *mysqlPlugin) setFromConfig(config *mysqlConfig) {
 
 func (mysql *mysqlPlugin) getTransaction(k common.HashableTCPTuple) *mysqlTransaction {
 	v := mysql.transactions.Get(k)
-	if trans, ok := v.(*mysqlTransaction); ok && v != nil {
-		return trans
+	if v != nil {
+		if trans, ok := v.(*mysqlTransaction); ok {
+			return trans
+		}
 	}
+
 	return nil
 }
 
@@ -238,9 +241,12 @@ type mysqlStmtMap map[int]*mysqlStmtData
 
 func (mysql *mysqlPlugin) getStmtsMap(k common.HashableTCPTuple) mysqlStmtMap {
 	v := mysql.prepareStatements.Get(k)
-	if stmtMap, ok := v.(mysqlStmtMap); ok && v != nil {
-		return stmtMap
+	if v != nil {
+		if stmtMap, ok := v.(mysqlStmtMap); ok {
+			return stmtMap
+		}
 	}
+
 	return nil
 }
 
@@ -383,7 +389,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 				// string[1] sql state marker
 				// string[5] sql state
 				// string<EOF> error message
-				if (m.start + 13) > len(s.data) {
+				if (m.start + 13) >= len(s.data) {
 					logp.Warn("MySql Error code is the wrong size. Ignoring.")
 					return false, false
 				}
@@ -1195,9 +1201,13 @@ func (mysql *mysqlPlugin) publishTransaction(t *mysqlTransaction) {
 	pbf.AddIP(t.dst.IP)
 	if t.bytesIn < math.MaxInt64 {
 		pbf.Source.Bytes = int64(t.bytesIn)
+	} else {
+		pbf.Source.Bytes = math.MaxInt64
 	}
 	if t.bytesOut < math.MaxInt64 {
 		pbf.Destination.Bytes = int64(t.bytesOut)
+	} else {
+		pbf.Destination.Bytes = math.MaxInt64
 	}
 
 	pbf.Event.Dataset = "mysql"


### PR DESCRIPTION
## Proposed commit message

This adds a few checks for integer overflows, linter issues, and array OOB access in the MySQL processor.

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
