### PR TITLE
packetbeat: tolerate equal flow timestamps in mysql test

### DIFF
--- a/packetbeat/tests/system/test_0060_flows.py
+++ b/packetbeat/tests/system/test_0060_flows.py
@@ -59,7 +59,7 @@ class Test(BaseTest):
 
         start_ts = parse_timestamp(objs[0]['event.start'])
         last_ts = parse_timestamp(objs[0]['event.end'])
-        assert last_ts > start_ts
+        assert last_ts >= start_ts
 
     def test_memcache_udp_flow(self):
         self.render_config_template(


### PR DESCRIPTION
## Proposed commit message

```text
packetbeat: tolerate equal flow timestamps in mysql test

Windows CI can process mysql_long.pcap in one clock tick, making
flow event.start and event.end equal for the final flow report.
Relax the assertion to >= so the test checks non-decreasing time
without flaking on platform clock precision.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

1. `cd packetbeat`
2. `mage buildSystemTestBinary`
3. `pytest tests/system/test_0060_flows.py -k mysql_flow`

## Use cases

This keeps the mysql flow system test stable on Windows where all packets
can be processed in a single clock tick and produce equal flow start/end
timestamps.

## Screenshots

N/A

## Logs

- Buildkite failure (expires):
  https://buildkite.com/elastic/beats-packetbeat/builds/29455#019df9d5-d685-48d5-b3ca-c0f67feb5675/L555

```
=========================== short test summary info ===========================
FAILED tests\system\test_0060_flows.py::Test::test_mysql_flow - assert datetime.datetime(2026, 5, 5, 20, 41, 22, 394000) > datetime.datetime(2026, 5, 5, 20, 41, 22, 394000)
====== 1 failed, 188 passed, 6 skipped, 3 warnings in 229.65s (0:03:49) =======
>> python test: Unit Testing Complete
```