### PR TITLE
fix(kafkapartitionerextension): use key hash instead of random for partitioner

### DIFF
--- a/x-pack/otel/extension/kafkapartitionerextension/partitioner.go
+++ b/x-pack/otel/extension/kafkapartitionerextension/partitioner.go
@@ -156,7 +156,7 @@ func makeHashKgoPartitioner() kgo.Partitioner {
 			hasher.Reset()
 			_, _ = hasher.Write(msg.Key)
 
-			return int(kafka.Hash2Partition(rand.Uint32(), int32(numPartitions))) //nolint:gosec // Conversion from int to int32 is safe here.
+			return int(kafka.Hash2Partition(hasher.Sum32(), int32(numPartitions))) //nolint:gosec // Conversion from int to int32 is safe here.
 		}
 	})
 }


### PR DESCRIPTION
## Proposed commit message

The code is currently using a random partition every call, instead of a consistent hash.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact


## How to test this PR locally

Fails on main, fixed with this PR

```
./script/stresstest.sh ./x-pack/otel/extension/kafkapartitionerextension ^TestHashPartitioner$
```

## Related issues

- Relates TODO