### PR TITLE
docs: fix `occured` and `colon-seperated` typos in exported field descriptions

### DIFF
--- a/docs/reference/filebeat/exported-fields-cef.md
+++ b/docs/reference/filebeat/exported-fields-cef.md
@@ -221,7 +221,7 @@ Collection of key-value pairs carried in the CEF extension field.
 
 
 **`cef.extensions.destinationMacAddress`**
-:   Six colon-seperated hexadecimal numbers.
+:   Six colon-separated hexadecimal numbers.
 
     type: keyword
 

--- a/docs/reference/metricbeat/exported-fields-oracle.md
+++ b/docs/reference/metricbeat/exported-fields-oracle.md
@@ -128,7 +128,7 @@ Opened cursors statistic
 
 ## parse [_parse]
 
-Parses statistic information that occured in the current session
+Parses statistic information that occurred in the current session
 
 **`oracle.performance.cursors.parse.real`**
 :   Real number of parses that occurred: session cursor cache hits - parse count (total)

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -3935,7 +3935,7 @@ type: keyword
 *`cef.extensions.destinationMacAddress`*::
 +
 --
-Six colon-seperated hexadecimal numbers.
+Six colon-separated hexadecimal numbers.
 
 type: keyword
 

--- a/x-pack/filebeat/processors/decode_cef/_meta/fields.yml
+++ b/x-pack/filebeat/processors/decode_cef/_meta/fields.yml
@@ -159,7 +159,7 @@
 
             - name: destinationMacAddress
               type: keyword
-              description: Six colon-seperated hexadecimal numbers.
+              description: Six colon-separated hexadecimal numbers.
 
             - name: destinationNtDomain
               type: keyword

--- a/x-pack/metricbeat/module/oracle/performance/_meta/fields.yml
+++ b/x-pack/metricbeat/module/oracle/performance/_meta/fields.yml
@@ -66,7 +66,7 @@
               description: Total number of cursors opened since the instance started
         - name: parse
           type: group
-          description: Parses statistic information that occured in the current session
+          description: Parses statistic information that occurred in the current session
           fields:
             - name: real
               type: long


### PR DESCRIPTION
<!-- Type of change -->
## What does this PR do?

Fixes two small spelling typos in exported-field descriptions flagged by #49847:

1. `occured` → `occurred` in the Oracle performance Metricbeat field description
   - `x-pack/metricbeat/module/oracle/performance/_meta/fields.yml` (source)
   - `docs/reference/metricbeat/exported-fields-oracle.md` (generated reference doc)

2. `colon-seperated` → `colon-separated` in the CEF `decode_cef` processor field description
   - `x-pack/filebeat/processors/decode_cef/_meta/fields.yml` (source)
   - `docs/reference/filebeat/exported-fields-cef.md` (generated reference doc)
   - `filebeat/docs/fields.asciidoc` (generated/exported fields doc)

User-facing text only; no behaviour change.

## Why is it important?

Both strings surface to users via field descriptions in generated docs and in exported field metadata. Fixing keeps the docs consistent with what's described in the audit issue.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — doc typo)
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc` (N/A — user-facing text-only typo)

## Related issues

- Closes part of #49847