### PR TITLE
Upgrade npm to v11 in non-wolfi heartbeat Docker images

### DIFF
--- a/changelog/fragments/1778525715-upgrade-npm-heartbeat-docker.yaml
+++ b/changelog/fragments/1778525715-upgrade-npm-heartbeat-docker.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: security
+
+# Change summary; a 80ish characters long description of the change.
+summary: Upgrade Node.js to v24 LTS in non-wolfi heartbeat Docker images
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: heartbeat
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1778525715-upgrade-npm-heartbeat-docker.yaml
+++ b/changelog/fragments/1778525715-upgrade-npm-heartbeat-docker.yaml
@@ -11,7 +11,7 @@
 kind: security
 
 # Change summary; a 80ish characters long description of the change.
-summary: Upgrade Node.js to v24 LTS in non-wolfi heartbeat Docker images
+summary: Upgrade npm to v11 in non-wolfi heartbeat Docker images
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -198,7 +198,7 @@ RUN echo \
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
 ENV TZ=UTC
-ENV NODE_VERSION=24.15.0
+ENV NODE_VERSION=22.22.2
 ENV PATH="$NODE_PATH/node/bin:$PATH"
 # Install the latest version of @elastic/synthetics forcefully ignoring the previously
 # cached node_modules, heartbeat then calls the global executable to run test suites
@@ -222,6 +222,9 @@ RUN cd /usr/share/heartbeat/.node \
     && mkdir -p node \
     && curl ${NODE_DOWNLOAD_URL} | tar -xJ --strip 1 -C node \
     && chmod ug+rwX -R $NODE_PATH
+
+# TODO: Remove this step when Node.js is bumped to a version that bundles npm >= 11.14.0
+RUN npm install -g npm@11.14.1
 
 # Install synthetics as a regular user, installing npm deps as root doesn't work
 RUN chown -R {{ .user }} $NODE_PATH

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -198,7 +198,7 @@ RUN echo \
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
 ENV TZ=UTC
-ENV NODE_VERSION=22.22.2
+ENV NODE_VERSION=24.15.0
 ENV PATH="$NODE_PATH/node/bin:$PATH"
 # Install the latest version of @elastic/synthetics forcefully ignoring the previously
 # cached node_modules, heartbeat then calls the global executable to run test suites

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -224,7 +224,10 @@ RUN cd /usr/share/heartbeat/.node \
     && chmod ug+rwX -R $NODE_PATH
 
 # TODO: Remove this step when Node.js is bumped to a version that bundles npm >= 11.14.0
-RUN npm install -g npm@11.14.1
+# Bootstrap npm 11.14.1 from a downloaded copy to avoid npm 10.x self-replacement failures
+RUN curl -fsSL https://registry.npmjs.org/npm/-/npm-11.14.1.tgz | tar xz -C /tmp \
+    && node /tmp/package/bin/npm-cli.js install -g npm@11.14.1 \
+    && rm -rf /tmp/package
 
 # Install synthetics as a regular user, installing npm deps as root doesn't work
 RUN chown -R {{ .user }} $NODE_PATH


### PR DESCRIPTION
## Proposed commit message

The non-wolfi (UBI) heartbeat Docker variant downloads Node.js 22.22.2 from
nodejs.org, which bundles npm 10.9.7. The wolfi variant already uses npm 11.12.0
via a separate apk package. This creates a discrepancy in npm versions between
the two image variants, meaning they ship different versions of npm's transitive
dependencies.

This PR adds a step after the Node.js tarball extraction in the non-wolfi
heartbeat Dockerfile template to bootstrap npm 11.14.1. Because the bundled
npm 10.x cannot reliably self-upgrade to npm 11.x (it fails with
`MODULE_NOT_FOUND: Cannot find module 'promise-retry'` due to overwriting its
own dependencies mid-operation), the upgrade is performed by downloading the
npm 11.14.1 tarball and running its CLI via `node` directly.

This step can be removed once Node.js is bumped to a version that bundles
npm >= 11.14.0.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. The wolfi variant already uses npm 11; this brings the non-wolfi variant
into alignment.

## How to test this PR locally

Build the non-wolfi heartbeat Docker image and verify:
```
docker run --rm <image> npm --version
# Should output: 11.14.1
```

## Related issues

-

## Use cases

Ensures both wolfi and non-wolfi heartbeat Docker images use the same npm major
version and its transitive dependencies.