### PR TITLE
filestream: optimise readFromSource line filtering

### DIFF
--- a/changelog/fragments/1771609453-filestream-optimise-readFromSource.yaml
+++ b/changelog/fragments/1771609453-filestream-optimise-readFromSource.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Optimize filestream to allocate less memory when applying include/exclude line filters.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: filebeat
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/49013
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -71,6 +71,7 @@ type filestream struct {
 	compression               string
 	includeFileOwnerName      bool
 	includeFileOwnerGroupName bool
+	hasLineFilter             bool
 
 	// Function references for testing
 	waitGracePeriodFn func(
@@ -150,6 +151,7 @@ func configure(
 		compression:               c.Compression,
 		includeFileOwnerName:      c.IncludeFileOwnerName,
 		includeFileOwnerGroupName: c.IncludeFileOwnerGroupName,
+		hasLineFilter:             len(c.Reader.IncludeLines) > 0 || len(c.Reader.ExcludeLines) > 0,
 		deleterConfig:             c.Delete,
 		waitGracePeriodFn:         waitGracePeriod,
 		tickFn:                    time.Tick,
@@ -754,7 +756,7 @@ func (inp *filestream) readFromSource(
 		if isGZIP {
 			metrics.MessagesGZIPRead.Inc()
 		}
-		if message.IsEmpty() || inp.isDroppedLine(log, string(message.Content)) {
+		if message.IsEmpty() || (inp.hasLineFilter && inp.isDroppedLine(log, message.Content)) {
 			continue
 		}
 
@@ -795,16 +797,16 @@ func (inp *filestream) readFromSource(
 
 // isDroppedLine decides if the line is exported or not based on
 // the include_lines and exclude_lines options.
-func (inp *filestream) isDroppedLine(log *logp.Logger, line string) bool {
+func (inp *filestream) isDroppedLine(log *logp.Logger, line []byte) bool {
 	if len(inp.readerConfig.IncludeLines) > 0 {
 		if !matchAny(inp.readerConfig.IncludeLines, line) {
-			log.Debug("Drop line as it does not match any of the include patterns %s", line)
+			log.Debugf("Drop line as it does not match any of the include patterns %s", line)
 			return true
 		}
 	}
 	if len(inp.readerConfig.ExcludeLines) > 0 {
 		if matchAny(inp.readerConfig.ExcludeLines, line) {
-			log.Debug("Drop line as it does match one of the exclude patterns%s", line)
+			log.Debugf("Drop line as it does match one of the exclude patterns %s", line)
 			return true
 		}
 	}
@@ -812,9 +814,9 @@ func (inp *filestream) isDroppedLine(log *logp.Logger, line string) bool {
 	return false
 }
 
-func matchAny(matchers []match.Matcher, text string) bool {
+func matchAny(matchers []match.Matcher, text []byte) bool {
 	for _, m := range matchers {
-		if m.MatchString(text) {
+		if m.Match(text) {
 			return true
 		}
 	}

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -126,6 +126,68 @@ paths:
 			}
 		})
 	})
+
+	b.Run("line filter", func(b *testing.B) {
+		lineCount := 10000
+		filename := generateFile(b, b.TempDir(), lineCount)
+		b.ResetTimer()
+
+		b.Run("no filter", func(b *testing.B) {
+			cfg := `
+type: filestream
+prospector.scanner.check_interval: 1s
+prospector.scanner.fingerprint.enabled: false
+paths:
+    - ` + filename + `
+`
+			for i := 0; i < b.N; i++ {
+				runFilestreamBenchmark(b, fmt.Sprintf("no-filter-%d", i), cfg, lineCount)
+			}
+		})
+
+		b.Run("with include_lines", func(b *testing.B) {
+			cfg := `
+type: filestream
+prospector.scanner.check_interval: 1s
+prospector.scanner.fingerprint.enabled: false
+include_lines: ['^rather']
+paths:
+    - ` + filename + `
+`
+			for i := 0; i < b.N; i++ {
+				runFilestreamBenchmark(b, fmt.Sprintf("include-lines-%d", i), cfg, lineCount)
+			}
+		})
+
+		b.Run("with exclude_lines", func(b *testing.B) {
+			cfg := `
+type: filestream
+prospector.scanner.check_interval: 1s
+prospector.scanner.fingerprint.enabled: false
+exclude_lines: ['^NOMATCH']
+paths:
+    - ` + filename + `
+`
+			for i := 0; i < b.N; i++ {
+				runFilestreamBenchmark(b, fmt.Sprintf("exclude-lines-%d", i), cfg, lineCount)
+			}
+		})
+
+		b.Run("with include_and_exclude_lines", func(b *testing.B) {
+			cfg := `
+type: filestream
+prospector.scanner.check_interval: 1s
+prospector.scanner.fingerprint.enabled: false
+include_lines: ['^rather']
+exclude_lines: ['^NOMATCH']
+paths:
+    - ` + filename + `
+`
+			for i := 0; i < b.N; i++ {
+				runFilestreamBenchmark(b, fmt.Sprintf("include-exclude-lines-%d", i), cfg, lineCount)
+			}
+		})
+	})
 }
 
 func TestTakeOverTags(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
    filestream: optimise readFromSource line filtering
    
    Skip isDroppedLine call when no include_lines/exclude_lines are configured by
    caching the check in a hasLineFilter bool.
    Do not convert the line to string, compare them as []byte.
    Add benchmarks for line filter scenarios.
    
    This reduces memory allocations by ~5.5% and memory usage by 7% per read cycle.
    
    Assisted by Cursor, Claude
```

### Benchmark results

```
goos: linux
goarch: amd64
pkg: github.com/elastic/beats/v7/filebeat/input/filestream
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                                         │ /tmp/bench-old.txt │         /tmp/bench-new.txt          │
                                                         │       sec/op       │    sec/op     vs base               │
Filestream/line_filter/no_filter-16                              23.91m ± 13%   22.30m ± 21%       ~ (p=0.529 n=10)
Filestream/line_filter/with_include_lines-16                     18.98m ±  6%   18.58m ± 13%       ~ (p=0.739 n=10)
Filestream/line_filter/with_exclude_lines-16                     17.92m ±  9%   17.55m ± 19%       ~ (p=0.393 n=10)
Filestream/line_filter/with_include_and_exclude_lines-16         17.69m ±  5%   16.62m ± 12%  -6.03% (p=0.015 n=10)
geomean                                                          19.47m         18.64m        -4.26%

                                                         │ /tmp/bench-old.txt │         /tmp/bench-new.txt          │
                                                         │        B/op        │     B/op      vs base               │
Filestream/line_filter/no_filter-16                              15.45Mi ± 0%   14.37Mi ± 0%  -7.00% (p=0.000 n=10)
Filestream/line_filter/with_include_lines-16                     15.45Mi ± 0%   14.36Mi ± 0%  -7.00% (p=0.000 n=10)
Filestream/line_filter/with_exclude_lines-16                     15.45Mi ± 0%   14.36Mi ± 0%  -7.00% (p=0.000 n=10)
Filestream/line_filter/with_include_and_exclude_lines-16         15.44Mi ± 0%   14.36Mi ± 0%  -7.00% (p=0.000 n=10)
geomean                                                          15.45Mi        14.36Mi       -7.00%

                                                         │ /tmp/bench-old.txt │         /tmp/bench-new.txt         │
                                                         │     allocs/op      │  allocs/op   vs base               │
Filestream/line_filter/no_filter-16                               180.5k ± 0%   170.5k ± 0%  -5.54% (p=0.000 n=10)
Filestream/line_filter/with_include_lines-16                      180.5k ± 0%   170.5k ± 0%  -5.54% (p=0.000 n=10)
Filestream/line_filter/with_exclude_lines-16                      180.5k ± 0%   170.5k ± 0%  -5.54% (p=0.000 n=10)
Filestream/line_filter/with_include_and_exclude_lines-16          180.5k ± 0%   170.5k ± 0%  -5.54% (p=0.000 n=10)
geomean                                                           180.5k        170.5k       -5.54%
```


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None


## How to test this PR locally

#### 1. Run benchmarks on main (old)
```                                                                                          
  git checkout main                                                                                                          
  cd filebeat                                                                                                                
  go test -bench='BenchmarkFilestream/line_filter' -benchmem -count=10 -run='^$' -timeout=30m ./input/filestream/ | tee      
  /tmp/bench-old.txt                                                                                                         
```

#### 2. Run benchmarks on the feature branch (new)
```                                                                            
  git checkout filestream-optmise-readFromSource
  cd filebeat                                                                                                                
  go test -bench='BenchmarkFilestream/line_filter' -benchmem -count=10 -run='^$' -timeout=30m ./input/filestream/ | tee
  /tmp/bench-new.txt                                                                                                         
```

#### 3. Compare                                                                                                               
```
  benchstat /tmp/bench-old.txt /tmp/bench-new.txt

  Note: the "line filter" benchmarks don't exist on main — you'll need to cherry-pick or copy the test additions from the    
  branch first. That's what I did when running them earlier.
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
