### PR TITLE
[AutoOps] Ignore `persistent` typed tasks

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/tasks_management/_meta/test/tasks.multi.8.15.3.json
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/_meta/test/tasks.multi.8.15.3.json
@@ -1,5 +1,26 @@
 {
     "tasks": {
+        "persistent:1": {
+            "node": "node1",
+            "id": 70238705,
+            "type": "persistent",
+            "action": "geoip-downloader[c]",
+            "status": {
+            "successful_downloads": 141,
+            "failed_downloads": 0,
+            "total_download_time": 573780,
+            "databases_count": 3,
+            "skipped_updates": 0,
+            "expired_databases": 0
+            },
+            "description": "id=geoip-downloader",
+            "start_time_in_millis": 1757650794568,
+            "running_time_in_nanos": 11996035542195824,
+            "cancellable": true,
+            "cancelled": false,
+            "parent_task_id": "cluster:211",
+            "headers": {}
+        },
         "node1:45": {
             "node": "node1",
             "id": 45,

--- a/x-pack/metricbeat/module/autoops_es/tasks_management/_meta/test/tasks.no_description.8.15.3.json
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/_meta/test/tasks.no_description.8.15.3.json
@@ -1,5 +1,25 @@
 {
     "tasks": {
+        "persistent:1": {
+            "node": "node1",
+            "id": 70238705,
+            "type": "persistent",
+            "action": "geoip-downloader[c]",
+            "status": {
+            "successful_downloads": 141,
+            "failed_downloads": 0,
+            "total_download_time": 573780,
+            "databases_count": 3,
+            "skipped_updates": 0,
+            "expired_databases": 0
+            },
+            "start_time_in_millis": 1757650794568,
+            "running_time_in_nanos": 11996035542195824,
+            "cancellable": true,
+            "cancelled": false,
+            "parent_task_id": "cluster:211",
+            "headers": {}
+        },
         "node1:45": {
             "node": "node1",
             "id": 45,

--- a/x-pack/metricbeat/module/autoops_es/tasks_management/data.go
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/data.go
@@ -35,7 +35,7 @@ var taskSchema = s.Schema{
 }
 
 type GroupedTasks struct {
-	Tasks map[string]map[string]interface{} `json:"tasks"`
+	Tasks map[string]map[string]any `json:"tasks"`
 }
 
 // Get the value from the environment for the TASK_RUNTIME_THRESHOLD_IN_SECONDS_NAME field.
@@ -54,6 +54,14 @@ func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, nodeTasks *GroupedT
 
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed applying task schema for %v: %w", taskId, err))
+			continue
+		}
+
+		// the schema validated that the value exists as a string
+		taskType, _ := task.GetValue("task_type")
+
+		// skip persistent tasks
+		if taskType == "persistent" {
 			continue
 		}
 


### PR DESCRIPTION
This adds logic to explicitly ignore persistent tasks incase we ever receive them as part of a response (we don't currently, but may in the future and this avoids any issues with future versions).

This is currently a non-issue, but it is intended to avoid the potential future issue that it presents.

## Proposed commit message

AutoOps should avoid tracking persistent tasks, which is already the behavior based on the request, but a future release of ES could change that (this is not planned or expected, but this avoids the potential).

## Disruptive User Impact

None. Existing behavior is unchanged because the current request does not get persistent tasks _and we do not want them anyway_.
