### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/activedirectory: fix device attribute field layout

### DIFF
--- a/changelog/fragments/1777850001-fix-ad-device-field-layout.yaml
+++ b/changelog/fragments/1777850001-fix-ad-device-field-layout.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Fix Active Directory entity analytics to emit device attributes under activedirectory.device.
+component: filebeat
+issue: https://github.com/elastic/beats/issues/50471

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/activedirectory.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/activedirectory.go
@@ -420,7 +420,7 @@ func (p *adInput) doFetchUsers(ctx context.Context, state *stateStore, fullSync 
 	if p.cfg.UserQuery != "" {
 		query = p.cfg.UserQuery
 	}
-	entries, err := activedirectory.GetDetails(query, p.cfg.URL, p.cfg.User, p.cfg.Password, p.baseDN, since, p.cfg.UserAttrs, p.cfg.GrpAttrs, p.cfg.PagingSize, nil, p.tlsConfig)
+	entries, err := activedirectory.GetDetails(query, p.cfg.URL, p.cfg.User, p.cfg.Password, p.baseDN, since, p.cfg.UserAttrs, p.cfg.GrpAttrs, p.cfg.PagingSize, nil, p.tlsConfig, "user")
 	p.logger.Debugf("received %d users from API", len(entries))
 	if err != nil {
 		return nil, err
@@ -452,7 +452,7 @@ func (p *adInput) doFetchDevices(ctx context.Context, state *stateStore, fullSyn
 	if p.cfg.DeviceQuery != "" {
 		query = p.cfg.DeviceQuery
 	}
-	entries, err := activedirectory.GetDetails(query, p.cfg.URL, p.cfg.User, p.cfg.Password, p.baseDN, since, p.cfg.UserAttrs, p.cfg.GrpAttrs, p.cfg.PagingSize, nil, p.tlsConfig)
+	entries, err := activedirectory.GetDetails(query, p.cfg.URL, p.cfg.User, p.cfg.Password, p.baseDN, since, p.cfg.UserAttrs, p.cfg.GrpAttrs, p.cfg.PagingSize, nil, p.tlsConfig, "device")
 	p.logger.Debugf("received %d devices from API", len(entries))
 	if err != nil {
 		return nil, err

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory.go
@@ -167,12 +167,14 @@ func buildMemberOfFilter(groupDNs []string) string {
 }
 
 // Entry is an Active Directory entry with associated group membership.
-// For user/device entries, User holds the entity attributes and Groups
-// holds resolved group memberships. For empty-group entries, Group holds
-// the group attributes and User and Groups are nil.
+// For user entries, User holds the entity attributes. For device
+// (computer) entries, Device holds the entity attributes. For
+// empty-group entries, Group holds the group attributes. Groups holds
+// resolved group memberships for user and device entries.
 type Entry struct {
 	ID          string         `json:"id"`
 	User        map[string]any `json:"user,omitempty"`
+	Device      map[string]any `json:"device,omitempty"`
 	Group       map[string]any `json:"group,omitempty"`
 	Groups      []any          `json:"groups,omitempty"`
 	WhenChanged time.Time      `json:"whenChanged"`
@@ -198,7 +200,15 @@ type Entry struct {
 // memberOf filters to find users who are members of those groups. This is
 // necessary because groups are leaf objects in LDAP and don't contain users
 // as children in the directory tree hierarchy.
-func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, userAttrs, grpAttrs []string, pagingSize uint32, dialer *net.Dialer, tlsconfig *tls.Config) ([]Entry, error) {
+//
+// entTyp controls which Entry field receives the entity attributes:
+// "user" populates Entry.User, "device" populates Entry.Device.
+func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, userAttrs, grpAttrs []string, pagingSize uint32, dialer *net.Dialer, tlsconfig *tls.Config, entTyp string) ([]Entry, error) {
+	switch entTyp {
+	case "user", "device":
+	default:
+		return nil, fmt.Errorf("invalid entity type: %q", entTyp)
+	}
 	if base == nil || len(base.RDNs) == 0 {
 		return nil, fmt.Errorf("%w: no path", ErrInvalidDistinguishedName)
 	}
@@ -259,7 +269,7 @@ func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, u
 		errs = []error{fmt.Errorf("%w: %w", ErrGroups, err)}
 		groups.Entries = entries{}
 	} else {
-		groups = collate(grps, nil)
+		groups = collate(grps, nil, "")
 	}
 
 	// Get users in the directory...
@@ -278,7 +288,7 @@ func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, u
 		return nil, errors.Join(errs...)
 	}
 	// ...and apply group membership.
-	users := collate(usrs, groups.Entries)
+	users := collate(usrs, groups.Entries, entTyp)
 
 	// Also collect users that are members of groups that have changed.
 	if sinceFmtd != "" {
@@ -287,7 +297,7 @@ func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, u
 			// Allow continuation if groups query fails, but warn.
 			errs = append(errs, fmt.Errorf("failed to collect changed groups: %w: %w", ErrGroups, err))
 		} else {
-			groups := collate(grps, nil)
+			groups := collate(grps, nil, "")
 
 			// Get users of the changed groups
 			var modGrps []string
@@ -316,7 +326,7 @@ func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, u
 				} else {
 					// ...and apply group membership, inserting into users
 					// if not present.
-					for dn, u := range collate(usrs, groups.Entries).Entries {
+					for dn, u := range collate(usrs, groups.Entries, entTyp).Entries {
 						_, ok := users.Entries[dn]
 						if ok {
 							continue
@@ -331,7 +341,7 @@ func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, u
 	// Assemble into a set of documents.
 	docs := make([]Entry, 0, len(users.Entries))
 	for id, u := range users.Entries {
-		user := u["user"].(map[string]any)
+		attrs := u[entTyp].(map[string]any)
 		var groups []any
 		switch g := u["groups"].(type) {
 		case nil:
@@ -339,7 +349,16 @@ func GetDetails(query, url, user, pass string, base *ldap.DN, since time.Time, u
 			// Do not bother concretising these.
 			groups = g
 		}
-		docs = append(docs, Entry{ID: id, User: user, Groups: groups, WhenChanged: whenChanged(user, groups)})
+		e := Entry{ID: id, Groups: groups, WhenChanged: whenChanged(attrs, groups)}
+		switch entTyp {
+		case "user":
+			e.User = attrs
+		case "device":
+			e.Device = attrs
+		default:
+			panic("unreachable")
+		}
+		docs = append(docs, e)
 	}
 	return docs, errors.Join(errs...)
 }
@@ -388,7 +407,7 @@ func GetEmptyGroups(url, user, pass string, base *ldap.DN, since time.Time, grpA
 		return nil, fmt.Errorf("%w: %w", ErrGroups, err)
 	}
 
-	groups := collate(result, nil)
+	groups := collate(result, nil, "")
 	docs := make([]Entry, 0, len(groups.Entries))
 	for _, g := range groups.Entries {
 		dn, _ := g["distinguishedName"].(string)
@@ -451,7 +470,9 @@ type directory struct {
 // group information if it is available. Fields with known types will be converted
 // from strings to the known type.
 // Also included in the returned map is the sets of referrals and controls.
-func collate(resp *ldap.SearchResult, groups entries) directory {
+// entTyp labels the entity attributes when group membership is being
+// resolved (e.g. "user" or "device"); it is ignored when groups is nil.
+func collate(resp *ldap.SearchResult, groups entries, entTyp string) directory {
 	dir := directory{
 		Entries: make(entries),
 	}
@@ -459,7 +480,7 @@ func collate(resp *ldap.SearchResult, groups entries) directory {
 		u := make(map[string]any)
 		m := u
 		if groups != nil {
-			m = map[string]any{"user": u}
+			m = map[string]any{entTyp: u}
 		}
 		for _, attr := range e.Attributes {
 			val := entype(attr)

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/internal/activedirectory/activedirectory_test.go
@@ -180,7 +180,7 @@ func Test(t *testing.T) {
 
 	var times []time.Time
 	t.Run("full", func(t *testing.T) {
-		users, err := GetDetails("(&(objectCategory=person)(objectClass=user))", url, user, pass, base, time.Time{}, nil, nil, 0, nil, nil)
+		users, err := GetDetails("(&(objectCategory=person)(objectClass=user))", url, user, pass, base, time.Time{}, nil, nil, 0, nil, nil, "user")
 		if err != nil {
 			t.Fatalf("unexpected error from GetDetails: %v", err)
 		}
@@ -226,7 +226,7 @@ func Test(t *testing.T) {
 				want++
 			}
 		}
-		users, err := GetDetails("(&(objectCategory=person)(objectClass=user))", url, user, pass, base, since, nil, nil, 0, nil, nil)
+		users, err := GetDetails("(&(objectCategory=person)(objectClass=user))", url, user, pass, base, since, nil, nil, 0, nil, nil, "user")
 		if err != nil {
 			t.Fatalf("unexpected error from GetDetails: %v", err)
 		}
@@ -271,5 +271,105 @@ func Test(t *testing.T) {
 			t.Errorf("failed to marshal groups for logging: %v", err)
 		}
 		t.Logf("empty groups: %s", b)
+	})
+}
+
+func TestGetDetailsInvalidEntTyp(t *testing.T) {
+	base, err := ldap.ParseDN("DC=example,DC=com")
+	if err != nil {
+		t.Fatalf("failed to parse DN: %v", err)
+	}
+	_, err = GetDetails("(objectClass=*)", "ldap://localhost", "", "", base, time.Time{}, nil, nil, 0, nil, nil, "bogus")
+	if err == nil {
+		t.Fatal("expected error for invalid entTyp")
+	}
+	if got := err.Error(); got != `invalid entity type: "bogus"` {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestEntryDeviceFieldJSON(t *testing.T) {
+	e := Entry{
+		ID:     "cn=host1,dc=example,dc=com",
+		Device: map[string]any{"cn": "host1"},
+		Groups: []any{map[string]any{"cn": "Admins"}},
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if _, ok := m["device"]; !ok {
+		t.Error("expected 'device' key in marshaled Entry")
+	}
+	if _, ok := m["user"]; ok {
+		t.Error("unexpected 'user' key in marshaled Entry with nil User")
+	}
+}
+
+func TestCollateEntityKey(t *testing.T) {
+	groups := entries{
+		"cn=Admins,dc=example,dc=com": map[string]any{
+			"cn": "Admins",
+		},
+	}
+
+	resp := &ldap.SearchResult{
+		Entries: []*ldap.Entry{
+			{
+				DN: "cn=host1,dc=example,dc=com",
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "cn", Values: []string{"host1"}},
+					{Name: "memberOf", Values: []string{"cn=Admins,dc=example,dc=com"}},
+				},
+			},
+		},
+	}
+
+	t.Run("user", func(t *testing.T) {
+		dir := collate(resp, groups, "user")
+		entry, ok := dir.Entries["cn=host1,dc=example,dc=com"]
+		if !ok {
+			t.Fatal("expected entry for cn=host1")
+		}
+		if _, ok := entry["user"]; !ok {
+			t.Error("expected 'user' key in collated entry")
+		}
+		if _, ok := entry["device"]; ok {
+			t.Error("unexpected 'device' key in collated entry")
+		}
+	})
+
+	t.Run("device", func(t *testing.T) {
+		dir := collate(resp, groups, "device")
+		entry, ok := dir.Entries["cn=host1,dc=example,dc=com"]
+		if !ok {
+			t.Fatal("expected entry for cn=host1")
+		}
+		if _, ok := entry["device"]; !ok {
+			t.Error("expected 'device' key in collated entry")
+		}
+		if _, ok := entry["user"]; ok {
+			t.Error("unexpected 'user' key in collated entry")
+		}
+	})
+
+	t.Run("groups_resolved", func(t *testing.T) {
+		dir := collate(resp, groups, "device")
+		entry := dir.Entries["cn=host1,dc=example,dc=com"]
+		grps, ok := entry["groups"]
+		if !ok {
+			t.Fatal("expected 'groups' key in collated entry")
+		}
+		grpSlice, ok := grps.([]any)
+		if !ok {
+			t.Fatalf("expected groups to be []any, got %T", grps)
+		}
+		if len(grpSlice) != 1 {
+			t.Fatalf("expected 1 group, got %d", len(grpSlice))
+		}
 	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics/provider/activedirectory: fix device attribute field layout

The Active Directory provider emitted device (computer) attributes
under activedirectory.user.* instead of activedirectory.device.*,
because collate() hardcoded the "user" wrapping key for all entity
types. This caused the entityanalytics_ad device.yml ingest pipeline
to fail on the dot-expander step since the expected device fields
were absent.

Add a Device field to Entry and thread an entTyp parameter through
GetDetails and collate so that device results are wrapped under
"device" and populate Entry.Device. User results are unchanged.

Fixes #50471

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #50471

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
