### PR TITLE
[AutoOps] Use UUIDv7 in place of UUIDv4 and drop dashes

### DIFF
--- a/changelog/fragments/1775859655-autoops-uuid-v7.yaml
+++ b/changelog/fragments/1775859655-autoops-uuid-v7.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: AutoOps ES module: update to use UUID v7 without dashes for transaction ids to reduce payloads
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1775859655-autoops-uuid-v7.yaml
+++ b/changelog/fragments/1775859655-autoops-uuid-v7.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: AutoOps ES module: update to use UUID v7 without dashes for transaction ids to reduce payloads
+summary: AutoOps ES module update to use UUID v7 without dashes to reduce payloads
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change

--- a/x-pack/metricbeat/module/autoops_es/auto_ops_testing/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/auto_ops_testing/testing.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -267,12 +266,10 @@ func CheckEventWithTransactionId(t *testing.T, event mb.Event, info utils.Cluste
 	require.Equal(t, transactionId, GetObjectValue(event.ModuleFields, "transaction_id"))
 }
 
-func CheckEventWithRandomTransactionId(t *testing.T, event mb.Event, info utils.ClusterInfo) {
+func CheckEventWithoutTransactionId(t *testing.T, event mb.Event, info utils.ClusterInfo) {
 	CheckEvent(t, event, info)
 
-	// valid, random UUID
-	_, err := uuid.FromString(GetObjectValue(event.ModuleFields, "transaction_id").(string))
-	require.NoError(t, err)
+	require.Nil(t, GetObjectValue(event.ModuleFields, "transaction_id"))
 }
 
 func CheckAllEventsUseSameTransactionId(t *testing.T, events []mb.Event) {

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/data.go
@@ -80,7 +80,7 @@ func eventsMapping(m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.Clus
 		appendNodeShards(nodeShards, &shard)
 	}
 
-	transactionID := utils.NewUUIDV4()
+	transactionID := utils.NewUUID()
 
 	sendNodeShardsEvent(r, info, slices.Collect(maps.Values(nodeShards)), transactionID)
 

--- a/x-pack/metricbeat/module/autoops_es/cat_template/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_template/data.go
@@ -36,7 +36,7 @@ type CatTemplate struct {
 	IndexPattern string `json:"t"`
 }
 
-func getNamedTemplates(transactionId string, info *utils.ClusterInfo, templates *map[string]any, reporter t.ReportNamedTemplate) (errs []error) {
+func getNamedTemplates(info *utils.ClusterInfo, templates *map[string]any, reporter t.ReportNamedTemplate) (errs []error) {
 	for name, templateData := range *templates {
 		if data, ok := templateData.(map[string]any); !ok {
 			errs = append(errs, fmt.Errorf("failed casting template data %v", templateData))
@@ -44,7 +44,7 @@ func getNamedTemplates(transactionId string, info *utils.ClusterInfo, templates 
 			errs = append(errs, fmt.Errorf("failed applying template schema for %v: %w", name, err))
 		} else {
 			template["template_name"] = name
-			reporter(transactionId, info, template)
+			reporter(info, template)
 		}
 	}
 
@@ -63,11 +63,8 @@ func eventsMapping(m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.Clus
 		},
 	)
 
-	transactionId, err := t.HandlePartitionedTemplates(m, r, info, templatePathPrefix, partitionedTemplates, getNamedTemplates)
-
-	if err != nil {
-		events.LogAndSendErrorEvent(err, info, r, CatTemplateMetricSet, CatTemplatePath, transactionId)
-		return nil
+	if err := t.HandlePartitionedTemplates(m, r, info, templatePathPrefix, partitionedTemplates, getNamedTemplates); err != nil {
+		events.LogAndSendErrorEventWithoutTransactionId(err, info, r, CatTemplateMetricSet, CatTemplatePath)
 	}
 
 	return nil

--- a/x-pack/metricbeat/module/autoops_es/cat_template/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_template/data_test.go
@@ -38,7 +38,7 @@ func expectValidParsedDataCheckingTemplateNames(t *testing.T, data metricset.Fet
 	auto_ops_testing.CheckAllEventsUseSameTransactionId(t, events)
 
 	for _, event := range events {
-		auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+		auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 		// metrics exist
 		require.NotNil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "template.order"))
@@ -65,7 +65,7 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[[]CatTemplat
 	auto_ops_testing.CheckAllEventsUseSameTransactionId(t, events)
 
 	for _, event := range events {
-		auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+		auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 		// metrics exist
 		require.NotNil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "template.order"))
@@ -90,7 +90,7 @@ func expectValidParsedDetailedTemplates(t *testing.T, data metricset.FetcherData
 	event1 := auto_ops_testing.GetEventByName(t, events, "template.template_name", "simple-response")
 	event2 := auto_ops_testing.GetEventByName(t, events, "template.template_name", "detailed-response")
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event2, data.ClusterInfo)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event2, data.ClusterInfo)
 
 	simpleMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "simple-response")))
 	require.NoError(t, err)

--- a/x-pack/metricbeat/module/autoops_es/cluster_health/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_health/data.go
@@ -41,11 +41,11 @@ func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, data *map[string]in
 
 	if err != nil {
 		err = fmt.Errorf("failed applying cluster health schema %w", err)
-		events.LogAndSendErrorEventWithRandomTransactionId(err, info, r, ClusterHealthMetricSet, ClusterHealthPath)
+		events.LogAndSendErrorEventWithoutTransactionId(err, info, r, ClusterHealthMetricSet, ClusterHealthPath)
 		return nil
 	}
 
-	r.Event(events.CreateEventWithRandomTransactionId(info, metricSetFields))
+	r.Event(events.CreateEventWithoutTransactionId(info, metricSetFields))
 
 	return nil
 }

--- a/x-pack/metricbeat/module/autoops_es/cluster_health/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_health/data_test.go
@@ -25,7 +25,7 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]i
 
 	event := data.Reporter.GetEvents()[0]
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 	// metrics exist
 	require.True(t, len(*event.MetricSetFields.FlattenKeys()) > 2)

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
@@ -239,12 +239,12 @@ func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, settings *map[strin
 
 	if err != nil {
 		err = fmt.Errorf("failed applying cluster settings schema %w", err)
-		events.LogAndSendErrorEventWithRandomTransactionId(err, info, r, ClusterSettingsMetricSet, ClusterSettingsPath)
+		events.LogAndSendErrorEventWithoutTransactionId(err, info, r, ClusterSettingsMetricSet, ClusterSettingsPath)
 		return nil
 	}
 
 	// Flatten settings with precedence: transient > persistent > defaults
-	r.Event(events.CreateEventWithRandomTransactionId(info, flattenSettings(metricSetFields)))
+	r.Event(events.CreateEventWithoutTransactionId(info, flattenSettings(metricSetFields)))
 
 	return nil
 }

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
@@ -25,7 +25,7 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]i
 
 	event := data.Reporter.GetEvents()[0]
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 	// metrics exist
 	require.True(t, len(*event.MetricSetFields.FlattenKeys()) > 3)

--- a/x-pack/metricbeat/module/autoops_es/component_template/data.go
+++ b/x-pack/metricbeat/module/autoops_es/component_template/data.go
@@ -36,7 +36,7 @@ type ComponentTemplates struct {
 	Templates []ComponentTemplate `json:"component_templates"`
 }
 
-func getNamedTemplates(transactionId string, info *utils.ClusterInfo, templates *ComponentTemplates, reporter t.ReportNamedTemplate) (errs []error) {
+func getNamedTemplates(info *utils.ClusterInfo, templates *ComponentTemplates, reporter t.ReportNamedTemplate) (errs []error) {
 	for _, templateData := range templates.Templates {
 		template, err := templateSchema.Apply(templateData.ComponentTemplate)
 
@@ -47,7 +47,7 @@ func getNamedTemplates(transactionId string, info *utils.ClusterInfo, templates 
 
 		template["template_name"] = templateData.Name
 
-		reporter(transactionId, info, template)
+		reporter(info, template)
 	}
 
 	return errs
@@ -66,7 +66,7 @@ func eventsMapping(m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.Clus
 
 	if err != nil {
 		err = fmt.Errorf("failed applying component template schema %w", err)
-		events.LogAndSendErrorEventWithRandomTransactionId(err, info, r, ComponentTemplateMetricSet, ComponentTemplatePath)
+		events.LogAndSendErrorEventWithoutTransactionId(err, info, r, ComponentTemplateMetricSet, ComponentTemplatePath)
 		return nil
 	}
 

--- a/x-pack/metricbeat/module/autoops_es/component_template/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/component_template/data_test.go
@@ -30,7 +30,7 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[ComponentTem
 	auto_ops_testing.CheckAllEventsUseSameTransactionId(t, events)
 
 	for _, event := range events {
-		auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+		auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 		// metrics exist
 		require.NotNil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "template.template"))
@@ -63,7 +63,7 @@ func expectValidParsedDataWithTemplateNames(t *testing.T, data metricset.Fetcher
 	auto_ops_testing.CheckAllEventsUseSameTransactionId(t, events)
 
 	for _, event := range events {
-		auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+		auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 		// metrics exist
 		require.NotNil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "template.template"))
@@ -84,7 +84,7 @@ func expectValidParsedDetailedTemplates(t *testing.T, data metricset.FetcherData
 	event1 := auto_ops_testing.GetEventByName(t, events, "template.template_name", "simple-response")
 	event2 := auto_ops_testing.GetEventByName(t, events, "template.template_name", "detailed-response")
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event2, data.ClusterInfo)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event2, data.ClusterInfo)
 
 	simpleMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "simple-response")))
 	require.NoError(t, err)

--- a/x-pack/metricbeat/module/autoops_es/events/error_event.go
+++ b/x-pack/metricbeat/module/autoops_es/events/error_event.go
@@ -17,16 +17,16 @@ import (
 	"github.com/elastic/elastic-agent-libs/version"
 )
 
-// LogAndSendErrorEventWithRandomTransactionId sends an error event with a random transaction id to the reporter with the provided details.
-func LogAndSendErrorEventWithRandomTransactionId(err error, clusterInfo *utils.ClusterInfo, r mb.ReporterV2, metricSetName string, path string) {
-	LogAndSendErrorEvent(err, clusterInfo, r, metricSetName, path, utils.NewUUID())
+// LogAndSendErrorEventWithoutTransactionId sends an error event without a transaction id to the reporter with the provided details.
+func LogAndSendErrorEventWithoutTransactionId(err error, clusterInfo *utils.ClusterInfo, r mb.ReporterV2, metricSetName string, path string) {
+	LogAndSendErrorEvent(err, clusterInfo, r, metricSetName, path, "")
 }
 
 // LogAndSendErrorEventWithoutClusterInfo sends an error event without cluster info to the reporter with the provided details.
 func LogAndSendErrorEventWithoutClusterInfo(err error, r mb.ReporterV2, metricSetName string) {
 	LogAndSendErrorEvent(err, &utils.ClusterInfo{
 		Version: utils.ClusterInfoVersion{Number: &version.V{}},
-	}, r, metricSetName, "/", utils.NewUUID())
+	}, r, metricSetName, "/", "")
 }
 
 // LogAndSendErrorEvent sends an error event to the reporter with the provided details.
@@ -74,14 +74,13 @@ func createError(info *utils.ClusterInfo, err error, path string, transactionID 
 	status, errorCode, body := getHTTPResponseBodyInfo(err)
 	path, query := extractPathAndQuery(path)
 
-	return mb.Event{
+	event := mb.Event{
 		ModuleFields: mapstr.M{
 			"cluster": mapstr.M{
 				"id":      info.ClusterID,
 				"name":    info.ClusterName,
 				"version": info.Version.Number.String(),
 			},
-			"transaction_id": transactionID,
 		},
 		RootFields: mapstr.M{
 			"error": mapstr.M{
@@ -111,4 +110,10 @@ func createError(info *utils.ClusterInfo, err error, path string, transactionID 
 			},
 		},
 	}
+
+	if transactionID != "" {
+		event.ModuleFields["transaction_id"] = transactionID
+	}
+
+	return event
 }

--- a/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
+++ b/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
@@ -233,7 +233,7 @@ func TestLogAndSendErrorEventWithoutClusterInfoDefaultValues(t *testing.T) {
 		require.Equal(t, http.MethodGet, auto_ops_testing.GetObjectValue(httpField, "request.method"))
 		require.Equal(t, 0, auto_ops_testing.GetObjectValue(httpField, "response.status_code"))
 
-		assert.NotEmpty(t, auto_ops_testing.GetObjectValue(event.ModuleFields, "transaction_id"))
+		assert.Nil(t, auto_ops_testing.GetObjectValue(event.ModuleFields, "transaction_id"))
 
 		return true
 	}))
@@ -269,7 +269,7 @@ func TestLogAndSendErrorEventWithoutClusterInfoNonDefaultValues(t *testing.T) {
 		assert.Equal(t, http.MethodGet, auto_ops_testing.GetObjectValue(httpField, "request.method"))
 		assert.Equal(t, 500, auto_ops_testing.GetObjectValue(httpField, "response.status_code"))
 
-		assert.NotEmpty(t, auto_ops_testing.GetObjectValue(event.ModuleFields, "transaction_id"))
+		assert.Nil(t, auto_ops_testing.GetObjectValue(event.ModuleFields, "transaction_id"))
 
 		return true
 	}))

--- a/x-pack/metricbeat/module/autoops_es/events/events.go
+++ b/x-pack/metricbeat/module/autoops_es/events/events.go
@@ -10,9 +10,28 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-// Create a new Metricbeat Event object with a random Transaction ID (so it has no predictable relationship to other events outside of @timestamp).
-func CreateEventWithRandomTransactionId(info *utils.ClusterInfo, metricSetFields mapstr.M) mb.Event {
-	return CreateEvent(info, metricSetFields, utils.NewUUIDV4())
+// Create a new Metricbeat Event object without a Transaction ID (so it has no predictable relationship to other events outside of @timestamp).
+func CreateEventWithoutTransactionId(info *utils.ClusterInfo, metricSetFields mapstr.M) mb.Event {
+	return mb.Event{
+		MetricSetFields: metricSetFields,
+		ModuleFields: mapstr.M{
+			"cluster": mapstr.M{
+				"id":      info.ClusterID,
+				"name":    info.ClusterName,
+				"version": info.Version.Number.String(),
+			},
+		},
+		RootFields: mapstr.M{
+			"event": mapstr.M{
+				"kind": "metric",
+			},
+			"orchestrator": mapstr.M{
+				"resource": mapstr.M{
+					"id": utils.GetResourceID(),
+				},
+			},
+		},
+	}
 }
 
 // Create a new Metricbeat Event object containing expected fields and the dynamic portion.
@@ -46,6 +65,18 @@ func ReportEvent(r mb.ReporterV2, event mb.Event, index int, total int) {
 	event.ModuleFields["total_amount_of_fractions"] = total
 
 	r.Event(event)
+}
+
+// Create a new Metricbeat Events without a Transaction ID (so it has no predictable relationship to other events outside of @timestamp) and report them.
+// This should only be used when it happens to be an array of events that have no relationship to each other.
+func CreateAndReportEventsWithoutTransactionId(r mb.ReporterV2, info *utils.ClusterInfo, metricSets []mapstr.M) {
+	var total = len(metricSets)
+
+	for index, metricSetFields := range metricSets {
+		event := CreateEventWithoutTransactionId(info, metricSetFields)
+
+		ReportEvent(r, event, index, total)
+	}
 }
 
 // Create a new Metricbeat Events

--- a/x-pack/metricbeat/module/autoops_es/events/events_test.go
+++ b/x-pack/metricbeat/module/autoops_es/events/events_test.go
@@ -26,9 +26,9 @@ func TestCreateEventWithRandomTransactionId(t *testing.T) {
 		"obj2.field1": "value3",
 	}
 
-	event := CreateEventWithRandomTransactionId(&info, metricSetFields)
+	event := CreateEventWithoutTransactionId(&info, metricSetFields)
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event, info)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event, info)
 
 	// metrics exist
 	require.True(t, len(*event.MetricSetFields.FlattenKeys()) == 3)

--- a/x-pack/metricbeat/module/autoops_es/index_template/data.go
+++ b/x-pack/metricbeat/module/autoops_es/index_template/data.go
@@ -44,7 +44,7 @@ type IndexTemplates struct {
 	Templates []IndexTemplate `json:"index_templates"`
 }
 
-func getNamedTemplates(transactionId string, info *utils.ClusterInfo, templates *IndexTemplates, reporter t.ReportNamedTemplate) (errs []error) {
+func getNamedTemplates(info *utils.ClusterInfo, templates *IndexTemplates, reporter t.ReportNamedTemplate) (errs []error) {
 	for _, templateData := range templates.Templates {
 		template, err := templateSchema.Apply(templateData.IndexTemplate)
 
@@ -55,7 +55,7 @@ func getNamedTemplates(transactionId string, info *utils.ClusterInfo, templates 
 
 		template["template_name"] = templateData.Name
 
-		reporter(transactionId, info, template)
+		reporter(info, template)
 	}
 
 	return errs
@@ -78,7 +78,7 @@ func eventsMapping(m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.Clus
 
 	if err != nil {
 		err = fmt.Errorf("failed applying index template schema: %w", err)
-		events.LogAndSendErrorEventWithRandomTransactionId(err, info, r, IndexTemplateMetricSet, IndexTemplatePath)
+		events.LogAndSendErrorEventWithoutTransactionId(err, info, r, IndexTemplateMetricSet, IndexTemplatePath)
 	}
 
 	return nil

--- a/x-pack/metricbeat/module/autoops_es/index_template/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/index_template/data_test.go
@@ -37,7 +37,7 @@ func expectValidParsedDataSkippingComposedOfCheck(t *testing.T, data metricset.F
 	auto_ops_testing.CheckAllEventsUseSameTransactionId(t, events)
 
 	for _, event := range events {
-		auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+		auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 		// metrics exist
 		require.NotNil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "template.priority"))
@@ -81,7 +81,7 @@ func expectValidParsedDataWithTemplateNames(t *testing.T, data metricset.Fetcher
 	auto_ops_testing.CheckAllEventsUseSameTransactionId(t, events)
 
 	for _, event := range events {
-		auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+		auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 		// metrics exist
 		require.NotNil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "template.priority"))
@@ -125,7 +125,7 @@ func expectValidParsedDetailedTemplatesCommon(t *testing.T, data metricset.Fetch
 	event1 := auto_ops_testing.GetEventByName(t, events, "template.template_name", "simple-response")
 	event2 := auto_ops_testing.GetEventByName(t, events, "template.template_name", "detailed-response")
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event2, data.ClusterInfo)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event2, data.ClusterInfo)
 
 	simpleMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "simple-response")))
 	require.NoError(t, err)

--- a/x-pack/metricbeat/module/autoops_es/license/data.go
+++ b/x-pack/metricbeat/module/autoops_es/license/data.go
@@ -39,11 +39,11 @@ func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, data *map[string]an
 
 	if err != nil {
 		err = fmt.Errorf("failed applying license schema: %w", err)
-		events.LogAndSendErrorEventWithRandomTransactionId(err, info, r, LicenseMetricsSet, LicensePath)
+		events.LogAndSendErrorEventWithoutTransactionId(err, info, r, LicenseMetricsSet, LicensePath)
 		return nil
 	}
 
-	r.Event(events.CreateEventWithRandomTransactionId(info, metricSetFields))
+	r.Event(events.CreateEventWithoutTransactionId(info, metricSetFields))
 
 	return nil
 }

--- a/x-pack/metricbeat/module/autoops_es/metricset/metricset_nested_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/metricset_nested_test.go
@@ -48,7 +48,7 @@ func nestedEventsMapping(m *elasticsearch.MetricSet, r mb.ReporterV2, info *util
 			return err
 		}
 
-		r.Event(events.CreateEventWithRandomTransactionId(info, parsed))
+		r.Event(events.CreateEventWithoutTransactionId(info, parsed))
 	}
 
 	return nil

--- a/x-pack/metricbeat/module/autoops_es/metricset/metricset_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/metricset_test.go
@@ -56,7 +56,7 @@ func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, data *testObjectTyp
 			return err
 		}
 
-		r.Event(events.CreateEventWithRandomTransactionId(info, parsed))
+		r.Event(events.CreateEventWithoutTransactionId(info, parsed))
 	}
 
 	return nil

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data.go
@@ -242,7 +242,7 @@ func eventsMapping(m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.Clus
 
 	timestampDiff := int64(0)
 	enrichedStats := map[string]mapstr.M{}
-	transactionId := utils.NewUUIDV4()
+	transactionId := utils.NewUUID()
 	metricSets := []mapstr.M{}
 	nodesList := make(map[string]string, len(nodeStats.Nodes))
 

--- a/x-pack/metricbeat/module/autoops_es/tasks_management/data.go
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/data.go
@@ -105,13 +105,12 @@ func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, nodeTasks *GroupedT
 		tasks = append(tasks, mapstr.M{"task": task})
 	}
 
-	transactionId := utils.NewUUIDV4()
-	e.CreateAndReportEvents(r, info, tasks, transactionId)
+	e.CreateAndReportEventsWithoutTransactionId(r, info, tasks)
 
 	err := errors.Join(errs...)
 
 	if err != nil {
-		e.LogAndSendErrorEvent(err, info, r, TasksMetricSet, TasksPath, transactionId)
+		e.LogAndSendErrorEventWithoutTransactionId(err, info, r, TasksMetricSet, TasksPath)
 	}
 
 	return nil

--- a/x-pack/metricbeat/module/autoops_es/tasks_management/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/data_test.go
@@ -29,7 +29,7 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[GroupedTasks
 
 	event := events[0]
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event, data.ClusterInfo)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event, data.ClusterInfo)
 
 	// metrics exist
 	require.True(t, len(*event.MetricSetFields.FlattenKeys()) > 2)
@@ -49,7 +49,7 @@ func expectValidParsedMultiTasks(t *testing.T, data metricset.FetcherData[Groupe
 	event1 := auto_ops_testing.GetEventByName(t, events, "task.task_id", "node1:45")
 	event2 := auto_ops_testing.GetEventByName(t, events, "task.task_id", "node2:501")
 
-	auto_ops_testing.CheckEventWithRandomTransactionId(t, event2, data.ClusterInfo)
+	auto_ops_testing.CheckEventWithoutTransactionId(t, event2, data.ClusterInfo)
 
 	// metrics exist
 

--- a/x-pack/metricbeat/module/autoops_es/templates/templates.go
+++ b/x-pack/metricbeat/module/autoops_es/templates/templates.go
@@ -92,9 +92,9 @@ var TemplateIndexNamesToIgnore = GetTemplateNamesToFilterOut()
 
 type FilterTemplate[T any] func(pattern []string) utils.Predicate[T]
 
-type ReportNamedTemplate func(transactionId string, info *utils.ClusterInfo, template mapstr.M)
+type ReportNamedTemplate func(info *utils.ClusterInfo, template mapstr.M)
 
-type GetNamedTemplates[T any] func(transactionId string, info *utils.ClusterInfo, templates *T, reporter ReportNamedTemplate) (errs []error)
+type GetNamedTemplates[T any] func(info *utils.ClusterInfo, templates *T, reporter ReportNamedTemplate) (errs []error)
 
 // Exposed as a function for testing. This should not change at runtime.
 func GetTemplateNamesToFilterOut() []string {
@@ -141,13 +141,11 @@ func GetPartitionedTemplatesWithErrors[T any](templates []T, namer utils.Supplie
 }
 
 // Loop across the `partitionedTemplates` and request them in associated batches, then extract and report them as events sharing a Transaction ID.
-func HandlePartitionedTemplates[T any](m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.ClusterInfo, templatePathPrefix string, partitionedTemplates [][]string, getNamedTemplates GetNamedTemplates[T]) (string, error) {
+func HandlePartitionedTemplates[T any](m *elasticsearch.MetricSet, r mb.ReporterV2, info *utils.ClusterInfo, templatePathPrefix string, partitionedTemplates [][]string, getNamedTemplates GetNamedTemplates[T]) error {
 	var errs []error
 	lastIndex := len(partitionedTemplates) - 1
 
 	excludeTemplateSubstring := utils.GetStrenv(EXCLUDE_STRING_IN_TEMPLATE_NAMES_NAME, "%{")
-
-	transactionId := utils.NewUUIDV4()
 
 	for i, templatesBatch := range partitionedTemplates {
 		if len(templatesBatch) == 0 {
@@ -164,8 +162,8 @@ func HandlePartitionedTemplates[T any](m *elasticsearch.MetricSet, r mb.Reporter
 			continue
 		}
 
-		namedTemplatesErrs := getNamedTemplates(transactionId, info, templates, func(transactionId string, info *utils.ClusterInfo, template mapstr.M) {
-			r.Event(events.CreateEvent(info, mapstr.M{"template": template}, transactionId))
+		namedTemplatesErrs := getNamedTemplates(info, templates, func(info *utils.ClusterInfo, template mapstr.M) {
+			r.Event(events.CreateEventWithoutTransactionId(info, mapstr.M{"template": template}))
 		})
 
 		errs = append(errs, namedTemplatesErrs...)
@@ -175,7 +173,7 @@ func HandlePartitionedTemplates[T any](m *elasticsearch.MetricSet, r mb.Reporter
 		}
 	}
 
-	return transactionId, errors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 // Loop across the `partitionedTemplates` and request them individually, then extract and report them as events sharing a Transaction ID.
@@ -184,8 +182,6 @@ func HandleIndividualTemplateRequests[T any](m *elasticsearch.MetricSet, r mb.Re
 	lastIndex := len(partitionedTemplates) - 1
 
 	excludeTemplateSubstring := utils.GetStrenv(EXCLUDE_STRING_IN_TEMPLATE_NAMES_NAME, "%{")
-
-	transactionId := utils.NewUUIDV4()
 
 	for i, templatesBatch := range partitionedTemplates {
 		if len(templatesBatch) == 0 {
@@ -203,8 +199,8 @@ func HandleIndividualTemplateRequests[T any](m *elasticsearch.MetricSet, r mb.Re
 				continue
 			}
 
-			namedTemplatesErrs := getNamedTemplates(transactionId, info, templateData, func(transactionId string, info *utils.ClusterInfo, template mapstr.M) {
-				r.Event(events.CreateEvent(info, mapstr.M{"template": template}, transactionId))
+			namedTemplatesErrs := getNamedTemplates(info, templateData, func(info *utils.ClusterInfo, template mapstr.M) {
+				r.Event(events.CreateEventWithoutTransactionId(info, mapstr.M{"template": template}))
 			})
 
 			errs = append(errs, namedTemplatesErrs...)

--- a/x-pack/metricbeat/module/autoops_es/utils/uuid.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/uuid.go
@@ -5,20 +5,12 @@
 package utils
 
 import (
+	"strings"
+
 	"github.com/gofrs/uuid/v5"
 )
 
-// Generate a random UUID using the default algorithm (v7)
+// Generate a random UUID using the default algorithm (v7) without dashes.
 func NewUUID() string {
-	return NewUUIDV7()
-}
-
-// Generate a random UUID using the v4 algorithm
-func NewUUIDV4() string {
-	return uuid.Must(uuid.NewV4()).String()
-}
-
-// Generate a random UUID using the v7 algorithm
-func NewUUIDV7() string {
-	return uuid.Must(uuid.NewV7()).String()
+	return strings.ReplaceAll(uuid.Must(uuid.NewV7()).String(), "-", "")
 }

--- a/x-pack/metricbeat/module/autoops_es/utils/uuid_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/uuid_test.go
@@ -8,7 +8,9 @@
 package utils
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -17,19 +19,21 @@ func TestNewUUID(t *testing.T) {
 	uuid := NewUUID()
 
 	require.NotEmpty(t, uuid)
+	require.Len(t, uuid, 32) // UUID v7 without dashes should be 32 characters long
 	require.NotEqual(t, uuid, NewUUID())
 }
 
-func TestNewUUIDV4(t *testing.T) {
-	uuid := NewUUIDV4()
+func TestNewUUIDIsUUIDv7(t *testing.T) {
+	uuid := NewUUID()
 
-	require.NotEmpty(t, uuid)
-	require.NotEqual(t, uuid, NewUUIDV4())
-}
+	// UUID v7 has the format xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx where y is one of [8, 9, A, B]
+	// Since our implementation removes dashes, the version character is at index 12 and the variant character is at index 16.
+	require.EqualValues(t, '7', uuid[12])    // Version should be '7'
+	require.Contains(t, "89ab", uuid[16:17]) // Variant should be one of '8', '9', 'A', or 'B'
 
-func TestNewUUIDV7(t *testing.T) {
-	uuid := NewUUIDV7()
-
-	require.NotEmpty(t, uuid)
-	require.NotEqual(t, uuid, NewUUIDV7())
+	// UUIDv7 encodes a Unix millisecond timestamp in the first 48 bits (12 hex chars).
+	// We can take the first 12 characters because our implementation removes dashes.
+	tsMillis, err := strconv.ParseInt(uuid[:12], 16, 64)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now(), time.UnixMilli(tsMillis), 10*time.Minute)
 }


### PR DESCRIPTION
This changes over from using random and unpredictable UUIDv4 to UUIDv7. While changing this, it also drops the dashes to avoid unneeded repetition (dashes can be reconstituted if needed given their predictable location).

This also drops usage of "random" Transaction IDs and simply stops sending them. Random Transaction IDs provide no value as it implies the data is not grouped and thus this even further reduces sending unneeded data.

## Proposed commit message

Change the the UUID usage from UUIDv4 to UUIDv7 without dashes for better compressable payloads.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

The user should notice less data and smaller over-the-wire payloads thanks to superior compressability and dropped data. There is no negative impact as the dropped data is / was unused.

## How to test this PR locally

Run AutoOps against an Elasticsearch cluster and observe that you still get unique `transaction_id`s for separate payloads, and not for the uncorrelated payloads (for example, single types like `cluster_health`, but also tasks and templates).

## Related issues

- Closes https://github.com/elastic/beats/issues/50077

## Use cases

The use case is to reduce data payload sizes.