### PR TITLE
Switch stale-issues to stale-issues-investigator

### DIFF
--- a/.github/workflows/trigger-stale-issues.yml
+++ b/.github/workflows/trigger-stale-issues.yml
@@ -1,4 +1,4 @@
-name: Stale Issues
+name: Stale Issues Investigator
 on:
   schedule:
     - cron: "0 15 * * 1"
@@ -12,14 +12,11 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-stale-issues.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-stale-issues-investigator.lock.yml@v0
     with:
       setup-commands: |
         sudo apt-get update && sudo apt-get install -y libpcap-dev librpm-dev python3-venv
         export GOTOOLCHAIN=auto
         make mage
-      additional-instructions: |
-        Add a note to the issue indicating that you do not have permission to actually
-        close the issues and that a person with permission will need to do so.
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces `gh-aw-stale-issues.lock.yml` with `gh-aw-stale-issues-investigator.lock.yml`
- The investigator actively examines open issues for evidence of resolution (linked PRs, code changes, conversation consensus) rather than just checking activity dates
- Labels identified candidates as `stale` and files a summary report issue
- Removes the `additional-instructions` workaround about not having permission to close issues — the investigator labels and reports instead of attempting to close


Made with [Cursor](https://cursor.com)