### PR TITLE
Revert "fix: pull vcs information from go binary (#48577)"

### DIFF
--- a/libbeat/version/helper.go
+++ b/libbeat/version/helper.go
@@ -18,32 +18,16 @@
 package version
 
 import (
-	"runtime/debug"
-	"sync"
 	"sync/atomic"
 	"time"
 )
 
 var (
 	packageVersion atomic.Value
-	vcsRevision    = "unknown"
-	vcsTime        time.Time
+	buildTime      = "unknown"
+	commit         = "unknown"
 	qualifier      = ""
-	vcsOnce        sync.Once
 )
-
-func readInfo() {
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			switch setting.Key {
-			case "vcs.time":
-				vcsTime, _ = time.Parse(time.RFC3339, setting.Value)
-			case "vcs.revision":
-				vcsRevision = setting.Value
-			}
-		}
-	}
-}
 
 // GetDefaultVersion returns the current version.
 // If running in stand-alone mode, it's the libbeat version. If running in
@@ -66,14 +50,16 @@ func GetDefaultVersion() string {
 // BuildTime exposes the compile-time build time information.
 // It will represent the zero time instant if parsing fails.
 func BuildTime() time.Time {
-	vcsOnce.Do(readInfo)
-	return vcsTime
+	t, err := time.Parse(time.RFC3339, buildTime)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
 }
 
 // Commit exposes the compile-time commit hash.
 func Commit() string {
-	vcsOnce.Do(readInfo)
-	return vcsRevision
+	return commit
 }
 
 // SetPackageVersion sets the package version, overriding the defaultBeatVersion.


### PR DESCRIPTION
This reverts commit 61ee85489de922ae0a595a727b176711a577ae42.

Reverts https://github.com/elastic/beats/pull/48577/ to fix https://github.com/elastic/beats/issues/49360

- Closes https://github.com/elastic/beats/issues/49360
