### PR TITLE
updatecli: filter files with Azure VM Images

### DIFF
--- a/.github/workflows/updatecli.d/updatecli-bump-vm-images.yml
+++ b/.github/workflows/updatecli.d/updatecli-bump-vm-images.yml
@@ -108,3 +108,4 @@ targets:
         - .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
       matchpattern: '(IMAGE_.+): "1.0.(.+)"'
       replacepattern: '$1: "1.0.{{ source "latestVersion" }}"'
+      searchpattern: 'IMAGE_.+: "1.0.+"'

--- a/.github/workflows/updatecli.d/updatecli-bump-vm-images.yml
+++ b/.github/workflows/updatecli.d/updatecli-bump-vm-images.yml
@@ -85,6 +85,8 @@ targets:
     scmid: githubConfig
     kind: file
     spec:
+      # Only files containing Azure Windows images (IMAGE_WIN_*: "1.0.*")
+      # Removed 6 files that don't have Azure images to prevent matchpattern failures
       files:
         - .buildkite/auditbeat/auditbeat-pipeline.yml
         - .buildkite/filebeat/filebeat-pipeline.yml
@@ -100,5 +102,5 @@ targets:
         - .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
         - .buildkite/x-pack/pipeline.xpack.packetbeat.yml
         - .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
-      matchpattern: '(IMAGE_.+): "1.0.(.+)"'
+      matchpattern: '(IMAGE_.+): "1\.0\.([\d]+)"'
       replacepattern: '$1: "1.0.{{ source "latestVersion" }}"'

--- a/.github/workflows/updatecli.d/updatecli-bump-vm-images.yml
+++ b/.github/workflows/updatecli.d/updatecli-bump-vm-images.yml
@@ -86,8 +86,6 @@ targets:
     kind: file
     spec:
       files:
-        - .buildkite/aws-tests-pipeline.yml
-        - .buildkite/packaging.pipeline.yml
         - .buildkite/auditbeat/auditbeat-pipeline.yml
         - .buildkite/filebeat/filebeat-pipeline.yml
         - .buildkite/heartbeat/heartbeat-pipeline.yml
@@ -95,17 +93,12 @@ targets:
         - .buildkite/metricbeat/pipeline.yml
         - .buildkite/packetbeat/pipeline.packetbeat.yml
         - .buildkite/winlogbeat/pipeline.winlogbeat.yml
-        - .buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml
         - .buildkite/x-pack/pipeline.xpack.auditbeat.yml
-        - .buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
         - .buildkite/x-pack/pipeline.xpack.filebeat.yml
         - .buildkite/x-pack/pipeline.xpack.heartbeat.yml
-        - .buildkite/x-pack/pipeline.xpack.libbeat.yml
         - .buildkite/x-pack/pipeline.xpack.metricbeat.yml
         - .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
-        - .buildkite/x-pack/pipeline.xpack.otel.yml
         - .buildkite/x-pack/pipeline.xpack.packetbeat.yml
         - .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
       matchpattern: '(IMAGE_.+): "1.0.(.+)"'
       replacepattern: '$1: "1.0.{{ source "latestVersion" }}"'
-      searchpattern: 'IMAGE_.+: "1.0.+"'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Fix automation to support the Azure VM Images bump

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

```bash
$ export GITHUB_TOKEN=$(gh auth token)
export GITHUB_ACTOR=v1v
export BRANCH_NAME=main
updatecli diff \
    --config .github/workflows/updatecli.d/updatecli-bump-vm-images.yml \
    --values .github/workflows/updatecli.d/values.d/scm.yml
```

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline ".github/workflows/updatecli.d/updatecli-bump-vm-images.yml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


####################################
# BUMP VM-IMAGES TO LATEST VERSION #
####################################

Pipeline ID	: updatecli-update-vm-images-main
Dry Run		: enabled

source: latestVersion
---------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "1776781006", found in file "https://storage.googleapis.com/artifacts-api/vm-images/beats/latest.json", for key ".date"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

condition: latestVersion-check
------------------------------

The shell 🐚 command "/bin/sh /var/folders/t7/ghqdh8cx2g12pwb_w0ncmw900000gn/T/updatecli/bin/aeb0b3104ea5d43a7bdbcf30910e4196fe95cfca83bf292b7d501ff119d01e95.sh" ran successfully with the following output:
----
----
✔ shell condition of type "console/output", passing

target: update-azure-buildkite-pipelines
----------------------------------------

Repository	: github.com/v1v/beats@main

".buildkite/x-pack/pipeline.xpack.osquerybeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
+++ .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
@@ -12,8 +12,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/x-pack/pipeline.xpack.packetbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.packetbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.packetbeat.yml
@@ -13,8 +13,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/x-pack/pipeline.xpack.winlogbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
@@ -8,8 +8,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/auditbeat/auditbeat-pipeline.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/auditbeat/auditbeat-pipeline.yml
+++ .buildkite/auditbeat/auditbeat-pipeline.yml
@@ -19,8 +19,8 @@
   IMAGE_UBUNTU_2404_ARM64: "platform-ingest-beats-ubuntu-2404-aarch64-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/filebeat/filebeat-pipeline.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/filebeat/filebeat-pipeline.yml
+++ .buildkite/filebeat/filebeat-pipeline.yml
@@ -12,8 +12,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/heartbeat/heartbeat-pipeline.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/heartbeat/heartbeat-pipeline.yml
+++ .buildkite/heartbeat/heartbeat-pipeline.yml
@@ -12,8 +12,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/libbeat/pipeline.libbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/libbeat/pipeline.libbeat.yml
+++ .buildkite/libbeat/pipeline.libbeat.yml
@@ -11,8 +11,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/metricbeat/pipeline.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/metricbeat/pipeline.yml
+++ .buildkite/metricbeat/pipeline.yml
@@ -12,8 +12,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/winlogbeat/pipeline.winlogbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/winlogbeat/pipeline.winlogbeat.yml
+++ .buildkite/winlogbeat/pipeline.winlogbeat.yml
@@ -12,8 +12,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/x-pack/pipeline.xpack.heartbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.heartbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.heartbeat.yml
@@ -13,8 +13,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/x-pack/pipeline.xpack.metricbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -13,8 +13,8 @@
   IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/packetbeat/pipeline.packetbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/packetbeat/pipeline.packetbeat.yml
+++ .buildkite/packetbeat/pipeline.packetbeat.yml
@@ -13,8 +13,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/x-pack/pipeline.xpack.auditbeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -13,8 +13,8 @@
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

".buildkite/x-pack/pipeline.xpack.filebeat.yml" updated with [dry run] content "$1: \"1.0.1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ .buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -13,8 +13,8 @@
   IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1772337686"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
-  IMAGE_WIN_10_VERSION: "1.0.1776697195"
-  IMAGE_WIN_11_VERSION: "1.0.1776697195"
+  IMAGE_WIN_10_VERSION: "1.0.1776781006"
+  IMAGE_WIN_11_VERSION: "1.0.1776781006"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"

```

⚠ - 14 file(s) updated with "$1: \"1.0.1776781006\"":
	* .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
	* .buildkite/x-pack/pipeline.xpack.packetbeat.yml
	* .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
	* .buildkite/auditbeat/auditbeat-pipeline.yml
	* .buildkite/filebeat/filebeat-pipeline.yml
	* .buildkite/heartbeat/heartbeat-pipeline.yml
	* .buildkite/libbeat/pipeline.libbeat.yml
	* .buildkite/metricbeat/pipeline.yml
	* .buildkite/winlogbeat/pipeline.winlogbeat.yml
	* .buildkite/x-pack/pipeline.xpack.heartbeat.yml
	* .buildkite/x-pack/pipeline.xpack.metricbeat.yml
	* .buildkite/packetbeat/pipeline.packetbeat.yml
	* .buildkite/x-pack/pipeline.xpack.auditbeat.yml
	* .buildkite/x-pack/pipeline.xpack.filebeat.yml
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: update-buildkite-pipelines
----------------------------------

Repository	: github.com/v1v/beats@main

".buildkite/auditbeat/auditbeat-pipeline.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/auditbeat/auditbeat-pipeline.yml
+++ .buildkite/auditbeat/auditbeat-pipeline.yml
@@ -10,21 +10,21 @@
 
   # The following images are defined here and their values will be updated by updatecli
   # Please do not change them manually.
-  IMAGE_RHEL9: "platform-ingest-beats-rhel-9-1772337686"
-  IMAGE_UBUNTU_2004_X86_64: "platform-ingest-beats-ubuntu-2004-1772337686"
-  IMAGE_UBUNTU_2004_ARM64: "platform-ingest-beats-ubuntu-2004-aarch64-1772337686"
-  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
-  IMAGE_UBUNTU_2204_ARM64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
-  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-beats-ubuntu-2404-1772337686"
-  IMAGE_UBUNTU_2404_ARM64: "platform-ingest-beats-ubuntu-2404-aarch64-1772337686"
+  IMAGE_RHEL9: "platform-ingest-beats-rhel-9-1776781006"
+  IMAGE_UBUNTU_2004_X86_64: "platform-ingest-beats-ubuntu-2004-1776781006"
+  IMAGE_UBUNTU_2004_ARM64: "platform-ingest-beats-ubuntu-2004-aarch64-1776781006"
+  IMAGE_UBUNTU_2204_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
+  IMAGE_UBUNTU_2204_ARM64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
+  IMAGE_UBUNTU_2404_X86_64: "platform-ingest-beats-ubuntu-2404-1776781006"
+  IMAGE_UBUNTU_2404_ARM64: "platform-ingest-beats-ubuntu-2404-aarch64-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/filebeat/filebeat-pipeline.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/filebeat/filebeat-pipeline.yml
+++ .buildkite/filebeat/filebeat-pipeline.yml
@@ -3,21 +3,21 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
@@ -3,13 +3,13 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.winlogbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
@@ -3,17 +3,17 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
 

```

".buildkite/aws-tests-pipeline.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/aws-tests-pipeline.yml
+++ .buildkite/aws-tests-pipeline.yml
@@ -2,7 +2,7 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   #  TEST_TAGS should be reviewed and updated: https://github.com/elastic/ingest-dev/issues/3476
   TEST_TAGS: "aws"

```

".buildkite/metricbeat/pipeline.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/metricbeat/pipeline.yml
+++ .buildkite/metricbeat/pipeline.yml
@@ -3,21 +3,21 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/packetbeat/pipeline.packetbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/packetbeat/pipeline.packetbeat.yml
+++ .buildkite/packetbeat/pipeline.packetbeat.yml
@@ -3,22 +3,22 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1772337686"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1776781006"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.heartbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.heartbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.heartbeat.yml
@@ -3,21 +3,21 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1772337686"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1776781006"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.libbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.libbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.libbeat.yml
@@ -3,10 +3,10 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.metricbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -3,21 +3,21 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
-  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
+  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/packaging.pipeline.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/packaging.pipeline.yml
+++ .buildkite/packaging.pipeline.yml
@@ -4,9 +4,9 @@
 env:
   ASDF_MAGE_VERSION: 1.15.0
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
   GCP_DEFAULT_MACHINE_TYPE: "c2d-standard-8"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
 
   PLATFORMS: "+all linux/amd64 windows/amd64 darwin/amd64"
   PLATFORMS_ARM: "+all linux/arm64 darwin/arm64 windows/arm64"

```

".buildkite/heartbeat/heartbeat-pipeline.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/heartbeat/heartbeat-pipeline.yml
+++ .buildkite/heartbeat/heartbeat-pipeline.yml
@@ -2,21 +2,21 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_RHEL9: "platform-ingest-beats-rhel-9-1772337686"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_RHEL9: "platform-ingest-beats-rhel-9-1776781006"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/libbeat/pipeline.libbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/libbeat/pipeline.libbeat.yml
+++ .buildkite/libbeat/pipeline.libbeat.yml
@@ -3,20 +3,20 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "t4g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2004-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2004-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.filebeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ .buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -3,21 +3,21 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
-  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
+  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-beats-ubuntu-2204-fips-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.osquerybeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
+++ .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
@@ -3,20 +3,20 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/winlogbeat/pipeline.winlogbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/winlogbeat/pipeline.winlogbeat.yml
+++ .buildkite/winlogbeat/pipeline.winlogbeat.yml
@@ -3,21 +3,21 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml
+++ .buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   MODULE: "kubernetes"
 

```

".buildkite/x-pack/pipeline.xpack.auditbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -3,22 +3,22 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1772337686"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1776781006"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.otel.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.otel.yml
+++ .buildkite/x-pack/pipeline.xpack.otel.yml
@@ -3,9 +3,9 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

".buildkite/x-pack/pipeline.xpack.packetbeat.yml" updated with [dry run] content "$1: \"platform-ingest-beats-$2-1776781006\""

```
--- .buildkite/x-pack/pipeline.xpack.packetbeat.yml
+++ .buildkite/x-pack/pipeline.xpack.packetbeat.yml
@@ -3,22 +3,22 @@
 
 env:
   AWS_ARM_INSTANCE_TYPE: "m6g.xlarge"
-  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1772337686"
+  AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   GCP_DEFAULT_MACHINE_TYPE: "c2d-highcpu-8"
   GCP_HI_PERF_MACHINE_TYPE: "c2d-highcpu-16"
   GCP_WIN_MACHINE_TYPE: "n2-standard-8"
 
-  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1772337686"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1772337686"
+  IMAGE_RHEL9_X86_64: "platform-ingest-beats-rhel-9-1776781006"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
   IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
   IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
   IMAGE_WIN_10_VERSION: "1.0.1776697195"
   IMAGE_WIN_11_VERSION: "1.0.1776697195"
-  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1772337686"
-  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1772337686"
-  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1772337686"
-  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1772337686"
+  IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
+  IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
+  IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
+  IMAGE_WIN_2025: "platform-ingest-beats-windows-2025-1776781006"
 
   IMAGE_BEATS_WITH_HOOKS_LATEST: "docker.elastic.co/ci-agent-images/platform-ingest/buildkite-agent-beats-ci-with-hooks:latest"
 

```

⚠ - 20 file(s) updated with "$1: \"platform-ingest-beats-$2-1776781006\"":
	* .buildkite/auditbeat/auditbeat-pipeline.yml
	* .buildkite/filebeat/filebeat-pipeline.yml
	* .buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
	* .buildkite/x-pack/pipeline.xpack.winlogbeat.yml
	* .buildkite/aws-tests-pipeline.yml
	* .buildkite/metricbeat/pipeline.yml
	* .buildkite/packetbeat/pipeline.packetbeat.yml
	* .buildkite/x-pack/pipeline.xpack.heartbeat.yml
	* .buildkite/x-pack/pipeline.xpack.libbeat.yml
	* .buildkite/x-pack/pipeline.xpack.metricbeat.yml
	* .buildkite/packaging.pipeline.yml
	* .buildkite/heartbeat/heartbeat-pipeline.yml
	* .buildkite/libbeat/pipeline.libbeat.yml
	* .buildkite/x-pack/pipeline.xpack.filebeat.yml
	* .buildkite/x-pack/pipeline.xpack.osquerybeat.yml
	* .buildkite/winlogbeat/pipeline.winlogbeat.yml
	* .buildkite/deploy/kubernetes/deploy-k8s-pipeline.yml
	* .buildkite/x-pack/pipeline.xpack.auditbeat.yml
	* .buildkite/x-pack/pipeline.xpack.otel.yml
	* .buildkite/x-pack/pipeline.xpack.packetbeat.yml
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.


ACTIONS
========

---
Pipeline Name	: Bump vm-images to latest version
Pipeline ID	: updatecli-update-vm-images-main
Dry run		: true
Repository	: github.com/v1v/beats@main
Action		: Bump vm-images to latest version
---

An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:

⚠ Bump vm-images to latest version:
	Source:
		✔ [latestVersion] Get latest available build
	Condition:
		✔ [latestVersion-check] Check if defined latest version differs
	Target:
		⚠ [update-azure-buildkite-pipelines] Update all Buildkite pipeline files (Azure)
		      * Repository: https://github.com/v1v/beats.git (branch: main)
		⚠ [update-buildkite-pipelines] Update all Buildkite pipeline files (AWS/GCP)
		      * Repository: https://github.com/v1v/beats.git (branch: main)


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
