### PR TITLE
x-pack/filebeat/input/cel: Fix OTel metric namespace conflicts

### DIFF
--- a/changelog/fragments/1776242921-fix-cel-otel-metric-namespace-conflict.yaml
+++ b/changelog/fragments/1776242921-fix-cel-otel-metric-namespace-conflict.yaml
@@ -1,0 +1,50 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix conflicting CEL periodic OTel metric field names.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  Rename the CEL periodic run counter from input.cel.periodic.run to
+  input.cel.periodic.run.count so the run namespace stays consistent
+  alongside input.cel.periodic.run.duration in Elasticsearch mappings.
+  Also correct related metric documentation and instrument creation
+  error messages.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/50135
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/49180

--- a/x-pack/filebeat/input/cel/cel_metrics.go
+++ b/x-pack/filebeat/input/cel/cel_metrics.go
@@ -253,11 +253,11 @@ func newOTELCELMetrics(log *logp.Logger,
 
 	meter := meterProvider.Meter("github.com/elastic/beats/x-pack/filebeat/otel/cel_metrics.go")
 
-	periodicRunCount, err := meter.Int64Counter("input.cel.periodic.run",
+	periodicRunCount, err := meter.Int64Counter("input.cel.periodic.run.count",
 		metric.WithDescription("Number of times a periodic run was started."),
 		metric.WithUnit("{run}"))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.run: %w", err)
+		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.run.count: %w", err)
 	}
 	programRunStartedCount, err := meter.Int64Counter("input.cel.periodic.program.run.started",
 		metric.WithDescription("Number of times a CEL program was started in a periodic run."),

--- a/x-pack/filebeat/input/cel/cel_metrics.go
+++ b/x-pack/filebeat/input/cel/cel_metrics.go
@@ -263,13 +263,13 @@ func newOTELCELMetrics(log *logp.Logger,
 		metric.WithDescription("Number of times a CEL program was started in a periodic run."),
 		metric.WithUnit("{run}"))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create input.cel.program.run.started: %w", err)
+		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.program.run.started: %w", err)
 	}
 	programRunSuccessCount, err := meter.Int64Counter("input.cel.periodic.program.run.success",
 		metric.WithDescription("Number of times a CEL program terminated without an error in a periodic run."),
 		metric.WithUnit("{run}"))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create input.cel.program.success: %w", err)
+		return nil, nil, fmt.Errorf("failed to create input.cel.periodic.program.run.success: %w", err)
 	}
 	periodicBatchCount, err := meter.Int64Counter("input.cel.periodic.batch.received",
 		metric.WithDescription("Number of event batches generated in a periodic run."),

--- a/x-pack/filebeat/input/cel/cel_metrics_collection.mermaid
+++ b/x-pack/filebeat/input/cel/cel_metrics_collection.mermaid
@@ -13,7 +13,7 @@ subgraph PERIODIC["Periodic Loop"]
            CEL["Run CEL<br/>Process Batches<br/>Generate Events"]
            PublishEvents["Publish Events"]
            ErrorCheck{"Error or Done?"}
-           RunStartMetric["Records: <br/>input.cel.periodic.run"]
+           RunStartMetric["Records: <br/>input.cel.periodic.run.count"]
            ProgramStartMetric["Records: <br/>input.cel.periodic.program.run.started"]
            HTTPMetrics["Records from HTTP Client Transport: <br/>http.client.request.duration <br/>http.client.request.body.size"]
            CELMetrics["Records: <br/>input.cel.periodic.cel.duration <br/>input.cel.program.run.duration<br/> input.cel.periodic.batch.received<br/> input.cel.program.batch.received<br/> input.cel.periodic.event.received<br/>  input.cel.program.event.received"]
@@ -48,4 +48,3 @@ subgraph PERIODIC["Periodic Loop"]
     style PublishMetrics fill:#009E73,stroke:#4a3728,color:#fff
     style EndLoopMetrics fill:#009E73,stroke:#4a3728,color:#fff
     style HTTPMetrics fill:#3d6a8f,stroke:#1e3a5f,color:#fff
-

--- a/x-pack/filebeat/input/cel/cel_metrics_test.go
+++ b/x-pack/filebeat/input/cel/cel_metrics_test.go
@@ -130,7 +130,7 @@ func TestOTELCELMetrics(t *testing.T) {
 
 	// Check for presence of expected OTEL metrics
 	expectedMetricNames := []string{
-		"input.cel.periodic.run",
+		"input.cel.periodic.run.count",
 		"input.cel.periodic.program.run.started",
 		"input.cel.periodic.program.run.success",
 		"input.cel.periodic.batch.received",

--- a/x-pack/filebeat/input/cel/doc.go
+++ b/x-pack/filebeat/input/cel/doc.go
@@ -63,7 +63,7 @@ CEL Metrics exported for each periodic run:
 
 		Name                                        Description                                                                              Metric Type
 
-		input.cel.periodic.run                      the number of times a periodic run was started.                                          Int64Counter
+		input.cel.periodic.run.count                the number of times a periodic run was started.                                          Int64Counter
 		input.cel.periodic.program.run.started      the number of times a program was started in a periodic run.                             Int64Counter
 		input.cel.periodic.program.run.success      the number of times a program terminated without an error in a periodic run.             Int64Counter
 		input.cel.periodic.batch.received           the number of the number of batches generated in a periodic run.                         Int64Counter

--- a/x-pack/filebeat/input/cel/doc.go
+++ b/x-pack/filebeat/input/cel/doc.go
@@ -71,8 +71,8 @@ CEL Metrics exported for each periodic run:
 		input.cel.periodic.event.received           the number of the number of events generated in a periodic run.                          Int64Counter
 		input.cel.periodic.event.published          the number of the number of events published in a periodic run.                          Int64Counter
 		input.cel.periodic.run.duration             the total duration of time in seconds spent in a periodic run.                           Float64Counter
-		input.cel.periodic.cel.duration             the total duration of time in seconds spent processing CEL programs in a periodic run.   Float64Histogram
-		input.cel.periodic.event.publish.duration   the total duration of time in seconds publishing events in a periodic run.               Float64Histogram
+		input.cel.periodic.cel.duration             the total duration of time in seconds spent processing CEL programs in a periodic run.   Float64Counter
+		input.cel.periodic.event.publish.duration   the total duration of time in seconds publishing events in a periodic run.               Float64Counter
 		input.cel.program.batch.received            the number of batches the program has generated.                                         Int64Histogram
 	    input.cel.program.event.received            the number of events the program has generated.                                          Int64Histogram
 	    input.cel.program.batch.published           the number of batches the program has published.                                         Int64Histogram


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/input/cel: Fix OTel metric namespace conflicts

Fixes an OpenTelemetry metric naming conflict in the CEL input and
cleans up related documentation and error reporting.

The CEL input exported `input.cel.periodic.run` as a counter while also
exporting `input.cel.periodic.run.duration`, which made `run` both a
numeric leaf field and an object namespace, causing a mapping conflict.

This change renames the counter to `input.cel.periodic.run.count` so
`run` remains a consistent object namespace.

There are two unrelated minor fixes:

- Corrects two documented metric types in `doc.go`.
- Fixes the instrument creation error strings for the periodic program
  run started and success counters.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

There is a change in exported metric names, but since this is very new functionality that's off by default the impact should be very limited. Also it removes an existing conflict, so there should be no reason not to adopt the change.

## Related issues

- Closes #49180