### PR TITLE
Fix concurrent map access race in TestReceiverHook

### DIFF
--- a/x-pack/otel/oteltest/oteltest.go
+++ b/x-pack/otel/oteltest/oteltest.go
@@ -188,8 +188,7 @@ func CheckReceivers(params CheckReceiversParams) {
 			require.NotNil(ct, host.getEvent(), "expected not nil, got nil")
 
 			if params.Status != nil {
-				assert.Equal(t, params.Status.Status(), params.Status.Status(), host.Evt.Status(),
-					"expected status to be %v, got %v", params.Status.Status(), host.Evt.Status())
+				assert.Equal(t, params.Status.Status(), host.Evt.Status())
 				assert.Equal(t, params.Status.Err(), host.Evt.Err())
 				assert.Equal(t, params.Status.Attributes().AsRaw(), host.Evt.Attributes().AsRaw())
 			}


### PR DESCRIPTION
## Proposed commit message
Add mutex to mockDiagExtension to protect the hooks map from concurrent read/write between RegisterDiagnosticHook (background goroutine -- called by beats/x-pack/libbeat/cmd/instance/receiver.go:120 ) and the EventuallyWithT polling callback.

Failure in https://buildkite.com/elastic/beats-xpack-metricbeat/builds/28781#019cb857-f39b-4268-8561-dbdfbe0c8897

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~