### PR TITLE
docs: fix typos in Kubernetes and Packetbeat docs

### DIFF
--- a/docs/reference/metricbeat/exported-fields-kubernetes.md
+++ b/docs/reference/metricbeat/exported-fields-kubernetes.md
@@ -69,7 +69,7 @@ Kubernetes API server metrics
 
 
 **`kubernetes.apiserver.request.dry_run`**
-:   Wether the request uses dry run
+:   Whether the request uses dry run
 
     type: keyword
 

--- a/docs/reference/packetbeat/packetbeat-http-options.md
+++ b/docs/reference/packetbeat/packetbeat-http-options.md
@@ -57,7 +57,7 @@ Instead of sending a white list of headers to Elasticsearch, you can send all he
 
 ### `redact_headers` [_redact_headers]
 
-A list of headers to redact if present in the HTTP request. This will keep the header field present, but will redact it’s value to show the header’s presence.
+A list of headers to redact if present in the HTTP request. This will keep the header field present, but will redact its value to show the header’s presence.
 
 
 ### `include_body_for` [_include_body_for]

--- a/docs/reference/packetbeat/packetbeat-reference-yml.md
+++ b/docs/reference/packetbeat/packetbeat-reference-yml.md
@@ -279,7 +279,7 @@ packetbeat.protocols:
   #send_all_headers: false
 
   # A list of headers to redact if present in the HTTP request. This will keep
-  # the header field present, but will redact it's value to show the headers
+  # the header field present, but will redact its value to show the headers
   # presence.
   #redact_headers: []
 

--- a/libbeat/autodiscover/README.md
+++ b/libbeat/autodiscover/README.md
@@ -178,7 +178,7 @@ spec:
 Everything works the same as Autodiscover without LeaderElection until step 8.
 
 8. If there is no conditions in the template set by the user, the configs will be generated from [hints](https://github.com/elastic/beats/blob/4b1f69923b3f2abbbf1860295fe5dbff7db3d63c/libbeat/autodiscover/providers/kubernetes/kubernetes.go#L186).
-9. Wether hints are enabled or not is part of the [Kubernetes Provider struct](https://github.com/elastic/beats/blob/4b1f69923b3f2abbbf1860295fe5dbff7db3d63c/libbeat/autodiscover/providers/kubernetes/kubernetes.go#L121) builders field.
+9. Whether hints are enabled or not is part of the [Kubernetes Provider struct](https://github.com/elastic/beats/blob/4b1f69923b3f2abbbf1860295fe5dbff7db3d63c/libbeat/autodiscover/providers/kubernetes/kubernetes.go#L121) builders field.
 10. [GenerateHints](https://github.com/elastic/beats/blob/eff92354db783001880f4bade9f59942fca747ba/libbeat/autodiscover/builder/helper.go#L213) function looks into the event's annotations. A [hints map](https://github.com/elastic/beats/blob/eff92354db783001880f4bade9f59942fca747ba/libbeat/autodiscover/builder/helper.go#L226) is created with all hints and returned.
 11. From those hints, configs are [created](https://github.com/elastic/beats/blob/4b1f69923b3f2abbbf1860295fe5dbff7db3d63c/libbeat/autodiscover/builder.go#L97) in the same form as in `Autodiscover without LeaderElection` step 8.
     They contain the same information as if they where set explicitly in the metricbeat configureation but actually derive from the pod annotations.

--- a/metricbeat/module/kubernetes/apiserver/_meta/fields.yml
+++ b/metricbeat/module/kubernetes/apiserver/_meta/fields.yml
@@ -39,7 +39,7 @@
     - name: request.dry_run
       type: keyword
       description: >
-        Wether the request uses dry run
+        Whether the request uses dry run
     - name: request.kind
       type: keyword
       description: >

--- a/packetbeat/_meta/config/beat.reference.yml.tmpl
+++ b/packetbeat/_meta/config/beat.reference.yml.tmpl
@@ -268,7 +268,7 @@ packetbeat.protocols:
   #send_all_headers: false
 
   # A list of headers to redact if present in the HTTP request. This will keep
-  # the header field present, but will redact it's value to show the headers
+  # the header field present, but will redact its value to show the headers
   # presence.
   #redact_headers: []
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -265,7 +265,7 @@ packetbeat.protocols:
   #send_all_headers: false
 
   # A list of headers to redact if present in the HTTP request. This will keep
-  # the header field present, but will redact it's value to show the headers
+  # the header field present, but will redact its value to show the headers
   # presence.
   #redact_headers: []
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -265,7 +265,7 @@ packetbeat.protocols:
   #send_all_headers: false
 
   # A list of headers to redact if present in the HTTP request. This will keep
-  # the header field present, but will redact it's value to show the headers
+  # the header field present, but will redact its value to show the headers
   # presence.
   #redact_headers: []
 


### PR DESCRIPTION
## Proposed commit message

Fix two families of typos identified in #49600:

1. **"Wether" → "Whether"** in Kubernetes autodiscover docs and apiserver field descriptions (3 files)
2. **"it's" → "its"** (possessive) in Packetbeat `redact_headers` config and docs (5 files)

See title.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added an entry in `./changelog/fragments`~~

## Disruptive User Impact

None. Documentation-only changes.

## How to test this PR locally

```bash
grep -rn "Wether" libbeat/ metricbeat/ docs/
grep -rn "it's value" packetbeat/ x-pack/packetbeat/ docs/reference/packetbeat/
```

Both should return no results after this fix.

## Related issues

- Closes #49600