### PR TITLE
filebeat: honor max_bytes when decoding JSON content

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -691,7 +691,7 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 	}
 
 	if h.config.JSON != nil {
-		r = readjson.NewJSONReader(r, h.config.JSON, h.logger)
+		r = readjson.NewJSONReader(r, h.config.JSON, h.config.MaxBytes, h.logger)
 	}
 
 	r = readfile.NewStripNewline(r, h.config.LineTerminator)

--- a/libbeat/reader/parser/parser.go
+++ b/libbeat/reader/parser/parser.go
@@ -165,7 +165,7 @@ func (c *Config) Create(in reader.Reader, log *logp.Logger) Parser {
 			if err != nil {
 				return p
 			}
-			p = readjson.NewJSONParser(p, &config, log)
+			p = readjson.NewJSONParser(p, &config, int(c.pCfg.MaxBytes), log)
 		case "container":
 			config := readjson.DefaultContainerConfig()
 			cfg := ns.Config()

--- a/libbeat/reader/readjson/json.go
+++ b/libbeat/reader/readjson/json.go
@@ -20,6 +20,7 @@ package readjson
 import (
 	"bytes"
 	gojson "encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -33,9 +34,10 @@ import (
 
 // JSONReader parses JSON inputs
 type JSONReader struct {
-	reader reader.Reader
-	cfg    *Config
-	logger *logp.Logger
+	reader   reader.Reader
+	cfg      *Config
+	maxBytes int
+	logger   *logp.Logger
 }
 
 type JSONParser struct {
@@ -43,21 +45,25 @@ type JSONParser struct {
 	field, target string
 }
 
+var errMaxBytesExceeded = errors.New("max_bytes exceeded while decoding JSON")
+
 // NewJSONReader creates a new reader that can decode JSON.
-func NewJSONReader(r reader.Reader, cfg *Config, logger *logp.Logger) *JSONReader {
+func NewJSONReader(r reader.Reader, cfg *Config, maxBytes int, logger *logp.Logger) *JSONReader {
 	return &JSONReader{
-		reader: r,
-		cfg:    cfg,
-		logger: logger.Named("reader_json"),
+		reader:   r,
+		cfg:      cfg,
+		maxBytes: maxBytes,
+		logger:   logger.Named("reader_json"),
 	}
 }
 
-func NewJSONParser(r reader.Reader, cfg *ParserConfig, logger *logp.Logger) *JSONParser {
+func NewJSONParser(r reader.Reader, cfg *ParserConfig, maxBytes int, logger *logp.Logger) *JSONParser {
 	return &JSONParser{
 		JSONReader{
-			reader: r,
-			cfg:    &cfg.Config,
-			logger: logger.Named("parser_json"),
+			reader:   r,
+			cfg:      &cfg.Config,
+			maxBytes: maxBytes,
+			logger:   logger.Named("parser_json"),
 		},
 		cfg.Field,
 		cfg.Target,
@@ -103,6 +109,25 @@ func (r *JSONReader) decode(text []byte) ([]byte, mapstr.M) {
 	return []byte(textString), jsonFields
 }
 
+func (r *JSONReader) decodeMessage(message *reader.Message, text []byte) ([]byte, mapstr.M) {
+	if r.maxBytes <= 0 || len(text) <= r.maxBytes {
+		return r.decode(text)
+	}
+
+	truncated := make([]byte, r.maxBytes)
+	copy(truncated, text)
+	message.AddFlagsWithKey("log.flags", "truncated") //nolint:errcheck // It is safe to ignore the error.
+
+	if !r.cfg.IgnoreDecodingError {
+		r.logger.Errorf("Error decoding JSON: %v", errMaxBytesExceeded)
+	}
+	if r.cfg.AddErrorKey {
+		return truncated, mapstr.M{"error": createJSONError(fmt.Sprintf("Error decoding JSON: %v", errMaxBytesExceeded))}
+	}
+
+	return truncated, nil
+}
+
 // unmarshal is equivalent with json.Unmarshal but it converts numbers
 // to int64 where possible, instead of using always float64.
 func unmarshal(text []byte, fields *map[string]interface{}) error {
@@ -124,7 +149,7 @@ func (r *JSONReader) Next() (reader.Message, error) {
 	}
 
 	var fields mapstr.M
-	message.Content, fields = r.decode(message.Content)
+	message.Content, fields = r.decodeMessage(&message, message.Content)
 	message.AddFields(mapstr.M{"json": fields})
 	return message, nil
 }
@@ -153,7 +178,7 @@ func (p *JSONParser) Next() (reader.Message, error) {
 		}
 	}
 	var jsonFields mapstr.M
-	message.Content, jsonFields = p.JSONReader.decode(from)
+	message.Content, jsonFields = p.JSONReader.decodeMessage(&message, from)
 
 	if len(jsonFields) == 0 {
 		return message, err

--- a/libbeat/reader/readjson/json_test.go
+++ b/libbeat/reader/readjson/json_test.go
@@ -206,6 +206,50 @@ func TestDecodeJSON(t *testing.T) {
 	}
 }
 
+func TestJSONReaderMaxBytesWithoutMessageKey(t *testing.T) {
+	input := []byte(`{"field":"012345678901234567890123456789"}`)
+	maxBytes := 20
+
+	r := &mockReader{messages: [][]byte{input}}
+	jsonReader := NewJSONReader(r, &Config{AddErrorKey: true}, maxBytes, logptest.NewTestingLogger(t, "json_test"))
+	message, err := jsonReader.Next()
+
+	assert.NoError(t, err)
+	assert.Equal(t, string(input[:maxBytes]), string(message.Content))
+	assertJSONTruncated(t, message.Fields)
+	assert.Equal(t,
+		mapstr.M{"error": mapstr.M{"message": "Error decoding JSON: max_bytes exceeded while decoding JSON", "type": "json"}},
+		message.Fields["json"],
+	)
+}
+
+func TestJSONParserMaxBytesWithoutMessageKey(t *testing.T) {
+	input := []byte(`{"field":"012345678901234567890123456789"}`)
+	maxBytes := 20
+
+	r := &mockReader{messages: [][]byte{input}}
+	jsonParser := NewJSONParser(r, &ParserConfig{Config: Config{AddErrorKey: true}}, maxBytes, logptest.NewTestingLogger(t, "json_test"))
+	message, err := jsonParser.Next()
+
+	assert.NoError(t, err)
+	assert.Equal(t, string(input[:maxBytes]), string(message.Content))
+	assert.Equal(t, string(input[:maxBytes]), message.Fields["message"])
+	assertJSONTruncated(t, message.Fields)
+	assert.Equal(t,
+		mapstr.M{"message": "Error decoding JSON: max_bytes exceeded while decoding JSON", "type": "json"},
+		message.Fields["error"],
+	)
+	assert.NotContains(t, message.Fields, "field")
+}
+
+func assertJSONTruncated(t *testing.T, fields mapstr.M) {
+	t.Helper()
+
+	flags, err := fields.GetValue("log.flags")
+	assert.NoError(t, err, "'log.flags' not present in event")
+	assert.Contains(t, flags, "truncated", "truncated flag should be set")
+}
+
 func TestMergeJSONFields(t *testing.T) {
 	type io struct {
 	}


### PR DESCRIPTION
Truncate JSON input before decode when content exceeds max_bytes, set the truncated log flag, and attach JSON error metadata when add_error_key is enabled. This keeps reader/parser behavior aligned with max_bytes limits and avoids decoding oversized payloads.

GenAI-Assisted: Yes
Human-Reviewed: Yes
Tool: Cursor-CLI, Model: GPT-5.3 Codex Extra High

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/beats/issues/49907


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
