### PR TITLE
[filebeat][fix] include `ESStorageExtension` identity in state store cache key    

### DIFF
--- a/filebeat/beater/store.go
+++ b/filebeat/beater/store.go
@@ -61,16 +61,20 @@ type filebeatStore struct {
 	notifier *es.Notifier
 }
 
-func storeKey(resolvedPath, backendName string) string {
+func storeKey(resolvedPath, backendName string, esExt backend.Registry) string {
 	if backendName == "" {
 		backendName = "memlog"
 	}
-	return backendName + "://" + resolvedPath
+	key := backendName + "://" + resolvedPath
+	if esExt != nil {
+		key = fmt.Sprintf("%s|esext:%p", key, esExt)
+	}
+	return key
 }
 
 func openStateStore(ctx context.Context, info beat.Info, logger *logp.Logger, cfg config.Registry, beatPaths *paths.Path) (*filebeatStore, error) {
 	resolvedPath := beatPaths.Resolve(paths.Data, cfg.Path)
-	key := storeKey(resolvedPath, cfg.Backend)
+	key := storeKey(resolvedPath, cfg.Backend, cfg.ESStorageExtension)
 
 	globalMu.Lock()
 	defer globalMu.Unlock()

--- a/filebeat/beater/store_test.go
+++ b/filebeat/beater/store_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/filebeat/config"
+	"github.com/elastic/beats/v7/filebeat/features"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -153,4 +155,51 @@ func TestOpenStateStore_ConcurrentOpenClose(t *testing.T) {
 	_, exists := globalStores[resolvedKey]
 	globalMu.Unlock()
 	assert.False(t, exists, "entry should be cleaned up after all stores are closed")
+}
+
+func TestOpenStateStore_DifferentESExtensionsShouldNotShare(t *testing.T) {
+	t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "dummy")
+	features.ReinitForTest()
+	t.Cleanup(func() {
+		t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "")
+		features.ReinitForTest()
+	})
+
+	beatPaths := paths.New()
+	beatPaths.Data = t.TempDir()
+
+	cfgWithExt := func(ext *storetest.MemoryStore) config.Registry {
+		return config.Registry{
+			Path:               "",
+			Permissions:        0600,
+			CleanInterval:      time.Second,
+			ESStorageExtension: ext,
+		}
+	}
+
+	extA := storetest.NewMemoryStoreBackend()
+	extB := storetest.NewMemoryStoreBackend()
+
+	s1, err := openStateStore(t.Context(), beat.Info{Beat: "testbeat"}, logp.NewNopLogger(), cfgWithExt(extA), beatPaths)
+	require.NoError(t, err)
+	t.Cleanup(s1.Close)
+
+	s2, err := openStateStore(t.Context(), beat.Info{Beat: "testbeat"}, logp.NewNopLogger(), cfgWithExt(extB), beatPaths)
+	require.NoError(t, err)
+	t.Cleanup(s2.Close)
+
+	storeA, err := s1.StoreFor("dummy")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeA.Close() })
+
+	storeB, err := s2.StoreFor("dummy")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeB.Close() })
+
+	require.NoError(t, storeA.Set("k", map[string]string{"v": "from-a"}))
+
+	var got map[string]string
+	err = storeB.Get("k", &got)
+	assert.Error(t, err, "expected independent storage extensions for stores with different ESStorageExtension instances")
+	assert.Nil(t, got, "no state should leak between stores with different ESStorageExtension instances")
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

- issue https://github.com/elastic/beats/issues/49656
- when `openStateStore` is called with different `ESStorageExtension` instances but the same `backend/path`, the global registry cache (globalStores) was keyed only by backend://path. The second caller would reuse the first caller's esRegistry, causing cross-receiver state leakage
- append the extension's pointer address (%p) to the cache key when ESStorageExtension is non-nil, ensuring each distinct extension gets its own sharedRegistries entry
- add suggested test in issue

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
