### PR TITLE
x-pack/filebeat/input/entityanalytic/provider/azuread: demote missing user/device state lookup to debug log

### DIFF
--- a/changelog/fragments/1772100585-36447-invalid-error-ea-azure.yaml
+++ b/changelog/fragments/1772100585-36447-invalid-error-ea-azure.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Demote missing user/device state lookup to debug log in Azure entity analytics provider.
+component: filebeat

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -440,7 +440,7 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 		updatedUsers.ForEach(func(userID uuid.UUID) {
 			u, ok := state.users[userID]
 			if !ok {
-				p.logger.Errorf("Unable to find user %q in state", userID)
+				p.logger.Debugf("Unable to find user %q in state", userID)
 				return
 			}
 			u.Modified = true
@@ -461,7 +461,7 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 		updatedDevices.ForEach(func(devID uuid.UUID) {
 			d, ok := state.devices[devID]
 			if !ok {
-				p.logger.Errorf("Unable to find device %q in state", devID)
+				p.logger.Debugf("Unable to find device %q in state", devID)
 				return
 			}
 			d.Modified = true


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/input/entityanalytic/provider/azuread: demote missing user/device state lookup to debug log

When Azure's delta API returns a deletion for a user or device that was
never tracked locally, the membership expansion loop logs an error
because the ID is not found in state. This is expected API behavior and
not a real error. Demote both log calls from Errorf to Debugf.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/36447

