### PR TITLE
metricbeat/autoops_es: clamp *_latency_in_millis to the sampling interval (fix #2471)

### DIFF
--- a/changelog/fragments/1778749056-autoops-es-clamp-latency-to-interval.yaml
+++ b/changelog/fragments/1778749056-autoops-es-clamp-latency-to-interval.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: "Clamp autoops_es *_latency_in_millis metrics to the sampling interval so a single-sample latency can never exceed the wall-clock time between samples (fixes #2471)"
+
+component: metricbeat

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cache.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cache.go
@@ -63,7 +63,8 @@ var (
 				IsUsable: func(obj *NodeIndexShards) bool {
 					return obj.IndexingIndexTotal != nil && obj.IndexingIndexTotalTime != nil
 				},
-				WriteValue: func(obj *NodeIndexShards, value float64) { obj.IndexLatencyInMillis = &value },
+				WriteValue:     func(obj *NodeIndexShards, value float64) { obj.IndexLatencyInMillis = &value },
+				MaxValueMillis: utils.SamplingIntervalMillis[NodeIndexShards],
 			},
 			{
 				CalculateValue: utils.CalculateLatency,
@@ -73,7 +74,8 @@ var (
 				IsUsable: func(obj *NodeIndexShards) bool {
 					return obj.MergesTotal != nil && obj.MergesTotalTime != nil
 				},
-				WriteValue: func(obj *NodeIndexShards, value float64) { obj.MergeLatencyInMillis = &value },
+				WriteValue:     func(obj *NodeIndexShards, value float64) { obj.MergeLatencyInMillis = &value },
+				MaxValueMillis: utils.SamplingIntervalMillis[NodeIndexShards],
 			},
 			{
 				CalculateValue: utils.CalculateLatency,
@@ -83,7 +85,8 @@ var (
 				IsUsable: func(obj *NodeIndexShards) bool {
 					return obj.SearchQueryTotal != nil && obj.SearchQueryTime != nil
 				},
-				WriteValue: func(obj *NodeIndexShards, value float64) { obj.SearchLatencyInMillis = &value },
+				WriteValue:     func(obj *NodeIndexShards, value float64) { obj.SearchLatencyInMillis = &value },
+				MaxValueMillis: utils.SamplingIntervalMillis[NodeIndexShards],
 			},
 		},
 	}

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cache_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cache_test.go
@@ -250,6 +250,49 @@ func TestEnrichNodeIndexShardsWithCachedValues(t *testing.T) {
 	}
 }
 
+func TestEnrichNodeIndexShardsClampsLatencyToInterval(t *testing.T) {
+	// 16s sampling interval
+	initCache(getNodeIndexShards(), 16)
+
+	indexMetadata := getIndexMetadata()
+	nodeIndexShardsMap := getNodeIndexShards()
+
+	for key, nodeIndexShards := range nodeIndexShardsMap {
+		// Small deltas for index and merge — raw latency well below 16 000 ms
+		*nodeIndexShards.IndexingIndexTotal += 3
+		*nodeIndexShards.IndexingIndexTotalTime += 30
+		*nodeIndexShards.IndexingFailedIndexTotal += 3
+		*nodeIndexShards.MergesTotal += 3
+		*nodeIndexShards.MergesTotalTime += 30
+		*nodeIndexShards.GetMissingDocTotal += 3
+		// Reproduces #2471: 3 search ops with combined query_time > interval
+		// raw latency = 126 000 / 3 = 42 000 ms/op; interval = 16 000 ms → clamped
+		*nodeIndexShards.SearchQueryTotal += 3
+		*nodeIndexShards.SearchQueryTime += 126_000
+
+		nodeIndexShardsMap[key] = nodeIndexShards
+	}
+
+	nodeIndexShardsList := enrichNodeIndexShards(nodeIndexShardsMap, indexMetadata)
+
+	require.Equal(t, len(nodeIndexShardsMap), len(nodeIndexShardsList))
+
+	for _, nodeIndexShards := range nodeIndexShardsList {
+		require.NotNil(t, nodeIndexShards.SearchLatencyInMillis, "SearchLatencyInMillis should be written")
+		require.EqualValues(t, 16_000, *nodeIndexShards.SearchLatencyInMillis,
+			"search latency exceeding the sampling interval should be clamped to the interval")
+
+		// Index and merge latencies are well below the interval and must not be clamped
+		require.NotNil(t, nodeIndexShards.IndexLatencyInMillis, "IndexLatencyInMillis should be written")
+		require.InDelta(t, 10, *nodeIndexShards.IndexLatencyInMillis, 0.01,
+			"index latency below interval should not be clamped")
+
+		require.NotNil(t, nodeIndexShards.MergeLatencyInMillis, "MergeLatencyInMillis should be written")
+		require.InDelta(t, 10, *nodeIndexShards.MergeLatencyInMillis, 0.01,
+			"merge latency below interval should not be clamped")
+	}
+}
+
 func TestEnrichNodeIndexShardsWithCachedValuesWithNoChange(t *testing.T) {
 	// 10s ago cache
 	initCache(getNodeIndexShards(), 10)

--- a/x-pack/metricbeat/module/autoops_es/node_stats/cache.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/cache.go
@@ -56,6 +56,7 @@ func createLatency(latencyKey string, key string, timestampKey string) utils.Enr
 		GetValue:       func(obj *mapstr.M) int64 { return getValue(obj, key) },
 		IsUsable:       func(obj *mapstr.M) bool { return hasKey(obj, key) && hasKey(obj, timestampKey) },
 		WriteValue:     func(obj *mapstr.M, value float64) { setValue(obj, latencyKey, value) },
+		MaxValueMillis: utils.SamplingIntervalMillis[mapstr.M],
 	}
 }
 

--- a/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
@@ -131,6 +131,47 @@ func TestEnrichNodeStatsWithCachedValues(t *testing.T) {
 	}
 }
 
+func TestEnrichNodeStatsSearchLatencyClampsToInterval(t *testing.T) {
+	// 10s sampling interval
+	initCache(getNodeStats(), 10)
+
+	nodeStatsMap := getNodeStats()
+
+	for key, nodeStats := range nodeStatsMap {
+		// Small deltas for index and merge — raw latencies well below 10 000 ms
+		nodeStats["indices.indexing.index_total"] = getValue(&nodeStats, "indices.indexing.index_total") + 3
+		nodeStats["indices.indexing.index_time_in_millis"] = getValue(&nodeStats, "indices.indexing.index_time_in_millis") + 30
+		nodeStats["indices.indexing.index_failed"] = getValue(&nodeStats, "indices.indexing.index_failed") + 3
+		nodeStats["indices.merges.total"] = getValue(&nodeStats, "indices.merges.total") + 3
+		nodeStats["indices.merges.total_time_in_millis"] = getValue(&nodeStats, "indices.merges.total_time_in_millis") + 30
+		// Reproduces #2471: 3 search ops with combined query_time > interval
+		// raw latency = 120 000 / 3 = 40 000 ms/op; interval = 10 000 ms → clamped
+		nodeStats["indices.search.query_total"] = getValue(&nodeStats, "indices.search.query_total") + 3
+		nodeStats["indices.search.query_time_in_millis"] = getValue(&nodeStats, "indices.search.query_time_in_millis") + 120_000
+
+		nodeStatsMap[key] = nodeStats
+	}
+
+	nodeStatsNode1 := nodeStatsMap["node1"]
+	enrichNodeStats("node1", &nodeStatsNode1, 10_000)
+	nodeStatsMap["node1"] = nodeStatsNode1
+
+	nodeStatsNode2 := nodeStatsMap["node2"]
+	enrichNodeStats("node2", &nodeStatsNode2, 10_000)
+	nodeStatsMap["node2"] = nodeStatsNode2
+
+	for _, nodeStats := range nodeStatsMap {
+		require.EqualValues(t, 10_000, nodeStats["search_latency_in_millis"],
+			"search latency exceeding the sampling interval should be clamped to the interval")
+
+		// Index and merge latencies are well below the interval and must not be clamped
+		require.InDelta(t, 10, nodeStats["index_latency_in_millis"], 0.01,
+			"index latency below interval should not be clamped")
+		require.InDelta(t, 10, nodeStats["merge_latency_in_millis"], 0.01,
+			"merge latency below interval should not be clamped")
+	}
+}
+
 func TestEnrichNodeStatsWithCachedValuesWithNoChange(t *testing.T) {
 	// 10s ago cache
 	initCache(getNodeStats(), 10)

--- a/x-pack/metricbeat/module/autoops_es/utils/enrich.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/enrich.go
@@ -12,6 +12,9 @@ type EnrichedType[T any] struct {
 	GetValue       func(*T) int64
 	IsUsable       func(*T) bool
 	WriteValue     func(*T, float64)
+	// If set, the calculated value is clamped to min(calculated, MaxValueMillis(cache)).
+	// Used to ensure latency cannot exceed the sampling interval.
+	MaxValueMillis func(cache EnrichedCache[T]) float64
 }
 
 type EnrichedCache[T any] struct {
@@ -25,6 +28,11 @@ type EnrichedCache[T any] struct {
 
 func CalculateLatency(timeDiff float64, valueDiff int64) float64 {
 	return timeDiff / float64(valueDiff)
+}
+
+// SamplingIntervalMillis returns the wall-clock milliseconds between the previous and current sample.
+func SamplingIntervalMillis[T any](cache EnrichedCache[T]) float64 {
+	return float64(cache.NewTimestamp - cache.PreviousTimestamp)
 }
 
 func CalculateRate(timeDiff float64, valueDiff int64) float64 {
@@ -69,6 +77,12 @@ func EnrichObject[T any](obj *T, prevObj *T, cache EnrichedCache[T]) {
 			// either being zero means there's no measurable value exists
 			if timeDiff > 0 && valueDiff > 0 {
 				calculated = enricher.CalculateValue(timeDiff, valueDiff)
+			}
+
+			if enricher.MaxValueMillis != nil {
+				if maxV := enricher.MaxValueMillis(cache); maxV > 0 && calculated > maxV {
+					calculated = maxV
+				}
 			}
 
 			enricher.WriteValue(obj, calculated)

--- a/x-pack/metricbeat/module/autoops_es/utils/enrich_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/enrich_test.go
@@ -115,3 +115,84 @@ func TestCacheHit(t *testing.T) {
 	require.EqualValues(t, 1, *data.IndexRatePerSecond)
 	require.EqualValues(t, 0.1, *data.IndexLatencyInMillis)
 }
+
+func clampedCacheWithInterval(nowMillis, prevMillis int64) EnrichedCache[cachedObject] {
+	return EnrichedCache[cachedObject]{
+		Enrichers: []EnrichedType[cachedObject]{
+			// RATE: no MaxValueMillis — must not be affected by clamping
+			{
+				CalculateValue: CalculateRate,
+				ConvertTime:    MillisToSeconds,
+				GetTime:        UseTimestamp[*cachedObject],
+				GetValue:       func(obj *cachedObject) int64 { return *obj.IndexingTotal },
+				IsUsable:       func(obj *cachedObject) bool { return obj.IndexingTotal != nil },
+				WriteValue:     func(obj *cachedObject, value float64) { obj.IndexRatePerSecond = &value },
+			},
+			// LATENCY: MaxValueMillis clamps to the sampling interval
+			{
+				CalculateValue: CalculateLatency,
+				ConvertTime:    UseTimeInMillis,
+				GetTime:        func(obj *cachedObject, _ int64) int64 { return *obj.IndexingTotalTime },
+				GetValue:       func(obj *cachedObject) int64 { return *obj.IndexingTotal },
+				IsUsable: func(obj *cachedObject) bool {
+					return obj.IndexingTotal != nil && obj.IndexingTotalTime != nil
+				},
+				WriteValue:     func(obj *cachedObject, value float64) { obj.IndexLatencyInMillis = &value },
+				MaxValueMillis: SamplingIntervalMillis[cachedObject],
+			},
+		},
+		NewTimestamp:      nowMillis,
+		PreviousTimestamp: prevMillis,
+		PreviousCache:     map[string]cachedObject{},
+	}
+}
+
+func TestClampAppliesWhenLatencyExceedsInterval(t *testing.T) {
+	nowMillis := time.Now().UnixMilli()
+	// 16 second sampling interval
+	clampCache := clampedCacheWithInterval(nowMillis, nowMillis-16_000)
+
+	// 3 ops with cumulative time 126 000 ms → raw latency = 42 000 ms/op
+	// interval is 16 000 ms → must be clamped to 16 000
+	prev := object(10, 1_000)
+	data := object(13, 127_000)
+
+	EnrichObject(&data, &prev, clampCache)
+
+	require.NotNil(t, data.IndexLatencyInMillis, "latency should be written")
+	require.EqualValues(t, 16_000, *data.IndexLatencyInMillis, "latency should be clamped to the sampling interval")
+}
+
+func TestClampNoOpWhenLatencyBelowInterval(t *testing.T) {
+	nowMillis := time.Now().UnixMilli()
+	// 16 second sampling interval
+	clampCache := clampedCacheWithInterval(nowMillis, nowMillis-16_000)
+
+	// 3 ops with cumulative time 4 000 ms → raw latency ≈ 1 333 ms/op, well below 16 000 ms
+	prev := object(10, 1_000)
+	data := object(13, 5_000)
+
+	EnrichObject(&data, &prev, clampCache)
+
+	require.NotNil(t, data.IndexLatencyInMillis, "latency should be written")
+	expected := 4_000.0 / 3.0
+	require.InDelta(t, expected, *data.IndexLatencyInMillis, 0.01, "latency below interval should not be clamped")
+}
+
+func TestClampDoesNotAffectRates(t *testing.T) {
+	nowMillis := time.Now().UnixMilli()
+	// 16 second sampling interval
+	clampCache := clampedCacheWithInterval(nowMillis, nowMillis-16_000)
+
+	// 3 ops with cumulative time 126 000 ms → latency clamped; rate = 3/16 ops/s unaffected
+	prev := object(10, 1_000)
+	data := object(13, 127_000)
+
+	EnrichObject(&data, &prev, clampCache)
+
+	require.NotNil(t, data.IndexRatePerSecond, "rate should be written")
+	require.InDelta(t, 3.0/16.0, *data.IndexRatePerSecond, 0.0001, "rate should not be affected by latency clamping")
+
+	require.NotNil(t, data.IndexLatencyInMillis, "latency should be written")
+	require.EqualValues(t, 16_000, *data.IndexLatencyInMillis, "latency should still be clamped")
+}


### PR DESCRIPTION
## AI-generated summary

**WHAT:** Adds a `MaxValueMillis` optional field to `EnrichedType` (the shared latency/rate enrichment machinery in `x-pack/metricbeat/module/autoops_es/utils/enrich.go`). When set, `EnrichObject` clamps the computed value to `min(calculated, MaxValueMillis(cache))`. A companion helper `SamplingIntervalMillis` returns the wall-clock milliseconds between the previous and current sample (`cache.NewTimestamp - cache.PreviousTimestamp`). The three latency enrichers in `cat_shards/cache.go` (`SearchLatencyInMillis`, `IndexLatencyInMillis`, `MergeLatencyInMillis`) and all three returned by `node_stats/cache.go`'s `createLatency()` helper now set `MaxValueMillis: utils.SamplingIntervalMillis[T]`.

**WHY:** When an index has multiple shards on the same node, `cat_shards/index_shards.go` sums `search_query_time` across shards without accounting for the fact that searches run in parallel. For a 32-core node handling 3 concurrent searches each taking ~42 s, the combined `query_time` can easily exceed the 16 s sampling window, making `search_latency_in_millis` report 42 000 ms/op — larger than the wall-clock interval between samples, which is impossible in reality. The agreed remediation is `latency = min(computed_latency, sampling_interval)`. The same over-counting applies to node-level latencies in `node_stats`, so the same clamp is applied there for consistency.

Rate metrics (`*_rate_per_second`) deliberately do not set `MaxValueMillis`; they are unaffected by this change. Raw counters (`SearchQueryTime`, etc.) continue to ship unchanged.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

`*_latency_in_millis` fields in `autoops_es` `cat_shards` and `node_stats` metricsets will no longer report values larger than the sampling interval. Any downstream alert or visualization that relied on the artificially inflated values will see lower (correct) numbers.

## How to test this PR locally

```bash
cd x-pack/metricbeat
go test -v -race ./module/autoops_es/utils/...
go test -v -race ./module/autoops_es/cat_shards/...
go test -v -race ./module/autoops_es/node_stats/...
```

All three packages should report `PASS`. The new tests that specifically exercise the clamp path are:
- `utils`: `TestClampAppliesWhenLatencyExceedsInterval`, `TestClampNoOpWhenLatencyBelowInterval`, `TestClampDoesNotAffectRates`
- `cat_shards`: `TestEnrichNodeIndexShardsClampsLatencyToInterval`
- `node_stats`: `TestEnrichNodeStatsSearchLatencyClampsToInterval`

## Related issues

- Closes elastic/autoops-services#2471

## Use cases

**Before:** A node with 3 parallel search ops, each taking ~42 s, over a 16 s sampling window reports `search_latency_in_millis = 42 000`. The value exceeds the sampling interval, which is physically impossible for a single op and confuses downstream analyzers.

**After:** The same scenario reports `search_latency_in_millis = 16 000` (clamped to the sampling interval).
