### PR TITLE
Add 8.19.15 release notes to CHANGELOG.asciidoc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,7 +53,7 @@ https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
 **Filebeat**
 
 * Fix `http_endpoint` input shared server lifecycle causing joiner deadlock and creator killing unrelated inputs. https://github.com/elastic/beats/pull/49415[#49415] https://github.com/elastic/beats/issues/47770[#47770]
-* Fix `container` input not respecting `max_bytes` when parsing CRI partial lines. ttps://github.com/elastic/beats/pull/49743[#49743] https://github.com/elastic/beats/issues/49259[#49259]
+* Fix `container` input not respecting `max_bytes` when parsing CRI partial lines. https://github.com/elastic/beats/pull/49743[#49743] https://github.com/elastic/beats/issues/49259[#49259]
 * Fix CSV decoder producing malformed JSON when field values contain double quotes in `azure-blob-storage` input. https://github.com/elastic/beats/pull/50097[#50097] https://github.com/elastic/beats/issues/50097[#50097]
 * Update mito to v1.23.2, fixing runtime error location reporting. https://github.com/elastic/beats/pull/50221[#50221]
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
 
 [discrete]
 [[new-features-8.19.15]]
-=== New features
+==== New features
 
 **Filebeat**
 
@@ -28,7 +28,7 @@ https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
 
 [discrete]
 [[enhancements-8.19.15]]
-=== Enhancements
+==== Enhancements
 
 **All**
 
@@ -40,7 +40,7 @@ https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
 
 [discrete]
 [[upgrades-8.19.15]]
-=== Upgrades
+==== Upgrades
 
 **Filebeat**
 
@@ -48,7 +48,7 @@ https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
 
 [discrete]
 [[bug-fixes-8.19.15]]
-=== Bug fixes
+==== Bug fixes
 
 **Filebeat**
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -3,6 +3,66 @@
 :issue: https://github.com/elastic/beats/issues/
 :pull: https://github.com/elastic/beats/pull/
 
+// begin 8.19.15 relnotes
+
+[[release-notes-8.19.15]]
+== Beats version 8.19.15
+
+https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
+
+[discrete]
+[[security-updates-8.19.15]]
+=== Security updates
+
+**Agentbeat**
+
+* Update transient dependency `github.com/go-jose/go-jose/v4` to v4.1.4. https://github.com/elastic/beats/pull/49975[#49975]
+
+[discrete]
+[[new-features-8.19.15]]
+=== New features
+
+**Filebeat**
+
+* Add AWS auth method for CEL and HTTP JSON inputs. https://github.com/elastic/beats/pull/47260[#47260] 
+
+[discrete]
+[[enhancements-8.19.15]]
+=== Enhancements
+
+**All**
+
+* Update OTel Collector components to v0.149.0/v1.55.0. https://github.com/elastic/beats/pull/50057[#50057]
+
+**Metricbeat**
+
+* Bump azure-sdk-for-go `armmonitor` from v0.8.0 to v0.11.0. https://github.com/elastic/beats/pull/49866[#49866] 
+
+[discrete]
+[[upgrades-8.19.15]]
+=== Upgrades
+
+**Filebeat**
+
+* Upgrade Azure Event Hubs SDK (`azeventhubs`) from v1.3.1 to v2.0.2. https://github.com/elastic/beats/pull/49867[#49867] 
+
+[discrete]
+[[bug-fixes-8.19.15]]
+=== Bug fixes
+
+**Filebeat**
+
+* Fix `http_endpoint` input shared server lifecycle causing joiner deadlock and creator killing unrelated inputs. https://github.com/elastic/beats/pull/49415[#49415] https://github.com/elastic/beats/issues/47770[#47770]
+* Fix `container` input not respecting `max_bytes` when parsing CRI partial lines. ttps://github.com/elastic/beats/pull/49743[#49743] https://github.com/elastic/beats/issues/49259[#49259]
+* Fix CSV decoder producing malformed JSON when field values contain double quotes in `azure-blob-storage` input. https://github.com/elastic/beats/pull/50097[#50097] https://github.com/elastic/beats/issues/50097[#50097]
+* Update mito to v1.23.2, fixing runtime error location reporting. https://github.com/elastic/beats/pull/50221[#50221]
+
+**Libbeat**
+
+* Fix `otelconsumer` logging hundreds of errors per second when queue is full. https://github.com/elastic/beats/pull/48807[#48807] https://github.com/elastic/beats/issues/48803[#48803] 
+
+// end 8.19.15 relnotes
+
 // begin 8.19.14 relnotes
 
 [[release-notes-8.19.14]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -12,7 +12,7 @@ https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
 
 [discrete]
 [[security-updates-8.19.15]]
-=== Security updates
+==== Security updates
 
 **Agentbeat**
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -6,7 +6,7 @@
 // begin 8.19.15 relnotes
 
 [[release-notes-8.19.15]]
-== Beats version 8.19.15
+=== Beats version 8.19.15
 
 https://github.com/elastic/beats/compare/v8.19.14\...v8.19.15[View commits]
 

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -8,6 +8,9 @@ This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
 
+* <<release-notes-8.19.15>>
+* <<release-notes-8.19.14>>
+* <<release-notes-8.19.13>>
 * <<release-notes-8.19.12>>
 * <<release-notes-8.19.11>>
 * <<release-notes-8.19.10>>


### PR DESCRIPTION
Docs

## Proposed commit message

This PR is a follow-up to https://github.com/elastic/beats/pull/50333. To publish the 8.19.15 release notes on the `8.19` branch, we need to update the following:

- `CHANGELOG.asciidoc` file
- `libbeat/docs/release.asciidoc`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).