### PR TITLE
x-pack/filebeat/input/cel: accept string values for secret_state

### DIFF
--- a/changelog/fragments/1778038687-cel-secret-state-unpack.yaml
+++ b/changelog/fragments/1778038687-cel-secret-state-unpack.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Accept string values for secret_state to support Fleet secret resolution.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/filebeat/input/cel/config.go
+++ b/x-pack/filebeat/input/cel/config.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
 	"github.com/elastic/beats/v7/x-pack/filebeat/otel"
@@ -57,7 +58,7 @@ type config struct {
 	// placed at state.secret before CEL program execution.
 	// The state.secret key is unconditionally redacted in
 	// debug logs.
-	SecretState map[string]interface{} `config:"secret_state"`
+	SecretState secretState `config:"secret_state"`
 	// Redact is the debug log state redaction configuration.
 	Redact *redact `config:"redact"`
 
@@ -98,6 +99,30 @@ func (c config) GetPackageData(key string) string {
 		return "unknown"
 	}
 	return value
+}
+
+// secretState holds secret key-value pairs. It implements
+// the ucfg Unpacker interface to accept either a map (from
+// direct config) or a string (from Fleet secret resolution,
+// which delivers the stored YAML text as a scalar).
+//
+// The string case is needed because Fleet resolves secrets
+// to their stored string values. See
+// https://github.com/elastic/kibana/issues/267859
+type secretState struct {
+	m map[string]interface{}
+}
+
+func (s *secretState) Unpack(v interface{}) error {
+	switch v := v.(type) {
+	case map[string]interface{}:
+		s.m = v
+		return nil
+	case string:
+		return yaml.Unmarshal([]byte(v), &s.m)
+	default:
+		return fmt.Errorf("secret_state: expected string or map, got %T", v)
+	}
 }
 
 type redact struct {

--- a/x-pack/filebeat/input/cel/config_test.go
+++ b/x-pack/filebeat/input/cel/config_test.go
@@ -54,6 +54,61 @@ func TestRegexpConfig(t *testing.T) {
 	}
 }
 
+func TestSecretStateUnpack(t *testing.T) {
+	t.Run("map", func(t *testing.T) {
+		var s secretState
+		err := s.Unpack(map[string]interface{}{"api_key": "secret"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.m["api_key"] != "secret" {
+			t.Fatalf("unexpected value: got %v, want %q", s.m["api_key"], "secret")
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		var s secretState
+		err := s.Unpack("api_key: secret")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.m["api_key"] != "secret" {
+			t.Fatalf("unexpected value: got %v, want %q", s.m["api_key"], "secret")
+		}
+	})
+
+	t.Run("nested_string", func(t *testing.T) {
+		var s secretState
+		err := s.Unpack("headers:\n  auth: token\n  key: secret")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		headers, ok := s.m["headers"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected map[string]interface{} for nested map, got %T", s.m["headers"])
+		}
+		if headers["auth"] != "token" {
+			t.Fatalf("unexpected value: got %v, want %q", headers["auth"], "token")
+		}
+	})
+
+	t.Run("invalid_type", func(t *testing.T) {
+		var s secretState
+		err := s.Unpack(42)
+		if err == nil {
+			t.Fatal("expected error for int value")
+		}
+	})
+
+	t.Run("invalid_yaml", func(t *testing.T) {
+		var s secretState
+		err := s.Unpack(":\ninvalid:\n  :\n")
+		if err == nil {
+			t.Fatal("expected error for invalid YAML")
+		}
+	})
+}
+
 func TestSecretStateValidation(t *testing.T) {
 	base := config{
 		Interval: time.Minute,

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -262,8 +262,8 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	} else {
 		state = cfg.State
 	}
-	if len(cfg.SecretState) > 0 {
-		state["secret"] = cfg.SecretState
+	if len(cfg.SecretState.m) > 0 {
+		state["secret"] = cfg.SecretState.m
 	}
 	if cfg.Redact == nil {
 		cfg.Redact = &redact{}

--- a/x-pack/filebeat/input/cel/input_manager.go
+++ b/x-pack/filebeat/input/cel/input_manager.go
@@ -51,7 +51,7 @@ func (c config) checkUnsupportedParams(logger *logp.Logger) {
 			"see documentation for details: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#cel-record-coverage")
 	}
 	if c.Redact == nil {
-		if len(c.SecretState) > 0 {
+		if len(c.SecretState.m) > 0 {
 			logger.Named("cel").Warn("state.secret is automatically redacted, but 'redact' configuration is recommended if other state fields contain sensitive values: " +
 				"see documentation for details: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#cel-state-redact")
 		} else {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/cel: accept string values for secret_state

Fleet resolves secrets to their stored string values, so when
secret_state is configured with secret: true in an integration
package, the agent delivers a YAML text string rather than a
parsed map. Change SecretState from map[string]interface{} to a
custom type that implements the ucfg Unpacker interface, accepting
either a map or a string and parsing the string as YAML.

This works around a Fleet bug where type: yaml variables with
secret: true are silently corrupted during policy compilation.
See https://github.com/elastic/kibana/issues/267859
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Ref elastic/kibana#267859

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
