### PR TITLE
Fix OTel xextension dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -511,7 +511,7 @@ require (
 	go.opentelemetry.io/collector/exporter/xexporter v0.151.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.151.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.151.0 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.151.0 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.151.0
 	go.opentelemetry.io/collector/featuregate v1.57.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.151.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.151.0 // indirect


### PR DESCRIPTION
## Proposed commit message

```
Fix OTel xextension dependency

`make update` now emits these new changes. In order to unblock all upcoming PRs, we must make this change first.
```

This blocks all currently open contributions.