### PR TITLE
Fix filebeat build after Paths moved to beat.Info

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -495,7 +495,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 			config.Autodiscover,
 			b.Keystore,
 			fb.logger,
-			b.Paths,
+			b.Info.Paths,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Proposed commit message

Commit 184a91bf68 moved Paths from beat.Beat to beat.Info but missed updating the autodiscover call in filebeat's Run method, breaking the build.