### PR TITLE
Skip flaky test TestLeak from Auditbeat

### DIFF
--- a/x-pack/auditbeat/abreceiver/receiver_leak_test.go
+++ b/x-pack/auditbeat/abreceiver/receiver_leak_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestLeak(t *testing.T) {
+	t.Skip("Flaky Test: https://github.com/elastic/beats/issues/50381")
 	monitorSocket := genSocketPath()
 	var monitorHost string
 	if runtime.GOOS == "windows" {

--- a/x-pack/auditbeat/abreceiver/receiver_test.go
+++ b/x-pack/auditbeat/abreceiver/receiver_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestNewReceiver(t *testing.T) {
+	t.Skip("Flaky Test: https://github.com/elastic/beats/issues/50381")
 	monitorSocket := genSocketPath()
 	var monitorHost string
 	if runtime.GOOS == "windows" {
@@ -92,6 +93,7 @@ func TestNewReceiver(t *testing.T) {
 }
 
 func TestMultipleReceivers(t *testing.T) {
+	t.Skip("Flaky Test: https://github.com/elastic/beats/issues/50381")
 	monitorSocket1 := genSocketPath()
 	var monitorHost1 string
 	if runtime.GOOS == "windows" {
@@ -331,6 +333,7 @@ func BenchmarkFactory(b *testing.B) {
 }
 
 func TestReceiverHook(t *testing.T) {
+	t.Skip("Flaky Test: https://github.com/elastic/beats/issues/50381")
 	cfg := Config{
 		Beatconfig: map[string]any{
 			"auditbeat": map[string]any{


### PR DESCRIPTION
## Proposed commit message

See title

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
## How to test this PR locally

```
go test -run=TestLeak -v ./x-pack/auditbeat/abreceiver
```

The test should be skipeed:
```
=== RUN   TestLeak
    receiver_leak_test.go:28: Flaky Test: https://github.com/elastic/beats/issues/50381
--- SKIP: TestLeak (0.00s)
PASS
ok      github.com/elastic/beats/v7/x-pack/auditbeat/abreceiver 0.016s
```

## Related issues

- Relates https://github.com/elastic/beats/issues/50381
- Relates https://github.com/elastic/beats/pull/50386


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~