### PR TITLE
[On Hold][Filebeat] Add configurable memlog checkpoint size for the registry

### DIFF
--- a/changelog/fragments/1776167104-add-memlog-checkpoint-size.yaml
+++ b/changelog/fragments/1776167104-add-memlog-checkpoint-size.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+summary: Add configurable memlog checkpoint size for the registry
+component: filebeat
+pr: https://github.com/elastic/beats/pull/50117
+issue: https://github.com/elastic/beats/issues/50114

--- a/docs/reference/filebeat/configuration-general-options.md
+++ b/docs/reference/filebeat/configuration-general-options.md
@@ -101,7 +101,7 @@ When set to `bbolt`, the database files are stored under the directory specified
 ### `registry.memlog.checkpoint_size` [_registry_memlog_checkpoint_size]
 
 ```{applies_to}
-stack: ga 9.4.0
+stack: ga 9.5.0
 ```
 
 The registry file size threshold, in bytes, that triggers a checkpoint. When the registry file reaches this size, Filebeat writes a full snapshot of the registry state and resets the file. Larger values mean fewer checkpoints, but a larger registry file. Default: `10485760` (10 MB).

--- a/docs/reference/filebeat/configuration-general-options.md
+++ b/docs/reference/filebeat/configuration-general-options.md
@@ -100,6 +100,10 @@ When set to `bbolt`, the database files are stored under the directory specified
 
 ### `registry.memlog.checkpoint_size` [_registry_memlog_checkpoint_size]
 
+```{applies_to}
+stack: ga 9.4.0
+```
+
 The registry file size threshold, in bytes, that triggers a checkpoint. When the registry file reaches this size, Filebeat writes a full snapshot of the registry state and resets the file. Larger values mean fewer checkpoints, but a larger registry file. Default: `10485760` (10 MB).
 
 The minimum value is `10485760` (10 MB). This setting only applies when `registry.backend` is set to `memlog` (the default). Increasing this value can improve performance when tracking tens of thousands of files or more.

--- a/docs/reference/filebeat/configuration-general-options.md
+++ b/docs/reference/filebeat/configuration-general-options.md
@@ -98,6 +98,17 @@ filebeat.registry.backend: memlog
 When set to `bbolt`, the database files are stored under the directory specified by `registry.path`. The bbolt-specific settings are configured under `registry.bbolt`.
 
 
+### `registry.memlog.checkpoint_size` [_registry_memlog_checkpoint_size]
+
+The registry file size threshold, in bytes, that triggers a checkpoint. When the registry file reaches this size, Filebeat writes a full snapshot of the registry state and resets the file. Larger values mean fewer checkpoints, but a larger registry file. Default: `10485760` (10 MB).
+
+The minimum value is `10485760` (10 MB). This setting only applies when `registry.backend` is set to `memlog` (the default). Increasing this value can improve performance when tracking tens of thousands of files or more.
+
+```yaml
+filebeat.registry.memlog.checkpoint_size: 10485760
+```
+
+
 ### `registry.bbolt.timeout` [_registry_bbolt_timeout]
 
 The amount of time to wait to obtain a file lock on the bbolt database file. Default: `1s`.

--- a/docs/reference/filebeat/filebeat-reference-yml.md
+++ b/docs/reference/filebeat/filebeat-reference-yml.md
@@ -1335,6 +1335,18 @@ filebeat.inputs:
 # persistent on-disk storage with support for compaction and TTL-based cleanup.
 #filebeat.registry.backend: memlog
 
+# ----------------------- Memlog backend settings ------------------------------
+# These settings apply only when filebeat.registry.backend is set to "memlog"
+# (the default).
+
+# The registry file size threshold (in bytes) that triggers a checkpoint.
+# When the registry file reaches this size, Filebeat writes a full snapshot
+# of the registry state and resets the file. Larger values mean fewer
+# checkpoints, but a larger registry file. Increasing this value can improve
+# performance when tracking tens of thousands of files or more.
+# Default: 10485760 (10 MB). Minimum: 10485760 (10 MB).
+#filebeat.registry.memlog.checkpoint_size: 10485760
+
 # ----------------------- Bbolt backend settings -------------------------------
 # WARNING: The bbolt backend is EXPERIMENTAL and may change or be removed in
 # future releases. Do not use in production without understanding the risks.

--- a/filebeat/_meta/config/filebeat.global.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.global.reference.yml.tmpl
@@ -31,6 +31,18 @@
 # persistent on-disk storage with support for compaction and TTL-based cleanup.
 #filebeat.registry.backend: memlog
 
+# ----------------------- Memlog backend settings ------------------------------
+# These settings apply only when filebeat.registry.backend is set to "memlog"
+# (the default).
+
+# The registry file size threshold (in bytes) that triggers a checkpoint.
+# When the registry file reaches this size, Filebeat writes a full snapshot
+# of the registry state and resets the file. Larger values mean fewer
+# checkpoints, but a larger registry file. Increasing this value can improve
+# performance when tracking tens of thousands of files or more.
+# Default: 10485760 (10 MB). Minimum: 10485760 (10 MB).
+#filebeat.registry.memlog.checkpoint_size: 10485760
+
 # ----------------------- Bbolt backend settings -------------------------------
 # WARNING: The bbolt backend is EXPERIMENTAL and may change or be removed in
 # future releases. Do not use in production without understanding the risks.

--- a/filebeat/beater/store.go
+++ b/filebeat/beater/store.go
@@ -90,9 +90,13 @@ func openStateStore(ctx context.Context, info beat.Info, logger *logp.Logger, cf
 				Config:   cfg.Bbolt,
 			})
 		case "memlog", "":
+			limit := cfg.Memlog.CheckpointSize
 			reg, err = memlog.New(logger, memlog.Settings{
 				Root:     resolvedPath,
 				FileMode: cfg.Permissions,
+				Checkpoint: func(filesize uint64) bool {
+					return filesize >= limit
+				},
 			})
 		default:
 			return nil, fmt.Errorf("unknown registry backend: %q", cfg.Backend)

--- a/filebeat/beater/store_test.go
+++ b/filebeat/beater/store_test.go
@@ -18,6 +18,10 @@
 package beater
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +31,7 @@ import (
 
 	"github.com/elastic/beats/v7/filebeat/config"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/statestore/backend/memlog"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -153,4 +158,191 @@ func TestOpenStateStore_ConcurrentOpenClose(t *testing.T) {
 	_, exists := globalStores[resolvedKey]
 	globalMu.Unlock()
 	assert.False(t, exists, "entry should be cleaned up after all stores are closed")
+}
+
+// TestOpenStateStore_CheckpointSize verifies that the memlog checkpoint is
+// triggered at the correct WAL size threshold, both for the default (10MB)
+// and for a custom configured value.
+//
+// Important: memlog deletes old checkpoint data files after each new
+// checkpoint, so at most 1 data file exists on disk at any time. We detect
+// checkpoint events by checking whether a data file exists and the WAL log
+// file has been reset (small size).
+func TestOpenStateStore_CheckpointSize(t *testing.T) {
+	const valueSize = 1024
+	value := strings.Repeat("x", valueSize)
+
+	// Test-only values well below the production minimum (10 MB) to keep
+	// tests fast. Config validation prevents these in production; here we
+	// construct memlog.Config directly, bypassing Validate().
+	testCases := []struct {
+		name           string
+		checkpointSize uint64
+	}{
+		{name: "custom 256KB", checkpointSize: 256 * 1024},
+		{name: "custom 64KB", checkpointSize: 64 * 1024},
+		{name: "custom 32KB", checkpointSize: 32 * 1024},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			s := testOpenStoreWithConfig(t, dir, config.Registry{
+				Path:          "",
+				Permissions:   0600,
+				CleanInterval: 5 * time.Second,
+				Memlog:        memlog.Config{CheckpointSize: tc.checkpointSize},
+			})
+			defer s.Close()
+
+			store, err := s.shared.registry.Get("test")
+			require.NoError(t, err)
+			defer store.Close()
+
+			registryDir := filepath.Join(dir, "test")
+
+			written := 0
+
+			// Phase 1: write entries until the WAL reaches ~80% of the
+			// threshold. This should NOT trigger a checkpoint.
+			target80 := tc.checkpointSize * 80 / 100
+			for walFileSize(t, registryDir) < target80 {
+				require.NoError(t, store.Set(fmt.Sprintf("key-%05d", written), map[string]any{"value": value}))
+				written++
+			}
+			assert.False(t, hasCheckpointFile(t, registryDir),
+				"no checkpoint should be triggered below the checkpointSize")
+			t.Logf("phase 1: wrote %d entries, WAL size %d, checkpointSize %d",
+				written, walFileSize(t, registryDir), tc.checkpointSize)
+
+			// Phase 2: write past the checkpointSize — a checkpoint should occur.
+			// After the checkpoint, the WAL is truncated and the data file
+			// appears. We write 2x the checkpointSize to be sure.
+			target2x := tc.checkpointSize * 2
+			for walFileSize(t, registryDir) < target2x {
+				require.NoError(t, store.Set(fmt.Sprintf("key-%05d", written), map[string]any{"value": value}))
+				written++
+
+				// Once a checkpoint fires, the WAL resets to near-zero.
+				// Detect this to avoid writing forever.
+				if hasCheckpointFile(t, registryDir) {
+					break
+				}
+			}
+			assert.True(t, hasCheckpointFile(t, registryDir),
+				"a checkpoint should have been triggered after crossing the checkpointSize")
+			t.Logf("phase 2: wrote %d total entries, checkpoint triggered", written)
+
+			// Phase 3: after checkpoint the WAL was reset. Write past the
+			// checkpointSize again and verify a second checkpoint occurs (the data
+			// file changes).
+			firstDataFile := currentCheckpointFile(t, registryDir)
+			require.NotEmpty(t, firstDataFile, "sanity: data file should exist")
+
+			for walFileSize(t, registryDir) < target2x {
+				require.NoError(t, store.Set(fmt.Sprintf("key-%05d", written), map[string]any{"value": value}))
+				written++
+
+				if cf := currentCheckpointFile(t, registryDir); cf != "" && cf != firstDataFile {
+					break
+				}
+			}
+
+			secondDataFile := currentCheckpointFile(t, registryDir)
+			assert.NotEqual(t, firstDataFile, secondDataFile,
+				"a second checkpoint should produce a new data file (old one is deleted)")
+
+			// The old data file should have been removed.
+			assert.NoFileExists(t, filepath.Join(registryDir, firstDataFile),
+				"the previous checkpoint file should be deleted")
+		})
+	}
+}
+
+// TestOpenStateStore_DefaultCheckpointSize verifies that the default memlog
+// checkpoint (10MB) triggers. This test writes enough data to cross the
+// threshold and checks that a checkpoint file appears.
+func TestOpenStateStore_DefaultCheckpointSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: writes ~10 MB to verify default checkpoint threshold")
+	}
+
+	dir := t.TempDir()
+
+	s := testOpenStoreWithConfig(t, dir, config.Registry{
+		Path:          "",
+		Permissions:   0600,
+		CleanInterval: 5 * time.Second,
+	})
+	defer s.Close()
+
+	store, err := s.shared.registry.Get("test")
+	require.NoError(t, err)
+	defer store.Close()
+
+	registryDir := filepath.Join(dir, "test")
+
+	const defaultThreshold = 10 * 1 << 20 // 10MB
+	value := strings.Repeat("x", 4096)
+
+	for i := 0; !hasCheckpointFile(t, registryDir); i++ {
+		require.NoError(t, store.Set(fmt.Sprintf("key-%06d", i), map[string]any{"value": value}))
+
+		if walFileSize(t, registryDir) > defaultThreshold*2 {
+			t.Fatal("WAL exceeded 2x the default threshold without a checkpoint")
+		}
+	}
+
+	assert.True(t, hasCheckpointFile(t, registryDir),
+		"checkpoint should have been triggered at the default 10MB threshold")
+}
+
+func testOpenStoreWithConfig(t *testing.T, dir string, cfg config.Registry) *filebeatStore {
+	t.Helper()
+	beatPaths := paths.New()
+	beatPaths.Data = dir
+
+	store, err := openStateStore(t.Context(), beat.Info{Beat: "test"}, logp.NewNopLogger(), cfg, beatPaths)
+	require.NoError(t, err)
+	return store
+}
+
+// hasCheckpointFile returns true if a checkpoint data file (numbered .json
+// like "42.json") exists in the registry directory. Memlog deletes old
+// checkpoint files after each new one, so at most 1 exists at a time.
+func hasCheckpointFile(t *testing.T, registryDir string) bool {
+	t.Helper()
+	return currentCheckpointFile(t, registryDir) != ""
+}
+
+// currentCheckpointFile returns the name of the checkpoint data file in the
+// registry directory, or "" if none exists.
+func currentCheckpointFile(t *testing.T, registryDir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(registryDir)
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		name := e.Name()
+		if name == "log.json" || name == "meta.json" || name == "active.dat" ||
+			strings.HasSuffix(name, ".new") {
+			continue
+		}
+		if filepath.Ext(name) == ".json" {
+			return name
+		}
+	}
+	return ""
+}
+
+// walFileSize returns the size of the WAL log file in the registry directory.
+func walFileSize(t *testing.T, registryDir string) uint64 {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(registryDir, "log.json"))
+	if os.IsNotExist(err) {
+		return 0
+	}
+	require.NoError(t, err)
+	return uint64(info.Size())
 }

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/autodiscover"
 	"github.com/elastic/beats/v7/libbeat/statestore/backend"
 	bboltst "github.com/elastic/beats/v7/libbeat/statestore/backend/bbolt"
+	memlogst "github.com/elastic/beats/v7/libbeat/statestore/backend/memlog"
 	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
@@ -53,6 +54,7 @@ type Registry struct {
 	MigrateFile        string           `config:"migrate_file"`
 	Backend            string           `config:"backend"`
 	Bbolt              bboltst.Config   `config:"bbolt"`
+	Memlog             memlogst.Config  `config:"memlog"`
 	ESStorageExtension backend.Registry `config:"-"`
 }
 
@@ -65,6 +67,7 @@ var DefaultConfig = Config{
 		FlushTimeout:  time.Second,
 		Backend:       "memlog",
 		Bbolt:         bboltst.DefaultConfig(),
+		Memlog:        memlogst.DefaultConfig(),
 	},
 	ShutdownTimeout:    0,
 	OverwritePipelines: false,

--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -36,12 +36,12 @@ func TestLoadConfig2(t *testing.T) {
 	assert.NotNil(t, absPath)
 	assert.NoError(t, err)
 
-	config := &Config{}
+	config := DefaultConfig
 
 	// Reads second config file
 	cfg, err := cfgfile.Load(absPath+"/config2.yml", nil)
 	assert.NoError(t, err)
-	err = cfg.Unpack(config)
+	err = cfg.Unpack(&config)
 	assert.NoError(t, err)
 }
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1383,6 +1383,18 @@ filebeat.inputs:
 # persistent on-disk storage with support for compaction and TTL-based cleanup.
 #filebeat.registry.backend: memlog
 
+# ----------------------- Memlog backend settings ------------------------------
+# These settings apply only when filebeat.registry.backend is set to "memlog"
+# (the default).
+
+# The registry file size threshold (in bytes) that triggers a checkpoint.
+# When the registry file reaches this size, Filebeat writes a full snapshot
+# of the registry state and resets the file. Larger values mean fewer
+# checkpoints, but a larger registry file. Increasing this value can improve
+# performance when tracking tens of thousands of files or more.
+# Default: 10485760 (10 MB). Minimum: 10485760 (10 MB).
+#filebeat.registry.memlog.checkpoint_size: 10485760
+
 # ----------------------- Bbolt backend settings -------------------------------
 # WARNING: The bbolt backend is EXPERIMENTAL and may change or be removed in
 # future releases. Do not use in production without understanding the risks.

--- a/filebeat/tests/integration/filestream_checkpoint_test.go
+++ b/filebeat/tests/integration/filestream_checkpoint_test.go
@@ -1,0 +1,237 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+)
+
+const checkpointTestCfgTemplate = `
+filebeat.inputs:
+  - type: filestream
+    id: checkpoint-test
+    paths:
+      - %s
+    prospector.scanner.check_interval: 100ms
+    close.on_state_change.inactive: 500ms
+    clean_removed: true
+
+filebeat.registry:
+  cleanup_interval: 1s
+  flush: 100ms
+  %s
+
+path.home: %s
+
+output.file:
+  path: ${path.home}
+  filename: output
+  rotate_every_kb: 100000
+
+logging:
+  level: info
+  metrics:
+    enabled: false
+`
+
+// TestFilestreamCheckpointSize verifies that the memlog registry checkpoint
+// triggers at the configured threshold when filebeat is running end-to-end.
+//
+// The test creates and deletes batches of log files to generate registry
+// operations that grow the WAL (log.json). A background goroutine monitors
+// the WAL file size and detects the checkpoint (any size drop). The maximum
+// WAL size observed before the drop should approximate the configured
+// checkpoint threshold.
+func TestFilestreamCheckpointSize(t *testing.T) {
+	testCases := []struct {
+		name           string
+		registryCfg    string // extra YAML under filebeat.registry
+		checkpointSize int64
+		fileBatchSize  int
+		maxBatches     int
+		deltaPercent   int64 // allowed overshoot percentage (e.g. 10 means 10%)
+	}{
+		{
+			name:           "default 10MB",
+			registryCfg:    "",
+			checkpointSize: 10 * 1024 * 1024,
+			fileBatchSize:  500,
+			maxBatches:     200,
+			deltaPercent:   10,
+		},
+		{
+			name:           "custom 15MB",
+			registryCfg:    "memlog.checkpoint_size: 15728640",
+			checkpointSize: 15 * 1024 * 1024,
+			fileBatchSize:  500,
+			maxBatches:     300,
+			deltaPercent:   10,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filebeat := integration.NewBeat(t, "filebeat", "../../filebeat.test")
+			homeDir := filebeat.TempDir()
+			logDir := filepath.Join(homeDir, "logs")
+			require.NoError(t, os.MkdirAll(logDir, 0o755))
+
+			glob := filepath.Join(logDir, "*.log")
+			filebeat.WriteConfigFile(fmt.Sprintf(
+				checkpointTestCfgTemplate, glob, tc.registryCfg, homeDir))
+			filebeat.Start()
+
+			t.Logf("path.home: %s", homeDir)
+			registryLogFile := filepath.Join(
+				homeDir, "data", "registry", "filebeat", "log.json")
+
+			// Wait for filebeat to initialise and create the registry.
+			require.Eventually(t, func() bool {
+				_, err := os.Stat(registryLogFile)
+				return err == nil
+			}, 30*time.Second, 200*time.Millisecond,
+				"registry log file was not created")
+
+			// walWatcher polls the WAL file and records the maximum size
+			// it sees. When the size drops (checkpoint truncated the WAL),
+			// it stops and reports back.
+			type walResult struct {
+				maxSize int64
+			}
+			resultCh := make(chan walResult, 1)
+			var walMaxSize atomic.Int64
+			var wg sync.WaitGroup
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ticker := time.NewTicker(200 * time.Millisecond)
+				defer ticker.Stop()
+
+				var prevSize int64
+				var maxSeen int64
+				for {
+					select {
+					case <-t.Context().Done():
+						return
+					case <-ticker.C:
+					}
+
+					info, err := os.Stat(registryLogFile)
+					if err != nil {
+						continue
+					}
+					size := info.Size()
+
+					if size > maxSeen {
+						maxSeen = size
+						walMaxSize.Store(maxSeen)
+					}
+
+					// Any drop in size means a checkpoint occurred.
+					if prevSize > 0 && size < prevSize {
+						resultCh <- walResult{maxSize: maxSeen}
+						return
+					}
+					prevSize = size
+				}
+			}()
+
+			// Create and delete batches of files until the checkpoint
+			// fires or we exceed maxBatches.
+			checkInterval := 100 * time.Millisecond
+			batchCycle := 2 * checkInterval
+
+			checkpointDetected := false
+			for batch := range tc.maxBatches {
+				// Create a batch of files, each > 1024 bytes for
+				// fingerprint identity.
+				for i := range tc.fileBatchSize {
+					name := filepath.Join(logDir,
+						fmt.Sprintf("batch%04d-file%04d.log", batch, i))
+					writeTestLogFile(t, name, batch, i)
+				}
+
+				time.Sleep(batchCycle)
+
+				// Delete the batch so cleanup generates more WAL ops.
+				for i := range tc.fileBatchSize {
+					name := filepath.Join(logDir,
+						fmt.Sprintf("batch%04d-file%04d.log", batch, i))
+					_ = os.Remove(name)
+				}
+
+				// Wait for cleanup to process the deletions.
+				time.Sleep(2 * time.Second)
+				// Check if the watcher detected a checkpoint.
+				select {
+				case res := <-resultCh:
+					t.Logf("checkpoint detected after %d batches, max WAL size: %d bytes (%.2f MB)",
+						batch+1, res.maxSize, float64(res.maxSize)/(1024*1024))
+					checkpointDetected = true
+
+					maxAllowed := tc.checkpointSize + tc.checkpointSize*tc.deltaPercent/100
+					assert.GreaterOrEqual(t, res.maxSize, tc.checkpointSize,
+						"WAL max size (%d) should be >= checkpoint threshold (%d)",
+						res.maxSize, tc.checkpointSize)
+					assert.LessOrEqual(t, res.maxSize, maxAllowed,
+						"WAL max size (%d) should be <= checkpoint threshold + %d%% (%d)",
+						res.maxSize, tc.deltaPercent, maxAllowed)
+				default:
+					t.Logf("batch %d done, WAL size: %.2f MB",
+						batch+1, float64(walMaxSize.Load())/(1024*1024))
+					continue
+				}
+				break
+			}
+
+			wg.Wait()
+			require.True(t, checkpointDetected,
+				"checkpoint was not triggered after %d batches", tc.maxBatches)
+		})
+	}
+}
+
+// writeTestLogFile writes a log file with content > 1024 bytes so the
+// fingerprint identity can track it.
+func writeTestLogFile(t *testing.T, path string, batch, fileIdx int) {
+	t.Helper()
+
+	// Each line: "batch0001-file0002: line 003 <padding>\n"
+	// Pad to ensure total file size > 1024 bytes.
+	var b strings.Builder
+	for line := range 20 {
+		fmt.Fprintf(&b, "batch%04d-file%04d: line %03d %s\n",
+			batch, fileIdx, line, strings.Repeat("x", 30))
+	}
+	require.NoError(t, os.WriteFile(path, []byte(b.String()), 0o644))
+}

--- a/libbeat/statestore/backend/memlog/config.go
+++ b/libbeat/statestore/backend/memlog/config.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package memlog
+
+// Config defines the user-facing configuration for the memlog storage backend.
+type Config struct {
+	// CheckpointSize is the registry file size threshold (in bytes) that
+	// triggers a checkpoint. Larger values reduce checkpoint frequency at the
+	// cost of a larger registry file. Minimum: 10 MB. Default: 10 MB.
+	CheckpointSize uint64 `config:"checkpoint_size" validate:"min=10485760"`
+}
+
+// DefaultConfig returns the default memlog configuration.
+func DefaultConfig() Config {
+	return Config{CheckpointSize: defaultCheckpointSize}
+}

--- a/libbeat/statestore/backend/memlog/config_test.go
+++ b/libbeat/statestore/backend/memlog/config_test.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package memlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	conf "github.com/elastic/elastic-agent-libs/config"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "valid default (field absent)",
+			yaml: "",
+		},
+		{
+			name: "valid 10MB",
+			yaml: "checkpoint_size: 10485760",
+		},
+		{
+			name: "valid 50MB",
+			yaml: "checkpoint_size: 52428800",
+		},
+		{
+			name:    "too small 1 byte",
+			yaml:    "checkpoint_size: 1",
+			wantErr: true,
+		},
+		{
+			name:    "too small 9MB",
+			yaml:    "checkpoint_size: 9437184",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+
+			raw, err := conf.NewConfigWithYAML([]byte(tt.yaml), "test")
+			require.NoError(t, err, "failed to parse test YAML")
+
+			err = raw.Unpack(&cfg)
+			if tt.wantErr {
+				require.Error(t, err, "expected validation error")
+				assert.Contains(t, err.Error(), "requires value >= 10485760",
+					"error message should mention the minimum")
+			} else {
+				assert.NoError(t, err, "expected valid config")
+			}
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, uint64(defaultCheckpointSize), cfg.CheckpointSize,
+		"default checkpoint size should be 10 MB")
+}

--- a/libbeat/statestore/backend/memlog/memlog.go
+++ b/libbeat/statestore/backend/memlog/memlog.go
@@ -67,9 +67,10 @@ const defaultFileMode os.FileMode = 0600
 
 const defaultBufferSize = 4 * 1024
 
+const defaultCheckpointSize = 10 * 1 << 20 // set rotation limit to 10MB by default
+
 func defaultCheckpoint(filesize uint64) bool {
-	const limit = 10 * 1 << 20 // set rotation limit to 10MB by default
-	return filesize >= limit
+	return filesize >= defaultCheckpointSize
 }
 
 // New configures a memlog Registry that can be used to open stores.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3329,6 +3329,18 @@ filebeat.inputs:
 # persistent on-disk storage with support for compaction and TTL-based cleanup.
 #filebeat.registry.backend: memlog
 
+# ----------------------- Memlog backend settings ------------------------------
+# These settings apply only when filebeat.registry.backend is set to "memlog"
+# (the default).
+
+# The registry file size threshold (in bytes) that triggers a checkpoint.
+# When the registry file reaches this size, Filebeat writes a full snapshot
+# of the registry state and resets the file. Larger values mean fewer
+# checkpoints, but a larger registry file. Increasing this value can improve
+# performance when tracking tens of thousands of files or more.
+# Default: 10485760 (10 MB). Minimum: 10485760 (10 MB).
+#filebeat.registry.memlog.checkpoint_size: 10485760
+
 # ----------------------- Bbolt backend settings -------------------------------
 # WARNING: The bbolt backend is EXPERIMENTAL and may change or be removed in
 # future releases. Do not use in production without understanding the risks.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
    [Filebeat] Add configurable memlog checkpoint size for the registry
    
    Add `filebeat.registry.memlog.checkpoint_size` to let users tune the
    registry log file size threshold that triggers a memlog checkpoint. The
    default remains the memlog-internal 10 MB; when unset, no custom
    checkpoint function is injected.
    
    At scale (25k+ tracked files with ~2000-character fingerprint keys), the
    10 MB threshold causes excessive checkpointing — each checkpoint
    serializes the entire in-memory store synchronously while holding the
    store lock, causing a 26% drop in events per second. Increasing the
    threshold restored full throughput.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

- None

## How to test this PR locally

- run the unit tests
- run the integration tests:
```shell
cd filebeat
go test -v -tags integration -run "^TestFilestreamCheckpointSize" ./tests/integration
```

- run filestream:
  - keep adding and deleting files
  - watch the memlog store files
  - a checkpoint should only happen
  - ensure it happens at the configured `checkpoint_size`

## Related issues
 should automatically close it.

- Closes #50114
- Relates #44780

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

- It can improve ingestion performance when ingesting tens of thousands of file, however it'll increase the disk usage