### PR TITLE
fix(otel): fix beatprocessor to honor `when` conditions

### DIFF
--- a/changelog/fragments/1778182489-honor-when-conditions-in-beatprocessor.yaml
+++ b/changelog/fragments/1778182489-honor-when-conditions-in-beatprocessor.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix OTel Beat processor to honor `when` conditions
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: all
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/issues/1234

--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -2175,15 +2175,8 @@ exporters:
 	assert.Equal(t, 1, processorInstanceCount, "expected beat processor to be configured once (shared instance), but got %d", processorInstanceCount)
 }
 
-// TestBeatProcessorWhenCondition verifies that `when` conditions configured on
-// Beat processors inside the OTel `beat` processor are honored. Without this
-// support, the `when` field is silently dropped and processors run
-// unconditionally — see https://github.com/elastic/beats/issues/50549.
-//
-// The test configures two add_fields processors with opposite conditions
-// against the event `message` field and sends a single event whose message
-// matches the first condition. Only the field gated by the matching condition
-// must appear in the exporter output.
+// TestBeatProcessorWhenCondition verifies that `when` conditions are
+// honored for beat processors.
 func TestBeatProcessorWhenCondition(t *testing.T) {
 	cfg := `service:
   pipelines:
@@ -2234,12 +2227,12 @@ exporters:
 			FilterMessageSnippet(`"message":"marker test message"`).
 			FilterMessageSnippet(`"should_be_added":"yes"`).
 			Len() == 1
-	}, 30*time.Second, 100*time.Millisecond, "expected event to be enriched when the `when` condition matches")
+	}, 30*time.Second, 100*time.Millisecond, "expected event to be enriched")
 
 	// The processor whose condition does not match must not enrich the event.
 	matchingNotAdded := col.ObservedLogs().
 		FilterMessageSnippet("Body: Map({").
 		FilterMessageSnippet(`"should_not_be_added"`).
 		Len()
-	assert.Equal(t, 0, matchingNotAdded, "expected `should_not_be_added` field to be absent — `when.not.contains` condition was not honored")
+	assert.Equal(t, 0, matchingNotAdded, "expected `should_not_be_added` field to be absent")
 }

--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -2174,3 +2174,72 @@ exporters:
 	processorInstanceCount := col.ObservedLogs().FilterMessageSnippet("Configured Beat processor").Len()
 	assert.Equal(t, 1, processorInstanceCount, "expected beat processor to be configured once (shared instance), but got %d", processorInstanceCount)
 }
+
+// TestBeatProcessorWhenCondition verifies that `when` conditions configured on
+// Beat processors inside the OTel `beat` processor are honored. Without this
+// support, the `when` field is silently dropped and processors run
+// unconditionally — see https://github.com/elastic/beats/issues/50549.
+//
+// The test configures two add_fields processors with opposite conditions
+// against the event `message` field and sends a single event whose message
+// matches the first condition. Only the field gated by the matching condition
+// must appear in the exporter output.
+func TestBeatProcessorWhenCondition(t *testing.T) {
+	cfg := `service:
+  pipelines:
+    logs:
+      receivers:
+        - filebeatreceiver
+      processors:
+        - beat
+      exporters:
+        - debug
+  telemetry:
+    logs:
+      level: debug
+    metrics:
+      level: none
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: benchmark
+          enabled: true
+          message: "marker test message"
+          count: 1
+    queue.mem.flush.timeout: 0s
+processors:
+  beat:
+    processors:
+      - add_fields:
+          target: ""
+          fields:
+            should_be_added: "yes"
+          when.contains.message: "marker"
+      - add_fields:
+          target: ""
+          fields:
+            should_not_be_added: "yes"
+          when.not.contains.message: "marker"
+exporters:
+  debug:
+    verbosity: detailed
+`
+	col := oteltestcol.New(t, cfg)
+	require.NotNil(t, col)
+
+	require.Eventually(t, func() bool {
+		return col.ObservedLogs().
+			FilterMessageSnippet("Body: Map({").
+			FilterMessageSnippet(`"message":"marker test message"`).
+			FilterMessageSnippet(`"should_be_added":"yes"`).
+			Len() == 1
+	}, 30*time.Second, 100*time.Millisecond, "expected event to be enriched when the `when` condition matches")
+
+	// The processor whose condition does not match must not enrich the event.
+	matchingNotAdded := col.ObservedLogs().
+		FilterMessageSnippet("Body: Map({").
+		FilterMessageSnippet(`"should_not_be_added"`).
+		Len()
+	assert.Equal(t, 0, matchingNotAdded, "expected `should_not_be_added` field to be absent — `when.not.contains` condition was not honored")
+}

--- a/x-pack/otel/processor/beatprocessor/processor.go
+++ b/x-pack/otel/processor/beatprocessor/processor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
+	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/actions/addfields"
 	"github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata"
 	"github.com/elastic/beats/v7/libbeat/processors/add_docker_metadata"
@@ -82,24 +83,26 @@ func createProcessor(processorNameAndConfig map[string]any, logpLogger *logp.Log
 			return nil, fmt.Errorf("failed to create config for processor '%s': %w", processorName, configError)
 		}
 
-		var processorInstance beat.Processor
-		var createProcessorError error
+		var constructor processors.Constructor
 
 		switch processorName {
 		case "add_cloud_metadata":
-			processorInstance, createProcessorError = add_cloud_metadata.New(processorConfig, logpLogger)
+			constructor = add_cloud_metadata.New
 		case "add_docker_metadata":
-			processorInstance, createProcessorError = add_docker_metadata.New(processorConfig, logpLogger)
+			constructor = add_docker_metadata.New
 		case "add_fields":
-			processorInstance, createProcessorError = addfields.CreateAddFields(processorConfig, logpLogger)
+			constructor = addfields.CreateAddFields
 		case "add_host_metadata":
-			processorInstance, createProcessorError = add_host_metadata.New(processorConfig, logpLogger)
+			constructor = add_host_metadata.New
 		case "add_kubernetes_metadata":
-			processorInstance, createProcessorError = add_kubernetes_metadata.New(processorConfig, logpLogger)
+			constructor = add_kubernetes_metadata.New
 		default:
 			return nil, fmt.Errorf("invalid processor name '%s'", processorName)
 		}
 
+		// Wrap the constructor with NewConditional so that `when` conditions
+		// configured on the processor are honored.
+		processorInstance, createProcessorError := processors.NewConditional(constructor)(processorConfig, logpLogger)
 		if createProcessorError != nil {
 			return nil, fmt.Errorf("failed to create processor '%s': %w", processorName, createProcessorError)
 		}

--- a/x-pack/otel/processor/beatprocessor/processor_test.go
+++ b/x-pack/otel/processor/beatprocessor/processor_test.go
@@ -144,6 +144,87 @@ func TestCreateProcessor(t *testing.T) {
 		require.NotNil(t, processor)
 		assert.Equal(t, "add_kubernetes_metadata", processor.String()[:len("add_kubernetes_metadata")])
 	})
+
+	t.Run("when condition is honored and processor is skipped when condition is false", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{
+			"add_fields": map[string]any{
+				"target": "",
+				"fields": map[string]any{
+					"enriched": "yes",
+				},
+				"when": map[string]any{
+					"contains": map[string]any{
+						"tags": "forwarded",
+					},
+				},
+			},
+		}, testLogger())
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		assert.Contains(t, processor.String(), "condition=", "expected processor to be wrapped with a condition")
+
+		event := &beat.Event{Fields: mapstr.M{"message": "hello"}}
+		out, err := processor.Run(event)
+		require.NoError(t, err)
+		_, lookupErr := out.Fields.GetValue("enriched")
+		assert.Error(t, lookupErr, "expected 'enriched' field to be absent when condition is not met")
+	})
+
+	t.Run("when condition is honored and processor runs when condition is true", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{
+			"add_fields": map[string]any{
+				"target": "",
+				"fields": map[string]any{
+					"enriched": "yes",
+				},
+				"when": map[string]any{
+					"contains": map[string]any{
+						"tags": "forwarded",
+					},
+				},
+			},
+		}, testLogger())
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+
+		event := &beat.Event{Fields: mapstr.M{"message": "hello", "tags": []string{"forwarded"}}}
+		out, err := processor.Run(event)
+		require.NoError(t, err)
+		val, err := out.Fields.GetValue("enriched")
+		require.NoError(t, err, "expected 'enriched' field to be added when condition is met")
+		assert.Equal(t, "yes", val)
+	})
+
+	t.Run("when.not.contains skips processor when matching tag is present", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{
+			"add_fields": map[string]any{
+				"target": "",
+				"fields": map[string]any{
+					"enriched": "yes",
+				},
+				"when.not.contains.tags": "forwarded",
+			},
+		}, testLogger())
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+
+		event := &beat.Event{Fields: mapstr.M{"message": "hello", "tags": []string{"forwarded"}}}
+		out, err := processor.Run(event)
+		require.NoError(t, err)
+		_, lookupErr := out.Fields.GetValue("enriched")
+		assert.Error(t, lookupErr, "expected 'enriched' field to be absent when 'forwarded' tag is present")
+	})
+
+	t.Run("invalid when condition returns error", func(t *testing.T) {
+		_, err := createProcessor(map[string]any{
+			"add_host_metadata": map[string]any{
+				"when": map[string]any{
+					"not_a_real_condition": map[string]any{},
+				},
+			},
+		}, testLogger())
+		require.Error(t, err)
+	})
 }
 
 func testLogger() *logp.Logger {


### PR DESCRIPTION
## Proposed commit message

The beat processor instantiated each processor by calling its New constructor directly, bypassing the conditional wrapping that processors.Namespace.Register applies on the standard libbeat path. The `when` field was unpacked into the config but silently dropped, so processors ran unconditionally.

Wrap each constructor with `processors.NewConditional` before invoking it so conditionals are honored, matching the behavior of standalone beats.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

```bash
go test -count=1 -v -run '^TestCreateProcessor$' ./x-pack/otel/processor/beatprocessor/
go test -count=1 -tags=integration -v -run '^TestBeatProcessorWhenCondition$' ./x-pack/filebeat/tests/integration/

./script/stresstest.sh ./x-pack/otel/processor/beatprocessor '^TestCreateProcessor$' -p 4
2m10s: 17012 runs so far, 0 failures, 4 active

./script/stresstest.sh --tags integration ./x-pack/filebeat/tests/integration '^TestBeatProcessorWhenCondition$' -p 2
3m10s: 683 runs so far, 0 failures, 2 active
```

## Related issues

- Closes https://github.com/elastic/beats/issues/50549