### PR TITLE
AGENTS.md: remove deprecated mage buildSystemTestBinary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,10 @@ script/stresstest.sh [--tags integration] [--race] ./path/to/package ^TestName$ 
 
 ### Integration Tests
 
-Integration tests require building the test binary and some need external dependencies
-that can be started with mage or manually.
+Integration tests may need external dependencies that can be started with mage
+or manually. The Go test binary is built automatically via `TestMain`.
 
 ```bash
-# Build the system test binary if the beat defines it
-mage buildSystemTestBinary
-
 # Run integration tests for a specific package
 go test -v -race -run TestName -tags integration ./path/to/package/...
 ```


### PR DESCRIPTION
## Proposed commit message

The `mage buildSystemTestBinary` target prints a deprecation warning for
Go integration tests — the test binary is now built automatically via
`TestMain`. The target is only still needed for Python system tests, so
drop it from the generic Integration Tests instructions in `AGENTS.md`
to avoid steering agents (human and AI) toward a deprecated step.

Verified by running `cd filebeat && mage buildSystemTestBinary`, which
emits:

> WARNING: BuildSystemTestBinary is deprecated for Go integration tests. The test binary is now built automatically via TestMain. This target is only needed for Python system tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

```bash
cd filebeat && mage buildSystemTestBinary
```

Observe the deprecation warning, then confirm the updated `AGENTS.md`
no longer references the target in the Integration Tests section.