### PR TITLE
x-pack/filebeat/input/http_endpoint: use OS-assigned ports in pool tests

### DIFF
--- a/x-pack/filebeat/input/http_endpoint/input_test.go
+++ b/x-pack/filebeat/input/http_endpoint/input_test.go
@@ -547,7 +547,8 @@ func TestServerPool(t *testing.T) {
 func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr error) ([]*httpEndpoint, []target, error) {
 	t.Helper()
 
-	m := make(map[string]string) // logical addr → real addr
+	m := make(map[string]string)      // logical addr → real addr
+	lns := make([]net.Listener, 0, 2) // hold open until all allocated
 	for _, cfg := range cfgs {
 		if _, ok := m[cfg.addr]; ok {
 			continue
@@ -557,6 +558,9 @@ func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr err
 			t.Fatalf("allocating port for %s: %v", cfg.addr, err)
 		}
 		m[cfg.addr] = ln.Addr().String()
+		lns = append(lns, ln)
+	}
+	for _, ln := range lns {
 		ln.Close()
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/input_test.go
+++ b/x-pack/filebeat/input/http_endpoint/input_test.go
@@ -530,7 +530,7 @@ func TestServerPool(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					err := servers.serve(ctx, cfg, pub.Publish, metrics)
-					if err != nil && err != http.ErrServerClosed && wantErr == nil {
+					if err != nil && err != http.ErrServerClosed && wantErr == nil { //nolint:errorlint // http.ErrServerClosed is a documented sentinel, never wrapped.
 						t.Errorf("failed to re-register %v: %v", cfg.addr, err)
 					}
 				}()
@@ -1206,7 +1206,7 @@ func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr err
 		if _, ok := m[cfg.addr]; ok {
 			continue
 		}
-		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatalf("allocating port for %s: %v", cfg.addr, err)
 		}
@@ -1236,7 +1236,7 @@ func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr err
 		}
 	}
 
-	if e, ok := wantErr.(invalidTLSStateErr); ok {
+	if e, ok := wantErr.(invalidTLSStateErr); ok { //nolint:errorlint // invalidTLSStateErr is never wrapped.
 		if actual, ok := m[e.addr]; ok {
 			e.addr = actual
 			wantErr = e
@@ -1251,7 +1251,7 @@ func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr err
 // OS will not recycle the port before the caller binds it.
 func freeAddr(t *testing.T) string {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("allocating port: %v", err)
 	}

--- a/x-pack/filebeat/input/http_endpoint/input_test.go
+++ b/x-pack/filebeat/input/http_endpoint/input_test.go
@@ -441,6 +441,8 @@ func (t target) isWantedHeader(got http.Header) bool {
 func TestServerPool(t *testing.T) {
 	for _, test := range serverPoolTests {
 		t.Run(test.name, func(t *testing.T) {
+			cfgs, events, wantErr := remapAddrs(t, test.cfgs, test.events, test.wantErr)
+
 			servers := pool{servers: make(map[string]*server)}
 
 			var (
@@ -450,7 +452,7 @@ func TestServerPool(t *testing.T) {
 			ctx, cancel := newCtx("server_pool_test", test.name)
 			metrics := newInputMetrics(monitoring.NewRegistry(), logp.NewNopLogger())
 			var wg sync.WaitGroup
-			for _, cfg := range test.cfgs {
+			for _, cfg := range cfgs {
 				cfg := cfg
 				wg.Add(1)
 				go func() {
@@ -464,9 +466,9 @@ func TestServerPool(t *testing.T) {
 					}
 				}()
 			}
-			if test.wantErr == nil {
+			if wantErr == nil {
 				addrCount := make(map[string]int)
-				for _, cfg := range test.cfgs {
+				for _, cfg := range cfgs {
 					addrCount[cfg.addr]++
 				}
 				for addr := range addrCount {
@@ -477,11 +479,11 @@ func TestServerPool(t *testing.T) {
 				}
 			}
 
-			if test.wantErr != nil {
+			if wantErr != nil {
 				select {
 				case err := <-fails:
-					if !errors.Is(err, test.wantErr) {
-						t.Errorf("unexpected error calling serve: got=%#q, want=%#q", err, test.wantErr)
+					if !errors.Is(err, wantErr) {
+						t.Errorf("unexpected error calling serve: got=%#q, want=%#q", err, wantErr)
 					}
 				case <-time.After(5 * time.Second):
 					t.Errorf("expected error calling serve")
@@ -493,7 +495,7 @@ func TestServerPool(t *testing.T) {
 				default:
 				}
 			}
-			for i, e := range test.events {
+			for i, e := range events {
 				resp, err := doRequest(test.method, e.url, "application/json", strings.NewReader(e.event))
 				if err != nil {
 					t.Fatalf("failed to post event #%d: %v", i, err)
@@ -522,13 +524,13 @@ func TestServerPool(t *testing.T) {
 
 			// Try to re-register the same addresses.
 			ctx, cancel = newCtx("server_pool_test", test.name)
-			for _, cfg := range test.cfgs {
+			for _, cfg := range cfgs {
 				cfg := cfg
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
 					err := servers.serve(ctx, cfg, pub.Publish, metrics)
-					if err != nil && err != http.ErrServerClosed && test.wantErr == nil {
+					if err != nil && err != http.ErrServerClosed && wantErr == nil {
 						t.Errorf("failed to re-register %v: %v", cfg.addr, err)
 					}
 				}()
@@ -564,14 +566,19 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 		acker.ACK()
 	}
 
+	addr := freeAddr(t)
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("splitting free address: %v", err)
+	}
 	cfg := &httpEndpoint{
-		addr: "127.0.0.1:9010",
+		addr: addr,
 		config: config{
 			Method:            http.MethodPost,
 			ResponseCode:      http.StatusOK,
 			ResponseBody:      `{"message": "success"}`,
-			ListenAddress:     "127.0.0.1",
-			ListenPort:        "9010",
+			ListenAddress:     host,
+			ListenPort:        port,
 			URL:               "/",
 			Prefix:            "json",
 			MaxInFlight:       100,
@@ -594,7 +601,7 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 			t.Errorf("unexpected serve error: %v", err)
 		}
 	}()
-	waitForServer(t, "127.0.0.1:9010", 5*time.Second)
+	waitForServer(t, addr, 5*time.Second)
 
 	var reqWg sync.WaitGroup
 
@@ -605,7 +612,7 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 	go func() {
 		defer reqWg.Done()
 		resp, err := doRequest(http.MethodPost,
-			"http://127.0.0.1:9010/?wait_for_completion_timeout=5s",
+			"http://"+addr+"/?wait_for_completion_timeout=5s",
 			"application/json",
 			strings.NewReader(`{"first":"request with enough bytes to exceed high water"}`))
 		if err != nil {
@@ -625,7 +632,7 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 	go func() {
 		defer reqWg.Done()
 		resp, err := doRequest(http.MethodPost,
-			"http://127.0.0.1:9010/?wait_for_completion_timeout=5s",
+			"http://"+addr+"/?wait_for_completion_timeout=5s",
 			"application/json",
 			strings.NewReader(`{"second":"request"}`))
 		if err != nil {
@@ -1188,6 +1195,71 @@ func TestSimultaneousShutdown(t *testing.T) {
 
 // waitForServer polls addr until a TCP connection succeeds or the
 // timeout expires.
+// remapAddrs allocates OS-assigned ports for each unique logical address in
+// cfgs and returns deep copies of cfgs, events, and wantErr with the real
+// addresses substituted. The originals are not modified.
+func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr error) ([]*httpEndpoint, []target, error) {
+	t.Helper()
+
+	m := make(map[string]string) // logical addr → real addr
+	for _, cfg := range cfgs {
+		if _, ok := m[cfg.addr]; ok {
+			continue
+		}
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("allocating port for %s: %v", cfg.addr, err)
+		}
+		m[cfg.addr] = ln.Addr().String()
+		ln.Close()
+	}
+
+	out := make([]*httpEndpoint, len(cfgs))
+	for i, cfg := range cfgs {
+		c := *cfg
+		actual := m[cfg.addr]
+		host, port, err := net.SplitHostPort(actual)
+		if err != nil {
+			t.Fatalf("splitting address %s: %v", actual, err)
+		}
+		c.addr = actual
+		c.config.ListenAddress = host
+		c.config.ListenPort = port
+		out[i] = &c
+	}
+
+	ev := make([]target, len(events))
+	copy(ev, events)
+	for i := range ev {
+		for logical, actual := range m {
+			ev[i].url = strings.Replace(ev[i].url, logical, actual, 1)
+		}
+	}
+
+	if e, ok := wantErr.(invalidTLSStateErr); ok {
+		if actual, ok := m[e.addr]; ok {
+			e.addr = actual
+			wantErr = e
+		}
+	}
+
+	return out, ev, wantErr
+}
+
+// freeAddr returns a 127.0.0.1:<port> address with an OS-assigned port that
+// was momentarily free. There is a small TOCTOU window, but in practice the
+// OS will not recycle the port before the caller binds it.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocating port: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+	return addr
+}
+
 func waitForServer(t *testing.T, addr string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.After(timeout)

--- a/x-pack/filebeat/input/http_endpoint/input_test.go
+++ b/x-pack/filebeat/input/http_endpoint/input_test.go
@@ -541,6 +541,57 @@ func TestServerPool(t *testing.T) {
 	}
 }
 
+// remapAddrs allocates OS-assigned ports for each unique logical address in
+// cfgs and returns deep copies of cfgs, events, and wantErr with the real
+// addresses substituted. The originals are not modified.
+func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr error) ([]*httpEndpoint, []target, error) {
+	t.Helper()
+
+	m := make(map[string]string) // logical addr → real addr
+	for _, cfg := range cfgs {
+		if _, ok := m[cfg.addr]; ok {
+			continue
+		}
+		ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("allocating port for %s: %v", cfg.addr, err)
+		}
+		m[cfg.addr] = ln.Addr().String()
+		ln.Close()
+	}
+
+	out := make([]*httpEndpoint, len(cfgs))
+	for i, cfg := range cfgs {
+		c := *cfg
+		actual := m[cfg.addr]
+		host, port, err := net.SplitHostPort(actual)
+		if err != nil {
+			t.Fatalf("splitting address %s: %v", actual, err)
+		}
+		c.addr = actual
+		c.config.ListenAddress = host
+		c.config.ListenPort = port
+		out[i] = &c
+	}
+
+	ev := make([]target, len(events))
+	copy(ev, events)
+	for i := range ev {
+		for logical, actual := range m {
+			ev[i].url = strings.Replace(ev[i].url, logical, actual, 1)
+		}
+	}
+
+	if e, ok := wantErr.(invalidTLSStateErr); ok { //nolint:errorlint // invalidTLSStateErr is never wrapped.
+		if actual, ok := m[e.addr]; ok {
+			e.addr = actual
+			wantErr = e
+		}
+	}
+
+	return out, ev, wantErr
+}
+
 // TestConcurrentExceedMaxInFlight tests that concurrent requests are properly
 // rejected when in-flight bytes exceed the high water mark. This requires
 // holding bytes until ACK, which means we need a publisher that delays ACK.
@@ -664,6 +715,20 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 
 	cancel()
 	wg.Wait()
+}
+
+// freeAddr returns a 127.0.0.1:<port> address with an OS-assigned port that
+// was momentarily free. There is a small TOCTOU window, but in practice the
+// OS will not recycle the port before the caller binds it.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocating port: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+	return addr
 }
 
 func TestNewHTTPEndpoint(t *testing.T) {
@@ -1195,71 +1260,6 @@ func TestSimultaneousShutdown(t *testing.T) {
 
 // waitForServer polls addr until a TCP connection succeeds or the
 // timeout expires.
-// remapAddrs allocates OS-assigned ports for each unique logical address in
-// cfgs and returns deep copies of cfgs, events, and wantErr with the real
-// addresses substituted. The originals are not modified.
-func remapAddrs(t *testing.T, cfgs []*httpEndpoint, events []target, wantErr error) ([]*httpEndpoint, []target, error) {
-	t.Helper()
-
-	m := make(map[string]string) // logical addr → real addr
-	for _, cfg := range cfgs {
-		if _, ok := m[cfg.addr]; ok {
-			continue
-		}
-		ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatalf("allocating port for %s: %v", cfg.addr, err)
-		}
-		m[cfg.addr] = ln.Addr().String()
-		ln.Close()
-	}
-
-	out := make([]*httpEndpoint, len(cfgs))
-	for i, cfg := range cfgs {
-		c := *cfg
-		actual := m[cfg.addr]
-		host, port, err := net.SplitHostPort(actual)
-		if err != nil {
-			t.Fatalf("splitting address %s: %v", actual, err)
-		}
-		c.addr = actual
-		c.config.ListenAddress = host
-		c.config.ListenPort = port
-		out[i] = &c
-	}
-
-	ev := make([]target, len(events))
-	copy(ev, events)
-	for i := range ev {
-		for logical, actual := range m {
-			ev[i].url = strings.Replace(ev[i].url, logical, actual, 1)
-		}
-	}
-
-	if e, ok := wantErr.(invalidTLSStateErr); ok { //nolint:errorlint // invalidTLSStateErr is never wrapped.
-		if actual, ok := m[e.addr]; ok {
-			e.addr = actual
-			wantErr = e
-		}
-	}
-
-	return out, ev, wantErr
-}
-
-// freeAddr returns a 127.0.0.1:<port> address with an OS-assigned port that
-// was momentarily free. There is a small TOCTOU window, but in practice the
-// OS will not recycle the port before the caller binds it.
-func freeAddr(t *testing.T) string {
-	t.Helper()
-	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("allocating port: %v", err)
-	}
-	addr := ln.Addr().String()
-	ln.Close()
-	return addr
-}
-
 func waitForServer(t *testing.T, addr string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.After(timeout)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/http_endpoint: use OS-assigned ports in pool tests

TestServerPool and TestConcurrentExceedMaxInFlight used hardcoded ports
(9001, 9002, 9010) which can collide with other processes on shared CI
machines. Both tests were reported as flaky in the same CI run.

Allocate ports dynamically via net.Listen on :0 so each subtest gets a
guaranteed-free port. The test table still uses the original port numbers
as logical topology identifiers (which configs share a port); remapAddrs
substitutes real addresses before each subtest runs.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #50053
- Fixes #50054
- Fixes #50055

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
