### PR TITLE
Doc: Change to Kafka timestamp behavior 

### DIFF
--- a/docs/reference/filebeat/kafka-output.md
+++ b/docs/reference/filebeat/kafka-output.md
@@ -14,9 +14,20 @@ The Kafka output sends events to Apache Kafka.
 
 To use this output, edit the Filebeat configuration file to disable the {{es}} output by commenting it out, and enable the Kafka output by uncommenting the Kafka section.
 
-::::{note}
-For Kafka version 0.10.0.0+ the message creation timestamp is set by beats and equals to the initial timestamp of the event. This affects the retention policy in Kafka: for example, if a beat event was created 2 weeks ago, the retention policy is set to 7 days and the message from beats arrives to Kafka today, it’s going to be immediately discarded since the timestamp value is before the last 7 days. It’s possible to change this behavior by setting timestamps on message arrival instead, so the message is not discarded but kept for 7 more days. To do that, please set `log.message.timestamp.type` to `LogAppendTime` (default `CreateTime`) in the Kafka configuration.
-::::
+:::{admonition} Kafka timestamps and beats
+* Kafka 3.6+ introduces stricter timestamp validation with the introduction of two new broker/topic-level properties: [log.message.timestamp.before.max.ms](https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#message-timestamp-before-max-ms) and 
+[log.message.timestamp.after.max.ms](https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#message-timestamp-after-max-ms).
+
+  These properties limit the time difference between the message timestamp (from beats) and the Kafka broker receive time. 
+  Messages can be rejected if the values are exceeded and `log.message.timestamp.type=CreateTime` is set. 
+
+  These checks are ignored if `log.message.timestamp.type=LogAppendTime` is set. 
+
+* For Kafka version 0.10.0.0+ the message creation timestamp is set by beats and equals the initial timestamp of the event. This behavior affects the retention policy in Kafka. For example, if a beat event was created 2 weeks ago, the retention policy is set to 7 days and the message from beats arrives to Kafka today, it is immediately discarded because the timestamp value is before the last 7 days. 
+
+  You can change this behavior by setting timestamps on message arrival instead.
+  The message is not discarded but kept for 7 more days. Set `log.message.timestamp.type` to `LogAppendTime` (default `CreateTime`) in the Kafka configuration.
+:::
 
 
 Example configuration:


### PR DESCRIPTION
Related: https://github.com/elastic/docs-content/issues/2587
Kafka 3.6 added two new properties that change the way that timestamps function. 

### Refine messaging and add to other Kafka output docs
- [x] filebeat
- [ ] auditbeat
- [ ] heartbeat
- [ ] packetbeat
- [ ] metricbeat
- [ ] winlogbeat

REMINDER: This beats PR must be backported to `9.3` for publishing. 

### Propagate to additional repos
Final content also belongs in other products: 
- [ ] Fleet: https://www.elastic.co/docs/reference/fleet/kafka-output
- [ ] APM server? https://www.elastic.co/docs/solutions/observability/apm/apm-server/configure-kafka-output
- [ ] Logstash