### PR TITLE
docs: note that Winlogbeat system tests use Go, not Python (#49193)

### DIFF
--- a/docs/extend/testing.md
+++ b/docs/extend/testing.md
@@ -69,6 +69,10 @@ A note about tags: the `--data` flag is a custom flag added by Metricbeat and Pa
 
 The system tests are defined in the `tests/system` (for legacy Python test) and on `tests/integration` (for Go tests) directory. They require a testing binary to be available and the python environment to be set up.
 
+::::{note}
+Winlogbeat does not use Python system tests. Its system tests are plain Go tests located in `winlogbeat/tests/testscript/` and require Windows to run.
+::::
+
 To create the testing binary run `mage buildSystemTestBinary`. This will create the test binary in the beat directory. To set up the Python testing environment run `mage pythonVirtualEnv` which will create a virtual environment with all test dependencies and print its location. To activate it, the instructions depend on your operating system. See the [virtualenv documentation](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#activating-a-virtual-environment).
 
 To run the system and integration tests use the `mage pythonIntegTest` target, which will start the required services using [docker compose](https://docs.docker.com/compose/) and run all integration tests. The default credentials for Elasticsearch and Kibana are `user: admin`, `password: testing`. Similar to Go integration tests, the individual steps can be done manually to allow selecting which tests should be run:


### PR DESCRIPTION
<!-- Type of change: Docs -->

## Proposed commit message

Winlogbeat removed Python `tests/system` tests and switched to Go
`tests/testscript`-based tests, but the shared testing guide still
directed contributors to the Python/pytest workflow for all beats.

Add a note in `docs/extend/testing.md` clarifying that Winlogbeat's
system tests are plain Go tests in `winlogbeat/tests/testscript/` and
require Windows to run.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Related issues

- Closes #49193

## Use cases

Contributors reading the testing guide are no longer told to use the Python/pytest
workflow for Winlogbeat system tests, which no longer exists.
