### PR TITLE
golangci-lint: skip workflow on non-Go PRs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,13 @@ on:
   #    - main
   #    - 8.*
   pull_request:
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.golangci.yml'
+      - '.github/workflows/golangci-lint.yml'
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.


### PR DESCRIPTION
The golangci-lint workflow ran unconditionally on every PR, burning three OS matrix runners (Ubuntu, macOS, Windows) for changes that never touch Go code.

## Change

Added `paths` filters to the `pull_request` trigger so the workflow only fires when relevant files change:

```yaml
pull_request:
  paths:
    - '**/*.go'
    - '**/go.mod'
    - '**/go.sum'
    - '.golangci.yml'
    - '.github/workflows/golangci-lint.yml'
```

PRs touching only docs, Helm charts, YAML configs, or other non-Go files will skip the job entirely.