### PR TITLE
[8.19](backport #49481) [Filebeat] filestream: degrade only on wrapped permanent harvester errors (#49481)

### DIFF
--- a/changelog/fragments/1773680180-filestream-permanent-harvester-errors.yaml
+++ b/changelog/fragments/1773680180-filestream-permanent-harvester-errors.yaml
@@ -1,0 +1,4 @@
+kind: bug
+summary: Filestream only reports degraded status for permanent harvester errors.
+component: filebeat
+issue: https://github.com/elastic/beats/issues/49451

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -38,6 +38,18 @@ var (
 	ErrHarvesterLimitReached   = errors.New("harvester limit reached")
 )
 
+type permanentHarvesterError struct {
+	err error
+}
+
+func (e permanentHarvesterError) Error() string {
+	return e.err.Error()
+}
+
+func (e permanentHarvesterError) Unwrap() error {
+	return e.err
+}
+
 // Harvester is the reader which collects the lines from
 // the configured source.
 type Harvester interface {
@@ -232,8 +244,8 @@ func startHarvester(
 				hg.readers.remove(srcID)
 			}
 
-			// Report any harvester error as a degraded state for the input
-			if err != nil {
+			// Report permanent harvester errors as a degraded state for the input.
+			if err != nil && isPermanentHarvesterError(err) {
 				ctx.UpdateStatus(
 					status.Degraded,
 					fmt.Sprintf("Harvester for Filestream input %q failed: %s", inputID, err),
@@ -280,7 +292,9 @@ func startHarvester(
 		})
 		if err != nil {
 			hg.readers.remove(srcID)
-			return fmt.Errorf("error while connecting to output with pipeline: %w", err)
+			return permanentHarvesterError{
+				err: fmt.Errorf("error while connecting to output with pipeline: %w", err),
+			}
 		}
 		defer client.Close()
 
@@ -404,4 +418,9 @@ func lockResource(log *logp.Logger, resource *resource, canceler inputv2.Cancele
 func releaseResource(resource *resource) {
 	resource.lock.Unlock()
 	resource.Release()
+}
+
+func isPermanentHarvesterError(err error) bool {
+	var permanentErr permanentHarvesterError
+	return errors.As(err, &permanentErr)
 }

--- a/filebeat/input/filestream/internal/input-logfile/harvester_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester_test.go
@@ -394,6 +394,39 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 		assert.Contains(t, testLog.String(), errHarvester.Error())
 	})
 
+	t.Run("assert non-permanent harvester errors do not report degraded status", func(t *testing.T) {
+		mockHarvester := &mockHarvester{onRun: errorOnRun}
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
+		statusReporter := &recordingStatusReporter{}
+
+		ctx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(statusReporter)
+		hg.Start(ctx, source)
+
+		requireEventually(t,
+			func() bool { return !hg.readers.hasID(hg.identifier.ID(source)) },
+			"source should be removed from bookkeeper after error")
+		require.NoError(t, hg.StopHarvesters())
+
+		assert.Zero(t, statusReporter.countWithStatus(status.Degraded))
+	})
+
+	t.Run("assert ConnectWith errors report degraded status", func(t *testing.T) {
+		hg := testDefaultHarvesterGroup(t, &mockHarvester{onRun: correctOnRun}, 0)
+		hg.pipeline = &MockPipeline{connectErr: errPipelineConnect}
+		statusReporter := &recordingStatusReporter{}
+
+		ctx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(statusReporter)
+		hg.Start(ctx, source)
+
+		requireEventually(t,
+			func() bool { return !hg.readers.hasID(hg.identifier.ID(source)) },
+			"source should be removed from bookkeeper after connect error")
+		require.NoError(t, hg.StopHarvesters())
+
+		require.Equal(t, 1, statusReporter.countWithStatus(status.Degraded))
+		assert.Contains(t, statusReporter.lastMessage(), errPipelineConnect.Error())
+	})
+
 	t.Run("assert already locked resource has to wait", func(t *testing.T) {
 		var wg sync.WaitGroup
 		mockHarvester := &mockHarvester{onRun: correctOnRun, wg: &wg}
@@ -538,6 +571,7 @@ func blockUntilCancelOnRun(c input.Context, _ Source, _ Cursor, _ Publisher) err
 }
 
 var errHarvester = fmt.Errorf("harvester error")
+var errPipelineConnect = fmt.Errorf("pipeline connect error")
 
 func errorOnRun(_ input.Context, _ Source, _ Cursor, _ Publisher) error {
 	return errHarvester
@@ -621,12 +655,17 @@ type MockPipeline struct {
 	c               beat.Client        // Client used by the pipeline
 	mu              sync.Mutex         // Mutex to synchronize access to the client
 	publishCallback func(e beat.Event) // Callback called when the client is publishing the event, but before acknowledging it
+	connectErr      error
 }
 
 // ConnectWith connects the mock pipeline with a client using the provided configuration.
 func (mp *MockPipeline) ConnectWith(config beat.ClientConfig) (beat.Client, error) {
 	mp.mu.Lock()
 	defer mp.mu.Unlock()
+
+	if mp.connectErr != nil {
+		return nil, mp.connectErr
+	}
 
 	c := &MockClient{}
 	if mp.publishCallback != nil {
@@ -647,6 +686,46 @@ type mockStatusReporter struct{}
 
 // UpdateStatus is a no-op
 func (m mockStatusReporter) UpdateStatus(status status.Status, msg string) {
+}
+
+type statusUpdate struct {
+	status status.Status
+	msg    string
+}
+
+type recordingStatusReporter struct {
+	mu      sync.Mutex
+	updates []statusUpdate
+}
+
+func (r *recordingStatusReporter) UpdateStatus(st status.Status, msg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.updates = append(r.updates, statusUpdate{status: st, msg: msg})
+}
+
+func (r *recordingStatusReporter) countWithStatus(st status.Status) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	count := 0
+	for _, update := range r.updates {
+		if update.status == st {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *recordingStatusReporter) lastMessage() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.updates) == 0 {
+		return ""
+	}
+	return r.updates[len(r.updates)-1].msg
 }
 
 func isClosed(done chan struct{}) bool {


### PR DESCRIPTION
Manual backport from https://github.com/elastic/beats/pull/49481

## Proposed commit message

```
Update Filestream status reporting to only report permanent errors, this puts the input in a degraded state.
Currently the only permanent errors are errors from connecting to the pipeline.

GenAI-Assisted: Yes
Human-Reviewed: Yes
Tool: Copilot, Model:  gpt-5.3-codex
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

**Run the new tests:**
```
cd filebeat

go test -v -count=1 -run=TestDefaultHarvesterGroup/assert_non-permanent ./input/filestream/internal/input-logfile
go test -v -count=1 -run=TestDefaultHarvesterGroup/assert_connectWith ./input/filestream/internal/input-logfile
```

**Run all Filestream unit tests**
```
cd filebeat

go test -count=1 ./input/filestream/...
mage buildSystemTestBinary
go test -count=1 -tags=integration ./input/filestream/...
```

## Related issues

- Backport from https://github.com/elastic/beats/pull/49481

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
