### PR TITLE
chore: fix user-facing typos 'defauling' and 'choosen'

### DIFF
--- a/changelog/fragments/1766100000-fix-user-facing-typos.yaml
+++ b/changelog/fragments/1766100000-fix-user-facing-typos.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Fix user-facing typos (defauling, choosen) in libbeat lifecycle log and x-pack/filebeat module docs
+component: libbeat
+pr: https://github.com/elastic/beats/issues/50262

--- a/libbeat/idxmgmt/lifecycle/file_client_handler.go
+++ b/libbeat/idxmgmt/lifecycle/file_client_handler.go
@@ -62,7 +62,7 @@ func NewFileClientHandler(c FileClient, info beat.Info, cfg RawConfig) (*FileCli
 		lifecycleCfg = DefaultILMConfig(info).ILM
 		err = cfg.ILM.Unpack(&lifecycleCfg)
 	} else {
-		info.Logger.Infof("No lifecycle config has been explicitly enabled, defauling to ILM")
+		info.Logger.Infof("No lifecycle config has been explicitly enabled, defaulting to ILM")
 	}
 
 	if err != nil {

--- a/x-pack/filebeat/module/fortinet/_meta/docs.md
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.md
@@ -16,7 +16,7 @@ This is a module for Fortinet logs sent in the syslog format. It supports the fo
 
 To configure a remote syslog destination, please reference the [Fortigate/FortiOS Documentation](https://docs.fortinet.com/document/fortigate/6.0.0/cli-reference/260508/log-syslogd-syslogd2-syslogd3-syslogd4-setting).
 
-The syslog format choosen should be `Default`.
+The syslog format chosen should be `Default`.
 
 ::::{tip}
 Read the [quick start](/reference/filebeat/filebeat-installation-configuration.md) to learn how to configure and run modules.

--- a/x-pack/filebeat/module/juniper/_meta/docs.md
+++ b/x-pack/filebeat/module/juniper/_meta/docs.md
@@ -79,7 +79,7 @@ The following processes and tags are supported:
 |  | AAMW_ACTION_LOG |
 | RT_SECINTEL | SECINTEL_ACTION_LOG |
 
-The syslog format choosen should be `Default`.
+The syslog format chosen should be `Default`.
 
 
 ## Compatibility [_compatibility_18]

--- a/x-pack/filebeat/module/sophos/_meta/docs.md
+++ b/x-pack/filebeat/module/sophos/_meta/docs.md
@@ -16,7 +16,7 @@ This is a module for Sophos Products, currently it accepts logs in syslog format
 
 To configure a remote syslog destination, please reference the [SophosXG/SFOS Documentation](https://docs.sophos.com/nsg/sophos-firewall/18.5/Help/en-us/webhelp/onlinehelp/nsg/tasks/SyslogServerAdd.md).
 
-The syslog format choosen in Sophos configuration should be `Central Reporting Format`.
+The syslog format chosen in Sophos configuration should be `Central Reporting Format`.
 
 ::::{tip}
 Read the [quick start](/reference/filebeat/filebeat-installation-configuration.md) to learn how to configure and run modules.

--- a/x-pack/filebeat/module/zoom/webhook/_meta/fields.yml
+++ b/x-pack/filebeat/module/zoom/webhook/_meta/fields.yml
@@ -551,15 +551,15 @@
     - name: registrant.purchasing_time_frame
       type: keyword
       description: >
-        Choosen purchase timeframe of the user registering to a meeting or webinar
+        Chosen purchase timeframe of the user registering to a meeting or webinar
     - name: registrant.role_in_purchase_process
       type: keyword
       description: >
-        Choosen role in a purchase process related to the user registering to a meeting or webinar
+        Chosen role in a purchase process related to the user registering to a meeting or webinar
     - name: registrant.no_of_employees
       type: keyword
       description: >
-        Number of employees choosen by the user registering to a meeting or webinar
+        Number of employees chosen by the user registering to a meeting or webinar
     - name: registrant.comments
       type: keyword
       description: >


### PR DESCRIPTION
Fixes elastic/beats#50262.

- `libbeat/idxmgmt/lifecycle/file_client_handler.go`: `defauling` → `defaulting` in the runtime log emitted when no lifecycle config is explicitly enabled.
- `x-pack/filebeat/module/{fortinet,juniper,sophos}/_meta/docs.md`: `syslog format choosen` → `syslog format chosen`.
- `x-pack/filebeat/module/zoom/webhook/_meta/fields.yml`: `Choosen` / `choosen` → `Chosen` / `chosen` in three field descriptions.

Changelog fragment attached.

No code-path changes; strings-only.