### PR TITLE
Fix flakiness on TestQueueDoesNotReplayLastEventAfterRestart

### DIFF
--- a/libbeat/publisher/queue/diskqueue/queue_test.go
+++ b/libbeat/publisher/queue/diskqueue/queue_test.go
@@ -126,7 +126,6 @@ func TestQueueDoesNotReplayLastEventAfterRestart(t *testing.T) {
 	run2Producer := run2Queue.Producer(queue.ProducerConfig{})
 	publishAndACKSingleEvent(t, run2Queue, run2Producer, "event-3")
 	run2Producer.Close()
-	requireSegmentFiles(t, diskQueuePath, 2)
 	closeQueueAndWait(t, run2Queue)
 
 	// Run 3: reopen queue without publishing a new event. Correct behavior is
@@ -138,7 +137,7 @@ func TestQueueDoesNotReplayLastEventAfterRestart(t *testing.T) {
 	replayedBatch := readBatch(t, run3Queue, 3*time.Second)
 	if replayedBatch != nil {
 		count := replayedBatch.Count()
-		var msg interface{}
+		var msg any
 		if count > 0 {
 			msg, _ = replayedBatch.Entry(0).Content.Fields.GetValue("message")
 		}
@@ -210,16 +209,4 @@ func makeDiskQueueTestEvent(msg string) publisher.Event {
 		"message": msg,
 		"payload": strings.Repeat("x", 2048),
 	})
-}
-
-func requireSegmentFiles(t *testing.T, dir string, expected int) {
-	segFiles, err := filepath.Glob(filepath.Join(dir, "*.seg"))
-	if err != nil {
-		t.Fatalf("cannot resolve segment files glob: %s", err)
-	}
-
-	gotSegments := len(segFiles)
-	if expected != gotSegments {
-		t.Fatalf("expecting %d segment files, got %d. Segment files:\n%s", expected, gotSegments, strings.Join(segFiles, "\n"))
-	}
 }


### PR DESCRIPTION
## Proposed commit message

```
TestQueueDoesNotReplayLastEventAfterRestart was flaky because there was a race condition between the 'requireSementFiles' assertion and the delete loop that removed the segments on disk. If the delete loop run and finished removing the file before 'requireSementFiles' listed the files, the test would fail.

Having all old segments on disk is not required for the test to work, so removing this assertion is the best fix.

An use of 'interface{}' is replaced by 'any'
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~


## How to test this PR locally

Run the tests multiple times:
```
go test -v -count=10 -run=TestQueueDoesNotReplayLastEventAfterRestart ./libbeat/publisher/queue/diskqueue
```

Btw, I never managed to reproduce the flakiness locally. However I it can be 'simulated' by adding a `time.Sleep` of 0.5s right before the removed assertion.

## Related issues

- Closes https://github.com/elastic/beats/issues/50613


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~