### PR TITLE
[logfile] Fix goroutine leak harvester_limit is set

### DIFF
--- a/changelog/fragments/1772031306-harvester-fix.yaml
+++ b/changelog/fragments/1772031306-harvester-fix.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix memory leak when harvester_limit is set
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -71,7 +71,7 @@ func (r *readerGroup) newContext(id string, cancelation inputv2.Canceler) (conte
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, ok := r.table[id]; ok {
+	if existing := r.table[id]; existing != nil {
 		return nil, nil, ErrHarvesterAlreadyRunning
 	}
 
@@ -85,21 +85,24 @@ func (r *readerGroup) remove(id string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	cancel, ok := r.table[id]
-	if !ok {
-		return
+	cancel := r.table[id]
+	if cancel != nil {
+		cancel()
 	}
 
-	cancel()
 	delete(r.table, id)
 }
 
-func (r *readerGroup) hasID(id string) bool {
+func (r *readerGroup) reserve(id string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	_, ok := r.table[id]
-	return ok
+	if ok {
+		return false
+	}
+	r.table[id] = nil
+	return true
 }
 
 // HarvesterGroup is responsible for running the
@@ -203,7 +206,7 @@ func startHarvester(
 	inputID string,
 ) func(context.Context) error {
 	srcID := hg.identifier.ID(src)
-	if !restart && hg.readers.hasID(srcID) {
+	if !restart && !hg.readers.reserve(srcID) {
 		// A harvester is already running for this source, no need to start another.
 		// This check must happen here, before task.Group.Go spawns a goroutine.
 		// When harvester_limit is set, the spawned goroutine blocks on a semaphore

--- a/filebeat/input/filestream/internal/input-logfile/harvester_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester_test.go
@@ -60,6 +60,14 @@ func requireEventuallyWithT(t *testing.T, condition func(c *assert.CollectT), ms
 	require.EventuallyWithT(t, condition, eventuallyTimeout, eventuallyInterval, msgAndArgs...)
 }
 
+// hasID is only used in tests to check if a source is registered in the reader group.
+func (r *readerGroup) hasID(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.table[id] != nil
+}
+
 func TestReaderGroup(t *testing.T) {
 	requireGroupSuccess := func(t *testing.T, ctx context.Context, cf context.CancelFunc, err error) {
 		require.NotNil(t, ctx)
@@ -93,6 +101,30 @@ func TestReaderGroup(t *testing.T) {
 
 		newCtx, newCf, err := rg.newContext("test-id", context.Background())
 		requireGroupError(t, newCtx, newCf, err)
+	})
+
+	t.Run("assert reserve allows newContext to upgrade the reservation", func(t *testing.T) {
+		rg := newReaderGroup()
+
+		assert.True(t, rg.reserve("test-id"), "first reserve should succeed")
+
+		ctx, cf, err := rg.newContext("test-id", context.Background())
+		requireGroupSuccess(t, ctx, cf, err)
+
+		// A second newContext should fail since a real harvester is now registered.
+		newCtx, newCf, err := rg.newContext("test-id", context.Background())
+		requireGroupError(t, newCtx, newCf, err)
+	})
+
+	t.Run("assert remove on a reserved entry and allows re-reserve", func(t *testing.T) {
+		rg := newReaderGroup()
+
+		assert.True(t, rg.reserve("test-id"), "first reserve should succeed")
+		assert.False(t, rg.reserve("test-id"), "second reserve for same id should fail")
+		rg.remove("test-id")
+		assert.Empty(t, rg.table)
+
+		assert.True(t, rg.reserve("test-id"), "reserve should succeed after remove")
 	})
 
 	t.Run("assert new key is added, can be removed and its context is cancelled", func(t *testing.T) {


### PR DESCRIPTION
## Proposed commit message
Prevent unbounded goroutine accumulation when the number of files exceeds `harvester_limit`. Previously, files waiting for a semaphore slot had no entry in the readers table, so every scanner cycle spawned a new goroutine that blocked on the semaphore — growing without bound.

Replace `hasID` with `reserve`, which atomically inserts a nil sentinel into the readers table before spawning the goroutine. This ensures subsequent scanner cycles see the reservation and skip the file. `newContext` then upgrades the nil entry to a real cancel func once the semaphore is acquired. `remove` is updated to handle nil entries safely.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally
[repro.zip](https://github.com/user-attachments/files/25549144/repro.zip)

Same as in https://github.com/elastic/beats/pull/48445 but with
```yaml
    harvester_limit: 3
```

**1. Setup the test environment:**

```bash
cd goroutine-leak-repro
./setup.sh
```

**2. Start log generation (Terminal 1):**

```bash
./generate_logs.sh
```

**3. Start filebeat (Terminal 2):**

```bash
../filebeat/filebeat -e -c filebeat.yml
```

**4. Monitor goroutines (Terminal 3):**

```bash
./monitor_goroutines.sh
```

## Related issues

- Relates https://github.com/elastic/beats/pull/48445
- Closes https://github.com/elastic/beats/issues/48496