### PR TITLE
filebeat/input/filestream: fix data races in test mocks

### DIFF
--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -587,8 +587,13 @@ type mockClient struct {
 	published  []beat.Event
 	ackHandler beat.EventListener
 	closed     atomic.Bool
-	mtx        sync.Mutex
-	canceler   context.CancelFunc
+	// publishingStarted is set the first time PublishAll is called. It must
+	// be readable without holding mtx because PublishAll keeps mtx while
+	// invoking ackHandler.ACKEvents, which can block (e.g. with a blocking
+	// ack handler used in TestFilestreamTruncateBlockedOutput).
+	publishingStarted atomic.Bool
+	mtx               sync.Mutex
+	canceler          context.CancelFunc
 }
 
 // GetEvents returns the published events
@@ -610,6 +615,12 @@ func (c *mockClient) PublishAll(events []beat.Event) {
 	defer c.mtx.Unlock()
 
 	c.publishing = append(c.publishing, events...)
+	if len(events) > 0 {
+		// Only flag as started for non-empty batches so an empty PublishAll
+		// does not wake waitUntilPublishingHasStarted prematurely (preserving
+		// the pre-fix semantics of `len(c.publishing) > 0`).
+		c.publishingStarted.Store(true)
+	}
 	for _, event := range events {
 		c.ackHandler.AddEvent(event, true)
 	}
@@ -619,7 +630,7 @@ func (c *mockClient) PublishAll(events []beat.Event) {
 }
 
 func (c *mockClient) waitUntilPublishingHasStarted() {
-	for len(c.publishing) == 0 {
+	for !c.publishingStarted.Load() {
 		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -317,8 +317,8 @@ func (e *inputTestingEnvironment) waitUntilOffsetInRegistry(
 			e.t.Fatalf("could not stat '%s', err: %s", filepath, err)
 		}
 
-		fileSizeString.WriteString(fmt.Sprint(fi.Size()))
-		cursorString.WriteString(fmt.Sprint(entry.Cursor.Offset))
+		fmt.Fprint(&fileSizeString, fi.Size())
+		fmt.Fprint(&cursorString, entry.Cursor.Offset)
 
 		return entry.Cursor.Offset == expectedOffset
 	},
@@ -492,9 +492,9 @@ func (e *inputTestingEnvironment) requireEventsReceived(events []string) {
 	}
 
 	var missingEvents []string
-	for i, found := range foundEvents {
-		if !found {
-			missingEvents = append(missingEvents, events[i])
+	for i, ev := range events {
+		if !foundEvents[i] {
+			missingEvents = append(missingEvents, ev)
 		}
 	}
 
@@ -593,7 +593,17 @@ type mockClient struct {
 	// ack handler used in TestFilestreamTruncateBlockedOutput).
 	publishingStarted atomic.Bool
 	mtx               sync.Mutex
-	canceler          context.CancelFunc
+	// done is closed by cancel() to release a blocked ack handler. Tests call
+	// cancel either directly (via this client) or via
+	// mockPipelineConnector.cancelAllClients.
+	done       chan struct{}
+	cancelOnce sync.Once
+}
+
+// cancel releases a blocked ack handler. Safe to call from multiple goroutines
+// and idempotent.
+func (c *mockClient) cancel() {
+	c.cancelOnce.Do(func() { close(c.done) })
 }
 
 // GetEvents returns the published events
@@ -678,15 +688,18 @@ func (pc *mockPipelineConnector) ConnectWith(config beat.ClientConfig) (beat.Cli
 	pc.mtx.Lock()
 	defer pc.mtx.Unlock()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c := &mockClient{
-		canceler:   cancel,
-		ackHandler: newMockACKHandler(ctx, pc.blocking, config),
-	}
-
+	c := newMockClient(pc.blocking, config)
 	pc.clients = append(pc.clients, c)
 
 	return c, nil
+}
+
+func newMockClient(blocking bool, config beat.ClientConfig) *mockClient {
+	done := make(chan struct{})
+	return &mockClient{
+		done:       done,
+		ackHandler: newMockACKHandler(done, blocking, config),
+	}
 }
 
 func (pc *mockPipelineConnector) cancelAllClients() {
@@ -694,22 +707,24 @@ func (pc *mockPipelineConnector) cancelAllClients() {
 	defer pc.mtx.Unlock()
 
 	for _, client := range pc.clients {
-		client.canceler()
+		client.cancel()
 	}
 }
 
-func newMockACKHandler(starter context.Context, blocking bool, config beat.ClientConfig) beat.EventListener {
+func newMockACKHandler(done <-chan struct{}, blocking bool, config beat.ClientConfig) beat.EventListener {
 	if !blocking {
 		return config.EventListener
 	}
 
-	return acker.Combine(blockingACKer(starter), config.EventListener)
+	return acker.Combine(blockingACKer(done), config.EventListener)
 }
 
-func blockingACKer(starter context.Context) beat.EventListener {
+// blockingACKer blocks the publisher's ack call until done is closed. Tests
+// rely on this to hold cursorPublisher.forward in PublishAll long enough to
+// observe back-pressure scenarios.
+func blockingACKer(done <-chan struct{}) beat.EventListener {
 	return acker.EventPrivateReporter(func(acked int, private []any) {
-		for starter.Err() == nil {
-		}
+		<-done
 	})
 }
 

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -286,7 +286,17 @@ scanner:
 		defer cancel()
 
 		fw := createWatcherWithConfig(t, logptest.NewTestingLogger(t, ""), paths, cfgStr)
-		go fw.Run(ctx)
+		// Wait for the watcher goroutine to exit before the subtest returns.
+		// logptest.NewTestingLogger writes via t.Log, which is unsafe to call
+		// after the subtest finishes and triggers a data race in
+		// testing.(*common).destination. The deferred cancel above runs
+		// before t.Cleanup, so this only needs to wait for Run to return.
+		runDone := make(chan struct{})
+		go func() {
+			defer close(runDone)
+			fw.Run(ctx)
+		}()
+		t.Cleanup(func() { <-runDone })
 
 		basename := "created.log"
 		filename := filepath.Join(dir, basename)
@@ -384,7 +394,15 @@ scanner:
 		inMemoryLog, buff := logp.NewInMemoryLocal("", logp.JSONEncoderConfig())
 		fw := createWatcherWithConfig(t, inMemoryLog, paths, cfgStr)
 
-		go fw.Run(ctx)
+		// Wrap Run so we can wait for the watcher goroutine to exit before
+		// inspecting the in-memory log buffer. The buffer returned by
+		// logp.NewInMemoryLocal is goroutine safe for writes only — reading
+		// it concurrently with watcher logging triggers the race detector.
+		runDone := make(chan struct{})
+		go func() {
+			defer close(runDone)
+			fw.Run(ctx)
+		}()
 
 		expectedEvents := []loginp.FSEvent{
 			{
@@ -426,6 +444,11 @@ scanner:
 		for i, actualEvent := range actualEvents {
 			requireEqualEvents(t, expectedEvents[i], actualEvent)
 		}
+
+		// Stop the watcher and wait for its goroutine to return so the buffer
+		// is no longer being written to before we read from it.
+		cancel()
+		<-runDone
 
 		require.NotContainsf(t, buff.String(), "WARN",
 			"must be no warning messages")

--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -845,7 +845,7 @@ func TestFilestreamTruncateBlockedOutput(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	env.pipeline.clients[0].waitUntilPublishingHasStarted()
-	env.pipeline.clients[0].canceler()
+	env.pipeline.clients[0].cancel()
 
 	env.waitUntilEventCount(2)
 	env.requireOffsetInRegistry(testlogName, id, len(testlines))

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -91,7 +91,7 @@ func TestProspector_InitCleanIfRemoved(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testStore := newMockStoreUpdater(testCase.entries)
 			p := fileProspector{
-				logger:       logp.L(),
+				logger:       logp.NewNopLogger(),
 				identifier:   mustPathIdentifier(false),
 				cleanRemoved: testCase.cleanRemoved,
 				filewatcher:  newMockFileWatcherWithFiles(testCase.filesOnDisk),
@@ -162,7 +162,7 @@ func TestProspector_InitUpdateIdentifiers(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testStore := newMockStoreUpdater(testCase.entries)
 			p := fileProspector{
-				logger:      logp.L(),
+				logger:      logp.NewNopLogger(),
 				identifier:  mustPathIdentifier(false),
 				filewatcher: newMockFileWatcherWithFiles(testCase.filesOnDisk),
 			}
@@ -262,7 +262,7 @@ func TestMigrateRegistryToFingerprint(t *testing.T) {
 			}
 
 			p := fileProspector{
-				logger:      logp.L(),
+				logger:      logp.NewNopLogger(),
 				identifier:  tc.newIdentifier,
 				filewatcher: newMockFileWatcherWithFiles(filesOnDisk),
 			}
@@ -379,12 +379,12 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			p := fileProspector{
-				logger:      logp.L(),
+				logger:      logp.NewNopLogger(),
 				filewatcher: newMockFileWatcher(test.events, len(test.events)),
 				identifier:  mustPathIdentifier(false),
 				ignoreOlder: test.ignoreOlder,
 			}
-			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
+			ctx := input.Context{Logger: logp.NewNopLogger(), Cancelation: context.Background()}
 			hg := newTestHarvesterGroup()
 
 			p.Run(ctx, newMockMetadataUpdater(), hg)
@@ -417,12 +417,12 @@ func TestProspectorHarvesterUpdateIgnoredFiles(t *testing.T) {
 
 	filewatcher := newMockFileWatcher([]loginp.FSEvent{eventCreate}, 2)
 	p := fileProspector{
-		logger:      logp.L(),
+		logger:      logp.NewNopLogger(),
 		filewatcher: filewatcher,
 		identifier:  mustPathIdentifier(false),
 		ignoreOlder: 10 * time.Second,
 	}
-	ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
+	ctx := input.Context{Logger: logp.NewNopLogger(), Cancelation: context.Background()}
 	hg := newTestHarvesterGroup()
 	testStore := newMockMetadataUpdater()
 	var wg sync.WaitGroup
@@ -482,12 +482,12 @@ func TestProspectorDeletedFile(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			p := fileProspector{
-				logger:       logp.L(),
+				logger:       logp.NewNopLogger(),
 				filewatcher:  newMockFileWatcher(test.events, len(test.events)),
 				identifier:   mustPathIdentifier(false),
 				cleanRemoved: test.cleanRemoved,
 			}
-			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
+			ctx := input.Context{Logger: logp.NewNopLogger(), Cancelation: context.Background()}
 
 			testStore := newMockMetadataUpdater()
 			testStore.set("path::/path/to/file")
@@ -564,12 +564,12 @@ func TestProspectorRenamedFile(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			p := fileProspector{
-				logger:            logp.L(),
+				logger:            logp.NewNopLogger(),
 				filewatcher:       newMockFileWatcher(test.events, len(test.events)),
 				identifier:        mustPathIdentifier(test.trackRename),
 				stateChangeCloser: stateChangeCloserConfig{Renamed: test.closeRenamed},
 			}
-			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
+			ctx := input.Context{Logger: logp.NewNopLogger(), Cancelation: context.Background()}
 
 			testStore := newMockMetadataUpdater()
 			testStore.set("path::/old/path/to/file")

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -700,8 +700,14 @@ func (m *mockFileWatcher) NotifyChan() chan loginp.HarvesterStatus {
 	return m.c
 }
 
+// mockMetadataUpdater is a test implementation of loginp.MetadataUpdater whose
+// methods may be invoked from the prospector's goroutines while the test
+// goroutine inspects the stored state (e.g. via assert.Eventually). Read paths
+// dominate (assert.Eventually polls), so an RWMutex is used to allow
+// concurrent reads.
 type mockMetadataUpdater struct {
-	table map[string]interface{}
+	mu    sync.RWMutex
+	table map[string]any
 }
 
 func newMockMetadataUpdater() *mockMetadataUpdater {
@@ -710,14 +716,38 @@ func newMockMetadataUpdater() *mockMetadataUpdater {
 	}
 }
 
-func (mu *mockMetadataUpdater) set(id string) { mu.table[id] = struct{}{} }
+func (mu *mockMetadataUpdater) set(id string) {
+	mu.mu.Lock()
+	defer mu.mu.Unlock()
+	mu.table[id] = struct{}{}
+}
+
+// setRaw stores an arbitrary value under id. Used by tests that pre-populate
+// the store before running the prospector.
+func (mu *mockMetadataUpdater) setRaw(id string, v any) {
+	mu.mu.Lock()
+	defer mu.mu.Unlock()
+	mu.table[id] = v
+}
+
+// get returns the raw value stored under id. Used by tests that need to
+// inspect the stored value after the prospector has run.
+func (mu *mockMetadataUpdater) get(id string) any {
+	mu.mu.RLock()
+	defer mu.mu.RUnlock()
+	return mu.table[id]
+}
 
 func (mu *mockMetadataUpdater) has(id string) bool {
+	mu.mu.RLock()
+	defer mu.mu.RUnlock()
 	_, ok := mu.table[id]
 	return ok
 }
 
 func (mu *mockMetadataUpdater) checkOffset(id string, offset int64) bool {
+	mu.mu.RLock()
+	defer mu.mu.RUnlock()
 	c, ok := mu.table[id]
 	if !ok {
 		return false
@@ -729,7 +759,9 @@ func (mu *mockMetadataUpdater) checkOffset(id string, offset int64) bool {
 	return cursor.Offset == offset
 }
 
-func (mu *mockMetadataUpdater) FindCursorMeta(s loginp.Source, v interface{}) error {
+func (mu *mockMetadataUpdater) FindCursorMeta(s loginp.Source, v any) error {
+	mu.mu.RLock()
+	defer mu.mu.RUnlock()
 	meta, ok := mu.table[s.Name()]
 	if !ok {
 		return fmt.Errorf("no such id [%q]", s.Name())
@@ -737,17 +769,23 @@ func (mu *mockMetadataUpdater) FindCursorMeta(s loginp.Source, v interface{}) er
 	return typeconv.Convert(v, meta)
 }
 
-func (mu *mockMetadataUpdater) ResetCursor(s loginp.Source, cur interface{}) error {
+func (mu *mockMetadataUpdater) ResetCursor(s loginp.Source, cur any) error {
+	mu.mu.Lock()
+	defer mu.mu.Unlock()
 	mu.table[s.Name()] = cur
 	return nil
 }
 
-func (mu *mockMetadataUpdater) UpdateMetadata(s loginp.Source, v interface{}) error {
+func (mu *mockMetadataUpdater) UpdateMetadata(s loginp.Source, v any) error {
+	mu.mu.Lock()
+	defer mu.mu.Unlock()
 	mu.table[s.Name()] = v
 	return nil
 }
 
 func (mu *mockMetadataUpdater) Remove(s loginp.Source) error {
+	mu.mu.Lock()
+	defer mu.mu.Unlock()
 	delete(mu.table, s.Name())
 	return nil
 }
@@ -867,13 +905,13 @@ func TestOnRenameFileIdentity(t *testing.T) {
 
 			testStore := newMockMetadataUpdater()
 			if tc.populateStore {
-				testStore.table[id] = fileMeta{Source: path, IdentifierName: expectedIdentifier}
+				testStore.setRaw(id, fileMeta{Source: path, IdentifierName: expectedIdentifier})
 			}
 
 			hg := newTestHarvesterGroup()
 			p.Run(ctx, testStore, hg)
 
-			got := testStore.table[id]
+			got := testStore.get(id)
 			meta := fileMeta{}
 			typeconv.Convert(&meta, got)
 

--- a/script/stresstest.sh
+++ b/script/stresstest.sh
@@ -5,7 +5,7 @@
 set -e
 
 function usage() {
-  echo "Usage: $0 [--tags tag1,tag2,...] [--race] [package_path] TestName [stress options...]"
+  echo "Usage: $0 [--tags tag1,tag2,...] [--race] package_path TestName [stress options...]"
   echo ""
   echo "--tags: Optional comma-separated list of build tags"
   echo "--race: Enable race detection"
@@ -13,9 +13,12 @@ function usage() {
   echo "TestName: Regular expression to match the test to run, equivalent to -test.run."
   echo "[stress options]: Options to pass to the stress command."
   echo ""
+  echo "--tags and --race may appear in any order but must come before package_path."
+  echo ""
   echo "Examples:"
   echo "  $0 ./libbeat/common/backoff ^TestBackoff$ -p 32"
   echo "  $0 --tags integration --race ./libbeat/common/backoff ^TestBackoff$ -p 32"
+  echo "  $0 --race --tags integration ./libbeat/common/backoff ^TestBackoff$ -p 32"
 }
 
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
@@ -23,24 +26,35 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
   exit 0
 fi
 
-# Parse optional --tags parameter
+# Parse optional --tags and --race parameters. They may appear in any order
+# but must come before the package_path argument.
 build_tags=""
-if [[ "$1" == "--tags" ]]; then
-  if [[ $# -lt 2 ]]; then
-    echo "Error: --tags requires a value."
-    usage
-    exit 1
-  fi
-  build_tags="$2"
-  shift 2
-fi
-
-# Parse optional --race parameter
 race_flag=""
-if [[ "$1" == "--race" ]]; then
-  race_flag="-race"
-  shift 1
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tags)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --tags requires a value."
+        usage
+        exit 1
+      fi
+      if [[ -n "$build_tags" ]]; then
+        echo "Error: --tags specified more than once."
+        usage
+        exit 1
+      fi
+      build_tags="$2"
+      shift 2
+      ;;
+    --race)
+      race_flag="-race"
+      shift 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [[ $# -lt 2 ]]; then
   echo "Error: Missing arguments."


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

Three filestream tests reported `WARNING: DATA RACE` when run with `-race`, all caused by test-only mocks whose internal state was read from the test goroutine and written from the prospector / harvester goroutines without synchronization:

- `TestProspectorHarvesterUpdateIgnoredFiles` raced on `mockMetadataUpdater.table` (read in `checkOffset` from `assert.Eventually`, written in `UpdateMetadata` / `ResetCursor` from `fileProspector.onFSEvent`).
- `TestFileWatcher` raced on the in-memory log buffer returned by `logp.NewInMemoryLocal` and on `t.Log` (used by `logptest.NewTestingLogger`) when the watcher goroutine kept logging after the subtest had returned.
- `TestFilestreamTruncateBlockedOutput` raced on `mockClient.publishing` between `waitUntilPublishingHasStarted` (test goroutine) and `PublishAll` (cursorPublisher goroutine).

All three are pre-existing on `upstream/main`, not regressions from a specific PR.

### Fixes (test-only)

- Add a `sync.RWMutex` to `mockMetadataUpdater` and lock all map accesses (RWMutex because `assert.Eventually` polling makes the read paths dominate). Replace the two direct `testStore.table[id]` accesses in `TestOnRenameFileIdentity` with new `setRaw`/`get` helpers.
- In the affected `TestFileWatcher` subtests, wrap `fw.Run(ctx)` in a goroutine that closes a `runDone` channel on exit and wait for it before reading the log buffer / before the subtest returns.
- Add a `publishingStarted atomic.Bool` to `mockClient` that `PublishAll` sets for non-empty batches (preserving the previous `len(c.publishing) > 0` semantics) and that `waitUntilPublishingHasStarted` reads without holding `mtx`. Holding `mtx` would deadlock with the blocking ack handler used by `TestFilestreamTruncateBlockedOutput`, which keeps the lock during `ackHandler.ACKEvents`.

### Drive-by cleanup (second commit)

While addressing pre-existing lint warnings in the touched files (per project convention), the `mockClient` cancel mechanism was reworked: the `context.WithCancel` + `canceler context.CancelFunc` field was replaced with an idempotent `cancel()` method backed by a `done chan struct{}` and `sync.Once`. `blockingACKer` now blocks on the channel instead of busy-spinning on `ctx.Err() == nil`, which kills a CPU-burning loop that pinned a core per blocked client. Other lint fixes: `logp.L()` → `logp.NewNopLogger()` in `prospector_test.go` and minor `staticcheck`/`gosec` cleanups.

### Out of scope

A fourth race surfaces only when the integration suite runs as a whole (e.g. `TestParsersJavaElasticsearchLogs`, `TestParsersCStyleLog`): `multiline.patternReader.state` is written by `Close` (called from a goroutine spawned by `ctxtool.WithFunc` when the input context is cancelled) and read by `Next` from the harvester read loop. That is a real production race in `libbeat/reader/multiline/pattern.go` and is not caused by the mocks, so it is intentionally left for a separate change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Test-only change; `skip-changelog` label applied.

## How to test this PR locally

Reproduce each race on `upstream/main`, then verify it disappears on this branch.

```bash
cd filebeat

# 1 — TestProspectorHarvesterUpdateIgnoredFiles (unit, 100% reproducer on main)
go test -race -count=1 -timeout=2m \
  -run '^TestProspectorHarvesterUpdateIgnoredFiles$' \
  ./input/filestream/

# 2 — TestFileWatcher (unit, two subtest races: empty-files and duplicate-globs)
go test -race -count=1 -timeout=2m \
  -run '^TestFileWatcher$' \
  ./input/filestream/

# 3 — TestFilestreamTruncateBlockedOutput (integration, in isolation)
go test -race -tags integration -count=1 -timeout=2m \
  -run '^TestFilestreamTruncateBlockedOutput$' \
  ./input/filestream/

# 4 — Full integration suite minus the unit-style tests (the race in
# TestFilestreamTruncateBlockedOutput only surfaces here on main; the
# patternReader race remains and is out of scope, see commit message)
go test -race -tags integration -count=1 -timeout=20m \
  -skip '^TestProspectorHarvesterUpdateIgnoredFiles$|^TestFileWatcher$' \
  ./input/filestream/

# Stress the previously-flaky tests
../script/stresstest.sh --race ./input/filestream \
  '^TestProspectorHarvesterUpdateIgnoredFiles$' -p 16
../script/stresstest.sh --race --tags integration ./input/filestream \
  '^TestFilestreamTruncateBlockedOutput$' -p 16
```

Locally on this branch:

- All four target tests pass under `-race`.
- 1296 stress runs of `TestProspectorHarvesterUpdateIgnoredFiles` and 528 stress runs of `TestFilestreamTruncateBlockedOutput` with 0 failures.
- The full integration suite still surfaces the unrelated `multiline.patternReader` race in `TestParsersJavaElasticsearchLogs` / `TestParsersCStyleLog` (pre-existing, called out above).

## Related issues

-

## Logs

Sample race trace removed by this PR (one of three):

```
==================
WARNING: DATA RACE
Read at 0x… by goroutine 15:
  filestream.(*mockMetadataUpdater).checkOffset()  prospector_test.go:721
  filestream.TestProspectorHarvesterUpdateIgnoredFiles.func2()  prospector_test.go:441
  testify/assert.Eventually.func1()

Previous write at 0x… by goroutine 13:
  filestream.(*mockMetadataUpdater).UpdateMetadata()  prospector_test.go:746
  filestream.(*fileProspector).onFSEvent()  prospector.go:371
  filestream.(*fileProspector).Run.func2()  prospector.go:341
==================
```
