### PR TITLE
github-actions: gate PR Actions Detective on failed workflow runs

### DIFF
--- a/.github/workflows/trigger-pr-actions-detective.yml
+++ b/.github/workflows/trigger-pr-actions-detective.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   run:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      toJSON(github.event.workflow_run.pull_requests) != '[]'
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-actions-detective.lock.yml@v0
     with:
       setup-commands: |


### PR DESCRIPTION
## Summary
- add a job-level `if` guard to `trigger-pr-actions-detective.yml`
- only run when `workflow_run.conclusion == 'failure'`
- also require associated PRs (`workflow_run.pull_requests` is not empty)

## Why
The detective workflow should not start for successful or cancelled workflow runs. This guard avoids unnecessary runner usage and AI agent invocations when there are no CI failures to investigate.

## Test plan
- [x] validate workflow file parses after change
- [x] confirm diff is limited to the job-level guard

Made with [Cursor](https://cursor.com)