### PR TITLE
x-pack/filebeat/input/cel: refactor periodic execution into phases

### DIFF
--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -312,443 +312,503 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	// In addition to this and the functions and globals available
 	// from mito/lib, a global, useragent, is available to use
 	// in requests.
-	err = periodically(ctx, cfg.Interval, func() error {
-		runSpanExecutionCount := 0
-		runSpanEventCount := 0
-		runCtx, runSpan := otelTracer.Start(ctx, "cel.periodic.run")
-		// set happy path attributes - overwritten in case of negative outcomes
-		runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", false))
-		defer func() {
-			runSpan.SetAttributes(
-				attribute.Int("cel.periodic.execution_count", runSpanExecutionCount),
-				attribute.Int("cel.periodic.event_count", runSpanEventCount),
-			)
-			runSpan.End()
-		}()
+	s := &runSession{
+		cfg:      cfg,
+		prg:      prg,
+		ast:      ast,
+		cov:      cov,
+		wantDump: wantDump,
+		doCov:    doCov,
 
-		runLog := logWithTracingIds(log, runSpan)
-		runLog.Debug("Starting otel periodic")
+		limiter: limiter,
+		trace:   trace,
 
-		metricsRecorder.StartPeriodic(runCtx)
-		defer metricsRecorder.EndPeriodic(runCtx)
-		runLog.Debug("process periodic request")
-		var (
-			budget    = *cfg.MaxExecutions
-			waitUntil time.Time
-		)
-		// Keep track of whether CEL is degraded for this periodic run.
-		var isDegraded bool
-		if doCov {
-			defer func() {
-				// If doCov is true, log the updated coverage details.
-				// Updates are a running aggregate for each call to run
-				// as cov is shared via the program compilation.
-				log.Debugw("coverage", "details", cov.Details())
-			}()
-		}
-		for {
-			if wait := time.Until(waitUntil); wait > 0 {
-				waitCtx, waitSpan := otelTracer.Start(runCtx, "cel.periodic.run.ratelimitwait")
-				// We have a special-case wait for when we have a zero limit.
-				// x/time/rate allow a burst through even when the limit is zero
-				// so in order to ensure that we don't try until we are out of
-				// purgatory we calculate how long we should wait according to
-				// the retry after for a 429 and rate limit headers if we have
-				// a zero rate quota. See handleResponse below.
-				select {
-				case <-waitCtx.Done():
-					runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
-					waitSpan.End()
-					return waitCtx.Err()
-				case <-time.After(wait):
-				}
-				waitSpan.End()
-			} else if err = runCtx.Err(); err != nil {
-				// Otherwise exit if we have been cancelled.
-				runSpan.SetStatus(codes.Unset, runCtx.Err().Error())
-				return err
-			}
+		env: env,
+		now: i.now,
 
-			runSpanExecutionCount++
-			execCtx, execSpan := otelTracer.Start(runCtx, "cel.program.execution")
-			execSpan.SetAttributes(
-				attribute.Int("cel.program.execution_number", runSpanExecutionCount),
-				attribute.Int("cel.program.event_count", 0), // to be overridden if there are events
-			)
-			execLog := logWithTracingIds(log, execSpan)
+		pub: pub,
 
-			// Process a set of event requests.
-			if trace != nil {
-				execLog.Debugw("previous transaction", "transaction.id", trace.TxID())
-			}
-			execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: state, cfg: cfg.Redact})
-			metricsRecorder.AddProgramExecution(execCtx)
-			start := i.now().In(time.UTC)
+		log:      log,
+		health:   health,
+		metrics:  metricsRecorder,
+		tracer:   otelTracer,
+		injector: contextInjector,
 
-			state, err = evalWith(execCtx, contextInjector, prg, ast, state, start, wantDump, budget-1)
-			metricsRecorder.AddCELDuration(execCtx, time.Since(start))
-			execLog.Debugw("response state", logp.Namespace("cel"), "state", redactor{state: state, cfg: cfg.Redact})
-			if err != nil {
-				var dump dumpError
-				switch {
-				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-					metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-					errorSpans(err, runSpan, end{execSpan})
-					return err
-				case errors.As(err, &dump):
-					path := strings.ReplaceAll(cfg.FailureDump.Filename, "*", sanitizeFileName(env.IDWithoutName))
-					dir := filepath.Dir(path)
-					base := filepath.Base(path)
-					ext := filepath.Ext(base)
-					prefix := strings.TrimSuffix(base, ext)
-					path = filepath.Join(dir, prefix+"-"+i.now().In(time.UTC).Format("2006-01-02T15-04-05.000")+ext)
-					execLog.Debugw("writing failure dump file", "path", path)
-					err := dump.writeToFile(path)
-					if err != nil {
-						execLog.Errorw("failed to write failure dump", "path", path, "error", err)
-					}
-				}
-				execLog.Errorw("failed evaluation", "error", err)
-				health.UpdateStatus(status.Degraded, "failed evaluation: "+err.Error())
-			}
-			isDegraded = err != nil
-			if trace != nil {
-				execLog.Debugw("final transaction", "transaction.id", trace.TxID())
-			}
+		state:      state,
+		cursor:     cursor,
+		goodCursor: goodCursor,
+		goodURL:    goodURL,
+	}
 
-			// On exit, state is expected to be in the shape:
-			//
-			// {
-			//     "cursor": [
-			//         {...},
-			//         ...
-			//     ],
-			//     "events": [
-			//         {...},
-			//         ...
-			//     ],
-			//     "url": <resource address>,
-			//     "status_code": <HTTP request status code if a network request>,
-			//     "header": <HTTP response headers if a network request>,
-			//     "rate_limit": <HTTP rate limit map if required by API>,
-			//     "want_more": bool
-			// }
-			//
-			// The "events" array must be present, but may be empty or null.
-			// In the case of an error condition in the CEL program it is
-			// acceptable to return a single object which will be wrapped as
-			// an array below. It is the responsibility of the downstream
-			// processor to handle this object correctly (which may be to drop
-			// the event). The error event will also be logged.
-			// If it is not empty, it must only have objects as elements.
-			// Additional fields may be present at the root of the object.
-			// The evaluation is repeated with the new state, after removing
-			// the events field, if the "want_more" field is present and true
-			// and a non-zero events array is returned.
-			//
-			// If cursor is present it must be either a single object or an
-			// array with the same length as events; each element i of the
-			// cursor array will be the details for obtaining the events at or
-			// beyond event i in events. If the cursor is a single object it
-			// is will be the details for obtaining events after the last
-			// event in the events array and will only be retained on
-			// successful publication of all the events in the array.
-			//
-			// If rate_limit is present it should be a map with numeric fields
-			// rate and burst. It may also have a string error field and
-			// other fields which will be logged. If it has an error field
-			// the rate and burst will not be used to set rate limit behaviour.
-			//
-			// The status code and rate_limit values may be omitted if they do
-			// not contribute to control.
-			//
-			// The following details how a cursor array works:
-			//
-			// Result after request resulting in 5 events. Each c obtained with
-			// an e points to the ~next e.
-			//
-			//    +----+   +----+        +----+
-			//    | e1 |   | c1 |        | e1 |
-			//    +----+   +----+        +----+   +----+
-			//    | e2 |   | c2 |        | e2 | < | c1 |
-			//    +----+   +----+        +----+   +----+
-			//    | e3 |   | c3 |        | e3 | < | c2 |
-			//    +----+   +----+   =>   +----+   +----+
-			//    | e4 |   | c4 |        | e4 | < | c3 |
-			//    +----+   +----+        +----+   +----+
-			//    | e5 |   | c5 |        | e5 | < | c4 |
-			//    +----+   +----+        +----+   +----+
-			//                           |next| < | c5 |
-			//                           +----+   +----+
-			//
-			// After a successful publication this will leave a single c and
-			// and empty events array. So the next evaluation has a boot.
-			//
-			// If the publication fails or execution is terminated at some
-			// point during the events array, we may end up with, e.g.
-			//
-			//    +----+  +----+        +----+   +----+
-			//    | e3 |  | c3 |        |next| < | c3 |
-			//    +----+  +----+        +----+   +----+
-			//    | e4 |  | c4 |   =>
-			//    +----+  +----+          lost events
-			//    | e5 |  | c5 |
-			//    +----+  +----+
-			//
-			// At this point, the c3 cursor (or at worst the c2 cursor) has
-			// been stored and we can continue from that point, recovering
-			// the lost events and potentially re-requesting e3.
-
-			var ok bool
-			ok, waitUntil, err = handleResponse(execLog, state, limiter)
-			if err != nil || !ok {
-				metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-				if err != nil {
-					errorSpans(err, end{execSpan}, runSpan)
-					return err
-				}
-				errorSpans(errors.New("invalid response"), end{execSpan})
-				continue
-			}
-
-			_, ok = state["url"]
-			if !ok && goodURL != "" {
-				state["url"] = goodURL
-				execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", goodURL)
-			}
-
-			e, ok := state["events"]
-			if !ok {
-				metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-				err := errors.New("unexpected missing events array from evaluation")
-				errorSpans(err, end{execSpan}, runSpan)
-				return err
-			}
-			var events []interface{}
-			switch e := e.(type) {
-			case []interface{}:
-				if len(e) == 0 {
-					metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-					metricsRecorder.AddProgramSuccessExecution(execCtx)
-					okSpans(end{execSpan})
-					return nil
-				}
-				events = e
-			case map[string]interface{}:
-				if e == nil {
-					metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-					metricsRecorder.AddProgramSuccessExecution(execCtx)
-					okSpans(end{execSpan})
-					return nil
-				}
-				if _, ok := e["error"]; ok {
-					// If we have an error, log the complete object on the basis
-					// that it is ECS-conformant.
-					if execLog.Core().Enabled(zapcore.ErrorLevel) {
-						kv := make([]any, 0, 2*len(e))
-						for k := range maps.Keys(e) {
-							kv = append(kv, k, e[k])
-						}
-						execLog.Errorw("single event object returned by evaluation", kv...)
-					}
-				} else {
-					// Otherwise, be consistent with the existing documented
-					// behaviour and log the entire object as the error.
-					execLog.Errorw("single event object returned by evaluation", "error", e)
-				}
-				if err, ok := e["error"]; ok {
-					health.UpdateStatus(status.Degraded, fmt.Sprintf("single event error object returned by evaluation: %s", mapstr.M{"error": err}))
-				} else {
-					health.UpdateStatus(status.Degraded, "single event object returned by evaluation")
-				}
-				isDegraded = true
-				events = []interface{}{e}
-				// Make sure the cursor is not updated.
-				delete(state, "cursor")
-			default:
-				err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-				metricsRecorder.AddProgramRunDuration(execCtx, time.Since(start))
-				errorSpans(err, end{execSpan}, runSpan)
-				return err
-			}
-
-			// We have a non-empty batch of events to process.
-			metricsRecorder.AddReceivedBatch(execCtx, 1)
-			metricsRecorder.AddReceivedEvents(execCtx, uint(len(events)))
-			runSpanEventCount += len(events)
-			execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
-			// Drop events from state. If we fail during the publication,
-			// we will re-request these events.
-			delete(state, "events")
-
-			// Get cursors if they exist.
-			var (
-				cursors      []interface{}
-				singleCursor bool
-			)
-			if c, ok := state["cursor"]; ok {
-				cursors, ok = c.([]interface{})
-				if ok {
-					if len(cursors) != len(events) {
-						execLog.Errorw("unexpected cursor list length", "cursors", len(cursors), "events", len(events))
-						health.UpdateStatus(status.Degraded, "unexpected cursor list length")
-						isDegraded = true
-						// But try to continue.
-						if len(cursors) < len(events) {
-							cursors = nil
-						}
-					}
-				} else {
-					cursors = []interface{}{c}
-					singleCursor = true
-				}
-			}
-			// Drop old cursor from state. This will be replaced with
-			// the current cursor object below; it is an array now.
-			delete(state, "cursor")
-
-			pubStart := time.Now()
-			var hadPublicationError bool
-
-			pubCtx, pubSpan := otelTracer.Start(execCtx, "cel.program.publish")
-			pubSpanEventCount := 0
-			pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
-			pubLog := logWithTracingIds(log, pubSpan)
-		loop:
-			for i, e := range events {
-				event, ok := e.(map[string]interface{})
-				if !ok {
-					err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-					errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-					return err
-				}
-				var pubCursor interface{}
-				if cursors != nil {
-					if singleCursor {
-						// Only set the cursor for publication at the last event
-						// when a single cursor object has been provided.
-						if i == len(events)-1 {
-							goodCursor = cursor
-							cursor, ok = cursors[0].(map[string]interface{})
-							if !ok {
-								err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
-								metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-								errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-								return err
-							}
-							pubCursor = cursor
-						}
-					} else {
-						goodCursor = cursor
-						cursor, ok = cursors[i].(map[string]interface{})
-						if !ok {
-							err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
-							metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-							errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-							return err
-						}
-						pubCursor = cursor
-					}
-				}
-				// This is checked prior to the publish attempt since the
-				// cursor.Publisher interface does not document the behaviour
-				// related to context cancellation and the context is not
-				// explicitly passed in, so favour this explicit clarity.
-				switch err := pubCtx.Err(); {
-				case err == nil:
-				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-					pubLog.Infow("context cancelled with unpublished events", "unpublished", len(events)-i)
-					// Don't update status, since we are about to pass
-					// through the Running state and then fall through
-					// to the input exit with a change to Stopped.
-					break loop
-				default:
-					// This should never happen.
-					pubLog.Warnw("failed with unpublished events", "error", err, "unpublished", len(events)-i)
-					health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
-					isDegraded = true
-					break loop
-				}
-				err = pub.Publish(beat.Event{
-					Timestamp: time.Now(),
-					Fields:    event,
-				}, pubCursor)
-				if err != nil {
-					hadPublicationError = true
-					pubLog.Errorw("error publishing event", "error", err)
-					health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
-					errorSpans(err, pubSpan)
-					isDegraded = true
-					cursors = nil // We are lost, so retry with this event's cursor,
-					continue      // but continue with the events that we have without
-					// advancing the cursor. This allows us to potentially publish the
-					// events we have now, with a fallback to the last guaranteed
-					// correctly published cursor.
-				}
-				if i == 0 {
-					metricsRecorder.AddPublishedBatch(pubCtx, 1)
-				}
-				metricsRecorder.AddPublishedEvents(pubCtx, 1)
-				pubSpanEventCount++
-				pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount))
-
-				err = pubCtx.Err()
-				if err != nil {
-					metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-					errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-					return err
-				}
-			}
-
-			if !isDegraded {
-				health.UpdateStatus(status.Running, "")
-			}
-
-			metricsRecorder.AddPublishDuration(pubCtx, time.Since(pubStart))
-			// Advance the cursor to the final state if there was no error during
-			// publications. This is needed to transition to the next set of events.
-			if !hadPublicationError && !isDegraded {
-				goodCursor = cursor
-				metricsRecorder.AddProgramSuccessExecution(pubCtx)
-				okSpans(pubSpan)
-			}
-			pubSpan.End()
-
-			// Replace the last known good cursor.
-			state["cursor"] = goodCursor
-			metricsRecorder.AddProgramRunDuration(pubCtx, time.Since(start))
-			if more, _ := state["want_more"].(bool); !more {
-				execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
-				okSpans(end{execSpan}, runSpan)
-				return nil
-			}
-			execSpan.SetAttributes(attribute.Bool("cel.program.want_more", true))
-
-			// Check we have a remaining execution budget.
-			budget--
-			if budget <= 0 {
-				msg := "reached maximum number of CEL executions"
-				execLog.Warnw(msg+": will continue at next periodic evaluation",
-					"limit", *cfg.MaxExecutions,
-					"next_eval_time", start.Add(cfg.Interval),
-				)
-				health.UpdateStatus(status.Degraded, msg)
-				execSpan.SetStatus(codes.Unset, msg)
-				execSpan.End()
-				runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
-				runSpan.SetStatus(codes.Unset, msg)
-				return nil
-			}
-
-			okSpans(end{execSpan})
-		}
-	})
+	err = periodically(ctx, cfg.Interval, s.runCycle)
 	switch {
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		log.Infof("input stopped because context was cancelled with: %v", err)
 		err = nil
 	}
 	return err
+}
+
+type runSession struct {
+	cfg config
+
+	prg      cel.Program
+	ast      *cel.Ast
+	cov      *lib.Coverage
+	wantDump bool
+	doCov    bool
+
+	limiter *rate.Limiter
+	trace   *httplog.LoggingRoundTripper
+
+	env v2.Context
+	now func() time.Time
+
+	pub inputcursor.Publisher
+
+	log      *logp.Logger
+	health   status.StatusReporter
+	metrics  *metricsRecorder
+	tracer   trace.Tracer
+	injector *otel.ContextInjector
+
+	state      map[string]any
+	cursor     map[string]any
+	goodCursor map[string]any
+	goodURL    string
+}
+
+func (s *runSession) runCycle(ctx context.Context) error {
+	runSpanExecutionCount := 0
+	runSpanEventCount := 0
+	runCtx, runSpan := s.tracer.Start(ctx, "cel.periodic.run")
+	// set happy path attributes - overwritten in case of negative outcomes
+	runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", false))
+	defer func() {
+		runSpan.SetAttributes(
+			attribute.Int("cel.periodic.execution_count", runSpanExecutionCount),
+			attribute.Int("cel.periodic.event_count", runSpanEventCount),
+		)
+		runSpan.End()
+	}()
+
+	runLog := logWithTracingIds(s.log, runSpan)
+	runLog.Debug("Starting otel periodic")
+
+	s.metrics.StartPeriodic(runCtx)
+	defer s.metrics.EndPeriodic(runCtx)
+	runLog.Debug("process periodic request")
+	var (
+		budget    = *s.cfg.MaxExecutions
+		waitUntil time.Time
+	)
+	// Keep track of whether CEL is degraded for this periodic run.
+	var isDegraded bool
+	if s.doCov {
+		defer func() {
+			// If doCov is true, log the updated coverage details.
+			// Updates are a running aggregate for each call to run
+			// as cov is shared via the program compilation.
+			s.log.Debugw("coverage", "details", s.cov.Details())
+		}()
+	}
+	for {
+		if wait := time.Until(waitUntil); wait > 0 {
+			waitCtx, waitSpan := s.tracer.Start(runCtx, "cel.periodic.run.ratelimitwait")
+			// We have a special-case wait for when we have a zero limit.
+			// x/time/rate allow a burst through even when the limit is zero
+			// so in order to ensure that we don't try until we are out of
+			// purgatory we calculate how long we should wait according to
+			// the retry after for a 429 and rate limit headers if we have
+			// a zero rate quota. See handleResponse below.
+			select {
+			case <-waitCtx.Done():
+				runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
+				waitSpan.End()
+				return waitCtx.Err()
+			case <-time.After(wait):
+			}
+			waitSpan.End()
+		} else if err := runCtx.Err(); err != nil {
+			// Otherwise exit if we have been cancelled.
+			runSpan.SetStatus(codes.Unset, runCtx.Err().Error())
+			return err
+		}
+
+		runSpanExecutionCount++
+		execCtx, execSpan := s.tracer.Start(runCtx, "cel.program.execution")
+		execSpan.SetAttributes(
+			attribute.Int("cel.program.execution_number", runSpanExecutionCount),
+			attribute.Int("cel.program.event_count", 0), // to be overridden if there are events
+		)
+		execLog := logWithTracingIds(s.log, execSpan)
+
+		// Process a set of event requests.
+		if s.trace != nil {
+			execLog.Debugw("previous transaction", "transaction.id", s.trace.TxID())
+		}
+		execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: s.state, cfg: s.cfg.Redact})
+		s.metrics.AddProgramExecution(execCtx)
+		start := s.now().In(time.UTC)
+
+		var err error
+		s.state, err = evalWith(execCtx, s.injector, s.prg, s.ast, s.state, start, s.wantDump, budget-1)
+		s.metrics.AddCELDuration(execCtx, time.Since(start))
+		execLog.Debugw("response state", logp.Namespace("cel"), "state", redactor{state: s.state, cfg: s.cfg.Redact})
+		if err != nil {
+			var dump dumpError
+			switch {
+			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+				s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+				errorSpans(err, runSpan, end{execSpan})
+				return err
+			case errors.As(err, &dump):
+				path := strings.ReplaceAll(s.cfg.FailureDump.Filename, "*", sanitizeFileName(s.env.IDWithoutName))
+				dir := filepath.Dir(path)
+				base := filepath.Base(path)
+				ext := filepath.Ext(base)
+				prefix := strings.TrimSuffix(base, ext)
+				path = filepath.Join(dir, prefix+"-"+s.now().In(time.UTC).Format("2006-01-02T15-04-05.000")+ext)
+				execLog.Debugw("writing failure dump file", "path", path)
+				err := dump.writeToFile(path)
+				if err != nil {
+					execLog.Errorw("failed to write failure dump", "path", path, "error", err)
+				}
+			}
+			execLog.Errorw("failed evaluation", "error", err)
+			s.health.UpdateStatus(status.Degraded, "failed evaluation: "+err.Error())
+		}
+		isDegraded = err != nil
+		if s.trace != nil {
+			execLog.Debugw("final transaction", "transaction.id", s.trace.TxID())
+		}
+
+		// On exit, state is expected to be in the shape:
+		//
+		// {
+		//     "cursor": [
+		//         {...},
+		//         ...
+		//     ],
+		//     "events": [
+		//         {...},
+		//         ...
+		//     ],
+		//     "url": <resource address>,
+		//     "status_code": <HTTP request status code if a network request>,
+		//     "header": <HTTP response headers if a network request>,
+		//     "rate_limit": <HTTP rate limit map if required by API>,
+		//     "want_more": bool
+		// }
+		//
+		// The "events" array must be present, but may be empty or null.
+		// In the case of an error condition in the CEL program it is
+		// acceptable to return a single object which will be wrapped as
+		// an array below. It is the responsibility of the downstream
+		// processor to handle this object correctly (which may be to drop
+		// the event). The error event will also be logged.
+		// If it is not empty, it must only have objects as elements.
+		// Additional fields may be present at the root of the object.
+		// The evaluation is repeated with the new state, after removing
+		// the events field, if the "want_more" field is present and true
+		// and a non-zero events array is returned.
+		//
+		// If cursor is present it must be either a single object or an
+		// array with the same length as events; each element i of the
+		// cursor array will be the details for obtaining the events at or
+		// beyond event i in events. If the cursor is a single object it
+		// is will be the details for obtaining events after the last
+		// event in the events array and will only be retained on
+		// successful publication of all the events in the array.
+		//
+		// If rate_limit is present it should be a map with numeric fields
+		// rate and burst. It may also have a string error field and
+		// other fields which will be logged. If it has an error field
+		// the rate and burst will not be used to set rate limit behaviour.
+		//
+		// The status code and rate_limit values may be omitted if they do
+		// not contribute to control.
+		//
+		// The following details how a cursor array works:
+		//
+		// Result after request resulting in 5 events. Each c obtained with
+		// an e points to the ~next e.
+		//
+		//    +----+   +----+        +----+
+		//    | e1 |   | c1 |        | e1 |
+		//    +----+   +----+        +----+   +----+
+		//    | e2 |   | c2 |        | e2 | < | c1 |
+		//    +----+   +----+        +----+   +----+
+		//    | e3 |   | c3 |        | e3 | < | c2 |
+		//    +----+   +----+   =>   +----+   +----+
+		//    | e4 |   | c4 |        | e4 | < | c3 |
+		//    +----+   +----+        +----+   +----+
+		//    | e5 |   | c5 |        | e5 | < | c4 |
+		//    +----+   +----+        +----+   +----+
+		//                           |next| < | c5 |
+		//                           +----+   +----+
+		//
+		// After a successful publication this will leave a single c and
+		// and empty events array. So the next evaluation has a boot.
+		//
+		// If the publication fails or execution is terminated at some
+		// point during the events array, we may end up with, e.g.
+		//
+		//    +----+  +----+        +----+   +----+
+		//    | e3 |  | c3 |        |next| < | c3 |
+		//    +----+  +----+        +----+   +----+
+		//    | e4 |  | c4 |   =>
+		//    +----+  +----+          lost events
+		//    | e5 |  | c5 |
+		//    +----+  +----+
+		//
+		// At this point, the c3 cursor (or at worst the c2 cursor) has
+		// been stored and we can continue from that point, recovering
+		// the lost events and potentially re-requesting e3.
+
+		var ok bool
+		ok, waitUntil, err = handleResponse(execLog, s.state, s.limiter)
+		if err != nil || !ok {
+			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+			if err != nil {
+				errorSpans(err, end{execSpan}, runSpan)
+				return err
+			}
+			errorSpans(errors.New("invalid response"), end{execSpan})
+			continue
+		}
+
+		_, ok = s.state["url"]
+		if !ok && s.goodURL != "" {
+			s.state["url"] = s.goodURL
+			execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", s.goodURL)
+		}
+
+		e, ok := s.state["events"]
+		if !ok {
+			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+			err := errors.New("unexpected missing events array from evaluation")
+			errorSpans(err, end{execSpan}, runSpan)
+			return err
+		}
+		var events []any
+		switch e := e.(type) {
+		case []any:
+			if len(e) == 0 {
+				s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+				s.metrics.AddProgramSuccessExecution(execCtx)
+				okSpans(end{execSpan})
+				return nil
+			}
+			events = e
+		case map[string]any:
+			if e == nil {
+				s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+				s.metrics.AddProgramSuccessExecution(execCtx)
+				okSpans(end{execSpan})
+				return nil
+			}
+			if _, ok := e["error"]; ok {
+				// If we have an error, log the complete object on the basis
+				// that it is ECS-conformant.
+				if execLog.Core().Enabled(zapcore.ErrorLevel) {
+					kv := make([]any, 0, 2*len(e))
+					for k := range maps.Keys(e) {
+						kv = append(kv, k, e[k])
+					}
+					execLog.Errorw("single event object returned by evaluation", kv...)
+				}
+			} else {
+				// Otherwise, be consistent with the existing documented
+				// behaviour and log the entire object as the error.
+				execLog.Errorw("single event object returned by evaluation", "error", e)
+			}
+			if err, ok := e["error"]; ok {
+				s.health.UpdateStatus(status.Degraded, fmt.Sprintf("single event error object returned by evaluation: %s", mapstr.M{"error": err}))
+			} else {
+				s.health.UpdateStatus(status.Degraded, "single event object returned by evaluation")
+			}
+			isDegraded = true
+			events = []any{e}
+			// Make sure the cursor is not updated.
+			delete(s.state, "cursor")
+		default:
+			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+			errorSpans(err, end{execSpan}, runSpan)
+			return err
+		}
+
+		// We have a non-empty batch of events to process.
+		s.metrics.AddReceivedBatch(execCtx, 1)
+		s.metrics.AddReceivedEvents(execCtx, uint(len(events)))
+		runSpanEventCount += len(events)
+		execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
+		// Drop events from state. If we fail during the publication,
+		// we will re-request these events.
+		delete(s.state, "events")
+
+		// Get cursors if they exist.
+		var (
+			cursors      []any
+			singleCursor bool
+		)
+		if c, ok := s.state["cursor"]; ok {
+			cursors, ok = c.([]any)
+			if ok {
+				if len(cursors) != len(events) {
+					execLog.Errorw("unexpected cursor list length", "cursors", len(cursors), "events", len(events))
+					s.health.UpdateStatus(status.Degraded, "unexpected cursor list length")
+					isDegraded = true
+					// But try to continue.
+					if len(cursors) < len(events) {
+						cursors = nil
+					}
+				}
+			} else {
+				cursors = []any{c}
+				singleCursor = true
+			}
+		}
+		// Drop old cursor from state. This will be replaced with
+		// the current cursor object below; it is an array now.
+		delete(s.state, "cursor")
+
+		pubStart := time.Now()
+		var hadPublicationError bool
+
+		pubCtx, pubSpan := s.tracer.Start(execCtx, "cel.program.publish")
+		pubSpanEventCount := 0
+		pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
+		pubLog := logWithTracingIds(s.log, pubSpan)
+	loop:
+		for i, e := range events {
+			event, ok := e.(map[string]any)
+			if !ok {
+				err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+				errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+				return err
+			}
+			var pubCursor any
+			if cursors != nil {
+				if singleCursor {
+					// Only set the cursor for publication at the last event
+					// when a single cursor object has been provided.
+					if i == len(events)-1 {
+						s.goodCursor = s.cursor
+						s.cursor, ok = cursors[0].(map[string]any)
+						if !ok {
+							err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
+							s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+							errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+							return err
+						}
+						pubCursor = s.cursor
+					}
+				} else {
+					s.goodCursor = s.cursor
+					s.cursor, ok = cursors[i].(map[string]any)
+					if !ok {
+						err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
+						s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+						errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+						return err
+					}
+					pubCursor = s.cursor
+				}
+			}
+			// This is checked prior to the publish attempt since the
+			// cursor.Publisher interface does not document the behaviour
+			// related to context cancellation and the context is not
+			// explicitly passed in, so favour this explicit clarity.
+			switch err := pubCtx.Err(); {
+			case err == nil:
+			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+				pubLog.Infow("context cancelled with unpublished events", "unpublished", len(events)-i)
+				// Don't update status, since we are about to pass
+				// through the Running state and then fall through
+				// to the input exit with a change to Stopped.
+				break loop
+			default:
+				// This should never happen.
+				pubLog.Warnw("failed with unpublished events", "error", err, "unpublished", len(events)-i)
+				s.health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
+				isDegraded = true
+				break loop
+			}
+			err = s.pub.Publish(beat.Event{
+				Timestamp: time.Now(),
+				Fields:    event,
+			}, pubCursor)
+			if err != nil {
+				hadPublicationError = true
+				pubLog.Errorw("error publishing event", "error", err)
+				s.health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
+				errorSpans(err, pubSpan)
+				isDegraded = true
+				cursors = nil // We are lost, so retry with this event's cursor,
+				continue      // but continue with the events that we have without
+				// advancing the cursor. This allows us to potentially publish the
+				// events we have now, with a fallback to the last guaranteed
+				// correctly published cursor.
+			}
+			if i == 0 {
+				s.metrics.AddPublishedBatch(pubCtx, 1)
+			}
+			s.metrics.AddPublishedEvents(pubCtx, 1)
+			pubSpanEventCount++
+			pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount))
+
+			err = pubCtx.Err()
+			if err != nil {
+				s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+				errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
+				return err
+			}
+		}
+
+		if !isDegraded {
+			s.health.UpdateStatus(status.Running, "")
+		}
+
+		s.metrics.AddPublishDuration(pubCtx, time.Since(pubStart))
+		// Advance the cursor to the final state if there was no error during
+		// publications. This is needed to transition to the next set of events.
+		if !hadPublicationError && !isDegraded {
+			s.goodCursor = s.cursor
+			s.metrics.AddProgramSuccessExecution(pubCtx)
+			okSpans(pubSpan)
+		}
+		pubSpan.End()
+
+		// Replace the last known good cursor.
+		s.state["cursor"] = s.goodCursor
+		s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+		if more, _ := s.state["want_more"].(bool); !more {
+			execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
+			okSpans(end{execSpan}, runSpan)
+			return nil
+		}
+		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", true))
+
+		// Check we have a remaining execution budget.
+		budget--
+		if budget <= 0 {
+			msg := "reached maximum number of CEL executions"
+			execLog.Warnw(msg+": will continue at next periodic evaluation",
+				"limit", *s.cfg.MaxExecutions,
+				"next_eval_time", start.Add(s.cfg.Interval),
+			)
+			s.health.UpdateStatus(status.Degraded, msg)
+			execSpan.SetStatus(codes.Unset, msg)
+			execSpan.End()
+			runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
+			runSpan.SetStatus(codes.Unset, msg)
+			return nil
+		}
+
+		okSpans(end{execSpan})
+	}
 }
 
 func logWithTracingIds(log *logp.Logger, span trace.Span) *logp.Logger {
@@ -783,12 +843,14 @@ func okSpans(spans ...trace.Span) {
 	}
 }
 
-func periodically(ctx context.Context, each time.Duration, fn func() error) error {
-	err := fn()
+func periodically(ctx context.Context, each time.Duration, fn func(context.Context) error) error {
+	err := fn(ctx)
 	if err != nil {
 		return err
 	}
-	return timed.Periodic(ctx, each, fn)
+	return timed.Periodic(ctx, each, func() error {
+		return fn(ctx)
+	})
 }
 
 // handleResponse checks the response status code and handles rate limit changes.

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -119,7 +119,7 @@ func (input) Test(src inputcursor.Source, _ v2.TestContext) error {
 func (input) Run(env v2.Context, src inputcursor.Source, crsr inputcursor.Cursor, pub inputcursor.Publisher) error {
 	dataStreamName := src.(*source).cfg.DataStream //nolint:errcheck // If this assertion fails, the program is incorrect and should panic. datastreamName may be empty
 
-	var cursor map[string]interface{}
+	var cursor map[string]any
 	env.UpdateStatus(status.Starting, dataStreamName)
 	if !crsr.IsNew() { // Allow the user to bootstrap the program if needed.
 		err := crsr.Unpack(&cursor)
@@ -173,7 +173,7 @@ func sanitizeFileName(name string) string {
 	return strings.ReplaceAll(name, string(filepath.Separator), "_")
 }
 
-func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, pub inputcursor.Publisher, health status.StatusReporter) error {
+func (i input) run(env v2.Context, src *source, cursor map[string]any, pub inputcursor.Publisher, health status.StatusReporter) error {
 	cfg := src.cfg
 	log := env.Logger.With("input_url", cfg.Resource.URL)
 
@@ -256,9 +256,9 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 		return err
 	}
 
-	var state map[string]interface{}
+	var state map[string]any
 	if cfg.State == nil {
-		state = make(map[string]interface{})
+		state = make(map[string]any)
 	} else {
 		state = cfg.State
 	}
@@ -274,7 +274,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 	if cursor != nil {
 		state["cursor"] = cursor
 	}
-	goodCursor := cursor
+	safeCursor := cursor
 	goodURL := cfg.Resource.URL.String()
 	state["url"] = goodURL
 	metricsRecorder.SetResourceURL(goodURL)
@@ -336,7 +336,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]interface{}, p
 
 		state:      state,
 		cursor:     cursor,
-		goodCursor: goodCursor,
+		safeCursor: safeCursor,
 		goodURL:    goodURL,
 	}
 
@@ -374,7 +374,7 @@ type runSession struct {
 
 	state      map[string]any
 	cursor     map[string]any
-	goodCursor map[string]any
+	safeCursor map[string]any
 	goodURL    string
 }
 
@@ -450,47 +450,6 @@ func (s *runSession) runCycle(ctx context.Context) error {
 			return nil
 		}
 	}
-}
-
-func logWithTracingIds(log *logp.Logger, span trace.Span) *logp.Logger {
-	ctx := span.SpanContext()
-	return log.With(
-		"trace.id", ctx.TraceID().String(),
-		"span.id", ctx.SpanID().String(),
-	)
-}
-
-func waitForRateLimit(ctx context.Context, runSpan trace.Span, tracer trace.Tracer, wait time.Duration) error {
-	waitCtx, waitSpan := tracer.Start(ctx, "cel.periodic.run.ratelimitwait")
-	defer waitSpan.End()
-	// We have a special-case wait for when we have a zero limit.
-	// x/time/rate allow a burst through even when the limit is zero
-	// so in order to ensure that we don't try until we are out of
-	// purgatory we calculate how long we should wait according to
-	// the retry after for a 429 and rate limit headers if we have
-	// a zero rate quota. See handleResponse below.
-	select {
-	case <-waitCtx.Done():
-		runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
-		return waitCtx.Err()
-	case <-time.After(wait):
-	}
-	return nil
-}
-
-type action bool
-
-const (
-	contAction     action = false
-	retry429Action action = true
-)
-
-func (a action) retry() bool { return a == retry429Action }
-
-type executeResult struct {
-	action     action
-	waitUntil  time.Time
-	eventCount int
 }
 
 func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (executeResult, error) {
@@ -746,8 +705,8 @@ func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (
 		s.health.UpdateStatus(status.Running, "")
 	}
 
-	// Replace the last known good cursor.
-	s.state["cursor"] = s.goodCursor
+	// Replace the last cursor known to be safe to persist.
+	s.state["cursor"] = s.safeCursor
 	s.metrics.AddProgramRunDuration(pubResult.pubCtx, time.Since(start))
 	if more, _ := s.state["want_more"].(bool); !more {
 		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
@@ -769,11 +728,6 @@ func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (
 
 	okSpans(execSpan)
 	return result, nil
-}
-
-type publishResult struct {
-	pubCtx   context.Context
-	degraded bool
 }
 
 func (s *runSession) publish(ctx context.Context, events, cursors []any, singleCursor bool, start time.Time, degraded bool) (publishResult, error) {
@@ -805,7 +759,7 @@ loop:
 				// Only set the cursor for publication at the last event
 				// when a single cursor object has been provided.
 				if i == len(events)-1 {
-					s.goodCursor = s.cursor
+					s.safeCursor = s.cursor
 					s.cursor, ok = cursors[0].(map[string]any)
 					if !ok {
 						err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
@@ -816,7 +770,7 @@ loop:
 					pubCursor = s.cursor
 				}
 			} else {
-				s.goodCursor = s.cursor
+				s.safeCursor = s.cursor
 				s.cursor, ok = cursors[i].(map[string]any)
 				if !ok {
 					err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
@@ -881,12 +835,58 @@ loop:
 	// Advance the cursor to the final state if there was no error during
 	// publications. This is needed to transition to the next set of events.
 	if !hadPublicationError && !result.degraded {
-		s.goodCursor = s.cursor
+		s.safeCursor = s.cursor
 		s.metrics.AddProgramSuccessExecution(pubCtx)
 		okSpans(pubSpan)
 	}
 
 	return result, nil
+}
+
+func logWithTracingIds(log *logp.Logger, span trace.Span) *logp.Logger {
+	ctx := span.SpanContext()
+	return log.With(
+		"trace.id", ctx.TraceID().String(),
+		"span.id", ctx.SpanID().String(),
+	)
+}
+
+func waitForRateLimit(ctx context.Context, runSpan trace.Span, tracer trace.Tracer, wait time.Duration) error {
+	waitCtx, waitSpan := tracer.Start(ctx, "cel.periodic.run.ratelimitwait")
+	defer waitSpan.End()
+	// We have a special-case wait for when we have a zero limit.
+	// x/time/rate allow a burst through even when the limit is zero
+	// so in order to ensure that we don't try until we are out of
+	// purgatory we calculate how long we should wait according to
+	// the retry after for a 429 and rate limit headers if we have
+	// a zero rate quota. See handleResponse below.
+	select {
+	case <-waitCtx.Done():
+		runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
+		return waitCtx.Err()
+	case <-time.After(wait):
+	}
+	return nil
+}
+
+type action bool
+
+const (
+	contAction     action = false
+	retry429Action action = true
+)
+
+func (a action) retry() bool { return a == retry429Action }
+
+type executeResult struct {
+	action     action
+	waitUntil  time.Time
+	eventCount int
+}
+
+type publishResult struct {
+	pubCtx   context.Context
+	degraded bool
 }
 
 func errorSpans(err error, spans ...trace.Span) {
@@ -924,13 +924,13 @@ func handleResponse(state map[string]any, limiter *rate.Limiter, log *logp.Logge
 			header = h
 		case map[string][]string:
 			header = h
-		case map[string]interface{}:
+		case map[string]any:
 			header = make(http.Header)
 			for k, v := range h {
 				switch v := v.(type) {
 				case []string:
 					header[k] = v
-				case []interface{}:
+				case []any:
 					vals := make([]string, len(v))
 					for i, e := range v {
 						vals[i], ok = e.(string)
@@ -952,7 +952,7 @@ func handleResponse(state map[string]any, limiter *rate.Limiter, log *logp.Logge
 	if ok {
 		delete(state, "rate_limit")
 		switch r := r.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			// The state of rate-limit headers is a disaster. This needs to be
 			// more robust, but there is no real consensus and the RFC is not
 			// past draft yet. The draft is more sane than what we have now, but
@@ -1021,7 +1021,7 @@ func handleResponse(state map[string]any, limiter *rate.Limiter, log *logp.Logge
 // A caveat here is that if a CEL program interacts with two API endpoints that
 // do not share the same overall rate limit budget, there will be confusion if
 // rate_limit is used, so rate limiting is not supported in that situation.
-func handleRateLimit(log *logp.Logger, rateLimit map[string]interface{}, header http.Header, limiter *rate.Limiter) (waitUntil time.Time) {
+func handleRateLimit(log *logp.Logger, rateLimit map[string]any, header http.Header, limiter *rate.Limiter) (waitUntil time.Time) {
 	if e, ok := rateLimit["error"]; ok {
 		// The error field should be a string, but we won't quibble here.
 		log.Errorw("rate limit error", "error", e, "rate_limit", mapstr.M(rateLimit), "header", header)
@@ -1093,7 +1093,7 @@ func handleRateLimit(log *logp.Logger, rateLimit map[string]interface{}, header 
 	return waitUntil
 }
 
-func getLimit(which string, rateLimit map[string]interface{}, log *logp.Logger) (limit rate.Limit, ok bool) {
+func getLimit(which string, rateLimit map[string]any, log *logp.Logger) (limit rate.Limit, ok bool) {
 	r, ok := rateLimit[which]
 	if !ok {
 		log.Errorw("rate limit missing "+which, "rate_limit", mapstr.M(rateLimit))

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -629,20 +629,18 @@ func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (
 	// been stored and we can continue from that point, recovering
 	// the lost events and potentially re-requesting e3.
 
-	var ok bool
-	ok, result.waitUntil, err = handleResponse(execLog, s.state, s.limiter)
-	if err != nil || !ok {
+	result.waitUntil, result.action, err = handleResponse(s.state, s.limiter, execLog)
+	if err != nil || result.action.retry() {
 		s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
 		if err != nil {
 			errorSpans(err, execSpan)
 			return result, err
 		}
-		result.action = retry429Action
 		errorSpans(errors.New("invalid response"), execSpan)
 		return result, nil
 	}
 
-	_, ok = s.state["url"]
+	_, ok := s.state["url"]
 	if !ok && s.goodURL != "" {
 		s.state["url"] = s.goodURL
 		execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", s.goodURL)
@@ -915,8 +913,8 @@ func periodically(ctx context.Context, each time.Duration, fn func(context.Conte
 }
 
 // handleResponse checks the response status code and handles rate limit changes.
-// It returns ok=true if the response is valid, otherwise false for a retry.
-func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rate.Limiter) (ok bool, waitUntil time.Time, err error) {
+func handleResponse(state map[string]any, limiter *rate.Limiter, log *logp.Logger) (time.Time, action, error) {
+	var waitUntil time.Time
 	var header http.Header
 	h, ok := state["header"]
 	if ok {
@@ -937,16 +935,16 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 					for i, e := range v {
 						vals[i], ok = e.(string)
 						if !ok {
-							return false, time.Time{}, fmt.Errorf("unexpected type returned for response header value: %T", v)
+							return time.Time{}, contAction, fmt.Errorf("unexpected type returned for response header value: %T", v)
 						}
 					}
 					header[k] = vals
 				default:
-					return false, waitUntil, fmt.Errorf("unexpected type returned for response header value set: %T", v)
+					return waitUntil, contAction, fmt.Errorf("unexpected type returned for response header value set: %T", v)
 				}
 			}
 		default:
-			return false, waitUntil, fmt.Errorf("unexpected type returned for response header: %T", h)
+			return waitUntil, contAction, fmt.Errorf("unexpected type returned for response header: %T", h)
 		}
 	}
 
@@ -963,7 +961,7 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 			// path.
 			waitUntil = handleRateLimit(log, r, header, limiter)
 		default:
-			return false, waitUntil, fmt.Errorf("unexpected type returned for response header: %T", h)
+			return waitUntil, contAction, fmt.Errorf("unexpected type returned for response header: %T", h)
 		}
 	}
 
@@ -979,11 +977,11 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 		case float64:
 			statusCode = int(sc)
 		default:
-			return false, waitUntil, fmt.Errorf("unexpected type returned for request status code: %T", sc)
+			return waitUntil, contAction, fmt.Errorf("unexpected type returned for request status code: %T", sc)
 		}
 		switch statusCode {
 		case http.StatusOK:
-			return true, time.Time{}, nil
+			return time.Time{}, contAction, nil
 		case http.StatusTooManyRequests:
 			// https://datatracker.ietf.org/doc/html/rfc6585#page-3
 			retry := header.Get("Retry-After")
@@ -997,17 +995,17 @@ func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rat
 					waitUntil = t
 				}
 			}
-			return false, waitUntil, nil
+			return waitUntil, retry429Action, nil
 		default:
 			status := http.StatusText(statusCode)
 			if status == "" {
 				status = "unknown status code"
 			}
 			state["events"] = errorMessage(fmt.Sprintf("failed http request with %s: %d", status, statusCode))
-			return true, time.Time{}, nil
+			return time.Time{}, contAction, nil
 		}
 	}
-	return true, waitUntil, nil
+	return waitUntil, contAction, nil
 }
 
 // handleRateLimit performs two related functions dealing with rate limits. The

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -738,116 +738,19 @@ func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (
 	// the current cursor object below; it is an array now.
 	delete(s.state, "cursor")
 
-	pubStart := time.Now()
-	var hadPublicationError bool
-
-	pubCtx, pubSpan := s.tracer.Start(execCtx, "cel.program.publish")
-	pubSpanEventCount := 0
-	pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
-	pubLog := logWithTracingIds(s.log, pubSpan)
-loop:
-	for i, e := range events {
-		event, ok := e.(map[string]any)
-		if !ok {
-			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-			errorSpans(err, end{pubSpan}, execSpan)
-			return result, err
-		}
-		var pubCursor any
-		if cursors != nil {
-			if singleCursor {
-				// Only set the cursor for publication at the last event
-				// when a single cursor object has been provided.
-				if i == len(events)-1 {
-					s.goodCursor = s.cursor
-					s.cursor, ok = cursors[0].(map[string]any)
-					if !ok {
-						err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
-						s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
-						errorSpans(err, end{pubSpan}, execSpan)
-						return result, err
-					}
-					pubCursor = s.cursor
-				}
-			} else {
-				s.goodCursor = s.cursor
-				s.cursor, ok = cursors[i].(map[string]any)
-				if !ok {
-					err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
-					s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
-					errorSpans(err, end{pubSpan}, execSpan)
-					return result, err
-				}
-				pubCursor = s.cursor
-			}
-		}
-		// This is checked prior to the publish attempt since the
-		// cursor.Publisher interface does not document the behaviour
-		// related to context cancellation and the context is not
-		// explicitly passed in, so favour this explicit clarity.
-		switch err := pubCtx.Err(); {
-		case err == nil:
-		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-			pubLog.Infow("context cancelled with unpublished events", "unpublished", len(events)-i)
-			// Don't update status, since we are about to pass
-			// through the Running state and then fall through
-			// to the input exit with a change to Stopped.
-			break loop
-		default:
-			// This should never happen.
-			pubLog.Warnw("failed with unpublished events", "error", err, "unpublished", len(events)-i)
-			s.health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
-			isDegraded = true
-			break loop
-		}
-		err = s.pub.Publish(beat.Event{
-			Timestamp: time.Now(),
-			Fields:    event,
-		}, pubCursor)
-		if err != nil {
-			hadPublicationError = true
-			pubLog.Errorw("error publishing event", "error", err)
-			s.health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
-			errorSpans(err, pubSpan)
-			isDegraded = true
-			cursors = nil // We are lost, so retry with this event's cursor,
-			continue      // but continue with the events that we have without
-			// advancing the cursor. This allows us to potentially publish the
-			// events we have now, with a fallback to the last guaranteed
-			// correctly published cursor.
-		}
-		if i == 0 {
-			s.metrics.AddPublishedBatch(pubCtx, 1)
-		}
-		s.metrics.AddPublishedEvents(pubCtx, 1)
-		pubSpanEventCount++
-		pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount))
-
-		err = pubCtx.Err()
-		if err != nil {
-			s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
-			errorSpans(err, end{pubSpan}, execSpan)
-			return result, err
-		}
+	pubResult, err := s.publish(execCtx, events, cursors, singleCursor, start, isDegraded)
+	if err != nil {
+		errorSpans(err, execSpan)
+		return result, err
 	}
 
-	if !isDegraded {
+	if !pubResult.degraded {
 		s.health.UpdateStatus(status.Running, "")
 	}
 
-	s.metrics.AddPublishDuration(pubCtx, time.Since(pubStart))
-	// Advance the cursor to the final state if there was no error during
-	// publications. This is needed to transition to the next set of events.
-	if !hadPublicationError && !isDegraded {
-		s.goodCursor = s.cursor
-		s.metrics.AddProgramSuccessExecution(pubCtx)
-		okSpans(pubSpan)
-	}
-	pubSpan.End()
-
 	// Replace the last known good cursor.
 	s.state["cursor"] = s.goodCursor
-	s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+	s.metrics.AddProgramRunDuration(pubResult.pubCtx, time.Since(start))
 	if more, _ := s.state["want_more"].(bool); !more {
 		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
 		okSpans(execSpan)
@@ -870,27 +773,134 @@ loop:
 	return result, nil
 }
 
-// end is a tag type indicating spans in errorSpans and okSpans should be ended.
-type end struct {
-	trace.Span
+type publishResult struct {
+	pubCtx   context.Context
+	degraded bool
+}
+
+func (s *runSession) publish(ctx context.Context, events, cursors []any, singleCursor bool, start time.Time, degraded bool) (publishResult, error) {
+	result := publishResult{
+		degraded: degraded,
+	}
+
+	pubStart := time.Now()
+
+	pubCtx, pubSpan := s.tracer.Start(ctx, "cel.program.publish")
+	result.pubCtx = pubCtx
+	defer pubSpan.End()
+
+	pubSpanEventCount := 0
+	pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
+	pubLog := logWithTracingIds(s.log, pubSpan)
+	var hadPublicationError bool
+loop:
+	for i, e := range events {
+		event, ok := e.(map[string]any)
+		if !ok {
+			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+			errorSpans(err, pubSpan)
+			return result, err
+		}
+		var pubCursor any
+		if cursors != nil {
+			if singleCursor {
+				// Only set the cursor for publication at the last event
+				// when a single cursor object has been provided.
+				if i == len(events)-1 {
+					s.goodCursor = s.cursor
+					s.cursor, ok = cursors[0].(map[string]any)
+					if !ok {
+						err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
+						s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+						errorSpans(err, pubSpan)
+						return result, err
+					}
+					pubCursor = s.cursor
+				}
+			} else {
+				s.goodCursor = s.cursor
+				s.cursor, ok = cursors[i].(map[string]any)
+				if !ok {
+					err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
+					s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+					errorSpans(err, pubSpan)
+					return result, err
+				}
+				pubCursor = s.cursor
+			}
+		}
+		// This is checked prior to the publish attempt since the
+		// cursor.Publisher interface does not document the behaviour
+		// related to context cancellation and the context is not
+		// explicitly passed in, so favour this explicit clarity.
+		switch err := pubCtx.Err(); {
+		case err == nil:
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			pubLog.Infow("context cancelled with unpublished events", "unpublished", len(events)-i)
+			// Don't update status, since we are about to pass
+			// through the Running state and then fall through
+			// to the input exit with a change to Stopped.
+			break loop
+		default:
+			// This should never happen.
+			pubLog.Warnw("failed with unpublished events", "error", err, "unpublished", len(events)-i)
+			s.health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
+			result.degraded = true
+			break loop
+		}
+		err := s.pub.Publish(beat.Event{
+			Timestamp: time.Now(),
+			Fields:    event,
+		}, pubCursor)
+		if err != nil {
+			hadPublicationError = true
+			pubLog.Errorw("error publishing event", "error", err)
+			s.health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
+			errorSpans(err, pubSpan)
+			result.degraded = true
+			cursors = nil // We are lost, so retry with this event's cursor,
+			continue      // but continue with the events that we have without
+			// advancing the cursor. This allows us to potentially publish the
+			// events we have now, with a fallback to the last guaranteed
+			// correctly published cursor.
+		}
+		if i == 0 {
+			s.metrics.AddPublishedBatch(pubCtx, 1)
+		}
+		s.metrics.AddPublishedEvents(pubCtx, 1)
+		pubSpanEventCount++
+		pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount))
+
+		err = pubCtx.Err()
+		if err != nil {
+			s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+			errorSpans(err, pubSpan)
+			return result, err
+		}
+	}
+
+	s.metrics.AddPublishDuration(pubCtx, time.Since(pubStart))
+	// Advance the cursor to the final state if there was no error during
+	// publications. This is needed to transition to the next set of events.
+	if !hadPublicationError && !result.degraded {
+		s.goodCursor = s.cursor
+		s.metrics.AddProgramSuccessExecution(pubCtx)
+		okSpans(pubSpan)
+	}
+
+	return result, nil
 }
 
 func errorSpans(err error, spans ...trace.Span) {
 	for _, sp := range spans {
 		sp.RecordError(err)
 		sp.SetStatus(codes.Error, err.Error())
-		if e, ok := sp.(end); ok {
-			e.End()
-		}
 	}
 }
 
 func okSpans(spans ...trace.Span) {
 	for _, sp := range spans {
 		sp.SetStatus(codes.Ok, "")
-		if e, ok := sp.(end); ok {
-			e.End()
-		}
 	}
 }
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -414,21 +414,9 @@ func (s *runSession) runCycle(ctx context.Context) error {
 	}
 	for {
 		if wait := time.Until(waitUntil); wait > 0 {
-			waitCtx, waitSpan := s.tracer.Start(runCtx, "cel.periodic.run.ratelimitwait")
-			// We have a special-case wait for when we have a zero limit.
-			// x/time/rate allow a burst through even when the limit is zero
-			// so in order to ensure that we don't try until we are out of
-			// purgatory we calculate how long we should wait according to
-			// the retry after for a 429 and rate limit headers if we have
-			// a zero rate quota. See handleResponse below.
-			select {
-			case <-waitCtx.Done():
-				runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
-				waitSpan.End()
-				return waitCtx.Err()
-			case <-time.After(wait):
+			if err := waitForRateLimit(runCtx, runSpan, s.tracer, wait); err != nil {
+				return err
 			}
-			waitSpan.End()
 		} else if err := runCtx.Err(); err != nil {
 			// Otherwise exit if we have been cancelled.
 			runSpan.SetStatus(codes.Unset, runCtx.Err().Error())
@@ -817,6 +805,24 @@ func logWithTracingIds(log *logp.Logger, span trace.Span) *logp.Logger {
 		"trace.id", ctx.TraceID().String(),
 		"span.id", ctx.SpanID().String(),
 	)
+}
+
+func waitForRateLimit(ctx context.Context, runSpan trace.Span, tracer trace.Tracer, wait time.Duration) error {
+	waitCtx, waitSpan := tracer.Start(ctx, "cel.periodic.run.ratelimitwait")
+	defer waitSpan.End()
+	// We have a special-case wait for when we have a zero limit.
+	// x/time/rate allow a burst through even when the limit is zero
+	// so in order to ensure that we don't try until we are out of
+	// purgatory we calculate how long we should wait according to
+	// the retry after for a 429 and rate limit headers if we have
+	// a zero rate quota. See handleResponse below.
+	select {
+	case <-waitCtx.Done():
+		runSpan.SetStatus(codes.Unset, waitCtx.Err().Error())
+		return waitCtx.Err()
+	case <-time.After(wait):
+	}
+	return nil
 }
 
 // end is a tag type indicating spans in errorSpans and okSpans should be ended.

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -402,8 +402,6 @@ func (s *runSession) runCycle(ctx context.Context) error {
 		budget    = *s.cfg.MaxExecutions
 		waitUntil time.Time
 	)
-	// Keep track of whether CEL is degraded for this periodic run.
-	var isDegraded bool
 	if s.doCov {
 		defer func() {
 			// If doCov is true, log the updated coverage details.
@@ -424,378 +422,33 @@ func (s *runSession) runCycle(ctx context.Context) error {
 		}
 
 		runSpanExecutionCount++
-		execCtx, execSpan := s.tracer.Start(runCtx, "cel.program.execution")
-		execSpan.SetAttributes(
-			attribute.Int("cel.program.execution_number", runSpanExecutionCount),
-			attribute.Int("cel.program.event_count", 0), // to be overridden if there are events
-		)
-		execLog := logWithTracingIds(s.log, execSpan)
-
-		// Process a set of event requests.
-		if s.trace != nil {
-			execLog.Debugw("previous transaction", "transaction.id", s.trace.TxID())
-		}
-		execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: s.state, cfg: s.cfg.Redact})
-		s.metrics.AddProgramExecution(execCtx)
-		start := s.now().In(time.UTC)
-
-		var err error
-		s.state, err = evalWith(execCtx, s.injector, s.prg, s.ast, s.state, start, s.wantDump, budget-1)
-		s.metrics.AddCELDuration(execCtx, time.Since(start))
-		execLog.Debugw("response state", logp.Namespace("cel"), "state", redactor{state: s.state, cfg: s.cfg.Redact})
+		result, err := s.execute(runCtx, runSpanExecutionCount, budget)
+		runSpanEventCount += result.eventCount
+		waitUntil = result.waitUntil
 		if err != nil {
-			var dump dumpError
-			switch {
-			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-				s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
-				errorSpans(err, runSpan, end{execSpan})
-				return err
-			case errors.As(err, &dump):
-				path := strings.ReplaceAll(s.cfg.FailureDump.Filename, "*", sanitizeFileName(s.env.IDWithoutName))
-				dir := filepath.Dir(path)
-				base := filepath.Base(path)
-				ext := filepath.Ext(base)
-				prefix := strings.TrimSuffix(base, ext)
-				path = filepath.Join(dir, prefix+"-"+s.now().In(time.UTC).Format("2006-01-02T15-04-05.000")+ext)
-				execLog.Debugw("writing failure dump file", "path", path)
-				err := dump.writeToFile(path)
-				if err != nil {
-					execLog.Errorw("failed to write failure dump", "path", path, "error", err)
-				}
-			}
-			execLog.Errorw("failed evaluation", "error", err)
-			s.health.UpdateStatus(status.Degraded, "failed evaluation: "+err.Error())
+			errorSpans(err, runSpan)
+			return err
 		}
-		isDegraded = err != nil
-		if s.trace != nil {
-			execLog.Debugw("final transaction", "transaction.id", s.trace.TxID())
-		}
-
-		// On exit, state is expected to be in the shape:
-		//
-		// {
-		//     "cursor": [
-		//         {...},
-		//         ...
-		//     ],
-		//     "events": [
-		//         {...},
-		//         ...
-		//     ],
-		//     "url": <resource address>,
-		//     "status_code": <HTTP request status code if a network request>,
-		//     "header": <HTTP response headers if a network request>,
-		//     "rate_limit": <HTTP rate limit map if required by API>,
-		//     "want_more": bool
-		// }
-		//
-		// The "events" array must be present, but may be empty or null.
-		// In the case of an error condition in the CEL program it is
-		// acceptable to return a single object which will be wrapped as
-		// an array below. It is the responsibility of the downstream
-		// processor to handle this object correctly (which may be to drop
-		// the event). The error event will also be logged.
-		// If it is not empty, it must only have objects as elements.
-		// Additional fields may be present at the root of the object.
-		// The evaluation is repeated with the new state, after removing
-		// the events field, if the "want_more" field is present and true
-		// and a non-zero events array is returned.
-		//
-		// If cursor is present it must be either a single object or an
-		// array with the same length as events; each element i of the
-		// cursor array will be the details for obtaining the events at or
-		// beyond event i in events. If the cursor is a single object it
-		// is will be the details for obtaining events after the last
-		// event in the events array and will only be retained on
-		// successful publication of all the events in the array.
-		//
-		// If rate_limit is present it should be a map with numeric fields
-		// rate and burst. It may also have a string error field and
-		// other fields which will be logged. If it has an error field
-		// the rate and burst will not be used to set rate limit behaviour.
-		//
-		// The status code and rate_limit values may be omitted if they do
-		// not contribute to control.
-		//
-		// The following details how a cursor array works:
-		//
-		// Result after request resulting in 5 events. Each c obtained with
-		// an e points to the ~next e.
-		//
-		//    +----+   +----+        +----+
-		//    | e1 |   | c1 |        | e1 |
-		//    +----+   +----+        +----+   +----+
-		//    | e2 |   | c2 |        | e2 | < | c1 |
-		//    +----+   +----+        +----+   +----+
-		//    | e3 |   | c3 |        | e3 | < | c2 |
-		//    +----+   +----+   =>   +----+   +----+
-		//    | e4 |   | c4 |        | e4 | < | c3 |
-		//    +----+   +----+        +----+   +----+
-		//    | e5 |   | c5 |        | e5 | < | c4 |
-		//    +----+   +----+        +----+   +----+
-		//                           |next| < | c5 |
-		//                           +----+   +----+
-		//
-		// After a successful publication this will leave a single c and
-		// and empty events array. So the next evaluation has a boot.
-		//
-		// If the publication fails or execution is terminated at some
-		// point during the events array, we may end up with, e.g.
-		//
-		//    +----+  +----+        +----+   +----+
-		//    | e3 |  | c3 |        |next| < | c3 |
-		//    +----+  +----+        +----+   +----+
-		//    | e4 |  | c4 |   =>
-		//    +----+  +----+          lost events
-		//    | e5 |  | c5 |
-		//    +----+  +----+
-		//
-		// At this point, the c3 cursor (or at worst the c2 cursor) has
-		// been stored and we can continue from that point, recovering
-		// the lost events and potentially re-requesting e3.
-
-		var ok bool
-		ok, waitUntil, err = handleResponse(execLog, s.state, s.limiter)
-		if err != nil || !ok {
-			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
-			if err != nil {
-				errorSpans(err, end{execSpan}, runSpan)
-				return err
-			}
-			errorSpans(errors.New("invalid response"), end{execSpan})
+		if result.action.retry() {
 			continue
 		}
 
-		_, ok = s.state["url"]
-		if !ok && s.goodURL != "" {
-			s.state["url"] = s.goodURL
-			execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", s.goodURL)
-		}
-
-		e, ok := s.state["events"]
-		if !ok {
-			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
-			err := errors.New("unexpected missing events array from evaluation")
-			errorSpans(err, end{execSpan}, runSpan)
-			return err
-		}
-		var events []any
-		switch e := e.(type) {
-		case []any:
-			if len(e) == 0 {
-				s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
-				s.metrics.AddProgramSuccessExecution(execCtx)
-				okSpans(end{execSpan})
-				return nil
-			}
-			events = e
-		case map[string]any:
-			if e == nil {
-				s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
-				s.metrics.AddProgramSuccessExecution(execCtx)
-				okSpans(end{execSpan})
-				return nil
-			}
-			if _, ok := e["error"]; ok {
-				// If we have an error, log the complete object on the basis
-				// that it is ECS-conformant.
-				if execLog.Core().Enabled(zapcore.ErrorLevel) {
-					kv := make([]any, 0, 2*len(e))
-					for k := range maps.Keys(e) {
-						kv = append(kv, k, e[k])
-					}
-					execLog.Errorw("single event object returned by evaluation", kv...)
-				}
-			} else {
-				// Otherwise, be consistent with the existing documented
-				// behaviour and log the entire object as the error.
-				execLog.Errorw("single event object returned by evaluation", "error", e)
-			}
-			if err, ok := e["error"]; ok {
-				s.health.UpdateStatus(status.Degraded, fmt.Sprintf("single event error object returned by evaluation: %s", mapstr.M{"error": err}))
-			} else {
-				s.health.UpdateStatus(status.Degraded, "single event object returned by evaluation")
-			}
-			isDegraded = true
-			events = []any{e}
-			// Make sure the cursor is not updated.
-			delete(s.state, "cursor")
-		default:
-			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
-			errorSpans(err, end{execSpan}, runSpan)
-			return err
-		}
-
-		// We have a non-empty batch of events to process.
-		s.metrics.AddReceivedBatch(execCtx, 1)
-		s.metrics.AddReceivedEvents(execCtx, uint(len(events)))
-		runSpanEventCount += len(events)
-		execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
-		// Drop events from state. If we fail during the publication,
-		// we will re-request these events.
-		delete(s.state, "events")
-
-		// Get cursors if they exist.
-		var (
-			cursors      []any
-			singleCursor bool
-		)
-		if c, ok := s.state["cursor"]; ok {
-			cursors, ok = c.([]any)
-			if ok {
-				if len(cursors) != len(events) {
-					execLog.Errorw("unexpected cursor list length", "cursors", len(cursors), "events", len(events))
-					s.health.UpdateStatus(status.Degraded, "unexpected cursor list length")
-					isDegraded = true
-					// But try to continue.
-					if len(cursors) < len(events) {
-						cursors = nil
-					}
-				}
-			} else {
-				cursors = []any{c}
-				singleCursor = true
-			}
-		}
-		// Drop old cursor from state. This will be replaced with
-		// the current cursor object below; it is an array now.
-		delete(s.state, "cursor")
-
-		pubStart := time.Now()
-		var hadPublicationError bool
-
-		pubCtx, pubSpan := s.tracer.Start(execCtx, "cel.program.publish")
-		pubSpanEventCount := 0
-		pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
-		pubLog := logWithTracingIds(s.log, pubSpan)
-	loop:
-		for i, e := range events {
-			event, ok := e.(map[string]any)
-			if !ok {
-				err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
-				errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-				return err
-			}
-			var pubCursor any
-			if cursors != nil {
-				if singleCursor {
-					// Only set the cursor for publication at the last event
-					// when a single cursor object has been provided.
-					if i == len(events)-1 {
-						s.goodCursor = s.cursor
-						s.cursor, ok = cursors[0].(map[string]any)
-						if !ok {
-							err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
-							s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
-							errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-							return err
-						}
-						pubCursor = s.cursor
-					}
-				} else {
-					s.goodCursor = s.cursor
-					s.cursor, ok = cursors[i].(map[string]any)
-					if !ok {
-						err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
-						s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
-						errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-						return err
-					}
-					pubCursor = s.cursor
-				}
-			}
-			// This is checked prior to the publish attempt since the
-			// cursor.Publisher interface does not document the behaviour
-			// related to context cancellation and the context is not
-			// explicitly passed in, so favour this explicit clarity.
-			switch err := pubCtx.Err(); {
-			case err == nil:
-			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-				pubLog.Infow("context cancelled with unpublished events", "unpublished", len(events)-i)
-				// Don't update status, since we are about to pass
-				// through the Running state and then fall through
-				// to the input exit with a change to Stopped.
-				break loop
-			default:
-				// This should never happen.
-				pubLog.Warnw("failed with unpublished events", "error", err, "unpublished", len(events)-i)
-				s.health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
-				isDegraded = true
-				break loop
-			}
-			err = s.pub.Publish(beat.Event{
-				Timestamp: time.Now(),
-				Fields:    event,
-			}, pubCursor)
-			if err != nil {
-				hadPublicationError = true
-				pubLog.Errorw("error publishing event", "error", err)
-				s.health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
-				errorSpans(err, pubSpan)
-				isDegraded = true
-				cursors = nil // We are lost, so retry with this event's cursor,
-				continue      // but continue with the events that we have without
-				// advancing the cursor. This allows us to potentially publish the
-				// events we have now, with a fallback to the last guaranteed
-				// correctly published cursor.
-			}
-			if i == 0 {
-				s.metrics.AddPublishedBatch(pubCtx, 1)
-			}
-			s.metrics.AddPublishedEvents(pubCtx, 1)
-			pubSpanEventCount++
-			pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount))
-
-			err = pubCtx.Err()
-			if err != nil {
-				s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
-				errorSpans(err, end{pubSpan}, end{execSpan}, runSpan)
-				return err
-			}
-		}
-
-		if !isDegraded {
-			s.health.UpdateStatus(status.Running, "")
-		}
-
-		s.metrics.AddPublishDuration(pubCtx, time.Since(pubStart))
-		// Advance the cursor to the final state if there was no error during
-		// publications. This is needed to transition to the next set of events.
-		if !hadPublicationError && !isDegraded {
-			s.goodCursor = s.cursor
-			s.metrics.AddProgramSuccessExecution(pubCtx)
-			okSpans(pubSpan)
-		}
-		pubSpan.End()
-
-		// Replace the last known good cursor.
-		s.state["cursor"] = s.goodCursor
-		s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
-		if more, _ := s.state["want_more"].(bool); !more {
-			execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
-			okSpans(end{execSpan}, runSpan)
+		// Empty or nil events finish the execution without setting runSpan status.
+		if result.eventCount == 0 {
 			return nil
 		}
-		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", true))
 
-		// Check we have a remaining execution budget.
+		if more, _ := s.state["want_more"].(bool); !more {
+			okSpans(runSpan)
+			return nil
+		}
 		budget--
 		if budget <= 0 {
 			msg := "reached maximum number of CEL executions"
-			execLog.Warnw(msg+": will continue at next periodic evaluation",
-				"limit", *s.cfg.MaxExecutions,
-				"next_eval_time", start.Add(s.cfg.Interval),
-			)
-			s.health.UpdateStatus(status.Degraded, msg)
-			execSpan.SetStatus(codes.Unset, msg)
-			execSpan.End()
 			runSpan.SetAttributes(attribute.Bool("cel.periodic.max_execution_limited", true))
 			runSpan.SetStatus(codes.Unset, msg)
 			return nil
 		}
-
-		okSpans(end{execSpan})
 	}
 }
 
@@ -823,6 +476,398 @@ func waitForRateLimit(ctx context.Context, runSpan trace.Span, tracer trace.Trac
 	case <-time.After(wait):
 	}
 	return nil
+}
+
+type action bool
+
+const (
+	contAction     action = false
+	retry429Action action = true
+)
+
+func (a action) retry() bool { return a == retry429Action }
+
+type executeResult struct {
+	action     action
+	waitUntil  time.Time
+	eventCount int
+}
+
+func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (executeResult, error) {
+	result := executeResult{
+		action: contAction,
+	}
+
+	execCtx, execSpan := s.tracer.Start(ctx, "cel.program.execution")
+	defer execSpan.End()
+	execSpan.SetAttributes(
+		attribute.Int("cel.program.execution_number", executionNumber),
+		attribute.Int("cel.program.event_count", 0), // to be overridden if there are events
+	)
+	execLog := logWithTracingIds(s.log, execSpan)
+
+	// Process a set of event requests.
+	if s.trace != nil {
+		execLog.Debugw("previous transaction", "transaction.id", s.trace.TxID())
+	}
+	execLog.Debugw("request state", logp.Namespace("cel"), "state", redactor{state: s.state, cfg: s.cfg.Redact})
+	s.metrics.AddProgramExecution(execCtx)
+	start := s.now().In(time.UTC)
+
+	var err error
+	s.state, err = evalWith(execCtx, s.injector, s.prg, s.ast, s.state, start, s.wantDump, budget-1)
+	s.metrics.AddCELDuration(execCtx, time.Since(start))
+	execLog.Debugw("response state", logp.Namespace("cel"), "state", redactor{state: s.state, cfg: s.cfg.Redact})
+	isDegraded := err != nil
+	if err != nil {
+		var dump dumpError
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+			errorSpans(err, execSpan)
+			return result, err
+		case errors.As(err, &dump):
+			path := strings.ReplaceAll(s.cfg.FailureDump.Filename, "*", sanitizeFileName(s.env.IDWithoutName))
+			dir := filepath.Dir(path)
+			base := filepath.Base(path)
+			ext := filepath.Ext(base)
+			prefix := strings.TrimSuffix(base, ext)
+			path = filepath.Join(dir, prefix+"-"+s.now().In(time.UTC).Format("2006-01-02T15-04-05.000")+ext)
+			execLog.Debugw("writing failure dump file", "path", path)
+			err := dump.writeToFile(path)
+			if err != nil {
+				execLog.Errorw("failed to write failure dump", "path", path, "error", err)
+			}
+		}
+		execLog.Errorw("failed evaluation", "error", err)
+		s.health.UpdateStatus(status.Degraded, "failed evaluation: "+err.Error())
+	}
+	if s.trace != nil {
+		execLog.Debugw("final transaction", "transaction.id", s.trace.TxID())
+	}
+
+	// On exit, state is expected to be in the shape:
+	//
+	// {
+	//     "cursor": [
+	//         {...},
+	//         ...
+	//     ],
+	//     "events": [
+	//         {...},
+	//         ...
+	//     ],
+	//     "url": <resource address>,
+	//     "status_code": <HTTP request status code if a network request>,
+	//     "header": <HTTP response headers if a network request>,
+	//     "rate_limit": <HTTP rate limit map if required by API>,
+	//     "want_more": bool
+	// }
+	//
+	// The "events" array must be present, but may be empty or null.
+	// In the case of an error condition in the CEL program it is
+	// acceptable to return a single object which will be wrapped as
+	// an array below. It is the responsibility of the downstream
+	// processor to handle this object correctly (which may be to drop
+	// the event). The error event will also be logged.
+	// If it is not empty, it must only have objects as elements.
+	// Additional fields may be present at the root of the object.
+	// The evaluation is repeated with the new state, after removing
+	// the events field, if the "want_more" field is present and true
+	// and a non-zero events array is returned.
+	//
+	// If cursor is present it must be either a single object or an
+	// array with the same length as events; each element i of the
+	// cursor array will be the details for obtaining the events at or
+	// beyond event i in events. If the cursor is a single object it
+	// is will be the details for obtaining events after the last
+	// event in the events array and will only be retained on
+	// successful publication of all the events in the array.
+	//
+	// If rate_limit is present it should be a map with numeric fields
+	// rate and burst. It may also have a string error field and
+	// other fields which will be logged. If it has an error field
+	// the rate and burst will not be used to set rate limit behaviour.
+	//
+	// The status code and rate_limit values may be omitted if they do
+	// not contribute to control.
+	//
+	// The following details how a cursor array works:
+	//
+	// Result after request resulting in 5 events. Each c obtained with
+	// an e points to the ~next e.
+	//
+	//    +----+   +----+        +----+
+	//    | e1 |   | c1 |        | e1 |
+	//    +----+   +----+        +----+   +----+
+	//    | e2 |   | c2 |        | e2 | < | c1 |
+	//    +----+   +----+        +----+   +----+
+	//    | e3 |   | c3 |        | e3 | < | c2 |
+	//    +----+   +----+   =>   +----+   +----+
+	//    | e4 |   | c4 |        | e4 | < | c3 |
+	//    +----+   +----+        +----+   +----+
+	//    | e5 |   | c5 |        | e5 | < | c4 |
+	//    +----+   +----+        +----+   +----+
+	//                           |next| < | c5 |
+	//                           +----+   +----+
+	//
+	// After a successful publication this will leave a single c and
+	// and empty events array. So the next evaluation has a boot.
+	//
+	// If the publication fails or execution is terminated at some
+	// point during the events array, we may end up with, e.g.
+	//
+	//    +----+  +----+        +----+   +----+
+	//    | e3 |  | c3 |        |next| < | c3 |
+	//    +----+  +----+        +----+   +----+
+	//    | e4 |  | c4 |   =>
+	//    +----+  +----+          lost events
+	//    | e5 |  | c5 |
+	//    +----+  +----+
+	//
+	// At this point, the c3 cursor (or at worst the c2 cursor) has
+	// been stored and we can continue from that point, recovering
+	// the lost events and potentially re-requesting e3.
+
+	var ok bool
+	ok, result.waitUntil, err = handleResponse(execLog, s.state, s.limiter)
+	if err != nil || !ok {
+		s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+		if err != nil {
+			errorSpans(err, execSpan)
+			return result, err
+		}
+		result.action = retry429Action
+		errorSpans(errors.New("invalid response"), execSpan)
+		return result, nil
+	}
+
+	_, ok = s.state["url"]
+	if !ok && s.goodURL != "" {
+		s.state["url"] = s.goodURL
+		execLog.Debugw("adding missing url from last valid value: state did not contain a url", "last_valid_url", s.goodURL)
+	}
+
+	e, ok := s.state["events"]
+	if !ok {
+		s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+		err := errors.New("unexpected missing events array from evaluation")
+		errorSpans(err, execSpan)
+		return result, err
+	}
+	var events []any
+	switch e := e.(type) {
+	case []any:
+		if len(e) == 0 {
+			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+			s.metrics.AddProgramSuccessExecution(execCtx)
+			okSpans(execSpan)
+			return result, nil
+		}
+		events = e
+	case map[string]any:
+		if e == nil {
+			s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+			s.metrics.AddProgramSuccessExecution(execCtx)
+			okSpans(execSpan)
+			return result, nil
+		}
+		if _, ok := e["error"]; ok {
+			// If we have an error, log the complete object on the basis
+			// that it is ECS-conformant.
+			if execLog.Core().Enabled(zapcore.ErrorLevel) {
+				kv := make([]any, 0, 2*len(e))
+				for k := range maps.Keys(e) {
+					kv = append(kv, k, e[k])
+				}
+				execLog.Errorw("single event object returned by evaluation", kv...)
+			}
+		} else {
+			// Otherwise, be consistent with the existing documented
+			// behaviour and log the entire object as the error.
+			execLog.Errorw("single event object returned by evaluation", "error", e)
+		}
+		if err, ok := e["error"]; ok {
+			s.health.UpdateStatus(status.Degraded, fmt.Sprintf("single event error object returned by evaluation: %s", mapstr.M{"error": err}))
+		} else {
+			s.health.UpdateStatus(status.Degraded, "single event object returned by evaluation")
+		}
+		isDegraded = true
+		events = []any{e}
+		// Make sure the cursor is not updated.
+		delete(s.state, "cursor")
+	default:
+		err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+		s.metrics.AddProgramRunDuration(execCtx, time.Since(start))
+		errorSpans(err, execSpan)
+		return result, err
+	}
+
+	// We have a non-empty batch of events to process.
+	s.metrics.AddReceivedBatch(execCtx, 1)
+	s.metrics.AddReceivedEvents(execCtx, uint(len(events)))
+	result.eventCount = len(events)
+	execSpan.SetAttributes(attribute.Int("cel.program.event_count", len(events)))
+	// Drop events from state. If we fail during the publication,
+	// we will re-request these events.
+	delete(s.state, "events")
+
+	// Get cursors if they exist.
+	var (
+		cursors      []any
+		singleCursor bool
+	)
+	if c, ok := s.state["cursor"]; ok {
+		cursors, ok = c.([]any)
+		if ok {
+			if len(cursors) != len(events) {
+				execLog.Errorw("unexpected cursor list length", "cursors", len(cursors), "events", len(events))
+				s.health.UpdateStatus(status.Degraded, "unexpected cursor list length")
+				isDegraded = true
+				// But try to continue.
+				if len(cursors) < len(events) {
+					cursors = nil
+				}
+			}
+		} else {
+			cursors = []any{c}
+			singleCursor = true
+		}
+	}
+	// Drop old cursor from state. This will be replaced with
+	// the current cursor object below; it is an array now.
+	delete(s.state, "cursor")
+
+	pubStart := time.Now()
+	var hadPublicationError bool
+
+	pubCtx, pubSpan := s.tracer.Start(execCtx, "cel.program.publish")
+	pubSpanEventCount := 0
+	pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount)) // to be overridden if there are events
+	pubLog := logWithTracingIds(s.log, pubSpan)
+loop:
+	for i, e := range events {
+		event, ok := e.(map[string]any)
+		if !ok {
+			err := fmt.Errorf("unexpected type returned for evaluation events: %T", e)
+			errorSpans(err, end{pubSpan}, execSpan)
+			return result, err
+		}
+		var pubCursor any
+		if cursors != nil {
+			if singleCursor {
+				// Only set the cursor for publication at the last event
+				// when a single cursor object has been provided.
+				if i == len(events)-1 {
+					s.goodCursor = s.cursor
+					s.cursor, ok = cursors[0].(map[string]any)
+					if !ok {
+						err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
+						s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+						errorSpans(err, end{pubSpan}, execSpan)
+						return result, err
+					}
+					pubCursor = s.cursor
+				}
+			} else {
+				s.goodCursor = s.cursor
+				s.cursor, ok = cursors[i].(map[string]any)
+				if !ok {
+					err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
+					s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+					errorSpans(err, end{pubSpan}, execSpan)
+					return result, err
+				}
+				pubCursor = s.cursor
+			}
+		}
+		// This is checked prior to the publish attempt since the
+		// cursor.Publisher interface does not document the behaviour
+		// related to context cancellation and the context is not
+		// explicitly passed in, so favour this explicit clarity.
+		switch err := pubCtx.Err(); {
+		case err == nil:
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			pubLog.Infow("context cancelled with unpublished events", "unpublished", len(events)-i)
+			// Don't update status, since we are about to pass
+			// through the Running state and then fall through
+			// to the input exit with a change to Stopped.
+			break loop
+		default:
+			// This should never happen.
+			pubLog.Warnw("failed with unpublished events", "error", err, "unpublished", len(events)-i)
+			s.health.UpdateStatus(status.Degraded, "error publishing events: "+err.Error())
+			isDegraded = true
+			break loop
+		}
+		err = s.pub.Publish(beat.Event{
+			Timestamp: time.Now(),
+			Fields:    event,
+		}, pubCursor)
+		if err != nil {
+			hadPublicationError = true
+			pubLog.Errorw("error publishing event", "error", err)
+			s.health.UpdateStatus(status.Degraded, "error publishing event: "+err.Error())
+			errorSpans(err, pubSpan)
+			isDegraded = true
+			cursors = nil // We are lost, so retry with this event's cursor,
+			continue      // but continue with the events that we have without
+			// advancing the cursor. This allows us to potentially publish the
+			// events we have now, with a fallback to the last guaranteed
+			// correctly published cursor.
+		}
+		if i == 0 {
+			s.metrics.AddPublishedBatch(pubCtx, 1)
+		}
+		s.metrics.AddPublishedEvents(pubCtx, 1)
+		pubSpanEventCount++
+		pubSpan.SetAttributes(attribute.Int("cel.publish.event_count", pubSpanEventCount))
+
+		err = pubCtx.Err()
+		if err != nil {
+			s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+			errorSpans(err, end{pubSpan}, execSpan)
+			return result, err
+		}
+	}
+
+	if !isDegraded {
+		s.health.UpdateStatus(status.Running, "")
+	}
+
+	s.metrics.AddPublishDuration(pubCtx, time.Since(pubStart))
+	// Advance the cursor to the final state if there was no error during
+	// publications. This is needed to transition to the next set of events.
+	if !hadPublicationError && !isDegraded {
+		s.goodCursor = s.cursor
+		s.metrics.AddProgramSuccessExecution(pubCtx)
+		okSpans(pubSpan)
+	}
+	pubSpan.End()
+
+	// Replace the last known good cursor.
+	s.state["cursor"] = s.goodCursor
+	s.metrics.AddProgramRunDuration(pubCtx, time.Since(start))
+	if more, _ := s.state["want_more"].(bool); !more {
+		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
+		okSpans(execSpan)
+		return result, nil
+	}
+	execSpan.SetAttributes(attribute.Bool("cel.program.want_more", true))
+
+	if budget <= 1 {
+		msg := "reached maximum number of CEL executions"
+		execLog.Warnw(msg+": will continue at next periodic evaluation",
+			"limit", *s.cfg.MaxExecutions,
+			"next_eval_time", start.Add(s.cfg.Interval),
+		)
+		s.health.UpdateStatus(status.Degraded, msg)
+		execSpan.SetStatus(codes.Unset, msg)
+		return result, nil
+	}
+
+	okSpans(execSpan)
+	return result, nil
 }
 
 // end is a tag type indicating spans in errorSpans and okSpans should be ended.

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -452,6 +452,94 @@ func (s *runSession) runCycle(ctx context.Context) error {
 	}
 }
 
+// execute runs one CEL evaluation and publishes any returned events.
+//
+// When it has the new state from the CEL evaluation, execute consumes
+// response-control fields, validates events and cursors, publishes events, and
+// leaves s.state ready for the next evaluation.
+//
+// The evaluated CEL state is expected to have this shape:
+//
+//	{
+//	    "cursor": [
+//	        {...},
+//	        ...
+//	    ],
+//	    "events": [
+//	        {...},
+//	        ...
+//	    ],
+//	    "url": <resource address>,
+//	    "status_code": <HTTP request status code if a network request>,
+//	    "header": <HTTP response headers if a network request>,
+//	    "rate_limit": <HTTP rate limit map if required by API>,
+//	    "want_more": bool
+//	}
+//
+// The "events" array must be present, but may be empty or null.
+// In the case of an error condition in the CEL program it is
+// acceptable to return a single object which will be wrapped as
+// an array below. It is the responsibility of the downstream
+// processor to handle this object correctly (which may be to drop
+// the event). The error event will also be logged.
+// If it is not empty, it must only have objects as elements.
+// Additional fields may be present at the root of the object.
+// The evaluation is repeated with the new state, after removing
+// the events field, if the "want_more" field is present and true
+// and a non-zero events array is returned.
+//
+// If cursor is present it must be either a single object or an
+// array with the same length as events; each element i of the
+// cursor array will be the details for obtaining the events at or
+// beyond event i in events. If the cursor is a single object it
+// will be the details for obtaining events after the last
+// event in the events array and will only be retained on
+// successful publication of all the events in the array.
+//
+// If rate_limit is present it should be a map with numeric fields
+// rate and burst. It may also have a string error field and
+// other fields which will be logged. If it has an error field
+// the rate and burst will not be used to set rate limit behaviour.
+//
+// The status code and rate_limit values may be omitted if they do
+// not contribute to control.
+//
+// Cursor arrays work as follows:
+//
+// Result after request resulting in 5 events. Each c obtained with
+// an e points to the ~next e.
+//
+//	+----+   +----+        +----+
+//	| e1 |   | c1 |        | e1 |
+//	+----+   +----+        +----+   +----+
+//	| e2 |   | c2 |        | e2 | < | c1 |
+//	+----+   +----+        +----+   +----+
+//	| e3 |   | c3 |        | e3 | < | c2 |
+//	+----+   +----+   =>   +----+   +----+
+//	| e4 |   | c4 |        | e4 | < | c3 |
+//	+----+   +----+        +----+   +----+
+//	| e5 |   | c5 |        | e5 | < | c4 |
+//	+----+   +----+        +----+   +----+
+//	                       |next| < | c5 |
+//	                       +----+   +----+
+//
+// After a successful publication this will leave a single c and
+// an empty events array. So the next evaluation has a boot.
+//
+// If the publication fails or execution is terminated at some
+// point during the events array, we may end up with, e.g.
+//
+//	+----+  +----+        +----+   +----+
+//	| e3 |  | c3 |        |next| < | c3 |
+//	+----+  +----+        +----+   +----+
+//	| e4 |  | c4 |   =>
+//	+----+  +----+          lost events
+//	| e5 |  | c5 |
+//	+----+  +----+
+//
+// At this point, the c3 cursor (or at worst the c2 cursor) has
+// been stored and we can continue from that point, recovering
+// the lost events and potentially re-requesting e3.
 func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (executeResult, error) {
 	result := executeResult{
 		action: contAction,
@@ -504,89 +592,6 @@ func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (
 	if s.trace != nil {
 		execLog.Debugw("final transaction", "transaction.id", s.trace.TxID())
 	}
-
-	// On exit, state is expected to be in the shape:
-	//
-	// {
-	//     "cursor": [
-	//         {...},
-	//         ...
-	//     ],
-	//     "events": [
-	//         {...},
-	//         ...
-	//     ],
-	//     "url": <resource address>,
-	//     "status_code": <HTTP request status code if a network request>,
-	//     "header": <HTTP response headers if a network request>,
-	//     "rate_limit": <HTTP rate limit map if required by API>,
-	//     "want_more": bool
-	// }
-	//
-	// The "events" array must be present, but may be empty or null.
-	// In the case of an error condition in the CEL program it is
-	// acceptable to return a single object which will be wrapped as
-	// an array below. It is the responsibility of the downstream
-	// processor to handle this object correctly (which may be to drop
-	// the event). The error event will also be logged.
-	// If it is not empty, it must only have objects as elements.
-	// Additional fields may be present at the root of the object.
-	// The evaluation is repeated with the new state, after removing
-	// the events field, if the "want_more" field is present and true
-	// and a non-zero events array is returned.
-	//
-	// If cursor is present it must be either a single object or an
-	// array with the same length as events; each element i of the
-	// cursor array will be the details for obtaining the events at or
-	// beyond event i in events. If the cursor is a single object it
-	// is will be the details for obtaining events after the last
-	// event in the events array and will only be retained on
-	// successful publication of all the events in the array.
-	//
-	// If rate_limit is present it should be a map with numeric fields
-	// rate and burst. It may also have a string error field and
-	// other fields which will be logged. If it has an error field
-	// the rate and burst will not be used to set rate limit behaviour.
-	//
-	// The status code and rate_limit values may be omitted if they do
-	// not contribute to control.
-	//
-	// The following details how a cursor array works:
-	//
-	// Result after request resulting in 5 events. Each c obtained with
-	// an e points to the ~next e.
-	//
-	//    +----+   +----+        +----+
-	//    | e1 |   | c1 |        | e1 |
-	//    +----+   +----+        +----+   +----+
-	//    | e2 |   | c2 |        | e2 | < | c1 |
-	//    +----+   +----+        +----+   +----+
-	//    | e3 |   | c3 |        | e3 | < | c2 |
-	//    +----+   +----+   =>   +----+   +----+
-	//    | e4 |   | c4 |        | e4 | < | c3 |
-	//    +----+   +----+        +----+   +----+
-	//    | e5 |   | c5 |        | e5 | < | c4 |
-	//    +----+   +----+        +----+   +----+
-	//                           |next| < | c5 |
-	//                           +----+   +----+
-	//
-	// After a successful publication this will leave a single c and
-	// and empty events array. So the next evaluation has a boot.
-	//
-	// If the publication fails or execution is terminated at some
-	// point during the events array, we may end up with, e.g.
-	//
-	//    +----+  +----+        +----+   +----+
-	//    | e3 |  | c3 |        |next| < | c3 |
-	//    +----+  +----+        +----+   +----+
-	//    | e4 |  | c4 |   =>
-	//    +----+  +----+          lost events
-	//    | e5 |  | c5 |
-	//    +----+  +----+
-	//
-	// At this point, the c3 cursor (or at worst the c2 cursor) has
-	// been stored and we can continue from that point, recovering
-	// the lost events and potentially re-requesting e3.
 
 	result.waitUntil, result.action, err = handleResponse(s.state, s.limiter, execLog)
 	if err != nil || result.action.retry() {

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -274,7 +274,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]any, pub input
 	if cursor != nil {
 		state["cursor"] = cursor
 	}
-	safeCursor := cursor
+	goodCursor := cursor
 	goodURL := cfg.Resource.URL.String()
 	state["url"] = goodURL
 	metricsRecorder.SetResourceURL(goodURL)
@@ -336,7 +336,7 @@ func (i input) run(env v2.Context, src *source, cursor map[string]any, pub input
 
 		state:      state,
 		cursor:     cursor,
-		safeCursor: safeCursor,
+		goodCursor: goodCursor,
 		goodURL:    goodURL,
 	}
 
@@ -374,7 +374,7 @@ type runSession struct {
 
 	state      map[string]any
 	cursor     map[string]any
-	safeCursor map[string]any
+	goodCursor map[string]any
 	goodURL    string
 }
 
@@ -710,8 +710,8 @@ func (s *runSession) execute(ctx context.Context, executionNumber, budget int) (
 		s.health.UpdateStatus(status.Running, "")
 	}
 
-	// Replace the last cursor known to be safe to persist.
-	s.state["cursor"] = s.safeCursor
+	// Replace the last known good cursor.
+	s.state["cursor"] = s.goodCursor
 	s.metrics.AddProgramRunDuration(pubResult.pubCtx, time.Since(start))
 	if more, _ := s.state["want_more"].(bool); !more {
 		execSpan.SetAttributes(attribute.Bool("cel.program.want_more", false))
@@ -764,7 +764,7 @@ loop:
 				// Only set the cursor for publication at the last event
 				// when a single cursor object has been provided.
 				if i == len(events)-1 {
-					s.safeCursor = s.cursor
+					s.goodCursor = s.cursor
 					s.cursor, ok = cursors[0].(map[string]any)
 					if !ok {
 						err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[0])
@@ -775,7 +775,7 @@ loop:
 					pubCursor = s.cursor
 				}
 			} else {
-				s.safeCursor = s.cursor
+				s.goodCursor = s.cursor
 				s.cursor, ok = cursors[i].(map[string]any)
 				if !ok {
 					err := fmt.Errorf("unexpected type returned for evaluation cursor element: %T", cursors[i])
@@ -840,7 +840,7 @@ loop:
 	// Advance the cursor to the final state if there was no error during
 	// publications. This is needed to transition to the next set of events.
 	if !hadPublicationError && !result.degraded {
-		s.safeCursor = s.cursor
+		s.goodCursor = s.cursor
 		s.metrics.AddProgramSuccessExecution(pubCtx)
 		okSpans(pubSpan)
 	}


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/input/cel: refactor periodic execution into phases

Refactor the CEL input run path by introducing `runSession` and
separating periodic orchestration, rate-limit waiting, CEL evaluation,
response handling, and event publication into smaller functions.

The intended behavior is unchanged: cursor persistence, 429 retry
handling, rate-limit waits, health transitions, publish error recovery,
metrics, and span status handling are preserved. The branch also cleans
up the extracted code by using any for touched dynamic state, replacing
the response-handling boolean with an explicit action, and moving the
evaluated-state contract onto execute.
```

## Discussion

Best reviewed commit by commit.

Here are some metrics covering the whole history of `input.go`:

<img width="1800" height="1250" alt="metrics" src="https://github.com/user-attachments/assets/7e792b08-5960-4e66-90d5-8305824b4b68" />

<details>
<summary>Expand for the plan used for this work</summary>

---
# CEL input refactoring plan

Target file: `x-pack/filebeat/input/cel/input.go`

## Goal

Refactor `(*input).run` by introducing a `runSession` type and extracting the periodic callback into a small set of phase-level methods. The refactor should preserve current behavior first, then leave any behavior fixes as explicit follow-up commits.

The main problem in `run` is not just length. The periodic callback mixes four lifetimes:

- Input lifetime: compiled CEL program, HTTP client, tracer, publisher, metrics recorder.
- Periodic run lifetime: `runSpan`, execution count, event count, wait state, degraded state.
- Execution lifetime: `execSpan`, evaluation start time, response handling, event normalization.
- Publish lifetime: `pubSpan`, publication errors, cursor advancement.

The extraction should make those lifetimes visible without spreading state through a long parameter list.

## Current State

`run` does setup first, then passes a large closure to `periodically`. The closure owns:

- Rate-limit wait handling.
- The execution budget loop.
- CEL evaluation.
- Response handling.
- Event normalization.
- Cursor preparation and advancement.
- Publication.
- Span status and span ending.
- Metrics timing and counters.
- Health status transitions.
- `want_more` and budget checks.

The refactor should keep setup in `run` and move only the periodic-run machinery into the session methods.

## Proposed Shape

```mermaid
graph TD
    run["run: setup"]
    session["runSession"]
    cycle["s.runCycle: one periodic run"]
    execute["s.execute: one CEL execution"]
    publish["s.publish: publish one non-empty event batch"]
    wait["waitForRateLimit"]

    run -->|"constructs"| session
    run -->|"periodically(..., s.runCycle)"| cycle
    cycle -->|"rate-limit wait"| wait
    cycle -->|"loop"| execute
    execute -->|"non-empty events"| publish
```

`runSession` holds input-lifetime and mutable input state. Per-run state stays local to `runCycle`, not hidden in long-lived session fields.

## Session State

```go
type runSession struct {
    cfg config

    prg      cel.Program
    ast      *cel.Ast
    cov      *lib.Coverage
    wantDump bool
    doCov    bool

    limiter *rate.Limiter
    trace   *httplog.LoggingRoundTripper

    env v2.Context
    now func() time.Time

    pub inputcursor.Publisher

    log      *logp.Logger
    health   status.StatusReporter
    metrics  *metricsRecorder
    tracer   trace.Tracer
    injector *otel.ContextInjector

    state      map[string]any
    cursor     map[string]any
    safeCursor map[string]any
    goodURL    string
}
```

Use `any` in new or touched code. Do not do a file-wide conversion unless the whole surrounding block is already being edited.

`safeCursor` is the renamed `goodCursor`: the last cursor known to be safe to persist after successful publication.

## Per-Run State

Keep these as locals in `runCycle`:

```go
executionCount := 0
eventCount := 0
budget := *s.cfg.MaxExecutions
waitUntil := time.Time{}
degraded := false
```

These values belong to one periodic run. Keeping them local prevents later executions from accidentally inheriting degraded state, event counts, or rate-limit waits from an earlier run.

## Result Types

Use small result structs where a method needs to report more than success or failure. This avoids both parameter explosion and hidden mutation.

```go
type action bool

const (
    contAction     action = false
    retry429Action action = true
)

func (a action) cont() bool  { return a == contAction }
func (a action) retry() bool { return a == retry429Action }

type executeResult struct {
    action     action
    waitUntil  time.Time
    eventCount int
    degraded   bool
}

type publishResult struct {
    hadPublicationError bool
    degraded            bool
}
```

The `action` still answers only one question: was this a 429 retry path? The `executeResult` carries the additional state that `runCycle` needs for accurate run-span attributes and loop decisions.

## Method Signatures

```go
func newRunSession(...) *runSession
func (s *runSession) runCycle(ctx context.Context) error
func (s *runSession) execute(ctx context.Context, executionNumber, budget int, degraded bool) (executeResult, error)
func (s *runSession) publish(ctx context.Context, events []any, start time.Time, degraded bool) (publishResult, error)
func waitForRateLimit(ctx context.Context, runSpan trace.Span, tracer trace.Tracer, wait time.Duration) error
```

The exact constructor parameters can follow what `run` already has in scope. Prefer a constructor only if it keeps `run` readable; otherwise a struct literal is fine.

`execute` takes `executionNumber` because 429 responses increment the execution count but do not consume budget. Do not derive the execution number from budget.

`execute` takes `degraded` and returns the updated value because single-event errors, cursor length mismatches, evaluation errors, and publication errors all affect later health, success metrics, and cursor finalization in the same periodic run.

`publish` takes the current degraded state and returns the updated degraded state plus whether publication had a recoverable error. Fatal errors still return `error`.

## Ownership Rules

`runCycle` owns:

- `runSpan` start, attributes, status, and end.
- Periodic metrics start and end.
- Rate-limit waiting.
- Execution count and event count.
- Budget decrement and max-execution handling.
- `want_more` and loop continuation decisions.
- Coverage logging for one periodic run.

`execute` owns:

- `execSpan` start, attributes, status, and end.
- One `evalWith` call.
- Non-fatal evaluation error fall-through into `handleResponse`.
- Response handling.
- URL repair from `goodURL`.
- Events normalization.
- Cursor preparation.
- Calling `publish` for non-empty event batches.
- Final `state["cursor"] = s.safeCursor`.
- `cel.program.want_more` span attribute.
- Program-run duration metrics, preserving the original `execCtx` vs `pubCtx` attribution.

`publish` owns:

- `pubSpan` start, attributes, status, and end.
- Per-event type checks.
- Cursor advancement during publication.
- Publication error recovery.
- Published batch and event metrics.
- Publish duration metrics.

Each method should set status only on the span it owns. Fatal errors propagate upward so callers can set their own parent span status.

## Behavior Preservation Rules

Preserve these details exactly during the refactor:

- A non-fatal `evalWith` error logs, degrades health, and then falls through to `handleResponse`.
- `handleResponse` returning 429 records run duration with `execCtx`, marks only the execution span as error, and continues the loop without decrementing budget.
- Missing `events` is fatal.
- Empty `[]any{}` and nil `map[string]any` currently end the periodic run successfully.
- Single event objects are wrapped and treated as degraded.
- Cursor-array length mismatches degrade health but try to continue.
- Publication errors are recoverable: keep publishing, mark degraded, avoid advancing to an unsafe cursor.
- Context cancellation before or during publish keeps the existing status behavior.
- `AddProgramRunDuration` must keep the same context attribution as today: pre-publish exits use `execCtx`, publish-phase exits use `pubCtx`.
- Span names, parentage, status, and attributes must remain the same.

Do not clear `want_more` on empty or nil events in the pure refactor. The current code returns successfully before checking `want_more` in those paths. Clearing it may be the correct contract, but it is a behavior change and should be a separate commit with tests.

## `handleResponse`

After the extraction is stable, change `handleResponse` from:

```go
func handleResponse(log *logp.Logger, state map[string]interface{}, limiter *rate.Limiter) (ok bool, waitUntil time.Time, err error)
```

to:

```go
func handleResponse(state map[string]any, limiter *rate.Limiter, log *logp.Logger) (time.Time, action, error)
```

Use `retry429Action` for HTTP 429 and `contAction` otherwise. Keep it as a plain function. It only needs the supplied state map, limiter, and logger.

## Commit Sequence

### Commit 1: Introduce `runSession` and `runCycle`

- Add `runSession`.
- Move the whole periodic callback body into `s.runCycle`.
- Keep the inner execution loop inline.
- Keep existing `end`, `errorSpans`, and `okSpans` behavior unchanged.
- Keep `runSpanExecutionCount`, `runSpanEventCount`, `budget`, `waitUntil`, and `isDegraded` as locals in `runCycle`.
- `run` should become setup, session construction, `periodically(ctx, cfg.Interval, s.runCycle)`, and cancellation handling.

This commit should be mostly mechanical. Captured variables become fields or local variables with the same behavior.

### Commit 2: Extract rate-limit wait

- Extract the rate-limit wait block into `waitForRateLimit`.
- Preserve the current cancellation behavior: return `waitCtx.Err()` and set the run span status to `codes.Unset`.
- Keep `waitForRateLimit` as a standalone function.

This is a small commit to reduce the size of `runCycle` before extracting execution.

### Commit 3: Extract `s.execute`

- Move one CEL execution from `execCtx, execSpan := ...` through the post-publish cursor finalization into `s.execute`.
- Use `executeResult` rather than returning only `(action, time.Time, error)`.
- `runCycle` increments `executionCount`, calls `execute`, adds `result.eventCount`, updates `degraded`, handles 429 retry, checks `want_more`, then decrements budget.
- `execute` owns `execSpan.End()` via `defer`.
- Replace `end{execSpan}` in this method with direct status handling plus deferred ending.
- Preserve `AddProgramRunDuration` context choices exactly.

Do not remove the `end` type yet unless no remaining caller uses it.

### Commit 4: Extract `s.publish`

- Move the publish loop into `s.publish`.
- Use `publishResult` to report recoverable publication errors and updated degraded state.
- `publish` owns `pubSpan.End()` via `defer`.
- Keep cursor advancement logic line-for-line equivalent before simplifying names.
- Keep final `state["cursor"] = s.safeCursor` in `execute`, after `publish` returns.
- Keep success metrics and OK span status conditional on no publication error and no degraded state.

After this commit, remove `end` only if all callers have moved to direct span ownership.

### Commit 5: Update `handleResponse`

- Change `handleResponse` to return `(time.Time, action, error)`.
- Reorder parameters to `(state, limiter, log)`.
- Replace the old `ok` checks with `act.retry()` or `act.cont()`.
- Use `retry429Action` only for HTTP 429.

This should be mechanical after `execute` exists.

### Commit 6: Naming, layout, and comment cleanup

- Rename `goodCursor` to `safeCursor`.
- Keep caller-before-callee order: `run`, `runSession`, `runCycle`, `execute`, `publish`, then helper types/functions used by those methods.
- Move the state-shape comments next to the code they describe.
- Keep the cursor-array diagram with cursor preparation or publish, whichever owns the relevant logic after extraction.
- Convert touched `interface{}` uses to `any`.
- Run `goimports` or `gofmt` on changed Go files.

No behavior change in this commit.

### Optional Commit 7: Align empty events with the documented `want_more` contract

Only do this if the intended behavior is confirmed.

- When `events` is empty or nil, clear `want_more` before returning success.
- Add or update tests showing that a CEL program cannot force another execution by returning `want_more: true` with no events.
- Keep this separate from the refactor so reviewers can evaluate it as a behavior change.

## Verification

Run from the repository root:

```bash
rtk go build ./x-pack/filebeat/input/cel/...
rtk go vet ./x-pack/filebeat/input/cel/...
rtk go test -v -race -count=1 ./x-pack/filebeat/input/cel/...
```

Important existing tests:

- `TestInput` table cases for cursor and event behavior.
- `TestTraceSpans_SingleExecution`.
- `TestTraceSpans_WantMore`.
- `TestTraceSpans_EvalError`.
- CEL metrics tests.
- Redactor tests.

The span tests verify existence, parentage, status, and key attributes. They do not prove exact span end ordering, so inspect span ownership paths manually when changing `defer` behavior.

## Review Checklist

- 429 retry increments execution count but does not decrement budget.
- `remaining_executions` passed to CEL still matches the old behavior.
- `want_more` is checked only after successful non-empty event processing, unless doing the optional behavior-change commit.
- `runSpan` event count only includes accepted non-empty event batches.
- `isDegraded` is reset for each periodic run, not for each execution.
- Publication errors set the publish span to error but do not immediately abort the batch.
- Cursor fallback still uses the last safe cursor after partial publication failure.
- `state["events"]` is deleted before publication so failed publication re-requests events.
- `state["cursor"]` is restored to `safeCursor` after publication.
- Health returns to `Running` only when the periodic run is not degraded.
- String literals and comments are not damaged by mechanical renames.

---

</details>

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. This is a refactoring PR that doesn't change behavior.

## Related issues

- Supersedes #50126
- Closes #48464