### PR TITLE
[filebeat][cel] Change noisy log from Info to Debug

### DIFF
--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -275,7 +275,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	// from mito/lib, a global, useragent, is available to use
 	// in requests.
 	err = periodically(ctx, cfg.Interval, func() error {
-		log.Info("process periodic request")
+		log.Debug("process periodic request")
 		var (
 			budget    = *cfg.MaxExecutions
 			waitUntil time.Time


### PR DESCRIPTION
This change was originally part of a bigger PR (https://github.com/elastic/beats/pull/47014/) that was not planned to be fully backported to 9.2 yet we still want to remove the noisy log.