### PR TITLE
x-pack/filebeat/input/streaming: reject non-event data from CrowdStri…

### DIFF
--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -296,6 +296,13 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 		}
 		defer resp.Body.Close()
 
+		if resp.StatusCode != http.StatusOK {
+			var buf bytes.Buffer
+			io.Copy(&buf, resp.Body)
+			s.log.Errorw("unsuccessful firehose request", "status_code", resp.StatusCode, "status", resp.Status, "body", buf.String())
+			return state, fmt.Errorf("unsuccessful firehose request: %s: %s", resp.Status, &buf)
+		}
+
 		// Prepare state to understand which feed is being processed.
 		// This is cleared by the deferred delete above the loop.
 		state["feed"] = feedName
@@ -313,6 +320,11 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 				return state, fmt.Errorf("error decoding event: %w", err)
 			}
 			s.metrics.receivedBytesTotal.Add(uint64(len(msg)))
+			if len(msg) == 0 || msg[0] != '{' {
+				s.metrics.errorsTotal.Inc()
+				s.log.Warnw("skipping non-object message from firehose", logp.Namespace(s.ns), "msg", debugMsg(msg))
+				continue
+			}
 			state["response"] = []byte(msg)
 			s.log.Debugw("received firehose message", logp.Namespace(s.ns), "msg", debugMsg(msg))
 			err = s.process(ctx, state, s.cursor, s.now().In(time.UTC))

--- a/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
@@ -1,0 +1,199 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package streaming
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+
+	cursor "github.com/elastic/beats/v7/filebeat/input/v2/input-cursor"
+)
+
+func TestFollowSession_FirehoseHTTPError(t *testing.T) {
+	logp.TestingSetup()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "400_plain_text", statusCode: 400, body: "400 Bad Request"},
+		{name: "401_unauthorized", statusCode: 401, body: `{"errors":[{"code":401,"message":"access denied"}]}`},
+		{name: "500_internal", statusCode: 500, body: "Internal Server Error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer srv.Close()
+
+			discoverResp := discoverResponse(t, srv.URL+"/firehose")
+			discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, discoverResp)
+			}))
+			defer discoverSrv.Close()
+
+			s := newTestStream(t, discoverSrv.URL, srv.Client())
+			state := map[string]any{}
+			state, err := s.followSession(context.Background(), discoverSrv.Client(), state)
+			if err == nil {
+				t.Fatal("expected error from followSession, got nil")
+			}
+			if !strings.Contains(err.Error(), "unsuccessful firehose request") {
+				t.Errorf("expected 'unsuccessful firehose request' error, got: %v", err)
+			}
+			if state == nil {
+				t.Error("expected non-nil state on non-hard error")
+			}
+		})
+	}
+}
+
+func TestFollowSession_NonObjectMessage(t *testing.T) {
+	logp.TestingSetup()
+
+	validEvent := `{"metadata":{"eventType":"TestEvent","offset":1},"event":{"TestField":"value"}}`
+
+	tests := []struct {
+		name          string
+		body          string
+		wantPublished int
+	}{
+		{
+			name:          "bare_number_skipped",
+			body:          "400\n",
+			wantPublished: 0,
+		},
+		{
+			name:          "bare_string_skipped",
+			body:          `"error"` + "\n",
+			wantPublished: 0,
+		},
+		{
+			name:          "array_skipped",
+			body:          `[1,2,3]` + "\n",
+			wantPublished: 0,
+		},
+		{
+			name:          "non_object_then_valid_event",
+			body:          "400\n" + validEvent + "\n",
+			wantPublished: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			firehoseSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, tt.body)
+			}))
+			defer firehoseSrv.Close()
+
+			discoverResp := discoverResponse(t, firehoseSrv.URL+"/firehose")
+			discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, discoverResp)
+			}))
+			defer discoverSrv.Close()
+
+			pub := new(countingPublisher)
+			s := newTestStreamWithPublisher(t, discoverSrv.URL, firehoseSrv.Client(), pub)
+			state := map[string]any{}
+			_, err := s.followSession(context.Background(), discoverSrv.Client(), state)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if pub.published() != tt.wantPublished {
+				t.Errorf("expected %d published events, got %d", tt.wantPublished, pub.published())
+			}
+		})
+	}
+}
+
+func discoverResponse(t *testing.T, feedURL string) string {
+	t.Helper()
+	resp := map[string]any{
+		"resources": []map[string]any{
+			{
+				"dataFeedURL": feedURL,
+				"sessionToken": map[string]any{
+					"token":      "test-token",
+					"expiration": "2099-01-01T00:00:00Z",
+				},
+				"refreshActiveSessionURL":      "http://localhost/refresh",
+				"refreshActiveSessionInterval": 1800,
+			},
+		},
+		"meta": map[string]any{},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("failed to marshal discover response: %v", err)
+	}
+	return string(b)
+}
+
+func newTestStream(t *testing.T, discoverURL string, firehoseClient *http.Client) *falconHoseStream {
+	t.Helper()
+	return newTestStreamWithPublisher(t, discoverURL, firehoseClient, new(countingPublisher))
+}
+
+func newTestStreamWithPublisher(t *testing.T, discoverURL string, firehoseClient *http.Client, pub cursor.Publisher) *falconHoseStream {
+	t.Helper()
+	log := logp.L()
+	reg := monitoring.NewRegistry()
+	m := newInputMetrics(reg, log)
+
+	ctx := context.Background()
+	prg, ast, err := newProgram(ctx, `
+		state.response.decode_json().as(body, {
+			"events": [body],
+			?"cursor": body.?metadata.optMap(m, {"offset": m.offset}),
+		})
+	`, root, nil, log)
+	if err != nil {
+		t.Fatalf("failed to compile CEL program: %v", err)
+	}
+
+	return &falconHoseStream{
+		cfg:         config{},
+		discoverURL: discoverURL,
+		plainClient: firehoseClient,
+		status:      noopReporter{},
+		processor: processor{
+			ns:      "test",
+			pub:     pub,
+			log:     log,
+			metrics: m,
+			prg:     prg,
+			ast:     ast,
+		},
+		time: time.Now,
+	}
+}
+
+type countingPublisher int
+
+func (p *countingPublisher) Publish(beat.Event, any) error {
+	*p++
+	return nil
+}
+
+func (p *countingPublisher) published() int {
+	return int(*p)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: reject non-event data from CrowdStrike firehose

When the firehose endpoint returns an HTTP error (e.g. from an
intermediary proxy), followSession feeds the error response body
directly into the JSON decoder. A response like "400 Bad Request"
decodes as the JSON number 400 — json.Decoder.Decode reads the
first valid token and stops — which is then published as an event.
This produces "crowdstrike": 400 in every document, all of which
fail at index time. Because EOF after the single decode is treated
as a normal stream end, the retry counter resets and the loop
repeats forever, producing one bad event per iteration.

Add a status code check on the firehose response, matching what
the discover endpoint already does. As defence-in-depth, also
skip any decoded message that is not a JSON object before passing
it to the CEL program.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #49119

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
