### PR TITLE
filebeat: fix TestFilebeatOTelHTTPJSONInputWithElasticStateStore

### DIFF
--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -1870,10 +1870,10 @@ func TestFilebeatOTelHTTPJSONInputWithElasticStateStore(t *testing.T) {
               value: '[[.last_event.published]]'
     queue.mem.flush.timeout: 0s
     setup.template.enabled: false
-    storage: elastic_storage
+    storage: elasticsearch_storage
     path.home: {{ .PathHome }}
 extensions:
-  elastic_storage:
+  elasticsearch_storage:
     hosts:
       - {{ .ESURL }}
     username: {{ .Username }}
@@ -1892,7 +1892,7 @@ exporters:
         flush_timeout: 1s
 service:
   extensions:
-    - elastic_storage
+    - elasticsearch_storage
   pipelines:
     logs:
       receivers:


### PR DESCRIPTION
Tests are failing on main because https://github.com/elastic/beats/commit/987765e10c47145762c8d2311c4653ef58f6ba75 changed the extension name but did not update filebeat's test. This fixes the test.

## Proposed commit message

```
filebeat: fix TestFilebeatOTelHTTPJSONInputWithElasticStateStore
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None


## How to test this PR locally

Run the test

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- N/A
