### PR TITLE
idxmgmt: remove redundant beatPaths parameter

### DIFF
--- a/libbeat/cmd/export/ilm_policy.go
+++ b/libbeat/cmd/export/ilm_policy.go
@@ -45,7 +45,7 @@ func GenGetILMPolicyCmd(settings instance.Settings) *cobra.Command {
 			// the way this works, we decide to export ILM or DSL based on the user's config.
 			// This means that if a user has no index management config, we'll default to ILM, regardless of what the user
 			// is connected to. Might not be a problem since a user who doesn't have any custom lifecycle config has nothing to export?
-			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Info.Paths, b.Config.LifecycleConfig)
+			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Config.LifecycleConfig)
 			if err != nil {
 				fatalf("error creating file handler: %s", err)
 			}

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -47,7 +47,7 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 				fatalfInitCmd(err)
 			}
 
-			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Info.Paths, b.Config.LifecycleConfig)
+			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Config.LifecycleConfig)
 			if err != nil {
 				fatalf("error creating file handler: %s", err)
 			}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -691,7 +691,7 @@ func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) er
 				loadILM = idxmgmt.LoadModeEnabled
 			}
 
-			mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Info.Paths, b.Config.LifecycleConfig)
+			mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Config.LifecycleConfig)
 			if err != nil {
 				return fmt.Errorf("error creating index management handler: %w", err)
 			}
@@ -1135,7 +1135,7 @@ func (b *Beat) registerESIndexManagement() error {
 
 func (b *Beat) indexSetupCallback() elasticsearch.ConnectCallback {
 	return func(esClient *eslegclient.Connection, _ *logp.Logger) error {
-		mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Info.Paths, b.Config.LifecycleConfig)
+		mgmtHandler, err := idxmgmt.NewESClientHandler(esClient, b.Info, b.Config.LifecycleConfig)
 		if err != nil {
 			return fmt.Errorf("error creating index management handler: %w", err)
 		}

--- a/libbeat/idxmgmt/client_handler.go
+++ b/libbeat/idxmgmt/client_handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt/lifecycle"
 	"github.com/elastic/beats/v7/libbeat/template"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/version"
 )
 
@@ -60,12 +59,12 @@ func NewClientHandler(ilm lifecycle.ClientHandler, template template.Loader) Cli
 
 // NewESClientHandler returns a new ESLoader instance,
 // initialized with an ilm and template client handler based on the passed in client.
-func NewESClientHandler(client ESClient, info beat.Info, beatPaths *paths.Path, cfg lifecycle.RawConfig) (ClientHandler, error) {
+func NewESClientHandler(client ESClient, info beat.Info, cfg lifecycle.RawConfig) (ClientHandler, error) {
 	esHandler, err := lifecycle.NewESClientHandler(client, info, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ES handler: %w", err)
 	}
-	loader, err := template.NewESLoader(client, esHandler, info.Logger, beatPaths)
+	loader, err := template.NewESLoader(client, esHandler, info.Logger, info.Paths)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ES loader: %w", err)
 	}
@@ -74,10 +73,10 @@ func NewESClientHandler(client ESClient, info beat.Info, beatPaths *paths.Path, 
 
 // NewFileClientHandler returns a new ESLoader instance,
 // initialized with an ilm and template client handler based on the passed in client.
-func NewFileClientHandler(client FileClient, info beat.Info, beatPaths *paths.Path, cfg lifecycle.RawConfig) (ClientHandler, error) {
+func NewFileClientHandler(client FileClient, info beat.Info, cfg lifecycle.RawConfig) (ClientHandler, error) {
 	mgmt, err := lifecycle.NewFileClientHandler(client, info, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating client handler: %w", err)
 	}
-	return NewClientHandler(mgmt, template.NewFileLoader(client, mgmt.Mode() == lifecycle.DSL, info.Logger, beatPaths)), nil
+	return NewClientHandler(mgmt, template.NewFileLoader(client, mgmt.Mode() == lifecycle.DSL, info.Logger, info.Paths)), nil
 }


### PR DESCRIPTION
## Proposed commit message

```
idxmgmt: remove redundant beatPaths parameter

NewESClientHandler and NewFileClientHandler accepted both beat.Info
and *paths.Path. Now that Info carries Paths, drop the separate
argument and pass info.Paths to the downstream template loaders.
```

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None. Internal API change only.

## How to test this PR locally

## Related issues

- Relates https://github.com/elastic/beats/issues/49803
- Blocked by https://github.com/elastic/beats/pull/49836