### PR TITLE
Pass configured intake queue id through to otelOutputController

### DIFF
--- a/libbeat/publisher/pipeline/output_otel.go
+++ b/libbeat/publisher/pipeline/output_otel.go
@@ -51,7 +51,13 @@ func newOTelOutputController(
 	monitors Monitors,
 	retryObserver retryObserver,
 	queueFactory queue.QueueFactory[publisher.Event],
+	intakeQueueID string,
 ) (*otelOutputController, error) {
+	if intakeQueueID != "" {
+		monitors.Logger.Debugf("newOTelOutputController: intake queue ID %v (inactive)", intakeQueueID)
+	} else {
+		monitors.Logger.Debugf("newOtelOutputController: no intake queue ID specified")
+	}
 
 	// Queue metrics are reported under the pipeline namespace
 	var pipelineMetrics *monitoring.Registry

--- a/libbeat/publisher/pipeline/output_otel_test.go
+++ b/libbeat/publisher/pipeline/output_otel_test.go
@@ -44,7 +44,8 @@ func TestOTelQueueMetrics(t *testing.T) {
 			Metrics: reg,
 		},
 		nilObserver,
-		memqueue.FactoryForSettings[publisher.Event](memqueue.Settings{Events: 1000}))
+		memqueue.FactoryForSettings[publisher.Event](memqueue.Settings{Events: 1000}),
+		"")
 	require.NoError(t, err, "creating OTel output controller should succeed")
 	defer controller.waitClose(context.Background(), true)
 	entry := reg.Get("pipeline.queue.max_events")

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -199,6 +199,7 @@ func NewForReceiver(
 	monitors Monitors,
 	userQueueConfig conf.Namespace,
 	settings Settings,
+	intakeQueueID string,
 ) (*Pipeline, error) {
 	p := &Pipeline{
 		beatInfo:         beatInfo,
@@ -221,7 +222,7 @@ func NewForReceiver(
 		return nil, err
 	}
 
-	p.outputController, err = newOTelOutputController(beatInfo, monitors, p.observer, queueFactory)
+	p.outputController, err = newOTelOutputController(beatInfo, monitors, p.observer, queueFactory, intakeQueueID)
 	if err != nil {
 		return nil, err
 	}

--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -86,14 +86,8 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 	// extracting it here for ease of use
 	logger := b.Info.Logger
 
-	// if output is set and if output is not otelconsumer, inform users
-	if receiverConfig["output"] != nil && receiverConfig["output"].(map[string]any)["otelconsumer"] == nil { //nolint: errcheck // output will always be of map type
-		logger.Debugf("configured output does not work with beatreceiver, please use appropriate exporter instead")
-	}
-
-	// all beatreceivers will use otelconsumer output by default
-	receiverConfig["output"] = map[string]any{
-		"otelconsumer": map[string]any{},
+	if receiverConfig["output"] != nil {
+		logger.Warnf("Output configuration is not supported by Beats receivers. Configure output behavior via exporter settings.")
 	}
 
 	tmp, err := ucfg.NewFrom(receiverConfig, cfOpts...)

--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -269,6 +269,15 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 		Tracer:    b.Instrumentation.Tracer(),
 	}
 
+	var intakeQueueID string
+	if queueID, ok := receiverConfig["shared_intake_queue"]; ok {
+		if queueStrID, ok := queueID.(string); ok {
+			intakeQueueID = queueStrID
+		} else {
+			return nil, fmt.Errorf("shared_intake_queue must be a string")
+		}
+	}
+
 	pipelineSettings := pipeline.Settings{
 		Processors:     b.GetProcessors(),
 		InputQueueSize: b.InputQueueSize,
@@ -276,7 +285,7 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 		WaitClose:      receiverPublisherCloseTimeout,
 		Paths:          b.Paths,
 	}
-	publisher, err := pipeline.NewForReceiver(b.Info, monitors, b.Config.Pipeline.Queue, pipelineSettings)
+	publisher, err := pipeline.NewForReceiver(b.Info, monitors, b.Config.Pipeline.Queue, pipelineSettings, intakeQueueID)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing publisher: %w", err)
 	}


### PR DESCRIPTION
In Beats receiver initialization, read the `shared_intake_queue` config parameter and pass it through to `pipeline.NewForReceiver` and `newOTelOutputController`, to prepare for shared queues in `otelOutputController`.

Closes https://github.com/elastic/beats/issues/50100.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
