### PR TITLE
x-pack/filebeat/input/httpjson: remove unnecessary allocations in cursor updates and splits

### DIFF
--- a/changelog/fragments/1777430032-reduce-httpjson-cursor-update-allocs.yaml
+++ b/changelog/fragments/1777430032-reduce-httpjson-cursor-update-allocs.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Reduce allocation pressure in httpjson cursor update and split paths.
+component: filebeat

--- a/x-pack/filebeat/input/httpjson/cursor_test.go
+++ b/x-pack/filebeat/input/httpjson/cursor_test.go
@@ -5,14 +5,17 @@
 package httpjson
 
 import (
+	"fmt"
+	"net/http"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -141,12 +144,74 @@ func TestCursorUpdate(t *testing.T) {
 			require.NoError(t, cfg.Unpack(&conf))
 
 			var stat testStatus
-			c := newCursor(conf, &stat, logp.NewLogger("cursor-test"))
+			c := newCursor(conf, &stat, logptest.NewTestingLogger(t, "cursor-test"))
 			c.state = tc.initialState
 			c.update(tc.trCtx)
 			assert.Equal(t, tc.expectedState, c.state)
 			sort.Strings(stat.updates) // Can happen out of order.
 			assert.Equal(t, tc.wantStatus, stat.updates)
+		})
+	}
+}
+
+// BenchmarkCursorUpdate measures the per-event cost of updateCursor(),
+// which drives template evaluation clones of lastEvent, firstEvent,
+// lastResponse, and firstResponse. The response body size is varied
+// to show how the clone cost scales with page size.
+func BenchmarkCursorUpdate(b *testing.B) {
+	for _, nItems := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("response_%d_items", nItems), func(b *testing.B) {
+			items := make([]interface{}, nItems)
+			for i := range items {
+				items[i] = map[string]interface{}{
+					"id":    i,
+					"name":  fmt.Sprintf("item-%d", i),
+					"value": strings.Repeat("x", 100),
+				}
+			}
+			responseBody := mapstr.M{
+				"items":         items,
+				"nextPageToken": "abc123",
+			}
+
+			lastEvent := mapstr.M{
+				"id":        map[string]interface{}{"time": "2025-01-01T00:00:00Z"},
+				"name":      "some-event",
+				"important": "data",
+			}
+
+			cursorCfg := conf.MustNewConfigFrom(map[string]interface{}{
+				"updated": map[string]interface{}{
+					"value": "[[ .last_event.id.time ]]",
+				},
+			})
+			cc := cursorConfig{}
+			if err := cursorCfg.Unpack(&cc); err != nil {
+				b.Fatal(err)
+			}
+
+			trCtx := &transformContext{
+				cursor:     &cursor{},
+				firstEvent: &lastEvent,
+				lastEvent:  &lastEvent,
+				lastResponse: &response{
+					header: http.Header{"Content-Type": {"application/json"}},
+					body:   responseBody,
+				},
+				firstResponse: &response{
+					header: http.Header{"Content-Type": {"application/json"}},
+					body:   responseBody,
+				},
+			}
+
+			var stat testStatus
+			c := newCursor(cc, &stat, logptest.NewTestingLogger(b, "cursor-bench"))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				c.update(trCtx)
+			}
 		})
 	}
 }

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -829,7 +829,7 @@ func (p *publisher) handleEvent(_ context.Context, msg mapstr.M) {
 			return
 		}
 	}
-	if len(*p.trCtx.firstEventClone()) == 0 {
+	if len(*p.trCtx.firstEvent) == 0 {
 		p.trCtx.updateFirstEvent(msg)
 	}
 	p.trCtx.updateLastEvent(msg)

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -82,14 +82,14 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	assert.EqualValues(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
-		trCtx.firstEventClone(),
+		trCtx.firstEvent,
 	)
 	assert.EqualValues(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
-		trCtx.lastEventClone(),
+		trCtx.lastEvent,
 	)
-	lastResp := trCtx.lastResponseClone()
+	lastResp := trCtx.lastResponse.clone()
 	// ignore since has dynamic date and content length values
 	// and is not relevant
 	lastResp.header = nil
@@ -114,16 +114,16 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	assert.EqualValues(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
-		trCtx.firstEventClone(),
+		trCtx.firstEvent,
 	)
 
 	assert.EqualValues(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
-		trCtx.lastEventClone(),
+		trCtx.lastEvent,
 	)
 
-	lastResp = trCtx.lastResponseClone()
+	lastResp = trCtx.lastResponse.clone()
 	lastResp.header = nil
 	assert.EqualValues(t,
 		&response{

--- a/x-pack/filebeat/input/httpjson/split.go
+++ b/x-pack/filebeat/input/httpjson/split.go
@@ -238,8 +238,9 @@ func (s *split) processMessage(ctx context.Context, trCtx *transformContext, roo
 		_, _ = obj.Put(s.keyField, key)
 	}
 
-	clone := root.Clone()
+	var clone mapstr.M
 	if s.keepParent {
+		clone = root.Clone()
 		_, _ = clone.Put(s.targetInfo.Name, v)
 	} else {
 		clone = obj

--- a/x-pack/filebeat/input/httpjson/transform.go
+++ b/x-pack/filebeat/input/httpjson/transform.go
@@ -45,24 +45,6 @@ func (ctx *transformContext) cursorMap() mapstr.M {
 	return ctx.cursor.clone()
 }
 
-func (ctx *transformContext) lastEventClone() *mapstr.M {
-	clone := ctx.lastEvent.Clone()
-	return &clone
-}
-
-func (ctx *transformContext) firstEventClone() *mapstr.M {
-	clone := ctx.firstEvent.Clone()
-	return &clone
-}
-
-func (ctx *transformContext) firstResponseClone() *response {
-	return ctx.firstResponse.clone()
-}
-
-func (ctx *transformContext) lastResponseClone() *response {
-	return ctx.lastResponse.clone()
-}
-
 func (ctx *transformContext) updateCursor() {
 	// we do not want to pass the cursor data to itself
 	newCtx := emptyTransformContext()

--- a/x-pack/filebeat/input/httpjson/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl.go
@@ -134,15 +134,14 @@ func (t *valueTpl) Execute(trCtx *transformContext, tr transformable, targetName
 	buf := new(bytes.Buffer)
 	data := tr.Clone()
 	data.Put("cursor", trCtx.cursorMap())
-	data.Put("first_event", trCtx.firstEventClone())
-	data.Put("last_event", trCtx.lastEventClone())
-	data.Put("last_response", trCtx.lastResponseClone().templateValues())
+	data.Put("first_event", trCtx.firstEvent)
+	data.Put("last_event", trCtx.lastEvent)
+	data.Put("last_response", trCtx.lastResponse.templateValues())
 	if trCtx.firstResponse != nil {
-		data.Put("first_response", trCtx.firstResponseClone().templateValues())
+		data.Put("first_response", trCtx.firstResponse.templateValues())
 	}
-	// This is only set when chaining is used
 	if trCtx.parentTrCtx != nil {
-		data.Put("parent_last_response", trCtx.parentTrCtx.lastResponseClone().templateValues())
+		data.Put("parent_last_response", trCtx.parentTrCtx.lastResponse.templateValues())
 	}
 
 	if err := t.Template.Execute(buf, data); err != nil {

--- a/x-pack/filebeat/input/httpjson/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl.go
@@ -133,6 +133,10 @@ func (t *valueTpl) Execute(trCtx *transformContext, tr transformable, targetName
 
 	buf := new(bytes.Buffer)
 	data := tr.Clone()
+	// Note that mapstr.M methods are available from within the template.
+	// This allows templates to mutate values within the maps. Doing so
+	// is not supported and will lead to undefined behaviour. The only way
+	// to prevent this is to clone the map, which is excessively expensive.
 	data.Put("cursor", trCtx.cursorMap())
 	data.Put("first_event", trCtx.firstEvent)
 	data.Put("last_event", trCtx.lastEvent)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/httpjson: remove unnecessary allocations in cursor updates and splits

In three places, mapstr.M values were being cloned when not necessary,
either based on logic or complete pointlessness. Make the logic clearer
and remove the pointless clones. The majority impact is from the change
in valueTpl.Execute which halves the total byte allocs per operation and
reduces allocs by more than a third.

                                    │  old.bench  │              new.bench              │
                                    │   sec/op    │   sec/op     vs base                │
CursorUpdate/response_100_items-22    4.732µ ± 3%   2.599µ ± 2%  -45.08% (p=0.000 n=10)
CursorUpdate/response_1000_items-22   4.618µ ± 2%   2.494µ ± 1%  -45.99% (p=0.000 n=10)
CursorUpdate/response_5000_items-22   4.233µ ± 3%   2.362µ ± 2%  -44.21% (p=0.000 n=10)
geomean                               4.522µ        2.483µ       -45.10%

                                    │  old.bench   │              new.bench               │
                                    │     B/op     │     B/op      vs base                │
CursorUpdate/response_100_items-22    6.252Ki ± 0%   3.075Ki ± 0%  -50.82% (p=0.000 n=10)
CursorUpdate/response_1000_items-22   6.250Ki ± 0%   3.074Ki ± 0%  -50.81% (p=0.000 n=10)
CursorUpdate/response_5000_items-22   6.246Ki ± 0%   3.072Ki ± 0%  -50.81% (p=0.000 n=10)
geomean                               6.249Ki        3.074Ki       -50.82%

                                    │ old.bench  │             new.bench              │
                                    │ allocs/op  │ allocs/op   vs base                │
CursorUpdate/response_100_items-22    60.00 ± 0%   38.00 ± 0%  -36.67% (p=0.000 n=10)
CursorUpdate/response_1000_items-22   60.00 ± 0%   38.00 ± 0%  -36.67% (p=0.000 n=10)
CursorUpdate/response_5000_items-22   60.00 ± 0%   38.00 ± 0%  -36.67% (p=0.000 n=10)
geomean                               60.00        38.00       -36.67%

Also remove pointless clone methods that become dead, and remove clones
in testing that were not doing real work and the methods that enabled
them.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
