### PR TITLE
[8.19] ci: migrate x-pack/libbeat Win 10/11 to Azure

### DIFF
--- a/.buildkite/x-pack/pipeline.xpack.libbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.libbeat.yml
@@ -6,8 +6,10 @@ env:
   AWS_IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64-1776781006"
 
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
-  IMAGE_WIN_10: "platform-ingest-beats-windows-10-1776781006"
-  IMAGE_WIN_11: "platform-ingest-beats-windows-11-1776781006"
+  IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
+  IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
+  IMAGE_WIN_10_VERSION: "1.0.1776697195"
+  IMAGE_WIN_11_VERSION: "1.0.1776697195"
   IMAGE_WIN_2016: "platform-ingest-beats-windows-2016-1776781006"
   IMAGE_WIN_2019: "platform-ingest-beats-windows-2019-1776781006"
   IMAGE_WIN_2022: "platform-ingest-beats-windows-2022-1776781006"
@@ -245,11 +247,11 @@ steps:
           automatic:
             - limit: 1
         agents:
-          provider: "gcp"
+          provider: "azure"
           image: "${IMAGE_WIN_10}"
-          machineType: "${GCP_WIN_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          imageVersion: "${IMAGE_WIN_10_VERSION}"
+          vmSize: "Standard_D8s_v5"
+          diskSizeGb: "256"
         artifact_paths:
           - "x-pack/libbeat/build/*.xml"
           - "x-pack/libbeat/build/*.json"
@@ -266,11 +268,11 @@ steps:
           automatic:
             - limit: 1
         agents:
-          provider: "gcp"
+          provider: "azure"
           image: "${IMAGE_WIN_11}"
-          machineType: "${GCP_WIN_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          imageVersion: "${IMAGE_WIN_11_VERSION}"
+          vmSize: "Standard_D8s_v5"
+          diskSizeGb: "256"
         artifact_paths:
           - "x-pack/libbeat/build/*.xml"
           - "x-pack/libbeat/build/*.json"


### PR DESCRIPTION
## What

Migrate the Win 10 / Win 11 Unit Tests in `.buildkite/x-pack/pipeline.xpack.libbeat.yml` from the GCP provider to Azure on `8.19`, mirroring the pattern used in the other 8.19 pipelines.

```diff
   IMAGE_UBUNTU_X86_64: "platform-ingest-beats-ubuntu-2204-1776781006"
-  IMAGE_WIN_10: "platform-ingest-beats-windows-10-1776781006"
-  IMAGE_WIN_11: "platform-ingest-beats-windows-11-1776781006"
+  IMAGE_WIN_10: "platform-ingest-beats-windows-10-pro"
+  IMAGE_WIN_11: "platform-ingest-beats-windows-11-pro"
+  IMAGE_WIN_10_VERSION: "1.0.1776697195"
+  IMAGE_WIN_11_VERSION: "1.0.1776697195"
...
         agents:
-          provider: "gcp"
+          provider: "azure"
           image: "${IMAGE_WIN_10}"
-          machineType: "${GCP_WIN_MACHINE_TYPE}"
-          disk_size: 100
-          disk_type: "pd-ssd"
+          imageVersion: "${IMAGE_WIN_10_VERSION}"
+          vmSize: "Standard_D8s_v5"
+          diskSizeGb: "256"
```

## Why

#50206 / #50218 (`bk: use azure images`) migrated all pipelines that reference Win 10/11 to Azure.

This file was missed by that migration because the corresponding file on `main` no longer contains Win 10/11 jobs — they were moved to `.buildkite/libbeat/pipeline.libbeat.yml` along with the ETW reader in #46360, which was not backported to 8.19 (`backport-skip` label, license refactor only). On 8.19 those Windows jobs still live here and are still meaningful — they exercise the ETW reader at its 8.19 location (`x-pack/libbeat/reader/etw/`).

The subsequent automated bump #50253 just renumbered the dead references (`1772337686` → `1776781006`), so every push to `8.19` and every Mergify backport branch that triggers `x-pack/libbeat` now fails at agent launch:

```
googleapi: Error 404: The resource
'projects/elastic-images-prod/global/images/platform-ingest-beats-windows-10-1776781006'
was not found, notFound
```

The Win 10/11 jobs are gated to non-PR builds (`build.env(\"BUILDKITE_PULL_REQUEST\") == \"false\" || GITHUB_PR_LABELS =~ /windows/`), which is why this only manifests on `8.19` branch builds and Mergify backport branches — and why all the open 8.19 backports (#50185 plus its 5 dependents) have been blocked behind it.

The file is already listed in the Azure section of `.github/workflows/updatecli.d/updatecli-bump-vm-images.yml`, so future automated bumps will keep `IMAGE_WIN_10/11_VERSION` in sync once this lands.

## Related

- Followup to #50218 / #50206 (Azure migration) and #50253 (dead-tag renumber)
- Unblocks #50185 and all 8.19 backports depending on it (#50248, #50313, #50335, #50338, #50366)