### PR TITLE
libbeat: Fix TestEmpty failure caused by pam_systemd CAP_WAKE_ALARM

### DIFF
--- a/libbeat/common/capabilities/capabilities_linux_test.go
+++ b/libbeat/common/capabilities/capabilities_linux_test.go
@@ -34,7 +34,7 @@ func TestEmpty(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, len(sl), 0)
 
-	// assumes non-root has no effective/permitted capabilities
+	// assumes non-root has no capabilities
 	if os.Geteuid() != 0 {
 		empty := cap.NewSet()
 		self := cap.GetProc()


### PR DESCRIPTION
## Proposed commit message

Since systemd v254, pam_systemd grants CAP_WAKE_ALARM as an inheritable capability to regular users on a physical seat. The test unconditionally asserted that the inheritable set is empty for non-root, which fails on developer workstations with systemd >= 254.

On CI (BUILDKITE/CI env), assert inheritable is empty since runners have no seat. On local machines, tolerate CAP_WAKE_ALARM but fail on any other unexpected inheritable capability.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

Run the unit test