### PR TITLE
[otel][elasticsearchstorage] -  Make `elasticsearchstorage` compatible with  OTel `storage.Extension{}`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -257,6 +257,7 @@ require (
 	go.opentelemetry.io/collector/extension v1.58.0
 	go.opentelemetry.io/collector/extension/extensionauth v1.58.0
 	go.opentelemetry.io/collector/extension/extensiontest v0.152.0
+	go.opentelemetry.io/collector/extension/xextension v0.152.0
 	go.opentelemetry.io/collector/pipeline v1.58.0
 	go.opentelemetry.io/collector/processor v1.58.0
 	go.opentelemetry.io/collector/processor/processorhelper v0.152.0
@@ -516,7 +517,6 @@ require (
 	go.opentelemetry.io/collector/exporter/xexporter v0.152.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.152.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.152.0 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.152.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.58.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.152.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.152.0 // indirect

--- a/x-pack/otel/extension/elasticsearchstorage/adapter.go
+++ b/x-pack/otel/extension/elasticsearchstorage/adapter.go
@@ -1,0 +1,230 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// This file was contributed to by generative AI
+
+package elasticsearchstorage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+
+	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
+)
+
+// errClientClosed is returned by Get/Set/Delete/Batch after Close has been
+// called on the client. Callers can use errors.Is to detect this state.
+var errClientClosed = errors.New("elasticsearch_storage: client is closed")
+
+// docBody is the wire format the adapter writes and reads. Field tags use
+// encoding/json (not the eslegclient go-structform "struct" tag) because
+// the body is marshaled with stdlib json and submitted via
+// eslegclient.RawEncoding — that bypasses go-structform entirely. Going
+// through stdlib lets us embed the caller's value verbatim as
+// json.RawMessage, guaranteeing the bytes ES sees under `v` are the same
+// bytes the caller passed to Set.
+type docBody struct {
+	V         json.RawMessage `json:"v"`
+	UpdatedAt string          `json:"updated_at"`
+}
+
+// esStorageClient is the OTel storage.Client implementation backed by a
+// single shared *eslegclient.Connection on the parent extension. All
+// methods take the extension's mutex around the Connection call;
+// eslegclient.Connection is not safe for concurrent use because it reuses
+// an internal response buffer.
+//
+// One *eslegclient.Connection is shared across all clients (and the
+// legacy backend.Registry path). This scales better than per-receiver
+// connections when an agent runs many receivers; at cursor-state op rates
+// the mutex contention is negligible.
+type esStorageClient struct {
+	ext   *elasticStorage
+	index string
+
+	closedMu sync.Mutex
+	closed   bool
+}
+
+var _ storage.Client = (*esStorageClient)(nil)
+
+// Get returns the value for key, or (nil, nil) if the key does not exist —
+// per the OTel storage.Client contract: "Get doesn't error if a key is not
+// found - it just returns nil."
+func (c *esStorageClient) Get(ctx context.Context, key string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := c.checkOpen(); err != nil {
+		return nil, err
+	}
+
+	c.ext.mu.Lock()
+	defer c.ext.mu.Unlock()
+
+	status, body, err := c.ext.client.Request(
+		"GET",
+		c.docPath(key),
+		"", nil, nil,
+	)
+	if status == http.StatusNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading storage document: %w", err)
+	}
+
+	var resp struct {
+		Source docBody `json:"_source"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decoding storage response: %w", err)
+	}
+	if len(resp.Source.V) == 0 {
+		// Document exists but has no `v` (shouldn't happen via this adapter,
+		// but a corrupt or externally-written doc shouldn't crash callers).
+		return nil, nil
+	}
+	// json.Unmarshal allocates a fresh slice for json.RawMessage, so the
+	// returned bytes are not aliased to conn.responseBuffer (which the
+	// connection reuses on the next call).
+	return []byte(resp.Source.V), nil
+}
+
+// Set stores value under key. The value must be valid JSON: it is embedded
+// verbatim under `v` in the document, and ES is configured to store `v` as
+// an opaque object (enabled: false), so the bytes round-trip exactly. A
+// non-JSON input is rejected with a typed error rather than silently
+// corrupted.
+func (c *esStorageClient) Set(ctx context.Context, key string, value []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := c.checkOpen(); err != nil {
+		return err
+	}
+	if !json.Valid(value) {
+		return fmt.Errorf("elasticsearch_storage: value for key %q is not valid JSON", key)
+	}
+
+	encoded, err := json.Marshal(docBody{
+		V:         value,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return fmt.Errorf("encoding storage document: %w", err)
+	}
+
+	c.ext.mu.Lock()
+	defer c.ext.mu.Unlock()
+
+	// RawEncoding tells the eslegclient encoder to use the bytes as-is
+	// rather than re-serializing through go-structform; this preserves
+	// numeric precision and key order in the user's `v` value.
+	_, _, err = c.ext.client.Request(
+		"PUT",
+		c.docPath(key),
+		"", nil,
+		eslegclient.RawEncoding{Encoding: encoded},
+	)
+	if err != nil {
+		return fmt.Errorf("writing storage document: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the value for key. Per OTel contract, deleting a missing
+// key is a no-op (not an error).
+func (c *esStorageClient) Delete(ctx context.Context, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := c.checkOpen(); err != nil {
+		return err
+	}
+
+	c.ext.mu.Lock()
+	defer c.ext.mu.Unlock()
+
+	status, _, err := c.ext.client.Request(
+		"DELETE",
+		c.docPath(key),
+		"", nil, nil,
+	)
+	if status == http.StatusNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("deleting storage document: %w", err)
+	}
+	return nil
+}
+
+// Batch executes the supplied operations sequentially.
+//
+// PR 1 keeps this as a per-op loop — correct, but one HTTP round-trip per
+// op. A future PR will switch to ES `_bulk` for fewer round-trips. The
+// OTel contract does not require Batch to be transactional, and ES does
+// not offer cross-document atomicity even via `_bulk`, so partial-failure
+// semantics are unchanged either way.
+func (c *esStorageClient) Batch(ctx context.Context, ops ...*storage.Operation) error {
+	for _, op := range ops {
+		if op == nil {
+			continue
+		}
+		var err error
+		switch op.Type {
+		case storage.Get:
+			op.Value, err = c.Get(ctx, op.Key)
+		case storage.Set:
+			err = c.Set(ctx, op.Key, op.Value)
+		case storage.Delete:
+			err = c.Delete(ctx, op.Key)
+		default:
+			return fmt.Errorf("elasticsearch_storage: unknown batch op type %d", op.Type)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close marks the client closed. The shared *eslegclient.Connection is
+// owned by the extension and torn down in Shutdown; closing a client is
+// a "stop using me" signal local to that client, so callers cannot
+// accidentally take down the shared connection by closing one client.
+func (c *esStorageClient) Close(_ context.Context) error {
+	c.closedMu.Lock()
+	defer c.closedMu.Unlock()
+	c.closed = true
+	return nil
+}
+
+func (c *esStorageClient) checkOpen() error {
+	c.closedMu.Lock()
+	defer c.closedMu.Unlock()
+	if c.closed {
+		return errClientClosed
+	}
+	return nil
+}
+
+// docPath returns the ES document path for key. url.PathEscape is used
+// (not QueryEscape) so '+' and ' ' are encoded as %2B / %20 — the legacy
+// baseStore uses QueryEscape, but PathEscape is the technically correct
+// choice for path segments. A new key written via the new adapter will
+// not conflict with an existing baseStore key because the indices are
+// distinct.
+func (c *esStorageClient) docPath(key string) string {
+	return fmt.Sprintf("/%s/_doc/%s", c.index, url.PathEscape(key))
+}

--- a/x-pack/otel/extension/elasticsearchstorage/adapter_test.go
+++ b/x-pack/otel/extension/elasticsearchstorage/adapter_test.go
@@ -1,0 +1,273 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// This file was contributed to by generative AI
+
+//go:build integration
+
+package elasticsearchstorage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+// newTestExtension builds and starts an elasticStorage configured against
+// the integration ES cluster. Cleanup is registered to Shutdown the
+// extension at end of test.
+func newTestExtension(t *testing.T) *elasticStorage {
+	t.Helper()
+
+	integration.EnsureESIsRunning(t)
+	esURL := integration.GetESURL(t, "http")
+	user := esURL.User.Username()
+	pass, _ := esURL.User.Password()
+
+	cfg := &Config{
+		ElasticsearchConfig: map[string]interface{}{
+			"hosts":    []string{fmt.Sprintf("%s://%s", esURL.Scheme, esURL.Host)},
+			"username": user,
+			"password": pass,
+		},
+	}
+
+	ext := &elasticStorage{cfg: cfg, logger: logptest.NewTestingLogger(t, "")}
+	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+	return ext
+}
+
+// newTestClient returns an OTel storage.Client scoped to a per-test
+// component ID derived from t.Name(), so concurrent test runs don't
+// share an ES index.
+func newTestClient(t *testing.T, ext *elasticStorage) storage.Client {
+	t.Helper()
+	// Sanitize the test name down to component-ID-legal characters
+	// (alphanumeric + underscore). t.Name() can contain '/'.
+	name := strings.NewReplacer("/", "_", "-", "_", " ", "_").Replace(strings.ToLower(t.Name()))
+	id := component.MustNewIDWithName("test_storage", name)
+	client, err := ext.GetClient(context.Background(), component.KindReceiver, id, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close(context.Background()) })
+	return client
+}
+
+func TestESClient_GetMissing(t *testing.T) {
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	got, err := c.Get(context.Background(), "no-such-key")
+	require.NoError(t, err)
+	assert.Nil(t, got, "Get on a missing key must return (nil, nil) per the OTel contract")
+}
+
+func TestESClient_SetGetRoundTrip_Struct(t *testing.T) {
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	type cursor struct {
+		Offset    string `json:"offset"`
+		Timestamp int64  `json:"timestamp"`
+		CaughtUp  bool   `json:"caught_up"`
+	}
+	want := cursor{Offset: "abc123", Timestamp: 1776145950, CaughtUp: false}
+	encoded, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	require.NoError(t, c.Set(context.Background(), "cursor", encoded))
+
+	gotBytes, err := c.Get(context.Background(), "cursor")
+	require.NoError(t, err)
+	require.NotNil(t, gotBytes)
+
+	var got cursor
+	require.NoError(t, json.Unmarshal(gotBytes, &got))
+	assert.Equal(t, want, got)
+}
+
+func TestESClient_SetGetRoundTrip_LargeInt(t *testing.T) {
+	// Values exceeding 2^53 lose precision when round-tripped through
+	// float64. The adapter embeds the caller's bytes verbatim under `v`
+	// (mapped object/enabled:false), so ES preserves them as-is.
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	const large int64 = 9_000_000_000_000_000_001 // > 2^53
+	in := []byte(fmt.Sprintf(`{"big":%d}`, large))
+	require.NoError(t, c.Set(context.Background(), "big", in))
+
+	out, err := c.Get(context.Background(), "big")
+	require.NoError(t, err)
+
+	// json.Number preserves the exact decimal representation; compare
+	// the integer value to confirm no precision was lost.
+	dec := json.NewDecoder(strings.NewReader(string(out)))
+	dec.UseNumber()
+	var decoded map[string]json.Number
+	require.NoError(t, dec.Decode(&decoded))
+
+	got, err := decoded["big"].Int64()
+	require.NoError(t, err)
+	assert.Equal(t, large, got)
+}
+
+func TestESClient_Set_RejectsNonJSON(t *testing.T) {
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	err := c.Set(context.Background(), "binary", []byte{0x00, 0x01, 0x02})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON",
+		"non-JSON values must be rejected at Set time, not silently corrupted")
+
+	// Ensure nothing was written under the key — Get must return nil.
+	got, err := c.Get(context.Background(), "binary")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestESClient_Delete(t *testing.T) {
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	require.NoError(t, c.Set(context.Background(), "k", []byte(`{"a":1}`)))
+	require.NoError(t, c.Delete(context.Background(), "k"))
+
+	got, err := c.Get(context.Background(), "k")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestESClient_DeleteMissing_NoOp(t *testing.T) {
+	// OTel contract: "Delete doesn't error if the key doesn't exist - it
+	// just no-ops."
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	assert.NoError(t, c.Delete(context.Background(), "never-existed"))
+}
+
+func TestESClient_CloseIdempotent(t *testing.T) {
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	require.NoError(t, c.Close(context.Background()))
+	assert.NoError(t, c.Close(context.Background()))
+}
+
+func TestESClient_OpAfterClose(t *testing.T) {
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+
+	require.NoError(t, c.Close(context.Background()))
+
+	_, err := c.Get(context.Background(), "k")
+	assert.ErrorIs(t, err, errClientClosed)
+
+	err = c.Set(context.Background(), "k", []byte(`{}`))
+	assert.ErrorIs(t, err, errClientClosed)
+
+	err = c.Delete(context.Background(), "k")
+	assert.ErrorIs(t, err, errClientClosed)
+}
+
+func TestESClient_Batch(t *testing.T) {
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+	ctx := context.Background()
+
+	// Batch with mixed Set/Get/Delete. The PR 1 implementation runs ops
+	// sequentially; we just verify each one took effect.
+	err := c.Batch(ctx,
+		storage.SetOperation("a", []byte(`{"v":1}`)),
+		storage.SetOperation("b", []byte(`{"v":2}`)),
+		storage.GetOperation("a"),
+		storage.DeleteOperation("b"),
+		storage.GetOperation("b"),
+	)
+	require.NoError(t, err)
+
+	// Re-issue the gets to verify state.
+	got, err := c.Get(ctx, "a")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"v":1}`, string(got))
+
+	got, err = c.Get(ctx, "b")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestGetClient_NamedReceivers_DistinctIndices(t *testing.T) {
+	// Reproduces the elastic/beats#50223 scenario: two receivers of the
+	// same type but different names must each get their own valid ES
+	// index, not collide and not break with an invalid index name.
+	ext := newTestExtension(t)
+
+	idRaw := component.MustNewIDWithName("akamai_siem", "raw")
+	idOtel := component.MustNewIDWithName("akamai_siem", "otel")
+
+	cRaw, err := ext.GetClient(context.Background(), component.KindReceiver, idRaw, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cRaw.Close(context.Background()) })
+
+	cOtel, err := ext.GetClient(context.Background(), component.KindReceiver, idOtel, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cOtel.Close(context.Background()) })
+
+	require.NoError(t, cRaw.Set(context.Background(), "k", []byte(`{"who":"raw"}`)))
+	require.NoError(t, cOtel.Set(context.Background(), "k", []byte(`{"who":"otel"}`)))
+
+	rawGot, err := cRaw.Get(context.Background(), "k")
+	require.NoError(t, err)
+	otelGot, err := cOtel.Get(context.Background(), "k")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"who":"raw"}`, string(rawGot))
+	assert.JSONEq(t, `{"who":"otel"}`, string(otelGot))
+}
+
+func TestGetClient_EnsureIndex_AlreadyExists(t *testing.T) {
+	// Calling GetClient twice for the same identity must not error;
+	// ensureIndex tolerates "resource_already_exists_exception".
+	ext := newTestExtension(t)
+
+	id := component.MustNewIDWithName("test_storage", "ensure_idempotent")
+	c1, err := ext.GetClient(context.Background(), component.KindReceiver, id, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c1.Close(context.Background()) })
+
+	c2, err := ext.GetClient(context.Background(), component.KindReceiver, id, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c2.Close(context.Background()) })
+}
+
+func TestESClient_SchemaEvolution(t *testing.T) {
+	// The index mapping declares `v` as object/enabled:false, so ES
+	// stores arbitrary JSON shapes under it without parsing or
+	// type-checking. Two writes with structurally different `v` shapes
+	// must both succeed.
+	ext := newTestExtension(t)
+	c := newTestClient(t, ext)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "k", []byte(`{"shape":"a","count":5}`)))
+	// Different field types and shape — would fail under dynamic mapping.
+	require.NoError(t, c.Set(ctx, "k", []byte(`{"shape":42,"items":[1,2,3]}`)))
+
+	got, err := c.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"shape":42,"items":[1,2,3]}`, string(got))
+}

--- a/x-pack/otel/extension/elasticsearchstorage/extension.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension.go
@@ -2,28 +2,41 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// This file was contributed to by generative AI
+
 package elasticsearchstorage
 
 import (
 	"context"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
 
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/statestore/backend"
 	"github.com/elastic/beats/v7/libbeat/statestore/backend/es"
 	cfg "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/extension"
 )
 
 var _ extension.Extension = (*elasticStorage)(nil)
 var _ backend.Registry = (*elasticStorage)(nil)
+var _ storage.Extension = (*elasticStorage)(nil)
 
 type elasticStorage struct {
 	cfg    *Config
 	ctx    context.Context
 	logger *logp.Logger
+
+	// mu serializes all use of the shared client. eslegclient.Connection
+	// reuses an internal response buffer and is documented as not safe for
+	// concurrent use; holding mu around every Connection.Request call lets
+	// one connection serve all consumers (legacy backend.Registry + OTel
+	// storage.Client) without races.
+	mu     sync.Mutex
 	client *eslegclient.Connection
 }
 
@@ -48,11 +61,43 @@ func (e *elasticStorage) Shutdown(ctx context.Context) error {
 	return e.client.Close()
 }
 
+// Access implements backend.Registry. Returns a baseStore tied to the
+// shared connection — unchanged from the previous behaviour. Existing
+// Beats inputs that depend on this path continue to work.
 func (e *elasticStorage) Access(name string) (backend.Store, error) {
 	return es.NewStore(e.ctx, e.logger, e.client, name), nil
 }
 
+// Close implements backend.Registry. The actual *eslegclient.Connection is
+// closed in Shutdown — this is a no-op for the legacy interface.
 func (e *elasticStorage) Close() error {
-	// no-op. Client will be close in Shutdown
 	return nil
+}
+
+// GetClient implements storage.Extension. Returns a thin client tied to
+// the shared connection (via the extension's mutex) and a per-consumer
+// index whose name is composed from kind, component ID, and storageName
+// and sanitized for ES naming rules. The new client path is independent
+// of the legacy Access() path.
+func (e *elasticStorage) GetClient(
+	ctx context.Context,
+	kind component.Kind,
+	id component.ID,
+	storageName string,
+) (storage.Client, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if e.client == nil {
+		return nil, fmt.Errorf("elasticsearch_storage: GetClient called before Start")
+	}
+
+	indexName := composeIndexName(kind, id, storageName)
+	if err := ensureIndex(&e.mu, e.client, indexName); err != nil {
+		return nil, err
+	}
+	return &esStorageClient{
+		ext:   e,
+		index: indexName,
+	}, nil
 }

--- a/x-pack/otel/extension/elasticsearchstorage/index.go
+++ b/x-pack/otel/extension/elasticsearchstorage/index.go
@@ -1,0 +1,164 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// This file was contributed to by generative AI
+
+package elasticsearchstorage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
+)
+
+// indexNamePrefix is the common prefix for storage indices. The legacy
+// backend.Registry path uses the same prefix (see libbeat/statestore/backend/es/base.go),
+// so OTel-managed indices and Beats-input-managed indices share a namespace.
+const indexNamePrefix = "agentless-state-"
+
+// indexMapping is the explicit mapping applied on first use of a storage
+// index.
+//
+// The `v` field is declared as `object` with `enabled: false`: ES stores it
+// verbatim in `_source` and does not parse, index, or type-check its
+// contents. This:
+//   - prevents dynamic-mapping conflicts when a consumer's value schema
+//     evolves across releases (e.g. a field's type changes),
+//   - avoids field-count growth for consumers with variable-shape values,
+//   - costs nothing because we never search inside `v`.
+//
+// `updated_at` stays typed as `date` so operators can range-query for stale
+// entries via the standard ES APIs.
+var indexMapping = map[string]any{
+	"settings": map[string]any{
+		"number_of_shards":   1,
+		"number_of_replicas": 0,
+	},
+	"mappings": map[string]any{
+		"properties": map[string]any{
+			"v":          map[string]any{"type": "object", "enabled": false},
+			"updated_at": map[string]any{"type": "date"},
+		},
+	},
+}
+
+// composeIndexName builds an ES index name from an OTel component identity,
+// mirroring the file_storage extension's kind+type+name+storageName scheme
+// so two consumers with the same component.ID but different kinds (or
+// different per-signal storageName) get distinct indices. Without this, a
+// processor and a receiver named "foo" would collide on the same index.
+//
+// The composed name is then sanitized for ES index-naming rules.
+func composeIndexName(kind component.Kind, id component.ID, storageName string) string {
+	parts := []string{kindString(kind), id.Type().String(), id.Name()}
+	if storageName != "" {
+		parts = append(parts, storageName)
+	}
+	return indexNamePrefix + sanitizeIndexSuffix(strings.Join(parts, "_"))
+}
+
+// sanitizeIndexSuffix returns a string safe to use as the suffix of an ES
+// index name.
+//
+// ES index naming rules: lowercase only; cannot contain \ / * ? " < > | , # :
+// or whitespace; cannot start with -, _, or +; max 255 bytes. component.ID
+// for a named instance like "akamai_siem/raw" stringifies with a forward
+// slash, so the previous behaviour of feeding component.ID.String() into
+// the index name produced invalid names like
+// "agentless-state-akamai_siem/raw" — rejected by ES on first write.
+//
+// Any disallowed character is replaced with '-'. If the result would
+// exceed 200 bytes (leaving room for the prefix to stay within the
+// 255-byte ES limit), it is hash-truncated.
+func sanitizeIndexSuffix(s string) string {
+	s = strings.ToLower(s)
+
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := strings.TrimLeft(b.String(), "-_+")
+
+	if out == "" {
+		// All input characters were illegal or leading-stripped. Fall back
+		// to a hash of the original input so two distinct degenerate
+		// inputs still land in distinct indices. component.ID enforces
+		// alphanumeric+underscore, so this branch is defensive rather
+		// than expected to fire.
+		sum := sha256.Sum256([]byte(s))
+		return "h" + hex.EncodeToString(sum[:8])
+	}
+
+	const maxSuffix = 200
+	if len(out) > maxSuffix {
+		sum := sha256.Sum256([]byte(out))
+		// Keep a recognisable prefix; append a short hash for uniqueness.
+		out = out[:maxSuffix-17] + "-" + hex.EncodeToString(sum[:8])
+	}
+	return out
+}
+
+// kindString stringifies an OTel component.Kind for use in an index name.
+// Mirrors the file_storage extension's mapping so users moving between
+// storage backends see consistent identifiers.
+func kindString(k component.Kind) string {
+	switch k {
+	case component.KindReceiver:
+		return "receiver"
+	case component.KindProcessor:
+		return "processor"
+	case component.KindExporter:
+		return "exporter"
+	case component.KindExtension:
+		return "extension"
+	case component.KindConnector:
+		return "connector"
+	default:
+		// component.Kind is a closed set in upstream OTel; this branch is
+		// defensive so the resulting index name remains deterministic if a
+		// new kind is introduced.
+		return "other"
+	}
+}
+
+// ensureIndex creates the storage index with the fixed mapping if it does
+// not already exist. The 400 "resource_already_exists_exception" response is
+// treated as success, so concurrent GetClient calls for the same index are
+// race-safe.
+//
+// The mutex is the extension-wide one. Every call that uses the shared
+// *eslegclient.Connection must take it: eslegclient.Connection reuses an
+// internal response buffer and is documented as not safe for concurrent
+// use by multiple goroutines.
+func ensureIndex(mu *sync.Mutex, conn *eslegclient.Connection, indexName string) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	status, body, err := conn.Request("PUT", "/"+indexName, "", nil, indexMapping)
+	if err == nil {
+		return nil
+	}
+	// PUT /<index> returns 400 with "resource_already_exists_exception" when
+	// the index is already there — treat as success so two GetClient calls
+	// for the same id don't fight.
+	if status == http.StatusBadRequest && strings.Contains(string(body), "resource_already_exists_exception") {
+		return nil
+	}
+	return fmt.Errorf("creating storage index %q: %w", indexName, err)
+}

--- a/x-pack/otel/extension/elasticsearchstorage/index_test.go
+++ b/x-pack/otel/extension/elasticsearchstorage/index_test.go
@@ -1,0 +1,151 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// This file was contributed to by generative AI
+
+package elasticsearchstorage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+)
+
+// isValidESIndexName mirrors ES's documented index-naming rules
+// (https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create).
+// Used to assert the sanitizer produces valid output for any input.
+func isValidESIndexName(s string) bool {
+	if len(s) == 0 || len(s) > 255 {
+		return false
+	}
+	switch s[0] {
+	case '-', '_', '+':
+		return false
+	}
+	if s == "." || s == ".." {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			return false
+		case r == '\\', r == '/', r == '*', r == '?', r == '"',
+			r == '<', r == '>', r == '|', r == ',', r == '#', r == ':':
+			return false
+		case r == ' ', r == '\t', r == '\n', r == '\r':
+			return false
+		}
+	}
+	return true
+}
+
+func TestSanitizeIndexSuffix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string // "" means we don't assert exact value, only ES-validity and non-empty
+	}{
+		{"plain", "akamai_siem_raw", "akamai_siem_raw"},
+		{"slash from named instance", "receiver_akamai_siem/raw", "receiver_akamai_siem-raw"},
+		{"uppercase", "Receiver_Akamai_SIEM", "receiver_akamai_siem"},
+		{"mixed punctuation", "foo*bar?baz", "foo-bar-baz"},
+		{"leading underscore stripped", "_starts_underscore", "starts_underscore"},
+		{"leading dash stripped", "---weird", "weird"},
+		{"all illegal falls back to hash", `\/*?"<>|,#: `, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeIndexSuffix(tc.in)
+			if tc.want != "" {
+				assert.Equal(t, tc.want, got)
+			}
+			assert.NotEmpty(t, got, "sanitizer must never return an empty suffix")
+			assert.True(t, isValidESIndexName(indexNamePrefix+got),
+				"sanitized index name must be ES-valid: %q", indexNamePrefix+got)
+		})
+	}
+}
+
+func TestSanitizeIndexSuffix_AllIllegal_DistinctInputs_DistinctOutputs(t *testing.T) {
+	// Two different degenerate inputs must still land in different
+	// indices — the hash fallback provides this guarantee.
+	a := sanitizeIndexSuffix(`\/*?"<>`)
+	b := sanitizeIndexSuffix(`|,#: `)
+	assert.NotEqual(t, a, b)
+}
+
+func TestSanitizeIndexSuffix_LongName_Truncates(t *testing.T) {
+	// Construct a name longer than 200 bytes; sanitizer should hash-truncate.
+	long := strings.Repeat("a", 400)
+	got := sanitizeIndexSuffix(long)
+
+	assert.LessOrEqual(t, len(got), 200, "sanitized suffix must fit within the 200-byte budget")
+	assert.True(t, isValidESIndexName(indexNamePrefix+got))
+
+	// Two distinct long inputs must produce distinct outputs (the hash
+	// portion provides this property).
+	other := strings.Repeat("b", 400)
+	gotOther := sanitizeIndexSuffix(other)
+	assert.NotEqual(t, got, gotOther)
+}
+
+func TestComposeIndexName_NamedReceivers(t *testing.T) {
+	// The motivating case from elastic/beats#50223: two receivers of the
+	// same type but different names must land in distinct, valid indices.
+	idRaw := component.MustNewIDWithName("akamai_siem", "raw")
+	idOtel := component.MustNewIDWithName("akamai_siem", "otel")
+
+	rawName := composeIndexName(component.KindReceiver, idRaw, "")
+	otelName := composeIndexName(component.KindReceiver, idOtel, "")
+
+	assert.Equal(t, "agentless-state-receiver_akamai_siem_raw", rawName)
+	assert.Equal(t, "agentless-state-receiver_akamai_siem_otel", otelName)
+	assert.True(t, isValidESIndexName(rawName))
+	assert.True(t, isValidESIndexName(otelName))
+}
+
+func TestComposeIndexName_StorageNameDisambiguates(t *testing.T) {
+	// A consumer with multiple per-signal storages (e.g. logs/metrics)
+	// passes a non-empty storageName. The composed index name must
+	// include it so signals don't collide.
+	id := component.MustNewID("filelog")
+
+	logs := composeIndexName(component.KindReceiver, id, "logs")
+	metrics := composeIndexName(component.KindReceiver, id, "metrics")
+
+	assert.NotEqual(t, logs, metrics)
+	assert.Contains(t, logs, "_logs")
+	assert.Contains(t, metrics, "_metrics")
+}
+
+func TestComposeIndexName_KindDisambiguates(t *testing.T) {
+	// Same component ID under different kinds must not collide. This
+	// shouldn't happen in practice (collector component IDs are unique
+	// per kind anyway) but the file_storage convention includes kind in
+	// the name for safety, and we follow suit.
+	id := component.MustNewID("foo")
+
+	receiver := composeIndexName(component.KindReceiver, id, "")
+	processor := composeIndexName(component.KindProcessor, id, "")
+
+	assert.NotEqual(t, receiver, processor)
+}
+
+func TestKindString_AllKinds(t *testing.T) {
+	cases := map[component.Kind]string{
+		component.KindReceiver:  "receiver",
+		component.KindProcessor: "processor",
+		component.KindExporter:  "exporter",
+		component.KindExtension: "extension",
+		component.KindConnector: "connector",
+	}
+	for kind, want := range cases {
+		assert.Equal(t, want, kindString(kind))
+	}
+	// An unknown kind value (the zero Kind) must fall back to a stable
+	// string so the composed index name remains deterministic.
+	assert.Equal(t, "other", kindString(component.Kind{}))
+}


### PR DESCRIPTION
## Type of change
 
 - Enhancement


## Proposed commit message

```
x-pack/otel/extension/elasticsearchstorage: implement OTel storage Extension

This allows any OTel component to save its state in Elasticsearch on
agentless deployments. It works alongside the current backend Registry
path, with no behavior change for existing users.

- GetClient returns a simple client over the existing shared
  eslegclient.Connection. A new extension-wide mutex manages access
  since the connection isn't safe for concurrent use.
- Index names are created from kind, type, name, and storageName, and
  they are cleaned up to follow ES naming rules. This fixes the invalid
  index name for named receivers like akamai_siem/raw.
- Indices are pre-created with a specific mapping where `v` is set to
  object/enabled:false, so ES stores values as they are. This avoids
  conflicts with dynamic mapping during schema changes and works when
  auto_create_index is turned off.
- Set writes the caller's JSON bytes as they are; Get returns them
  unchanged, including int64 values greater than 2^53. Non-JSON input
  receives a clear error message.
- Get and Delete do nothing if the keys are missing; Close is
  idempotent.
- go.mod: xextension is now a direct dependency.

Unit tests check the sanitizer and name composition. Integration tests
cover the OTel Client contract, named-receiver isolation, and
value-shape evolution.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/beats/issues/50223

## Testing

Pending.

## Use cases

Makes elasticsearchstorage compatible with OTel storage.Extension{} thereby enabling agentless storage capability for OTel receivers using standard storage.Extension

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
