### PR TITLE
[Docs] Formatting fix for auditbeat system socket 

### DIFF
--- a/docs/reference/auditbeat/auditbeat-dataset-system-socket.md
+++ b/docs/reference/auditbeat/auditbeat-dataset-system-socket.md
@@ -24,8 +24,10 @@ This is the `socket` dataset of the system module. It allows to monitor network 
 * Works on stock kernels without the need of custom modules, external libraries or development headers.
 * Correlates IP addresses with DNS requests.
 
-This dataset does not analyze application-layer protocols nor provide any other advanced features present in Packetbeat: - Monitor network traffic whose destination is not a local process, as is the case with traffic forwarding. - Monitor layer 2 traffic, ICMP or raw sockets.
+This dataset does not analyze application-layer protocols nor provide any other advanced features present in Packetbeat:
 
+* Monitor network traffic whose destination is not a local process, as is the case with traffic forwarding. 
+* Monitor layer 2 traffic, ICMP or raw sockets.
 
 ## Implementation [_implementation_2]
 


### PR DESCRIPTION
In [System socket dataset](https://www.elastic.co/docs/reference/beats/auditbeat/auditbeat-dataset-system-socket), a bullet list does not render correctly:

-------------------
<img width="1285" height="156" alt="image" src="https://github.com/user-attachments/assets/29642841-3b5e-4d21-9052-1c790e2dbb91" />

-------------------

This PR adds the following changes:
- Reformats the bullet list
-  Updates the list to use the existing convention of `*` instead of `-`

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Adds documentation fix for bulleted list.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

No impact

## Author's Checklist

n/a

## How to test this PR locally

n/a

## Related issues

n/a

## Use cases

n/a

## Screenshots

n/a

## Logs

n/a
