### PR TITLE
fix(ci): install mage via asdf if missing in pre-command hook

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -28,6 +28,11 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "auditbeat" || \
   export BUILDKITE_ANALYTICS_TOKEN
 fi
 
+# Ensure the required mage version is installed (the CI agent image may not have it)
+if [[ -n "${ASDF_MAGE_VERSION:-}" ]] && command -v asdf &>/dev/null; then
+    asdf install mage "$ASDF_MAGE_VERSION"
+fi
+
 CPU_ARCH=$(uname -m)
 PLATFORM_TYPE=$(uname)
 


### PR DESCRIPTION
## Proposed commit message

This PR adds a guard in `.buildkite/hooks/pre-command` to `asdf install mage` the required version if missing.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added an entry in `./changelog/fragments`~~

## Related issues

- Observed in [beats-xpack-agentbeat build 955](https://buildkite.com/elastic/beats-xpack-agentbeat/builds/955) ([elastic/beats#49765](https://github.com/elastic/beats/pull/49765))