### PR TITLE
[winlogbeat] Fix gap detection to skip forwarded events

### DIFF
--- a/changelog/fragments/1775006120-winlog-forwarded-gap-detection.yaml
+++ b/changelog/fragments/1775006120-winlog-forwarded-gap-detection.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Skip record ID gap detection for forwarded Windows events.
+
+component: winlogbeat

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -191,6 +191,13 @@ func (l *winEventLog) isForwarded() bool {
 	return (c.Forwarded != nil && *c.Forwarded) || (c.Forwarded == nil && c.Name == "ForwardedEvents")
 }
 
+func (l *winEventLog) shouldDetectGap(prevRecordID, currentRecordID uint64) bool {
+	if l.file || l.isForwarded() || prevRecordID == 0 {
+		return false
+	}
+	return currentRecordID > prevRecordID+1
+}
+
 func (l *winEventLog) hasWin2025ForwardedBugRisk() bool {
 	if !l.isForwarded() {
 		return false
@@ -492,9 +499,10 @@ func (l *winEventLog) processHandle(h win.EvtHandle) (*Record, error) {
 	}
 
 	prevRecordID := l.lastRead.RecordNumber
-	if !l.file && prevRecordID > 0 && r.RecordID > prevRecordID+1 {
+	if l.shouldDetectGap(prevRecordID, r.RecordID) {
 		// Gap detection is channel-only. File reads can legitimately contain
-		// non-contiguous record IDs and should not trigger recovery.
+		// non-contiguous record IDs and should not trigger recovery. Forwarded
+		// events can also be non-contiguous.
 		l.log.Warnw("Record ID gap detected, resetting subscription.",
 			"channel", l.channelName,
 			"previous_record_id", prevRecordID,

--- a/winlogbeat/eventlog/wineventlog_retry_test.go
+++ b/winlogbeat/eventlog/wineventlog_retry_test.go
@@ -67,3 +67,39 @@ func TestRenderNoEventRetryKey(t *testing.T) {
 		assert.Contains(t, err.RetryKey(), "no-bookmark:")
 	})
 }
+
+func TestShouldDetectGap(t *testing.T) {
+	prevRecordID := uint64(100)
+	currentRecordID := uint64(105)
+
+	t.Run("no previous record", func(t *testing.T) {
+		l := &winEventLog{config: config{Name: "Security"}}
+		assert.False(t, l.shouldDetectGap(0, currentRecordID))
+	})
+
+	t.Run("no gap", func(t *testing.T) {
+		l := &winEventLog{config: config{Name: "Security"}}
+		assert.False(t, l.shouldDetectGap(prevRecordID, prevRecordID+1))
+	})
+
+	t.Run("regular channel detects gap", func(t *testing.T) {
+		l := &winEventLog{config: config{Name: "Security"}}
+		assert.True(t, l.shouldDetectGap(prevRecordID, currentRecordID))
+	})
+
+	t.Run("file input skips gap detection", func(t *testing.T) {
+		l := &winEventLog{file: true, config: config{Name: "Security"}}
+		assert.False(t, l.shouldDetectGap(prevRecordID, currentRecordID))
+	})
+
+	t.Run("forwarded channel skips gap detection", func(t *testing.T) {
+		l := &winEventLog{config: config{Name: "ForwardedEvents"}}
+		assert.False(t, l.shouldDetectGap(prevRecordID, currentRecordID))
+	})
+
+	t.Run("forwarded flag skips gap detection", func(t *testing.T) {
+		forwarded := true
+		l := &winEventLog{config: config{Name: "Security", Forwarded: &forwarded}}
+		assert.False(t, l.shouldDetectGap(prevRecordID, currentRecordID))
+	})
+}


### PR DESCRIPTION
## Proposed commit message

Fix gap detection to skip forwarded events since these can legitimately contain non contiguous record IDs.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
