### PR TITLE
[winlog] Implement log suppression for repeated channel-not-found errors in winlogbeat

### DIFF
--- a/changelog/fragments/1771519200-winlogbeat-channel-not-found-log-suppression.yaml
+++ b/changelog/fragments/1771519200-winlogbeat-channel-not-found-log-suppression.yaml
@@ -1,0 +1,12 @@
+kind: bug-fix
+summary: Restore suppression of repeated channel-not-found open errors in winlogbeat eventlog runner
+
+description: |
+  Reintroduces channel-not-found retry log suppression that was lost during the eventlog runner refactor.
+  The first channel-not-found open error is logged at WARN, subsequent retries are logged at DEBUG, and
+  the suppression state is reset after a successful open. This prevents repeated WARN/ERROR log noise
+  when a configured channel is missing.
+
+component: winlogbeat
+
+issue: https://github.com/elastic/beats/issues/48979

--- a/winlogbeat/eventlog/errors_unix.go
+++ b/winlogbeat/eventlog/errors_unix.go
@@ -29,3 +29,7 @@ func IsRecoverable(error, bool) bool {
 func mustIgnoreError(error, EventLog) bool {
 	return false
 }
+
+func isChannelNotFound(error) bool {
+	return false
+}

--- a/winlogbeat/eventlog/errors_windows.go
+++ b/winlogbeat/eventlog/errors_windows.go
@@ -43,3 +43,7 @@ func IsRecoverable(err error, isFile bool) bool {
 func mustIgnoreError(err error, api EventLog) bool {
 	return api.IgnoreMissingChannel() && errors.Is(err, win.ERROR_EVT_CHANNEL_NOT_FOUND)
 }
+
+func isChannelNotFound(err error) bool {
+	return errors.Is(err, win.ERROR_EVT_CHANNEL_NOT_FOUND)
+}


### PR DESCRIPTION
Restore the suppression of repeated channel-not-found open errors in the winlogbeat eventlog runner. The first occurrence is logged at WARN level, while subsequent retries are logged at DEBUG level, reducing log noise when a configured channel is missing. The suppression state resets after a successful open.

Related issue: https://github.com/elastic/beats/issues/48979

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/48979
