### PR TITLE
Replace global paths.Resolve in filebeat generate command

### DIFF
--- a/filebeat/cmd/generate.go
+++ b/filebeat/cmd/generate.go
@@ -114,4 +114,3 @@ func genGenerateFieldsCmd() *cobra.Command {
 
 	return genFieldsCmd
 }
-


### PR DESCRIPTION
## Proposed commit message

Replace the package-level `var defaultHomePath = paths.Resolve(paths.Home, "")` in
`filebeat/cmd/generate.go` with an explicit `"."` (CWD) default, removing the
`elastic-agent-libs/paths` import entirely.

**WHAT:** The old code evaluated `paths.Resolve(paths.Home, "")` at package import
time as a package-level variable. At that point `paths.Paths.Home` is always `""`
(the singleton is created by `paths.New()` with zero-valued fields, and
`HandleFlags()` hasn't run yet). So `defaultHomePath` was silently always `""`,
making the commands operate relative to CWD -- not the binary directory as the
code appeared to intend.

This PR replaces the broken `paths.Resolve` call with an explicit `"."` default,
preserving the actual historical CWD behavior and removing the global paths
dependency.

**WHY:** Global paths cleanup -- https://github.com/elastic/beats/issues/46993

**Design choice -- CWD vs binary directory:** I considered replacing the broken
default with `filepath.Abs(filepath.Dir(os.Args[0]))` (the binary's directory,
matching `paths.Home` semantics). However, CWD is the better default for this
dev tool because:

- It preserves the actual behavior users have had for years (the old bug meant
  it was always CWD)
- It works with `go run`, `go build`, and any other invocation method
- Binary-dir breaks with `go run` (`os.Args[0]` points to a temp build directory)
- The generate command is only used by developers working inside a beats checkout

**Alternative -- non-global initialized paths:** A more complete approach would
be to create a properly initialized `*paths.Path` instance via `paths.New()` and
`InitPaths()` inside the command handler (similar to how
`NewBeatForReceiver` initializes per-receiver paths in
`x-pack/libbeat/cmd/instance/beat.go`). This would allow the generate commands
to respect `--path.home` and filebeat configuration. However, this is out of
scope for this minimal fix. `--path.{home,config,data,logs}` never had any
effect on the generate commands.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None. The old `paths.Resolve` default was silently broken (always evaluated
to `""`), so all users were already getting CWD behavior. This PR makes that
explicit. Users who pass `--modules-path` and `--es-beats` flags (which includes
all existing system tests) are unaffected. The global path flags (`--path.home`,
`--path.config`, `--path.data`, `--path.logs`) never affected the generate
commands and still don't.

## How to test this PR locally

### Test the generate commands with explicit flags (from `filebeat/` dir)

```bash
cd filebeat && go build -o filebeat .

mkdir /tmp/test_modules

# Generate a module
./filebeat generate module my_module \
  --modules-path /tmp/test_modules \
  --es-beats .

ls /tmp/test_modules/module/my_module/
# Expected: _meta/  module.yml

# Generate a fileset
./filebeat generate fileset my_module my_fileset \
  --modules-path /tmp/test_modules \
  --es-beats .

ls /tmp/test_modules/module/my_module/my_fileset/
# Expected: _meta/  config/  ingest/  manifest.yml  test/

rm -rf /tmp/test_modules
```

### Verify `--help` shows `"."` as the default

```bash
./filebeat generate module --help | grep -E 'modules-path|es-beats'
# Expected: both flags show default "."
```

## Related issues

- Closes #46993
