### PR TITLE
x-pack/filebeat/input/streaming: add URL and query parsing and formatting

### DIFF
--- a/changelog/fragments/1774403004-i17875-proofpoint_on_demand.yaml
+++ b/changelog/fragments/1774403004-i17875-proofpoint_on_demand.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Add support for URL and URL query parsing and formatting in the Streaming input CEL environment.
+component: filebeat

--- a/x-pack/filebeat/input/streaming/cel.go
+++ b/x-pack/filebeat/input/streaming/cel.go
@@ -9,10 +9,18 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
+	"path"
+	"reflect"
 	"regexp"
+	"runtime"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
 
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -60,6 +68,7 @@ func newProgram(ctx context.Context, src, root string, patterns map[string]*rege
 		lib.JSON(nil),
 		lib.Strings(),
 		lib.Time(),
+		cel.Lib(urlLib{}),
 		lib.Try(),
 		lib.Debug(debug(log)),
 		lib.MIME(mimetypes),
@@ -97,5 +106,263 @@ func debug(log *logp.Logger) func(string, any) {
 		}
 
 		log.Debugw(level, "tag", tag, "value", value)
+	}
+}
+
+// urlLib provides URL and query parsing and formatting functions consistent
+// with the equivalent functions in the mito/lib.HTTP library.
+//   - parse_url
+//   - format_url
+//   - parse_query
+//   - format_query
+type urlLib struct{}
+
+var (
+	// Type used in overloads.
+	mapStringDyn = cel.MapType(cel.StringType, cel.DynType)
+
+	// Type used for reflect conversion.
+	reflectMapStringAnyType         = reflect.TypeFor[map[string]any]()
+	reflectMapStringStringSliceType = reflect.TypeFor[map[string][]string]()
+)
+
+func (urlLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("parse_url",
+			cel.MemberOverload(
+				"string_parse_url",
+				[]*cel.Type{cel.StringType},
+				mapStringDyn,
+				cel.UnaryBinding(catch(parseURL)),
+			),
+		),
+		cel.Function("format_url",
+			cel.MemberOverload(
+				"map_format_url",
+				[]*cel.Type{mapStringDyn},
+				cel.StringType,
+				cel.UnaryBinding(catch(formatURL)),
+			),
+		),
+
+		cel.Function("parse_query",
+			cel.MemberOverload(
+				"string_parse_query",
+				[]*cel.Type{cel.StringType},
+				mapStringDyn,
+				cel.UnaryBinding(catch(parseQuery)),
+			),
+		),
+		cel.Function("format_query",
+			cel.MemberOverload(
+				"map_format_query",
+				[]*cel.Type{mapStringDyn},
+				cel.StringType,
+				cel.UnaryBinding(catch(formatQuery)),
+			),
+		),
+	}
+}
+
+type (
+	unop  = func(value ref.Val) ref.Val
+	binop = func(lhs ref.Val, rhs ref.Val) ref.Val
+	varop = func(values ...ref.Val) ref.Val
+
+	bindings interface {
+		unop | binop | varop
+	}
+)
+
+func catch[B bindings](binding B) B {
+	switch binding := any(binding).(type) {
+	case unop:
+		return any(func(arg ref.Val) (ret ref.Val) {
+			defer handlePanic(&ret)
+			return binding(arg)
+		}).(B)
+	case binop:
+		return any(func(arg0, arg1 ref.Val) (ret ref.Val) {
+			defer handlePanic(&ret)
+			return binding(arg0, arg1)
+		}).(B)
+	case varop:
+		return any(func(args ...ref.Val) (ret ref.Val) {
+			defer handlePanic(&ret)
+			return binding(args...)
+		}).(B)
+	default:
+		panic("unreachable")
+	}
+}
+
+func handlePanic(ret *ref.Val) {
+	switch r := recover().(type) {
+	case nil:
+		return
+	default:
+		// We'll only try 64 stack frames deep. There are a no recursive
+		// functions in extensions.
+		pc := make([]uintptr, 64)
+		n := runtime.Callers(2, pc)
+		cf := runtime.CallersFrames(pc[:n])
+		for {
+			f, more := cf.Next()
+			if !more {
+				break
+			}
+			file := f.File
+			if strings.Contains(file, "filebeat/input/streaming") {
+				_, file, _ := strings.Cut(file, "filebeat/input/")
+				*ret = types.NewErr("%s: %s %s:%d", r, path.Base(f.Function), file, f.Line)
+				return
+			}
+		}
+		*ret = types.NewErr("%s", r)
+	}
+}
+
+func (urlLib) ProgramOptions() []cel.ProgramOption { return nil }
+
+func parseURL(arg ref.Val) ref.Val {
+	addr, ok := arg.(types.String)
+	if !ok {
+		return types.ValOrErr(addr, "no such overload for request")
+	}
+	u, err := url.Parse(string(addr))
+	if err != nil {
+		return types.NewErr("%s", err)
+	}
+	var user interface{}
+	if u.User != nil {
+		password, passwordSet := u.User.Password()
+		user = map[string]interface{}{
+			"Username":    u.User.Username(),
+			"Password":    password,
+			"PasswordSet": passwordSet,
+		}
+	}
+	return types.NewStringInterfaceMap(types.DefaultTypeAdapter, map[string]interface{}{
+		"Scheme":      u.Scheme,
+		"Opaque":      u.Opaque,
+		"User":        user,
+		"Host":        u.Host,
+		"Path":        u.Path,
+		"RawPath":     u.RawPath,
+		"ForceQuery":  u.ForceQuery,
+		"RawQuery":    u.RawQuery,
+		"Fragment":    u.Fragment,
+		"RawFragment": u.RawFragment,
+	})
+}
+
+func formatURL(arg ref.Val) ref.Val {
+	urlMap, ok := arg.(traits.Mapper)
+	if !ok {
+		return types.ValOrErr(urlMap, "no such overload")
+	}
+	v, err := urlMap.ConvertToNative(reflectMapStringAnyType)
+	if err != nil {
+		return types.NewErr("no such overload for format_url: %v", err)
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		// This should never happen.
+		return types.NewErr("unexpected type for url map: %T", v)
+	}
+	u := url.URL{
+		Scheme:      maybeStringLookup(m, "Scheme"),
+		Opaque:      maybeStringLookup(m, "Opaque"),
+		Host:        maybeStringLookup(m, "Host"),
+		Path:        maybeStringLookup(m, "Path"),
+		RawPath:     maybeStringLookup(m, "RawPath"),
+		ForceQuery:  maybeBoolLookup(m, "ForceQuery"),
+		RawQuery:    maybeStringLookup(m, "RawQuery"),
+		Fragment:    maybeStringLookup(m, "Fragment"),
+		RawFragment: maybeStringLookup(m, "RawFragment"),
+	}
+	user, ok := urlMap.Find(types.String("User"))
+	if ok {
+		switch user := user.(type) {
+		case nil:
+		case traits.Mapper:
+			var username types.String
+			un, ok := user.Find(types.String("Username"))
+			if ok {
+				username, ok = un.(types.String)
+				if !ok {
+					return types.NewErr("invalid type for username: %s", un.Type())
+				}
+			}
+			if user.Get(types.String("PasswordSet")) == types.True {
+				var password types.String
+				pw, ok := user.Find(types.String("Password"))
+				if ok {
+					password, ok = pw.(types.String)
+					if !ok {
+						return types.NewErr("invalid type for password: %s", pw.Type())
+					}
+				}
+				u.User = url.UserPassword(string(username), string(password))
+			} else {
+				u.User = url.User(string(username))
+			}
+		default:
+			if user != types.NullValue {
+				return types.NewErr("unsupported type: %T", user)
+			}
+		}
+	}
+	return types.String(u.String())
+}
+
+// maybeStringLookup returns a string from m[key] if it is present and the
+// empty string if not. It panics is m[key] is not a string.
+func maybeStringLookup(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	return v.(string)
+}
+
+// maybeBoolLookup returns a bool from m[key] if it is present and false if
+// not. It panics is m[key] is not a bool.
+func maybeBoolLookup(m map[string]interface{}, key string) bool {
+	v, ok := m[key]
+	if !ok {
+		return false
+	}
+	return v.(bool)
+}
+
+func parseQuery(arg ref.Val) ref.Val {
+	query, ok := arg.(types.String)
+	if !ok {
+		return types.ValOrErr(query, "no such overload")
+	}
+	q, err := url.ParseQuery(string(query))
+	if err != nil {
+		return types.NewErr("%s", err)
+	}
+	return types.DefaultTypeAdapter.NativeToValue(q)
+}
+
+func formatQuery(arg ref.Val) ref.Val {
+	queryMap, ok := arg.(traits.Mapper)
+	if !ok {
+		return types.ValOrErr(queryMap, "no such overload")
+	}
+	q, err := queryMap.ConvertToNative(reflectMapStringStringSliceType)
+	if err != nil {
+		return types.NewErr("no such overload for format_query: %v", err)
+	}
+	switch q := q.(type) {
+	case url.Values:
+		return types.String(q.Encode())
+	case map[string][]string:
+		return types.String(url.Values(q).Encode())
+	default:
+		return types.NewErr("invalid type for format_query: %T", q)
 	}
 }

--- a/x-pack/filebeat/input/streaming/cel_test.go
+++ b/x-pack/filebeat/input/streaming/cel_test.go
@@ -1,0 +1,73 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package streaming
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+var urlTests = []struct {
+	name string
+	src  string
+	want any
+}{
+	{
+		name: "parse_url",
+		src:  `"http://example.com/".parse_url()`,
+		want: map[string]any{
+			"ForceQuery":  false,
+			"Fragment":    "",
+			"Host":        "example.com",
+			"Opaque":      "",
+			"Path":        "/",
+			"RawFragment": "",
+			"RawPath":     "",
+			"RawQuery":    "",
+			"Scheme":      "http",
+			"User":        nil,
+		},
+	},
+	{
+		name: "format_url",
+		src:  `{"url": {"Host": "example.com", "Path": "/", "Scheme": "https"}.format_url()}`,
+		want: map[string]any{"url": "https://example.com/"},
+	},
+	{
+		name: "parse_query",
+		src:  `"q=1&a=42".parse_query()`,
+		want: map[string]any{"a": []any{"42"}, "q": []any{"1"}},
+	},
+	{
+		name: "format_query",
+		src:  `{"query": {"q": ["1"], "a": ["42"]}.format_query()}`,
+		want: map[string]any{"query": "a=42&q=1"},
+	},
+}
+
+func TestUrlLib(t *testing.T) {
+	now := time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+	for _, test := range urlTests {
+		t.Run(test.name, func(t *testing.T) {
+			prg, ast, err := newProgram(ctx, test.src, "state", nil, logptest.NewTestingLogger(t, ""))
+			if err != nil {
+				t.Fatalf("failed to compile src: %v", err)
+			}
+			got, err := evalWith(ctx, prg, ast, map[string]any{}, now)
+			if err != nil {
+				t.Fatalf("failed to run program: %v", err)
+			}
+			if !cmp.Equal(test.want, got) {
+				t.Errorf("unexpected result\n--- want\n+++ got\n%s", cmp.Diff(test.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: add URL and query parsing and formatting

Add a local implementation of the equivalent functions from the
mito/lib.HTTP extension library.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For elastic/integrations#17875

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
