### PR TITLE
x-pack/filebeat/input/streaming: re-evaluate url_program on reconnect

### DIFF
--- a/changelog/fragments/1777418848-streaming-url-program-reconnect.yaml
+++ b/changelog/fragments/1777418848-streaming-url-program-reconnect.yaml
@@ -9,7 +9,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: enhancement
+kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.

--- a/changelog/fragments/1777418848-streaming-url-program-reconnect.yaml
+++ b/changelog/fragments/1777418848-streaming-url-program-reconnect.yaml
@@ -1,0 +1,51 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Re-evaluate url_program on each websocket reconnect using evolved cursor state.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  The streaming input now re-evaluates url_program before each websocket
+  reconnection (both error recovery and OAuth2 token refresh), allowing
+  cursor state accumulated during the session to influence the reconnect URL.
+  Previously url_program was evaluated once at startup and the result was
+  reused for all subsequent connections. The process function also now returns
+  the evolved cursor so that callers can propagate it into the shared state.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -395,7 +395,10 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 			}
 			state["response"] = []byte(msg)
 			s.log.Debugw("received firehose message", logp.Namespace(s.ns), "msg", debugMsg(msg))
-			err = s.process(ctx, state, s.cursor, s.now().In(time.UTC))
+			newCursor, err := s.process(ctx, state, s.cursor, s.now().In(time.UTC))
+			if newCursor != nil {
+				state["cursor"] = newCursor
+			}
 			if err != nil {
 				s.log.Errorw("failed to process and publish data", "error", err)
 				s.status.UpdateStatus(status.Failed, "failed to process and publish data: "+err.Error())

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -395,7 +395,11 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 			}
 			state["response"] = []byte(msg)
 			s.log.Debugw("received firehose message", logp.Namespace(s.ns), "msg", debugMsg(msg))
-			newCursor, err := s.process(ctx, state, s.cursor, s.now().In(time.UTC))
+			currentCursor, ok := state["cursor"].(map[string]any)
+			if !ok {
+				currentCursor = s.cursor
+			}
+			newCursor, err := s.process(ctx, state, currentCursor, s.now().In(time.UTC))
 			if newCursor != nil {
 				state["cursor"] = newCursor
 			}

--- a/x-pack/filebeat/input/streaming/input.go
+++ b/x-pack/filebeat/input/streaming/input.go
@@ -121,7 +121,7 @@ type noopReporter struct{}
 
 func (noopReporter) UpdateStatus(status.Status, string) {}
 
-// getURL initializes the input URL with the help of the url_program.
+// getURL evaluates the url_program to compute the input URL from the current state.
 func getURL(ctx context.Context, name, src, url string, state map[string]any, redaction *redact, log *logp.Logger, now func() time.Time) (string, error) {
 	if src == "" {
 		return url, nil
@@ -177,10 +177,10 @@ type processor struct {
 }
 
 // process processes the data in state, updates the cursor and publishes it to
-// the reciever's publisher. The CEL program here only executes a single time,
+// the receiver's publisher. The CEL program here only executes a single time,
 // since the connection is persistent and events are received and processed in
-// real time.
-func (p processor) process(ctx context.Context, state, cursor map[string]any, start time.Time) error {
+// real time. It returns the last known good cursor after publication.
+func (p processor) process(ctx context.Context, state, cursor map[string]any, start time.Time) (map[string]any, error) {
 	goodCursor := cursor
 	p.log.Debugw("cel engine state before eval", logp.Namespace(p.ns), "state", redactor{state: state, cfg: p.redact})
 	state, err := evalWith(ctx, p.prg, p.ast, state, start)
@@ -189,7 +189,7 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 		p.metrics.celEvalErrors.Add(1)
 		switch {
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-			return err
+			return goodCursor, err
 		default:
 			p.metrics.errorsTotal.Inc()
 		}
@@ -205,17 +205,17 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 	switch e := e.(type) {
 	case []any:
 		if len(e) == 0 {
-			return nil
+			return goodCursor, nil
 		}
 		events = e
 	case map[string]any:
 		if e == nil {
-			return nil
+			return goodCursor, nil
 		}
 		p.log.Debugw("single event object returned by evaluation", "event", e)
 		events = []any{e}
 	default:
-		return fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+		return goodCursor, fmt.Errorf("unexpected type returned for evaluation events: %T", e)
 	}
 
 	// We have a non-empty batch of events to process.
@@ -255,7 +255,7 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 	for i, e := range events {
 		event, ok := e.(map[string]any)
 		if !ok {
-			return fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+			return goodCursor, fmt.Errorf("unexpected type returned for evaluation events: %T", e)
 		}
 		var pubCursor any
 		if cursors != nil {
@@ -266,7 +266,7 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 					goodCursor = cursor
 					cursor, ok = cursors[0].(map[string]any)
 					if !ok {
-						return fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
+						return goodCursor, fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
 					}
 					pubCursor = cursor
 				}
@@ -274,7 +274,7 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 				goodCursor = cursor
 				cursor, ok = cursors[i].(map[string]any)
 				if !ok {
-					return fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
+					return goodCursor, fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
 				}
 				pubCursor = cursor
 			}
@@ -301,7 +301,7 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 
 		err = ctx.Err()
 		if err != nil {
-			return err
+			return goodCursor, err
 		}
 	}
 	// calculate batch processing time
@@ -322,7 +322,7 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 		p.log.Infof("input stopped because context was cancelled with: %v", err)
 		err = nil
 	}
-	return err
+	return goodCursor, err
 }
 
 func evalWith(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[string]interface{}, now time.Time) (map[string]interface{}, error) {

--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/testing/testutils"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
@@ -953,8 +954,6 @@ func TestInput(t *testing.T) {
 func TestURLProgramReconnect(t *testing.T) {
 	testutils.SkipIfFIPSOnly(t, "websocket uses SHA-1.")
 
-	logp.TestingSetup()
-
 	var (
 		mu        sync.Mutex
 		urls      []string
@@ -1017,7 +1016,7 @@ func TestURLProgramReconnect(t *testing.T) {
 	defer cancel()
 
 	v2Ctx := v2.Context{
-		Logger:          logp.NewLogger("websocket_test"),
+		Logger:          logptest.NewTestingLogger(t, "websocket_test"),
 		ID:              "test_id:url_program_reconnect",
 		Cancelation:     ctx,
 		MetricsRegistry: monitoring.NewRegistry(),

--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -1045,6 +1045,114 @@ func TestURLProgramReconnect(t *testing.T) {
 	assert.Contains(t, urls[1], "sinceTime=2024-01-01T01:00:00Z")
 }
 
+// TestURLProgramReconnectZeroEvents verifies that a zero-events message does
+// not regress the cursor to the startup snapshot. The scenario:
+//
+//  1. Input starts with an initial persisted cursor (last_timestamp=00:00:00Z).
+//  2. First message advances the cursor to 01:00:00Z.
+//  3. Second message produces zero events (empty data field).
+//  4. Connection drops, triggering a reconnect.
+//  5. The reconnect URL must contain sinceTime=01:00:00Z (advanced), not
+//     sinceTime=00:00:00Z (initial).
+func TestURLProgramReconnectZeroEvents(t *testing.T) {
+	testutils.SkipIfFIPSOnly(t, "websocket uses SHA-1.")
+
+	var (
+		mu        sync.Mutex
+		urls      []string
+		connCount int
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		urls = append(urls, r.URL.String())
+		connCount++
+		n := connCount
+		mu.Unlock()
+
+		upgrader := websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		if n == 1 {
+			// First connection: send a message that advances the cursor,
+			// then one that produces zero events, then close.
+			conn.WriteMessage(websocket.TextMessage, []byte(`{"ts":"2024-01-01T01:00:00Z","data":"msg-1"}`))
+			conn.WriteMessage(websocket.TextMessage, []byte(`{"ts":"","data":""}`))
+			time.Sleep(50 * time.Millisecond)
+			conn.Close()
+			return
+		}
+		// Second connection: send a message so the test can complete.
+		conn.WriteMessage(websocket.TextMessage, []byte(`{"ts":"2024-01-01T02:00:00Z","data":"msg-2"}`))
+	}))
+	defer server.Close()
+
+	config := map[string]interface{}{
+		"url":         "ws" + server.URL[4:] + "/v1/stream",
+		"url_program": `has(state.?cursor.last_timestamp) ? state.url + "?sinceTime=" + state.cursor.last_timestamp : state.url`,
+		"program": `
+			state.response.decode_json().as(body,
+				body.data != "" ?
+					{"cursor": {"last_timestamp": body.ts}, "events": [body]}
+				:
+					{"events": []}
+			)`,
+		"retry": map[string]interface{}{
+			"blanket_retries": true,
+			"wait_min":        "10ms",
+			"wait_max":        "50ms",
+		},
+	}
+	cfg := conf.MustNewConfigFrom(config)
+
+	c := defaultConfig()
+	c.Redact = &redact{}
+	err := cfg.Unpack(&c)
+	if err != nil {
+		t.Fatalf("unexpected error unpacking config: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	v2Ctx := v2.Context{
+		Logger:          logptest.NewTestingLogger(t, "websocket_test"),
+		ID:              "test_id:url_program_reconnect_zero_events",
+		Cancelation:     ctx,
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+	var client publisher
+	client.done = func() {
+		if len(client.published) >= 2 {
+			cancel()
+		}
+	}
+
+	initialCursor := map[string]any{"last_timestamp": "2024-01-01T00:00:00Z"}
+	src := &source{c}
+	err = input{}.run(v2Ctx, src, initialCursor, &client)
+	if err != nil && err != context.Canceled { //nolint:errorlint // ctx.Err() is never wrapped.
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(urls) < 2 {
+		t.Fatalf("expected at least 2 connections, got %d", len(urls))
+	}
+
+	assert.Contains(t, urls[0], "sinceTime=2024-01-01T00:00:00Z",
+		"first connection should use the initial persisted cursor")
+	assert.Contains(t, urls[1], "sinceTime=2024-01-01T01:00:00Z",
+		"second connection should use the advanced cursor, not the initial one")
+}
+
 var _ inputcursor.Publisher = (*publisher)(nil)
 
 type publisher struct {

--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -61,7 +61,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 		},
@@ -125,7 +125,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 		},
@@ -241,7 +241,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 					"cursor":["What's next?"],
 				})`,
@@ -261,7 +261,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 		},
@@ -273,7 +273,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-	              bytes(state.response).decode_json().as(inner_body,{
+	              state.response.decode_json().as(inner_body,{
 					"events": has(state.cursor) && inner_body.ts > state.cursor.last_updated ?  [inner_body] : [],
 	          })`,
 			"state": map[string]interface{}{
@@ -315,7 +315,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 			"auth": map[string]interface{}{
@@ -348,7 +348,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 			"auth": map[string]interface{}{
@@ -381,7 +381,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 			"auth": map[string]interface{}{
@@ -417,7 +417,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 			"retry": map[string]interface{}{
@@ -452,7 +452,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 			"retry": map[string]interface{}{
@@ -469,7 +469,7 @@ var inputTests = []struct {
 		handler: defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 			"ssl": map[string]interface{}{
@@ -539,7 +539,7 @@ var inputTests = []struct {
 		handler:     defaultHandler,
 		config: map[string]interface{}{
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 		},
@@ -621,7 +621,7 @@ var inputTests = []struct {
 				},
 			},
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 		},
@@ -704,7 +704,7 @@ var inputTests = []struct {
 				},
 			},
 			"program": `
-					bytes(state.response).decode_json().as(inner_body,{
+					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 		},
@@ -938,6 +938,112 @@ func TestInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestURLProgramReconnect verifies that url_program is re-evaluated before
+// each reconnection using the evolved cursor state. The test server records
+// the request URL for each connection and closes the first connection after
+// sending one message to force the error-reconnect path. The CEL program
+// updates the cursor with a timestamp from the message, and url_program
+// appends sinceTime from the cursor when present. The test asserts that:
+//   - the first connection URL has no sinceTime (no cursor yet)
+//   - the second connection URL includes sinceTime from the first message's
+//     timestamp, proving that url_program was re-evaluated with the cursor
+//     that process() returned after handling the first message
+func TestURLProgramReconnect(t *testing.T) {
+	testutils.SkipIfFIPSOnly(t, "websocket uses SHA-1.")
+
+	logp.TestingSetup()
+
+	var (
+		mu        sync.Mutex
+		urls      []string
+		connCount int
+	)
+
+	// The server records the request URL for each connection. It sends one
+	// JSON message per connection and closes the first connection to force
+	// the client through the error-reconnect path in FollowStream.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		urls = append(urls, r.URL.String())
+		connCount++
+		n := connCount
+		mu.Unlock()
+
+		upgrader := websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		msg := fmt.Sprintf(`{"ts":"2024-01-01T%02d:00:00Z","data":"msg-%d"}`, n, n)
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
+			return
+		}
+
+		if n == 1 {
+			conn.Close()
+		}
+	}))
+	defer server.Close()
+
+	config := map[string]interface{}{
+		"url":         "ws" + server.URL[4:] + "/v1/stream",
+		"url_program": `has(state.?cursor.last_timestamp) ? state.url + "?sinceTime=" + state.cursor.last_timestamp : state.url`,
+		"program": `
+			state.response.decode_json().as(body, {
+				"cursor": {"last_timestamp": body.ts},
+				"events": [body],
+			})`,
+		"retry": map[string]interface{}{
+			"blanket_retries": true,
+			"wait_min":        "10ms",
+			"wait_max":        "50ms",
+		},
+	}
+	cfg := conf.MustNewConfigFrom(config)
+
+	c := defaultConfig()
+	c.Redact = &redact{}
+	err := cfg.Unpack(&c)
+	if err != nil {
+		t.Fatalf("unexpected error unpacking config: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	v2Ctx := v2.Context{
+		Logger:          logp.NewLogger("websocket_test"),
+		ID:              "test_id:url_program_reconnect",
+		Cancelation:     ctx,
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+	var client publisher
+	client.done = func() {
+		if len(client.published) >= 2 {
+			cancel()
+		}
+	}
+
+	src := &source{c}
+	err = input{}.run(v2Ctx, src, nil, &client)
+	if err != nil && err != context.Canceled {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(urls) < 2 {
+		t.Fatalf("expected at least 2 connections, got %d", len(urls))
+	}
+
+	assert.Equal(t, "/v1/stream", urls[0])
+	assert.Contains(t, urls[1], "sinceTime=2024-01-01T01:00:00Z")
 }
 
 var _ inputcursor.Publisher = (*publisher)(nil)

--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -1030,7 +1030,7 @@ func TestURLProgramReconnect(t *testing.T) {
 
 	src := &source{c}
 	err = input{}.run(v2Ctx, src, nil, &client)
-	if err != nil && err != context.Canceled {
+	if err != nil && err != context.Canceled { //nolint:errorlint // ctx.Err() is never wrapped.
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/x-pack/filebeat/input/streaming/websocket.go
+++ b/x-pack/filebeat/input/streaming/websocket.go
@@ -283,6 +283,15 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 			s.cfg.Auth.OAuth2.accessToken = token.AccessToken
 			// set the new token expiry channel with 2 mins buffer
 			s.tokenExpiry = time.After(time.Until(token.Expiry) - s.cfg.Auth.OAuth2.TokenExpiryBuffer)
+			// Re-evaluate url_program before reconnecting so that cursor
+			// changes since the last connection are reflected in the URL.
+			updatedURL, err := getURL(ctx, "websocket", s.cfg.URLProgram, s.cfg.URL.String(), state, s.cfg.Redact, s.log, s.now)
+			if err != nil {
+				s.metrics.errorsTotal.Inc()
+				s.log.Errorw("failed to re-evaluate url_program on token refresh, using previous url", "error", err)
+			} else {
+				url = updatedURL
+			}
 			// establish a new connection with the new token
 			c, resp, err = connectWebSocket(ctx, s.cfg, url, s.status, s.log)
 			handleConnectionResponse(resp, s.metrics, s.log)
@@ -319,6 +328,15 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 						s.log.Errorw("encountered an error while closing the websocket connection", "error", err)
 					}
 				}
+				// Re-evaluate url_program before reconnecting so that cursor
+				// changes since the last connection are reflected in the URL.
+				updatedURL, err := getURL(ctx, "websocket", s.cfg.URLProgram, s.cfg.URL.String(), state, s.cfg.Redact, s.log, s.now)
+				if err != nil {
+					s.metrics.errorsTotal.Inc()
+					s.log.Errorw("failed to re-evaluate url_program on reconnect, using previous url", "error", err)
+				} else {
+					url = updatedURL
+				}
 				// Since c is already a pointer, we can reassign it to the new connection
 				// and the defer func will still handle it.
 				c, resp, err = connectWebSocket(ctx, s.cfg, url, s.status, s.log)
@@ -340,7 +358,10 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 			s.metrics.receivedBytesTotal.Add(uint64(len(message)))
 			state["response"] = message
 			s.log.Debugw("received websocket message", logp.Namespace(s.ns), "msg", string(message))
-			err = s.process(ctx, state, s.cursor, s.now().In(time.UTC))
+			newCursor, err := s.process(ctx, state, s.cursor, s.now().In(time.UTC))
+			if newCursor != nil {
+				state["cursor"] = newCursor
+			}
 			if err != nil {
 				s.metrics.errorsTotal.Inc()
 				s.status.UpdateStatus(status.Failed, "failed to process and publish data: "+err.Error())

--- a/x-pack/filebeat/input/streaming/websocket.go
+++ b/x-pack/filebeat/input/streaming/websocket.go
@@ -358,7 +358,11 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 			s.metrics.receivedBytesTotal.Add(uint64(len(message)))
 			state["response"] = message
 			s.log.Debugw("received websocket message", logp.Namespace(s.ns), "msg", string(message))
-			newCursor, err := s.process(ctx, state, s.cursor, s.now().In(time.UTC))
+			currentCursor, ok := state["cursor"].(map[string]any)
+			if !ok {
+				currentCursor = s.cursor
+			}
+			newCursor, err := s.process(ctx, state, currentCursor, s.now().In(time.UTC))
 			if newCursor != nil {
 				state["cursor"] = newCursor
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: re-evaluate url_program on reconnect

Previously url_program was evaluated once at the start of FollowStream
and the resulting URL was reused for all reconnections within the
session. This meant cursor changes from processed messages could not
influence the URL used on reconnect.

Move the getURL call into both reconnect paths (error recovery and
OAuth2 token refresh) so that url_program sees the current cursor
state. On evaluation failure, fall back to the previously computed URL
rather than terminating the input.

To make the evolved cursor visible to url_program, change process() to
return the last known good cursor so callers can write it back into
the shared state map. The previous signature only returned an error;
the cursor updates from evalWith were confined to a shadowed local
variable and never propagated to FollowStream's state.

Also remove unnecessary bytes() wrapping from CEL programs in tests;
state.response already supports decode_json() directly.

Assisted-By: Cursor (claude-opus-4-6)
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For elastic/integrations#14241

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
