### PR TITLE
x-pack/filebeat/input/httpjson: allow string and number arrays in chained responses

### DIFF
--- a/changelog/fragments/1773196999-allow-string-number-array-in-httpjson-chain.yaml
+++ b/changelog/fragments/1773196999-allow-string-number-array-in-httpjson-chain.yaml
@@ -1,0 +1,4 @@
+kind: enhancement
+summary: Allow string and number arrays in httpjson chained configurations.
+component: filebeat
+issue: https://github.com/elastic/integrations/pull/16662

--- a/docs/reference/filebeat/filebeat-input-httpjson.md
+++ b/docs/reference/filebeat/filebeat-input-httpjson.md
@@ -1506,9 +1506,10 @@ Example:
 
 1. If you want the `value` to be treated as an expression to be evaluated for data extraction from context variables, it should always have a **single *.* (dot) prefix**. Example: `replace_with: '$.exportId,.first_response.body.exportId'`. Anything more or less will have the internal processor treat it as a hard coded value, `replace_with: '$.exportId,..first_response.body.exportId'` (more than one *.* (dot) as prefix) or `replace_with:'$.exportId,first_response.body.exportId'` (no *.* dot as prefix)
 2. Incomplete `value expressions` will cause an error while processing. Example: `replace_with: '$.exportId,.first_response.'`, `replace_with: '$.exportId,.last_response.'` etc. These expressions are incomplete because they do not evaluate down to a valid key that can be extracted from the context variables. The value expression: `.first_response.`, on processing, will result in an array `[first_response ""]` where the key to be extrated becomes `"" (an empty string)`, which has no definition within any context variable.
+3. All but the last response in a chain may be an array of strings or numbers, where each element is an identifier used to construct subsequent requests. The replace expression to access the identifiers is `replace: $[:]`.
 
 ::::{note}
-Fixed patterns must not contain commas in their definition. String replacement patterns are matched by the `replace_with` processor with exact string matching. The `first_response` object at the moment can only store flat JSON structures (i.e. no support for JSONS having array at root level, NDJSON or Gzipped JSON), hence it should only be used in scenarios where the this is the case. Splits cannot be performed on `first_response`. It needs to be explicitly enabled by setting the flag `response.save_first_response` to `true` in the httpjson config.
+Fixed patterns must not contain commas in their definition. String replacement patterns are matched by the `replace_with` processor with exact string matching. The `first_response` object can only store flat JSON structures (no support for NDJSON or Gzipped JSON), except for chained configurations where an array of strings or numbers is allowed. Splits cannot be performed on `first_response`. It needs to be explicitly enabled by setting the flag `response.save_first_response` to `true` in the httpjson config.
 ::::
 
 

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -61,6 +61,16 @@ var testCases = []struct {
 		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 	},
 	{
+		name:        "simple_GET_request_returns_an_array_of_strings_no_events",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+		},
+		handler:  defaultHandler(http.MethodGet, "", `["123", "456"]`),
+		expected: nil,
+	},
+	{
 		name:        "request_honors_rate_limit",
 		setupServer: newTestServer(httptest.NewServer),
 		baseConfig: map[string]interface{}{
@@ -1035,6 +1045,114 @@ var testCases = []struct {
 						"request.method": http.MethodGet,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,.first_response.body.exportId",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_with_clause_with_values_from_string_array",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"text":["1", "2"]}`)
+				case "/2212/1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.text[:]"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.text[:]",
+						"replace_with":   "$.exportId,2212",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_clause_with_string_from_string_array",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `["1", "2"]`)
+				case "/2212/1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$[:]"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$[:]",
+						"replace_with":   "$.exportId,2212",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_clause_with_int_from_int_array",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `[1, 2]`)
+				case "/2212/1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$[:]"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$[:]",
+						"replace_with":   "$.exportId,2212",
 					},
 				},
 			},

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -104,7 +104,7 @@ func (r *requester) doRequest(ctx context.Context, trCtx *transformContext, publ
 			if len(r.requestFactories) == 1 {
 				finalResps = append(finalResps, httpResp)
 				p := newPublisher(trCtx, publisher, true, r.metrics, r.status, r.log)
-				r.responseProcessors[i].startProcessing(ctx, trCtx, finalResps, true, p)
+				r.responseProcessors[i].startProcessing(ctx, trCtx, finalResps, true, false, p)
 				n = p.eventCount()
 				continue
 			}
@@ -141,7 +141,7 @@ func (r *requester) doRequest(ctx context.Context, trCtx *transformContext, publ
 			}
 			// we avoid unnecessary pagination here since chaining is present, thus avoiding any unexpected updates to cursor values
 			p := newPublisher(trCtx, publisher, false, r.metrics, r.status, r.log)
-			r.responseProcessors[i].startProcessing(ctx, trCtx, finalResps, false, p)
+			r.responseProcessors[i].startProcessing(ctx, trCtx, finalResps, false, true, p)
 			n = p.eventCount()
 		} else {
 			if len(ids) == 0 {
@@ -217,10 +217,11 @@ func (r *requester) doRequest(ctx context.Context, trCtx *transformContext, publ
 			}
 
 			p := newPublisher(chainTrCtx, publisher, i < len(r.requestFactories), r.metrics, r.status, r.log)
+			allowStringArray := i < len(r.requestFactories)-1
 			if rf.isChain {
-				rf.chainResponseProcessor.startProcessing(ctx, chainTrCtx, resps, true, p)
+				rf.chainResponseProcessor.startProcessing(ctx, chainTrCtx, resps, true, allowStringArray, p)
 			} else {
-				r.responseProcessors[i].startProcessing(ctx, trCtx, resps, true, p)
+				r.responseProcessors[i].startProcessing(ctx, trCtx, resps, true, false, p)
 			}
 			n += p.eventCount()
 		}
@@ -576,7 +577,7 @@ func (r *requester) getIdsFromResponses(intermediateResps []*http.Response, repl
 func (r *requester) processRemainingChainEvents(stdCtx context.Context, trCtx *transformContext, publisher inputcursor.Publisher, initialResp []*http.Response, chainIndex int) int {
 	// we start from 0, and skip the 1st event since we have already processed it
 	p := newChainProcessor(r, trCtx, publisher, chainIndex, r.status)
-	r.responseProcessors[0].startProcessing(stdCtx, trCtx, initialResp, true, p)
+	r.responseProcessors[0].startProcessing(stdCtx, trCtx, initialResp, true, true, p)
 	return p.eventCount()
 }
 
@@ -759,7 +760,7 @@ func (r *requester) processChainPaginationEvents(ctx context.Context, trCtx *tra
 			resps = intermediateResps
 		}
 		p := newPublisher(chainTrCtx, publisher, i < len(r.requestFactories), r.metrics, r.status, r.log)
-		rf.chainResponseProcessor.startProcessing(ctx, chainTrCtx, resps, true, p)
+		rf.chainResponseProcessor.startProcessing(ctx, chainTrCtx, resps, true, i < len(r.requestFactories)-1, p)
 		n += p.eventCount()
 	}
 

--- a/x-pack/filebeat/input/httpjson/response.go
+++ b/x-pack/filebeat/input/httpjson/response.go
@@ -48,7 +48,7 @@ func (resp *response) clone() *response {
 	return clone
 }
 
-func (resp *response) asTransformables(stat status.StatusReporter, log *logp.Logger) []transformable {
+func (resp *response) asTransformables(stat status.StatusReporter, log *logp.Logger, allowStringArray bool) []transformable {
 	var ts []transformable
 
 	convertAndAppend := func(m map[string]interface{}) {
@@ -61,15 +61,23 @@ func (resp *response) asTransformables(stat status.StatusReporter, log *logp.Log
 
 	switch tresp := resp.body.(type) {
 	case []interface{}:
+		var scalars int
 		for _, v := range tresp {
-			m, ok := v.(map[string]interface{})
-			if !ok {
+			switch v := v.(type) {
+			case string, float64:
+				scalars++
+			case map[string]interface{}:
+				convertAndAppend(v)
+			default:
 				msg := fmt.Sprintf("events must be JSON objects, but got %T: skipping", v)
 				log.Debug(msg)
 				stat.UpdateStatus(status.Degraded, msg)
-				continue
 			}
-			convertAndAppend(m)
+		}
+		if scalars > 0 && (scalars != len(tresp) || !allowStringArray) {
+			msg := fmt.Sprintf("events must be JSON objects, but got %d scalar values in array of length %d", scalars, len(tresp))
+			log.Debug(msg)
+			stat.UpdateStatus(status.Degraded, msg)
 		}
 	case map[string]interface{}:
 		convertAndAppend(tresp)
@@ -194,7 +202,7 @@ type handler interface {
 	handleError(error)
 }
 
-func (rp *responseProcessor) startProcessing(ctx context.Context, trCtx *transformContext, resps []*http.Response, paginate bool, h handler) {
+func (rp *responseProcessor) startProcessing(ctx context.Context, trCtx *transformContext, resps []*http.Response, paginate, allowStringArray bool, h handler) {
 	trCtx.clearIntervalData()
 
 	var npages int64
@@ -215,7 +223,7 @@ func (rp *responseProcessor) startProcessing(ctx context.Context, trCtx *transfo
 				return
 			}
 
-			respTrs := page.asTransformables(rp.status, rp.log)
+			respTrs := page.asTransformables(rp.status, rp.log, allowStringArray)
 
 			if len(respTrs) == 0 {
 				return

--- a/x-pack/filebeat/input/httpjson/response_test.go
+++ b/x-pack/filebeat/input/httpjson/response_test.go
@@ -5,11 +5,15 @@
 package httpjson
 
 import (
+	"encoding/json"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -41,4 +45,159 @@ func TestTemplateValues(t *testing.T) {
 
 	assert.NotNil(t, vals)
 	assert.Equal(t, 0, len(vals))
+}
+
+var asTransformablesTests = []struct {
+	name                   string
+	message                string
+	allowStringArray       bool
+	expectedTransformables int
+	expectStatusUpdates    bool
+	statusUpdate           status.Status
+	expectLogs             bool
+}{
+	{
+		name:                   "string_array_allowed",
+		message:                `["123456789abcdefgh8866123","123456789zxcvbnmas8a8q60"]`,
+		allowStringArray:       true,
+		expectedTransformables: 0,
+		expectStatusUpdates:    false,
+		expectLogs:             false,
+	},
+	{
+		name:                   "single_string_allowed",
+		message:                `["123456789abcdefgh8866123"]`,
+		allowStringArray:       true,
+		expectedTransformables: 0,
+		expectStatusUpdates:    false,
+		expectLogs:             false,
+	},
+	{
+		name:                   "number_array_allowed",
+		message:                `[1, 2]`,
+		allowStringArray:       true,
+		expectedTransformables: 0,
+		expectStatusUpdates:    false,
+		expectLogs:             false,
+	},
+	{
+		name:                   "mixed_strings_and_objects_degrades",
+		message:                `["123456789abcdefgh8866123", {"text": "123456789zxcvbnmas8a8q60"}, {"text": "4853489589345y8934"}]`,
+		allowStringArray:       true,
+		expectedTransformables: 2,
+		expectStatusUpdates:    true,
+		expectLogs:             true,
+		statusUpdate:           status.Degraded,
+	},
+	{
+		name:                   "mixed_objects_and_strings_degrades",
+		message:                `[{"text": "123456789zxcvbnmas8a8q60"}, "123456789abcdefgh8866123", {"text": "4853489589345y8934"}]`,
+		allowStringArray:       true,
+		expectedTransformables: 2,
+		expectStatusUpdates:    true,
+		expectLogs:             true,
+		statusUpdate:           status.Degraded,
+	},
+	{
+		name:                   "string_array_not_allowed_degrades",
+		message:                `["123456789abcdefgh8866123","123456789zxcvbnmas8a8q60"]`,
+		allowStringArray:       false,
+		expectedTransformables: 0,
+		expectStatusUpdates:    true,
+		expectLogs:             true,
+		statusUpdate:           status.Degraded,
+	},
+	{
+		name:                   "single_string_not_allowed_degrades",
+		message:                `["123456789abcdefgh8866123"]`,
+		allowStringArray:       false,
+		expectedTransformables: 0,
+		expectStatusUpdates:    true,
+		expectLogs:             true,
+		statusUpdate:           status.Degraded,
+	},
+	{
+		name:                   "number_array_not_allowed_degrades",
+		message:                `[1, 2]`,
+		allowStringArray:       false,
+		expectedTransformables: 0,
+		expectStatusUpdates:    true,
+		expectLogs:             true,
+		statusUpdate:           status.Degraded,
+	},
+	{
+		name:                   "object_response",
+		message:                `{"response":{"empty":[]}}`,
+		allowStringArray:       false,
+		expectedTransformables: 1,
+		expectStatusUpdates:    false,
+		expectLogs:             false,
+	},
+}
+
+func TestAsTransformables(t *testing.T) {
+	for _, test := range asTransformablesTests {
+		t.Run(test.name, func(t *testing.T) {
+			var data interface{}
+			err := json.Unmarshal([]byte(test.message), &data)
+			if err != nil {
+				t.Fatalf("error unmarshalling json: %s", err)
+			}
+
+			resp := &response{
+				page: 1,
+				url:  *(newURL("http://test?p1=v1")),
+				header: http.Header{
+					"Authorization": []string{"Bearer token"},
+				},
+				body: data,
+			}
+
+			stat := &testStatusReporter{}
+
+			logger, logs := logptest.NewTestingLoggerWithObserver(t, "")
+			transformables := resp.asTransformables(stat, logger, test.allowStringArray)
+
+			if test.expectStatusUpdates {
+				assert.NotEmpty(t, stat.updates(), "expected status updates but got none")
+				if len(stat.updates()) > 0 {
+					assert.Equal(t, test.statusUpdate, stat.updates()[0].state,
+						"status update does not match: got %v, want %v", stat.updates()[0].state, test.statusUpdate)
+				}
+			} else {
+				assert.Empty(t, stat.updates(), "expected no status updates")
+			}
+
+			allLogs := logs.All()
+			if test.expectLogs {
+				assert.NotEmpty(t, allLogs, "expected logs but got none")
+			} else {
+				assert.Empty(t, allLogs, "expected no logs")
+			}
+
+			assert.Len(t, transformables, test.expectedTransformables, "unexpected number of transformables")
+		})
+	}
+}
+
+type testStatusReporter struct {
+	mu      sync.RWMutex
+	entries []statusUpdate
+}
+
+func (r *testStatusReporter) UpdateStatus(s status.Status, msg string) {
+	r.mu.Lock()
+	r.entries = append(r.entries, statusUpdate{s, msg})
+	r.mu.Unlock()
+}
+
+func (r *testStatusReporter) updates() []statusUpdate {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]statusUpdate{}, r.entries...)
+}
+
+type statusUpdate struct {
+	state status.Status
+	msg   string
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/httpjson: allow string and number arrays in chained responses

The httpjson input degrades when a JSON response is an array of
non-object values. This is correct for top-level requests, but in
chained configurations the intermediate responses are often arrays of
identifiers (strings or numbers) used to construct subsequent request
URLs. The degradation is incorrect in that context.

Add an allowStringArray parameter to asTransformables and thread it
through startProcessing to all six call sites. Intermediate chain
steps pass true, suppressing the degradation for pure scalar arrays.
Non-chained and final-step contexts pass false, preserving the
existing behaviour. Mixed arrays (scalars and objects together)
always degrade regardless of context.
```

> [!NOTE]
> This is largely taken from #48592 with clean up. The documentation is verbatim, and tests are essentially verbatim from that change; only minor alterations to `asTransformables` to reduce allocation during the mapping over the response body for non-object elements.
> Sending as a new PR to make sure approval is not by author.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #48254
- Close #48592
- Ref elastic/integrations#16662
## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
