### PR TITLE
Stop docker watcher in docker autodiscover

### DIFF
--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
@@ -61,6 +62,7 @@ type Provider struct {
 	stoppers      map[string]*time.Timer
 	stopTrigger   chan *dockerContainerMetadata
 	logger        *logp.Logger
+	stopWg        sync.WaitGroup
 }
 
 // AutodiscoverBuilder builds and returns an autodiscover provider
@@ -129,17 +131,19 @@ func AutodiscoverBuilder(
 		stoppers:      make(map[string]*time.Timer),
 		stopTrigger:   make(chan *dockerContainerMetadata),
 		logger:        logger,
+		stopWg:        sync.WaitGroup{},
 	}, nil
 }
 
 // Start the autodiscover process
 func (d *Provider) Start() {
-	go func() {
+	d.stopWg.Go(func() {
 		for {
 			select {
 			case <-d.stop:
 				d.startListener.Stop()
 				d.stopListener.Stop()
+				d.watcher.Stop()
 
 				// Stop all timers before closing the channel
 				for _, stopper := range d.stoppers {
@@ -158,7 +162,7 @@ func (d *Provider) Start() {
 				d.stopContainer(target.container, target.metadata)
 			}
 		}
-	}()
+	})
 }
 
 type dockerContainerMetadata struct {
@@ -399,6 +403,7 @@ func (d *Provider) generateHints(event bus.Event) bus.Event {
 // Stop the autodiscover process
 func (d *Provider) Stop() {
 	close(d.stop)
+	d.stopWg.Wait()
 }
 
 func (d *Provider) String() string {


### PR DESCRIPTION
## Proposed commit message

```
The docker watcher in the docker autodiscover was not stopped and the Provider Stop method did not wait the provider goroutines to return.

That caused two problems:
 - improper shutdown
 - tests using the testing.T as logger output could panic.

This commit fixes it by calling stop in the watcher and waiting all started goroutines to finish.

```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
## How to test this PR locally

Run the tests, use `-count=2` or a larger value
```
cd libbeat/autodiscover/providers/docker
go test -count=1 -v -run=TestDockerStart ./... -tags=integration -count=2
```

## Related issues

- Closes https://github.com/elastic/beats/issues/50545


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
