### PR TITLE
docs: clarify client vs server SSL configuration sections

### DIFF
--- a/docs/reference/auditbeat/configuration-ssl.md
+++ b/docs/reference/auditbeat/configuration-ssl.md
@@ -138,10 +138,10 @@ This check is not a replacement for the normal SSL validation, but it adds addit
 
 ## Client configuration options [ssl-client-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `auditbeat` acts as a **client** connecting to a remote service (for example, Elasticsearch, Logstash, or Kibana). These options control how `auditbeat` verifies the server it connects to and, optionally, presents a client certificate. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [client-certificate-authorities]
+### `certificate_authorities` (client) [client-certificate-authorities]
 
 The list of root certificates for verifications is required. If `certificate_authorities` is empty or not set, the system keystore is used. If `certificate_authorities` is self-signed, the host system needs to trust that CA cert as well.
 
@@ -277,10 +277,10 @@ openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=
 
 ## Server configuration options [ssl-server-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `auditbeat` acts as a **server** accepting incoming connections. These options control the certificate `auditbeat` presents to connecting clients and, optionally, how it verifies client certificates. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [server-certificate-authorities]
+### `certificate_authorities` (server) [server-certificate-authorities]
 
 The list of root certificates for client verifications is only required if `client_authentication` is configured. If `certificate_authorities` is empty or not set, and `client_authentication` is configured, the system keystore is used.
 

--- a/docs/reference/filebeat/configuration-ssl.md
+++ b/docs/reference/filebeat/configuration-ssl.md
@@ -138,10 +138,10 @@ This check is not a replacement for the normal SSL validation, but it adds addit
 
 ## Client configuration options [ssl-client-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `filebeat` acts as a **client** connecting to a remote service (for example, Elasticsearch, Logstash, or Kibana). These options control how `filebeat` verifies the server it connects to and, optionally, presents a client certificate. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [client-certificate-authorities]
+### `certificate_authorities` (client) [client-certificate-authorities]
 
 The list of root certificates for verifications is required. If `certificate_authorities` is empty or not set, the system keystore is used. If `certificate_authorities` is self-signed, the host system needs to trust that CA cert as well.
 
@@ -277,10 +277,10 @@ openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=
 
 ## Server configuration options [ssl-server-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `filebeat` acts as a **server** accepting incoming connections (for example, an HTTP JSON or TCP/UDP input listener). These options control the certificate `filebeat` presents to connecting clients and, optionally, how it verifies client certificates. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [server-certificate-authorities]
+### `certificate_authorities` (server) [server-certificate-authorities]
 
 The list of root certificates for client verifications is only required if `client_authentication` is configured. If `certificate_authorities` is empty or not set, and `client_authentication` is configured, the system keystore is used.
 

--- a/docs/reference/heartbeat/configuration-ssl.md
+++ b/docs/reference/heartbeat/configuration-ssl.md
@@ -151,10 +151,10 @@ This check is not a replacement for the normal SSL validation, but it adds addit
 
 ## Client configuration options [ssl-client-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `heartbeat` acts as a **client** connecting to a remote service (for example, Elasticsearch, Logstash, or Kibana). These options control how `heartbeat` verifies the server it connects to and, optionally, presents a client certificate. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [client-certificate-authorities]
+### `certificate_authorities` (client) [client-certificate-authorities]
 
 The list of root certificates for verifications is required. If `certificate_authorities` is empty or not set, the system keystore is used. If `certificate_authorities` is self-signed, the host system needs to trust that CA cert as well.
 
@@ -290,10 +290,10 @@ openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=
 
 ## Server configuration options [ssl-server-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `heartbeat` acts as a **server** accepting incoming connections. These options control the certificate `heartbeat` presents to connecting clients and, optionally, how it verifies client certificates. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [server-certificate-authorities]
+### `certificate_authorities` (server) [server-certificate-authorities]
 
 The list of root certificates for client verifications is only required if `client_authentication` is configured. If `certificate_authorities` is empty or not set, and `client_authentication` is configured, the system keystore is used.
 

--- a/docs/reference/metricbeat/configuration-ssl.md
+++ b/docs/reference/metricbeat/configuration-ssl.md
@@ -153,10 +153,10 @@ This check is not a replacement for the normal SSL validation, but it adds addit
 
 ## Client configuration options [ssl-client-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `metricbeat` acts as a **client** connecting to a remote service (for example, Elasticsearch, Logstash, or Kibana). These options control how `metricbeat` verifies the server it connects to and, optionally, presents a client certificate. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [client-certificate-authorities]
+### `certificate_authorities` (client) [client-certificate-authorities]
 
 The list of root certificates for verifications is required. If `certificate_authorities` is empty or not set, the system keystore is used. If `certificate_authorities` is self-signed, the host system needs to trust that CA cert as well.
 
@@ -292,10 +292,10 @@ openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=
 
 ## Server configuration options [ssl-server-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `metricbeat` acts as a **server** accepting incoming connections. These options control the certificate `metricbeat` presents to connecting clients and, optionally, how it verifies client certificates. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [server-certificate-authorities]
+### `certificate_authorities` (server) [server-certificate-authorities]
 
 The list of root certificates for client verifications is only required if `client_authentication` is configured. If `certificate_authorities` is empty or not set, and `client_authentication` is configured, the system keystore is used.
 

--- a/docs/reference/packetbeat/configuration-ssl.md
+++ b/docs/reference/packetbeat/configuration-ssl.md
@@ -138,10 +138,10 @@ This check is not a replacement for the normal SSL validation, but it adds addit
 
 ## Client configuration options [ssl-client-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `packetbeat` acts as a **client** connecting to a remote service (for example, Elasticsearch, Logstash, or Kibana). These options control how `packetbeat` verifies the server it connects to and, optionally, presents a client certificate. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [client-certificate-authorities]
+### `certificate_authorities` (client) [client-certificate-authorities]
 
 The list of root certificates for verifications is required. If `certificate_authorities` is empty or not set, the system keystore is used. If `certificate_authorities` is self-signed, the host system needs to trust that CA cert as well.
 
@@ -277,10 +277,10 @@ openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=
 
 ## Server configuration options [ssl-server-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `packetbeat` acts as a **server** accepting incoming connections. These options control the certificate `packetbeat` presents to connecting clients and, optionally, how it verifies client certificates. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [server-certificate-authorities]
+### `certificate_authorities` (server) [server-certificate-authorities]
 
 The list of root certificates for client verifications is only required if `client_authentication` is configured. If `certificate_authorities` is empty or not set, and `client_authentication` is configured, the system keystore is used.
 

--- a/docs/reference/winlogbeat/configuration-ssl.md
+++ b/docs/reference/winlogbeat/configuration-ssl.md
@@ -138,10 +138,10 @@ This check is not a replacement for the normal SSL validation, but it adds addit
 
 ## Client configuration options [ssl-client-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `winlogbeat` acts as a **client** connecting to a remote service (for example, Elasticsearch, Logstash, or Kibana). These options control how `winlogbeat` verifies the server it connects to and, optionally, presents a client certificate. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [client-certificate-authorities]
+### `certificate_authorities` (client) [client-certificate-authorities]
 
 The list of root certificates for verifications is required. If `certificate_authorities` is empty or not set, the system keystore is used. If `certificate_authorities` is self-signed, the host system needs to trust that CA cert as well.
 
@@ -277,10 +277,10 @@ openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=
 
 ## Server configuration options [ssl-server-config]
 
-You can specify the following options in the `ssl` section of each subsystem that supports SSL.
+Use these settings when `winlogbeat` acts as a **server** accepting incoming connections. These options control the certificate `winlogbeat` presents to connecting clients and, optionally, how it verifies client certificates. You can specify the following options in the `ssl` section of each subsystem that supports SSL.
 
 
-### `certificate_authorities` [server-certificate-authorities]
+### `certificate_authorities` (server) [server-certificate-authorities]
 
 The list of root certificates for client verifications is only required if `client_authentication` is configured. If `certificate_authorities` is empty or not set, and `client_authentication` is configured, the system keystore is used.
 


### PR DESCRIPTION
## Summary
- Add descriptive introductions to the Client and Server SSL configuration sections across all beats, explaining when each set of options applies (client role vs server role)
- Disambiguate the duplicate `certificate_authorities` headings with `(client)` and `(server)` labels so readers can tell them apart at a glance

Closes https://github.com/elastic/docs-content/issues/5615

🤖 Generated with [Claude Code](https://claude.com/claude-code)