### PR TITLE
FallbackManager WaitForStop calls Stop

### DIFF
--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -180,12 +180,15 @@ func (n *FallbackManager) Stop() {
 // the nilManager is still used for shutdown on some cases,
 // but that does not mean the Beat is being managed externally,
 // hence it will always return false.
-func (n *FallbackManager) Enabled() bool                      { return false }
-func (n *FallbackManager) AgentInfo() AgentInfo               { return AgentInfo{} }
-func (n *FallbackManager) PreInit() error                     { return nil }
-func (n *FallbackManager) PostInit()                          {}
-func (n *FallbackManager) Start() error                       { return nil }
-func (n *FallbackManager) WaitForStop(_ time.Duration) bool   { return true }
+func (n *FallbackManager) Enabled() bool        { return false }
+func (n *FallbackManager) AgentInfo() AgentInfo { return AgentInfo{} }
+func (n *FallbackManager) PreInit() error       { return nil }
+func (n *FallbackManager) PostInit()            {}
+func (n *FallbackManager) Start() error         { return nil }
+func (n *FallbackManager) WaitForStop(_ time.Duration) bool {
+	n.Stop()
+	return true
+}
 func (n *FallbackManager) CheckRawConfig(cfg *config.C) error { return nil }
 func (n *FallbackManager) RegisterAction(action Action)       {}
 func (n *FallbackManager) UnregisterAction(action Action)     {}


### PR DESCRIPTION
## Proposed commit message

```
Update the FallbackManager to call Stop in WaitForStop to be consistent with the method goal and all other implementations (real or mocks).
```

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
~~## How to test this PR locally~~

## Related issues

- Follow up from https://github.com/elastic/beats/pull/49796/

~~## Use cases~~
~~## Screenshotsv
~~## Logs~~
