### PR TITLE
fix: correct typos in Metricbeat and Packetbeat runtime messages

### DIFF
--- a/metricbeat/module/windows/wmi/wmi.go
+++ b/metricbeat/module/windows/wmi/wmi.go
@@ -222,7 +222,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 				for _, propertyName := range properties {
 					propertyValue, err := instance.GetProperty(propertyName)
 					if err != nil {
-						m.Logger().Error("Unable to get propery by name: %v", err)
+						m.Logger().Error("Unable to get property by name: %v", err)
 						continue
 					}
 

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -226,7 +226,7 @@ func validateProtocolDevice(device string, config *conf.C) (bool, error) {
 
 func (s ProtocolsStruct) register(proto Protocol, client beat.Client, plugin Plugin) {
 	if _, exists := s.all[proto]; exists {
-		logp.Warn("Protocol (%s) plugin will overwritten by another plugin", proto.String())
+		logp.Warn("Protocol (%s) plugin will be overwritten by another plugin", proto.String())
 	}
 
 	s.all[proto] = protocolInstance{


### PR DESCRIPTION
## Summary

Fixes #50663

Two user-facing text issues found by the text-auditor workflow:

### Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `metricbeat/module/windows/wmi/wmi.go` | 225 | `Unable to get propery by name` | `Unable to get property by name` |
| `packetbeat/protos/protos.go` | 229 | `will overwritten` | `will be overwritten` |

### Details

1. **wmi.go**: Misspelling of "property" as "propery" in a WMI error log message
2. **protos.go**: Missing "be" verb in a plugin overwrite warning message

Both fixes are in user-facing runtime log/error messages.

---
*Generated with Auto Bounty Hunter.*