### PR TITLE
Fix flaky test TestFilebeatOTelNoEventLossDuringESOutage

### DIFF
--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -1783,6 +1783,7 @@ func TestFilebeatOTelNoEventLossDuringESOutage(t *testing.T) {
     http.enabled: true
     http.host: localhost
     http.port: {{.MonitoringPort}}
+    output.otelconsumer.enabled: true
 exporters:
   elasticsearch:
     auth:


### PR DESCRIPTION
## Proposed commit message

```
Fix flaky test TestFilebeatOTelNoEventLossDuringESOutage by adding the otelconsumer output configuration.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
~~## Author's Checklist~~

## How to test this PR locally

```
go test -run ^TestFilebeatOTelNoEventLossDuringESOutage$ -v -count=1 -tags=integration ./x-pack/filebeat/tests/integration

./script/stresstest.sh --tags integration ./x-pack/filebeat/tests/integration ^TestFilebeatOTelNoEventLossDuringESOutage$ -p 1
```

## Related issues

- Closes https://github.com/elastic/beats/issues/48892


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
