### PR TITLE
Adds a log class limitation to the docs for the AWS CloudWatch input

### DIFF
--- a/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
+++ b/docs/reference/filebeat/filebeat-input-aws-cloudwatch.md
@@ -10,7 +10,7 @@ applies_to:
 # AWS CloudWatch input [filebeat-input-aws-cloudwatch]
 
 
-`aws-cloudwatch` input can be used to retrieve all logs from all log streams in a specific log group. `filterLogEvents` AWS API is used to list log events from the specified log group. Amazon CloudWatch Logs can be used to store log files from Amazon Elastic Compute Cloud(EC2), AWS CloudTrail, Route53, and other sources.
+The `aws-cloudwatch` input can be used to retrieve all logs from all log streams in a specific log group. The `FilterLogEvents` AWS API is used to list log events from the specified log group. Amazon CloudWatch Logs can be used to store log files from Amazon Elastic Compute Cloud(EC2), AWS CloudTrail, Route53, and other sources.
 
 A log group is a group of log streams that share the same retention, monitoring, and access control settings. You can define log groups and specify which streams to put into each group. There is no limit on the number of log streams that can belong to one log group.
 
@@ -53,10 +53,6 @@ Note: `region_name` is required when log_group_name is given.
 The prefix for a group of log group names. See `include_linked_accounts_for_prefix_mode` option for linked source accounts behavior.
 
 Note: `region_name` is required when `log_group_name_prefix` is given. `log_group_name` and `log_group_name_prefix` cannot be given at the same time. The number of workers that will process the log groups under this prefix is set through the `number_of_workers` config.
-
-:::{note}
-When you use `log_group_name_prefix`, all matching log groups are included regardless of their log class. If any matching log groups use the Infrequent Access log class, API errors occur because the `FilterLogEvents` API is not supported for that log class. Make sure all log groups that match the prefix use the Standard log class.
-:::
 
 
 ### `include_linked_accounts_for_prefix_mode` [_include_linked_accounts_for_prefix_mode]


### PR DESCRIPTION
Docs

## Proposed commit message

This PR clarifies that the `aws-cloudwatch` input only supports log groups using the Standard log class, since it relies on the `FilterLogEvents` API which AWS does not support for Infrequent Access log groups.

Resolves elastic/docs-content#2418

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
