### PR TITLE
ci: switch Buildkite detective trigger from check_run to status event

### DIFF
--- a/changelog/fragments/1774373217-buildkite-detective-status-trigger.yaml
+++ b/changelog/fragments/1774373217-buildkite-detective-status-trigger.yaml
@@ -1,5 +1,0 @@
-kind: other
-
-summary: Switch PR Buildkite Detective workflow trigger from check_run to status event
-
-component: ci


### PR DESCRIPTION
## Summary
- Replaces the `check_run` event trigger with `status` on the PR Buildkite Detective workflow
- Buildkite reports results via commit statuses (not check runs) when check runs are disabled in the integration, so the `check_run` trigger never matched Buildkite and the job was always skipped
- The workflow now triggers on `status` events and filters for `state == 'failure'` with a context containing `buildkite`

## Test plan
- [ ] Verify the workflow triggers on a Buildkite commit status failure (requires merge to `main` since `status` events only trigger workflows on the default branch)

Made with [Cursor](https://cursor.com)