### PR TITLE
x-pack/filebeat/input/cel: General refactoring

### DIFF
--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -301,7 +301,7 @@ func checkPublishResultContext(ctx context.Context, metricsRecorder *metricsReco
 	}
 
 	metricsRecorder.AddProgramRunDuration(ctx, time.Since(start))
-	errorSpans(err, end{pubSpan}, execSpan, runSpan)
+	errorSpans(err, pubSpan, execSpan, runSpan)
 	return err
 }
 
@@ -356,7 +356,7 @@ func publishEventLoop(
 		event, ok := e.(map[string]interface{})
 		if !ok {
 			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-			errorSpans(err, end{pubSpan}, execSpan, runSpan)
+			errorSpans(err, pubSpan, execSpan, runSpan)
 			return state, err
 		}
 
@@ -364,7 +364,7 @@ func publishEventLoop(
 		state.safeCursor = cursorState.safeCursor
 		if err != nil {
 			metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-			errorSpans(err, end{pubSpan}, execSpan, runSpan)
+			errorSpans(err, pubSpan, execSpan, runSpan)
 			return state, err
 		}
 
@@ -434,6 +434,7 @@ func publishEvents(
 
 	pubStart := time.Now()
 	pubCtx, pubSpan := otelTracer.Start(execCtx, "cel.program.publish")
+	defer pubSpan.End()
 	pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", 0)) // to be overridden if there are events
 	pubLog := logWithTracingIds(log, pubSpan)
 
@@ -474,7 +475,6 @@ func publishEvents(
 		metricsRecorder.AddProgramSuccessExecution(pubCtx)
 		okSpans(pubSpan)
 	}
-	pubSpan.End()
 
 	return result, nil
 }

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -673,6 +673,64 @@ func completeExecution(
 	return executionCompletion{}
 }
 
+func publishResponseEvents(
+	runState *periodicRunState,
+	events []interface{},
+	execCtx context.Context,
+	otelTracer trace.Tracer,
+	log *logp.Logger,
+	pub inputcursor.Publisher,
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	start time.Time,
+	execLog *logp.Logger,
+	execSpan trace.Span,
+	runSpan trace.Span,
+) error {
+	runState.eventCount = len(events)
+	// We have a non-empty batch of events to process.
+	metricsRecorder.AddReceivedBatch(execCtx, 1)
+	metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
+	execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
+	// Drop events from state. If we fail during the publication,
+	// we will re-request these events.
+	delete(runState.state, "events")
+
+	cursor, hasCursor := runState.state["cursor"]
+	prepared := getPublishCursors(cursor, hasCursor, len(events), execLog, health)
+	// Drop old cursor from state. This will be replaced with
+	// the current cursor object below; it is an array now.
+	delete(runState.state, "cursor")
+	if prepared.degraded {
+		runState.degraded = true
+	}
+
+	publishResult, err := publishEvents(
+		execCtx,
+		otelTracer,
+		log,
+		pub,
+		health,
+		metricsRecorder,
+		start,
+		events,
+		prepared.cursors,
+		prepared.hasSingleCursor,
+		runState.currentCursor,
+		runState.safeCursor,
+		runState.degraded,
+		execSpan,
+		runSpan,
+	)
+	if err != nil {
+		return err
+	}
+	runState.currentCursor = publishResult.currentCursor
+	runState.safeCursor = publishResult.safeCursor
+	runState.degraded = publishResult.degraded
+	return nil
+}
+
 func (i input) executeOnce(
 	runCtx context.Context,
 	env v2.Context,
@@ -847,27 +905,9 @@ func (i input) executeOnce(
 		outcome = executeOnceOutcome{kind: executeOnceFinish}
 		return outcome, nil
 	}
-	events := response.events
-
-	runState.eventCount = len(events)
-	// We have a non-empty batch of events to process.
-	metricsRecorder.AddReceivedBatch(execCtx, 1)
-	metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
-	execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
-	// Drop events from state. If we fail during the publication,
-	// we will re-request these events.
-	delete(runState.state, "events")
-
-	cursor, hasCursor := runState.state["cursor"]
-	prepared := getPublishCursors(cursor, hasCursor, len(events), execLog, health)
-	// Drop old cursor from state. This will be replaced with
-	// the current cursor object below; it is an array now.
-	delete(runState.state, "cursor")
-	if prepared.degraded {
-		runState.degraded = true
-	}
-
-	publishResult, err := publishEvents(
+	err = publishResponseEvents(
+		runState,
+		response.events,
 		execCtx,
 		otelTracer,
 		log,
@@ -875,21 +915,13 @@ func (i input) executeOnce(
 		health,
 		metricsRecorder,
 		start,
-		events,
-		prepared.cursors,
-		prepared.hasSingleCursor,
-		runState.currentCursor,
-		runState.safeCursor,
-		runState.degraded,
+		execLog,
 		execSpan,
 		runSpan,
 	)
 	if err != nil {
 		return outcome, err
 	}
-	runState.currentCursor = publishResult.currentCursor
-	runState.safeCursor = publishResult.safeCursor
-	runState.degraded = publishResult.degraded
 
 	// Check we have a remaining execution budget.
 	budget--

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -531,11 +531,6 @@ type evaluationResponse struct {
 	shouldRetry bool
 }
 
-type executionCompletion struct {
-	done                bool
-	maxExecutionLimited bool
-}
-
 type executeOnceOutcomeKind uint8
 
 const (
@@ -633,9 +628,8 @@ func processEvaluationResponse(
 	return result, nil
 }
 
-func completeExecution(
-	state map[string]interface{},
-	safeCursor map[string]interface{},
+func finishExecution(
+	runState *periodicRunState,
 	start time.Time,
 	interval time.Duration,
 	remainingBudget int,
@@ -645,13 +639,16 @@ func completeExecution(
 	execCtx context.Context,
 	execLog *logp.Logger,
 	execSpan trace.Span,
-) executionCompletion {
+) executeOnceOutcome {
 	// Replace the last safe cursor.
-	state["cursor"] = safeCursor
+	runState.state["cursor"] = runState.safeCursor
 	metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-	if more, _ := state["want_more"].(bool); !more {
+	if more, _ := runState.state["want_more"].(bool); !more {
 		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
-		return executionCompletion{done: true}
+		return executeOnceOutcome{
+			kind:          executeOnceFinish,
+			markRunSpanOK: true,
+		}
 	}
 	execSpan.SetAttributes(attribute.Bool("cel.program.want_more", true))
 
@@ -664,13 +661,13 @@ func completeExecution(
 		)
 		health.UpdateStatus(status.Degraded, msg)
 		execSpan.SetStatus(codes.Unset, msg)
-		return executionCompletion{
-			done:                true,
+		return executeOnceOutcome{
+			kind:                executeOnceFinish,
 			maxExecutionLimited: true,
 		}
 	}
 
-	return executionCompletion{}
+	return executeOnceOutcome{kind: executeOnceContinue}
 }
 
 func publishResponseEvents(
@@ -925,9 +922,8 @@ func (i input) executeOnce(
 
 	// Check we have a remaining execution budget.
 	budget--
-	completion := completeExecution(
-		runState.state,
-		runState.safeCursor,
+	outcome = finishExecution(
+		runState,
 		start,
 		cfg.Interval,
 		budget,
@@ -938,19 +934,10 @@ func (i input) executeOnce(
 		execLog,
 		execSpan,
 	)
-	if completion.maxExecutionLimited {
-		outcome = executeOnceOutcome{
-			kind:                executeOnceFinish,
-			maxExecutionLimited: true,
-		}
-		return outcome, nil
-	}
-	if completion.done {
+	if outcome.markRunSpanOK {
 		okSpans(execSpan)
-		outcome = executeOnceOutcome{
-			kind:          executeOnceFinish,
-			markRunSpanOK: true,
-		}
+	}
+	if outcome.kind == executeOnceFinish {
 		return outcome, nil
 	}
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -556,14 +556,13 @@ type executeOnceOutcome struct {
 	maxExecutionLimited bool
 }
 
-type executeOnceResult struct {
+type periodicRunState struct {
 	state         map[string]interface{}
 	waitUntil     time.Time
 	currentCursor map[string]interface{}
 	safeCursor    map[string]interface{}
 	degraded      bool
 	eventCount    int
-	outcome       executeOnceOutcome
 }
 
 func processEvaluationResponse(
@@ -722,7 +721,7 @@ func (i input) executeOnce(
 	contextInjector *otel.ContextInjector,
 	prg cel.Program,
 	ast *cel.Ast,
-	state map[string]interface{},
+	runState *periodicRunState,
 	budget int,
 	wantDump bool,
 	metricsRecorder *metricsRecorder,
@@ -733,19 +732,11 @@ func (i input) executeOnce(
 	health status.StatusReporter,
 	limiter *rate.Limiter,
 	goodURL string,
-	currentCursor map[string]interface{},
-	safeCursor map[string]interface{},
-	isDegraded bool,
 	executionNumber int,
-) (executeOnceResult, error) {
-	result := executeOnceResult{
-		state:         state,
-		currentCursor: currentCursor,
-		safeCursor:    safeCursor,
-		degraded:      isDegraded,
-		outcome: executeOnceOutcome{
-			kind: executeOnceContinue,
-		},
+) (executeOnceOutcome, error) {
+	runState.eventCount = 0
+	outcome := executeOnceOutcome{
+		kind: executeOnceContinue,
 	}
 
 	execCtx, execSpan := otelTracer.Start(runCtx, "cel.program.execution")
@@ -760,18 +751,18 @@ func (i input) executeOnce(
 	if trace != nil {
 		execLog.Debugw("previous transaction", "transaction.id", trace.TxID())
 	}
-	execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: result.state, cfg: cfg.Redact})
+	execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: runState.state, cfg: cfg.Redact})
 	metricsRecorder.AddProgramExecution(execCtx)
 	start := time.Time{}
 	var err error
-	result.state, start, result.degraded, err = i.executeEvaluation(
+	runState.state, start, runState.degraded, err = i.executeEvaluation(
 		execCtx,
 		env,
 		cfg,
 		contextInjector,
 		prg,
 		ast,
-		result.state,
+		runState.state,
 		budget,
 		wantDump,
 		metricsRecorder,
@@ -781,7 +772,7 @@ func (i input) executeOnce(
 		health,
 	)
 	if err != nil {
-		return result, err
+		return outcome, err
 	}
 	if trace != nil {
 		execLog.Debugw("final transaction", "transaction.id", trace.TxID())
@@ -870,7 +861,7 @@ func (i input) executeOnce(
 	// been stored and we can continue from that point, recovering
 	// the lost events and potentially re-requesting e3.
 	response, err := processEvaluationResponse(
-		result.state,
+		runState.state,
 		limiter,
 		goodURL,
 		health,
@@ -880,35 +871,35 @@ func (i input) executeOnce(
 		execCtx,
 		execSpan,
 		runSpan,
-		result.degraded,
+		runState.degraded,
 	)
 	if err != nil {
-		return result, err
+		return outcome, err
 	}
-	result.waitUntil = response.waitUntil
-	result.degraded = response.degraded
+	runState.waitUntil = response.waitUntil
+	runState.degraded = response.degraded
 	if response.shouldRetry {
-		result.outcome = executeOnceOutcome{kind: executeOnceRetry}
-		return result, nil
+		outcome = executeOnceOutcome{kind: executeOnceRetry}
+		return outcome, nil
 	}
 	if response.done {
-		result.outcome = executeOnceOutcome{kind: executeOnceFinish}
-		return result, nil
+		outcome = executeOnceOutcome{kind: executeOnceFinish}
+		return outcome, nil
 	}
 	events := response.events
 
-	result.eventCount = len(events)
+	runState.eventCount = len(events)
 	prepared := preparePublishState(
-		result.state,
+		runState.state,
 		events,
 		execLog,
 		health,
 		metricsRecorder,
 		execCtx,
 		execSpan,
-		result.degraded,
+		runState.degraded,
 	)
-	result.degraded = prepared.degraded
+	runState.degraded = prepared.degraded
 
 	publishResult, err := publishEvents(
 		execCtx,
@@ -921,24 +912,24 @@ func (i input) executeOnce(
 		events,
 		prepared.cursors,
 		prepared.hasSingleCursor,
-		result.currentCursor,
-		result.safeCursor,
-		result.degraded,
+		runState.currentCursor,
+		runState.safeCursor,
+		runState.degraded,
 		execSpan,
 		runSpan,
 	)
 	if err != nil {
-		return result, err
+		return outcome, err
 	}
-	result.currentCursor = publishResult.currentCursor
-	result.safeCursor = publishResult.safeCursor
-	result.degraded = publishResult.degraded
+	runState.currentCursor = publishResult.currentCursor
+	runState.safeCursor = publishResult.safeCursor
+	runState.degraded = publishResult.degraded
 
 	// Check we have a remaining execution budget.
 	budget--
 	completion := completeExecution(
-		result.state,
-		result.safeCursor,
+		runState.state,
+		runState.safeCursor,
 		start,
 		cfg.Interval,
 		budget,
@@ -950,23 +941,23 @@ func (i input) executeOnce(
 		execSpan,
 	)
 	if completion.maxExecutionLimited {
-		result.outcome = executeOnceOutcome{
+		outcome = executeOnceOutcome{
 			kind:                executeOnceFinish,
 			maxExecutionLimited: true,
 		}
-		return result, nil
+		return outcome, nil
 	}
 	if completion.done {
 		okSpans(execSpan)
-		result.outcome = executeOnceOutcome{
+		outcome = executeOnceOutcome{
 			kind:          executeOnceFinish,
 			markRunSpanOK: true,
 		}
-		return result, nil
+		return outcome, nil
 	}
 
 	okSpans(execSpan)
-	return result, nil
+	return outcome, nil
 }
 
 func (i input) run(env v2.Context, src *source, currentCursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -1070,7 +1061,6 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 	if currentCursor != nil {
 		state["cursor"] = currentCursor
 	}
-	safeCursor := currentCursor
 	goodURL := cfg.Resource.URL.String()
 	state["url"] = goodURL
 	metricsRecorder.SetResourceURL(goodURL)
@@ -1108,6 +1098,11 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 	// In addition to this and the functions and globals available
 	// from mito/lib, a global, useragent, is available to use
 	// in requests.
+	runState := periodicRunState{
+		state:         state,
+		currentCursor: currentCursor,
+		safeCursor:    currentCursor,
+	}
 	err = periodically(ctx, cfg.Interval, func() error {
 		runSpanExecutionCount := 0
 		runSpanEventCount := 0
@@ -1129,11 +1124,11 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 		defer metricsRecorder.EndPeriodic(runCtx)
 		runLog.Debug("process periodic request")
 		var (
-			budget    = *cfg.MaxExecutions
-			waitUntil time.Time
+			budget = *cfg.MaxExecutions
 		)
 		// Keep track of whether CEL is degraded for this periodic run.
-		var isDegraded bool
+		runState.waitUntil = time.Time{}
+		runState.degraded = false
 		if doCov {
 			defer func() {
 				// If doCov is true, log the updated coverage details.
@@ -1143,7 +1138,7 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 			}()
 		}
 		for {
-			if wait := time.Until(waitUntil); wait > 0 {
+			if wait := time.Until(runState.waitUntil); wait > 0 {
 				err = waitForRateLimit(runCtx, runSpan, otelTracer, wait)
 				if err != nil {
 					return err
@@ -1155,7 +1150,7 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 			}
 
 			runSpanExecutionCount++
-			result, err := i.executeOnce(
+			outcome, err := i.executeOnce(
 				runCtx,
 				env,
 				cfg,
@@ -1163,7 +1158,7 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 				contextInjector,
 				prg,
 				ast,
-				state,
+				&runState,
 				budget,
 				wantDump,
 				metricsRecorder,
@@ -1174,31 +1169,23 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 				health,
 				limiter,
 				goodURL,
-				currentCursor,
-				safeCursor,
-				isDegraded,
 				runSpanExecutionCount,
 			)
 			if err != nil {
 				return err
 			}
-			state = result.state
-			waitUntil = result.waitUntil
-			currentCursor = result.currentCursor
-			safeCursor = result.safeCursor
-			isDegraded = result.degraded
-			runSpanEventCount += result.eventCount
-			switch result.outcome.kind {
+			runSpanEventCount += runState.eventCount
+			switch outcome.kind {
 			case executeOnceContinue:
 			case executeOnceRetry:
 				continue
 			case executeOnceFinish:
-				if result.outcome.maxExecutionLimited {
+				if outcome.maxExecutionLimited {
 					runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
 					runSpan.SetStatus(codes.Unset, "reached maximum number of CEL executions")
 					return nil
 				}
-				if result.outcome.markRunSpanOK {
+				if outcome.markRunSpanOK {
 					okSpans(runSpan)
 				}
 				return nil

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -552,12 +552,9 @@ func processEvaluationResponse(
 		degraded: degraded,
 	}
 
-	var (
-		ok  bool
-		err error
-	)
-	ok, result.waitUntil, err = handleResponse(execLog, state, limiter)
-	if err != nil || !ok {
+	waitUntil, shouldRetry, err := handleResponse(execLog, state, limiter)
+	result.waitUntil = waitUntil
+	if err != nil || shouldRetry {
 		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
 		if err != nil {
 			errorSpans(err, end{execSpan}, runSpan)
@@ -568,7 +565,7 @@ func processEvaluationResponse(
 		return result, nil
 	}
 
-	_, ok = state["url"]
+	_, ok := state["url"]
 	if !ok && goodURL != "" {
 		state["url"] = goodURL
 		execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", goodURL)
@@ -1077,8 +1074,8 @@ func periodically(ctx context.Context, each time.Duration, fn func() error) erro
 }
 
 // handleResponse checks the response status code and handles rate limit changes.
-// It returns ok=true if the response is valid, otherwise false for a retry.
-func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rate.Limiter) (ok bool, waitUntil time.Time, err error) {
+// It returns shouldRetry=true when evaluation should be retried after waiting.
+func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rate.Limiter) (waitUntil time.Time, shouldRetry bool, err error) {
 	var header http.Header
 	h, ok := state["header"]
 	if ok {
@@ -1099,16 +1096,16 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 					for i, e := range v {
 						vals[i], ok = e.(string)
 						if !ok {
-							return false, time.Time{}, fmt.Errorf("unexpected type returned for response header value: %T", v)
+							return time.Time{}, false, fmt.Errorf("unexpected type returned for response header value: %T", v)
 						}
 					}
 					header[k] = vals
 				default:
-					return false, waitUntil, fmt.Errorf("unexpected type returned for response header value set: %T", v)
+					return waitUntil, false, fmt.Errorf("unexpected type returned for response header value set: %T", v)
 				}
 			}
 		default:
-			return false, waitUntil, fmt.Errorf("unexpected type returned for response header: %T", h)
+			return waitUntil, false, fmt.Errorf("unexpected type returned for response header: %T", h)
 		}
 	}
 
@@ -1125,7 +1122,7 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 			// path.
 			waitUntil = handleRateLimit(log, r, header, limiter)
 		default:
-			return false, waitUntil, fmt.Errorf("unexpected type returned for response header: %T", h)
+			return waitUntil, false, fmt.Errorf("unexpected type returned for response header: %T", h)
 		}
 	}
 
@@ -1141,11 +1138,11 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 		case float64:
 			statusCode = int(sc)
 		default:
-			return false, waitUntil, fmt.Errorf("unexpected type returned for request status code: %T", sc)
+			return waitUntil, false, fmt.Errorf("unexpected type returned for request status code: %T", sc)
 		}
 		switch statusCode {
 		case http.StatusOK:
-			return true, time.Time{}, nil
+			return time.Time{}, false, nil
 		case http.StatusTooManyRequests:
 			// https://datatracker.ietf.org/doc/html/rfc6585#page-3
 			retry := header.Get("Retry-After")
@@ -1159,17 +1156,17 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 					waitUntil = t
 				}
 			}
-			return false, waitUntil, nil
+			return waitUntil, true, nil
 		default:
 			status := http.StatusText(statusCode)
 			if status == "" {
 				status = "unknown status code"
 			}
 			state["events"] = errorMessage(fmt.Sprintf("failed http request with %s: %d", status, statusCode))
-			return true, time.Time{}, nil
+			return time.Time{}, false, nil
 		}
 	}
-	return true, waitUntil, nil
+	return waitUntil, false, nil
 }
 
 // handleRateLimit performs two related functions dealing with rate limits. The

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -173,6 +173,13 @@ type publishLoopState struct {
 	eventCount          int
 }
 
+type publishResult struct {
+	cursor         map[string]interface{}
+	goodCursor     map[string]interface{}
+	degraded       bool
+	runDurationCtx context.Context
+}
+
 func (r namedStatusReporter) UpdateStatus(status status.Status, msg string) {
 	switch {
 	case r.name != "" && msg != "":
@@ -378,6 +385,78 @@ func publishEventLoop(
 	}
 
 	return state, nil
+}
+
+func publishEvents(
+	execCtx context.Context,
+	otelTracer trace.Tracer,
+	log *logp.Logger,
+	pub inputcursor.Publisher,
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	start time.Time,
+	events []interface{},
+	cursors []interface{},
+	singleCursor bool,
+	cursor map[string]interface{},
+	goodCursor map[string]interface{},
+	degraded bool,
+	execSpan trace.Span,
+	runSpan trace.Span,
+) (publishResult, error) {
+	result := publishResult{
+		cursor:         cursor,
+		goodCursor:     goodCursor,
+		degraded:       degraded,
+		runDurationCtx: execCtx,
+	}
+
+	pubStart := time.Now()
+	pubCtx, pubSpan := otelTracer.Start(execCtx, "cel.program.publish")
+	pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", 0)) // to be overridden if there are events
+	pubLog := logWithTracingIds(log, pubSpan)
+
+	publishState, err := publishEventLoop(
+		events,
+		cursors,
+		singleCursor,
+		cursor,
+		goodCursor,
+		degraded,
+		pub,
+		pubCtx,
+		pubSpan,
+		execSpan,
+		runSpan,
+		pubLog,
+		health,
+		metricsRecorder,
+		start,
+	)
+	if err != nil {
+		return result, err
+	}
+
+	result.cursor = publishState.cursor
+	result.goodCursor = publishState.goodCursor
+	result.degraded = publishState.degraded
+
+	if !result.degraded {
+		health.UpdateStatus(status.Running, "")
+	}
+
+	metricsRecorder.AddPublishDuration(pubCtx, time.Since(pubStart))
+	// Advance the cursor to the final state if there was no error during
+	// publications. This is needed to transition to the next set of events.
+	if !publishState.hadPublicationError && !result.degraded {
+		result.goodCursor = result.cursor
+		metricsRecorder.AddProgramSuccessExecution(pubCtx)
+		okSpans(pubSpan)
+	}
+	pubSpan.End()
+
+	result.runDurationCtx = pubCtx
+	return result, nil
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -796,56 +875,33 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			// the current cursor object below; it is an array now.
 			delete(state, "cursor")
 
-			pubStart := time.Now()
-			var hadPublicationError bool
-
-			pubCtx, pubSpan := otelTracer.Start(execCtx, "cel.program.publish")
-			pubSpanEventCount := 0
-			pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
-			pubLog := logWithTracingIds(log, pubSpan)
-			publishState, err := publishEventLoop(
+			publishResult, err := publishEvents(
+				execCtx,
+				otelTracer,
+				log,
+				pub,
+				health,
+				metricsRecorder,
+				start,
 				events,
 				cursors,
 				singleCursor,
 				cursor,
 				goodCursor,
 				isDegraded,
-				pub,
-				pubCtx,
-				pubSpan,
 				execSpan,
 				runSpan,
-				pubLog,
-				health,
-				metricsRecorder,
-				start,
 			)
 			if err != nil {
 				return err
 			}
-			cursor = publishState.cursor
-			goodCursor = publishState.goodCursor
-			isDegraded = publishState.degraded
-			hadPublicationError = publishState.hadPublicationError
-			pubSpanEventCount = publishState.eventCount
-
-			if !isDegraded {
-				health.UpdateStatus(status.Running, "")
-			}
-
-			metricsRecorder.AddPublishDuration(pubCtx, time.Since(pubStart))
-			// Advance the cursor to the final state if there was no error during
-			// publications. This is needed to transition to the next set of events.
-			if !hadPublicationError && !isDegraded {
-				goodCursor = cursor
-				metricsRecorder.AddProgramSuccessExecution(pubCtx)
-				okSpans(pubSpan)
-			}
-			pubSpan.End()
+			cursor = publishResult.cursor
+			goodCursor = publishResult.goodCursor
+			isDegraded = publishResult.degraded
 
 			// Replace the last known good cursor.
 			state["cursor"] = goodCursor
-			metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
+			metricsRecorder.AddProgramRunDuration(publishResult.runDurationCtx, time.Since(start))
 			if more, _ := state["want_more"].(bool); !more {
 				execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
 				okSpans(end{execSpan}, runSpan)

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -170,14 +170,12 @@ type publishLoopState struct {
 	goodCursor          map[string]interface{}
 	degraded            bool
 	hadPublicationError bool
-	eventCount          int
 }
 
 type publishResult struct {
-	cursor         map[string]interface{}
-	goodCursor     map[string]interface{}
-	degraded       bool
-	runDurationCtx context.Context
+	cursor     map[string]interface{}
+	goodCursor map[string]interface{}
+	degraded   bool
 }
 
 func (r namedStatusReporter) UpdateStatus(status status.Status, msg string) {
@@ -329,6 +327,7 @@ func publishEventLoop(
 		goodCursor: goodCursor,
 		degraded:   degraded,
 	}
+	eventCount := 0
 
 	for i, e := range events {
 		event, ok := e.(map[string]interface{})
@@ -377,7 +376,7 @@ func publishEventLoop(
 			// correctly published cursor.
 		}
 
-		state.eventCount = recordPublishedEvent(metricsRecorder, pubCtx, pubSpan, i+1, state.eventCount)
+		eventCount = recordPublishedEvent(metricsRecorder, pubCtx, pubSpan, i+1, eventCount)
 		err = checkPublishResultContext(pubCtx, metricsRecorder, start, pubSpan, execSpan, runSpan)
 		if err != nil {
 			return state, err
@@ -403,12 +402,11 @@ func publishEvents(
 	degraded bool,
 	execSpan trace.Span,
 	runSpan trace.Span,
-) (publishResult, error) {
+) (publishResult, context.Context, error) {
 	result := publishResult{
-		cursor:         cursor,
-		goodCursor:     goodCursor,
-		degraded:       degraded,
-		runDurationCtx: execCtx,
+		cursor:     cursor,
+		goodCursor: goodCursor,
+		degraded:   degraded,
 	}
 
 	pubStart := time.Now()
@@ -434,7 +432,7 @@ func publishEvents(
 		start,
 	)
 	if err != nil {
-		return result, err
+		return result, pubCtx, err
 	}
 
 	result.cursor = publishState.cursor
@@ -455,8 +453,7 @@ func publishEvents(
 	}
 	pubSpan.End()
 
-	result.runDurationCtx = pubCtx
-	return result, nil
+	return result, pubCtx, nil
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -875,7 +872,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			// the current cursor object below; it is an array now.
 			delete(state, "cursor")
 
-			publishResult, err := publishEvents(
+			publishResult, publishCtx, err := publishEvents(
 				execCtx,
 				otelTracer,
 				log,
@@ -901,7 +898,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 
 			// Replace the last known good cursor.
 			state["cursor"] = goodCursor
-			metricsRecorder.AddProgramRunDuration(publishResult.runDurationCtx, time.Since(start))
+			metricsRecorder.AddProgramRunDuration(publishCtx, time.Since(start))
 			if more, _ := state["want_more"].(bool); !more {
 				execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
 				okSpans(end{execSpan}, runSpan)

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -192,29 +192,31 @@ func sanitizeFileName(name string) string {
 	return strings.ReplaceAll(name, string(filepath.Separator), "_")
 }
 
-func getPublishCursors(state map[string]interface{}, events []interface{}, log *logp.Logger, health status.StatusReporter, degraded bool) publishCursors {
+// getPublishCursors normalizes the evaluation cursor into the slice form used
+// during publication.
+func getPublishCursors(cursor any, hasCursor bool, eventCount int, log *logp.Logger, health status.StatusReporter, degraded bool) publishCursors {
 	result := publishCursors{degraded: degraded}
 
-	c, ok := state["cursor"]
-	if !ok {
+	if !hasCursor {
 		return result
 	}
 
-	result.cursors, ok = c.([]interface{})
+	cursors, ok := cursor.([]interface{})
 	if ok {
-		if len(result.cursors) != len(events) {
-			log.Errorw("unexpected cursor list length", "cursors", len(result.cursors), "events", len(events))
+		result.cursors = cursors
+		if len(result.cursors) != eventCount {
+			log.Errorw("unexpected cursor list length", "cursors", len(result.cursors), "events", eventCount)
 			health.UpdateStatus(status.Degraded, "unexpected cursor list length")
 			result.degraded = true
 			// But try to continue.
-			if len(result.cursors) < len(events) {
+			if len(result.cursors) < eventCount {
 				result.cursors = nil
 			}
 		}
 		return result
 	}
 
-	result.cursors = []interface{}{c}
+	result.cursors = []interface{}{cursor}
 	result.hasSingleCursor = true
 	return result
 }
@@ -659,7 +661,8 @@ func preparePublishState(
 	// we will re-request these events.
 	delete(state, "events")
 
-	cursorState := getPublishCursors(state, events, execLog, health, runDegraded)
+	cursor, hasCursor := state["cursor"]
+	cursorState := getPublishCursors(cursor, hasCursor, len(events), execLog, health, runDegraded)
 	// Drop old cursor from state. This will be replaced with
 	// the current cursor object below; it is an array now.
 	delete(state, "cursor")

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -305,6 +305,29 @@ func checkPublishResultContext(ctx context.Context, metricsRecorder *metricsReco
 	return err
 }
 
+func handleSingleEventObject(event map[string]interface{}, log *logp.Logger, health status.StatusReporter) {
+	if _, ok := event["error"]; ok {
+		// If we have an error, log the complete object on the basis
+		// that it is ECS-conformant.
+		if log.Core().Enabled(zapcore.ErrorLevel) {
+			kv := make([]any, 0, 2*len(event))
+			for k := range maps.Keys(event) {
+				kv = append(kv, k, event[k])
+			}
+			log.Errorw("single event object returned by evaluation", kv...)
+		}
+	} else {
+		// Otherwise, be consistent with the existing documented
+		// behaviour and log the entire object as the error.
+		log.Errorw("single event object returned by evaluation", "error", event)
+	}
+	if err, ok := event["error"]; ok {
+		health.UpdateStatus(status.Degraded, fmt.Sprintf("single event error object returned by evaluation: %s", mapstr.M{"error": err}))
+	} else {
+		health.UpdateStatus(status.Degraded, "single event object returned by evaluation")
+	}
+}
+
 func publishEventLoop(
 	events []interface{},
 	cursors []interface{},
@@ -824,26 +847,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 					okSpans(end{execSpan})
 					return nil
 				}
-				if _, ok := e["error"]; ok {
-					// If we have an error, log the complete object on the basis
-					// that it is ECS-conformant.
-					if execLog.Core().Enabled(zapcore.ErrorLevel) {
-						kv := make([]any, 0, 2*len(e))
-						for k := range maps.Keys(e) {
-							kv = append(kv, k, e[k])
-						}
-						execLog.Errorw("single event object returned by evaluation", kv...)
-					}
-				} else {
-					// Otherwise, be consistent with the existing documented
-					// behaviour and log the entire object as the error.
-					execLog.Errorw("single event object returned by evaluation", "error", e)
-				}
-				if err, ok := e["error"]; ok {
-					health.UpdateStatus(status.Degraded, fmt.Sprintf("single event error object returned by evaluation: %s", mapstr.M{"error": err}))
-				} else {
-					health.UpdateStatus(status.Degraded, "single event object returned by evaluation")
-				}
+				handleSingleEventObject(e, execLog, health)
 				isDegraded = true
 				events = []interface{}{e}
 				// Make sure the cursor is not updated.

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -153,6 +153,12 @@ type namedStatusReporter struct {
 	parent status.StatusReporter
 }
 
+type publishCursors struct {
+	cursors      []interface{}
+	singleCursor bool
+	degraded     bool
+}
+
 func (r namedStatusReporter) UpdateStatus(status status.Status, msg string) {
 	switch {
 	case r.name != "" && msg != "":
@@ -171,6 +177,33 @@ func sanitizeFileName(name string) string {
 	name = strings.ReplaceAll(name, ":", string(filepath.Separator))
 	name = filepath.Clean(name)
 	return strings.ReplaceAll(name, string(filepath.Separator), "_")
+}
+
+func getPublishCursors(state map[string]interface{}, events []interface{}, log *logp.Logger, health status.StatusReporter, degraded bool) publishCursors {
+	result := publishCursors{degraded: degraded}
+
+	c, ok := state["cursor"]
+	if !ok {
+		return result
+	}
+
+	result.cursors, ok = c.([]interface{})
+	if ok {
+		if len(result.cursors) != len(events) {
+			log.Errorw("unexpected cursor list length", "cursors", len(result.cursors), "events", len(events))
+			health.UpdateStatus(status.Degraded, "unexpected cursor list length")
+			result.degraded = true
+			// But try to continue.
+			if len(result.cursors) < len(events) {
+				result.cursors = nil
+			}
+		}
+		return result
+	}
+
+	result.cursors = []interface{}{c}
+	result.singleCursor = true
+	return result
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -581,28 +614,10 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			// we will re-request these events.
 			delete(state, "events")
 
-			// Get cursors if they exist.
-			var (
-				cursors      []interface{}
-				singleCursor bool
-			)
-			if c, ok := state["cursor"]; ok {
-				cursors, ok = c.([]interface{})
-				if ok {
-					if len(cursors) != len(events) {
-						execLog.Errorw("unexpected cursor list length", "cursors", len(cursors), "events", len(events))
-						health.UpdateStatus(status.Degraded, "unexpected cursor list length")
-						isDegraded = true
-						// But try to continue.
-						if len(cursors) < len(events) {
-							cursors = nil
-						}
-					}
-				} else {
-					cursors = []interface{}{c}
-					singleCursor = true
-				}
-			}
+			cursorState := getPublishCursors(state, events, execLog, health, isDegraded)
+			cursors := cursorState.cursors
+			singleCursor := cursorState.singleCursor
+			isDegraded = cursorState.degraded
 			// Drop old cursor from state. This will be replaced with
 			// the current cursor object below; it is an array now.
 			delete(state, "cursor")

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1147,21 +1147,10 @@ func (i input) run(env v2.Context, src *source, currentCursor map[string]interfa
 		}
 		for {
 			if wait := time.Until(waitUntil); wait > 0 {
-				waitCtx, waitSpan := otelTracer.Start(runCtx, "cel.periodic.run.ratelimitwait")
-				// We have a special-case wait for when we have a zero limit.
-				// x/time/rate allow a burst through even when the limit is zero
-				// so in order to ensure that we don't try until we are out of
-				// purgatory we calculate how long we should wait according to
-				// the retry after for a 429 and rate limit headers if we have
-				// a zero rate quota. See handleResponse below.
-				select {
-				case <-waitCtx.Done():
-					runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
-					waitSpan.End()
-					return waitCtx.Err()
-				case <-time.After(wait):
+				err = waitForRateLimit(runCtx, runSpan, otelTracer, wait)
+				if err != nil {
+					return err
 				}
-				waitSpan.End()
 			} else if err = runCtx.Err(); err != nil {
 				// Otherwise exit if we have been cancelled.
 				runSpan.SetStatus(codes.Unset, runCtx.Err().Error())
@@ -1256,6 +1245,25 @@ func okSpans(spans ...trace.Span) {
 		if e, ok := sp.(end); ok {
 			e.End()
 		}
+	}
+}
+
+func waitForRateLimit(runCtx context.Context, runSpan trace.Span, otelTracer trace.Tracer, wait time.Duration) error {
+	waitCtx, waitSpan := otelTracer.Start(runCtx, "cel.periodic.run.ratelimitwait")
+	defer waitSpan.End()
+
+	// We have a special-case wait for when we have a zero limit.
+	// x/time/rate allow a burst through even when the limit is zero
+	// so in order to ensure that we don't try until we are out of
+	// purgatory we calculate how long we should wait according to
+	// the retry after for a 429 and rate limit headers if we have
+	// a zero rate quota. See handleResponse below.
+	select {
+	case <-waitCtx.Done():
+		runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
+		return waitCtx.Err()
+	case <-time.After(wait):
+		return nil
 	}
 }
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -301,7 +301,7 @@ func checkPublishResultContext(ctx context.Context, metricsRecorder *metricsReco
 	}
 
 	metricsRecorder.AddProgramRunDuration(ctx, time.Since(start))
-	errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+	errorSpans(err, end{pubSpan}, execSpan, runSpan)
 	return err
 }
 
@@ -356,7 +356,7 @@ func publishEventLoop(
 		event, ok := e.(map[string]interface{})
 		if !ok {
 			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-			errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+			errorSpans(err, end{pubSpan}, execSpan, runSpan)
 			return state, err
 		}
 
@@ -364,7 +364,7 @@ func publishEventLoop(
 		state.goodCursor = cursorState.goodCursor
 		if err != nil {
 			metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-			errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+			errorSpans(err, end{pubSpan}, execSpan, runSpan)
 			return state, err
 		}
 
@@ -505,7 +505,7 @@ func (i input) executeEvaluation(
 		switch {
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-			errorSpans(err, runSpan, end{execSpan})
+			errorSpans(err, runSpan, execSpan)
 			return state, start, false, err
 		case errors.As(err, &dump):
 			path := strings.ReplaceAll(cfg.FailureDump.Filename, "*", sanitizeFileName(env.IDWithoutName))
@@ -581,10 +581,10 @@ func processEvaluationResponse(
 	if err != nil || shouldRetry {
 		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
 		if err != nil {
-			errorSpans(err, end{execSpan}, runSpan)
+			errorSpans(err, execSpan, runSpan)
 			return result, err
 		}
-		errorSpans(errors.New("invalid response"), end{execSpan})
+		errorSpans(errors.New("invalid response"), execSpan)
 		result.shouldRetry = true
 		return result, nil
 	}
@@ -599,7 +599,7 @@ func processEvaluationResponse(
 	if !ok {
 		err := errors.New("unexpected missing events array from evaluation")
 		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-		errorSpans(err, end{execSpan}, runSpan)
+		errorSpans(err, execSpan, runSpan)
 		return result, err
 	}
 
@@ -608,7 +608,7 @@ func processEvaluationResponse(
 		if len(e) == 0 {
 			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
 			metricsRecorder.AddProgramSuccessExecution(execCtx)
-			okSpans(end{execSpan})
+			okSpans(execSpan)
 			result.done = true
 			return result, nil
 		}
@@ -617,7 +617,7 @@ func processEvaluationResponse(
 		if e == nil {
 			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
 			metricsRecorder.AddProgramSuccessExecution(execCtx)
-			okSpans(end{execSpan})
+			okSpans(execSpan)
 			result.done = true
 			return result, nil
 		}
@@ -629,7 +629,7 @@ func processEvaluationResponse(
 	default:
 		err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
 		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-		errorSpans(err, end{execSpan}, runSpan)
+		errorSpans(err, execSpan, runSpan)
 		return result, err
 	}
 
@@ -738,6 +738,7 @@ func (i input) executeOnce(
 	}
 
 	execCtx, execSpan := otelTracer.Start(runCtx, "cel.program.execution")
+	defer execSpan.End()
 	execSpan.SetAttributes(
 		attribute.Int("cel.program.execution_number", executionNumber),
 		attribute.Int("cel.program.event_count", 0), // to be overridden if there are events
@@ -938,19 +939,18 @@ func (i input) executeOnce(
 		execSpan,
 	)
 	if completion.maxExecutionLimited {
-		execSpan.End()
 		result.finishRun = true
 		result.maxExecutionLimited = true
 		return result, nil
 	}
 	if completion.done {
-		okSpans(end{execSpan})
+		okSpans(execSpan)
 		result.finishRun = true
 		result.markRunSpanOK = true
 		return result, nil
 	}
 
-	okSpans(end{execSpan})
+	okSpans(execSpan)
 	return result, nil
 }
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -527,6 +527,94 @@ func (i input) executeEvaluation(
 	return state, start, err != nil, nil
 }
 
+type evaluationResponse struct {
+	events      []interface{}
+	waitUntil   time.Time
+	degraded    bool
+	done        bool
+	shouldRetry bool
+}
+
+func processEvaluationResponse(
+	state map[string]interface{},
+	limiter *rate.Limiter,
+	goodURL string,
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	start time.Time,
+	execLog *logp.Logger,
+	execCtx context.Context,
+	execSpan trace.Span,
+	runSpan trace.Span,
+	degraded bool,
+) (evaluationResponse, error) {
+	result := evaluationResponse{
+		degraded: degraded,
+	}
+
+	var (
+		ok  bool
+		err error
+	)
+	ok, result.waitUntil, err = handleResponse(execLog, state, limiter)
+	if err != nil || !ok {
+		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+		if err != nil {
+			errorSpans(err, end{execSpan}, runSpan)
+			return result, err
+		}
+		errorSpans(errors.New("invalid response"), end{execSpan})
+		result.shouldRetry = true
+		return result, nil
+	}
+
+	_, ok = state["url"]
+	if !ok && goodURL != "" {
+		state["url"] = goodURL
+		execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", goodURL)
+	}
+
+	e, ok := state["events"]
+	if !ok {
+		err := errors.New("unexpected missing events array from evaluation")
+		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+		errorSpans(err, end{execSpan}, runSpan)
+		return result, err
+	}
+
+	switch e := e.(type) {
+	case []interface{}:
+		if len(e) == 0 {
+			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+			metricsRecorder.AddProgramSuccessExecution(execCtx)
+			okSpans(end{execSpan})
+			result.done = true
+			return result, nil
+		}
+		result.events = e
+	case map[string]interface{}:
+		if e == nil {
+			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+			metricsRecorder.AddProgramSuccessExecution(execCtx)
+			okSpans(end{execSpan})
+			result.done = true
+			return result, nil
+		}
+		handleSingleEventObject(e, execLog, health)
+		result.degraded = true
+		result.events = []interface{}{e}
+		// Make sure the cursor is not updated.
+		delete(state, "cursor")
+	default:
+		err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+		errorSpans(err, end{execSpan}, runSpan)
+		return result, err
+	}
+
+	return result, nil
+}
+
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
 	cfg := src.cfg
 	log := env.Logger.With("input_url", cfg.Resource.URL)
@@ -844,59 +932,31 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			// been stored and we can continue from that point, recovering
 			// the lost events and potentially re-requesting e3.
 
-			var ok bool
-			ok, waitUntil, err = handleResponse(execLog, state, limiter)
-			if err != nil || !ok {
-				metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-				if err != nil {
-					errorSpans(err, end{execSpan}, runSpan)
-					return err
-				}
-				errorSpans(errors.New("invalid response"), end{execSpan})
+			response, err := processEvaluationResponse(
+				state,
+				limiter,
+				goodURL,
+				health,
+				metricsRecorder,
+				start,
+				execLog,
+				execCtx,
+				execSpan,
+				runSpan,
+				isDegraded,
+			)
+			if err != nil {
+				return err
+			}
+			waitUntil = response.waitUntil
+			isDegraded = response.degraded
+			if response.shouldRetry {
 				continue
 			}
-
-			_, ok = state["url"]
-			if !ok && goodURL != "" {
-				state["url"] = goodURL
-				execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", goodURL)
+			if response.done {
+				return nil
 			}
-
-			e, ok := state["events"]
-			if !ok {
-				metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-				err := errors.New("unexpected missing events array from evaluation")
-				errorSpans(err, end{execSpan}, runSpan)
-				return err
-			}
-			var events []interface{}
-			switch e := e.(type) {
-			case []interface{}:
-				if len(e) == 0 {
-					metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-					metricsRecorder.AddProgramSuccessExecution(execCtx)
-					okSpans(end{execSpan})
-					return nil
-				}
-				events = e
-			case map[string]interface{}:
-				if e == nil {
-					metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-					metricsRecorder.AddProgramSuccessExecution(execCtx)
-					okSpans(end{execSpan})
-					return nil
-				}
-				handleSingleEventObject(e, execLog, health)
-				isDegraded = true
-				events = []interface{}{e}
-				// Make sure the cursor is not updated.
-				delete(state, "cursor")
-			default:
-				err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-				metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-				errorSpans(err, end{execSpan}, runSpan)
-				return err
-			}
+			events := response.events
 
 			// We have a non-empty batch of events to process.
 			metricsRecorder.AddReceivedBatch(execCtx, 1)

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -546,6 +546,19 @@ type executionCompletion struct {
 	maxExecutionLimited bool
 }
 
+type executeOnceResult struct {
+	state               map[string]interface{}
+	waitUntil           time.Time
+	cursor              map[string]interface{}
+	goodCursor          map[string]interface{}
+	degraded            bool
+	eventCount          int
+	retry               bool
+	finishRun           bool
+	markRunSpanOK       bool
+	maxExecutionLimited bool
+}
+
 func processEvaluationResponse(
 	state map[string]interface{},
 	limiter *rate.Limiter,
@@ -691,6 +704,254 @@ func completeExecution(
 	}
 
 	return executionCompletion{}
+}
+
+func (i input) executeOnce(
+	runCtx context.Context,
+	env v2.Context,
+	cfg config,
+	trace *httplog.LoggingRoundTripper,
+	contextInjector *otel.ContextInjector,
+	prg cel.Program,
+	ast *cel.Ast,
+	state map[string]interface{},
+	budget int,
+	wantDump bool,
+	metricsRecorder *metricsRecorder,
+	otelTracer trace.Tracer,
+	runSpan trace.Span,
+	log *logp.Logger,
+	pub inputcursor.Publisher,
+	health status.StatusReporter,
+	limiter *rate.Limiter,
+	goodURL string,
+	cursor map[string]interface{},
+	goodCursor map[string]interface{},
+	isDegraded bool,
+	executionNumber int,
+) (executeOnceResult, error) {
+	result := executeOnceResult{
+		state:      state,
+		cursor:     cursor,
+		goodCursor: goodCursor,
+		degraded:   isDegraded,
+	}
+
+	execCtx, execSpan := otelTracer.Start(runCtx, "cel.program.execution")
+	execSpan.SetAttributes(
+		attribute.Int("cel.program.execution_number", executionNumber),
+		attribute.Int("cel.program.event_count", 0), // to be overridden if there are events
+	)
+	execLog := logWithTracingIds(log, execSpan)
+
+	// Process a set of event requests.
+	if trace != nil {
+		execLog.Debugw("previous transaction", "transaction.id", trace.TxID())
+	}
+	execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: result.state, cfg: cfg.Redact})
+	metricsRecorder.AddProgramExecution(execCtx)
+	start := time.Time{}
+	var err error
+	result.state, start, result.degraded, err = i.executeEvaluation(
+		execCtx,
+		env,
+		cfg,
+		contextInjector,
+		prg,
+		ast,
+		result.state,
+		budget,
+		wantDump,
+		metricsRecorder,
+		execLog,
+		execSpan,
+		runSpan,
+		health,
+	)
+	if err != nil {
+		return result, err
+	}
+	if trace != nil {
+		execLog.Debugw("final transaction", "transaction.id", trace.TxID())
+	}
+
+	// On exit, state is expected to be in the shape:
+	//
+	// {
+	//     "cursor": [
+	//         {...},
+	//         ...
+	//     ],
+	//     "events": [
+	//         {...},
+	//         ...
+	//     ],
+	//     "url": <resource address>,
+	//     "status_code": <HTTP request status code if a network request>,
+	//     "header": <HTTP response headers if a network request>,
+	//     "rate_limit": <HTTP rate limit map if required by API>,
+	//     "want_more": bool
+	// }
+	//
+	// The "events" array must be present, but may be empty or null.
+	// In the case of an error condition in the CEL program it is
+	// acceptable to return a single object which will be wrapped as
+	// an array below. It is the responsibility of the downstream
+	// processor to handle this object correctly (which may be to drop
+	// the event). The error event will also be logged.
+	// If it is not empty, it must only have objects as elements.
+	// Additional fields may be present at the root of the object.
+	// The evaluation is repeated with the new state, after removing
+	// the events field, if the "want_more" field is present and true
+	// and a non-zero events array is returned.
+	//
+	// If cursor is present it must be either a single object or an
+	// array with the same length as events; each element i of the
+	// cursor array will be the details for obtaining the events at or
+	// beyond event i in events. If the cursor is a single object it
+	// is will be the details for obtaining events after the last
+	// event in the events array and will only be retained on
+	// successful publication of all the events in the array.
+	//
+	// If rate_limit is present it should be a map with numeric fields
+	// rate and burst. It may also have a string error field and
+	// other fields which will be logged. If it has an error field
+	// the rate and burst will not be used to set rate limit behaviour.
+	//
+	// The status code and rate_limit values may be omitted if they do
+	// not contribute to control.
+	//
+	// The following details how a cursor array works:
+	//
+	// Result after request resulting in 5 events. Each c obtained with
+	// an e points to the ~next e.
+	//
+	//    +----+   +----+        +----+
+	//    | e1 |   | c1 |        | e1 |
+	//    +----+   +----+        +----+   +----+
+	//    | e2 |   | c2 |        | e2 | < | c1 |
+	//    +----+   +----+        +----+   +----+
+	//    | e3 |   | c3 |        | e3 | < | c2 |
+	//    +----+   +----+   =>   +----+   +----+
+	//    | e4 |   | c4 |        | e4 | < | c3 |
+	//    +----+   +----+        +----+   +----+
+	//    | e5 |   | c5 |        | e5 | < | c4 |
+	//    +----+   +----+        +----+   +----+
+	//                           |next| < | c5 |
+	//                           +----+   +----+
+	//
+	// After a successful publication this will leave a single c and
+	// and empty events array. So the next evaluation has a boot.
+	//
+	// If the publication fails or execution is terminated at some
+	// point during the events array, we may end up with, e.g.
+	//
+	//    +----+  +----+        +----+   +----+
+	//    | e3 |  | c3 |        |next| < | c3 |
+	//    +----+  +----+        +----+   +----+
+	//    | e4 |  | c4 |   =>
+	//    +----+  +----+          lost events
+	//    | e5 |  | c5 |
+	//    +----+  +----+
+	//
+	// At this point, the c3 cursor (or at worst the c2 cursor) has
+	// been stored and we can continue from that point, recovering
+	// the lost events and potentially re-requesting e3.
+	response, err := processEvaluationResponse(
+		result.state,
+		limiter,
+		goodURL,
+		health,
+		metricsRecorder,
+		start,
+		execLog,
+		execCtx,
+		execSpan,
+		runSpan,
+		result.degraded,
+	)
+	if err != nil {
+		return result, err
+	}
+	result.waitUntil = response.waitUntil
+	result.degraded = response.degraded
+	if response.shouldRetry {
+		result.retry = true
+		return result, nil
+	}
+	if response.done {
+		result.finishRun = true
+		return result, nil
+	}
+	events := response.events
+
+	result.eventCount = len(events)
+	prepared := preparePublishState(
+		result.state,
+		events,
+		execLog,
+		health,
+		metricsRecorder,
+		execCtx,
+		execSpan,
+		result.degraded,
+	)
+	result.degraded = prepared.degraded
+
+	publishResult, err := publishEvents(
+		execCtx,
+		otelTracer,
+		log,
+		pub,
+		health,
+		metricsRecorder,
+		start,
+		events,
+		prepared.cursors,
+		prepared.singleCursor,
+		result.cursor,
+		result.goodCursor,
+		result.degraded,
+		execSpan,
+		runSpan,
+	)
+	if err != nil {
+		return result, err
+	}
+	result.cursor = publishResult.cursor
+	result.goodCursor = publishResult.goodCursor
+	result.degraded = publishResult.degraded
+
+	// Check we have a remaining execution budget.
+	budget--
+	completion := completeExecution(
+		result.state,
+		result.goodCursor,
+		start,
+		cfg.Interval,
+		budget,
+		*cfg.MaxExecutions,
+		health,
+		metricsRecorder,
+		execCtx,
+		execLog,
+		execSpan,
+	)
+	if completion.maxExecutionLimited {
+		execSpan.End()
+		result.finishRun = true
+		result.maxExecutionLimited = true
+		return result, nil
+	}
+	if completion.done {
+		okSpans(end{execSpan})
+		result.finishRun = true
+		result.markRunSpanOK = true
+		return result, nil
+	}
+
+	okSpans(end{execSpan})
+	return result, nil
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -890,24 +1151,11 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			}
 
 			runSpanExecutionCount++
-			execCtx, execSpan := otelTracer.Start(runCtx, "cel.program.execution")
-			execSpan.SetAttributes(
-				attribute.Int("cel.program.execution_number", runSpanExecutionCount),
-				attribute.Int("cel.program.event_count", 0), // to be overridden if there are events
-			)
-			execLog := logWithTracingIds(log, execSpan)
-
-			// Process a set of event requests.
-			if trace != nil {
-				execLog.Debugw("previous transaction", "transaction.id", trace.TxID())
-			}
-			execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: state, cfg: cfg.Redact})
-			metricsRecorder.AddProgramExecution(execCtx)
-			start := time.Time{}
-			state, start, isDegraded, err = i.executeEvaluation(
-				execCtx,
+			result, err := i.executeOnce(
+				runCtx,
 				env,
 				cfg,
+				trace,
 				contextInjector,
 				prg,
 				ast,
@@ -915,192 +1163,41 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 				budget,
 				wantDump,
 				metricsRecorder,
-				execLog,
-				execSpan,
-				runSpan,
-				health,
-			)
-			if err != nil {
-				return err
-			}
-			if trace != nil {
-				execLog.Debugw("final transaction", "transaction.id", trace.TxID())
-			}
-
-			// On exit, state is expected to be in the shape:
-			//
-			// {
-			//     "cursor": [
-			//         {...},
-			//         ...
-			//     ],
-			//     "events": [
-			//         {...},
-			//         ...
-			//     ],
-			//     "url": <resource address>,
-			//     "status_code": <HTTP request status code if a network request>,
-			//     "header": <HTTP response headers if a network request>,
-			//     "rate_limit": <HTTP rate limit map if required by API>,
-			//     "want_more": bool
-			// }
-			//
-			// The "events" array must be present, but may be empty or null.
-			// In the case of an error condition in the CEL program it is
-			// acceptable to return a single object which will be wrapped as
-			// an array below. It is the responsibility of the downstream
-			// processor to handle this object correctly (which may be to drop
-			// the event). The error event will also be logged.
-			// If it is not empty, it must only have objects as elements.
-			// Additional fields may be present at the root of the object.
-			// The evaluation is repeated with the new state, after removing
-			// the events field, if the "want_more" field is present and true
-			// and a non-zero events array is returned.
-			//
-			// If cursor is present it must be either a single object or an
-			// array with the same length as events; each element i of the
-			// cursor array will be the details for obtaining the events at or
-			// beyond event i in events. If the cursor is a single object it
-			// is will be the details for obtaining events after the last
-			// event in the events array and will only be retained on
-			// successful publication of all the events in the array.
-			//
-			// If rate_limit is present it should be a map with numeric fields
-			// rate and burst. It may also have a string error field and
-			// other fields which will be logged. If it has an error field
-			// the rate and burst will not be used to set rate limit behaviour.
-			//
-			// The status code and rate_limit values may be omitted if they do
-			// not contribute to control.
-			//
-			// The following details how a cursor array works:
-			//
-			// Result after request resulting in 5 events. Each c obtained with
-			// an e points to the ~next e.
-			//
-			//    +----+   +----+        +----+
-			//    | e1 |   | c1 |        | e1 |
-			//    +----+   +----+        +----+   +----+
-			//    | e2 |   | c2 |        | e2 | < | c1 |
-			//    +----+   +----+        +----+   +----+
-			//    | e3 |   | c3 |        | e3 | < | c2 |
-			//    +----+   +----+   =>   +----+   +----+
-			//    | e4 |   | c4 |        | e4 | < | c3 |
-			//    +----+   +----+        +----+   +----+
-			//    | e5 |   | c5 |        | e5 | < | c4 |
-			//    +----+   +----+        +----+   +----+
-			//                           |next| < | c5 |
-			//                           +----+   +----+
-			//
-			// After a successful publication this will leave a single c and
-			// and empty events array. So the next evaluation has a boot.
-			//
-			// If the publication fails or execution is terminated at some
-			// point during the events array, we may end up with, e.g.
-			//
-			//    +----+  +----+        +----+   +----+
-			//    | e3 |  | c3 |        |next| < | c3 |
-			//    +----+  +----+        +----+   +----+
-			//    | e4 |  | c4 |   =>
-			//    +----+  +----+          lost events
-			//    | e5 |  | c5 |
-			//    +----+  +----+
-			//
-			// At this point, the c3 cursor (or at worst the c2 cursor) has
-			// been stored and we can continue from that point, recovering
-			// the lost events and potentially re-requesting e3.
-
-			response, err := processEvaluationResponse(
-				state,
-				limiter,
-				goodURL,
-				health,
-				metricsRecorder,
-				start,
-				execLog,
-				execCtx,
-				execSpan,
-				runSpan,
-				isDegraded,
-			)
-			if err != nil {
-				return err
-			}
-			waitUntil = response.waitUntil
-			isDegraded = response.degraded
-			if response.shouldRetry {
-				continue
-			}
-			if response.done {
-				return nil
-			}
-			events := response.events
-
-			runSpanEventCount += len(events)
-			prepared := preparePublishState(
-				state,
-				events,
-				execLog,
-				health,
-				metricsRecorder,
-				execCtx,
-				execSpan,
-				isDegraded,
-			)
-			cursors := prepared.cursors
-			singleCursor := prepared.singleCursor
-			isDegraded = prepared.degraded
-
-			publishResult, err := publishEvents(
-				execCtx,
 				otelTracer,
+				runSpan,
 				log,
 				pub,
 				health,
-				metricsRecorder,
-				start,
-				events,
-				cursors,
-				singleCursor,
+				limiter,
+				goodURL,
 				cursor,
 				goodCursor,
 				isDegraded,
-				execSpan,
-				runSpan,
+				runSpanExecutionCount,
 			)
 			if err != nil {
 				return err
 			}
-			cursor = publishResult.cursor
-			goodCursor = publishResult.goodCursor
-			isDegraded = publishResult.degraded
-
-			// Check we have a remaining execution budget.
-			budget--
-			completion := completeExecution(
-				state,
-				goodCursor,
-				start,
-				cfg.Interval,
-				budget,
-				*cfg.MaxExecutions,
-				health,
-				metricsRecorder,
-				execCtx,
-				execLog,
-				execSpan,
-			)
-			if completion.maxExecutionLimited {
-				execSpan.End()
+			state = result.state
+			waitUntil = result.waitUntil
+			cursor = result.cursor
+			goodCursor = result.goodCursor
+			isDegraded = result.degraded
+			runSpanEventCount += result.eventCount
+			if result.retry {
+				continue
+			}
+			if result.maxExecutionLimited {
 				runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
 				runSpan.SetStatus(codes.Unset, "reached maximum number of CEL executions")
 				return nil
 			}
-			if completion.done {
-				okSpans(end{execSpan}, runSpan)
+			if result.finishRun {
+				if result.markRunSpanOK {
+					okSpans(runSpan)
+				}
 				return nil
 			}
-			okSpans(end{execSpan})
 		}
 	})
 	switch {

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -636,33 +636,6 @@ func processEvaluationResponse(
 	return result, nil
 }
 
-func preparePublishState(
-	state map[string]interface{},
-	events []interface{},
-	execLog *logp.Logger,
-	health status.StatusReporter,
-	metricsRecorder *metricsRecorder,
-	execCtx context.Context,
-	execSpan trace.Span,
-	runDegraded bool,
-) publishCursors {
-	// We have a non-empty batch of events to process.
-	metricsRecorder.AddReceivedBatch(execCtx, 1)
-	metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
-	execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
-	// Drop events from state. If we fail during the publication,
-	// we will re-request these events.
-	delete(state, "events")
-
-	cursor, hasCursor := state["cursor"]
-	cursorState := getPublishCursors(cursor, hasCursor, len(events), execLog, health, runDegraded)
-	// Drop old cursor from state. This will be replaced with
-	// the current cursor object below; it is an array now.
-	delete(state, "cursor")
-
-	return cursorState
-}
-
 func completeExecution(
 	state map[string]interface{},
 	safeCursor map[string]interface{},
@@ -879,16 +852,19 @@ func (i input) executeOnce(
 	events := response.events
 
 	runState.eventCount = len(events)
-	prepared := preparePublishState(
-		runState.state,
-		events,
-		execLog,
-		health,
-		metricsRecorder,
-		execCtx,
-		execSpan,
-		runState.degraded,
-	)
+	// We have a non-empty batch of events to process.
+	metricsRecorder.AddReceivedBatch(execCtx, 1)
+	metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
+	execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
+	// Drop events from state. If we fail during the publication,
+	// we will re-request these events.
+	delete(runState.state, "events")
+
+	cursor, hasCursor := runState.state["cursor"]
+	prepared := getPublishCursors(cursor, hasCursor, len(events), execLog, health, runState.degraded)
+	// Drop old cursor from state. This will be replaced with
+	// the current cursor object below; it is an array now.
+	delete(runState.state, "cursor")
 	runState.degraded = prepared.degraded
 
 	publishResult, err := publishEvents(

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -570,11 +570,8 @@ func processEvaluationResponse(
 	execCtx context.Context,
 	execSpan trace.Span,
 	runSpan trace.Span,
-	degraded bool,
 ) (evaluationResponse, error) {
-	result := evaluationResponse{
-		degraded: degraded,
-	}
+	result := evaluationResponse{}
 
 	waitUntil, shouldRetry, err := handleResponse(execLog, state, limiter)
 	result.waitUntil = waitUntil
@@ -834,13 +831,14 @@ func (i input) executeOnce(
 		execCtx,
 		execSpan,
 		runSpan,
-		runState.degraded,
 	)
 	if err != nil {
 		return outcome, err
 	}
 	runState.waitUntil = response.waitUntil
-	runState.degraded = response.degraded
+	if response.degraded {
+		runState.degraded = true
+	}
 	if response.shouldRetry {
 		outcome = executeOnceOutcome{kind: executeOnceRetry}
 		return outcome, nil

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -402,7 +402,7 @@ func publishEvents(
 	degraded bool,
 	execSpan trace.Span,
 	runSpan trace.Span,
-) (publishResult, context.Context, error) {
+) (publishResult, error) {
 	result := publishResult{
 		cursor:     cursor,
 		goodCursor: goodCursor,
@@ -432,7 +432,7 @@ func publishEvents(
 		start,
 	)
 	if err != nil {
-		return result, pubCtx, err
+		return result, err
 	}
 
 	result.cursor = publishState.cursor
@@ -453,7 +453,7 @@ func publishEvents(
 	}
 	pubSpan.End()
 
-	return result, pubCtx, nil
+	return result, nil
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -872,7 +872,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			// the current cursor object below; it is an array now.
 			delete(state, "cursor")
 
-			publishResult, publishCtx, err := publishEvents(
+			publishResult, err := publishEvents(
 				execCtx,
 				otelTracer,
 				log,
@@ -898,7 +898,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 
 			// Replace the last known good cursor.
 			state["cursor"] = goodCursor
-			metricsRecorder.AddProgramRunDuration(publishCtx, time.Since(start))
+			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
 			if more, _ := state["want_more"].(bool); !more {
 				execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
 				okSpans(end{execSpan}, runSpan)

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -728,6 +728,48 @@ func publishResponseEvents(
 	return nil
 }
 
+func interpretEvaluationResponse(
+	runState *periodicRunState,
+	limiter *rate.Limiter,
+	goodURL string,
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	start time.Time,
+	execLog *logp.Logger,
+	execCtx context.Context,
+	execSpan trace.Span,
+	runSpan trace.Span,
+) ([]interface{}, executeOnceOutcome, error) {
+	outcome := executeOnceOutcome{kind: executeOnceContinue}
+
+	response, err := processEvaluationResponse(
+		runState.state,
+		limiter,
+		goodURL,
+		health,
+		metricsRecorder,
+		start,
+		execLog,
+		execCtx,
+		execSpan,
+		runSpan,
+	)
+	if err != nil {
+		return nil, outcome, err
+	}
+	runState.waitUntil = response.waitUntil
+	if response.degraded {
+		runState.degraded = true
+	}
+	if response.shouldRetry {
+		return nil, executeOnceOutcome{kind: executeOnceRetry}, nil
+	}
+	if response.done {
+		return nil, executeOnceOutcome{kind: executeOnceFinish}, nil
+	}
+	return response.events, outcome, nil
+}
+
 func (i input) executeOnce(
 	runCtx context.Context,
 	env v2.Context,
@@ -875,8 +917,8 @@ func (i input) executeOnce(
 	// At this point, the c3 cursor (or at worst the c2 cursor) has
 	// been stored and we can continue from that point, recovering
 	// the lost events and potentially re-requesting e3.
-	response, err := processEvaluationResponse(
-		runState.state,
+	events, outcome, err := interpretEvaluationResponse(
+		runState,
 		limiter,
 		goodURL,
 		health,
@@ -890,21 +932,12 @@ func (i input) executeOnce(
 	if err != nil {
 		return outcome, err
 	}
-	runState.waitUntil = response.waitUntil
-	if response.degraded {
-		runState.degraded = true
-	}
-	if response.shouldRetry {
-		outcome = executeOnceOutcome{kind: executeOnceRetry}
-		return outcome, nil
-	}
-	if response.done {
-		outcome = executeOnceOutcome{kind: executeOnceFinish}
+	if outcome.kind != executeOnceContinue {
 		return outcome, nil
 	}
 	err = publishResponseEvents(
 		runState,
-		response.events,
+		events,
 		execCtx,
 		otelTracer,
 		log,

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -546,17 +546,28 @@ type executionCompletion struct {
 	maxExecutionLimited bool
 }
 
-type executeOnceResult struct {
-	state               map[string]interface{}
-	waitUntil           time.Time
-	cursor              map[string]interface{}
-	goodCursor          map[string]interface{}
-	degraded            bool
-	eventCount          int
-	retry               bool
-	finishRun           bool
+type executeOnceOutcomeKind uint8
+
+const (
+	executeOnceContinue executeOnceOutcomeKind = iota
+	executeOnceRetry
+	executeOnceFinish
+)
+
+type executeOnceOutcome struct {
+	kind                executeOnceOutcomeKind
 	markRunSpanOK       bool
 	maxExecutionLimited bool
+}
+
+type executeOnceResult struct {
+	state      map[string]interface{}
+	waitUntil  time.Time
+	cursor     map[string]interface{}
+	goodCursor map[string]interface{}
+	degraded   bool
+	eventCount int
+	outcome    executeOnceOutcome
 }
 
 func processEvaluationResponse(
@@ -735,6 +746,9 @@ func (i input) executeOnce(
 		cursor:     cursor,
 		goodCursor: goodCursor,
 		degraded:   isDegraded,
+		outcome: executeOnceOutcome{
+			kind: executeOnceContinue,
+		},
 	}
 
 	execCtx, execSpan := otelTracer.Start(runCtx, "cel.program.execution")
@@ -877,11 +891,11 @@ func (i input) executeOnce(
 	result.waitUntil = response.waitUntil
 	result.degraded = response.degraded
 	if response.shouldRetry {
-		result.retry = true
+		result.outcome = executeOnceOutcome{kind: executeOnceRetry}
 		return result, nil
 	}
 	if response.done {
-		result.finishRun = true
+		result.outcome = executeOnceOutcome{kind: executeOnceFinish}
 		return result, nil
 	}
 	events := response.events
@@ -939,14 +953,18 @@ func (i input) executeOnce(
 		execSpan,
 	)
 	if completion.maxExecutionLimited {
-		result.finishRun = true
-		result.maxExecutionLimited = true
+		result.outcome = executeOnceOutcome{
+			kind:                executeOnceFinish,
+			maxExecutionLimited: true,
+		}
 		return result, nil
 	}
 	if completion.done {
 		okSpans(execSpan)
-		result.finishRun = true
-		result.markRunSpanOK = true
+		result.outcome = executeOnceOutcome{
+			kind:          executeOnceFinish,
+			markRunSpanOK: true,
+		}
 		return result, nil
 	}
 
@@ -1184,16 +1202,17 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			goodCursor = result.goodCursor
 			isDegraded = result.degraded
 			runSpanEventCount += result.eventCount
-			if result.retry {
+			switch result.outcome.kind {
+			case executeOnceContinue:
+			case executeOnceRetry:
 				continue
-			}
-			if result.maxExecutionLimited {
-				runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
-				runSpan.SetStatus(codes.Unset, "reached maximum number of CEL executions")
-				return nil
-			}
-			if result.finishRun {
-				if result.markRunSpanOK {
+			case executeOnceFinish:
+				if result.outcome.maxExecutionLimited {
+					runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
+					runSpan.SetStatus(codes.Unset, "reached maximum number of CEL executions")
+					return nil
+				}
+				if result.outcome.markRunSpanOK {
 					okSpans(runSpan)
 				}
 				return nil

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -541,6 +541,11 @@ type publishPreparation struct {
 	degraded     bool
 }
 
+type executionCompletion struct {
+	done                bool
+	maxExecutionLimited bool
+}
+
 func processEvaluationResponse(
 	state map[string]interface{},
 	limiter *rate.Limiter,
@@ -646,6 +651,46 @@ func preparePublishState(
 		singleCursor: cursorState.singleCursor,
 		degraded:     cursorState.degraded,
 	}
+}
+
+func completeExecution(
+	state map[string]interface{},
+	goodCursor map[string]interface{},
+	start time.Time,
+	interval time.Duration,
+	remainingBudget int,
+	maxExecutions int,
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	execCtx context.Context,
+	execLog *logp.Logger,
+	execSpan trace.Span,
+) executionCompletion {
+	// Replace the last known good cursor.
+	state["cursor"] = goodCursor
+	metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+	if more, _ := state["want_more"].(bool); !more {
+		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
+		return executionCompletion{done: true}
+	}
+	execSpan.SetAttributes(attribute.Bool("cel.program.want_more", true))
+
+	// Check we have a remaining execution budget.
+	if remainingBudget <= 0 {
+		msg := "reached maximum number of CEL executions"
+		execLog.Warnw(msg+": will continue at next periodic evaluation",
+			"limit", maxExecutions,
+			"next_eval_time", start.Add(interval),
+		)
+		health.UpdateStatus(status.Degraded, msg)
+		execSpan.SetStatus(codes.Unset, msg)
+		return executionCompletion{
+			done:                true,
+			maxExecutionLimited: true,
+		}
+	}
+
+	return executionCompletion{}
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -1030,32 +1075,31 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			goodCursor = publishResult.goodCursor
 			isDegraded = publishResult.degraded
 
-			// Replace the last known good cursor.
-			state["cursor"] = goodCursor
-			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-			if more, _ := state["want_more"].(bool); !more {
-				execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
+			// Check we have a remaining execution budget.
+			budget--
+			completion := completeExecution(
+				state,
+				goodCursor,
+				start,
+				cfg.Interval,
+				budget,
+				*cfg.MaxExecutions,
+				health,
+				metricsRecorder,
+				execCtx,
+				execLog,
+				execSpan,
+			)
+			if completion.maxExecutionLimited {
+				execSpan.End()
+				runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
+				runSpan.SetStatus(codes.Unset, "reached maximum number of CEL executions")
+				return nil
+			}
+			if completion.done {
 				okSpans(end{execSpan}, runSpan)
 				return nil
 			}
-			execSpan.SetAttributes(attribute.Bool("cel.program.want_more", true))
-
-			// Check we have a remaining execution budget.
-			budget--
-			if budget <= 0 {
-				msg := "reached maximum number of CEL executions"
-				execLog.Warnw(msg+": will continue at next periodic evaluation",
-					"limit", *cfg.MaxExecutions,
-					"next_eval_time", start.Add(cfg.Interval),
-				)
-				health.UpdateStatus(status.Degraded, msg)
-				execSpan.SetStatus(codes.Unset, msg)
-				execSpan.End()
-				runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
-				runSpan.SetStatus(codes.Unset, msg)
-				return nil
-			}
-
 			okSpans(end{execSpan})
 		}
 	})

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -554,6 +554,52 @@ type periodicRunState struct {
 	eventCount    int
 }
 
+func normalizeEvaluationEvents(
+	state map[string]interface{},
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	start time.Time,
+	execLog *logp.Logger,
+	execCtx context.Context,
+	execSpan trace.Span,
+	runSpan trace.Span,
+) (events []interface{}, done bool, degraded bool, err error) {
+	e, ok := state["events"]
+	if !ok {
+		err = errors.New("unexpected missing events array from evaluation")
+		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+		errorSpans(err, execSpan, runSpan)
+		return nil, false, false, err
+	}
+
+	switch e := e.(type) {
+	case []interface{}:
+		if len(e) == 0 {
+			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+			metricsRecorder.AddProgramSuccessExecution(execCtx)
+			okSpans(execSpan)
+			return nil, true, false, nil
+		}
+		return e, false, false, nil
+	case map[string]interface{}:
+		if e == nil {
+			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+			metricsRecorder.AddProgramSuccessExecution(execCtx)
+			okSpans(execSpan)
+			return nil, true, false, nil
+		}
+		handleSingleEventObject(e, execLog, health)
+		// Make sure the cursor is not updated.
+		delete(state, "cursor")
+		return []interface{}{e}, false, true, nil
+	default:
+		err = fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+		errorSpans(err, execSpan, runSpan)
+		return nil, false, false, err
+	}
+}
+
 func processEvaluationResponse(
 	state map[string]interface{},
 	limiter *rate.Limiter,
@@ -587,41 +633,17 @@ func processEvaluationResponse(
 		execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", goodURL)
 	}
 
-	e, ok := state["events"]
-	if !ok {
-		err := errors.New("unexpected missing events array from evaluation")
-		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-		errorSpans(err, execSpan, runSpan)
-		return result, err
-	}
-
-	switch e := e.(type) {
-	case []interface{}:
-		if len(e) == 0 {
-			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-			metricsRecorder.AddProgramSuccessExecution(execCtx)
-			okSpans(execSpan)
-			result.done = true
-			return result, nil
-		}
-		result.events = e
-	case map[string]interface{}:
-		if e == nil {
-			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-			metricsRecorder.AddProgramSuccessExecution(execCtx)
-			okSpans(execSpan)
-			result.done = true
-			return result, nil
-		}
-		handleSingleEventObject(e, execLog, health)
-		result.degraded = true
-		result.events = []interface{}{e}
-		// Make sure the cursor is not updated.
-		delete(state, "cursor")
-	default:
-		err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-		metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-		errorSpans(err, execSpan, runSpan)
+	result.events, result.done, result.degraded, err = normalizeEvaluationEvents(
+		state,
+		health,
+		metricsRecorder,
+		start,
+		execLog,
+		execCtx,
+		execSpan,
+		runSpan,
+	)
+	if err != nil {
 		return result, err
 	}
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -172,12 +172,6 @@ type publishLoopState struct {
 	hadPublicationError bool
 }
 
-type publishResult struct {
-	currentCursor map[string]interface{}
-	safeCursor    map[string]interface{}
-	degraded      bool
-}
-
 func (r namedStatusReporter) UpdateStatus(status status.Status, msg string) {
 	switch {
 	case r.name != "" && msg != "":
@@ -425,8 +419,8 @@ func publishEvents(
 	degraded bool,
 	execSpan trace.Span,
 	runSpan trace.Span,
-) (publishResult, error) {
-	result := publishResult{
+) (publishLoopState, error) {
+	result := publishLoopState{
 		currentCursor: currentCursor,
 		safeCursor:    safeCursor,
 		degraded:      degraded,

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -266,6 +266,11 @@ func checkPublishContext(ctx context.Context, log *logp.Logger, health status.St
 	}
 }
 
+func handlePublishError(err error, log *logp.Logger, health status.StatusReporter) {
+	log.Errorw("error publishing event", "error", err)
+	health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
+}
+
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
 	cfg := src.cfg
 	log := env.Logger.With("input_url", cfg.Resource.URL)
@@ -723,8 +728,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 				}, pubCursor)
 				if err != nil {
 					hadPublicationError = true
-					pubLog.Errorw("error publishing event", "error", err)
-					health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
+					handlePublishError(err, pubLog, health)
 					errorSpans(err, pubSpan)
 					isDegraded = true
 					cursors = nil // We are lost, so retry with this event's cursor,

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -535,6 +535,12 @@ type evaluationResponse struct {
 	shouldRetry bool
 }
 
+type publishPreparation struct {
+	cursors      []interface{}
+	singleCursor bool
+	degraded     bool
+}
+
 func processEvaluationResponse(
 	state map[string]interface{},
 	limiter *rate.Limiter,
@@ -610,6 +616,36 @@ func processEvaluationResponse(
 	}
 
 	return result, nil
+}
+
+func preparePublishState(
+	state map[string]interface{},
+	events []interface{},
+	execLog *logp.Logger,
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	execCtx context.Context,
+	execSpan trace.Span,
+	runDegraded bool,
+) publishPreparation {
+	// We have a non-empty batch of events to process.
+	metricsRecorder.AddReceivedBatch(execCtx, 1)
+	metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
+	execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
+	// Drop events from state. If we fail during the publication,
+	// we will re-request these events.
+	delete(state, "events")
+
+	cursorState := getPublishCursors(state, events, execLog, health, runDegraded)
+	// Drop old cursor from state. This will be replaced with
+	// the current cursor object below; it is an array now.
+	delete(state, "cursor")
+
+	return publishPreparation{
+		cursors:      cursorState.cursors,
+		singleCursor: cursorState.singleCursor,
+		degraded:     cursorState.degraded,
+	}
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -955,22 +991,20 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			}
 			events := response.events
 
-			// We have a non-empty batch of events to process.
-			metricsRecorder.AddReceivedBatch(execCtx, 1)
-			metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
 			runSpanEventCount += len(events)
-			execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
-			// Drop events from state. If we fail during the publication,
-			// we will re-request these events.
-			delete(state, "events")
-
-			cursorState := getPublishCursors(state, events, execLog, health, isDegraded)
-			cursors := cursorState.cursors
-			singleCursor := cursorState.singleCursor
-			isDegraded = cursorState.degraded
-			// Drop old cursor from state. This will be replaced with
-			// the current cursor object below; it is an array now.
-			delete(state, "cursor")
+			prepared := preparePublishState(
+				state,
+				events,
+				execLog,
+				health,
+				metricsRecorder,
+				execCtx,
+				execSpan,
+				isDegraded,
+			)
+			cursors := prepared.cursors
+			singleCursor := prepared.singleCursor
+			isDegraded = prepared.degraded
 
 			publishResult, err := publishEvents(
 				execCtx,

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -248,6 +248,24 @@ func getPublishCursorForEvent(index int, eventCount int, cursors []interface{}, 
 	return result, nil
 }
 
+func checkPublishContext(ctx context.Context, log *logp.Logger, health status.StatusReporter, unpublished int) (breakLoop bool, markDegraded bool) {
+	switch err := ctx.Err(); {
+	case err == nil:
+		return false, false
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		log.Infow("context cancelled with unpublished events", "unpublished", unpublished)
+		// Don't update status, since we are about to pass
+		// through the Running state and then fall through
+		// to the input exit with a change to Stopped.
+		return true, false
+	default:
+		// This should never happen.
+		log.Warnw("failed with unpublished events", "error", err, "unpublished", unpublished)
+		health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
+		return true, true
+	}
+}
+
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
 	cfg := src.cfg
 	log := env.Logger.With("input_url", cfg.Resource.URL)
@@ -692,19 +710,11 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 				// cursor.Publisher interface does not document the behaviour
 				// related to context cancellation and the context is not
 				// explicitly passed in, so favour this explicit clarity.
-				switch err := pubCtx.Err(); {
-				case err == nil:
-				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-					pubLog.Infow("context cancelled with unpublished events", "unpublished", len(events)-i)
-					// Don't update status, since we are about to pass
-					// through the Running state and then fall through
-					// to the input exit with a change to Stopped.
-					break loop
-				default:
-					// This should never happen.
-					pubLog.Warnw("failed with unpublished events", "error", err, "unpublished", len(events)-i)
-					health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
+				breakLoop, markDegraded := checkPublishContext(pubCtx, pubLog, health, len(events)-i)
+				if markDegraded {
 					isDegraded = true
+				}
+				if breakLoop {
 					break loop
 				}
 				err = pub.Publish(beat.Event{

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -194,8 +194,8 @@ func sanitizeFileName(name string) string {
 
 // getPublishCursors normalizes the evaluation cursor into the slice form used
 // during publication.
-func getPublishCursors(cursor any, hasCursor bool, eventCount int, log *logp.Logger, health status.StatusReporter, degraded bool) publishCursors {
-	result := publishCursors{degraded: degraded}
+func getPublishCursors(cursor any, hasCursor bool, eventCount int, log *logp.Logger, health status.StatusReporter) publishCursors {
+	result := publishCursors{}
 
 	if !hasCursor {
 		return result
@@ -861,11 +861,13 @@ func (i input) executeOnce(
 	delete(runState.state, "events")
 
 	cursor, hasCursor := runState.state["cursor"]
-	prepared := getPublishCursors(cursor, hasCursor, len(events), execLog, health, runState.degraded)
+	prepared := getPublishCursors(cursor, hasCursor, len(events), execLog, health)
 	// Drop old cursor from state. This will be replaced with
 	// the current cursor object below; it is an array now.
 	delete(runState.state, "cursor")
-	runState.degraded = prepared.degraded
+	if prepared.degraded {
+		runState.degraded = true
+	}
 
 	publishResult, err := publishEvents(
 		execCtx,

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -271,6 +271,27 @@ func handlePublishError(err error, log *logp.Logger, health status.StatusReporte
 	health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
 }
 
+func recordPublishedEvent(metricsRecorder *metricsRecorder, ctx context.Context, pubSpan trace.Span, batchNum int, eventCount int) int {
+	if batchNum == 1 {
+		metricsRecorder.AddPublishedBatch(ctx, 1)
+	}
+	metricsRecorder.AddPublishedEvents(ctx, 1)
+	eventCount++
+	pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", eventCount))
+	return eventCount
+}
+
+func checkPublishResultContext(ctx context.Context, metricsRecorder *metricsRecorder, start time.Time, pubSpan trace.Span, execSpan trace.Span, runSpan trace.Span) error {
+	err := ctx.Err()
+	if err == nil {
+		return nil
+	}
+
+	metricsRecorder.AddProgramRunDuration(ctx, time.Since(start))
+	errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+	return err
+}
+
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
 	cfg := src.cfg
 	log := env.Logger.With("input_url", cfg.Resource.URL)
@@ -737,17 +758,10 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 					// events we have now, with a fallback to the last guaranteed
 					// correctly published cursor.
 				}
-				if i == 0 {
-					metricsRecorder.AddPublishedBatch(pubCtx, 1)
-				}
-				metricsRecorder.AddPublishedEvents(pubCtx, 1)
-				pubSpanEventCount++
-				pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount))
+				pubSpanEventCount = recordPublishedEvent(metricsRecorder, pubCtx, pubSpan, i+1, pubSpanEventCount)
 
-				err = pubCtx.Err()
+				err = checkPublishResultContext(pubCtx, metricsRecorder, start, pubSpan, execSpan, runSpan)
 				if err != nil {
-					metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-					errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
 					return err
 				}
 			}

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -154,28 +154,28 @@ type namedStatusReporter struct {
 }
 
 type publishCursors struct {
-	cursors      []interface{}
-	singleCursor bool
-	degraded     bool
+	cursors         []interface{}
+	hasSingleCursor bool
+	degraded        bool
 }
 
 type publishCursorState struct {
-	pubCursor  interface{}
-	cursor     map[string]interface{}
-	goodCursor map[string]interface{}
+	pubCursor     interface{}
+	currentCursor map[string]interface{}
+	safeCursor    map[string]interface{}
 }
 
 type publishLoopState struct {
-	cursor              map[string]interface{}
-	goodCursor          map[string]interface{}
+	currentCursor       map[string]interface{}
+	safeCursor          map[string]interface{}
 	degraded            bool
 	hadPublicationError bool
 }
 
 type publishResult struct {
-	cursor     map[string]interface{}
-	goodCursor map[string]interface{}
-	degraded   bool
+	currentCursor map[string]interface{}
+	safeCursor    map[string]interface{}
+	degraded      bool
 }
 
 func (r namedStatusReporter) UpdateStatus(status status.Status, msg string) {
@@ -221,42 +221,42 @@ func getPublishCursors(state map[string]interface{}, events []interface{}, log *
 	}
 
 	result.cursors = []interface{}{c}
-	result.singleCursor = true
+	result.hasSingleCursor = true
 	return result
 }
 
-func getPublishCursorForEvent(index int, eventCount int, cursors []interface{}, singleCursor bool, cursor map[string]interface{}, goodCursor map[string]interface{}) (publishCursorState, error) {
+func getPublishCursorForEvent(index int, eventCount int, cursors []interface{}, hasSingleCursor bool, currentCursor map[string]interface{}, safeCursor map[string]interface{}) (publishCursorState, error) {
 	result := publishCursorState{
-		cursor:     cursor,
-		goodCursor: goodCursor,
+		currentCursor: currentCursor,
+		safeCursor:    safeCursor,
 	}
 	if cursors == nil {
 		return result, nil
 	}
 
-	if singleCursor {
+	if hasSingleCursor {
 		// Only set the cursor for publication at the last event
 		// when a single cursor object has been provided.
 		if index != eventCount-1 {
 			return result, nil
 		}
 
-		result.goodCursor = cursor
+		result.safeCursor = currentCursor
 		nextCursor, ok := cursors[0].(map[string]interface{})
 		if !ok {
 			return result, fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
 		}
-		result.cursor = nextCursor
+		result.currentCursor = nextCursor
 		result.pubCursor = nextCursor
 		return result, nil
 	}
 
-	result.goodCursor = cursor
+	result.safeCursor = currentCursor
 	nextCursor, ok := cursors[index].(map[string]interface{})
 	if !ok {
 		return result, fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[index])
 	}
-	result.cursor = nextCursor
+	result.currentCursor = nextCursor
 	result.pubCursor = nextCursor
 	return result, nil
 }
@@ -331,9 +331,9 @@ func handleSingleEventObject(event map[string]interface{}, log *logp.Logger, hea
 func publishEventLoop(
 	events []interface{},
 	cursors []interface{},
-	singleCursor bool,
-	cursor map[string]interface{},
-	goodCursor map[string]interface{},
+	hasSingleCursor bool,
+	currentCursor map[string]interface{},
+	safeCursor map[string]interface{},
 	degraded bool,
 	pub inputcursor.Publisher,
 	pubCtx context.Context,
@@ -346,9 +346,9 @@ func publishEventLoop(
 	start time.Time,
 ) (publishLoopState, error) {
 	state := publishLoopState{
-		cursor:     cursor,
-		goodCursor: goodCursor,
-		degraded:   degraded,
+		currentCursor: currentCursor,
+		safeCursor:    safeCursor,
+		degraded:      degraded,
 	}
 	eventCount := 0
 
@@ -360,8 +360,8 @@ func publishEventLoop(
 			return state, err
 		}
 
-		cursorState, err := getPublishCursorForEvent(i, len(events), cursors, singleCursor, state.cursor, state.goodCursor)
-		state.goodCursor = cursorState.goodCursor
+		cursorState, err := getPublishCursorForEvent(i, len(events), cursors, hasSingleCursor, state.currentCursor, state.safeCursor)
+		state.safeCursor = cursorState.safeCursor
 		if err != nil {
 			metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
 			errorSpans(err, end{pubSpan}, execSpan, runSpan)
@@ -369,7 +369,7 @@ func publishEventLoop(
 		}
 
 		pubCursor := cursorState.pubCursor
-		state.cursor = cursorState.cursor
+		state.currentCursor = cursorState.currentCursor
 
 		// This is checked prior to the publish attempt since the
 		// cursor.Publisher interface does not document the behaviour
@@ -392,11 +392,11 @@ func publishEventLoop(
 			handlePublishError(err, pubLog, health)
 			errorSpans(err, pubSpan)
 			state.degraded = true
-			cursors = nil // We are lost, so retry with this event's cursor,
+			cursors = nil // We are lost, so retry with this event's current cursor,
 			continue      // but continue with the events that we have without
 			// advancing the cursor. This allows us to potentially publish the
-			// events we have now, with a fallback to the last guaranteed
-			// correctly published cursor.
+			// events we have now, with a fallback to the last safe
+			// cursor.
 		}
 
 		eventCount = recordPublishedEvent(metricsRecorder, pubCtx, pubSpan, i+1, eventCount)
@@ -419,17 +419,17 @@ func publishEvents(
 	start time.Time,
 	events []interface{},
 	cursors []interface{},
-	singleCursor bool,
-	cursor map[string]interface{},
-	goodCursor map[string]interface{},
+	hasSingleCursor bool,
+	currentCursor map[string]interface{},
+	safeCursor map[string]interface{},
 	degraded bool,
 	execSpan trace.Span,
 	runSpan trace.Span,
 ) (publishResult, error) {
 	result := publishResult{
-		cursor:     cursor,
-		goodCursor: goodCursor,
-		degraded:   degraded,
+		currentCursor: currentCursor,
+		safeCursor:    safeCursor,
+		degraded:      degraded,
 	}
 
 	pubStart := time.Now()
@@ -440,9 +440,9 @@ func publishEvents(
 	publishState, err := publishEventLoop(
 		events,
 		cursors,
-		singleCursor,
-		cursor,
-		goodCursor,
+		hasSingleCursor,
+		currentCursor,
+		safeCursor,
 		degraded,
 		pub,
 		pubCtx,
@@ -458,8 +458,8 @@ func publishEvents(
 		return result, err
 	}
 
-	result.cursor = publishState.cursor
-	result.goodCursor = publishState.goodCursor
+	result.currentCursor = publishState.currentCursor
+	result.safeCursor = publishState.safeCursor
 	result.degraded = publishState.degraded
 
 	if !result.degraded {
@@ -470,7 +470,7 @@ func publishEvents(
 	// Advance the cursor to the final state if there was no error during
 	// publications. This is needed to transition to the next set of events.
 	if !publishState.hadPublicationError && !result.degraded {
-		result.goodCursor = result.cursor
+		result.safeCursor = result.currentCursor
 		metricsRecorder.AddProgramSuccessExecution(pubCtx)
 		okSpans(pubSpan)
 	}
@@ -536,9 +536,9 @@ type evaluationResponse struct {
 }
 
 type publishPreparation struct {
-	cursors      []interface{}
-	singleCursor bool
-	degraded     bool
+	cursors         []interface{}
+	hasSingleCursor bool
+	degraded        bool
 }
 
 type executionCompletion struct {
@@ -561,13 +561,13 @@ type executeOnceOutcome struct {
 }
 
 type executeOnceResult struct {
-	state      map[string]interface{}
-	waitUntil  time.Time
-	cursor     map[string]interface{}
-	goodCursor map[string]interface{}
-	degraded   bool
-	eventCount int
-	outcome    executeOnceOutcome
+	state         map[string]interface{}
+	waitUntil     time.Time
+	currentCursor map[string]interface{}
+	safeCursor    map[string]interface{}
+	degraded      bool
+	eventCount    int
+	outcome       executeOnceOutcome
 }
 
 func processEvaluationResponse(
@@ -671,15 +671,15 @@ func preparePublishState(
 	delete(state, "cursor")
 
 	return publishPreparation{
-		cursors:      cursorState.cursors,
-		singleCursor: cursorState.singleCursor,
-		degraded:     cursorState.degraded,
+		cursors:         cursorState.cursors,
+		hasSingleCursor: cursorState.hasSingleCursor,
+		degraded:        cursorState.degraded,
 	}
 }
 
 func completeExecution(
 	state map[string]interface{},
-	goodCursor map[string]interface{},
+	safeCursor map[string]interface{},
 	start time.Time,
 	interval time.Duration,
 	remainingBudget int,
@@ -690,8 +690,8 @@ func completeExecution(
 	execLog *logp.Logger,
 	execSpan trace.Span,
 ) executionCompletion {
-	// Replace the last known good cursor.
-	state["cursor"] = goodCursor
+	// Replace the last safe cursor.
+	state["cursor"] = safeCursor
 	metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
 	if more, _ := state["want_more"].(bool); !more {
 		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
@@ -736,16 +736,16 @@ func (i input) executeOnce(
 	health status.StatusReporter,
 	limiter *rate.Limiter,
 	goodURL string,
-	cursor map[string]interface{},
-	goodCursor map[string]interface{},
+	currentCursor map[string]interface{},
+	safeCursor map[string]interface{},
 	isDegraded bool,
 	executionNumber int,
 ) (executeOnceResult, error) {
 	result := executeOnceResult{
-		state:      state,
-		cursor:     cursor,
-		goodCursor: goodCursor,
-		degraded:   isDegraded,
+		state:         state,
+		currentCursor: currentCursor,
+		safeCursor:    safeCursor,
+		degraded:      isDegraded,
 		outcome: executeOnceOutcome{
 			kind: executeOnceContinue,
 		},
@@ -923,9 +923,9 @@ func (i input) executeOnce(
 		start,
 		events,
 		prepared.cursors,
-		prepared.singleCursor,
-		result.cursor,
-		result.goodCursor,
+		prepared.hasSingleCursor,
+		result.currentCursor,
+		result.safeCursor,
 		result.degraded,
 		execSpan,
 		runSpan,
@@ -933,15 +933,15 @@ func (i input) executeOnce(
 	if err != nil {
 		return result, err
 	}
-	result.cursor = publishResult.cursor
-	result.goodCursor = publishResult.goodCursor
+	result.currentCursor = publishResult.currentCursor
+	result.safeCursor = publishResult.safeCursor
 	result.degraded = publishResult.degraded
 
 	// Check we have a remaining execution budget.
 	budget--
 	completion := completeExecution(
 		result.state,
-		result.goodCursor,
+		result.safeCursor,
 		start,
 		cfg.Interval,
 		budget,
@@ -972,7 +972,7 @@ func (i input) executeOnce(
 	return result, nil
 }
 
-func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
+func (i input) run(env v2.Context, src *source, currentCursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
 	cfg := src.cfg
 	log := env.Logger.With("input_url", cfg.Resource.URL)
 
@@ -1070,10 +1070,10 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	if !slices.Contains(cfg.Redact.Fields, "secret") {
 		cfg.Redact.Fields = append(cfg.Redact.Fields, "secret")
 	}
-	if cursor != nil {
-		state["cursor"] = cursor
+	if currentCursor != nil {
+		state["cursor"] = currentCursor
 	}
-	goodCursor := cursor
+	safeCursor := currentCursor
 	goodURL := cfg.Resource.URL.String()
 	state["url"] = goodURL
 	metricsRecorder.SetResourceURL(goodURL)
@@ -1188,8 +1188,8 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 				health,
 				limiter,
 				goodURL,
-				cursor,
-				goodCursor,
+				currentCursor,
+				safeCursor,
 				isDegraded,
 				runSpanExecutionCount,
 			)
@@ -1198,8 +1198,8 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			}
 			state = result.state
 			waitUntil = result.waitUntil
-			cursor = result.cursor
-			goodCursor = result.goodCursor
+			currentCursor = result.currentCursor
+			safeCursor = result.safeCursor
 			isDegraded = result.degraded
 			runSpanEventCount += result.eventCount
 			switch result.outcome.kind {

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -531,12 +531,6 @@ type evaluationResponse struct {
 	shouldRetry bool
 }
 
-type publishPreparation struct {
-	cursors         []interface{}
-	hasSingleCursor bool
-	degraded        bool
-}
-
 type executionCompletion struct {
 	done                bool
 	maxExecutionLimited bool
@@ -651,7 +645,7 @@ func preparePublishState(
 	execCtx context.Context,
 	execSpan trace.Span,
 	runDegraded bool,
-) publishPreparation {
+) publishCursors {
 	// We have a non-empty batch of events to process.
 	metricsRecorder.AddReceivedBatch(execCtx, 1)
 	metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
@@ -666,11 +660,7 @@ func preparePublishState(
 	// the current cursor object below; it is an array now.
 	delete(state, "cursor")
 
-	return publishPreparation{
-		cursors:         cursorState.cursors,
-		hasSingleCursor: cursorState.hasSingleCursor,
-		degraded:        cursorState.degraded,
-	}
+	return cursorState
 }
 
 func completeExecution(

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -479,6 +479,54 @@ func publishEvents(
 	return result, nil
 }
 
+func (i input) executeEvaluation(
+	execCtx context.Context,
+	env v2.Context,
+	cfg config,
+	contextInjector *otel.ContextInjector,
+	prg cel.Program,
+	ast *cel.Ast,
+	state map[string]interface{},
+	budget int,
+	wantDump bool,
+	metricsRecorder *metricsRecorder,
+	execLog *logp.Logger,
+	execSpan trace.Span,
+	runSpan trace.Span,
+	health status.StatusReporter,
+) (map[string]interface{}, time.Time, bool, error) {
+	start := i.now().In(time.UTC)
+
+	state, err := evalWith(execCtx, contextInjector, prg, ast, state, start, wantDump, budget-1)
+	metricsRecorder.AddCELDuration(execCtx, time.Since(start))
+	execLog.Debugw("response state", logp.Namespace("cel"), "state", redactor{state: state, cfg: cfg.Redact})
+	if err != nil {
+		var dump dumpError
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
+			errorSpans(err, runSpan, end{execSpan})
+			return state, start, false, err
+		case errors.As(err, &dump):
+			path := strings.ReplaceAll(cfg.FailureDump.Filename, "*", sanitizeFileName(env.IDWithoutName))
+			dir := filepath.Dir(path)
+			base := filepath.Base(path)
+			ext := filepath.Ext(base)
+			prefix := strings.TrimSuffix(base, ext)
+			path = filepath.Join(dir, prefix+"-"+i.now().In(time.UTC).Format("2006-01-02T15-04-05.000")+ext)
+			execLog.Debugw("writing failure dump file", "path", path)
+			err := dump.writeToFile(path)
+			if err != nil {
+				execLog.Errorw("failed to write failure dump", "path", path, "error", err)
+			}
+		}
+		execLog.Errorw("failed evaluation", "error", err)
+		health.UpdateStatus(status.Degraded, "failed evaluation: "+err.Error())
+	}
+
+	return state, start, err != nil, nil
+}
+
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
 	cfg := src.cfg
 	log := env.Logger.With("input_url", cfg.Resource.URL)
@@ -689,35 +737,26 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			}
 			execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: state, cfg: cfg.Redact})
 			metricsRecorder.AddProgramExecution(execCtx)
-			start := i.now().In(time.UTC)
-
-			state, err = evalWith(execCtx, contextInjector, prg, ast, state, start, wantDump, budget-1)
-			metricsRecorder.AddCELDuration(execCtx, time.Since(start))
-			execLog.Debugw("response state", logp.Namespace("cel"), "state", redactor{state: state, cfg: cfg.Redact})
+			start := time.Time{}
+			state, start, isDegraded, err = i.executeEvaluation(
+				execCtx,
+				env,
+				cfg,
+				contextInjector,
+				prg,
+				ast,
+				state,
+				budget,
+				wantDump,
+				metricsRecorder,
+				execLog,
+				execSpan,
+				runSpan,
+				health,
+			)
 			if err != nil {
-				var dump dumpError
-				switch {
-				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-					metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-					errorSpans(err, runSpan, end{execSpan})
-					return err
-				case errors.As(err, &dump):
-					path := strings.ReplaceAll(cfg.FailureDump.Filename, "*", sanitizeFileName(env.IDWithoutName))
-					dir := filepath.Dir(path)
-					base := filepath.Base(path)
-					ext := filepath.Ext(base)
-					prefix := strings.TrimSuffix(base, ext)
-					path = filepath.Join(dir, prefix+"-"+i.now().In(time.UTC).Format("2006-01-02T15-04-05.000")+ext)
-					execLog.Debugw("writing failure dump file", "path", path)
-					err := dump.writeToFile(path)
-					if err != nil {
-						execLog.Errorw("failed to write failure dump", "path", path, "error", err)
-					}
-				}
-				execLog.Errorw("failed evaluation", "error", err)
-				health.UpdateStatus(status.Degraded, "failed evaluation: "+err.Error())
+				return err
 			}
-			isDegraded = err != nil
 			if trace != nil {
 				execLog.Debugw("final transaction", "transaction.id", trace.TxID())
 			}

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -159,6 +159,12 @@ type publishCursors struct {
 	degraded     bool
 }
 
+type publishCursorState struct {
+	pubCursor  interface{}
+	cursor     map[string]interface{}
+	goodCursor map[string]interface{}
+}
+
 func (r namedStatusReporter) UpdateStatus(status status.Status, msg string) {
 	switch {
 	case r.name != "" && msg != "":
@@ -204,6 +210,42 @@ func getPublishCursors(state map[string]interface{}, events []interface{}, log *
 	result.cursors = []interface{}{c}
 	result.singleCursor = true
 	return result
+}
+
+func getPublishCursorForEvent(index int, eventCount int, cursors []interface{}, singleCursor bool, cursor map[string]interface{}, goodCursor map[string]interface{}) (publishCursorState, error) {
+	result := publishCursorState{
+		cursor:     cursor,
+		goodCursor: goodCursor,
+	}
+	if cursors == nil {
+		return result, nil
+	}
+
+	if singleCursor {
+		// Only set the cursor for publication at the last event
+		// when a single cursor object has been provided.
+		if index != eventCount-1 {
+			return result, nil
+		}
+
+		result.goodCursor = cursor
+		nextCursor, ok := cursors[0].(map[string]interface{})
+		if !ok {
+			return result, fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
+		}
+		result.cursor = nextCursor
+		result.pubCursor = nextCursor
+		return result, nil
+	}
+
+	result.goodCursor = cursor
+	nextCursor, ok := cursors[index].(map[string]interface{})
+	if !ok {
+		return result, fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[index])
+	}
+	result.cursor = nextCursor
+	result.pubCursor = nextCursor
+	return result, nil
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -637,34 +679,15 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 					errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
 					return err
 				}
-				var pubCursor interface{}
-				if cursors != nil {
-					if singleCursor {
-						// Only set the cursor for publication at the last event
-						// when a single cursor object has been provided.
-						if i == len(events)-1 {
-							goodCursor = cursor
-							cursor, ok = cursors[0].(map[string]interface{})
-							if !ok {
-								err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
-								metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-								errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-								return err
-							}
-							pubCursor = cursor
-						}
-					} else {
-						goodCursor = cursor
-						cursor, ok = cursors[i].(map[string]interface{})
-						if !ok {
-							err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
-							metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-							errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-							return err
-						}
-						pubCursor = cursor
-					}
+				cursorState, err := getPublishCursorForEvent(i, len(events), cursors, singleCursor, cursor, goodCursor)
+				goodCursor = cursorState.goodCursor
+				if err != nil {
+					metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
+					errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+					return err
 				}
+				pubCursor := cursorState.pubCursor
+				cursor = cursorState.cursor
 				// This is checked prior to the publish attempt since the
 				// cursor.Publisher interface does not document the behaviour
 				// related to context cancellation and the context is not

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1224,27 +1224,16 @@ func logWithTracingIds(log *logp.Logger, span trace.Span) *logp.Logger {
 	)
 }
 
-// end is a tag type indicating spans in errorSpans and okSpans should be ended.
-type end struct {
-	trace.Span
-}
-
 func errorSpans(err error, spans ...trace.Span) {
 	for _, sp := range spans {
 		sp.RecordError(err)
 		sp.SetStatus(codes.Error, err.Error())
-		if e, ok := sp.(end); ok {
-			e.End()
-		}
 	}
 }
 
 func okSpans(spans ...trace.Span) {
 	for _, sp := range spans {
 		sp.SetStatus(codes.Ok, "")
-		if e, ok := sp.(end); ok {
-			e.End()
-		}
 	}
 }
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -165,6 +165,14 @@ type publishCursorState struct {
 	goodCursor map[string]interface{}
 }
 
+type publishLoopState struct {
+	cursor              map[string]interface{}
+	goodCursor          map[string]interface{}
+	degraded            bool
+	hadPublicationError bool
+	eventCount          int
+}
+
 func (r namedStatusReporter) UpdateStatus(status status.Status, msg string) {
 	switch {
 	case r.name != "" && msg != "":
@@ -290,6 +298,86 @@ func checkPublishResultContext(ctx context.Context, metricsRecorder *metricsReco
 	metricsRecorder.AddProgramRunDuration(ctx, time.Since(start))
 	errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
 	return err
+}
+
+func publishEventLoop(
+	events []interface{},
+	cursors []interface{},
+	singleCursor bool,
+	cursor map[string]interface{},
+	goodCursor map[string]interface{},
+	degraded bool,
+	pub inputcursor.Publisher,
+	pubCtx context.Context,
+	pubSpan trace.Span,
+	execSpan trace.Span,
+	runSpan trace.Span,
+	pubLog *logp.Logger,
+	health status.StatusReporter,
+	metricsRecorder *metricsRecorder,
+	start time.Time,
+) (publishLoopState, error) {
+	state := publishLoopState{
+		cursor:     cursor,
+		goodCursor: goodCursor,
+		degraded:   degraded,
+	}
+
+	for i, e := range events {
+		event, ok := e.(map[string]interface{})
+		if !ok {
+			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+			errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+			return state, err
+		}
+
+		cursorState, err := getPublishCursorForEvent(i, len(events), cursors, singleCursor, state.cursor, state.goodCursor)
+		state.goodCursor = cursorState.goodCursor
+		if err != nil {
+			metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
+			errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+			return state, err
+		}
+
+		pubCursor := cursorState.pubCursor
+		state.cursor = cursorState.cursor
+
+		// This is checked prior to the publish attempt since the
+		// cursor.Publisher interface does not document the behaviour
+		// related to context cancellation and the context is not
+		// explicitly passed in, so favour this explicit clarity.
+		breakLoop, markDegraded := checkPublishContext(pubCtx, pubLog, health, len(events)-i)
+		if markDegraded {
+			state.degraded = true
+		}
+		if breakLoop {
+			return state, nil
+		}
+
+		err = pub.Publish(beat.Event{
+			Timestamp: time.Now(),
+			Fields:    event,
+		}, pubCursor)
+		if err != nil {
+			state.hadPublicationError = true
+			handlePublishError(err, pubLog, health)
+			errorSpans(err, pubSpan)
+			state.degraded = true
+			cursors = nil // We are lost, so retry with this event's cursor,
+			continue      // but continue with the events that we have without
+			// advancing the cursor. This allows us to potentially publish the
+			// events we have now, with a fallback to the last guaranteed
+			// correctly published cursor.
+		}
+
+		state.eventCount = recordPublishedEvent(metricsRecorder, pubCtx, pubSpan, i+1, state.eventCount)
+		err = checkPublishResultContext(pubCtx, metricsRecorder, start, pubSpan, execSpan, runSpan)
+		if err != nil {
+			return state, err
+		}
+	}
+
+	return state, nil
 }
 
 func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
@@ -715,56 +803,31 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 			pubSpanEventCount := 0
 			pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
 			pubLog := logWithTracingIds(log, pubSpan)
-		loop:
-			for i, e := range events {
-				event, ok := e.(map[string]interface{})
-				if !ok {
-					err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-					errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-					return err
-				}
-				cursorState, err := getPublishCursorForEvent(i, len(events), cursors, singleCursor, cursor, goodCursor)
-				goodCursor = cursorState.goodCursor
-				if err != nil {
-					metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-					errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-					return err
-				}
-				pubCursor := cursorState.pubCursor
-				cursor = cursorState.cursor
-				// This is checked prior to the publish attempt since the
-				// cursor.Publisher interface does not document the behaviour
-				// related to context cancellation and the context is not
-				// explicitly passed in, so favour this explicit clarity.
-				breakLoop, markDegraded := checkPublishContext(pubCtx, pubLog, health, len(events)-i)
-				if markDegraded {
-					isDegraded = true
-				}
-				if breakLoop {
-					break loop
-				}
-				err = pub.Publish(beat.Event{
-					Timestamp: time.Now(),
-					Fields:    event,
-				}, pubCursor)
-				if err != nil {
-					hadPublicationError = true
-					handlePublishError(err, pubLog, health)
-					errorSpans(err, pubSpan)
-					isDegraded = true
-					cursors = nil // We are lost, so retry with this event's cursor,
-					continue      // but continue with the events that we have without
-					// advancing the cursor. This allows us to potentially publish the
-					// events we have now, with a fallback to the last guaranteed
-					// correctly published cursor.
-				}
-				pubSpanEventCount = recordPublishedEvent(metricsRecorder, pubCtx, pubSpan, i+1, pubSpanEventCount)
-
-				err = checkPublishResultContext(pubCtx, metricsRecorder, start, pubSpan, execSpan, runSpan)
-				if err != nil {
-					return err
-				}
+			publishState, err := publishEventLoop(
+				events,
+				cursors,
+				singleCursor,
+				cursor,
+				goodCursor,
+				isDegraded,
+				pub,
+				pubCtx,
+				pubSpan,
+				execSpan,
+				runSpan,
+				pubLog,
+				health,
+				metricsRecorder,
+				start,
+			)
+			if err != nil {
+				return err
 			}
+			cursor = publishState.cursor
+			goodCursor = publishState.goodCursor
+			isDegraded = publishState.degraded
+			hadPublicationError = publishState.hadPublicationError
+			pubSpanEventCount = publishState.eventCount
 
 			if !isDegraded {
 				health.UpdateStatus(status.Running, "")


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/input/cel: General refactoring

TBD
```

## Draft PR status

Working with AI on this refactoring, I initially made bigger changes but found it was introducing regressions. I tried again with smaller changes.

Now it's part-way through and I'd like feedback from the team on how it's going.

Here are some metrics covering the full history of `input.go` up to 76d7904cce:

<img width="1800" height="1250" alt="metrics" src="https://github.com/user-attachments/assets/7f365cc7-d6da-4049-b940-ab664d821bce" />

Here's what the AI had to say about where we started, what's be achieved and what's left to do:

> On `main`, `(*input).run` is carrying too many responsibilities in one place. It sets up state, drives the periodic loop, waits on rate limits, executes the CEL program, interprets the returned state, handles cursor semantics, publishes events, updates health, and records tracing and metrics. The logic is well documented, but the function is still hard to reason about because all of those concerns are interleaved. That makes the control flow difficult to scan and increases the cost of reviewing or modifying any one part of the behavior.
> 
> So far, this branch has focused on shrinking `(*input).run` by extracting large parts of its inline logic into helpers. The main areas moved out are the periodic execution loop, the work for a single evaluation step, and the event publishing path. That is a real structural improvement over `main`, because `run` is no longer carrying every concern directly. At the same time, the current branch is still an intermediate state rather than the intended end state: the code has become split across a fairly large number of small helpers and state/result structs, which makes the top-level function easier to scan but can make the end-to-end behavior harder to follow.
> 
> What remains is to turn that extraction into a clearer phase-based design. The plan is to consolidate the current helper graph into a smaller number of stronger abstractions: one helper for a periodic cycle, one for a single CEL execution step and response interpretation, and one for publishing a batch and advancing cursors. Along the way, shared mutable state should be given one clear owner, the large contract comments should move next to the helpers that implement those rules, and the refactor should be done in small commits that are easy to review for behavioral equivalence. The goal is not just a shorter `run`, but a version of `input.go` that is materially easier to understand and maintain than both `main` and the current branch.

<details>
<summary>Expand for a detailed plan of what's next</summary>

---

# Refactor plan for `input.go`

## Goal

Produce a version of `input.go` that is clearly better than both:

- `main`, where `(*input).run` contains too many concerns inline.
- The current branch, where the logic is split into too many small helpers
  and state/result structs, making the overall flow harder to follow.

The target is a refactor that improves readability and maintainability
without changing behavior. Every step should be small enough for reviewers to
diff carefully and reason about without depending on test coverage.

## Design target

Refactor around the actual phases of the algorithm rather than around
micro-operations.

The target structure is:

1. `run` orchestrates lifecycle only.
2. One helper owns a single periodic cycle.
3. One helper owns one CEL execution step.
4. One helper owns publication of one evaluated batch.
5. Shared mutable state is kept in one coherent session/run-state object.

This should make the happy path readable top-to-bottom with minimal jumping
between helpers.

## Problems in `main`

- `run` mixes setup, periodic scheduling, rate-limit waiting, evaluation,
  response interpretation, event normalization, cursor semantics,
  publication, status updates, metrics, tracing, and budget control.
- The function is long enough that readers must keep too much state in
  memory at once.
- Important concepts are documented, but the implementation is still hard to
  scan because all concerns are interleaved.

## Problems in the current branch

- `run` is shorter, but complexity has mostly been moved sideways.
- The logic is fragmented across many micro-helpers.
- Several small state/result structs force the reader to reconstruct control
  flow across many call sites.
- Publish flow is especially split up into helpers that are individually
  simple but collectively harder to reason about than one cohesive function.
- Tracing and metrics still shape the code heavily, so the domain flow is not
  yet as clear as it should be.

## Desired end state

The end state should look conceptually like this:

```go
func (i input) run(...) error {
    session := newRunSession(...)
    return periodically(ctx, cfg.Interval, func() error {
        return session.runPeriodicCycle(ctx)
    })
}
```

Then the main work is split by phase:

```go
func (s *runSession) runPeriodicCycle(ctx context.Context) error
func (s *runSession) executeStep(ctx context.Context, budget int) (stepResult, error)
func (s *runSession) publishBatch(ctx context.Context, batch evaluatedBatch) (publishResult, error)
```

The exact names may differ, but the structure should follow this shape.

## Structural principles

### 1. Use phase-level helpers, not micro-helpers

Helpers should capture a complete idea:

- waiting for rate limits
- executing and interpreting one CEL evaluation
- publishing one batch and updating cursors
- running one periodic cycle

Avoid helpers that only hide a few lines unless they remove meaningful
conceptual duplication.

### 2. Minimize state fragmentation

Consolidate long-lived mutable state into one main struct for the run/session.

Likely fields:

- `state map[string]interface{}`
- `currentCursor map[string]interface{}`
- `safeCursor map[string]interface{}`
- `goodURL string`
- logger, tracer, metrics, publisher, health reporter

Keep phase results narrow and purpose-built rather than carrying many flags
plus shared mutation.

### 3. Make control flow explicit

Use a small step result contract rather than ad hoc combinations of:

- returned error
- mutated state
- booleans like `done`, `degraded`, `shouldRetry`
- separate outcome structs

Prefer one result type for the periodic loop to consume.

Example shape:

```go
type stepAction uint8

const (
    stepContinue stepAction = iota
    stepRetry
    stepStop
)

type stepResult struct {
    action     stepAction
    eventCount int
    degraded   bool
    waitUntil  time.Time
}
```

This keeps the outer loop readable and keeps branching decisions obvious.

### 4. Keep algorithm comments with the owning helper

The large contract comments in `main` are valuable. Preserve them, but move
them so they sit next to the helper that owns the relevant behavior:

- evaluation result shape comment near the evaluation/interpretation helper
- cursor array semantics comment near the publish helper

### 5. Make telemetry support the flow, not define it

Metrics and tracing must remain correct, but they should not be the primary
thing a reader sees. Phase boundaries should own their own telemetry and keep
it close to the success/failure transitions they describe.

## Concrete refactor plan

### Phase 1: Stabilize the target boundaries

Objective:

- Decide the final helper boundaries before further code movement.

Actions:

- Treat these as the only target high-level helpers:
  - `runPeriodicCycle`
  - `executeStep`
  - `publishBatch`
  - `waitForRateLimit` or equivalent
- Stop adding new micro-helpers unless they are clearly justified.
- Document these boundaries in code comments or commit messages before major
  consolidation begins.

Regression review focus:

- No behavior changes.
- No changed ordering of status, metric, or cursor updates yet.

### Phase 2: Consolidate publish flow into one cohesive helper

Objective:

- Replace the current publish micro-helper cluster with one publish-phase
  helper that can be read top-to-bottom.

Current pieces to consider folding together:

- `getPublishCursors`
- `getPublishCursorForEvent`
- `checkPublishContext`
- `handlePublishError`
- `recordPublishedEvent`
- `checkPublishResultContext`
- `publishEventLoop`
- `publishEvents`
- `publishResponseEvents`

Target:

- One main helper for publish behavior.
- At most one small helper for cursor normalization if it remains genuinely
  useful and improves clarity.

Constraints:

- Preserve cursor semantics exactly.
- Preserve publication retry/fallback behavior exactly.
- Preserve when status becomes degraded vs running.
- Preserve metrics/tracing ordering unless a dedicated follow-up commit is
  explicitly about observability cleanup.

Regression review focus:

- Cursor advancement rules for single cursor vs cursor array.
- Fallback to safe cursor after partial publication failure.
- Context cancellation behavior before and after `pub.Publish`.
- Event count, published batch, and published events metrics.

### Phase 3: Consolidate evaluation and response interpretation

Objective:

- Make one helper own "run CEL once, interpret response, decide next action".

Current pieces to consider folding together:

- `executeEvaluation`
- `normalizeEvaluationEvents`
- `processEvaluationResponse`
- `interpretEvaluationResponse`
- `finishExecution`

Target:

- One phase-level evaluation helper plus at most one narrowly-scoped helper
  for response parsing if it still reads better that way.

Constraints:

- Preserve failure-dump behavior.
- Preserve `handleResponse` semantics exactly.
- Preserve URL restoration behavior.
- Preserve single-event-object degraded handling.
- Preserve `want_more` and execution-budget behavior.

Regression review focus:

- Missing `events` handling.
- Empty or `nil` events behavior.
- Error object behavior and cursor deletion.
- HTTP error handling via synthetic event generation.
- Rate-limit wait and retry behavior.
- Maximum execution limit behavior and status reporting.

### Phase 4: Introduce one coherent session/run-state object

Objective:

- Reduce the number of state/result structs and make ownership clearer.

Actions:

- Replace `periodicRunState` with a clearer session-style struct that owns
  long-lived mutable state across a periodic run.
- Eliminate helper-specific state/result structs where they no longer add
  clarity after consolidation.
- Keep result structs only where they model a phase outcome clearly.

Likely outcome:

- One main run/session state struct.
- One small periodic-step result type.
- Possibly one publish result type if it remains necessary.

Regression review focus:

- All mutable fields still update in the same order and under the same
  conditions.
- No accidental state sharing or reuse between periodic cycles.

### Phase 5: Extract the periodic cycle cleanly

Objective:

- Reduce `run` to lifecycle and setup orchestration.

Actions:

- Move the body of the `periodically` callback into a named helper such as
  `runPeriodicCycle`.
- Ensure `run` does only:
  - setup
  - program/session initialization
  - periodic scheduling
  - final cancellation handling

Target readability:

- A reader should understand the shape of the lifecycle from `run` alone.

Regression review focus:

- No changes to interval timing semantics.
- No changes to cancellation handling.
- No changes to periodic metrics span setup/teardown ordering.

### Phase 6: Align comments and naming with the final structure

Objective:

- Make the final code self-explanatory without changing behavior.

Actions:

- Move contract comments to the helpers that own those contracts.
- Rename fields and helpers only after structure stabilizes.
- Use names that reflect domain meaning, not implementation history.

Possible renames to evaluate:

- `currentCursor` vs `safeCursor`
- `goodURL`
- `executeOnce` -> `executeStep`
- `publishResponseEvents` -> `publishBatch`

Constraints:

- Do not mix naming cleanup with major logic movement in the same commit.

Regression review focus:

- Naming-only commit should be semantics-free.

## Proposed commit sequence

This sequence is designed for small, reviewable changes.

### Commit 1: document target helper boundaries

Purpose:

- Establish the refactor direction and reduce churn during implementation.

Expected change:

- Minimal code movement, possibly comments only.

### Commit 2: fold publish helpers into one publish-phase helper

Purpose:

- Make the publish flow readable as one unit.

Expected change:

- Mostly mechanical consolidation of current publish helpers.

### Commit 3: fold evaluation/response helpers into one evaluation-phase helper

Purpose:

- Make one execution step readable as one unit.

Expected change:

- Consolidation of current response and finish helpers.

### Commit 4: introduce session/run-state object

Purpose:

- Reduce scattered mutable state and helper-specific structs.

Expected change:

- Replace fragmented state carriers with one coherent owner.

### Commit 5: extract periodic cycle from `run`

Purpose:

- Make `run` a clear lifecycle orchestrator.

Expected change:

- Move callback body into a named helper with equivalent behavior.

### Commit 6: comment relocation and naming cleanup

Purpose:

- Make the final structure easier to read and review.

Expected change:

- Semantics-free cleanup only.

## Review checklist for each commit

For every commit, review against `main` or the previous commit with these
questions:

- Are cursor updates still identical on all success and failure paths?
- Are degraded/running status updates still triggered at the same points?
- Are retry and wait-until behaviors preserved exactly?
- Are metrics still recorded on the same paths and in the same order?
- Are spans still created, marked, and ended on the same paths?
- Is cancellation still handled the same way before and after publication?
- Did any helper change a contract, or only move code?

If the answer to any of these is unclear, split the change further.

## Heuristics for "significantly better"

The refactor should be considered successful only if all of the following are
true:

- `run` is short and only describes lifecycle.
- A reader can follow one periodic cycle without jumping through many tiny
  helpers.
- Publish behavior is readable in one place.
- Evaluation behavior is readable in one place.
- Long-lived mutable state has one obvious owner.
- Telemetry concerns are present but no longer obscure the core algorithm.
- A reviewer can compare each commit mechanically and reason about behavior
  preservation without leaning on tests.

## What to avoid

- More tiny helpers.
- More temporary result structs unless they reduce ambiguity.
- Mixing logic movement with naming cleanup.
- Mixing telemetry redesign with structural refactoring unless isolated in its
  own commit.
- Reordering control flow just to make the diff look cleaner.
- Broad rewrites that prevent reviewers from validating cursor and retry
  semantics.

## Practical implementation note

The safest path is not to keep extracting from the current branch. The safer
path is to use the current branch as a staging point and then consolidate it
into fewer, stronger abstractions. The best final result will likely contain
fewer helpers and fewer structs than the current branch, while still being
more modular than `main`.

---

</details>

Do you agree, or have other advice about what you'd like to see?

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

Should have no functional changes.

## Related issues

- Closes #48464
