### PR TITLE
Skip FIPS integration tests due to SSH key incompatibility.

### DIFF
--- a/.buildkite/libbeat/pipeline.libbeat.yml
+++ b/.buildkite/libbeat/pipeline.libbeat.yml
@@ -97,6 +97,7 @@ steps:
               context: "libbeat: Ubuntu x86_64 Unit Tests"
 
       - label: ":ubuntu: Libbeat: Ubuntu x86_64 Go Unit Tests with fips provider and requirefips build tag"
+        skip: "https://github.com/elastic/beats/issues/50269: ssh keys not FIPS"
         key: "mandatory-linux-unit-test-fips-tag"
         command: |
           cd libbeat

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -219,6 +219,7 @@ steps:
               context: "x-pack/filebeat: Go fips140=only Integration Tests"
 
       - label: ":ubuntu: x-pack/filebeat: FIPS ECH Integration Tests"
+        skip: "https://github.com/elastic/beats/issues/50269: ssh keys not FIPS"
         env:
           ASDF_TERRAFORM_VERSION: "1.9.3"
           ASDF_PYTHON_VERSION: "3.9.13" # Not needed by ECH tests, but needed by VM

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -258,6 +258,7 @@ steps:
               context: "x-pack/metricbeat: Go fips140=only Integration Tests (Module)"
 
       - label: ":ubuntu: x-pack/metricbeat: FIPS ECH Integration Tests"
+        skip: "https://github.com/elastic/beats/issues/50269: ssh keys not FIPS"
         env:
           ASDF_TERRAFORM_VERSION: "1.9.3"
           ASDF_PYTHON_VERSION: "3.9.13" # Not needed by ECH tests, but needed by VM


### PR DESCRIPTION
See https://github.com/elastic/beats/issues/50269 for details, skipping while we work out the solution.