### PR TITLE
fix: update azeventhubs v2 import in v2_input_test.go

### DIFF
--- a/x-pack/filebeat/input/azureeventhub/v2_input_test.go
+++ b/x-pack/filebeat/input/azureeventhub/v2_input_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -97,19 +97,19 @@ func TestProcessReceivedEventsUpdatesProcessingTimeOnce(t *testing.T) {
 			EventData:    azeventhubs.EventData{Body: []byte(`{"records":[{"msg":"one"}]}`)},
 			EnqueuedTime: &now,
 			PartitionKey: &partitionKey,
-			Offset:       0,
+			Offset:       "0",
 		},
 		{
 			EventData:    azeventhubs.EventData{Body: []byte(`{"records":[{"msg":"two"}]}`)},
 			EnqueuedTime: &now,
 			PartitionKey: &partitionKey,
-			Offset:       1,
+			Offset:       "1",
 		},
 		{
 			EventData:    azeventhubs.EventData{Body: []byte(`{"records":[{"msg":"three"}]}`)},
 			EnqueuedTime: &now,
 			PartitionKey: &partitionKey,
-			Offset:       2,
+			Offset:       "2",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Fix broken import in `v2_input_test.go` after the azeventhubs SDK v2 upgrade (#49867)
- Update import path from `azeventhubs` to `azeventhubs/v2`
- Update `Offset` field values from `int64` to `string` (v2 breaking change)

This was missed in #49867 and is currently breaking lint CI on all open PRs (e.g. #50022).

## Test plan
- [x] Lint CI passes (the only change is fixing the broken import/type)
- [x] `go vet ./x-pack/filebeat/input/azureeventhub/...` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)