### PR TITLE
metricbeat/module/mongodb: skip integration tests in FIPS mode

### DIFF
--- a/metricbeat/module/mongodb/collstats/collstats_integration_test.go
+++ b/metricbeat/module/mongodb/collstats/collstats_integration_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build integration
+//go:build integration && !requirefips
 
 package collstats
 

--- a/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build integration
+//go:build integration && !requirefips
 
 package dbstats
 

--- a/metricbeat/module/mongodb/metrics/metrics_intergration_test.go
+++ b/metricbeat/module/mongodb/metrics/metrics_intergration_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build integration
+//go:build integration && !requirefips
 
 package metrics
 

--- a/metricbeat/module/mongodb/replstatus/replstatus_integration_test.go
+++ b/metricbeat/module/mongodb/replstatus/replstatus_integration_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build integration
+//go:build integration && !requirefips
 
 package replstatus
 

--- a/metricbeat/module/mongodb/status/status_integration_test.go
+++ b/metricbeat/module/mongodb/status/status_integration_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build integration
+//go:build integration && !requirefips
 
 package status
 


### PR DESCRIPTION
## Proposed commit message

`metricbeat/module/mongodb`: skip integration tests in FIPS mode

The mongodb module is disabled in FIPS mode (#43536) — every source file
under `metricbeat/module/mongodb` carries a `//go:build !requirefips`
constraint, so the metricsets are not registered and `mongodb.NewClient`
is not defined when building with `requirefips`.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
-
## Disruptive User Impact

None. The change only affects which test files are compiled during
`mage goFIPSOnlyIntegTest`. mongodb is already disabled in FIPS mode for
end users; this PR simply makes the FIPS integration test runner agree
with that fact instead of failing to compile/run the tests.

## How to test this PR locally

From `metricbeat/`:

```bash
# Before the fix this fails to compile:
#   vet: module/mongodb/replstatus/replstatus_integration_test.go:109:25: undefined: mongodb.NewClient
go vet -tags="integration requirefips" ./module/mongodb/...

# After the fix the FIPS-only integration runner sees no test files
# in any mongodb package and exits cleanly:
go test -tags="integration requirefips" -run NONE -count=1 ./module/mongodb/...
#  ?  github.com/elastic/beats/v7/metricbeat/module/mongodb              [no test files]
#  ?  github.com/elastic/beats/v7/metricbeat/module/mongodb/collstats    [no test files]
#  ?  github.com/elastic/beats/v7/metricbeat/module/mongodb/dbstats      [no test files]
#  ?  github.com/elastic/beats/v7/metricbeat/module/mongodb/metrics      [no test files]
#  ?  github.com/elastic/beats/v7/metricbeat/module/mongodb/replstatus   [no test files]
#  ?  github.com/elastic/beats/v7/metricbeat/module/mongodb/status       [no test files]

# Non-FIPS integration mode is unchanged — all five integration tests
# are still selected:
go list -tags="integration" -f '{{.ImportPath}}: TestGoFiles={{.TestGoFiles}}' ./module/mongodb/...
```

End-to-end:

```bash
cd metricbeat
mage goFIPSOnlyIntegTest   # mongodb module no longer fails
```

## Use cases

CI-only: keeps `metricbeat: Go fips140=only Integration Tests (Module)`
green so unrelated PRs (e.g. #50176 / #50180) are not blocked by a
latent build-tag bug in the mongodb integration tests.