### PR TITLE
fix: correct Elastisearch typo to Elasticsearch in docs and changelog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -10347,7 +10347,7 @@ https://github.com/elastic/beats/compare/v6.2.3\...v6.3.0[View commits]
 - Add `has_fields` conditional to filter events based on the existence of all the given fields. {issue}6285[6285] {pull}6653[6653]
 - Add support for spooling to disk to the beats event publishing pipeline. {pull}6581[6581]
 - Added logging of system info at Beat startup. {issue}5946[5946]
-- Do not log errors if X-Pack Monitoring is enabled but Elastisearch X-Pack is not. {pull}6627[6627]
+- Do not log errors if X-Pack Monitoring is enabled but Elasticsearch X-Pack is not. {pull}6627[6627]
 - Add rename processor. {pull}6292[6292]
 - Allow override of dynamic template `match_mapping_type` for fields with object_type. {pull}6691[6691]
 

--- a/docs/reference/auditbeat/add-fields.md
+++ b/docs/reference/auditbeat/add-fields.md
@@ -50,5 +50,5 @@ processors:
         op_type: "index"
 ```
 
-When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.
+When the event is ingested (e.g. by Elasticsearch) the document will have `op_type: "index"` set as a metadata field.
 

--- a/docs/reference/filebeat/add-fields.md
+++ b/docs/reference/filebeat/add-fields.md
@@ -50,5 +50,5 @@ processors:
         op_type: "index"
 ```
 
-When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.
+When the event is ingested (e.g. by Elasticsearch) the document will have `op_type: "index"` set as a metadata field.
 

--- a/docs/reference/heartbeat/add-fields.md
+++ b/docs/reference/heartbeat/add-fields.md
@@ -50,5 +50,5 @@ processors:
         op_type: "index"
 ```
 
-When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.
+When the event is ingested (e.g. by Elasticsearch) the document will have `op_type: "index"` set as a metadata field.
 

--- a/docs/reference/metricbeat/add-fields.md
+++ b/docs/reference/metricbeat/add-fields.md
@@ -50,5 +50,5 @@ processors:
         op_type: "index"
 ```
 
-When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.
+When the event is ingested (e.g. by Elasticsearch) the document will have `op_type: "index"` set as a metadata field.
 

--- a/docs/reference/packetbeat/add-fields.md
+++ b/docs/reference/packetbeat/add-fields.md
@@ -50,5 +50,5 @@ processors:
         op_type: "index"
 ```
 
-When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.
+When the event is ingested (e.g. by Elasticsearch) the document will have `op_type: "index"` set as a metadata field.
 

--- a/docs/reference/winlogbeat/add-fields.md
+++ b/docs/reference/winlogbeat/add-fields.md
@@ -50,5 +50,5 @@ processors:
         op_type: "index"
 ```
 
-When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.
+When the event is ingested (e.g. by Elasticsearch) the document will have `op_type: "index"` set as a metadata field.
 

--- a/libbeat/processors/actions/docs/add_fields.asciidoc
+++ b/libbeat/processors/actions/docs/add_fields.asciidoc
@@ -52,4 +52,4 @@ processors:
         op_type: "index"
 ------------------------------------------------------------------------------
 
-When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.
+When the event is ingested (e.g. by Elasticsearch) the document will have `op_type: "index"` set as a metadata field.


### PR DESCRIPTION
## Summary
Fixes 8 occurrences of `Elastisearch` → `Elasticsearch` typo across documentation and CHANGELOG.

Files changed:
- `libbeat/processors/actions/docs/add_fields.asciidoc` (line 55)
- `docs/reference/filebeat/add-fields.md` (line 53)
- `docs/reference/packetbeat/add-fields.md` (line 53)
- `docs/reference/winlogbeat/add-fields.md` (line 53)
- `docs/reference/metricbeat/add-fields.md` (line 53)
- `docs/reference/heartbeat/add-fields.md` (line 53)
- `docs/reference/auditbeat/add-fields.md` (line 53)
- `CHANGELOG.asciidoc` (line 10350)

Closes #50701