### PR TITLE
x-pack/filebeat/input/streaming: add rate-limit backoff to CrowdStrike oauth2 transport

### DIFF
--- a/changelog/fragments/1773350293-crowdstrike-streaming-rate-limit.yaml
+++ b/changelog/fragments/1773350293-crowdstrike-streaming-rate-limit.yaml
@@ -1,0 +1,10 @@
+kind: bug-fix
+summary: Add rate-limit backoff to CrowdStrike streaming input oauth2 transport.
+description: |
+  Wrap the oauth2 HTTP transport used by the CrowdStrike falcon streaming input
+  with a rate-limit-aware transport that intercepts 429 responses, reads the
+  Retry-After header, and backs off before retrying. This prevents the oauth2
+  token refresh from generating a burst of unauthorized requests that triggers
+  CrowdStrike's 15-per-minute rate limit. The discover endpoint also returns a
+  retry-after hint to the session-level retry loop as a minimum wait floor.
+component: filebeat

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
@@ -35,9 +36,10 @@ type falconHoseStream struct {
 
 	status status.StatusReporter
 
-	creds       *clientcredentials.Config
-	discoverURL string
-	plainClient *http.Client
+	creds         *clientcredentials.Config
+	authTransport *rateLimitTransport
+	discoverURL   string
+	plainClient   *http.Client
 
 	time func() time.Time
 }
@@ -131,6 +133,26 @@ func NewFalconHoseFollower(ctx context.Context, env v2.Context, cfg config, curs
 	u.RawQuery = query.Encode()
 	s.discoverURL = u.String()
 
+	// Build the auth transport before zeroing timeouts for the streaming
+	// client. The oauth2 token endpoint needs normal request timeouts;
+	// moving this after the timeout zeroing will cause auth requests to
+	// hang indefinitely.
+	authClient, err := cfg.Transport.Client(httpcommon.WithAPMHTTPInstrumentation(), httpcommon.WithLogger(log))
+	if err != nil {
+		stat.UpdateStatus(status.Failed, "failed to configure auth client: "+err.Error())
+		return nil, err
+	}
+	if now == nil {
+		now = time.Now
+	}
+	s.authTransport = &rateLimitTransport{
+		base:     authClient.Transport,
+		maxRetry: 3,
+		wait:     60 * time.Second,
+		log:      log,
+		now:      now,
+	}
+
 	cfg.Transport.Timeout = 0
 	cfg.Transport.IdleConnTimeout = 0
 	s.plainClient, err = cfg.Transport.Client(httpcommon.WithAPMHTTPInstrumentation(), httpcommon.WithLogger(log))
@@ -153,6 +175,7 @@ func (s *falconHoseStream) FollowStream(ctx context.Context) error {
 		state["cursor"] = s.cursor
 	}
 
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: s.authTransport})
 	cli := s.creds.Client(ctx)
 	// Normally we would not bother with this, but since connections
 	// are in keep-alive in normal operation, let's clean up.
@@ -188,6 +211,10 @@ func (s *falconHoseStream) FollowStream(ctx context.Context) error {
 				s.log.Warnw("no retry configured: using linear back-off")
 				waitTime = min(time.Duration(attempt)*time.Second, 30*time.Second)
 			}
+			var rle *rateLimitError
+			if errors.As(err, &rle) && rle.wait > waitTime {
+				waitTime = rle.wait
+			}
 
 			s.status.UpdateStatus(status.Degraded, err.Error())
 			s.log.Warnw("session warning", "error", err, "attempt", attempt, "wait", waitTime.String())
@@ -222,9 +249,23 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, resp.Body)
+		wait := parseRetryAfter(resp.Header.Get("Retry-After"), 60*time.Second, s.now())
+		s.log.Warnw("rate limited by discover endpoint",
+			"status_code", resp.StatusCode,
+			"body", buf.String(),
+			"retry_after", wait,
+		)
+		return state, &rateLimitError{
+			wait: wait,
+			err:  fmt.Errorf("rate limited by discover endpoint: %s", resp.Status),
+		}
+	}
 	if resp.StatusCode != http.StatusOK {
 		var buf bytes.Buffer
-		io.Copy(&buf, resp.Body)
+		_, _ = io.Copy(&buf, resp.Body)
 		s.log.Errorw("unsuccessful request", "status_code", resp.StatusCode, "status", resp.Status, "body", buf.String())
 		return state, fmt.Errorf("unsuccessful request: %s: %s", resp.Status, &buf)
 	}
@@ -325,7 +366,7 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 
 		if resp.StatusCode != http.StatusOK {
 			var buf bytes.Buffer
-			io.Copy(&buf, resp.Body)
+			_, _ = io.Copy(&buf, resp.Body)
 			s.log.Errorw("unsuccessful firehose request", "status_code", resp.StatusCode, "status", resp.Status, "body", buf.String())
 			return state, fmt.Errorf("unsuccessful firehose request: %s: %s", resp.Status, &buf)
 		}
@@ -366,6 +407,16 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	}
 	return state, nil
 }
+
+// rateLimitError carries a retry-after duration from a 429 response so
+// the session-level retry loop can use it as a minimum wait.
+type rateLimitError struct {
+	wait time.Duration
+	err  error
+}
+
+func (e *rateLimitError) Error() string { return e.err.Error() }
+func (e *rateLimitError) Unwrap() error { return e.err }
 
 // hardError is an input-terminating error.
 type hardError struct {

--- a/x-pack/filebeat/input/streaming/crowdstrike_ratelimit.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_ratelimit.go
@@ -1,0 +1,115 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package streaming
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+var _ http.RoundTripper = (*rateLimitTransport)(nil)
+
+// rateLimitTransport wraps an http.RoundTripper to intercept 429 responses
+// and retry after the duration indicated by the Retry-After header. This sits
+// below the oauth2 transport so that rate-limited token-refresh requests are
+// retried before the oauth2 library sees the failure and generates additional
+// unauthorized requests.
+type rateLimitTransport struct {
+	base     http.RoundTripper
+	maxRetry int
+	wait     time.Duration // default wait when Retry-After is absent
+	log      *logp.Logger
+	now      func() time.Time
+}
+
+func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Buffer the body so POST requests (token endpoint) can be replayed.
+	var body []byte
+	if req.Body != nil {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("rate limit transport: reading request body: %w", err)
+		}
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	for attempt := 0; ; attempt++ {
+		resp, err := t.base.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusTooManyRequests || attempt >= t.maxRetry {
+			return resp, nil
+		}
+
+		wait := parseRetryAfter(resp.Header.Get("Retry-After"), t.wait, t.timeNow())
+		resp.Body.Close()
+
+		t.log.Warnw("rate limited, backing off",
+			"attempt", attempt+1,
+			"max_retries", t.maxRetry,
+			"retry_after", wait,
+		)
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, req.Context().Err()
+		case <-timer.C:
+		}
+
+		if body != nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+		}
+	}
+}
+
+func (t *rateLimitTransport) timeNow() time.Time {
+	if t.now != nil {
+		return t.now()
+	}
+	return time.Now()
+}
+
+// parseRetryAfter parses a Retry-After header as either an integer number
+// of seconds or an HTTP-date (RFC 7231 §7.1.3). If the value is empty or
+// unparseable, fallback is returned. ref is the reference time for computing
+// the delay from an HTTP-date.
+//
+// CrowdStrike's documented response headers include X-Ratelimit-Limit and
+// X-Ratelimit-Remaining but not Retry-After. The 429 that triggers this
+// code path is a security rate limit (15 unauthorized requests/minute/IP),
+// not the normal 6000 req/min API limit, and may return no retry guidance
+// at all. The fallback duration (60s, matching the rate-limit window) is
+// expected to do the real work in practice; the header parsing is defensive.
+func parseRetryAfter(val string, fallback time.Duration, ref time.Time) time.Duration {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return fallback
+	}
+	if secs, err := strconv.ParseInt(val, 10, 64); err == nil {
+		if secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+		return fallback
+	}
+	if t, err := http.ParseTime(val); err == nil {
+		if d := t.Sub(ref); d > 0 {
+			return d
+		}
+		return fallback
+	}
+	return fallback
+}

--- a/x-pack/filebeat/input/streaming/crowdstrike_ratelimit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_ratelimit_test.go
@@ -1,0 +1,226 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package streaming
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	ref := time.Date(2026, 3, 13, 12, 0, 0, 0, time.UTC)
+	fallback := 60 * time.Second
+
+	tests := []struct {
+		name string
+		val  string
+		want time.Duration
+	}{
+		{name: "empty", val: "", want: fallback},
+		{name: "seconds", val: "30", want: 30 * time.Second},
+		{name: "large_seconds", val: "120", want: 120 * time.Second},
+		{name: "zero", val: "0", want: fallback},
+		{name: "negative", val: "-5", want: fallback},
+		{name: "http_date_future", val: "Thu, 13 Mar 2026 12:01:00 GMT", want: 60 * time.Second},
+		{name: "http_date_past", val: "Thu, 13 Mar 2026 11:59:00 GMT", want: fallback},
+		{name: "invalid", val: "garbage", want: fallback},
+		{name: "whitespace", val: "  30  ", want: 30 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseRetryAfter(tt.val, fallback, ref)
+			if got != tt.want {
+				t.Errorf("parseRetryAfter(%q, %v, _) = %v, want %v", tt.val, fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimitTransport(t *testing.T) {
+	log := logptest.NewTestingLogger(t, "")
+
+	t.Run("passthrough_200", func(t *testing.T) {
+		t.Parallel()
+		ft := &fakeTransport{statuses: []int{200}}
+		rt := &rateLimitTransport{base: ft, maxRetry: 3, wait: time.Millisecond, log: log}
+
+		req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com", nil)
+		got, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer got.Body.Close()
+		if got.StatusCode != 200 {
+			t.Errorf("got status %d, want 200", got.StatusCode)
+		}
+		if ft.call != 1 {
+			t.Errorf("got %d calls, want 1", ft.call)
+		}
+	})
+
+	t.Run("retry_then_success", func(t *testing.T) {
+		t.Parallel()
+		ft := &fakeTransport{statuses: []int{429, 429, 200}}
+		rt := &rateLimitTransport{base: ft, maxRetry: 3, wait: time.Millisecond, log: log}
+
+		req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com", nil)
+		got, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer got.Body.Close()
+		if got.StatusCode != 200 {
+			t.Errorf("got status %d, want 200", got.StatusCode)
+		}
+		if ft.call != 3 {
+			t.Errorf("got %d calls, want 3", ft.call)
+		}
+	})
+
+	t.Run("max_retries_exceeded", func(t *testing.T) {
+		t.Parallel()
+		ft := &fakeTransport{statuses: []int{429, 429, 429, 429}}
+		rt := &rateLimitTransport{base: ft, maxRetry: 3, wait: time.Millisecond, log: log}
+
+		req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com", nil)
+		got, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer got.Body.Close()
+		if got.StatusCode != http.StatusTooManyRequests {
+			t.Errorf("got status %d, want 429", got.StatusCode)
+		}
+		if ft.call != 4 {
+			t.Errorf("got %d calls, want 4", ft.call)
+		}
+	})
+
+	t.Run("context_cancelled_during_wait", func(t *testing.T) {
+		t.Parallel()
+		ft := &fakeTransport{statuses: []int{429, 429}}
+		rt := &rateLimitTransport{base: ft, maxRetry: 3, wait: time.Hour, log: log}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
+		_, err := rt.RoundTrip(req)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("got error %v, want context.Canceled", err)
+		}
+	})
+}
+
+func TestRateLimitTransportBodyReplay(t *testing.T) {
+	t.Parallel()
+
+	log := logptest.NewTestingLogger(t, "")
+	ft := &fakeTransport{statuses: []int{429, 200}}
+	rt := &rateLimitTransport{base: ft, maxRetry: 3, wait: time.Millisecond, log: log}
+
+	body := "grant_type=client_credentials&client_id=test"
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "http://example.com/token", io.NopCloser(strings.NewReader(body)))
+	got, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer got.Body.Close()
+	if got.StatusCode != 200 {
+		t.Errorf("got status %d, want 200", got.StatusCode)
+	}
+	if ft.call != 2 {
+		t.Errorf("got %d calls, want 2", ft.call)
+	}
+	for i, b := range ft.bodies {
+		if !bytes.Equal(b, []byte(body)) {
+			t.Errorf("call %d: body = %q, want %q", i, b, body)
+		}
+	}
+}
+
+// fakeTransport returns canned responses built from statuses.
+// Responses are constructed inside RoundTrip so that bodyclose
+// can trace each *http.Response to the caller.
+type fakeTransport struct {
+	statuses []int
+	call     int
+	bodies   [][]byte // captured request bodies, indexed by call
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := f.call
+	f.call++
+	if req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		req.Body.Close()
+		for len(f.bodies) <= idx {
+			f.bodies = append(f.bodies, nil)
+		}
+		f.bodies[idx] = b
+	}
+	status := 500
+	if idx < len(f.statuses) {
+		status = f.statuses[idx]
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func TestFollowSessionRateLimit(t *testing.T) {
+	t.Parallel()
+
+	log := logptest.NewTestingLogger(t, "")
+	const retryAfter = "45"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", retryAfter)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"rate limit exceeded"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	s := &falconHoseStream{
+		processor: processor{
+			ns:      "test",
+			log:     log,
+			metrics: newInputMetrics(monitoring.NewRegistry(), log),
+		},
+		status:      noopReporter{},
+		discoverURL: srv.URL,
+	}
+
+	state := map[string]any{}
+	_, err := s.followSession(context.Background(), srv.Client(), state)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var rle *rateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected *rateLimitError, got %T: %v", err, err)
+	}
+	if rle.wait != 45*time.Second {
+		t.Errorf("rateLimitError.wait = %v, want %v", rle.wait, 45*time.Second)
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: add rate-limit backoff to CrowdStrike oauth2 transport

When a CrowdStrike bearer token expires, the oauth2 client retries
authentication with no backoff. If these retries produce more than
15 failed requests from the same IP within one minute, CrowdStrike
returns 429 and blocks further attempts. The input's session-level
retry loop then restarts and triggers another burst.

Wrap the oauth2 HTTP transport with a rateLimitTransport that
intercepts 429 responses, reads the Retry-After header, and backs
off before retrying (up to 3 transport-level retries, 60s default
wait). The discover endpoint also surfaces 429 as a rateLimitError
so the session-level retry loop uses the retry-after duration as a
minimum wait floor.

The auth transport is built from the configured transport settings
before timeouts are zeroed for the streaming client, preserving
proxy and TLS configuration with normal request timeouts.
```

> [!NOTE]
> CrowdStrike's API returns `X-Ratelimit-Limit` and `X-Ratelimit-Remaining` on all responses (visible in PSFalcon verbose output and the FalconPy response-handling docs at falconpy.io). There is no evidence of a standard `Retry-After` header or `X-Ratelimit-RetryAfter` on 429 responses. The official Go SDK (gofalcon) has no rate-limit handling at all; the Python SDK (falconpy) documents only the two headers above in its response structure.
>
> The 429 that matters here is not the normal 6,000 req/min API rate limit. It is a security rate limit: after 15 unauthorized (401) requests from the same IP in one minute, CrowdStrike blocks further attempts with 429. This is brute-force protection on the token endpoint, and security blocks typically return bare 429s with no retry guidance.
>
> The `rateLimitTransport` implementation parses `Retry-After` defensively (costs nothing, and honours it if CrowdStrike adds the header in the future), but the 60-second default fallback (matching the 1-minute rate-limit window) is what provides the actual protection.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
