### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/okta: add minimal-state provider

### DIFF
--- a/changelog/fragments/1778707911-entityanalytics-okta-minimal-state.yaml
+++ b/changelog/fragments/1778707911-entityanalytics-okta-minimal-state.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add minimal-state Okta entity analytics provider with bulk-fetch group enrichment.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.4.1
 	github.com/cilium/ebpf v0.21.0
 	github.com/coder/websocket v1.8.14
-	github.com/elastic/entcollect v0.0.0-20260511104345-004e6a6b71bf
+	github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d
 	github.com/elastic/gokrb5/v8 v8.0.0-20251105095404-23cc45e6a102
 	github.com/jimlambrt/gldap v0.1.14
 	github.com/mattn/go-sqlite3 v1.14.32
@@ -367,7 +367,7 @@ require (
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20251226215517-609e4778396f // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/elastic/elastic-agent-system-metrics v0.14.3 h1:v867kcgCVguOX3AYIHEVn
 github.com/elastic/elastic-agent-system-metrics v0.14.3/go.mod h1:JNfnZrC0viAjlJRUzQKKuMpDlXgjXBn4WdWEXQF7jcA=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
 github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/entcollect v0.0.0-20260511104345-004e6a6b71bf h1:Uf4Nxu6BJmN1uRe+TrJ3bz0sEFDGG2vR9wN+w36dK2s=
-github.com/elastic/entcollect v0.0.0-20260511104345-004e6a6b71bf/go.mod h1:mnRddx/BGDMLz3tdg5jAG9NgRAIBBHTUfwMHWV9XeVc=
+github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d h1:eKAtaQ8G4w9j3LctyOaSoYXnxfSGAcnix8y81esjtJs=
+github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d/go.mod h1:geO9V37Ibo+caL/8JpeqUE5ZJd8jzHjvOcEvAGEaZgI=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQVCpGSRXmLqjEHpJKbR60rxh1nQZY4=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/fsnotify v1.6.1-0.20240920222514-49f82bdbc9e3 h1:UyNbxdkQiSfyipwsOCWAlO+ju3xXC61Z4prx/HBTtFk=

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/equivalence_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/equivalence_test.go
@@ -1,0 +1,333 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//nolint:errcheck // test file; error returns from w.Write are intentionally unchecked
+package okta
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	legacyokta "github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider/okta/internal/okta"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/entcollect"
+	ecokta "github.com/elastic/entcollect/provider/okta"
+)
+
+// TestEquivalence_UserTypes verifies that the entcollect Okta User type
+// and the legacy internal/okta User type produce identical JSON when
+// given the same API response. This ensures the minimal-state provider
+// emits the same user payloads as the legacy provider.
+//
+// Intentional differences between legacy and minimal-state (not tested
+// here, documented for reference):
+//   - Legacy emits start/end marker events; minimal-state does not.
+//   - Legacy never emits deletion events (State.Deleted is never set);
+//     minimal-state uses idset deletion detection.
+//   - event.kind: asset is set only by the minimal-state consumer.
+//   - Supervises on incremental sync is computed from the current batch
+//     only (minimal-state), vs globally from all stored users (legacy).
+func TestEquivalence_UserTypes(t *testing.T) {
+	fixture := equivUserFixtureJSON()
+
+	// Parse through legacy types.
+	var legacyUsers []legacyokta.User
+	if err := json.Unmarshal(fixture, &legacyUsers); err != nil {
+		t.Fatalf("unmarshal legacy users: %v", err)
+	}
+
+	// Parse through entcollect types.
+	var ecUsers []ecokta.User
+	if err := json.Unmarshal(fixture, &ecUsers); err != nil {
+		t.Fatalf("unmarshal entcollect users: %v", err)
+	}
+
+	if len(legacyUsers) != len(ecUsers) {
+		t.Fatalf("user count: legacy=%d, entcollect=%d", len(legacyUsers), len(ecUsers))
+	}
+
+	for i := range legacyUsers {
+		legacyJSON, _ := json.Marshal(legacyUsers[i])
+		ecJSON, _ := json.Marshal(ecUsers[i])
+		if string(legacyJSON) != string(ecJSON) {
+			t.Errorf("user[%d] %q payload mismatch:\n  legacy:     %s\n  entcollect: %s",
+				i, legacyUsers[i].ID, legacyJSON, ecJSON)
+		}
+	}
+}
+
+// TestEquivalence_DeviceTypes verifies the same JSON round-trip for devices.
+func TestEquivalence_DeviceTypes(t *testing.T) {
+	fixture := equivDeviceFixtureJSON()
+
+	var legacyDevices []legacyokta.Device
+	if err := json.Unmarshal(fixture, &legacyDevices); err != nil {
+		t.Fatalf("unmarshal legacy devices: %v", err)
+	}
+
+	var ecDevices []ecokta.Device
+	if err := json.Unmarshal(fixture, &ecDevices); err != nil {
+		t.Fatalf("unmarshal entcollect devices: %v", err)
+	}
+
+	if len(legacyDevices) != len(ecDevices) {
+		t.Fatalf("device count: legacy=%d, entcollect=%d", len(legacyDevices), len(ecDevices))
+	}
+
+	for i := range legacyDevices {
+		legacyJSON, _ := json.Marshal(legacyDevices[i])
+		ecJSON, _ := json.Marshal(ecDevices[i])
+		if string(legacyJSON) != string(ecJSON) {
+			t.Errorf("device[%d] %q payload mismatch:\n  legacy:     %s\n  entcollect: %s",
+				i, legacyDevices[i].ID, legacyJSON, ecJSON)
+		}
+	}
+}
+
+// TestEquivalence_FullSync runs the entcollect provider's FullSync against
+// an httptest mock and verifies it produces the expected user and device
+// documents with correct group enrichment.
+func TestEquivalence_FullSync(t *testing.T) {
+	srv := startEquivOktaServer(t)
+
+	cfg := ecokta.DefaultConfig()
+	cfg.Domain = strings.TrimPrefix(srv.URL, "https://")
+	cfg.Token = "test-token"
+	cfg.EnrichWith = []string{"groups"}
+
+	p := ecokta.NewWithClient(cfg, srv.Client())
+
+	store := newEquivMemStore()
+	var docs []entcollect.Document
+	pub := func(_ context.Context, doc entcollect.Document) error {
+		docs = append(docs, doc)
+		return nil
+	}
+
+	log := slog.New(slog.NewTextHandler(&testWriter{t}, nil))
+	if err := p.FullSync(t.Context(), store, pub, log); err != nil {
+		t.Fatalf("FullSync: %v", err)
+	}
+
+	users := filterDocsByKind(docs, entcollect.KindUser)
+	devices := filterDocsByKind(docs, entcollect.KindDevice)
+
+	if len(users) != 3 {
+		t.Errorf("user count: got %d, want 3", len(users))
+	}
+	if len(devices) != 1 {
+		t.Errorf("device count: got %d, want 1", len(devices))
+	}
+
+	// Verify group enrichment: u1 is in both groups, u2 is in group g1 only.
+	for _, doc := range users {
+		groups, _ := doc.Fields["groups"].([]ecokta.Group)
+		switch doc.ID {
+		case "u1":
+			if len(groups) != 2 {
+				t.Errorf("u1 has %d groups, want 2", len(groups))
+			}
+		case "u2":
+			if len(groups) != 1 {
+				t.Errorf("u2 has %d groups, want 1", len(groups))
+			}
+		case "u3":
+			if len(groups) != 0 {
+				t.Errorf("u3 (DEPROVISIONED) has %d groups, want 0", len(groups))
+			}
+		}
+	}
+
+	// Verify the legacy API returns the same user set by calling
+	// GetUserDetails directly against the same mock.
+	log2 := logptest.NewTestingLogger(t, "equiv")
+	lim := legacyokta.NewRateLimiter(time.Minute, nil)
+	legacyUsers, _, err := legacyokta.GetUserDetails(t.Context(), srv.Client(), srv.Listener.Addr().String(), "test-token", "", nil, legacyokta.OmitCredentials|legacyokta.OmitCredentialsLinks|legacyokta.OmitTransitioningToStatus, lim, log2)
+	if err != nil {
+		t.Fatalf("legacy GetUserDetails: %v", err)
+	}
+
+	// The mock serves all users regardless of omit flags, so compare IDs.
+	legacyIDs := make([]string, len(legacyUsers))
+	for i, u := range legacyUsers {
+		legacyIDs[i] = u.ID
+	}
+	sort.Strings(legacyIDs)
+
+	ecIDs := make([]string, len(users))
+	for i, d := range users {
+		ecIDs[i] = d.ID
+	}
+	sort.Strings(ecIDs)
+
+	if len(legacyIDs) != len(ecIDs) {
+		t.Fatalf("user ID count: legacy=%d, entcollect=%d", len(legacyIDs), len(ecIDs))
+	}
+	for i := range legacyIDs {
+		if legacyIDs[i] != ecIDs[i] {
+			t.Errorf("user ID[%d]: legacy=%q, entcollect=%q", i, legacyIDs[i], ecIDs[i])
+		}
+	}
+}
+
+func startEquivOktaServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(equivUserFixtureJSON())
+	})
+
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(equivGroupFixtureJSON())
+	})
+
+	mux.HandleFunc("/api/v1/groups/g1/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":"u1"},{"id":"u2"}]`))
+	})
+
+	mux.HandleFunc("/api/v1/groups/g2/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":"u1"}]`))
+	})
+
+	mux.HandleFunc("/api/v1/devices", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(equivDeviceFixtureJSON())
+	})
+
+	mux.HandleFunc("/api/v1/devices/d1/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"created":"2026-01-01T12:00:00.000Z","managementStatus":"NOT_MANAGED","screenLockType":"NONE","user":{"id":"u1","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Smith"}}}]`))
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func equivUserFixtureJSON() []byte {
+	now := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	return []byte(`[
+		{
+			"id": "u1",
+			"status": "ACTIVE",
+			"created": "2026-01-01T12:00:00.000Z",
+			"activated": "2026-01-01T12:00:00.000Z",
+			"lastUpdated": "` + now.Format(ecokta.ISO8601) + `",
+			"profile": {"login": "alice@example.com", "email": "alice@example.com", "firstName": "Alice", "lastName": "Smith", "managerId": "u2"}
+		},
+		{
+			"id": "u2",
+			"status": "ACTIVE",
+			"created": "2026-01-01T12:00:00.000Z",
+			"activated": "2026-01-01T12:00:00.000Z",
+			"lastUpdated": "` + now.Format(ecokta.ISO8601) + `",
+			"profile": {"login": "bob@example.com", "email": "bob@example.com", "firstName": "Bob", "lastName": "Jones"}
+		},
+		{
+			"id": "u3",
+			"status": "DEPROVISIONED",
+			"created": "2026-01-01T12:00:00.000Z",
+			"activated": "2026-01-01T12:00:00.000Z",
+			"lastUpdated": "` + now.Format(ecokta.ISO8601) + `",
+			"profile": {"login": "charlie@example.com", "email": "charlie@example.com", "firstName": "Charlie", "lastName": "Brown"}
+		}
+	]`)
+}
+
+func equivGroupFixtureJSON() []byte {
+	return []byte(`[
+		{"id": "g1", "profile": {"name": "Staff", "description": "All staff"}},
+		{"id": "g2", "profile": {"name": "Engineering", "description": "Engineering team"}}
+	]`)
+}
+
+func equivDeviceFixtureJSON() []byte {
+	return []byte(`[
+		{
+			"id": "d1",
+			"created": "2026-01-01T12:00:00.000Z",
+			"lastUpdated": "2026-01-02T12:00:00.000Z",
+			"status": "ACTIVE",
+			"profile": {"displayName": "Alice Laptop"},
+			"resourceAlternateID": "",
+			"resourceDisplayName": {"sensitive": false, "value": "Alice Laptop"},
+			"resourceID": "d1",
+			"resourceType": "UDDevice"
+		}
+	]`)
+}
+
+func filterDocsByKind(docs []entcollect.Document, kind entcollect.EntityKind) []entcollect.Document {
+	var out []entcollect.Document
+	for _, d := range docs {
+		if d.Kind == kind {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+type equivMemStore struct {
+	data map[string]json.RawMessage
+}
+
+func newEquivMemStore() *equivMemStore {
+	return &equivMemStore{data: make(map[string]json.RawMessage)}
+}
+
+func (m *equivMemStore) Get(key string, dst any) error {
+	raw, ok := m.data[key]
+	if !ok {
+		return entcollect.ErrKeyNotFound
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+func (m *equivMemStore) Set(key string, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	m.data[key] = raw
+	return nil
+}
+
+func (m *equivMemStore) Delete(key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *equivMemStore) Each(fn func(string, func(any) error) (bool, error)) error {
+	for k, v := range m.data {
+		v := v
+		cont, err := fn(k, func(dst any) error { return json.Unmarshal(v, dst) })
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return nil
+		}
+	}
+	return nil
+}

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/minimal.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/minimal.go
@@ -1,0 +1,138 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package okta
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/entcollect"
+	ecokta "github.com/elastic/entcollect/provider/okta"
+)
+
+func init() {
+	err := provider.RegisterMinimalStateProvider(Name, minimalProvider)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// minimalOAuth2Conf mirrors the legacy oAuth2Config fields with config
+// tags for ucfg Unpack.
+type minimalOAuth2Conf struct {
+	Enabled      *bool           `config:"enabled"`
+	ClientID     string          `config:"client.id"`
+	ClientSecret string          `config:"client.secret"`
+	Scopes       []string        `config:"scopes"`
+	TokenURL     string          `config:"token_url"`
+	OktaJWKFile  string          `config:"jwk_file"`
+	OktaJWKJSON  common.JSONBlob `config:"jwk_json"`
+	OktaJWKPEM   string          `config:"jwk_pem"`
+}
+
+func (o *minimalOAuth2Conf) isEnabled() bool {
+	return o != nil && (o.Enabled == nil || *o.Enabled)
+}
+
+func minimalProvider(cfg *config.C, _ *logp.Logger) (entcollect.Provider, time.Duration, time.Duration, error) {
+	// localConf mirrors ecokta.Config with config:"" tags for ucfg Unpack.
+	// If ecokta.Config gains a new field, add it here and in the mapping
+	// below; TestMinimalConfigRoundTrip (minimal_test.go) will catch any drift.
+	type localConf struct {
+		OktaDomain string             `config:"okta_domain" validate:"required"`
+		OktaToken  string             `config:"okta_token"`
+		OAuth2     *minimalOAuth2Conf `config:"oauth2"`
+
+		Dataset    string   `config:"dataset"`
+		EnrichWith []string `config:"enrich_with"`
+
+		BatchSize      int           `config:"batch_size"`
+		SyncInterval   time.Duration `config:"sync_interval"`
+		UpdateInterval time.Duration `config:"update_interval"`
+		IDSetShards    int           `config:"idset_shards"`
+
+		LimitWindow time.Duration `config:"limit_window"`
+		LimitFixed  *int          `config:"limit_fixed"`
+	}
+
+	d := ecokta.DefaultConfig()
+	lc := localConf{
+		EnrichWith:     d.EnrichWith,
+		SyncInterval:   d.SyncInterval,
+		UpdateInterval: d.UpdateInterval,
+		IDSetShards:    d.IDSetShards,
+		LimitWindow:    d.LimitWindow,
+	}
+	if err := cfg.Unpack(&lc); err != nil {
+		return nil, 0, 0, err
+	}
+
+	ec := ecokta.Config{
+		Domain:         lc.OktaDomain,
+		Token:          lc.OktaToken,
+		Dataset:        lc.Dataset,
+		EnrichWith:     lc.EnrichWith,
+		BatchSize:      lc.BatchSize,
+		SyncInterval:   lc.SyncInterval,
+		UpdateInterval: lc.UpdateInterval,
+		IDSetShards:    lc.IDSetShards,
+		LimitWindow:    lc.LimitWindow,
+		LimitFixed:     lc.LimitFixed,
+	}
+
+	if lc.OAuth2.isEnabled() {
+		jwk, err := resolveJWK(lc.OAuth2)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("oauth2 jwk: %w", err)
+		}
+		ec.OAuth2 = &ecokta.OAuth2Config{
+			ClientID:     lc.OAuth2.ClientID,
+			ClientSecret: lc.OAuth2.ClientSecret,
+			TokenURL:     lc.OAuth2.TokenURL,
+			Scopes:       lc.OAuth2.Scopes,
+			JWK:          jwk,
+		}
+	}
+
+	if err := ec.Validate(); err != nil {
+		return nil, 0, 0, err
+	}
+	return ecokta.New(ec), ec.SyncInterval, ec.UpdateInterval, nil
+}
+
+// resolveJWK converts one of the three JWK input forms (JSON, file, PEM)
+// into raw JSON bytes suitable for ecokta.OAuth2Config.JWK. Returns nil
+// when none are set (client-secret auth).
+func resolveJWK(o *minimalOAuth2Conf) (json.RawMessage, error) {
+	switch {
+	case o.OktaJWKJSON != nil:
+		return json.RawMessage(o.OktaJWKJSON), nil
+	case o.OktaJWKFile != "":
+		b, err := os.ReadFile(o.OktaJWKFile)
+		if err != nil {
+			return nil, fmt.Errorf("read jwk_file %q: %w", o.OktaJWKFile, err)
+		}
+		if !json.Valid(b) {
+			return nil, fmt.Errorf("jwk_file %q does not contain valid JSON", o.OktaJWKFile)
+		}
+		return json.RawMessage(b), nil
+	case o.OktaJWKPEM != "":
+		key, err := pemPKCS8PrivateKey([]byte(o.OktaJWKPEM))
+		if err != nil {
+			return nil, fmt.Errorf("parse jwk_pem: %w", err)
+		}
+		return jose.JSONWebKey{Key: key}.MarshalJSON()
+	default:
+		return nil, nil
+	}
+}

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/minimal_test.go
@@ -1,0 +1,59 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package okta
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	ecokta "github.com/elastic/entcollect/provider/okta"
+)
+
+// TestMinimalConfigRoundTrip verifies that every exported field of
+// ecokta.Config is represented in the localConf mirror inside
+// minimalProvider. It does this in two ways:
+//
+//  1. Field-count assertion — if ecokta.Config gains a field, the count
+//     check fails, forcing the developer to update localConf and this test.
+//  2. Functional round-trip — all fields are set to non-default sentinel
+//     values; the returned sync intervals must match, confirming that at
+//     least the duration fields are wired through end-to-end.
+func TestMinimalConfigRoundTrip(t *testing.T) {
+	const wantFields = 11
+	if got := reflect.TypeOf(ecokta.Config{}).NumField(); got != wantFields {
+		t.Fatalf("ecokta.Config has %d exported fields, want %d; "+
+			"update localConf inside minimalProvider and this test", got, wantFields)
+	}
+
+	wantSync := 48 * time.Hour
+	wantUpdate := 30 * time.Minute
+	limitFixed := 50
+
+	cfg := config.MustNewConfigFrom(map[string]any{
+		"okta_domain":     "test.okta.com",
+		"okta_token":      "test-token",
+		"dataset":         "users",
+		"enrich_with":     []string{"groups", "factors"},
+		"batch_size":      100,
+		"sync_interval":   wantSync.String(),
+		"update_interval": wantUpdate.String(),
+		"idset_shards":    32,
+		"limit_window":    "2m",
+		"limit_fixed":     limitFixed,
+	})
+
+	_, gotSync, gotUpdate, err := minimalProvider(cfg, nil)
+	if err != nil {
+		t.Fatalf("minimalProvider returned unexpected error: %v", err)
+	}
+	if gotSync != wantSync {
+		t.Errorf("sync_interval: got %v, want %v", gotSync, wantSync)
+	}
+	if gotUpdate != wantUpdate {
+		t.Errorf("update_interval: got %v, want %v", gotUpdate, wantUpdate)
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics/provider/okta: add minimal-state provider

Register the entcollect Okta provider as a minimal-state provider in
beats. The adapter maps ucfg config to ecokta.Config, including OAuth2
with JWK resolution from jwk_json, jwk_file, and jwk_pem inputs.

Equivalence tests verify that entcollect and legacy types produce
identical JSON for users and devices, and that FullSync returns the
same user set as the legacy GetUserDetails API.

Bump entcollect to 6d4034497b3d (Okta provider).

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #49163

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
