### PR TITLE
[winlogbeat] Use per-beat paths for registry file resolution

### DIFF
--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -66,7 +66,7 @@ func New(b *beat.Beat, _ *conf.C) (beat.Beater, error) {
 	log := logp.NewLogger("winlogbeat")
 
 	// resolve registry file path
-	config.RegistryFile = paths.Resolve(paths.Data, config.RegistryFile)
+	config.RegistryFile = b.Paths.Resolve(paths.Data, config.RegistryFile)
 	log.Infof("State will be read from and persisted to %s",
 		config.RegistryFile)
 

--- a/winlogbeat/tests/system/config/winlogbeat.yml.j2
+++ b/winlogbeat/tests/system/config/winlogbeat.yml.j2
@@ -1,5 +1,9 @@
 ############################# Winlogbeat ######################################
 
+{%- if registry_file %}
+winlogbeat.registry_file: "{{ registry_file }}"
+{% endif %}
+
 {%- if event_logs %}
 winlogbeat.event_logs:
   {% for log in event_logs -%}
@@ -99,3 +103,8 @@ output.file:
   {% endif %}
   rotate_every_kb: 1000
 
+#================================ Paths =====================================
+{% if path_data %}
+path:
+  data: {{path_data}}
+{% endif %}

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -116,9 +116,11 @@ class WriteReadTest(BaseTest):
         proc.check_kill_and_wait()
         return self.read_output()
 
-    def read_registry(self, requireBookmark=False):
-        f = open(os.path.join(self.working_dir, "data", ".winlogbeat.yml"), "r")
-        data = yaml.load(f, Loader=yaml.FullLoader)
+    def read_registry(self, requireBookmark=False, registry_path=None):
+        if registry_path is None:
+            registry_path = os.path.join(self.working_dir, "data", ".winlogbeat.yml")
+        with open(registry_path, "r") as f:
+            data = yaml.load(f, Loader=yaml.FullLoader)
         self.assertIn("update_time", data)
         self.assertIn("event_logs", data)
 


### PR DESCRIPTION
## Proposed commit message

Replace the global `paths.Resolve()` with the per-beat `b.Paths.Resolve()` when resolving the registry file path in winlogbeat's `New()` function.

This aligns winlogbeat with the pattern already used by filebeat and metricbeat.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None. In the standalone beat flow, `b.Paths` and `paths.Paths` point to the same object, so behavior is identical. The change only corrects behavior for beat receivers, where each receiver gets its own paths instance.

## Related issues

- Closes https://github.com/elastic/beats/issues/46994