### PR TITLE
[Flaky test] Use no-op logger for `TestSimpleInputConfig`

### DIFF
--- a/x-pack/libbeat/management/simple_input_config_test.go
+++ b/x-pack/libbeat/management/simple_input_config_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestSimpleInputConfig(t *testing.T) {
@@ -144,7 +144,7 @@ func TestSimpleInputConfig(t *testing.T) {
 		},
 		r,
 		client,
-		logptest.NewTestingLogger(t, ""),
+		logp.NewNopLogger(),
 	)
 	if err != nil {
 		t.Fatalf("could not instantiate ManagerV2: %s", err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
After https://github.com/elastic/beats/pull/49414 was merged -  TestSimpleInputConfig has become flaky again. Using no-op logger inside the test to keep CI stable 

