### PR TITLE
x-pack/filebeat/input/{cel,httpjson,http_endpoint,entityanalytics},internal/httplog: fix request tracer path validation under OTel receiver runtime

### DIFF
--- a/changelog/fragments/1778461362-i18803-tracer-path-receiver-runtime.yaml
+++ b/changelog/fragments/1778461362-i18803-tracer-path-receiver-runtime.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix request tracer path validation for cel, httpjson, http_endpoint, and entityanalytics inputs when filebeat runs as an OTel receiver.
+component: filebeat

--- a/x-pack/filebeat/input/cel/config.go
+++ b/x-pack/filebeat/input/cel/config.go
@@ -15,10 +15,8 @@ import (
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
 	"github.com/elastic/beats/v7/x-pack/filebeat/otel"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/mito/lib"
 )
@@ -318,13 +316,6 @@ func (c *ResourceConfig) Validate() error {
 		// is excessive for a debugging logger, so default to 1MB
 		// which is the minimum.
 		c.Tracer.MaxSize = 1
-	}
-	ok, err := httplog.IsPathInLogsFor(inputName, c.Tracer.Filename)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return fmt.Errorf("request tracer path must be within %q path", paths.Resolve(paths.Logs, inputName))
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -200,12 +200,12 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	if cfg.Resource.Tracer.enabled() {
 		id := sanitizeFileName(env.IDWithoutName)
 		path := strings.ReplaceAll(cfg.Resource.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(inputName, path)
+		resolved, ok, err := httplog.ResolvePathInLogsFor(env.Agent.Paths, inputName, path)
 		if err != nil {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, paths.Resolve(paths.Logs, inputName))
+			return fmt.Errorf("request tracer path %q must be within %q path", path, env.Agent.Paths.Resolve(paths.Logs, inputName))
 		}
 		cfg.Resource.Tracer.Filename = resolved
 	}

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 var runRemote = flag.Bool("run_remote", false, "run tests using remote endpoints")
@@ -1502,18 +1503,10 @@ var inputTests = []struct {
 		},
 		wantNoFile: filepath.Join("cel", "logs", "http-request-trace-test_id_tracer_filename_sanitization_disabled*"),
 	},
-	{
-		name: "tracer_escaping_logs",
-		config: map[string]interface{}{
-			"interval":                 1,
-			"resource.url":             "https://example.com/",
-			"resource.tracer.enabled":  true,
-			"resource.tracer.filename": "/var/log/http-request-trace-*.ndjson",
-			"state":                    map[string]interface{}{},
-			"program":                  "{}",
-		},
-		wantErr: fmt.Errorf(`request tracer path must be within %q path accessing 'resource'`, inputName),
-	},
+	// Path containment for enabled tracers is tested in
+	// x-pack/filebeat/input/internal/httplog.TestResolvePathInLogsFor.
+	// The input-level test only verifies that a disabled tracer does
+	// not reject an out-of-tree path (next case below).
 	{
 		name: "tracer_disabled_escaping_logs",
 		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
@@ -2451,11 +2444,16 @@ func TestInput(t *testing.T) {
 			defer cancel()
 
 			id := "test_id:" + test.name
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("failed to get working directory: %v", err)
+			}
 			v2Ctx := v2.Context{
 				Logger:          logp.NewLogger("cel_test"),
 				ID:              id,
 				IDWithoutName:   id,
 				Cancelation:     ctx,
+				Agent:           beat.Info{Paths: &paths.Path{Logs: cwd}},
 				MetricsRegistry: monitoring.NewRegistry(),
 			}
 			var client publisher

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -109,7 +109,7 @@ func (p *azure) Run(inputCtx v2.Context, store *kvstore.Store, client beat.Clien
 	}
 	p.auth.SetLogger(p.logger)
 
-	p.fetcher, err = graph.New(ctxtool.FromCanceller(p.ctx.Cancelation), p.ctx.ID, p.cfg, p.Manager.Logger, p.auth)
+	p.fetcher, err = graph.New(ctxtool.FromCanceller(p.ctx.Cancelation), p.ctx.ID, p.cfg, p.Manager.Logger, p.auth, p.ctx.Agent.Paths)
 	if err != nil {
 		return fmt.Errorf("unable to create fetcher: %w", err)
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
@@ -166,13 +166,6 @@ func (c *tracerConfig) Validate() error {
 		// which is the minimum.
 		c.MaxSize = 1
 	}
-	ok, err := httplog.IsPathInLogsFor(inputName, c.Filename)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return fmt.Errorf("request tracer path must be within %q path", paths.Resolve(paths.Logs, inputName))
-	}
 	return nil
 }
 
@@ -464,7 +457,7 @@ func (f *graph) doRequest(ctx context.Context, method, url string, body io.Reade
 }
 
 // New creates a new instance of the graph fetcher.
-func New(ctx context.Context, id string, cfg *config.C, logger *logp.Logger, auth authenticator.Authenticator) (fetcher.Fetcher, error) {
+func New(ctx context.Context, id string, cfg *config.C, logger *logp.Logger, auth authenticator.Authenticator, p *paths.Path) (fetcher.Fetcher, error) {
 	var c graphConf
 	if err := cfg.Unpack(&c); err != nil {
 		return nil, fmt.Errorf("unable to unpack Graph API Fetcher config: %w", err)
@@ -473,12 +466,12 @@ func New(ctx context.Context, id string, cfg *config.C, logger *logp.Logger, aut
 	if c.Tracer.enabled() {
 		id = sanitizeFileName(id)
 		path := strings.ReplaceAll(c.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(inputName, path)
+		resolved, ok, err := httplog.ResolvePathInLogsFor(p, inputName, path)
 		if err != nil {
 			return nil, err
 		}
 		if !ok {
-			return nil, fmt.Errorf("request tracer path %q must be within %q path", path, paths.Resolve(paths.Logs, inputName))
+			return nil, fmt.Errorf("request tracer path %q must be within %q path", path, p.Resolve(paths.Logs, inputName))
 		}
 		c.Tracer.Filename = resolved
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph_test.go
@@ -7,7 +7,6 @@ package graph
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -28,6 +27,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 var trace = flag.Bool("request_trace", false, "enable request tracing during tests")
@@ -385,7 +385,7 @@ func TestGraph_Groups(t *testing.T) {
 	require.NoError(t, err)
 	auth := mock.New(mock.DefaultTokenValue)
 
-	f, err := New(context.Background(), t.Name(), c, logp.L(), auth)
+	f, err := New(context.Background(), t.Name(), c, logp.L(), auth, &paths.Path{Logs: t.TempDir()})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -449,7 +449,7 @@ func TestGraph_Users(t *testing.T) {
 	require.NoError(t, err)
 	auth := mock.New(mock.DefaultTokenValue)
 
-	f, err := New(context.Background(), t.Name(), c, logp.L(), auth)
+	f, err := New(context.Background(), t.Name(), c, logp.L(), auth, &paths.Path{Logs: t.TempDir()})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -559,7 +559,7 @@ func TestGraph_Devices(t *testing.T) {
 			require.NoError(t, err)
 			auth := mock.New(mock.DefaultTokenValue)
 
-			f, err := New(context.Background(), t.Name(), c, logp.L(), auth)
+			f, err := New(context.Background(), t.Name(), c, logp.L(), auth, &paths.Path{Logs: t.TempDir()})
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -622,7 +622,7 @@ func TestGraph_UserMFADetails(t *testing.T) {
 	require.NoError(t, err)
 	auth := mock.New(mock.DefaultTokenValue)
 
-	f, err := New(context.Background(), t.Name(), c, logp.L(), auth)
+	f, err := New(context.Background(), t.Name(), c, logp.L(), auth, &paths.Path{Logs: t.TempDir()})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -737,12 +737,11 @@ var validateConfigTests = []struct {
 		},
 	},
 	{
-		name: "invalid_path",
+		name: "invalid_path_accepted_at_config_time",
 		config: map[string]any{
 			"tracer.enabled":  true,
 			"tracer.filename": "/var/logs/path.log",
 		},
-		wantErr: errors.New(`request tracer path must be within "azure-ad" path accessing 'tracer'`),
 	},
 }
 

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/conf.go
@@ -6,13 +6,10 @@ package jamf
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
@@ -189,13 +186,6 @@ func (c *conf) Validate() error {
 		// is excessive for a debugging logger, so default to 1MB
 		// which is the minimum.
 		c.Tracer.MaxSize = 1
-	}
-	ok, err := httplog.IsPathInLogsFor(Name, c.Tracer.Filename)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return fmt.Errorf("request tracer path must be within %q path", paths.Resolve(paths.Logs, Name))
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/conf_test.go
@@ -72,7 +72,7 @@ var validateTests = []struct {
 		},
 	},
 	{
-		name: "invalid_path",
+		name: "invalid_path_accepted_at_config_time",
 		cfg: conf{
 			SyncInterval: 24 * time.Hour, UpdateInterval: 15 * time.Minute,
 			Tracer: &tracerConfig{
@@ -80,7 +80,6 @@ var validateTests = []struct {
 				Logger:  lumberjack.Logger{Filename: "/var/logs/path.log"},
 			},
 		},
-		wantErr: errors.New(`request tracer path must be within "jamf" path`),
 	},
 }
 

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
@@ -116,12 +116,12 @@ func (p *jamfInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	if p.cfg.Tracer.enabled() {
 		id := sanitizeFileName(inputCtx.IDWithoutName)
 		path := strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(Name, path)
+		resolved, ok, err := httplog.ResolvePathInLogsFor(inputCtx.Agent.Paths, Name, path)
 		if err != nil {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, paths.Resolve(paths.Logs, Name))
+			return fmt.Errorf("request tracer path %q must be within %q path", path, inputCtx.Agent.Paths.Resolve(paths.Logs, Name))
 		}
 		p.cfg.Tracer.Filename = resolved
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
@@ -18,8 +18,6 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
@@ -323,13 +321,6 @@ func (c *conf) Validate() error {
 		// is excessive for a debugging logger, so default to 1MB
 		// which is the minimum.
 		c.Tracer.MaxSize = 1
-	}
-	ok, err := httplog.IsPathInLogsFor(Name, c.Tracer.Filename)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return fmt.Errorf("request tracer path must be within %q path", paths.Resolve(paths.Logs, Name))
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf_test.go
@@ -89,7 +89,7 @@ var validateTests = []struct {
 		}(),
 	},
 	{
-		name: "invalid_path",
+		name: "invalid_path_accepted_at_config_time",
 		cfg: func() conf {
 			cfg := defaultConfig()
 			cfg.OktaDomain = "test.okta.com"
@@ -100,7 +100,6 @@ var validateTests = []struct {
 			}
 			return cfg
 		}(),
-		wantErr: errors.New(`request tracer path must be within "okta" path`),
 	},
 }
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -121,12 +121,12 @@ func (p *oktaInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	if p.cfg.Tracer.enabled() {
 		id := sanitizeFileName(inputCtx.IDWithoutName)
 		path := strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(Name, path)
+		resolved, ok, err := httplog.ResolvePathInLogsFor(inputCtx.Agent.Paths, Name, path)
 		if err != nil {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, paths.Resolve(paths.Logs, Name))
+			return fmt.Errorf("request tracer path %q must be within %q path", path, inputCtx.Agent.Paths.Resolve(paths.Logs, Name))
 		}
 		p.cfg.Tracer.Filename = resolved
 	}

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -14,8 +14,6 @@ import (
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
@@ -145,13 +143,6 @@ func (c *config) Validate() error {
 		// is excessive for a debugging logger, so default to 1MB
 		// which is the minimum.
 		c.Tracer.MaxSize = 1
-	}
-	ok, err := httplog.IsPathInLogsFor(inputName, c.Tracer.Filename)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return fmt.Errorf("request tracer path must be within %q path", paths.Resolve(paths.Logs, inputName))
 	}
 
 	return nil

--- a/x-pack/filebeat/input/http_endpoint/config_test.go
+++ b/x-pack/filebeat/input/http_endpoint/config_test.go
@@ -6,7 +6,6 @@ package http_endpoint
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -60,14 +59,13 @@ func Test_validateConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid log destination",
+			name: "invalid_log_destination_accepted_at_config_time",
 			config: config{
 				URL:          "/",
 				ResponseBody: `{"message": "success"}`,
 				Method:       http.MethodPost,
 				Tracer:       &tracerConfig{Enabled: ptrTo(true), Logger: lumberjack.Logger{Filename: "/var/log"}},
 			},
-			wantError: fmt.Errorf(`request tracer path must be within %q path accessing config`, inputName),
 		},
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -119,12 +119,12 @@ func (e *httpEndpoint) Run(ctx v2.Context, pipeline beat.Pipeline) error {
 	if e.config.Tracer.enabled() {
 		id := sanitizeFileName(ctx.IDWithoutName)
 		path := strings.ReplaceAll(e.config.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(inputName, path)
+		resolved, ok, err := httplog.ResolvePathInLogsFor(ctx.Agent.Paths, inputName, path)
 		if err != nil {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, paths.Resolve(paths.Logs, inputName))
+			return fmt.Errorf("request tracer path %q must be within %q path", path, ctx.Agent.Paths.Resolve(paths.Logs, inputName))
 		}
 		e.config.Tracer.Filename = resolved
 	}

--- a/x-pack/filebeat/input/httpjson/config_request.go
+++ b/x-pack/filebeat/input/httpjson/config_request.go
@@ -14,9 +14,7 @@ import (
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
-	"github.com/elastic/beats/v7/x-pack/filebeat/input/internal/httplog"
 	"github.com/elastic/elastic-agent-libs/mapstr"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
@@ -187,14 +185,6 @@ func (c *requestConfig) Validate() error {
 			// is excessive for a debugging logger, so default to 1MB
 			// which is the minimum.
 			c.Tracer.MaxSize = 1
-		}
-
-		ok, err := httplog.IsPathInLogsFor(inputName, c.Tracer.Filename)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return fmt.Errorf("request tracer path must be within %q path", paths.Resolve(paths.Logs, inputName))
 		}
 	}
 

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -187,12 +187,12 @@ func run(ctx v2.Context, cfg config, pub inputcursor.Publisher, crsr *inputcurso
 	if cfg.Request.Tracer.enabled() {
 		id := sanitizeFileName(ctx.IDWithoutName)
 		path := strings.ReplaceAll(cfg.Request.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(inputName, path)
+		resolved, ok, err := httplog.ResolvePathInLogsFor(ctx.Agent.Paths, inputName, path)
 		if err != nil {
 			return err
 		}
 		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, paths.Resolve(paths.Logs, inputName))
+			return fmt.Errorf("request tracer path %q must be within %q path", path, ctx.Agent.Paths.Resolve(paths.Logs, inputName))
 		}
 		cfg.Request.Tracer.Filename = resolved
 

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -1708,8 +1708,11 @@ func TestInput(t *testing.T) {
 			chanClient := beattest.NewChanClient(len(test.expected))
 			t.Cleanup(func() { _ = chanClient.Close() })
 
-			ctx, cancel := newV2Context("httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248::https://somesource/someapi")
+			ctx, cancel, err := newV2Context("httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248::https://somesource/someapi")
 			t.Cleanup(cancel)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			var g errgroup.Group
 			g.Go(func() error {
@@ -1787,8 +1790,11 @@ func BenchmarkInput(b *testing.B) {
 				chanClient := beattest.NewChanClient(len(test.expected))
 				b.Cleanup(func() { _ = chanClient.Close() })
 
-				ctx, cancel := newV2Context(fmt.Sprintf("%s-%d", test.name, i))
+				ctx, cancel, err := newV2Context(fmt.Sprintf("%s-%d", test.name, i))
 				b.Cleanup(cancel)
+				if err != nil {
+					b.Fatal(err)
+				}
 
 				var g errgroup.Group
 				g.Go(func() error {
@@ -1904,9 +1910,12 @@ func newChainPaginationTestServer(
 	}
 }
 
-func newV2Context(id string) (v2.Context, func()) {
+func newV2Context(id string) (v2.Context, func(), error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return v2.Context{}, cancel, fmt.Errorf("failed to get working directory: %w", err)
+	}
 	return v2.Context{
 		Logger:          logp.NewLogger("httpjson_test"),
 		ID:              id,
@@ -1914,7 +1923,7 @@ func newV2Context(id string) (v2.Context, func()) {
 		Cancelation:     ctx,
 		Agent:           beat.Info{Paths: &paths.Path{Logs: cwd}},
 		MetricsRegistry: monitoring.NewRegistry(),
-	}, cancel
+	}, cancel, nil
 }
 
 //nolint:errcheck // We can safely ignore errors here

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -20,11 +20,13 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
 	beattest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-libs/paths"
 )
 
 var testCases = []struct {
@@ -444,18 +446,10 @@ var testCases = []struct {
 		},
 		expectedNoFile: filepath.Join("httpjson", "logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi*"),
 	},
-	{
-		name:        "tracer_escaping_logs",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {},
-		baseConfig: map[string]interface{}{
-			"interval":                1,
-			"request.method":          http.MethodGet,
-			"request.url":             "https://example.com/",
-			"request.tracer.enabled":  true,
-			"request.tracer.filename": "/var/log/http-request-trace-*.ndjson",
-		},
-		wantErr: fmt.Errorf(`request tracer path must be within %q path accessing 'request'`, inputName),
-	},
+	// Path containment for enabled tracers is tested in
+	// x-pack/filebeat/input/internal/httplog.TestResolvePathInLogsFor.
+	// The input-level test only verifies that a disabled tracer does
+	// not reject an out-of-tree path (next case below).
 	{
 		name: "tracer_disabled_escaping_logs",
 		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
@@ -1912,11 +1906,13 @@ func newChainPaginationTestServer(
 
 func newV2Context(id string) (v2.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
+	cwd, _ := os.Getwd()
 	return v2.Context{
 		Logger:          logp.NewLogger("httpjson_test"),
 		ID:              id,
 		IDWithoutName:   id,
 		Cancelation:     ctx,
+		Agent:           beat.Info{Paths: &paths.Path{Logs: cwd}},
 		MetricsRegistry: monitoring.NewRegistry(),
 	}, cancel
 }

--- a/x-pack/filebeat/input/httpjson/metrics_test.go
+++ b/x-pack/filebeat/input/httpjson/metrics_test.go
@@ -121,8 +121,11 @@ func TestMetrics(t *testing.T) {
 			chanClient := beattest.NewChanClient(len(tc.expectedEvents))
 			t.Cleanup(func() { _ = chanClient.Close() })
 
-			ctx, cancel := newV2Context("httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248::https://somesource/someapi")
+			ctx, cancel, err := newV2Context("httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248::https://somesource/someapi")
 			t.Cleanup(cancel)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			var g errgroup.Group
 			g.Go(func() error {

--- a/x-pack/filebeat/input/internal/httplog/roundtripper.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper.go
@@ -31,20 +31,11 @@ import (
 
 var _ http.RoundTripper = (*LoggingRoundTripper)(nil)
 
-// IsPathInLogsFor returns whether path is a valid path for logs written by the
-// specified input after resolving symbolic links in path.
-func IsPathInLogsFor(input, path string) (ok bool, err error) {
-	root := paths.Resolve(paths.Logs, input)
-	if !filepath.IsAbs(path) && !isRooted(path) {
-		path = filepath.Join(root, path)
-	}
-	return IsPathIn(root, path)
-}
-
 // ResolvePathInLogsFor resolves path relative to the logs directory for the
 // specified input and reports whether the result is within that directory.
-func ResolvePathInLogsFor(input, path string) (resolved string, ok bool, err error) {
-	root := paths.Resolve(paths.Logs, input)
+// p must not be nil.
+func ResolvePathInLogsFor(p *paths.Path, input, path string) (resolved string, ok bool, err error) {
+	root := p.Resolve(paths.Logs, input)
 	if !filepath.IsAbs(path) && !isRooted(path) {
 		path = filepath.Join(root, path)
 	}

--- a/x-pack/filebeat/input/internal/httplog/roundtripper_test.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper_test.go
@@ -242,11 +242,8 @@ func TestResolveSymlinks(t *testing.T) {
 }
 
 func TestResolvePathInLogsFor(t *testing.T) {
-	origLogs := paths.Paths.Logs
-	t.Cleanup(func() { paths.Paths.Logs = origLogs })
-
 	logsDir := filepath.Join(t.TempDir(), "logs")
-	paths.Paths.Logs = logsDir
+	p := &paths.Path{Logs: logsDir}
 
 	const input = "cel"
 	root := filepath.Join(logsDir, input)
@@ -351,7 +348,7 @@ func TestResolvePathInLogsFor(t *testing.T) {
 			continue
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			resolved, ok, err := ResolvePathInLogsFor(input, tt.path)
+			resolved, ok, err := ResolvePathInLogsFor(p, input, tt.path)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/{cel,httpjson,http_endpoint,entityanalytics},internal/httplog: fix request tracer path validation under OTel receiver runtime

When filebeat runs as a receiver inside elastic-otel-collector (the
default since elastic-agent#13991), NewBeatForReceiver creates a
per-instance *paths.Path and stores it in b.Info.Paths without
updating the global paths.Paths singleton. IsPathInLogsFor and
ResolvePathInLogsFor used the global, so paths.Resolve(paths.Logs,
input) returned a bare relative name like "cel" and the tracer
filename's ../../logs/cel/ pattern resolved outside that root,
failing validation.

Remove the IsPathInLogsFor call from all Validate methods. These
run during config unpacking and cannot access the correct
per-receiver paths. The same check already runs at input start via
ResolvePathInLogsFor, so no coverage is lost.

Change ResolvePathInLogsFor to accept a *paths.Path so callers can
pass the correct per-instance paths from beat.Info. When nil, the
global paths.Paths is used as a fallback.

Update all runtime callers (cel, httpjson, http_endpoint,
entityanalytics/okta, jamf, azuread) to pass ctx.Agent.Paths.

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For elastic/integrations#18803

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
