### PR TITLE
otel(tests): add test for event delivery during Elasticsearch outage

### DIFF
--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -1502,7 +1502,7 @@ func setupRoleMapping(t *testing.T, client *elasticsearch.Client) {
 }
 
 func TestFilebeatOTelNoEventLossDuringESOutage(t *testing.T) {
-	const numTestEvents = 5
+	const numTestEvents = 100
 
 	tmpdir := t.TempDir()
 	logFilePath := filepath.Join(tmpdir, "log.log")


### PR DESCRIPTION
## Proposed commit message

Add a test that verifies Beat receivers do not lose events when the
Elasticsearch instance is temporarily unavailable.

This test does not cover request- or document-level HTTP errors, which
are already validated by TestFilebeatOTelDocumentLevelRetries. Instead,
it focuses on the case where the Elasticsearch instance is completely
unreachable.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).


## How to test this PR locally

```bash
go test -run ^TestFilebeatOTelNoEventLossDuringESOutage$ -v -count=1 -tags=integration ./x-pack/filebeat/tests/integration

./script/stresstest.sh --tags integration ./x-pack/filebeat/tests/integration ^TestFilebeatOTelNoEventLossDuringESOutage$ -p 1
```

## Related issues

- Relates to https://github.com/elastic/elastic-agent/issues/12413.