### PR TITLE
filebeat/input/{v2,logv2}: add Redirector interface for general input migration

### DIFF
--- a/changelog/fragments/1774300895-id6318-filebeat-director.yaml
+++ b/changelog/fragments/1774300895-id6318-filebeat-director.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Add input redirection support through a new Redirector mechanism.
+component: filebeat

--- a/filebeat/input/default-inputs/inputs.go
+++ b/filebeat/input/default-inputs/inputs.go
@@ -45,7 +45,7 @@ func genericInputs(log *logp.Logger, components statestore.States) []v2.Plugin {
 		tcp.Plugin(),
 		udp.Plugin(),
 		unix.Plugin(),
-		logv2.LogPluginV2(log, components),
-		logv2.ContainerPluginV2(log, components),
+		logv2.LogPluginV2(log),
+		logv2.ContainerPluginV2(log),
 	}
 }

--- a/filebeat/input/logv2/README.md
+++ b/filebeat/input/logv2/README.md
@@ -1,26 +1,33 @@
 # Log v2
 The LogV2 input is used as an entrypoint to select whether to run the
-Log input or (as normally done) the Filestream input as part of
-the effort to fully deprecate and remove the Log input.
+Log or Container input as Filestream as part of the effort to fully
+deprecate and remove the Log input.
 
-Currently there are two ways to run the Filestream input in place of
-the Log input:
+The logv2 manager implements the `v2.Redirector` interface. When a
+redirect is active the Loader resolves the filestream plugin from its
+own registry and calls its `Create` with the translated config. The
+logv2 package does not import or instantiate filestream directly.
+
+When no redirect is needed, `Create` returns `v2.ErrUnknownInput` and
+`compat.Combine` falls through to the V1 log input as before.
+
+Currently there are two ways to enable the redirect:
  - When Filebeat is running under Elastic Agent and
    `run_as_filestream: true` is added to the input configuration. This
-   allows to control the migration at the input level.
+   allows control of the migration at the input level.
  - When Filebeat is running standalone and the feature flag
    `log_input_run_as_filestream` is enabled (this is done by setting
    `features.log_input_run_as_filestream.enabled: true`). This forces
    *all* Log inputs on Filebeat to run as Filestream.
 
+Both the Log and Container input types are supported.
+
 ## Limitations
-Regarding of how the migration is enabled, to run the Log input as
-Filestream all conditions listed below need to be met: 
- - The Log input configuration must contain an unique ID, this ID will
-   become the Filestream input ID.
- - The Container input is not supported
+Regardless of how the migration is enabled, to run the Log input as
+Filestream all conditions listed below need to be met:
+ - The input configuration must contain a unique ID, which becomes the
+   Filestream input ID.
  - Only states of files being actively harvested are migrated.
 
 ## Next steps
- - [ ] Support migrating the Container input
  - [ ] [Implement manual fallback mechanism for Filestream running as Log input under Elastic Agent](https://github.com/elastic/beats/issues/47747)

--- a/filebeat/input/logv2/input.go
+++ b/filebeat/input/logv2/input.go
@@ -23,13 +23,11 @@ import (
 
 	"github.com/elastic/beats/v7/filebeat/channel"
 	v1 "github.com/elastic/beats/v7/filebeat/input"
-	"github.com/elastic/beats/v7/filebeat/input/filestream"
 	loginput "github.com/elastic/beats/v7/filebeat/input/log"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	"github.com/elastic/beats/v7/libbeat/features"
 	"github.com/elastic/beats/v7/libbeat/management"
-	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-concert/unison"
@@ -126,76 +124,71 @@ func NewV1Input(
 	return inp, err
 }
 
-// LogPluginV2 returns a v2.Plugin with a manager that can convert
-// the Log input configuration to Filestream and run the Filestream
-// input instead of the Log input.
-func LogPluginV2(logger *logp.Logger, store statestore.States) v2.Plugin {
-	return pluginV2(logger, store, logPluginName)
+// LogPluginV2 returns a v2.Plugin with a manager that can redirect
+// a Log input configuration to Filestream via the Redirector interface.
+// The Loader resolves the filestream plugin from its own registry;
+// this package no longer imports or instantiates filestream directly.
+func LogPluginV2(logger *logp.Logger) v2.Plugin {
+	return pluginV2(logger, logPluginName)
 }
 
-// ContainerPluginV2 returns a v2.Plugin with a manager that can convert
-// the Container input configuration to Filestream and run the Filestream
-// input instead of the Log input.
-func ContainerPluginV2(logger *logp.Logger, store statestore.States) v2.Plugin {
-	return pluginV2(logger, store, containerPluginName)
+// ContainerPluginV2 returns a v2.Plugin with a manager that can redirect
+// a Container input configuration to Filestream via the Redirector interface.
+func ContainerPluginV2(logger *logp.Logger) v2.Plugin {
+	return pluginV2(logger, containerPluginName)
 }
 
-// pluginV2 returns a v2.Plugin with a manager that can convert
-// the Log/Container input configuration to Filestream and run the Filestream
-// input instead of the Log or Container input.
-func pluginV2(logger *logp.Logger, store statestore.States, pluginName string) v2.Plugin {
-	// The InputManager for Filestream input is from an internal package, so we
-	// cannot instantiate it directly here. To circumvent that, we instantiate
-	// the whole Filestream Plugin and get its manager.
-	filestreamPlugin := filestream.Plugin(logger, store)
-
-	m := manager{
-		next:   filestreamPlugin.Manager,
-		logger: logger,
-	}
-
-	p := v2.Plugin{
+// pluginV2 builds a v2.Plugin whose manager implements Redirector
+// for translating log/container configs to filestream.
+func pluginV2(logger *logp.Logger, pluginName string) v2.Plugin {
+	return v2.Plugin{
 		Name:      pluginName,
 		Stability: feature.Stable,
 		Info:      "log input running filestream",
 		Doc:       "Log input running Filestream input",
-		Manager:   m,
+		Manager:   manager{logger: logger},
 	}
-	return p
 }
 
+// manager implements v2.InputManager and v2.Redirector for the
+// log and container input types. It delegates to filestream via
+// the Loader's plugin registry rather than importing filestream.
 type manager struct {
-	next   v2.InputManager
 	logger *logp.Logger
 }
 
-func (m manager) Init(grp unison.Group) error {
-	return m.next.Init(grp)
+// Init is a no-op. The filestream manager is initialised by the
+// Loader from its own registry; this manager has no resources.
+func (m manager) Init(_ unison.Group) error { return nil }
+
+// Create unconditionally returns ErrUnknownInput. When a redirect is
+// needed, the Loader handles it via the Redirector interface before
+// reaching Create. When no redirect is needed, compat.Combine falls
+// through to the V1 log input.
+func (m manager) Create(_ *config.C) (v2.Input, error) {
+	return nil, v2.ErrUnknownInput
 }
 
-// Create first checks whether the config is supposed to run as Filestream
-// and creates the Filestream input if needed.
-// If the configuration is not supposed to run as Filestream,
-// v2.ErrUnknownInput is returned.
-func (m manager) Create(cfg *config.C) (v2.Input, error) {
+// Redirect implements v2.Redirector. It checks whether the config
+// should run as filestream and, if so, translates the config and
+// returns the target type. The Loader resolves the filestream plugin
+// and calls its Create with the translated config.
+func (m manager) Redirect(cfg *config.C) (string, *config.C, error) {
 	asFilestream, err := runAsFilestream(m.logger, cfg)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-
 	if !asFilestream {
-		return nil, v2.ErrUnknownInput
+		return "", nil, nil
 	}
 
 	newCfg, err := convertConfig(m.logger, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("cannot translate log config to filestream: %w", err)
+		return "", nil, fmt.Errorf("cannot translate log config to filestream: %w", err)
 	}
 
-	// We know 'id' exists in the config and can be retrieved because
-	// 'runAsFilestream' has already validated it, hence it is safe to
-	// ignore the error.
+	// runAsFilestream validated that id exists when redirect is active.
 	id, _ := cfg.String("id", -1)
 	m.logger.Infow("Log input (deprecated) running as Filestream input", "id", id)
-	return m.next.Create(newCfg)
+	return "filestream", newCfg, nil
 }

--- a/filebeat/input/logv2/input_test.go
+++ b/filebeat/input/logv2/input_test.go
@@ -94,7 +94,6 @@ func TestRunAsFilestream(t *testing.T) {
 
 func TestManagerRedirect(t *testing.T) {
 	setUnderAgent := func(t *testing.T, v bool) {
-		t.Helper()
 		prev := management.UnderAgent()
 		t.Cleanup(func() { management.SetUnderAgent(prev) })
 		management.SetUnderAgent(v)

--- a/filebeat/input/logv2/input_test.go
+++ b/filebeat/input/logv2/input_test.go
@@ -20,6 +20,8 @@ package logv2
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -88,4 +90,57 @@ func TestRunAsFilestream(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagerRedirect(t *testing.T) {
+	setUnderAgent := func(t *testing.T, v bool) {
+		t.Helper()
+		prev := management.UnderAgent()
+		t.Cleanup(func() { management.SetUnderAgent(prev) })
+		management.SetUnderAgent(v)
+	}
+
+	t.Run("redirects_to_filestream", func(t *testing.T) {
+		setUnderAgent(t, true)
+		m := manager{logger: logp.NewNopLogger()}
+		cfg := config.MustNewConfigFrom(map[string]any{
+			"type":              "log",
+			"id":                "test-id",
+			"paths":             []string{"/var/log.log"},
+			"run_as_filestream": true,
+		})
+
+		target, translated, err := m.Redirect(cfg)
+		require.NoError(t, err)
+		require.Equal(t, "filestream", target)
+		require.NotNil(t, translated)
+
+		typ, err := translated.String("type", -1)
+		require.NoError(t, err)
+		require.Equal(t, "filestream", typ)
+	})
+
+	t.Run("no_redirect_when_flag_is_absent", func(t *testing.T) {
+		setUnderAgent(t, true)
+		m := manager{logger: logp.NewNopLogger()}
+		cfg := config.MustNewConfigFrom(map[string]any{
+			"type":  "log",
+			"paths": []string{"/var/log.log"},
+		})
+
+		target, translated, err := m.Redirect(cfg)
+		require.NoError(t, err)
+		require.Empty(t, target)
+		require.Nil(t, translated)
+	})
+
+	t.Run("error_on_invalid_config", func(t *testing.T) {
+		m := manager{logger: logp.NewNopLogger()}
+		cfg := config.NewConfig()
+
+		target, translated, err := m.Redirect(cfg)
+		require.Error(t, err)
+		require.Empty(t, target)
+		require.Nil(t, translated)
+	})
 }

--- a/filebeat/input/v2/loader.go
+++ b/filebeat/input/v2/loader.go
@@ -101,7 +101,11 @@ func (l *Loader) Configure(cfg *conf.C) (Input, error) {
 		return nil, fmt.Errorf("running a FIPS-capable distribution but input [%s] is not FIPS capable", name)
 	}
 
-	return p.Manager.Create(cfg)
+	targetPlugin, targetCfg, err := l.resolveRedirect(name, p, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return targetPlugin.Manager.Create(targetCfg)
 }
 
 func (l *Loader) loadFromCfg(cfg *conf.C) (string, Plugin, error) {
@@ -123,18 +127,57 @@ func (l *Loader) loadFromCfg(cfg *conf.C) (string, Plugin, error) {
 	return name, p, nil
 }
 
+// Delete removes any resources associated with an input configuration.
+// If the plugin's InputManager implements Redirector, Delete follows
+// the redirect and calls the target's Delete with the translated config.
 func (l *Loader) Delete(cfg *conf.C) error {
-	_, p, err := l.loadFromCfg(cfg)
+	name, p, err := l.loadFromCfg(cfg)
 	if err != nil {
 		return err
 	}
 
-	pp, ok := p.Manager.(interface{ Delete(cfg *conf.C) error })
+	targetPlugin, targetCfg, err := l.resolveRedirect(name, p, cfg)
+	if err != nil {
+		return err
+	}
+
+	pp, ok := targetPlugin.Manager.(interface{ Delete(cfg *conf.C) error })
 	if ok {
-		return pp.Delete(cfg)
+		return pp.Delete(targetCfg)
 	}
 
 	return nil
+}
+
+// resolveRedirect checks whether the plugin's InputManager implements
+// Redirector and, if so, resolves the redirect target from the registry.
+// Only one redirect hop is allowed; the target's Redirector is not consulted.
+// If no redirect is needed, the original plugin and config are returned.
+func (l *Loader) resolveRedirect(name string, p Plugin, cfg *conf.C) (Plugin, *conf.C, error) {
+	r, ok := p.Manager.(Redirector)
+	if !ok {
+		return p, cfg, nil
+	}
+
+	targetType, translatedCfg, err := r.Redirect(cfg)
+	if err != nil {
+		return Plugin{}, nil, fmt.Errorf("input %q redirect failed: %w", name, err)
+	}
+	if targetType == "" {
+		return p, cfg, nil
+	}
+
+	target, exists := l.registry[targetType]
+	if !exists {
+		return Plugin{}, nil, &LoadError{
+			Name:    targetType,
+			Reason:  ErrUnknownInput,
+			Message: fmt.Sprintf("redirect target %q from %q not found", targetType, name),
+		}
+	}
+
+	l.log.Infof("Input %q redirecting to %q", name, targetType)
+	return target, translatedCfg, nil
 }
 
 // validatePlugins checks if there are multiple plugins with the same name in

--- a/filebeat/input/v2/loader_test.go
+++ b/filebeat/input/v2/loader_test.go
@@ -183,6 +183,224 @@ func TestLoader_Configure(t *testing.T) {
 	}
 }
 
+func TestLoader_ConfigureRedirect(t *testing.T) {
+	targetManager := ConfigureWith(
+		makeConfigFakeInput(fakeInput{Type: "target"}),
+		logp.NewNopLogger(),
+	)
+
+	cases := map[string]struct {
+		setup  loaderConfig
+		config map[string]interface{}
+		check  inputCheck
+	}{
+		"redirect_success": {
+			setup: loaderConfig{
+				Plugins: []Plugin{
+					{
+						Name:      "source",
+						Stability: feature.Stable,
+						Manager: &fakeRedirectManager{
+							fakeInputManager: fakeInputManager{
+								OnConfigure: func(_ *conf.C) (Input, error) {
+									return nil, errors.New("should not be called")
+								},
+							},
+							OnRedirect: func(cfg *conf.C) (string, *conf.C, error) {
+								return "target", cfg, nil
+							},
+						},
+					},
+					{Name: "target", Stability: feature.Stable, Manager: targetManager},
+				},
+				TypeField: "type",
+			},
+			config: map[string]interface{}{"type": "source"},
+			check:  okSetup,
+		},
+		"no_redirect_passthrough": {
+			setup: loaderConfig{
+				Plugins: []Plugin{
+					{
+						Name:      "source",
+						Stability: feature.Stable,
+						Manager: &fakeRedirectManager{
+							fakeInputManager: fakeInputManager{
+								OnConfigure: func(_ *conf.C) (Input, error) {
+									return &fakeInput{Type: "source"}, nil
+								},
+							},
+							OnRedirect: func(_ *conf.C) (string, *conf.C, error) {
+								return "", nil, nil
+							},
+						},
+					},
+				},
+				TypeField: "type",
+			},
+			config: map[string]interface{}{"type": "source"},
+			check:  okSetup,
+		},
+		"redirect_to_unknown_target": {
+			setup: loaderConfig{
+				Plugins: []Plugin{
+					{
+						Name:      "source",
+						Stability: feature.Stable,
+						Manager: &fakeRedirectManager{
+							OnRedirect: func(_ *conf.C) (string, *conf.C, error) {
+								return "nonexistent", conf.NewConfig(), nil
+							},
+						},
+					},
+				},
+				TypeField: "type",
+			},
+			config: map[string]interface{}{"type": "source"},
+			check:  failSetup,
+		},
+		"redirect_error": {
+			setup: loaderConfig{
+				Plugins: []Plugin{
+					{
+						Name:      "source",
+						Stability: feature.Stable,
+						Manager: &fakeRedirectManager{
+							OnRedirect: func(_ *conf.C) (string, *conf.C, error) {
+								return "", nil, errors.New("translation failed")
+							},
+						},
+					},
+				},
+				TypeField: "type",
+			},
+			config: map[string]interface{}{"type": "source"},
+			check:  failSetup,
+		},
+		"non-redirector_manager_unchanged": {
+			setup: loaderConfig{
+				Plugins: []Plugin{
+					{
+						Name:      "plain",
+						Stability: feature.Stable,
+						Manager:   ConfigureWith(makeConfigFakeInput(fakeInput{Type: "plain"}), logp.NewNopLogger()),
+					},
+				},
+				TypeField: "type",
+			},
+			config: map[string]interface{}{"type": "plain"},
+			check:  okSetup,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			loader := test.setup.MustNewLoader()
+			input, err := loader.Configure(conf.MustNewConfigFrom(test.config))
+			test.check(t, input, err)
+		})
+	}
+}
+
+func TestLoader_DeleteRedirect(t *testing.T) {
+	t.Run("delete_follows_redirect", func(t *testing.T) {
+		var deletedWith *conf.C
+		translatedCfg := conf.MustNewConfigFrom(map[string]interface{}{
+			"type": "target",
+			"key":  "translated",
+		})
+
+		setup := loaderConfig{
+			Plugins: []Plugin{
+				{
+					Name:      "source",
+					Stability: feature.Stable,
+					Manager: &fakeRedirectManager{
+						OnRedirect: func(_ *conf.C) (string, *conf.C, error) {
+							return "target", translatedCfg, nil
+						},
+					},
+				},
+				{
+					Name:      "target",
+					Stability: feature.Stable,
+					Manager: &fakeDeleteManager{
+						fakeInputManager: fakeInputManager{
+							OnConfigure: func(_ *conf.C) (Input, error) {
+								return &fakeInput{Type: "target"}, nil
+							},
+						},
+						OnDelete: func(cfg *conf.C) error {
+							deletedWith = cfg
+							return nil
+						},
+					},
+				},
+			},
+			TypeField: "type",
+		}
+
+		loader := setup.MustNewLoader()
+		err := loader.Delete(conf.MustNewConfigFrom(map[string]interface{}{"type": "source"}))
+		require.NoError(t, err)
+		require.NotNil(t, deletedWith, "Delete should have been called on target")
+
+		key, err := deletedWith.String("key", -1)
+		require.NoError(t, err)
+		require.Equal(t, "translated", key)
+	})
+
+	t.Run("delete_no_redirect", func(t *testing.T) {
+		var deleted bool
+		setup := loaderConfig{
+			Plugins: []Plugin{
+				{
+					Name:      "source",
+					Stability: feature.Stable,
+					Manager: &fakeDeleteManager{
+						OnDelete: func(_ *conf.C) error {
+							deleted = true
+							return nil
+						},
+					},
+				},
+			},
+			TypeField: "type",
+		}
+
+		loader := setup.MustNewLoader()
+		err := loader.Delete(conf.MustNewConfigFrom(map[string]interface{}{"type": "source"}))
+		require.NoError(t, err)
+		require.True(t, deleted, "Delete should have been called on source")
+	})
+
+	t.Run("delete_on_non-deletable_manager_is_noop", func(t *testing.T) {
+		setup := loaderConfig{
+			Plugins: []Plugin{
+				{
+					Name:      "source",
+					Stability: feature.Stable,
+					Manager: &fakeRedirectManager{
+						OnRedirect: func(_ *conf.C) (string, *conf.C, error) {
+							return "target", conf.NewConfig(), nil
+						},
+					},
+				},
+				{
+					Name:      "target",
+					Stability: feature.Stable,
+					Manager:   ConfigureWith(nil, logp.NewNopLogger()),
+				},
+			},
+			TypeField: "type",
+		}
+
+		loader := setup.MustNewLoader()
+		err := loader.Delete(conf.MustNewConfigFrom(map[string]interface{}{"type": "source"}))
+		require.NoError(t, err)
+	})
+}
+
 func TestLoader_ConfigureFIPS(t *testing.T) {
 	loaderCfg := loaderConfig{
 		Plugins: []Plugin{

--- a/filebeat/input/v2/redirect.go
+++ b/filebeat/input/v2/redirect.go
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v2
+
+import conf "github.com/elastic/elastic-agent-libs/config"
+
+// Redirector is an optional interface that an InputManager can implement
+// to redirect input creation to a different input type. The Loader checks
+// for this interface before calling Create.
+//
+// When an InputManager implements Redirector, the Loader calls Redirect
+// first. If Redirect returns a non-empty target type, the Loader resolves
+// the target plugin from its registry and calls its Create with the
+// translated config. Only one redirect hop is allowed; the target's
+// Redirector (if any) is not consulted.
+//
+// If Redirect returns an empty target type, the Loader proceeds to call
+// Create on the original InputManager as usual.
+type Redirector interface {
+	// Redirect examines the config and returns the name of the target
+	// input type and a translated config if this input should be run as
+	// another type. Return ("", nil, nil) for no redirect.
+	Redirect(cfg *conf.C) (targetType string, translatedCfg *conf.C, err error)
+}

--- a/filebeat/input/v2/util_test.go
+++ b/filebeat/input/v2/util_test.go
@@ -74,6 +74,30 @@ func (f *fakeInput) Run(ctx Context, pipeline beat.PipelineConnector) error {
 	return nil
 }
 
+type fakeRedirectManager struct {
+	fakeInputManager
+	OnRedirect func(*conf.C) (string, *conf.C, error)
+}
+
+func (m *fakeRedirectManager) Redirect(cfg *conf.C) (string, *conf.C, error) {
+	if m.OnRedirect != nil {
+		return m.OnRedirect(cfg)
+	}
+	return "", nil, nil
+}
+
+type fakeDeleteManager struct {
+	fakeInputManager
+	OnDelete func(*conf.C) error
+}
+
+func (m *fakeDeleteManager) Delete(cfg *conf.C) error {
+	if m.OnDelete != nil {
+		return m.OnDelete(cfg)
+	}
+	return nil
+}
+
 func expectError(t *testing.T, err error) {
 	if err == nil {
 		t.Errorf("expected error")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
filebeat/input/{v2,logv2}: add Redirector interface for general input migration

Add an optional Redirector interface to the v2 input system so the
Loader can transparently redirect one input type to another. This
replaces the bespoke approach where logv2 directly imported and
instantiated the filestream plugin.

The Loader checks for Redirector before calling Create. If Redirect
returns a non-empty target type, the Loader resolves the target from
its plugin registry and calls its Create with the translated config.
Only one redirect hop is allowed. Delete follows the same redirect
path so CheckConfig cleanup operates on the correct target.

Refactor the logv2 manager to implement Redirector instead of holding
a direct reference to the filestream manager. This removes logv2's
import of the filestream package, eliminates a duplicate filestream
manager instance (and its redundant Init call), and makes the pattern
reusable for future V2-to-V2 migrations such as httpjson to cel.
```

> [!NOTE]
> It may be worth reading the partner PR, #49614, to this to see its operation in context.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
