### PR TITLE
filebeat: stabilize test_rotating_file in test_registrar

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -308,11 +308,21 @@ class Test(BaseTest):
         self.wait_until(lambda: self.output_has(lines=2),
                         max_timeout=10)
 
+        # The "Updating state for renamed file" message is only logged once
+        # the harvester for the renamed file has finished (closed via
+        # close_inactive). Wait explicitly for the harvester close so that
+        # the rename detection check below is not racing with close_inactive
+        # on slow CI workers (see #26378).
+        self.wait_until(
+            lambda: self.log_contains(
+                "File is inactive. Closing because close_inactive"),
+            max_timeout=30)
+
         # Wait until rotation is detected
         self.wait_until(
             lambda: self.log_contains(
                 "Updating state for renamed file"),
-            max_timeout=10)
+            max_timeout=30)
 
         time.sleep(1)
 


### PR DESCRIPTION
## Proposed commit message

The `Updating state for renamed file` debug message in the deprecated `log` input prospector is only emitted once **both**:

1. The scanner detects the renamed file (every `scan_frequency=0.1s`).
2. The harvester for the renamed file has finished, which only happens after `close_inactive=1s` of no new bytes (`filebeat/input/log/input.go` lines 626-646 — the `oldState.Finished` branch).

`test_rotating_file` previously relied on a single 10s wait for that message after `output_has(lines=2)`, which raced `close_inactive` on slow CI workers and produced recurring flaky failures (4-6 instances every couple of days, see #26378).

This PR makes the test wait explicitly for the harvester's `File is inactive. Closing because close_inactive` log line first, ensuring the harvester is finished, before waiting for the rename detection. Both waits also get a 30s timeout to give the scanner enough headroom on loaded workers.

The test still uses the deprecated `log` input on purpose; equivalent filestream rename behavior is covered by Go integration tests in `filebeat/input/filestream/input_integration_test.go` (`TestFilestreamCloseRenamed`, `TestFilestreamMetadataUpdatedOnRename`, `TestFilestreamCloseAfterIntervalRenamed`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` — test-only change, `skip-changelog` applied.

## How to test this PR locally

```bash
cd filebeat
mage buildSystemTestBinary
# venv setup once
python3 -m venv build/ve/linux
source build/ve/linux/bin/activate
pip install -r ../libbeat/tests/system/requirements.txt

# run the test repeatedly (ideally under CPU load)
for i in {1..20}; do pytest tests/system/test_registrar.py::Test::test_rotating_file; done
```

Locally I ran the test 10 times back-to-back and another 5 times under simulated CPU load (`yes > /dev/null` x4) — all passed (~2.5s each).

## Related issues

- Closes #26378
