### PR TITLE
docs: clarify precedence of logging.to_* options

### DIFF
--- a/docs/reference/auditbeat/configuration-logging.md
+++ b/docs/reference/auditbeat/configuration-logging.md
@@ -38,6 +38,11 @@ When Auditbeat is running on a Linux system with systemd, it uses by default the
 You can specify the following options in the `logging` section of the `auditbeat.yml` config file:
 
 
+::::{warning}
+The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+::::
+
+
 ### `logging.to_stderr` [_logging_to_stderr]
 
 When true, writes all logging output to standard error output. This is equivalent to using the `-e` command line option.

--- a/docs/reference/auditbeat/configuration-logging.md
+++ b/docs/reference/auditbeat/configuration-logging.md
@@ -39,7 +39,7 @@ You can specify the following options in the `logging` section of the `auditbeat
 
 
 ::::{warning}
-The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+The `logging.to_*` options are mutually exclusive. If multiple are set to `true`, only the first one takes effect, following the precedence order of the options listed below.
 ::::
 
 

--- a/docs/reference/filebeat/configuration-logging.md
+++ b/docs/reference/filebeat/configuration-logging.md
@@ -38,6 +38,11 @@ When Filebeat is running on a Linux system with systemd, it uses by default the 
 You can specify the following options in the `logging` section of the `filebeat.yml` config file:
 
 
+::::{warning}
+The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+::::
+
+
 ### `logging.to_stderr` [_logging_to_stderr]
 
 When true, writes all logging output to standard error output. This is equivalent to using the `-e` command line option.

--- a/docs/reference/filebeat/configuration-logging.md
+++ b/docs/reference/filebeat/configuration-logging.md
@@ -39,7 +39,7 @@ You can specify the following options in the `logging` section of the `filebeat.
 
 
 ::::{warning}
-The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+The `logging.to_*` options are mutually exclusive. If multiple are set to `true`, only the first one takes effect, following the precedence order of the options listed below.
 ::::
 
 

--- a/docs/reference/heartbeat/configuration-logging.md
+++ b/docs/reference/heartbeat/configuration-logging.md
@@ -38,6 +38,11 @@ When Heartbeat is running on a Linux system with systemd, it uses by default the
 You can specify the following options in the `logging` section of the `heartbeat.yml` config file:
 
 
+::::{warning}
+The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+::::
+
+
 ### `logging.to_stderr` [_logging_to_stderr]
 
 When true, writes all logging output to standard error output. This is equivalent to using the `-e` command line option.

--- a/docs/reference/heartbeat/configuration-logging.md
+++ b/docs/reference/heartbeat/configuration-logging.md
@@ -39,7 +39,7 @@ You can specify the following options in the `logging` section of the `heartbeat
 
 
 ::::{warning}
-The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+The `logging.to_*` options are mutually exclusive. If multiple are set to `true`, only the first one takes effect, following the precedence order of the options listed below.
 ::::
 
 

--- a/docs/reference/metricbeat/configuration-logging.md
+++ b/docs/reference/metricbeat/configuration-logging.md
@@ -39,7 +39,7 @@ You can specify the following options in the `logging` section of the `metricbea
 
 
 ::::{warning}
-The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+The `logging.to_*` options are mutually exclusive. If multiple are set to `true`, only the first one takes effect, following the precedence order of the options listed below.
 ::::
 
 

--- a/docs/reference/metricbeat/configuration-logging.md
+++ b/docs/reference/metricbeat/configuration-logging.md
@@ -38,6 +38,11 @@ When Metricbeat is running on a Linux system with systemd, it uses by default th
 You can specify the following options in the `logging` section of the `metricbeat.yml` config file:
 
 
+::::{warning}
+The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+::::
+
+
 ### `logging.to_stderr` [_logging_to_stderr]
 
 When true, writes all logging output to standard error output. This is equivalent to using the `-e` command line option.

--- a/docs/reference/packetbeat/configuration-logging.md
+++ b/docs/reference/packetbeat/configuration-logging.md
@@ -39,7 +39,7 @@ You can specify the following options in the `logging` section of the `packetbea
 
 
 ::::{warning}
-The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+The `logging.to_*` options are mutually exclusive. If multiple are set to `true`, only the first one takes effect, following the precedence order of the options listed below.
 ::::
 
 

--- a/docs/reference/packetbeat/configuration-logging.md
+++ b/docs/reference/packetbeat/configuration-logging.md
@@ -38,6 +38,11 @@ When Packetbeat is running on a Linux system with systemd, it uses by default th
 You can specify the following options in the `logging` section of the `packetbeat.yml` config file:
 
 
+::::{warning}
+The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+::::
+
+
 ### `logging.to_stderr` [_logging_to_stderr]
 
 When true, writes all logging output to standard error output. This is equivalent to using the `-e` command line option.

--- a/docs/reference/winlogbeat/configuration-logging.md
+++ b/docs/reference/winlogbeat/configuration-logging.md
@@ -36,7 +36,7 @@ You can specify the following options in the `logging` section of the `winlogbea
 
 
 ::::{warning}
-The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+The `logging.to_*` options are mutually exclusive. If multiple are set to `true`, only the first one takes effect, following the precedence order of the options listed below.
 ::::
 
 

--- a/docs/reference/winlogbeat/configuration-logging.md
+++ b/docs/reference/winlogbeat/configuration-logging.md
@@ -35,6 +35,11 @@ In addition to setting logging options in the config file, you can modify the lo
 You can specify the following options in the `logging` section of the `winlogbeat.yml` config file:
 
 
+::::{warning}
+The `logging.to_*` options are mutually exclusive. Only one option should be set to `true`. If multiple are set, only the first one will be used and the rest will be silently ignored.
+::::
+
+
 ### `logging.to_stderr` [_logging_to_stderr]
 
 When true, writes all logging output to standard error output. This is equivalent to using the `-e` command line option.


### PR DESCRIPTION
## Proposed commit message

The logging.to_* options are [mutually exclusive](https://github.com/elastic/elastic-agent-libs/blob/6b3792458a773e16e74582489842ef89c94a9bb6/logp/core.go#L364-L386). Only the first truthy
one is used, the rest are silently ignored. Add a warning callout to the
logging reference for all beats to make this explicit.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

- Closes https://github.com/elastic/beats/issues/50031