### PR TITLE
perf(inputmon): pool gzip.Writer for monitoring HTTP responses

### DIFF
--- a/libbeat/monitoring/inputmon/httphandler.go
+++ b/libbeat/monitoring/inputmon/httphandler.go
@@ -18,10 +18,12 @@
 package inputmon
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/gorilla/handlers"
 
@@ -223,8 +225,60 @@ func (h queryParamHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 func validationHandler(method string, queryParams []string, h http.HandlerFunc) http.Handler {
 	var next http.Handler = h
-	next = handlers.CompressHandler(next)
+	next = pooledGzipHandler(next)
 	next = newQueryParamHandler(queryParams, next)
 	next = handlers.MethodHandler{method: next}
 	return next
+}
+
+// gzipWriterPool reuses gzip.Writer instances across HTTP responses.
+// Each gzip.Writer allocates ~256 KB of internal hash and deflate state;
+// pooling avoids re-allocating that on every monitoring scrape.
+var gzipWriterPool = sync.Pool{
+	New: func() interface{} {
+		// The writer is initialised with a nil destination; Reset is called
+		// with the real http.ResponseWriter before each use.
+		w, _ := gzip.NewWriterLevel(nil, gzip.DefaultCompression)
+		return w
+	},
+}
+
+// pooledGzipHandler is a drop-in replacement for handlers.CompressHandler
+// that reuses gzip.Writer instances via sync.Pool.
+func pooledGzipHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		gz := gzipWriterPool.Get().(*gzip.Writer) //nolint:errcheck // pool only contains *gzip.Writer
+		gz.Reset(w)
+
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Add("Vary", "Accept-Encoding")
+		w.Header().Del("Content-Length")
+
+		gzw := &pooledGzipResponseWriter{ResponseWriter: w, gz: gz}
+		next.ServeHTTP(gzw, r)
+
+		gz.Close()
+		gzipWriterPool.Put(gz)
+	})
+}
+
+type pooledGzipResponseWriter struct {
+	http.ResponseWriter
+	gz *gzip.Writer
+}
+
+func (w *pooledGzipResponseWriter) Write(b []byte) (int, error) {
+	return w.gz.Write(b)
+}
+
+func (w *pooledGzipResponseWriter) Flush() {
+	w.gz.Flush()
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }

--- a/libbeat/monitoring/inputmon/httphandler_test.go
+++ b/libbeat/monitoring/inputmon/httphandler_test.go
@@ -110,6 +110,37 @@ func TestHandler(t *testing.T) {
 	}
 }
 
+func TestPooledGzipHandler(t *testing.T) {
+	parent := monitoring.NewRegistry()
+	reg := NewMetricsRegistry(
+		"gzip-test", "foo", parent, logptest.NewTestingLogger(t, ""))
+	monitoring.NewInt(reg, "gauge").Set(42)
+
+	r := http.NewServeMux()
+	s := httptest.NewServer(r)
+	defer s.Close()
+	err := AttachHandler(r, parent)
+	assert.NoError(t, err)
+
+	// Make multiple gzip requests to exercise pooling.
+	for i := 0; i < 5; i++ {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, s.URL+"/inputs/", nil)
+		assert.NoError(t, err)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		resp, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, body, "gzip response body should not be empty")
+	}
+}
+
 func BenchmarkHandlers(b *testing.B) {
 	reg := monitoring.NewRegistry()
 	log := logptest.NewTestingLogger(b, "")


### PR DESCRIPTION
## Summary

- Replace `gorilla/handlers.CompressHandler` with a pooled gzip handler that reuses `gzip.Writer` instances via `sync.Pool`
- Each `gzip.Writer` allocates ~256 KB of internal hash and deflate state; the previous code allocated a fresh writer on every monitoring scrape request
- Production diagnostics from an Elastic Agent deployment showed `compress/flate.NewWriter` accounting for **35-40% of total allocations** in idle filebeat components (`filestream-default` and `log-default`), entirely from the inputmon HTTP endpoint being scraped every ~23 seconds

## How it works

The `gzip.Writer` type supports `Reset(w io.Writer)` which reinitializes the writer to compress to a new destination without reallocating internal state. The pooled handler:

1. Gets a `*gzip.Writer` from the pool (or creates one on first use)
2. Calls `Reset(w)` to point it at the current `http.ResponseWriter`
3. Wraps the response writer to redirect `Write()` calls through the gzip writer
4. After the response completes, calls `Close()` and returns the writer to the pool

## Test plan

- [x] Existing `TestHandler` tests pass (exercise non-gzip path)
- [x] New `TestPooledGzipHandler` verifies gzip responses work correctly across 5 sequential requests (exercises pool reuse)
- [x] `go vet` and `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)