### PR TITLE
[ci] fix flaky abreceiver test case

### DIFF
--- a/x-pack/auditbeat/abreceiver/receiver_leak_test.go
+++ b/x-pack/auditbeat/abreceiver/receiver_leak_test.go
@@ -24,14 +24,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/otel/oteltest"
 )
 
-func TestLeak(t *testing.T) {
-	monitorSocket := genSocketPath()
-	var monitorHost string
-	if runtime.GOOS == "windows" {
-		monitorHost = "npipe:///" + filepath.Base(monitorSocket)
-	} else {
-		monitorHost = "unix://" + monitorSocket
-	}
+func getConfigAndFactory(t *testing.T, monitorHost string) (Config, receiver.Factory) {
 	config := Config{
 		Beatconfig: map[string]any{
 			"auditbeat": map[string]any{
@@ -56,13 +49,26 @@ func TestLeak(t *testing.T) {
 		},
 	}
 	factory := NewFactoryWithSettings(Settings{Home: t.TempDir()})
+	return config, factory
+}
+
+func TestLeak(t *testing.T) {
+	monitorSocket := genSocketPath()
+	var monitorHost string
+	if runtime.GOOS == "windows" {
+		monitorHost = "npipe:///" + filepath.Base(monitorSocket)
+	} else {
+		monitorHost = "unix://" + monitorSocket
+	}
 
 	t.Run("healthy consumer", func(t *testing.T) {
+		config, factory := getConfigAndFactory(t, monitorHost)
 		defer oteltest.VerifyNoLeaks(t)
 		var consumeLogs oteltest.DummyConsumer
 		startAndStopReceiver(t, factory, &consumeLogs, &config)
 	})
 	t.Run("unhealthy consumer", func(t *testing.T) {
+		config, factory := getConfigAndFactory(t, monitorHost)
 		defer oteltest.VerifyNoLeaks(t)
 		consumeLogs := oteltest.DummyConsumer{ConsumeError: errors.New("cannot publish data")}
 		startAndStopReceiver(t, factory, &consumeLogs, &config)


### PR DESCRIPTION
Fix flaky `TestLeak` test.

The build fails on windows with 

`TempDir RemoveAll cleanup: unlinkat C:\Users\BUILDK~1\AppData\Local\Temp\TestLeak3064262852\002\data\beat.db: The process cannot access the file because it is being used by another process`

Both the sub-tests are using same tempDir and that's causing issues.

Build: https://buildkite.com/elastic/beats-xpack-auditbeat/builds/27727#019dd2e8-84dd-4dc6-968e-afa4b4b51eb3