### PR TITLE
x-pack/filebeat/input/streaming: apply configured timeout to OAuth2 token requests

### DIFF
--- a/changelog/fragments/1777958918-49988-streaming.yaml
+++ b/changelog/fragments/1777958918-49988-streaming.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix handling of OAuth2.0 timeouts in CrowdStrike streaming input.
+component: filebeat

--- a/x-pack/filebeat/input/http_endpoint/handler_test.go
+++ b/x-pack/filebeat/input/http_endpoint/handler_test.go
@@ -843,7 +843,7 @@ func TestConcurrentRequestsExceedHighWater(t *testing.T) {
 
 	pub := new(publisher)
 	metrics := newInputMetrics(monitoring.NewRegistry(), logp.NewNopLogger())
-	h := newHandler(ctx, c, nil, pub.Publish, nil, logp.NewLogger("test"), metrics)
+	h := newHandler(ctx, c, nil, pub.Publish, nil, logp.NewLogger("test"), metrics).(*handler) //nolint:errcheck // newHandler is statically known to return a *handler.
 
 	// Create a slow request body that will hold in-flight bytes while reading.
 	// The body is large enough to exceed high water mark (50 bytes).
@@ -868,9 +868,11 @@ func TestConcurrentRequestsExceedHighWater(t *testing.T) {
 		slowReqStatus = respRec.Code
 	}()
 
-	// Give the slow request time to read a few chunks and accumulate in-flight bytes.
-	// After ~150ms, it should have read at least 60 bytes, exceeding high water (30).
-	time.Sleep(150 * time.Millisecond)
+	// Wait until the slow request has accumulated enough in-flight bytes
+	// to cross the high-water mark before sending the second request.
+	require.Eventually(t, func() bool {
+		return h.inFlight.Load() >= c.HighWaterInFlight
+	}, 5*time.Second, 5*time.Millisecond)
 
 	// Send a fast request while the slow one is still reading.
 	// This should be rejected because in-flight is above high water mark (30).

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -147,6 +147,7 @@ func NewFalconHoseFollower(ctx context.Context, env v2.Context, cfg config, curs
 	}
 	s.authTransport = &rateLimitTransport{
 		base:     authClient.Transport,
+		timeout:  authClient.Timeout,
 		maxRetry: 3,
 		wait:     60 * time.Second,
 		log:      log,

--- a/x-pack/filebeat/input/streaming/crowdstrike_ratelimit.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_ratelimit.go
@@ -6,6 +6,7 @@ package streaming
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +26,7 @@ var _ http.RoundTripper = (*rateLimitTransport)(nil)
 // unauthorized requests.
 type rateLimitTransport struct {
 	base     http.RoundTripper
+	timeout  time.Duration // per-request timeout applied via context
 	maxRetry int
 	wait     time.Duration // default wait when Retry-After is absent
 	log      *logp.Logger
@@ -32,6 +34,12 @@ type rateLimitTransport struct {
 }
 
 func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.timeout > 0 {
+		ctx, cancel := context.WithTimeout(req.Context(), t.timeout)
+		defer cancel()
+		req = req.WithContext(ctx)
+	}
+
 	// Buffer the body so POST requests (token endpoint) can be replayed.
 	var body []byte
 	if req.Body != nil {

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -8,6 +8,9 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"sync/atomic"
@@ -19,6 +22,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
 var (
@@ -222,6 +226,69 @@ func TestRefreshSessionWait(t *testing.T) {
 				t.Fatalf("unexpected wait duration: got %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCrowdstrikeOAuthHTTPClientRespectsConfiguredTimeout(t *testing.T) {
+	t.Parallel()
+
+	const requestTimeout = 50 * time.Millisecond
+	const tokenDelay = 200 * time.Millisecond
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(tokenDelay)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"token","token_type":"bearer","expires_in":3600}`)
+	}))
+	defer tokenSrv.Close()
+
+	discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("discover endpoint should not be reached when token fetch times out")
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer discoverSrv.Close()
+
+	u, err := url.Parse(discoverSrv.URL)
+	if err != nil {
+		t.Fatalf("failed to parse discover URL: %v", err)
+	}
+	cfg := config{
+		Type: "crowdstrike",
+		URL:  &urlConfig{u},
+		Auth: authConfig{
+			OAuth2: oAuth2Config{
+				ClientID:     "id",
+				ClientSecret: "secret",
+				TokenURL:     tokenSrv.URL,
+			},
+		},
+		CrowdstrikeAppID: "test",
+		Retry:            &retry{MaxAttempts: 1, WaitMin: time.Millisecond, WaitMax: time.Millisecond},
+		Transport:        httpcommon.HTTPTransportSettings{Timeout: requestTimeout},
+		Program: `
+			state.response.decode_json().as(body,{
+				"events": [body],
+			})`,
+	}
+
+	log := logp.NewNopLogger()
+	env := v2.Context{
+		ID:              "crowdstrike_timeout_test",
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+	s, err := NewFalconHoseFollower(context.Background(), env, cfg, nil, &testPublisher{log}, nil, log, time.Now)
+	if err != nil {
+		t.Fatalf("failed to construct follower: %v", err)
+	}
+
+	start := time.Now()
+	err = s.FollowStream(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected FollowStream to fail due to token request timeout, but it succeeded")
+	}
+	if elapsed > tokenDelay {
+		t.Fatalf("expected FollowStream to fail before server delay %v, but it took %v: %v", tokenDelay, elapsed, err)
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: apply configured timeout to OAuth2 token requests

The CrowdStrike FalconHose input constructed the OAuth2 HTTP client
with only the Transport from the auth client, dropping the Timeout
set by httpcommon.HTTPTransportSettings. Token endpoint requests
could hang indefinitely instead of respecting the configured timeout.

Apply the timeout via context.WithTimeout in rateLimitTransport
rather than http.Client.Timeout to avoid the deprecated
oauth2.Transport.CancelRequest path.

Also fix flaky test.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #49988

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
