### PR TITLE
fix(x-pack/filebeat/input/cel): add descriptions and units to OTel metrics

### DIFF
--- a/changelog/fragments/1770215700-add-otel-metric-metadata-to-cel-input.yaml
+++ b/changelog/fragments/1770215700-add-otel-metric-metadata-to-cel-input.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Add descriptions and units to CEL input OpenTelemetry metrics.
+component: filebeat

--- a/x-pack/filebeat/input/cel/cel_metrics.go
+++ b/x-pack/filebeat/input/cel/cel_metrics.go
@@ -238,74 +238,107 @@ func newOTELCELMetrics(log *logp.Logger,
 
 	meter := meterProvider.Meter("github.com/elastic/beats/x-pack/filebeat/otel/cel_metrics.go")
 
-	periodicRunCount, err := meter.Int64Counter("input.cel.periodic.run")
+	periodicRunCount, err := meter.Int64Counter("input.cel.periodic.run",
+		metric.WithDescription("Number of times a periodic run was started."),
+		metric.WithUnit("{run}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.run: %w", err)
 	}
-	programRunStartedCount, err := meter.Int64Counter("input.cel.periodic.program.run.started")
+	programRunStartedCount, err := meter.Int64Counter("input.cel.periodic.program.run.started",
+		metric.WithDescription("Number of times a CEL program was started in a periodic run."),
+		metric.WithUnit("{run}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.run.started: %w", err)
 	}
-	programRunSuccessCount, err := meter.Int64Counter("input.cel.periodic.program.run.success")
+	programRunSuccessCount, err := meter.Int64Counter("input.cel.periodic.program.run.success",
+		metric.WithDescription("Number of times a CEL program terminated without an error in a periodic run."),
+		metric.WithUnit("{run}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.success: %w", err)
 	}
-	periodicBatchCount, err := meter.Int64Counter("input.cel.periodic.batch.received")
+	periodicBatchCount, err := meter.Int64Counter("input.cel.periodic.batch.received",
+		metric.WithDescription("Number of event batches generated in a periodic run."),
+		metric.WithUnit("{batch}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.batch.received: %w", err)
 	}
-	periodicPublishedBatchCount, err := meter.Int64Counter("input.cel.periodic.batch.published")
+	periodicPublishedBatchCount, err := meter.Int64Counter("input.cel.periodic.batch.published",
+		metric.WithDescription("Number of event batches successfully published in a periodic run."),
+		metric.WithUnit("{batch}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.batch.published: %w", err)
 	}
-	periodicEventCount, err := meter.Int64Counter("input.cel.periodic.event.received")
+	periodicEventCount, err := meter.Int64Counter("input.cel.periodic.event.received",
+		metric.WithDescription("Number of events generated in a periodic run."),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.event.received: %w", err)
 	}
-	periodicPublishedEventCount, err := meter.Int64Counter("input.cel.periodic.event.published")
+	periodicPublishedEventCount, err := meter.Int64Counter("input.cel.periodic.event.published",
+		metric.WithDescription("Number of events published in a periodic run."),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.event.published: %w", err)
 	}
-	periodicTotalDuration, err := meter.Float64Counter("input.cel.periodic.run.duration")
+	periodicTotalDuration, err := meter.Float64Counter("input.cel.periodic.run.duration",
+		metric.WithDescription("Total time spent in a periodic run."),
+		metric.WithUnit("s"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.run.duration: %w", err)
 	}
-	periodicCELDuration, err := meter.Float64Counter("input.cel.periodic.cel.duration")
+	periodicCELDuration, err := meter.Float64Counter("input.cel.periodic.cel.duration",
+		metric.WithDescription("Total time spent processing CEL programs in a periodic run."),
+		metric.WithUnit("s"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.cel.duration: %w", err)
 	}
-	periodicPublishDuration, err := meter.Float64Counter("input.cel.periodic.event.publish.duration")
+	periodicPublishDuration, err := meter.Float64Counter("input.cel.periodic.event.publish.duration",
+		metric.WithDescription("Total time spent publishing events in a periodic run."),
+		metric.WithUnit("s"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.event.publish.duration: %w", err)
 	}
 
-	programBatchProcessed, err := meter.Int64Histogram("input.cel.program.batch.received")
+	programBatchProcessed, err := meter.Int64Histogram("input.cel.program.batch.received",
+		metric.WithDescription("Number of event batches the CEL program has generated."),
+		metric.WithUnit("{batch}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.batch.received: %w", err)
 	}
-	programBatchPublished, err := meter.Int64Histogram("input.cel.program.batch.published")
+	programBatchPublished, err := meter.Int64Histogram("input.cel.program.batch.published",
+		metric.WithDescription("Number of event batches the CEL program has published."),
+		metric.WithUnit("{batch}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.batch.published: %w", err)
 	}
-	programEventGenerated, err := meter.Int64Histogram("input.cel.program.event.received")
+	programEventGenerated, err := meter.Int64Histogram("input.cel.program.event.received",
+		metric.WithDescription("Number of events the CEL program has generated."),
+		metric.WithUnit("{event}"))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed"+
-			" to create input.cel.program.event.received: %w", err)
+		return nil, nil, fmt.Errorf("failed to create input.cel.program.event.received: %w", err)
 	}
-	programEventPublished, err := meter.Int64Histogram("input.cel.program.event.published")
+	programEventPublished, err := meter.Int64Histogram("input.cel.program.event.published",
+		metric.WithDescription("Number of events the CEL program has published."),
+		metric.WithUnit("{event}"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.event.published: %w", err)
 	}
 
-	programRunDuration, err := meter.Float64Histogram("input.cel.program.run.duration")
+	programRunDuration, err := meter.Float64Histogram("input.cel.program.run.duration",
+		metric.WithDescription("Time spent executing the CEL program."),
+		metric.WithUnit("s"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.run.duration: %w", err)
 	}
-	programCELDuration, err := meter.Float64Histogram("input.cel.program.cel.duration")
+	programCELDuration, err := meter.Float64Histogram("input.cel.program.cel.duration",
+		metric.WithDescription("Time spent processing the CEL program."),
+		metric.WithUnit("s"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.cel.duration: %w", err)
 	}
-	programPublishDuration, err := meter.Float64Histogram("input.cel.program.publish.duration")
+	programPublishDuration, err := meter.Float64Histogram("input.cel.program.publish.duration",
+		metric.WithDescription("Time spent publishing events in the CEL program."),
+		metric.WithUnit("s"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create input.cel.program.publish.duration: %w", err)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
Add OpenTelemetry metric metadata (descriptions and units) to all CEL
input metrics to enable proper context when viewing data in metrics
databases.

Units follow UCUM [1] standard codes:
- "s" for duration metrics (seconds)
- "{run}", "{batch}", "{event}" for count metrics

Descriptions follow otelhttp style (capitalized, ending with period).

References:

[1]: https://ucum.org/ucum
[2]: https://opentelemetry.io/docs/specs/semconv/general/metrics/
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Local verification

Use `OTEL_METRICS_EXPORTER=console go test -v` which will write the OTel metrics structure to the console where `Description` and `Unit` are present:

```json
             {                                                                                                                                                                                    
               "Name": "input.cel.periodic.program.run.success",                                                                                                                                  
               "Description": "Number of times a CEL program terminated without an error in a periodic run.",                                                                                     
               "Unit": "{run}",                                                                                                                                                                   
               "Data": {                                                                                                                                                                          
                 "DataPoints": [                                                                                                                                                                  
                   {                                                                                                                                                                              
                     "Attributes": [],                                                                                                                                                            
                     "StartTime": "2026-02-05T14:41:00.87318-05:00",                                                                                                                              
                     "Time": "2026-02-05T14:41:00.873602-05:00",                                                                                                                                  
                     "Value": 1                                                                                                                                                                   
                   }                                                                                                                                                                              
                 ],                                                                                                                                                                               
                 "Temporality": "DeltaTemporality",                                                                                                                                               
                 "IsMonotonic": true                                                                                                                                                              
               }                                                                                                                                                                                  
             },
```

## Related issues

- Relates #47014 

# References

- https://opentelemetry.io/docs/specs/semconv/general/metrics/ (guidelines for OTel metrics)
- https://ucum.org/ucum


