### PR TITLE
[AutoOps] Reduce Noisey Logging

### DIFF
--- a/changelog/fragments/1773700260-reduce-autoops-logging-from-info-to-debug.yaml
+++ b/changelog/fragments/1773700260-reduce-autoops-logging-from-info-to-debug.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Reduce AutoOps logging from info to debug for polling
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/metricbeat/module/autoops_es/metricset/metricset.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/metricset.go
@@ -93,7 +93,7 @@ func newAutoOpsMetricSet[T any](base mb.BaseMetricSet, routePath string, mapper 
 func (m *AutoOpsMetricSet[T]) Fetch(r mb.ReporterV2) error {
 	metricSetName := m.Name()
 
-	m.Logger().Infof("fetching %v metricset", metricSetName)
+	m.Logger().Debugf("fetching %v metricset", metricSetName)
 
 	// because Fetch() is part ReporterV2 interface, we're purposely not returning an error
 	// we do not want to the metricset Error() method to be called, so we are returning nil to avoid duplicate errors sent and logger
@@ -128,7 +128,7 @@ func (m *AutoOpsMetricSet[T]) Fetch(r mb.ReporterV2) error {
 		return nil //nolint: nilerr // The error is reported by the mapper
 	}
 
-	m.Logger().Infof("completed fetching %v metricset", metricSetName)
+	m.Logger().Debugf("completed fetching %v metricset", metricSetName)
 	return nil
 }
 


### PR DESCRIPTION
This reduces the primary logging from the AutoOps module to only important, unpredictable details. Info logging is reduced to avoid spamming the user's logs.

The same logging can be turned back on by enabling debug logging.

## Proposed commit message

Reduce constant, noisey logging by downgrading the existing, repetitive `info` level logs to `debug`. This actually improves debugging because, once you realize that it reports failures, you can focus on what matters: either logs indicate there are problems, or there are no problems.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

The logging may appear disruptive because of a sudden lack of output by default, but the release note and accompanying issue are here to help.

## How to test this PR locally

Run the agent and observe data continues to be published, but the logging only appears in with debug enabled (`logging.level: debug`).

## Related issues

- Closes #49506 

## Use cases

Running many agents can produce a lot of wastefully expensive O11y without this change.