### PR TITLE
Docs: Fix heading structure in configuration-monitor.md

### DIFF
--- a/docs/reference/filebeat/configuration-monitor.md
+++ b/docs/reference/filebeat/configuration-monitor.md
@@ -12,7 +12,7 @@ Use the following settings to configure internal collection when you are not usi
 
 You specify these settings in the X-Pack monitoring section of the `filebeat.yml` config file.
 
-The following example shows the expected structure for `monitoring` settings:
+This example shows the expected structure for `monitoring` settings:
 
 ```yaml
 monitoring:
@@ -30,7 +30,7 @@ Refer to [Use internal collection to send monitoring data](/reference/filebeat/m
 
 ## `monitoring.enabled` [_monitoring_enabled]
 
-The `monitoring.enabled` config is a boolean setting to enable or disable {{monitoring}}. If set to `true`, monitoring is enabled.
+The `monitoring.enabled` config is a boolean setting that controls whether {{monitoring}} is enabled. If set to `true`, monitoring is enabled.
 
 The default value is `false`.
 


### PR DESCRIPTION
Docs

## Proposed commit message

This PR fixes the heading structure in the [Settings for internal collection](https://www.elastic.co/docs/reference/beats/filebeat/configuration-monitor) doc and adds an example for the configuration structure.

Resolves https://github.com/elastic/docs-content/issues/4921

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

Made with Cursor
