### PR TITLE
security: bump aws-sdk-go-v2 cloudwatchlogs to fix GHSA-xmrv-pmrh-hhx2

### DIFF
--- a/changelog/fragments/1776709378-bump-aws-sdk-go-v2-cloudwatchlogs-s3-ghsa-xmrv-pmrh-hhx2.yaml
+++ b/changelog/fragments/1776709378-bump-aws-sdk-go-v2-cloudwatchlogs-s3-ghsa-xmrv-pmrh-hhx2.yaml
@@ -1,0 +1,7 @@
+kind: security
+
+summary: Bump aws-sdk-go-v2 cloudwatchlogs to v1.65.0 and s3 to v1.97.3 to fix GHSA-xmrv-pmrh-hhx2
+
+component: all
+
+pr: https://github.com/elastic/beats/pull/50215

--- a/changelog/fragments/1776709378-bump-aws-sdk-go-v2-cloudwatchlogs-s3-ghsa-xmrv-pmrh-hhx2.yaml
+++ b/changelog/fragments/1776709378-bump-aws-sdk-go-v2-cloudwatchlogs-s3-ghsa-xmrv-pmrh-hhx2.yaml
@@ -1,6 +1,6 @@
 kind: security
 
-summary: Bump aws-sdk-go-v2 cloudwatchlogs to v1.65.0 and s3 to v1.97.3 to fix GHSA-xmrv-pmrh-hhx2
+summary: Bump aws-sdk-go-v2/service/cloudwatchlogs to v1.65.0 to fix GHSA-xmrv-pmrh-hhx2
 
 component: all
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.13
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.13
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.45.2
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.50.2
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.65.0
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.277.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.4

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.28.3 h1:8frWkH+rWP1joKQlWJe
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.28.3/go.mod h1:7M/THRNcz6t6fMas6nZ/ldxGM/Dx2BWGRRcSJxn6X7o=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.45.2 h1:pc8D62wqqWtXlIFp5/e/rhpVPxWnA0craqovONbol5M=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.45.2/go.mod h1:W6zagkMLyJeopkbOOzERmC4tTQD2I3vdrpw30ywOeEU=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.50.2 h1:3/bbtfzzGkbhzMUBCwX4BcfBx7YDDjENC2sZvIySKa0=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.50.2/go.mod h1:Wd99awP91azT7t59fylEjtBYazJvNAneRveTthS7g/0=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.65.0 h1:3yaFbUbuLfN8n1q01wZtQtHRzUDc/jm0VvniMY0IPE8=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.65.0/go.mod h1:PobeppEnIjw4pcgjFryNDZCTH7AiqZw0yb5r98Gvf9c=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.51.1 h1:JbMktMCPMjlTwzmy0naf32foE8sRqhhF168INXesYcM=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.51.1/go.mod h1:KHj6GnIt74Ke10Z4kRFDoEvldmSA6mkYJMy804s9E7E=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.277.0 h1:RHJSkRXDGkAKrV4CTEsZsZkOmSpxXKO4aKx4rXd94K4=


### PR DESCRIPTION
## Summary

- Bumps `github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs` from v1.50.2 → v1.65.0

The other two affected packages from GHSA-xmrv-pmrh-hhx2 were already resolved on main:
- `aws/protocol/eventstream` was already at the patched version v1.7.8
- `service/s3` was already bumped to v1.98.0 (≥ v1.97.3 fix) on main

Addresses [GHSA-xmrv-pmrh-hhx2](https://github.com/aws/aws-sdk-go-v2/security/advisories/GHSA-xmrv-pmrh-hhx2): a Denial-of-Service vulnerability in the EventStream header decoder where a malformed response frame with a crafted header value type byte outside the valid range causes the host process to terminate.

Related: https://github.com/elastic/security/issues/9748

## Test plan

- [ ] Verify `go mod tidy` produces no further changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)