### PR TITLE
[azure monitor] Add internal metricset instrumentation

### DIFF
--- a/x-pack/metricbeat/module/azure/api_metrics.go
+++ b/x-pack/metricbeat/module/azure/api_metrics.go
@@ -1,0 +1,179 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !requirefips
+
+package azure
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/rcrowley/go-metrics"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-libs/monitoring/adapter"
+)
+
+type apiOperation string
+
+const (
+	operationGetResourceDefinitions    apiOperation = "get_resource_definitions"
+	operationGetResourceDefinitionByID apiOperation = "get_resource_definition_by_id"
+	operationGetMetricNamespaces       apiOperation = "get_metric_namespaces"
+	operationGetMetricDefinitions      apiOperation = "get_metric_definitions"
+	operationGetMetricValues           apiOperation = "get_metric_values"
+	operationQueryResources            apiOperation = "query_resources"
+)
+
+type apiResult string
+
+const (
+	apiResultSuccess apiResult = "success"
+	apiResultFailure apiResult = "failure"
+)
+
+type apiErrorKind string
+
+const (
+	apiErrorKindNone          apiErrorKind = "none"
+	apiErrorKindThrottle      apiErrorKind = "throttle"
+	apiErrorKindAzureResponse apiErrorKind = "azure_response"
+	apiErrorKindTransport     apiErrorKind = "transport"
+	apiErrorKindOther         apiErrorKind = "other"
+)
+
+type apiMetricKey struct {
+	operation apiOperation
+	result    apiResult
+	errorKind apiErrorKind
+}
+
+type apiMetric struct {
+	count    *monitoring.Uint
+	duration metrics.Sample
+}
+
+type azureAPIMetrics struct {
+	mu      sync.Mutex
+	reg     *monitoring.Registry
+	logger  *logp.Logger
+	metrics map[apiMetricKey]*apiMetric
+}
+
+// newAzureAPIMetrics creates a new API metrics collector. It returns nil
+// when reg is nil, making all observe calls a no-op.
+func newAzureAPIMetrics(reg *monitoring.Registry, logger *logp.Logger) *azureAPIMetrics {
+	if reg == nil {
+		return nil
+	}
+	if logger == nil {
+		logger = logp.NewNopLogger()
+	}
+	return &azureAPIMetrics{
+		reg:     reg,
+		logger:  logger,
+		metrics: make(map[apiMetricKey]*apiMetric),
+	}
+}
+
+func (m *azureAPIMetrics) observe(operation apiOperation, durationNanos int64, err error) {
+	if m == nil {
+		return
+	}
+
+	result := apiResultSuccess
+	errorKind := apiErrorKindNone
+	if err != nil {
+		result = apiResultFailure
+		errorKind = classifyAPIError(err)
+	}
+
+	key := apiMetricKey{
+		operation: operation,
+		result:    result,
+		errorKind: errorKind,
+	}
+
+	m.mu.Lock()
+	metric, ok := m.metrics[key]
+	if !ok {
+		metric = m.addMetric(operation, result, errorKind)
+		m.metrics[key] = metric
+	}
+	m.mu.Unlock()
+
+	metric.count.Add(1)
+	metric.duration.Update(durationNanos)
+}
+
+// addMetric creates and registers a new metric for the given operation/result/errorKind.
+// Must be called with m.mu held.
+func (m *azureAPIMetrics) addMetric(operation apiOperation, result apiResult, errorKind apiErrorKind) *apiMetric {
+	counterName := apiMetricName(operation, result, errorKind, "total")
+	histogramName := apiMetricName(operation, result, errorKind, "duration")
+
+	duration := metrics.NewUniformSample(1024)
+
+	met := &apiMetric{
+		count:    monitoring.NewUint(m.reg, counterName),
+		duration: duration,
+	}
+
+	_ = adapter.GetGoMetrics(m.reg, histogramName, m.logger, adapter.Accept).
+		GetOrRegister("histogram", metrics.NewHistogram(duration))
+
+	return met
+}
+
+// apiMetricName returns a flat underscore-separated metric name for the
+// given operation, result, error kind, and suffix.
+//
+// For success cases the error kind is omitted:
+//
+//	api_calls_get_metric_values_success_total
+//	api_calls_get_metric_values_success_duration
+//
+// For failures the error kind is included:
+//
+//	api_calls_get_metric_values_failure_throttle_total
+//	api_calls_get_metric_values_failure_throttle_duration
+func apiMetricName(operation apiOperation, result apiResult, errorKind apiErrorKind, suffix string) string {
+	name := fmt.Sprintf("api_calls_%s_%s", operation, result)
+	if errorKind != apiErrorKindNone {
+		name += "_" + string(errorKind)
+	}
+	return name + "_" + suffix
+}
+
+func classifyAPIError(err error) apiErrorKind {
+	if err == nil {
+		return apiErrorKindNone
+	}
+
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) {
+		if responseErr.StatusCode == 429 {
+			return apiErrorKindThrottle
+		}
+		return apiErrorKindAzureResponse
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return apiErrorKindTransport
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return apiErrorKindTransport
+	}
+
+	return apiErrorKindOther
+}

--- a/x-pack/metricbeat/module/azure/api_metrics.go
+++ b/x-pack/metricbeat/module/azure/api_metrics.go
@@ -119,7 +119,18 @@ func (m *azureAPIMetrics) addMetric(operation apiOperation, result apiResult, er
 	counterName := apiMetricName(operation, result, errorKind, "total")
 	histogramName := apiMetricName(operation, result, errorKind, "duration")
 
-	duration := metrics.NewUniformSample(1024)
+	// Exponentially decaying reservoir so the histogram reflects recent API
+	// behaviour rather than weighting hours-old observations equally with fresh
+	// ones. Values are the Dropwizard ExponentiallyDecayingReservoir defaults:
+	//   - 1028: reservoir size — enough samples for stable p50/p95/p99.
+	//   - 0.015: decay rate — a sample weighs e^(-α·Δt), so one ~46s old is
+	//     about half as important as one that just arrived, and anything older
+	//     than ~10 min is effectively invisible.
+	//
+	// This fits Azure metricsets, which typically poll every 60s–5min: the
+	// percentile histograms reflect the last few polling cycles, which is what
+	// an operator asking "is Azure throttling us right now?" wants to see.
+	duration := metrics.NewExpDecaySample(1028, 0.015)
 
 	met := &apiMetric{
 		count:    monitoring.NewUint(m.reg, counterName),

--- a/x-pack/metricbeat/module/azure/azure.go
+++ b/x-pack/metricbeat/module/azure/azure.go
@@ -117,13 +117,15 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	// check wether metricset is part of supported metricsets and if BatchApi is enabled
 	if slices.Contains(supportedMonitorMetricsets, metricsetName) && config.EnableBatchApi {
 		// instantiate Batch Client which enables fetching metric values for multiple resources using azure batch api
-		monitorBatchClient, err = NewBatchClient(config, base.Logger())
+		// base.Metrics() is the Metricbeat registry for this metricset instance; the client tolerates nil for tests.
+		monitorBatchClient, err = NewBatchClient(config, base.Logger(), base.Metrics())
 		if err != nil {
 			return nil, fmt.Errorf("error initializing the monitor batch client: module azure - %s metricset: %w", metricsetName, err)
 		}
 	} else {
 		// default case
-		monitorClient, err = NewClient(config, base.Logger())
+		// base.Metrics() is the Metricbeat registry for this metricset instance; the client tolerates nil for tests.
+		monitorClient, err = NewClient(config, base.Logger(), base.Metrics())
 		if err != nil {
 			return nil, fmt.Errorf("error initializing the monitor client: module azure - %s metricset: %w", metricsetName, err)
 		}

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
 // MetricCollectionInfo contains information about the last time
@@ -46,17 +47,18 @@ type Client struct {
 type mapResourceMetrics func(client *Client, resources []*armresources.GenericResourceExpanded, resourceConfig ResourceConfig) ([]Metric, error)
 
 // NewClient instantiates the Azure monitoring client
-func NewClient(config Config, logger *logp.Logger) (*Client, error) {
+func NewClient(config Config, logger *logp.Logger, registries ...*monitoring.Registry) (*Client, error) {
 	azureMonitorService, err := NewService(config, logger)
 	if err != nil {
 		return nil, err
 	}
+	observedAzureMonitorService := newObservedAzureMonitorService(azureMonitorService, optionalMetricsRegistry(registries), logger)
 
 	logger = logger.Named("azure monitor client")
 
 	client := &Client{
 		BaseClient: &BaseClient{
-			AzureMonitorService: azureMonitorService,
+			AzureMonitorService: observedAzureMonitorService,
 			Config:              config,
 			Log:                 logger,
 			MetricRegistry:      NewMetricRegistry(logger),

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -46,13 +46,14 @@ type Client struct {
 // mapResourceMetrics function type will map the configuration options to client metrics (depending on the metricset)
 type mapResourceMetrics func(client *Client, resources []*armresources.GenericResourceExpanded, resourceConfig ResourceConfig) ([]Metric, error)
 
-// NewClient instantiates the Azure monitoring client
-func NewClient(config Config, logger *logp.Logger, registries ...*monitoring.Registry) (*Client, error) {
+// NewClient instantiates the Azure monitoring client. Pass nil for metrics
+// to disable API instrumentation (e.g. in tests).
+func NewClient(config Config, logger *logp.Logger, metrics *monitoring.Registry) (*Client, error) {
 	azureMonitorService, err := NewService(config, logger)
 	if err != nil {
 		return nil, err
 	}
-	observedAzureMonitorService := newObservedAzureMonitorService(azureMonitorService, optionalMetricsRegistry(registries), logger)
+	observedAzureMonitorService := newObservedAzureMonitorService(azureMonitorService, metrics, logger)
 
 	logger = logger.Named("azure monitor client")
 

--- a/x-pack/metricbeat/module/azure/client_batch.go
+++ b/x-pack/metricbeat/module/azure/client_batch.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
 // BatchClient represents the azure batch client which will make use of the azure sdk go metrics related clients
@@ -41,17 +42,18 @@ type ResDefGroupingCriteria struct {
 type concurrentMapResourceMetrics func(client *BatchClient, resources []*armresources.GenericResourceExpanded, resourceConfig ResourceConfig, wg *sync.WaitGroup)
 
 // NewBatchClient instantiates the Azure monitoring batch client
-func NewBatchClient(config Config, logger *logp.Logger) (*BatchClient, error) {
+func NewBatchClient(config Config, logger *logp.Logger, registries ...*monitoring.Registry) (*BatchClient, error) {
 	azureMonitorService, err := NewService(config, logger)
 	if err != nil {
 		return nil, err
 	}
+	observedAzureMonitorService := newObservedAzureMonitorService(azureMonitorService, optionalMetricsRegistry(registries), logger)
 
 	logger = logger.Named("azure monitor client")
 
 	client := &BatchClient{
 		BaseClient: &BaseClient{
-			AzureMonitorService: azureMonitorService,
+			AzureMonitorService: observedAzureMonitorService,
 			Config:              config,
 			Log:                 logger,
 			MetricRegistry:      NewMetricRegistry(logger),

--- a/x-pack/metricbeat/module/azure/client_batch.go
+++ b/x-pack/metricbeat/module/azure/client_batch.go
@@ -41,13 +41,14 @@ type ResDefGroupingCriteria struct {
 // concurrentMapResourceMetrics function type will map the configuration options to Batch Client metrics (depending on the metricset)
 type concurrentMapResourceMetrics func(client *BatchClient, resources []*armresources.GenericResourceExpanded, resourceConfig ResourceConfig, wg *sync.WaitGroup)
 
-// NewBatchClient instantiates the Azure monitoring batch client
-func NewBatchClient(config Config, logger *logp.Logger, registries ...*monitoring.Registry) (*BatchClient, error) {
+// NewBatchClient instantiates the Azure monitoring batch client. Pass nil
+// for metrics to disable API instrumentation (e.g. in tests).
+func NewBatchClient(config Config, logger *logp.Logger, metrics *monitoring.Registry) (*BatchClient, error) {
 	azureMonitorService, err := NewService(config, logger)
 	if err != nil {
 		return nil, err
 	}
-	observedAzureMonitorService := newObservedAzureMonitorService(azureMonitorService, optionalMetricsRegistry(registries), logger)
+	observedAzureMonitorService := newObservedAzureMonitorService(azureMonitorService, metrics, logger)
 
 	logger = logger.Named("azure monitor client")
 

--- a/x-pack/metricbeat/module/azure/observed_service.go
+++ b/x-pack/metricbeat/module/azure/observed_service.go
@@ -1,0 +1,119 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !requirefips
+
+package azure
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+type observedService struct {
+	next    Service
+	metrics *azureAPIMetrics
+}
+
+func newObservedService(next Service, metrics *azureAPIMetrics) Service {
+	if metrics == nil {
+		return next
+	}
+	return &observedService{
+		next:    next,
+		metrics: metrics,
+	}
+}
+
+func newObservedAzureMonitorService(next Service, registry *monitoring.Registry, logger *logp.Logger) Service {
+	return newObservedService(next, newAzureAPIMetrics(registry, logger))
+}
+
+func optionalMetricsRegistry(registries []*monitoring.Registry) *monitoring.Registry {
+	if len(registries) == 0 {
+		return nil
+	}
+	return registries[0]
+}
+
+func (s *observedService) GetResourceDefinitionById(id string) (resp armresources.GenericResource, err error) {
+	start := time.Now()
+	defer func() {
+		s.metrics.observe(operationGetResourceDefinitionByID, time.Since(start).Nanoseconds(), err)
+	}()
+
+	return s.next.GetResourceDefinitionById(id)
+}
+
+func (s *observedService) GetResourceDefinitions(id []string, group []string, rType string, query string) (resp []*armresources.GenericResourceExpanded, err error) {
+	start := time.Now()
+	defer func() {
+		s.metrics.observe(operationGetResourceDefinitions, time.Since(start).Nanoseconds(), err)
+	}()
+
+	return s.next.GetResourceDefinitions(id, group, rType, query)
+}
+
+func (s *observedService) GetMetricDefinitionsWithRetry(resourceId string, namespace string) (resp armmonitor.MetricDefinitionCollection, err error) {
+	start := time.Now()
+	defer func() {
+		s.metrics.observe(operationGetMetricDefinitions, time.Since(start).Nanoseconds(), err)
+	}()
+
+	return s.next.GetMetricDefinitionsWithRetry(resourceId, namespace)
+}
+
+func (s *observedService) GetMetricNamespaces(resourceId string) (resp armmonitor.MetricNamespaceCollection, err error) {
+	start := time.Now()
+	defer func() {
+		s.metrics.observe(operationGetMetricNamespaces, time.Since(start).Nanoseconds(), err)
+	}()
+
+	return s.next.GetMetricNamespaces(resourceId)
+}
+
+func (s *observedService) GetMetricValues(
+	resourceId string,
+	namespace string,
+	timegrain string,
+	timespan string,
+	metricNames []string,
+	aggregations string,
+	filter string,
+) (resp []armmonitor.Metric, responseTimegrain string, err error) {
+	start := time.Now()
+	defer func() {
+		s.metrics.observe(operationGetMetricValues, time.Since(start).Nanoseconds(), err)
+	}()
+
+	return s.next.GetMetricValues(resourceId, namespace, timegrain, timespan, metricNames, aggregations, filter)
+}
+
+func (s *observedService) QueryResources(
+	resourceIDs []string,
+	subscriptionID string,
+	namespace string,
+	timegrain string,
+	startTime string,
+	endTime string,
+	metricNames []string,
+	aggregations string,
+	filter string,
+	location string,
+) (resp []azmetrics.MetricData, err error) {
+	start := time.Now()
+	defer func() {
+		s.metrics.observe(operationQueryResources, time.Since(start).Nanoseconds(), err)
+	}()
+
+	return s.next.QueryResources(resourceIDs, subscriptionID, namespace, timegrain, startTime, endTime, metricNames, aggregations, filter, location)
+}
+
+var _ Service = (*observedService)(nil)

--- a/x-pack/metricbeat/module/azure/observed_service.go
+++ b/x-pack/metricbeat/module/azure/observed_service.go
@@ -36,13 +36,6 @@ func newObservedAzureMonitorService(next Service, registry *monitoring.Registry,
 	return newObservedService(next, newAzureAPIMetrics(registry, logger))
 }
 
-func optionalMetricsRegistry(registries []*monitoring.Registry) *monitoring.Registry {
-	if len(registries) == 0 {
-		return nil
-	}
-	return registries[0]
-}
-
 func (s *observedService) GetResourceDefinitionById(id string) (resp armresources.GenericResource, err error) {
 	start := time.Now()
 	defer func() {

--- a/x-pack/metricbeat/module/azure/observed_service_test.go
+++ b/x-pack/metricbeat/module/azure/observed_service_test.go
@@ -1,0 +1,242 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !requirefips
+
+package azure
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-libs/monitoring/adapter"
+)
+
+func TestObservedServiceRecordsGetMetricValues_Success(t *testing.T) {
+	reg := monitoring.NewRegistry()
+	apiMetrics := newAzureAPIMetrics(reg, logptest.NewTestingLogger(t, ""))
+	next := &recordingService{
+		getMetricValuesResponse:  []armmonitor.Metric{{}},
+		getMetricValuesTimegrain: "PT1M",
+	}
+	service := newObservedService(next, apiMetrics)
+
+	resp, timegrain, err := service.GetMetricValues(
+		"resource",
+		"namespace",
+		"PT1M",
+		"2026-05-07T20:00:00Z/2026-05-07T20:01:00Z",
+		[]string{"Requests"},
+		"Total",
+		"",
+	)
+
+	require.NoError(t, err, "GetMetricValues should return the wrapped service result")
+	assert.Len(t, resp, 1, "GetMetricValues should return the wrapped response")
+	assert.Equal(t, "PT1M", timegrain, "GetMetricValues should return the wrapped timegrain")
+	assert.Equal(t, 1, next.getMetricValuesCalls, "GetMetricValues should delegate exactly once")
+	assert.Equal(t, uint64(1), metricCount(t, reg, operationGetMetricValues, apiResultSuccess, apiErrorKindNone), "success count should increment")
+	assert.Equal(t, int64(1), metricDurationCount(t, reg, operationGetMetricValues, apiResultSuccess, apiErrorKindNone), "success duration should be recorded")
+	assert.NotNil(t, reg.Get("api_calls_get_metric_values_success_total"), "metric name must use underscore naming")
+}
+
+func TestObservedServiceRecordsQueryResources_Failure(t *testing.T) {
+	reg := monitoring.NewRegistry()
+	apiMetrics := newAzureAPIMetrics(reg, logptest.NewTestingLogger(t, ""))
+	expectedErr := errors.New("query failed")
+	next := &recordingService{queryResourcesErr: expectedErr}
+	service := newObservedService(next, apiMetrics)
+
+	resp, err := service.QueryResources(
+		[]string{"resource"},
+		"subscription",
+		"namespace",
+		"PT1M",
+		"2026-05-07T20:00:00Z",
+		"2026-05-07T20:01:00Z",
+		[]string{"Requests"},
+		"Total",
+		"",
+		"westeurope",
+	)
+
+	require.ErrorIs(t, err, expectedErr, "QueryResources should return the wrapped service error")
+	assert.Nil(t, resp, "QueryResources should return the wrapped response")
+	assert.Equal(t, 1, next.queryResourcesCalls, "QueryResources should delegate exactly once")
+	assert.Equal(t, uint64(1), metricCount(t, reg, operationQueryResources, apiResultFailure, apiErrorKindOther), "failure count should increment")
+	assert.Equal(t, int64(1), metricDurationCount(t, reg, operationQueryResources, apiResultFailure, apiErrorKindOther), "failure duration should be recorded")
+}
+
+func TestObservedServiceClassifiesThrottleFailures_Throttle(t *testing.T) {
+	reg := monitoring.NewRegistry()
+	apiMetrics := newAzureAPIMetrics(reg, logptest.NewTestingLogger(t, ""))
+	next := &recordingService{
+		getMetricDefinitionsErr: &azcore.ResponseError{StatusCode: 429},
+	}
+	service := newObservedService(next, apiMetrics)
+
+	_, err := service.GetMetricDefinitionsWithRetry("resource", "namespace")
+
+	require.Error(t, err, "GetMetricDefinitionsWithRetry should return the wrapped service error")
+	assert.Equal(t, uint64(1), metricCount(t, reg, operationGetMetricDefinitions, apiResultFailure, apiErrorKindThrottle), "throttle failure count should increment")
+	assert.Equal(t, int64(1), metricDurationCount(t, reg, operationGetMetricDefinitions, apiResultFailure, apiErrorKindThrottle), "throttle duration should be recorded")
+}
+
+func TestObservedServiceClassifiesTransportFailures_Transport(t *testing.T) {
+	reg := monitoring.NewRegistry()
+	apiMetrics := newAzureAPIMetrics(reg, logptest.NewTestingLogger(t, ""))
+	next := &recordingService{
+		getMetricDefinitionsErr: &url.Error{
+			Op:  "Get",
+			URL: "https://management.azure.com",
+			Err: errors.New("connection refused"),
+		},
+	}
+	service := newObservedService(next, apiMetrics)
+
+	_, err := service.GetMetricDefinitionsWithRetry("resource", "namespace")
+
+	require.Error(t, err, "GetMetricDefinitionsWithRetry should return the wrapped service error")
+	assert.Equal(t, uint64(1), metricCount(t, reg, operationGetMetricDefinitions, apiResultFailure, apiErrorKindTransport), "transport failure count should increment")
+	assert.Equal(t, int64(1), metricDurationCount(t, reg, operationGetMetricDefinitions, apiResultFailure, apiErrorKindTransport), "transport duration should be recorded")
+}
+
+func TestObservedServiceClassifiesAzureResponseErrors_Non429(t *testing.T) {
+	reg := monitoring.NewRegistry()
+	apiMetrics := newAzureAPIMetrics(reg, logptest.NewTestingLogger(t, ""))
+	next := &recordingService{
+		getMetricDefinitionsErr: &azcore.ResponseError{StatusCode: 403},
+	}
+	service := newObservedService(next, apiMetrics)
+
+	_, err := service.GetMetricDefinitionsWithRetry("resource", "namespace")
+
+	require.Error(t, err, "GetMetricDefinitionsWithRetry should return the wrapped service error")
+	assert.Equal(t, uint64(1), metricCount(t, reg, operationGetMetricDefinitions, apiResultFailure, apiErrorKindAzureResponse), "non-429 Azure response failure count should increment")
+	assert.Equal(t, int64(1), metricDurationCount(t, reg, operationGetMetricDefinitions, apiResultFailure, apiErrorKindAzureResponse), "non-429 Azure response duration should be recorded")
+}
+
+func TestNewClientWiresObservedService(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
+
+	t.Run("client wraps service when registry is provided", func(t *testing.T) {
+		reg := monitoring.NewRegistry()
+		mockService := new(MockService)
+
+		// Simulate the wiring that NewMetricSet → NewClient does:
+		// newObservedAzureMonitorService wraps the service with metrics.
+		observed := newObservedAzureMonitorService(mockService, reg, logger)
+
+		_, ok := observed.(*observedService)
+		assert.True(t, ok, "newObservedAzureMonitorService should return an *observedService when a registry is provided")
+	})
+
+	t.Run("client returns original service when no registry is provided", func(t *testing.T) {
+		mockService := new(MockService)
+
+		observed := newObservedAzureMonitorService(mockService, nil, logger)
+
+		// When no registry is provided, newObservedAzureMonitorService
+		// returns the original service unwrapped (via newObservedService's
+		// nil-metrics fast path).
+		assert.Equal(t, mockService, observed, "newObservedAzureMonitorService should return the original service when no registry is provided")
+	})
+
+	t.Run("batch client wraps service when registry is provided", func(t *testing.T) {
+		reg := monitoring.NewRegistry()
+		mockService := new(MockService)
+
+		// BatchClient uses the same newObservedAzureMonitorService function.
+		observed := newObservedAzureMonitorService(mockService, reg, logger)
+
+		_, ok := observed.(*observedService)
+		assert.True(t, ok, "newObservedAzureMonitorService should return an *observedService for batch clients when a registry is provided")
+	})
+}
+
+func metricCount(t *testing.T, reg *monitoring.Registry, operation apiOperation, result apiResult, errorKind apiErrorKind) uint64 {
+	t.Helper()
+
+	name := apiMetricName(operation, result, errorKind, "total")
+	counter, ok := reg.Get(name).(*monitoring.Uint)
+	require.True(t, ok, "counter metric %s should exist", name)
+	return counter.Get()
+}
+
+func metricDurationCount(t *testing.T, reg *monitoring.Registry, operation apiOperation, result apiResult, errorKind apiErrorKind) int64 {
+	t.Helper()
+
+	name := apiMetricName(operation, result, errorKind, "duration")
+	histogram, ok := adapter.GetGoMetrics(reg, name, logptest.NewTestingLogger(t, ""), adapter.Accept).
+		Get("histogram").(interface{ Count() int64 })
+	require.True(t, ok, "duration histogram %s should exist in monitoring registry", name)
+	return histogram.Count()
+}
+
+type recordingService struct {
+	getResourceDefinitionByIDCalls    int
+	getResourceDefinitionByIDResponse armresources.GenericResource
+	getResourceDefinitionByIDErr      error
+
+	getResourceDefinitionsCalls    int
+	getResourceDefinitionsResponse []*armresources.GenericResourceExpanded
+	getResourceDefinitionsErr      error
+
+	getMetricDefinitionsCalls    int
+	getMetricDefinitionsResponse armmonitor.MetricDefinitionCollection
+	getMetricDefinitionsErr      error
+
+	getMetricNamespacesCalls    int
+	getMetricNamespacesResponse armmonitor.MetricNamespaceCollection
+	getMetricNamespacesErr      error
+
+	getMetricValuesCalls     int
+	getMetricValuesResponse  []armmonitor.Metric
+	getMetricValuesTimegrain string
+	getMetricValuesErr       error
+
+	queryResourcesCalls    int
+	queryResourcesResponse []azmetrics.MetricData
+	queryResourcesErr      error
+}
+
+func (s *recordingService) GetResourceDefinitionById(id string) (armresources.GenericResource, error) {
+	s.getResourceDefinitionByIDCalls++
+	return s.getResourceDefinitionByIDResponse, s.getResourceDefinitionByIDErr
+}
+
+func (s *recordingService) GetResourceDefinitions(id []string, group []string, rType string, query string) ([]*armresources.GenericResourceExpanded, error) {
+	s.getResourceDefinitionsCalls++
+	return s.getResourceDefinitionsResponse, s.getResourceDefinitionsErr
+}
+
+func (s *recordingService) GetMetricDefinitionsWithRetry(resourceId string, namespace string) (armmonitor.MetricDefinitionCollection, error) {
+	s.getMetricDefinitionsCalls++
+	return s.getMetricDefinitionsResponse, s.getMetricDefinitionsErr
+}
+
+func (s *recordingService) GetMetricNamespaces(resourceId string) (armmonitor.MetricNamespaceCollection, error) {
+	s.getMetricNamespacesCalls++
+	return s.getMetricNamespacesResponse, s.getMetricNamespacesErr
+}
+
+func (s *recordingService) GetMetricValues(resourceId string, namespace string, timegrain string, timespan string, metricNames []string, aggregations string, filter string) ([]armmonitor.Metric, string, error) {
+	s.getMetricValuesCalls++
+	return s.getMetricValuesResponse, s.getMetricValuesTimegrain, s.getMetricValuesErr
+}
+
+func (s *recordingService) QueryResources(resourceIDs []string, subscriptionID string, namespace string, timegrain string, startTime string, endTime string, metricNames []string, aggregations string, filter string, location string) ([]azmetrics.MetricData, error) {
+	s.queryResourcesCalls++
+	return s.queryResourcesResponse, s.queryResourcesErr
+}


### PR DESCRIPTION
## Proposed commit message

Add internal Azure Monitor metricset instrumentation.

Wrap Azure monitor service calls with internal metrics so API call outcomes and durations can be observed without changing collection logic. This provides the first safety layer for evaluating future Azure Monitor metricset changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

No disruptive user impact expected. This adds internal monitoring around Azure Monitor service calls without changing collection behavior or event output.

## How to test this PR locally

```bash
go test ./x-pack/metricbeat/module/azure/...
```

## Related issues

-

## Use cases

This helps maintainers inspect Azure Monitor metricset API behavior during development and future refactors by recording service call outcomes and durations with low-cardinality internal metrics.

## Screenshots

N/A

## Logs

```text
ok  github.com/elastic/beats/v7/x-pack/metricbeat/module/azure
ok  github.com/elastic/beats/v7/x-pack/metricbeat/module/azure/monitor
ok  github.com/elastic/beats/v7/x-pack/metricbeat/module/azure/storage
```

Made with [Cursor](https://cursor.com)