### PR TITLE
testing/go-ech: add missing integration build tag

### DIFF
--- a/testing/go-ech/ech.go
+++ b/testing/go-ech/ech.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build integration
+
 package ech
 
 import (


### PR DESCRIPTION
ech.go imports integration.NewStandardBeat which is defined in a file guarded by //go:build integration. Without the same constraint, ech.go fails to compile when running `go test ./...` without -tags=integration.