### PR TITLE
docs: fix spelling typos in community-beats and remote-debugger docs

### DIFF
--- a/changelog/fragments/1777737600-fix-typos-docs.yaml
+++ b/changelog/fragments/1777737600-fix-typos-docs.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix spelling typos in community-beats docs (`recurssively`, `synchonisation`) and in the metricbeat Kubernetes remote-debugger README (`buld`).
+component: docs

--- a/docs/extend/community-beats.md
+++ b/docs/extend/community-beats.md
@@ -98,7 +98,7 @@ Elastic provides no warranty or support for community-sourced {{beats}}.
 :   Periodically gather internet download speed from  [fast.com](https://fast.com).
 
 [fileoccurencebeat](https://github.com/cloudronics/fileoccurancebeat)
-:   Checks for file existence recurssively under a given directory, handy while handling queues/pipeline buffers.
+:   Checks for file existence recursively under a given directory, handy while handling queues/pipeline buffers.
 
 [flowbeat](https://github.com/FStelzer/flowbeat)
 :   Collects, parses, and indexes [sflow](http://www.sflow.org/index.php) samples.
@@ -293,7 +293,7 @@ Elastic provides no warranty or support for community-sourced {{beats}}.
 :   Runs an external command and forwards the [stdout](https://www.computerhope.com/jargon/s/stdout.htm) for the same to Elasticsearch/Logstash.
 
 [timebeat](https://timebeat.app/download.php)
-:   NTP and PTP clock synchonisation beat that reports accuracy metrics to elastic. Includes Kibana dashboards.
+:   NTP and PTP clock synchronisation beat that reports accuracy metrics to elastic. Includes Kibana dashboards.
 
 [tracebeat](https://github.com/berfinsari/tracebeat)
 :   Reads traceroute output and indexes them into Elasticsearch.

--- a/docs/reference/libbeat/community-beats.md
+++ b/docs/reference/libbeat/community-beats.md
@@ -100,7 +100,7 @@ Elastic provides no warranty or support for community-sourced {{beats}}.
 :   Periodically gather internet download speed from  [fast.com](https://fast.com).
 
 [fileoccurencebeat](https://github.com/cloudronics/fileoccurancebeat)
-:   Checks for file existence recurssively under a given directory, handy while handling queues/pipeline buffers.
+:   Checks for file existence recursively under a given directory, handy while handling queues/pipeline buffers.
 
 [flowbeat](https://github.com/FStelzer/flowbeat)
 :   Collects, parses, and indexes [sflow](http://www.sflow.org/index.php) samples.
@@ -295,7 +295,7 @@ Elastic provides no warranty or support for community-sourced {{beats}}.
 :   Runs an external command and forwards the [stdout](https://www.computerhope.com/jargon/s/stdout.htm) for the same to Elasticsearch/Logstash.
 
 [timebeat](https://timebeat.app/download.php)
-:   NTP and PTP clock synchonisation beat that reports accuracy metrics to elastic. Includes Kibana dashboards.
+:   NTP and PTP clock synchronisation beat that reports accuracy metrics to elastic. Includes Kibana dashboards.
 
 [tracebeat](https://github.com/berfinsari/tracebeat)
 :   Reads traceroute output and indexes them into Elasticsearch.

--- a/metricbeat/module/kubernetes/_meta/remote-debugger/README.md
+++ b/metricbeat/module/kubernetes/_meta/remote-debugger/README.md
@@ -16,7 +16,7 @@ cd metricbeat
 GOOS=linux GOARCH=amd64 go build -gcflags "-N -l" -o metricbeat main.go
 ```
 
-2. buld docker container
+2. build docker container
 
 ```bash
 docker build -t metricbeat-debugger-image -f Dockerfile.debug .
@@ -49,7 +49,7 @@ cd metricbeat
 GOOS=linux GOARCH=amd64 go build -gcflags "-N -l" -o metricbeat main.go
 ```
 
-2. buld docker container
+2. build docker container
 
 ```bash
 docker build -t metricbeat-debugger-image -f Dockerfile.debug .


### PR DESCRIPTION
## Proposed commit message

Fixes the spelling typos surfaced by the text-auditor workflow in #50214:

- `recurssively` → `recursively` in `docs/extend/community-beats.md` (line 101) and `docs/reference/libbeat/community-beats.md` (line 103)
- `synchonisation` → `synchronisation` in the same two files (lines 296 and 298)
- `buld docker container` → `build docker container` in `metricbeat/module/kubernetes/_meta/remote-debugger/README.md` (lines 19 and 52)

Docs-only change; no code, no configuration, no tests affected.

Closes #50214.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None; these are user-facing docs with no code or configuration changes.

## How to test this PR locally

Verify each fix renders correctly in the updated docs.

## Related issues

Closes #50214