### PR TITLE
[DNM] perf: defer mapstr.M allocation in EncoderReader until fields are needed

### DIFF
--- a/changelog/fragments/1776000000-perf-lazy-fields-init.yaml
+++ b/changelog/fragments/1776000000-perf-lazy-fields-init.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+
+summary: "perf: defer mapstr.M allocation in EncoderReader until fields are actually needed, reducing allocations per line"
+
+component: filebeat

--- a/libbeat/reader/readfile/encode.go
+++ b/libbeat/reader/readfile/encode.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/reader"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile/encoding"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 // Reader produces lines by reading lines from an io.Reader
@@ -69,7 +68,6 @@ func (r EncoderReader) Next() (reader.Message, error) {
 		Ts:      time.Now(),
 		Content: bytes.TrimPrefix(c, []byte("\uFEFF")),
 		Bytes:   sz,
-		Fields:  mapstr.M{},
 	}, err
 }
 

--- a/libbeat/reader/readfile/metafields.go
+++ b/libbeat/reader/readfile/metafields.go
@@ -54,6 +54,9 @@ func (r *FileMetaReader) Next() (reader.Message, error) {
 		return message, err
 	}
 
+	if message.Fields == nil {
+		message.Fields = mapstr.M{}
+	}
 	message.Fields.DeepUpdate(mapstr.M{
 		"log": mapstr.M{
 			"offset": r.offset,


### PR DESCRIPTION
## Summary

- `EncoderReader.Next()` was pre-allocating an empty `mapstr.M{}` on every line read, even for empty/skipped lines that never use the field map
- Moved allocation to `FileMetaReader`, the first reader in the chain that actually writes to `Fields`, and only when the message is non-empty (already gated by the existing `IsEmpty()` check)
- Change is 5 lines: remove 2 in `encode.go`, add 3 in `metafields.go`

## Benchmark results

`BenchmarkEncoderReader`, Apple M2 Pro, 6 runs × 100 lines:

```
                             │    before    │            after            │
                             │   allocs/op  │  allocs/op    vs base       │
EncoderReader/buffer-sized   │   320 ± 0%   │   219 ± 0%   -31.6% (p=0.002)
EncoderReader/short_lines    │   222 ± 0%   │   121 ± 0%   -45.5% (p=0.002)
EncoderReader/long_lines     │   773 ± 0%   │   672 ± 0%   -13.1% (p=0.002)
geomean                      │   389.7      │   293.9      -24.6%

                             │    B/op      │    B/op       vs base       │
EncoderReader/buffer-sized   │  228 Ki ± 0% │  223 Ki ± 0%  -2.1% (p=0.002)
EncoderReader/short_lines    │  9.4 Ki ± 0% │  4.7 Ki ± 0% -50.3% (p=0.002)
EncoderReader/long_lines     │  4.86 Mi ± 0%│  4.85 Mi ± 0% -0.1% (p=0.002)
geomean                      │  218.7 Ki    │  182.6 Ki    -16.5%

                             │   sec/op     │   sec/op      vs base       │
EncoderReader/short_lines    │  11.4µ ± 4%  │  8.6µ ± 7%   -24.2% (p=0.002)
EncoderReader/buffer-sized   │  63.6µ ± 5%  │  63.6µ ± 10%     ~ (p=1.000)
EncoderReader/long_lines     │  978µ ± 7%   │  908µ ± 24%      ~ (p=0.132)
geomean                      │  93.1µ       │  85.4µ        -8.3%
```

The per-line saving is exactly one `mapstr.M` allocation (~48 B). For short log lines — typical syslog/application logs — this is proportionally large, hence the 24% latency improvement.

## Why this is safe

`message.Fields` being `nil` is already handled gracefully throughout the reader chain:
- `message.IsEmpty()` is safe with nil `Fields` (only checks `len(m.Fields)`)
- `mapstr.M.GetValue` on a nil map returns `(nil, error)` — same as an empty map
- `FileMetaReader` is the first point in the chain that writes to `Fields` for non-empty messages; the nil guard there is the correct initialization site

## Test plan
- [x] All `TestEncodeLines` cases pass (including `bom-on-each-rune` — BOM stripping behavior unchanged)
- [x] All `TestMetaFields` cases pass
- [x] `filebeat/input/filestream/...` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)