### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/okta: fix config unpacking for jwk_json and jwk_pem

### DIFF
--- a/changelog/fragments/1777491987-fix-okta-jwk-config-unpacking.yaml
+++ b/changelog/fragments/1777491987-fix-okta-jwk-config-unpacking.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix Okta entity analytics OAuth2 config unpacking for jwk_json and jwk_pem fields.
+component: filebeat

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
@@ -17,6 +17,7 @@ import (
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
 	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
@@ -107,9 +108,9 @@ type oAuth2Config struct {
 	TokenURL     string   `config:"token_url" validate:"required"`
 
 	// JWT-based authentication (private key)
-	OktaJWKFile string `config:"jwk_file"`
-	OktaJWKJSON []byte `config:"jwk_json"`
-	OktaJWKPEM  []byte `config:"jwk_pem"`
+	OktaJWKFile string          `config:"jwk_file"`
+	OktaJWKJSON common.JSONBlob `config:"jwk_json"`
+	OktaJWKPEM  string          `config:"jwk_pem"`
 }
 
 func (o *oAuth2Config) isEnabled() bool {
@@ -130,7 +131,7 @@ func (o *oAuth2Config) Validate() error {
 
 	// Determine authentication method based on provided credentials
 	hasClientSecret := o.ClientSecret != ""
-	hasJWTKeys := o.OktaJWKFile != "" || o.OktaJWKJSON != nil || o.OktaJWKPEM != nil
+	hasJWTKeys := o.OktaJWKFile != "" || o.OktaJWKJSON != nil || o.OktaJWKPEM != ""
 
 	if hasClientSecret && hasJWTKeys {
 		return errors.New("oauth2 validation error: cannot use both client secret and JWT private keys")
@@ -150,7 +151,7 @@ func (o *oAuth2Config) Validate() error {
 		if o.OktaJWKJSON != nil {
 			n++
 		}
-		if o.OktaJWKPEM != nil {
+		if o.OktaJWKPEM != "" {
 			n++
 		}
 		if n > 1 {
@@ -179,8 +180,8 @@ func (o *oAuth2Config) Validate() error {
 				return fmt.Errorf("oauth2 validation error: invalid JWK JSON format: %w", err)
 			}
 		}
-		if o.OktaJWKPEM != nil {
-			if _, err := pemPKCS8PrivateKey(o.OktaJWKPEM); err != nil {
+		if o.OktaJWKPEM != "" {
+			if _, err := pemPKCS8PrivateKey([]byte(o.OktaJWKPEM)); err != nil {
 				return fmt.Errorf("oauth2 validation error: %w", err)
 			}
 		}
@@ -352,7 +353,7 @@ func (c *conf) wantDevices() bool {
 }
 
 // populateJSONFromFile reads a JSON file and populates the destination.
-func populateJSONFromFile(file string, dst *[]byte) error {
+func populateJSONFromFile(file string, dst *common.JSONBlob) error {
 	_, err := os.Stat(file)
 	if errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("the file %q cannot be found", file)

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2.go
@@ -65,7 +65,7 @@ func (o *oAuth2Config) fetchOktaOauthClient(ctx context.Context, client *http.Cl
 
 	// Determine authentication method based on provided credentials
 	hasClientSecret := o.ClientSecret != ""
-	hasJWTKeys := o.OktaJWKFile != "" || o.OktaJWKJSON != nil || o.OktaJWKPEM != nil
+	hasJWTKeys := o.OktaJWKFile != "" || o.OktaJWKJSON != nil || o.OktaJWKPEM != ""
 
 	switch {
 	case hasClientSecret:
@@ -94,8 +94,8 @@ func (o *oAuth2Config) fetchOktaOauthClient(ctx context.Context, client *http.Cl
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate Okta JWT: %w", err)
 			}
-		case o.OktaJWKPEM != nil:
-			oktaJWT, err = generateOktaJWTPEM(string(o.OktaJWKPEM), oauthConfig)
+		case o.OktaJWKPEM != "":
+			oktaJWT, err = generateOktaJWTPEM(o.OktaJWKPEM, oauthConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate Okta JWT: %w", err)
 			}

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
 )
 
 func TestOAuth2ConfigValidation(t *testing.T) {
@@ -24,7 +26,7 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 				ClientID: "test-client",
 				Scopes:   []string{"okta.users.read"},
 				TokenURL: "https://test.okta.com/oauth2/v1/token",
-				OktaJWKJSON: []byte(`{
+				OktaJWKJSON: common.JSONBlob(`{
 					"kty": "RSA",
 					"n": "test-n",
 					"e": "AQAB",
@@ -37,6 +39,57 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 				}`),
 			},
 			wantErr: false,
+		},
+		{
+			name: "valid oauth2 config with jwk_pem",
+			config: &oAuth2Config{
+				Enabled:  boolPtr(true),
+				ClientID: "test-client",
+				Scopes:   []string{"okta.users.read"},
+				TokenURL: "https://test.okta.com/oauth2/v1/token",
+				OktaJWKPEM: `
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCOuef3HMRhohVT
+5kSoAJgV+atpDjkwTwkOq+ImnbBlv75GaApG90w8VpjXjhqN/1KJmwfyrKiquiMq
+OPu+o/672Dys5rUAaWSbT7wRF1GjLDDZrM0GHRdV4DGxM/LKI8I5yE1Mx3EzV+D5
+ZLmcRc5U4oEoMwtGpr0zRZ7uUr6a28UQwcUsVIPItc1/9rERlo1WTv8dcaj4ECC3
+2Sc0y/F+9XqwJvLd4Uv6ckzP0Sv4tbDA+7jpD9MneAIUiZ4LVj2cwbBd+YRY6jXx
+MkevcCSmSX60clBY1cIFkw1DYHqtdHEwAQcQHLGMoi72xRP2qrdzIPsaTKVYoHVo
+WA9vADdHAgMBAAECggEAIlx7jjCsztyYyeQsL05FTzUWoWo9NnYwtgmHnshkCXsK
+MiUmJEOxZO1sSqj5l6oakupyFWigCspZYPbrFNCiqVK7+NxqQzkccY/WtT6p9uDS
+ufUyPwCN96zMCd952lSVlBe3FH8Hr9a+YQxw60CbFjCZ67WuR0opTsi6JKJjJSDb
+TQQZ4qJR97D05I1TgfmO+VO7G/0/dDaNHnnlYz0AnOgZPSyvrU2G5cYye4842EMB
+ng81xjHD+xp55JNui/xYkhmYspYhrB2KlEjkKb08OInUjBeaLEAgA1r9yOHsfV/3
+DQzDPRO9iuqx5BfJhdIqUB1aifrye+sbxt9uMBtUgQKBgQDVdfO3GYT+ZycOQG9P
+QtdMn6uiSddchVCGFpk331u6M6yafCKjI/MlJDl29B+8R5sVsttwo8/qnV/xd3cn
+pY14HpKAsE4l6/Ciagzoj+0NqfPEDhEzbo8CyArcd7pSxt3XxECAfZe2+xivEPHe
+gFO60vSFjFtvlLRMDMOmqX3kYQKBgQCrK1DISyQTnD6/axsgh2/ESOmT7n+JRMx/
+YzA7Lxu3zGzUC8/sRDa1C41t054nf5ZXJueYLDSc4kEAPddzISuCLxFiTD2FQ75P
+lHWMgsEzQObDm4GPE9cdKOjoAvtAJwbvZcjDa029CDx7aCaDzbNvdmplZ7EUrznR
+55U8Wsm8pwKBgBytxTmzZwfbCgdDJvFKNKzpwuCB9TpL+v6Y6Kr2Clfg+26iAPFU
+MiWqUUInGGBuamqm5g6jI5sM28gQWeTsvC4IRXyes1Eq+uCHSQax15J/Y+3SSgNT
+9kjUYYkvWMwoRcPobRYWSZze7XkP2L8hFJ7EGvAaZGqAWxzgliS9HtnhAoGAONZ/
+UqMw7Zoac/Ga5mhSwrj7ZvXxP6Gqzjofj+eKqrOlB5yMhIX6LJATfH6iq7cAMxxm
+Fu/G4Ll4oB3o5wACtI3wldV/MDtYfJBtoCTjBqPsfNOsZ9hMvBATlsc2qwzKjsAb
+tFhzTevoOYpSD75EcSS/G8Ec2iN9bagatBnpl00CgYBVqAOFZelNfP7dj//lpk8y
+EUAw7ABOq0S9wkpFWTXIVPoBQUipm3iAUqGNPmvr/9ShdZC9xeu5AwKram4caMWJ
+ExRhcDP1hFM6CdmSkIYEgBKvN9N0O4Lx1ba34gk74Hm65KXxokjJHOC0plO7c7ok
+LNV/bIgMHOMoxiGrwyjAhg==
+-----END PRIVATE KEY-----
+`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid - bad jwk_pem data",
+			config: &oAuth2Config{
+				Enabled:    boolPtr(true),
+				ClientID:   "test-client",
+				Scopes:     []string{"okta.users.read"},
+				TokenURL:   "https://test.okta.com/oauth2/v1/token",
+				OktaJWKPEM: "not-valid-pem-data",
+			},
+			wantErr: true,
 		},
 		{
 			name: "valid oauth2 config with client secret",
@@ -55,7 +108,7 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 				Enabled:     boolPtr(true),
 				Scopes:      []string{"okta.users.read"},
 				TokenURL:    "https://test.okta.com/oauth2/v1/token",
-				OktaJWKJSON: []byte(`{"kty": "RSA"}`),
+				OktaJWKJSON: common.JSONBlob(`{"kty": "RSA"}`),
 			},
 			wantErr: true,
 		},
@@ -65,7 +118,7 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 				Enabled:     boolPtr(true),
 				ClientID:    "test-client",
 				TokenURL:    "https://test.okta.com/oauth2/v1/token",
-				OktaJWKJSON: []byte(`{"kty": "RSA"}`),
+				OktaJWKJSON: common.JSONBlob(`{"kty": "RSA"}`),
 			},
 			wantErr: true,
 		},
@@ -75,7 +128,7 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 				Enabled:     boolPtr(true),
 				ClientID:    "test-client",
 				Scopes:      []string{"okta.users.read"},
-				OktaJWKJSON: []byte(`{"kty": "RSA"}`),
+				OktaJWKJSON: common.JSONBlob(`{"kty": "RSA"}`),
 			},
 			wantErr: true,
 		},
@@ -87,7 +140,7 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 				ClientSecret: "test-secret",
 				Scopes:       []string{"okta.users.read"},
 				TokenURL:     "https://test.okta.com/oauth2/v1/token",
-				OktaJWKJSON:  []byte(`{"kty": "RSA"}`),
+				OktaJWKJSON:  common.JSONBlob(`{"kty": "RSA"}`),
 			},
 			wantErr: true,
 		},
@@ -172,7 +225,7 @@ func TestConfValidationWithOAuth2(t *testing.T) {
 					ClientID: "test-client",
 					Scopes:   []string{"okta.users.read"},
 					TokenURL: "https://test.okta.com/oauth2/v1/token",
-					OktaJWKJSON: []byte(`{
+					OktaJWKJSON: common.JSONBlob(`{
 						"kty": "RSA",
 						"kid": "test-key",
 						"use": "sig",
@@ -221,7 +274,7 @@ func TestConfValidationWithOAuth2(t *testing.T) {
 					ClientID: "test-client",
 					Scopes:   []string{"okta.users.read"},
 					TokenURL: "https://test.okta.com/oauth2/v1/token",
-					OktaJWKJSON: []byte(`{
+					OktaJWKJSON: common.JSONBlob(`{
 						"kty": "RSA",
 						"kid": "test-key",
 						"use": "sig",


### PR DESCRIPTION


## Proposed commit message
```
x-pack/filebeat/input/entityanalytics/provider/okta: fix config unpacking for jwk_json and jwk_pem

The oAuth2Config struct declared OktaJWKJSON as []byte and OktaJWKPEM
as []byte. When go-ucfg tries to assign a YAML string value into a
[]byte field (byte is uint8), it rejects the conversion with "can not
convert 'string' into 'uint'". This prevents the Okta Entity Analytics
integration from starting when OAuth2 + JWK JSON authentication is
configured.

Change OktaJWKJSON to common.JSONBlob, which implements an Unpack
method that accepts strings, matching the working httpjson input.
Change OktaJWKPEM to string since PEM data is naturally text. Update
validation, downstream consumers, and tests for the new types.

Assisted-By: Cursor (claude-opus-4-6)
```


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
