### PR TITLE
fix(otel): align elasticsearchexporter retry behavior with standalone beats

### DIFF
--- a/x-pack/otel/beatconverter/beatconverter_test.go
+++ b/x-pack/otel/beatconverter/beatconverter_test.go
@@ -33,6 +33,19 @@ exporters:
       initial_interval: 1s
       max_interval: 1m0s
       max_retries: 3
+      retry_on_status:
+        - 429
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        - 506
+        - 507
+        - 508
+        - 510
+        - 511
     user: elastic
     max_conns_per_host: 1
     logs_dynamic_pipeline:
@@ -197,6 +210,19 @@ exporters:
       initial_interval: 1s
       max_interval: 1m0s
       max_retries: 3
+      retry_on_status:
+        - 429
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        - 506
+        - 507
+        - 508
+        - 510
+        - 511
     user: elastic-cloud
     logs_dynamic_pipeline:
       enabled: true
@@ -668,6 +694,19 @@ exporters:
       initial_interval: 1s
       max_interval: 1m0s
       max_retries: 3
+      retry_on_status:
+        - 429
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        - 506
+        - 507
+        - 508
+        - 510
+        - 511
     logs_index: some-index
     password: changeme
     user: elastic

--- a/x-pack/otel/oteltranslate/outputs/elasticsearch/config_otel_test.go
+++ b/x-pack/otel/oteltranslate/outputs/elasticsearch/config_otel_test.go
@@ -58,6 +58,19 @@ retry:
   initial_interval: 42s
   max_interval: 7m0s
   max_retries: 3
+  retry_on_status:
+    - 429
+    - 500
+    - 501
+    - 502
+    - 503
+    - 504
+    - 505
+    - 506
+    - 507
+    - 508
+    - 510
+    - 511
 sending_queue:
   batch:
     flush_timeout: 10s
@@ -106,6 +119,19 @@ retry:
   initial_interval: 1s
   max_interval: 1m0s
   max_retries: 3
+  retry_on_status:
+    - 429
+    - 500
+    - 501
+    - 502
+    - 503
+    - 504
+    - 505
+    - 506
+    - 507
+    - 508
+    - 510
+    - 511
 sending_queue:
   batch:
     flush_timeout: 10s
@@ -156,6 +182,19 @@ retry:
   initial_interval: 1s
   max_interval: 1m0s
   max_retries: 3
+  retry_on_status:
+    - 429
+    - 500
+    - 501
+    - 502
+    - 503
+    - 504
+    - 505
+    - 506
+    - 507
+    - 508
+    - 510
+    - 511
 logs_index: some-index
 password: changeme
 user: elastic
@@ -214,6 +253,19 @@ retry:
   initial_interval: 5s
   max_interval: 5m0s
   max_retries: 3
+  retry_on_status:
+    - 429
+    - 500
+    - 501
+    - 502
+    - 503
+    - 504
+    - 505
+    - 506
+    - 507
+    - 508
+    - 510
+    - 511
 logs_index: some-index
 logs_dynamic_pipeline:
   enabled: true
@@ -311,6 +363,19 @@ retry:
   initial_interval: 1s
   max_interval: 1m0s
   max_retries: 3
+  retry_on_status:
+    - 429
+    - 500
+    - 501
+    - 502
+    - 503
+    - 504
+    - 505
+    - 506
+    - 507
+    - 508
+    - 510
+    - 511
 logs_dynamic_pipeline:
   enabled: true  
 max_conns_per_host: 1


### PR DESCRIPTION
## Proposed commit message

The elasticsearch output in standalone Beats retries 429 and 5xx errors
by default, as well as 413 after splitting the problematic batch.
For the elasticsearchexporter, we can use the retry_on_status setting
to specify which status codes should be retried, matching the standard
Beats behavior. Currently, this setting is not configured, so only 429
responses are retried which can lead to data loss.

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).


## Related issues

-
