### PR TITLE
fix(packetbeat): reject invalid negative RESP bulk length in Redis parser

### DIFF
--- a/changelog/fragments/1766000000-fix-redis-parser-negative-bulk-length-panic.yaml
+++ b/changelog/fragments/1766000000-fix-redis-parser-negative-bulk-length-panic.yaml
@@ -1,0 +1,31 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+summary: Reject RESP bulk-string lengths other than -1 (nil) and >=0 in the packetbeat Redis parser
+
+# REQUIRED for breaking-change, deprecation, known-issue
+description: |
+  The Redis RESP parser accepted arbitrary negative bulk-string lengths (e.g. `$-2\r\n`)
+  and forwarded them into streambuf.Buffer.CollectWithSuffix, which sliced the
+  underlying buffer with a negative index and crashed the parser goroutine with
+  "slice bounds out of range". A malformed on-the-wire Redis packet was enough
+  to take out a packetbeat scrape.
+
+# REQUIRED (List of components affected):
+component: packetbeat
+
+# AUTHOR
+# Name of the contributor submitting the fragment
+pr: https://github.com/elastic/beats/issues/50205
+issue: https://github.com/elastic/beats/issues/50205

--- a/packetbeat/protos/redis/redis_parse.go
+++ b/packetbeat/protos/redis/redis_parse.go
@@ -349,6 +349,16 @@ func (p *parser) parseString(buf *streambuf.Buffer) (common.NetString, bool, boo
 		return empty, false, false
 	}
 
+	// RESP defines -1 as nil (handled above); any other negative length
+	// is malformed. Without this guard a hostile or corrupted packet
+	// with e.g. $-2\r\n passed a negative count into CollectWithSuffix,
+	// whose streambuf.Buffer.Avail treated it as "available" and then
+	// sliced data[mark+count:] with a negative index, panicking the
+	// parser goroutine with "slice bounds out of range [-2:]".
+	if length < 0 {
+		return empty, false, false
+	}
+
 	content, err := buf.CollectWithSuffix(int(length), []byte("\r\n"))
 	if err != nil {
 		if !errors.Is(err, streambuf.ErrNoMoreBytes) {


### PR DESCRIPTION
Refs elastic/beats#50205.

## Problem

`packetbeat/protos/redis/redis_parse.go` treated `$-1\\r\\n` as nil but forwarded any other negative bulk-string length straight into `streambuf.Buffer.CollectWithSuffix`. `Avail` returned true for `count <= available` regardless of sign, so `CollectWithSuffix` computed `end := mark + count` with a negative count and sliced `data[end:]` with a negative index, panicking the parser goroutine:

```
panic: runtime error: slice bounds out of range [-2:]
```

A single malformed (or adversarial) Redis packet on the wire, e.g. `$-2\\r\\n`, was enough to crash a packetbeat scrape.

## Fix

Short-circuit any `length < 0` after the `-1` nil sentinel check with the standard `(empty, false, false)` failure tuple, so the parser bails on malformed input before reaching the buffer code.

## Test

`go test ./protos/redis/...` passes locally (and existing tests still cover the $-1 nil-bulk path).