### PR TITLE
[DRAFT] add Otel tracing to filebeat receiver

### DIFF
--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -156,6 +156,7 @@ func (r *runner) Start() {
 			Cancelation:     r.sig,
 			MetricsRegistry: reg,
 			Logger:          log,
+			TracerProvider:  r.agent.TracerProvider,
 		}
 		ctx = ctx.WithStatusReporter(r.statusReporter)
 

--- a/filebeat/input/v2/input.go
+++ b/filebeat/input/v2/input.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/monitoring/inputmon"
@@ -86,6 +88,9 @@ type Context struct {
 	// Logger provides a structured logger to inputs. The logger is initialized
 	// with labels that will identify logs for the input.
 	Logger *logp.Logger
+
+	// TracerProvider provides the OpenTelemetry TracerProvider for creating tracers.
+	TracerProvider trace.TracerProvider
 
 	// The input ID.
 	ID string

--- a/go.mod
+++ b/go.mod
@@ -260,10 +260,13 @@ require (
 	go.opentelemetry.io/otel v1.39.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.38.0
 	go.opentelemetry.io/otel/metric v1.39.0
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.opentelemetry.io/otel/sdk/metric v1.39.0
+	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/goleak v1.3.0
 	sigs.k8s.io/kind v0.29.0
 	www.velocidex.com/golang/regparser v0.0.0-20250203141505-31e704a67ef7
@@ -499,14 +502,11 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.60.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.14.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/log v0.15.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.14.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/libbeat/beat/info.go
+++ b/libbeat/beat/info.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -42,9 +43,10 @@ type Info struct {
 	UserAgent        string    // A string of the user-agent that can be passed to any outputs or network connections
 	FIPSDistribution bool      // If the beat was compiled as a FIPS distribution.
 
-	LogConsumer consumer.Logs // otel log consumer
-	ComponentID string        // otel component id from the collector config e.g. "filebeatreceiver/logs"
-	Logger      *logp.Logger
+	LogConsumer    consumer.Logs // otel log consumer
+	ComponentID    string        // otel component id from the collector config e.g. "filebeatreceiver/logs"
+	Logger         *logp.Logger
+	TracerProvider trace.TracerProvider // otel tracer provider
 }
 
 func (i Info) FQDNAwareHostname(useFQDN bool) string {

--- a/x-pack/filebeat/fbreceiver/receiver.go
+++ b/x-pack/filebeat/fbreceiver/receiver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 
+	fbOtel "github.com/elastic/beats/v7/x-pack/filebeat/otel"
 	xpInstance "github.com/elastic/beats/v7/x-pack/libbeat/cmd/instance"
 
 	"go.opentelemetry.io/collector/component"
@@ -38,5 +39,10 @@ func (fb *filebeatReceiver) Shutdown(ctx context.Context) error {
 		return fmt.Errorf("error stopping filebeat receiver: %w", err)
 	}
 	fb.wg.Wait()
+
+	if err := fbOtel.ShutdownTracing(ctx); err != nil {
+		fb.Logger.Error("failed to shutdown OpenTelemetry tracing", zap.Error(err))
+	}
+
 	return nil
 }

--- a/x-pack/filebeat/otel/tracing_exporter_factory.go
+++ b/x-pack/filebeat/otel/tracing_exporter_factory.go
@@ -1,0 +1,159 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package otel
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/gofrs/uuid/v5"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+type TracesExporterType string
+
+const (
+	TracesGRPC    TracesExporterType = "grpc"
+	TracesHTTP    TracesExporterType = "http"
+	tracesDefault TracesExporterType = TracesGRPC
+	serviceName                      = "filebeatreceiver"
+
+	endpointEnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	protocolEnvVar = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+)
+
+var (
+	traceOnce      sync.Once
+	traceShutdown  = func(context.Context) error { return nil }
+	traceErr       error
+	tracerProvider *sdktrace.TracerProvider
+)
+
+// newOTelTraceProvider builds an SDK TracerProvider if OTEL_TRACES_EXPORTER
+// indicates traces should be exported.
+func newOTelTraceProvider(ctx context.Context, version string) (*sdktrace.TracerProvider, error) {
+	if !tracesEnabled() {
+		return nil, nil
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithFromEnv(),
+		resource.WithTelemetrySDK(),
+		resource.WithAttributes(defaultServiceAttributes(version)...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build OTel resource: %w", err)
+	}
+
+	exporterType := tracesExporterType()
+	exporter, err := buildExporter(ctx, exporterType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTLP trace exporter (%s): %w", exporterType, err)
+	}
+
+	spanProcessor := sdktrace.NewBatchSpanProcessor(exporter)
+	traceProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(spanProcessor),
+		sdktrace.WithResource(res),
+	)
+
+	return traceProvider, nil
+}
+
+// buildExporter creates an OTLP trace exporter based on the given type (gRPC or HTTP).
+func buildExporter(ctx context.Context, exporterType TracesExporterType) (sdktrace.SpanExporter, error) {
+	var exporter sdktrace.SpanExporter
+	var err error
+	switch exporterType {
+	case TracesHTTP:
+		var option []otlptracehttp.Option
+		// Allow skipping TLS verification for testing purposes with ELASTIC_OTEL_INSECURE_SKIP_VERIFY=true
+		if v := os.Getenv("ELASTIC_OTEL_INSECURE_SKIP_VERIFY"); strings.ToLower(strings.TrimSpace(v)) == "true" {
+			option = append(option, otlptracehttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true}))
+		}
+		exporter, err = otlptracehttp.New(ctx, option...)
+	case TracesGRPC:
+		fallthrough
+	default:
+		exporter, err = otlptracegrpc.New(ctx)
+	}
+
+	return exporter, err
+}
+
+// tracesEnabled checks if tracing is enabled via OTEL_EXPORTER_OTLP_ENDPOINT.
+func tracesEnabled() bool {
+	endpoint, ok := os.LookupEnv(endpointEnvVar)
+
+	return ok && strings.TrimSpace(endpoint) != ""
+}
+
+// tracesExporterType reads OTEL_EXPORTER_OTLP_TRACES_PROTOCOL to determine
+func tracesExporterType() TracesExporterType {
+	protocol, ok := os.LookupEnv(protocolEnvVar)
+	if !ok || strings.TrimSpace(protocol) == "" {
+		return tracesDefault
+	}
+	p := strings.ToLower(strings.TrimSpace(protocol))
+	if strings.Contains(p, "http") {
+		return TracesHTTP
+	}
+	if strings.Contains(p, "grpc") {
+		return TracesGRPC
+	}
+	return tracesDefault
+}
+
+// defaultServiceAttributes returns default service.* attributes for the resource.
+func defaultServiceAttributes(version string) []attribute.KeyValue {
+	// Add a stable-ish service.instance.id if user didn't set it.
+	inst := os.Getenv("OTEL_SERVICE_INSTANCE_ID")
+	if strings.TrimSpace(inst) == "" {
+		inst = uuid.Must(uuid.NewV4()).String()
+	}
+
+	return []attribute.KeyValue{
+		semconv.ServiceName(serviceName),
+		semconv.ServiceVersion(version),
+		semconv.ServiceInstanceID(inst),
+	}
+}
+
+// TracerProvider configures the global OpenTelemetry tracer provider for
+// the current process based on standard OTEL_* environment variables.
+//
+// It is safe to call multiple times.
+func TracerProvider(ctx context.Context, version string) (*sdktrace.TracerProvider, error) {
+	traceOnce.Do(func() {
+		tracerProvider, traceErr = newOTelTraceProvider(ctx, version)
+		if traceErr != nil || tracerProvider == nil {
+			return
+		}
+
+		traceShutdown = func(ctx context.Context) error {
+			// Ensure processor flushes.
+			return tracerProvider.Shutdown(ctx)
+		}
+	})
+	return tracerProvider, traceErr
+}
+
+// ShutdownTracing flushes and shuts down the global tracer provider configured
+// by TracerProvider.
+func ShutdownTracing(ctx context.Context) error {
+	if traceShutdown == nil {
+		return nil
+	}
+	return traceShutdown(ctx)
+}

--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -52,7 +53,14 @@ var fqdnOnce = sync.OnceValues(func() (string, error) {
 })
 
 // NewBeatForReceiver creates a Beat that will be used in the context of an otel receiver
-func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]any, consumer consumer.Logs, componentID string, core zapcore.Core) (*instance.Beat, error) {
+func NewBeatForReceiver(
+	settings instance.Settings,
+	receiverConfig map[string]any,
+	consumer consumer.Logs,
+	componentID string,
+	core zapcore.Core,
+	tracerProvider trace.TracerProvider,
+) (*instance.Beat, error) {
 	b, err := instance.NewBeat(settings.Name,
 		settings.IndexPrefix,
 		settings.Version,
@@ -71,6 +79,8 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 	}
 
 	b.InputQueueSize = settings.InputQueueSize
+
+	b.Info.TracerProvider = tracerProvider
 
 	cfOpts := []ucfg.Option{
 		ucfg.PathSep("."),

--- a/x-pack/libbeat/cmd/instance/receiver.go
+++ b/x-pack/libbeat/cmd/instance/receiver.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/elastic/beats/v7/libbeat/api"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
@@ -34,6 +36,7 @@ type BeatReceiver struct {
 	beater   beat.Beater
 	reporter *log.Reporter
 	Logger   *logp.Logger
+	Tracer   trace.Tracer
 }
 
 // NewBeatReceiver creates a BeatReceiver.  This will also create the beater and start the monitoring server if configured

--- a/x-pack/metricbeat/mbreceiver/factory.go
+++ b/x-pack/metricbeat/mbreceiver/factory.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
@@ -51,7 +52,7 @@ func createReceiver(ctx context.Context, set receiver.Settings, baseCfg componen
 	settings.ElasticLicensed = true
 	settings.Initialize = append(settings.Initialize, include.InitializeModule)
 
-	b, err := xpInstance.NewBeatForReceiver(settings, cfg.Beatconfig, consumer, set.ID.String(), set.Logger.Core())
+	b, err := xpInstance.NewBeatForReceiver(settings, cfg.Beatconfig, consumer, set.ID.String(), set.Logger.Core(), noop.TracerProvider{})
 	if err != nil {
 		return nil, fmt.Errorf("error creating %s: %w", Name, err)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

**Disclaimer: This PR is a draft to validate or discard the approach to add Otel tracing to beats. It's not finished and there are no tests (yet)**

This pull request introduces OpenTelemetry tracing support to Filebeat inputs. The main goal is to add Otel instrumentation to beats as receivers, so this draft only covers that part, but if the approach is validated, ensuring that it works in both scenarios should be feasible.

* When running as Otel receivers, multiple beats run under the same process, so this approach creates a TracesProvider per beat, and it gets injected instead of using global TracerProvider.
* Currently there is only one span in httpjson input to test it and validate it.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
