### PR TITLE
[libbeat/processing] add a new shared processor wrapper

### DIFF
--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/processors/shared"
 )
 
 const (
@@ -60,7 +61,7 @@ type kubernetesAnnotator struct {
 }
 
 func init() {
-	processors.RegisterPlugin("add_kubernetes_metadata", New)
+	processors.RegisterPlugin("add_kubernetes_metadata", shared.New(New))
 
 	// Register default indexers
 	Indexing.AddIndexer(PodNameIndexerName, NewPodNameIndexer)

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_concurrent_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_concurrent_test.go
@@ -171,13 +171,13 @@ func TestAnnotatorRun_EachEventAnnotatedIndependently(t *testing.T) {
 
 		containerRaw, err := r.event.Fields.GetValue("container")
 		require.NoError(t, err, "goroutine %d: event must have container field", i)
-		container := containerRaw.(mapstr.M)
+		container := containerRaw.(mapstr.M) //nolint:errcheck // it's a test
 		assert.Equal(t, cid, container["id"], "goroutine %d: container.id must match its own cache key", i)
 
 		k8sRaw, err := r.event.Fields.GetValue("kubernetes")
 		require.NoError(t, err)
-		k8s := k8sRaw.(mapstr.M)
-		pod := k8s["pod"].(mapstr.M)
+		k8s := k8sRaw.(mapstr.M)     //nolint:errcheck // it's a test
+		pod := k8s["pod"].(mapstr.M) //nolint:errcheck // it's a test
 		assert.Equal(t, "uid-"+cid, pod["uid"], "goroutine %d: kubernetes.pod.uid must match its own cache key", i)
 	}
 }
@@ -209,7 +209,7 @@ func TestAnnotatorRun_MutatingOneResultDoesNotAffectOthers(t *testing.T) {
 	if events[0] != nil {
 		containerRaw, err := events[0].Fields.GetValue("container")
 		require.NoError(t, err)
-		container := containerRaw.(mapstr.M)
+		container := containerRaw.(mapstr.M) //nolint:errcheck // it's a test
 		container["_injected_by_goroutine_0"] = true
 	}
 
@@ -220,7 +220,7 @@ func TestAnnotatorRun_MutatingOneResultDoesNotAffectOthers(t *testing.T) {
 		}
 		containerRaw, err := events[i].Fields.GetValue("container")
 		require.NoError(t, err, "goroutine %d event must still have container field", i)
-		container := containerRaw.(mapstr.M)
+		container := containerRaw.(mapstr.M) //nolint:errcheck // it's a test
 		assert.NotContains(t, container, "_injected_by_goroutine_0",
 			"goroutine %d's container must be independent from goroutine 0's result", i)
 	}
@@ -255,7 +255,7 @@ func TestAnnotatorRun_CacheMutationDoesNotAffectInFlightEvents(t *testing.T) {
 			defer wg.Done()
 			// Write a completely different metadata map to the same key.
 			newMeta := metaMap(containerID)
-			newMeta["kubernetes"].(mapstr.M)["pod"].(mapstr.M)["name"] = "replaced-pod"
+			newMeta["kubernetes"].(mapstr.M)["pod"].(mapstr.M)["name"] = "replaced-pod" //nolint:errcheck // it's a test
 			processor.cache.set(containerID, newMeta)
 		}()
 	}
@@ -273,8 +273,8 @@ func TestAnnotatorRun_CacheMutationDoesNotAffectInFlightEvents(t *testing.T) {
 			// event may have been processed before the first cache.set.
 			continue
 		}
-		k8s := k8sRaw.(mapstr.M)
-		pod := k8s["pod"].(mapstr.M)
+		k8s := k8sRaw.(mapstr.M)     //nolint:errcheck // it's a test
+		pod := k8s["pod"].(mapstr.M) //nolint:errcheck // it's a test
 		name, ok := pod["name"].(string)
 		assert.True(t, ok, "event %d: pod.name must be a string", i)
 		assert.Contains(t, []string{"mypod", "replaced-pod"}, name,
@@ -337,15 +337,15 @@ func TestAnnotatorRun_SharedWrapper_EventIndependenceUnderConcurrency(t *testing
 		// container.id must match this goroutine's own cache key.
 		containerRaw, getErr := r.event.Fields.GetValue("container")
 		require.NoError(t, getErr, "goroutine %d: event must have container field", i)
-		container := containerRaw.(mapstr.M)
+		container := containerRaw.(mapstr.M) //nolint:errcheck // it's a test
 		assert.Equal(t, r.cid, container["id"],
 			"goroutine %d: container.id must equal its own cache key, not another goroutine's", i)
 
 		// kubernetes.pod.uid must also be specific to this goroutine's entry.
 		k8sRaw, getErr := r.event.Fields.GetValue("kubernetes")
 		require.NoError(t, getErr, "goroutine %d: event must have kubernetes field", i)
-		k8s := k8sRaw.(mapstr.M)
-		pod := k8s["pod"].(mapstr.M)
+		k8s := k8sRaw.(mapstr.M)     //nolint:errcheck // it's a test
+		pod := k8s["pod"].(mapstr.M) //nolint:errcheck // it's a test
 		assert.Equal(t, "uid-"+r.cid, pod["uid"],
 			"goroutine %d: kubernetes.pod.uid must belong to its own cache entry", i)
 	}

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_concurrent_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_concurrent_test.go
@@ -1,0 +1,352 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build linux || darwin || windows
+
+package add_kubernetes_metadata
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors/shared"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+func metaMap(containerID string) mapstr.M {
+	return mapstr.M{
+		"kubernetes": mapstr.M{
+			"pod": mapstr.M{
+				"name":      "mypod",
+				"uid":       "uid-" + containerID,
+				"namespace": "default",
+				"labels":    mapstr.M{"app": "myapp"},
+			},
+			"node": mapstr.M{"name": "node-1"},
+			"container": mapstr.M{
+				"name":    "mycontainer",
+				"image":   "myimage:latest",
+				"id":      containerID,
+				"runtime": "containerd",
+			},
+		},
+	}
+}
+
+func newAnnotatorWithMeta(t testing.TB, containerID string) *kubernetesAnnotator {
+	t.Helper()
+	return newAnnotatorForTest(t, containerID, metaMap(containerID))
+}
+
+func containerEvent(containerID string) *beat.Event {
+	return &beat.Event{
+		Fields: mapstr.M{
+			"container": mapstr.M{"id": containerID},
+		},
+	}
+}
+
+func TestAnnotatorRun_ConcurrentRace(t *testing.T) {
+	const goroutines = 100
+	const containerID = "race-cid"
+
+	processor := newAnnotatorWithMeta(t, containerID)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			event := containerEvent(containerID)
+			out, err := processor.Run(event)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if out == nil {
+				t.Error("Run returned nil event")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestAnnotatorRun_ConcurrentRace_CacheWrite(t *testing.T) {
+	const goroutines = 50
+	const containerID = "cache-write-cid"
+
+	processor := newAnnotatorWithMeta(t, containerID)
+	meta := metaMap(containerID)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	// Half of the goroutines read via Run.
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = processor.Run(containerEvent(containerID))
+		}()
+	}
+
+	// Half write via the cache directly (simulating the watcher callbacks).
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			processor.cache.set(containerID, meta)
+		}()
+	}
+
+	wg.Wait()
+}
+
+// verify that when many  goroutines each process a distinct event, every event is enriched with the
+// correct kubernetes metadata.
+func TestAnnotatorRun_EachEventAnnotatedIndependently(t *testing.T) {
+	const goroutines = 50
+
+	cfg := config.MustNewConfigFrom(map[string]interface{}{
+		"lookup_fields": []string{"container.id"},
+	})
+	matcher, err := NewFieldMatcher(*cfg, logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+
+	processor := &kubernetesAnnotator{
+		log:                 logptest.NewTestingLogger(t, selector),
+		cache:               newCache(10 * time.Second),
+		matchers:            &Matchers{matchers: []Matcher{matcher}},
+		kubernetesAvailable: true,
+	}
+
+	for i := 0; i < goroutines; i++ {
+		cid := fmt.Sprintf("cid-%d", i)
+		processor.cache.set(cid, metaMap(cid))
+	}
+
+	type result struct {
+		event *beat.Event
+		err   error
+	}
+	results := make([]result, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			cid := fmt.Sprintf("cid-%d", i)
+			out, runErr := processor.Run(containerEvent(cid))
+			results[i] = result{event: out, err: runErr}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		cid := fmt.Sprintf("cid-%d", i)
+		require.NoError(t, r.err, "goroutine %d must not return an error", i)
+		require.NotNil(t, r.event, "goroutine %d must receive a non-nil event", i)
+
+		containerRaw, err := r.event.Fields.GetValue("container")
+		require.NoError(t, err, "goroutine %d: event must have container field", i)
+		container := containerRaw.(mapstr.M)
+		assert.Equal(t, cid, container["id"], "goroutine %d: container.id must match its own cache key", i)
+
+		k8sRaw, err := r.event.Fields.GetValue("kubernetes")
+		require.NoError(t, err)
+		k8s := k8sRaw.(mapstr.M)
+		pod := k8s["pod"].(mapstr.M)
+		assert.Equal(t, "uid-"+cid, pod["uid"], "goroutine %d: kubernetes.pod.uid must match its own cache key", i)
+	}
+}
+
+func TestAnnotatorRun_MutatingOneResultDoesNotAffectOthers(t *testing.T) {
+	const goroutines = 30
+	const containerID = "shared-cid"
+
+	processor := newAnnotatorWithMeta(t, containerID)
+
+	events := make([]*beat.Event, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			out, err := processor.Run(containerEvent(containerID))
+			if err != nil {
+				t.Errorf("goroutine %d: unexpected error: %v", i, err)
+				return
+			}
+			events[i] = out
+		}()
+	}
+	wg.Wait()
+
+	// mutate the first event's container map.
+	if events[0] != nil {
+		containerRaw, err := events[0].Fields.GetValue("container")
+		require.NoError(t, err)
+		container := containerRaw.(mapstr.M)
+		container["_injected_by_goroutine_0"] = true
+	}
+
+	// all other events must be unaffected.
+	for i := 1; i < goroutines; i++ {
+		if events[i] == nil {
+			continue
+		}
+		containerRaw, err := events[i].Fields.GetValue("container")
+		require.NoError(t, err, "goroutine %d event must still have container field", i)
+		container := containerRaw.(mapstr.M)
+		assert.NotContains(t, container, "_injected_by_goroutine_0",
+			"goroutine %d's container must be independent from goroutine 0's result", i)
+	}
+}
+
+func TestAnnotatorRun_CacheMutationDoesNotAffectInFlightEvents(t *testing.T) {
+	const containerID = "inflight-cid"
+	processor := newAnnotatorWithMeta(t, containerID)
+
+	const readers = 40
+	const writers = 10
+
+	results := make([]*beat.Event, readers)
+	var wg sync.WaitGroup
+	wg.Add(readers + writers)
+
+	for i := 0; i < readers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			out, err := processor.Run(containerEvent(containerID))
+			if err != nil {
+				t.Errorf("reader %d: unexpected error: %v", i, err)
+				return
+			}
+			results[i] = out
+		}()
+	}
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			// Write a completely different metadata map to the same key.
+			newMeta := metaMap(containerID)
+			newMeta["kubernetes"].(mapstr.M)["pod"].(mapstr.M)["name"] = "replaced-pod"
+			processor.cache.set(containerID, newMeta)
+		}()
+	}
+
+	wg.Wait()
+
+	// every event that was annotated should have pod.name that is either
+	// "mypod" (original) or "replaced-pod" (updated)
+	for i, event := range results {
+		if event == nil {
+			continue
+		}
+		k8sRaw, err := event.Fields.GetValue("kubernetes")
+		if err != nil {
+			// event may have been processed before the first cache.set.
+			continue
+		}
+		k8s := k8sRaw.(mapstr.M)
+		pod := k8s["pod"].(mapstr.M)
+		name, ok := pod["name"].(string)
+		assert.True(t, ok, "event %d: pod.name must be a string", i)
+		assert.Contains(t, []string{"mypod", "replaced-pod"}, name,
+			"event %d: pod.name must be one of the two valid values", i)
+	}
+}
+
+func TestAnnotatorRun_SharedWrapper_EventIndependenceUnderConcurrency(t *testing.T) {
+	const goroutines = 60
+
+	cfg := config.MustNewConfigFrom(map[string]interface{}{
+		"lookup_fields": []string{"container.id"},
+	})
+	matcher, err := NewFieldMatcher(*cfg, logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+
+	cache := newCache(10 * time.Second)
+	annotator := &kubernetesAnnotator{
+		log:                 logptest.NewTestingLogger(t, selector),
+		cache:               cache,
+		matchers:            &Matchers{matchers: []Matcher{matcher}},
+		kubernetesAvailable: true,
+	}
+
+	// each goroutine has its own container ID in the cache.
+	for i := range goroutines {
+		cid := fmt.Sprintf("ev-%d", i)
+		cache.set(cid, metaMap(cid))
+	}
+
+	sharedConstructor := shared.New(func(_ *config.C, _ *logp.Logger) (beat.Processor, error) {
+		return annotator, nil
+	})
+	proc, err := sharedConstructor(nil, nil)
+	require.NoError(t, err)
+
+	type result struct {
+		event *beat.Event
+		cid   string
+		err   error
+	}
+	results := make([]result, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		cid := fmt.Sprintf("ev-%d", i)
+		go func() {
+			defer wg.Done()
+			out, runErr := proc.Run(containerEvent(cid))
+			results[i] = result{event: out, cid: cid, err: runErr}
+		}()
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		require.NoError(t, r.err, "goroutine %d must not return an error", i)
+		require.NotNil(t, r.event, "goroutine %d must receive a non-nil event", i)
+
+		// container.id must match this goroutine's own cache key.
+		containerRaw, getErr := r.event.Fields.GetValue("container")
+		require.NoError(t, getErr, "goroutine %d: event must have container field", i)
+		container := containerRaw.(mapstr.M)
+		assert.Equal(t, r.cid, container["id"],
+			"goroutine %d: container.id must equal its own cache key, not another goroutine's", i)
+
+		// kubernetes.pod.uid must also be specific to this goroutine's entry.
+		k8sRaw, getErr := r.event.Fields.GetValue("kubernetes")
+		require.NoError(t, getErr, "goroutine %d: event must have kubernetes field", i)
+		k8s := k8sRaw.(mapstr.M)
+		pod := k8s["pod"].(mapstr.M)
+		assert.Equal(t, "uid-"+r.cid, pod["uid"],
+			"goroutine %d: kubernetes.pod.uid must belong to its own cache entry", i)
+	}
+}

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
@@ -234,7 +234,7 @@ func TestNewProcessorConfigDefaultIndexers(t *testing.T) {
 
 // newAnnotatorForTest builds a kubernetesAnnotator with a pre-populated cache
 // (no network calls). The matcher looks up events by "container.id".
-func newAnnotatorForTest(t *testing.T, cacheKey string, meta mapstr.M) *kubernetesAnnotator {
+func newAnnotatorForTest(t testing.TB, cacheKey string, meta mapstr.M) *kubernetesAnnotator {
 	t.Helper()
 
 	cfg := config.MustNewConfigFrom(map[string]interface{}{

--- a/libbeat/processors/shared/shared.go
+++ b/libbeat/processors/shared/shared.go
@@ -79,9 +79,6 @@ func New(constructor processors.Constructor) processors.Constructor {
 func (p *SharedProcessorWithClose) Close() error {
 	p.sharedProcessorMu.Lock()
 	defer p.sharedProcessorMu.Unlock()
-	if p.refCount < 0 {
-		return nil
-	}
 	p.refCount--
 	if p.refCount == 0 {
 		delete(p.sharedProcessors, p.hash)

--- a/libbeat/processors/shared/shared.go
+++ b/libbeat/processors/shared/shared.go
@@ -27,35 +27,36 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-type SharedProcessorWithClose struct {
+type sharedProcessorWithClose struct {
 	beat.Processor
 	hash     uint64
 	refCount int
 
-	sharedProcessors  map[uint64]*SharedProcessorWithClose
+	sharedProcessors  map[uint64]*sharedProcessorWithClose
 	sharedProcessorMu *sync.Mutex
 }
 
 // New wraps a processor constructor to return a shared processor.
 // The shared processor will be shared across all processors with the same configuration.
 // The shared processor will be closed when the last processor using it is closed.
+// Warning: the processor is built only once and then reused. Subsequent calls ignore the provided logger.
+// Warning: To be used in conjunction with SafeProcessor. Ref: https://github.com/elastic/beats/blob/5586a1dcc31a748de8805e68c07094d08291fd7c/libbeat/processors/safe_processor.go#L133
 func New(constructor processors.Constructor) processors.Constructor {
-	sharedProcessors := make(map[uint64]*SharedProcessorWithClose)
+	sharedProcessors := make(map[uint64]*sharedProcessorWithClose)
 	sharedProcessorMu := &sync.Mutex{}
 
 	return func(cfg *config.C, logger *logp.Logger) (beat.Processor, error) {
+		hash := uint64(0)
+		if cfg != nil {
+			var err error
+			hash, err = cfgfile.HashConfig(cfg)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		sharedProcessorMu.Lock()
 		defer sharedProcessorMu.Unlock()
-
-		hash, err := cfgfile.HashConfig(cfg)
-		if cfg == nil {
-			err = nil
-			hash = 0
-		}
-		if err != nil {
-			return nil, err
-		}
-
 		if p, ok := sharedProcessors[hash]; ok {
 			p.refCount++
 			return p, nil
@@ -71,12 +72,12 @@ func New(constructor processors.Constructor) processors.Constructor {
 			return proc, nil
 		}
 
-		sharedProcessors[hash] = &SharedProcessorWithClose{Processor: proc, hash: hash, sharedProcessors: sharedProcessors, sharedProcessorMu: sharedProcessorMu, refCount: 1}
+		sharedProcessors[hash] = &sharedProcessorWithClose{Processor: proc, hash: hash, sharedProcessors: sharedProcessors, sharedProcessorMu: sharedProcessorMu, refCount: 1}
 		return sharedProcessors[hash], nil
 	}
 }
 
-func (p *SharedProcessorWithClose) Close() error {
+func (p *sharedProcessorWithClose) Close() error {
 	p.sharedProcessorMu.Lock()
 	defer p.sharedProcessorMu.Unlock()
 	p.refCount--

--- a/libbeat/processors/shared/shared.go
+++ b/libbeat/processors/shared/shared.go
@@ -14,7 +14,6 @@ type SharedProcessorWithClose struct {
 	beat.Processor
 	hash     uint64
 	refCount int
-	refLock  sync.RWMutex
 
 	sharedProcessors  map[uint64]*SharedProcessorWithClose
 	sharedProcessorMu *sync.Mutex
@@ -41,9 +40,7 @@ func New(constructor processors.Constructor) processors.Constructor {
 		}
 
 		if p, ok := sharedProcessors[hash]; ok {
-			p.refLock.Lock()
 			p.refCount++
-			p.refLock.Unlock()
 			return p, nil
 		}
 
@@ -65,22 +62,13 @@ func New(constructor processors.Constructor) processors.Constructor {
 func (p *SharedProcessorWithClose) Close() error {
 	p.sharedProcessorMu.Lock()
 	defer p.sharedProcessorMu.Unlock()
-	p.refLock.Lock()
-	defer p.refLock.Unlock()
 	if p.refCount < 0 {
 		return nil
 	}
 	p.refCount--
 	if p.refCount == 0 {
-		p.deleteFromSharedMap()
+		delete(p.sharedProcessors, p.hash)
 		return processors.Close(p.Processor)
 	}
 	return nil
-}
-
-func (p *SharedProcessorWithClose) deleteFromSharedMap() {
-	if _, ok := p.sharedProcessors[p.hash]; !ok {
-		return
-	}
-	delete(p.sharedProcessors, p.hash)
 }

--- a/libbeat/processors/shared/shared.go
+++ b/libbeat/processors/shared/shared.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package shared
 
 import (

--- a/libbeat/processors/shared/shared.go
+++ b/libbeat/processors/shared/shared.go
@@ -1,0 +1,91 @@
+package shared
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+type SharedProcessor struct {
+	beat.Processor
+}
+
+type SharedProcessorWithClose struct {
+	beat.Processor
+	hash     uint64
+	refCount int
+	refLock  sync.RWMutex
+
+	sharedProcessors  map[uint64]*SharedProcessorWithClose
+	sharedProcessorMu *sync.Mutex
+}
+
+// New wraps a processor constructor to return a shared processor.
+// The shared processor will be shared across all processors with the same configuration.
+// The shared processor will be closed when the last processor using it is closed.
+func New(constructor processors.Constructor) processors.Constructor {
+	sharedProcessors := make(map[uint64]*SharedProcessorWithClose)
+	sharedProcessorMu := &sync.Mutex{}
+
+	return func(cfg *config.C, logger *logp.Logger) (beat.Processor, error) {
+		sharedProcessorMu.Lock()
+		defer sharedProcessorMu.Unlock()
+
+		hash, err := cfgfile.HashConfig(cfg)
+		if cfg == nil {
+			err = nil
+			hash = 0
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if p, ok := sharedProcessors[hash]; ok {
+			p.refLock.Lock()
+			p.refCount++
+			p.refLock.Unlock()
+			return p, nil
+		}
+
+		proc, err := constructor(cfg, logger)
+		if err != nil {
+			return nil, err
+		}
+		// if the processor does not implement `Closer` it does not need a wrap.
+		// We can extend this in future, if needed.
+		if _, ok := proc.(processors.Closer); !ok {
+			return proc, nil
+		}
+
+		sharedProcessors[hash] = &SharedProcessorWithClose{Processor: proc, hash: hash, sharedProcessors: sharedProcessors, sharedProcessorMu: sharedProcessorMu}
+		return sharedProcessors[hash], nil
+	}
+}
+
+func (p *SharedProcessorWithClose) Close() error {
+	p.sharedProcessorMu.Lock()
+	defer p.sharedProcessorMu.Unlock()
+	p.refLock.Lock()
+	defer p.refLock.Unlock()
+	if p.refCount < 0 {
+		return nil
+	}
+	p.refCount--
+	if p.refCount == 0 {
+		p.deleteFromSharedMap()
+		return processors.Close(p.Processor)
+	}
+	return nil
+}
+
+// NOTE: To be called while holding the sharedProcessorMu lock to ensure.
+func (p *SharedProcessorWithClose) deleteFromSharedMap() {
+	if _, ok := p.sharedProcessors[p.hash]; !ok {
+		return
+	}
+	delete(p.sharedProcessors, p.hash)
+}

--- a/libbeat/processors/shared/shared.go
+++ b/libbeat/processors/shared/shared.go
@@ -10,10 +10,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-type SharedProcessor struct {
-	beat.Processor
-}
-
 type SharedProcessorWithClose struct {
 	beat.Processor
 	hash     uint64
@@ -61,7 +57,7 @@ func New(constructor processors.Constructor) processors.Constructor {
 			return proc, nil
 		}
 
-		sharedProcessors[hash] = &SharedProcessorWithClose{Processor: proc, hash: hash, sharedProcessors: sharedProcessors, sharedProcessorMu: sharedProcessorMu}
+		sharedProcessors[hash] = &SharedProcessorWithClose{Processor: proc, hash: hash, sharedProcessors: sharedProcessors, sharedProcessorMu: sharedProcessorMu, refCount: 1}
 		return sharedProcessors[hash], nil
 	}
 }
@@ -82,7 +78,6 @@ func (p *SharedProcessorWithClose) Close() error {
 	return nil
 }
 
-// NOTE: To be called while holding the sharedProcessorMu lock to ensure.
 func (p *SharedProcessorWithClose) deleteFromSharedMap() {
 	if _, ok := p.sharedProcessors[p.hash]; !ok {
 		return

--- a/libbeat/processors/shared/shared_test.go
+++ b/libbeat/processors/shared/shared_test.go
@@ -141,28 +141,12 @@ func TestSharedProcessor_CloseUnderlyingWhenLastUserGone(t *testing.T) {
 			}
 
 			if tc.expectClosed {
-				assert.Equal(t, int64(1), fp.closeCalls.Load())
+				assert.Equal(t, int64(1), fp.closeCalls.Load(), "expected processor to be closed once")
 			} else {
-				assert.Equal(t, int64(0), fp.closeCalls.Load())
+				assert.Equal(t, int64(0), fp.closeCalls.Load(), "didn't expect processor to be closed")
 			}
 		})
 	}
-}
-
-func TestSharedProcessor_DoubleCloseIsHarmless(t *testing.T) {
-	fp := &fakeProcessor{}
-	constructor := shared.New(newFakeConstructor(fp))
-	cfg := config.MustNewConfigFrom(map[string]interface{}{"k": "v"})
-
-	p1, err := constructor(cfg, nil)
-	require.NoError(t, err)
-	p2, err := constructor(cfg, nil)
-	require.NoError(t, err)
-
-	require.NoError(t, processors.Close(p1))
-	require.NoError(t, processors.Close(p2))
-	require.NoError(t, processors.Close(p2))
-	assert.Equal(t, int64(1), fp.closeCalls.Load())
 }
 
 func TestNew_ConcurrentSameConfig_NoRace(t *testing.T) {

--- a/libbeat/processors/shared/shared_test.go
+++ b/libbeat/processors/shared/shared_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build linux || darwin || windows
-
 package shared_test
 
 import (
@@ -72,7 +70,7 @@ func TestNew_SameConfigReturnsSameInstance(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), created.Load())
-	assert.True(t, p1 == p2)
+	assert.Equal(t, p1, p2)
 }
 
 func TestNew_DifferentConfigsReturnDifferentInstances(t *testing.T) {
@@ -88,7 +86,7 @@ func TestNew_DifferentConfigsReturnDifferentInstances(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(2), created.Load())
-	assert.False(t, pA == pB)
+	assert.NotEqual(t, pA, pB)
 }
 
 func TestNew_NilConfigReturnsSameInstance(t *testing.T) {
@@ -104,7 +102,7 @@ func TestNew_NilConfigReturnsSameInstance(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), created.Load())
-	assert.True(t, p1 == p2)
+	assert.Equal(t, p1, p2)
 }
 
 func TestNew_NonCloserIsNotWrapped(t *testing.T) {
@@ -114,7 +112,7 @@ func TestNew_NonCloserIsNotWrapped(t *testing.T) {
 
 	p, err := constructor(nil, nil)
 	require.NoError(t, err)
-	assert.True(t, p == inner)
+	assert.Equal(t, p, inner)
 }
 
 func TestSharedProcessor_CloseUnderlyingWhenLastUserGone(t *testing.T) {
@@ -195,7 +193,7 @@ func TestNew_ConcurrentSameConfig_NoRace(t *testing.T) {
 
 	assert.Equal(t, int32(1), created.Load())
 	for i, p := range results {
-		assert.True(t, p == results[0], "goroutine %d got different instance", i)
+		assert.Equalf(t, results[0], p, "goroutine %d got different instance", i)
 	}
 }
 

--- a/libbeat/processors/shared/shared_test.go
+++ b/libbeat/processors/shared/shared_test.go
@@ -313,3 +313,25 @@ func TestSharedProcessor_RunEventIsolation(t *testing.T) {
 	assert.NotContains(t, e2.Fields, "injected")
 	assert.Equal(t, 2, e2.Fields["id"])
 }
+
+func TestSafeProcessorWithSafe(t *testing.T) {
+	fp := &fakeProcessor{}
+	safeProcConstructor := processors.SafeWrap(shared.New(newFakeConstructor(fp)))
+	proc1, err := safeProcConstructor(nil, nil)
+	require.NoError(t, err)
+	proc2, err := safeProcConstructor(nil, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, processors.Close(proc1))
+	// processors should not be closed
+	require.Zero(t, fp.closeCalls.Load())
+
+	// double-close on first instance
+	require.NoError(t, processors.Close(proc1))
+	// processors should not be closed, yet
+	require.Zero(t, fp.closeCalls.Load())
+
+	require.NoError(t, processors.Close(proc2))
+	// processors should be closed now.
+	require.Equal(t, int64(1), fp.closeCalls.Load())
+}

--- a/libbeat/processors/shared/shared_test.go
+++ b/libbeat/processors/shared/shared_test.go
@@ -1,0 +1,317 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build linux || darwin || windows
+
+package shared_test
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/processors/shared"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+// fakeProcessor records Run/Close call counts.
+type fakeProcessor struct {
+	runCalls   atomic.Int64
+	closeCalls atomic.Int64
+}
+
+func (f *fakeProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	f.runCalls.Add(1)
+	return event, nil
+}
+
+func (f *fakeProcessor) Close() error   { f.closeCalls.Add(1); return nil }
+func (f *fakeProcessor) String() string { return "fake" }
+
+func newFakeConstructor(fp *fakeProcessor) processors.Constructor {
+	return func(_ *config.C, _ *logp.Logger) (beat.Processor, error) { return fp, nil }
+}
+
+func newEvent(id int) *beat.Event {
+	return &beat.Event{Fields: mapstr.M{"id": id}}
+}
+
+func TestNew_SameConfigReturnsSameInstance(t *testing.T) {
+	var created atomic.Int32
+	constructor := shared.New(func(_ *config.C, _ *logp.Logger) (beat.Processor, error) {
+		created.Add(1)
+		return &fakeProcessor{}, nil
+	})
+	cfg := config.MustNewConfigFrom(map[string]interface{}{"key": "value"})
+
+	p1, err := constructor(cfg, nil)
+	require.NoError(t, err)
+	p2, err := constructor(cfg, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), created.Load())
+	assert.True(t, p1 == p2)
+}
+
+func TestNew_DifferentConfigsReturnDifferentInstances(t *testing.T) {
+	var created atomic.Int32
+	constructor := shared.New(func(_ *config.C, _ *logp.Logger) (beat.Processor, error) {
+		created.Add(1)
+		return &fakeProcessor{}, nil
+	})
+
+	pA, err := constructor(config.MustNewConfigFrom(map[string]interface{}{"key": "A"}), nil)
+	require.NoError(t, err)
+	pB, err := constructor(config.MustNewConfigFrom(map[string]interface{}{"key": "B"}), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), created.Load())
+	assert.False(t, pA == pB)
+}
+
+func TestNew_NilConfigReturnsSameInstance(t *testing.T) {
+	var created atomic.Int32
+	constructor := shared.New(func(_ *config.C, _ *logp.Logger) (beat.Processor, error) {
+		created.Add(1)
+		return &fakeProcessor{}, nil
+	})
+
+	p1, err := constructor(nil, nil)
+	require.NoError(t, err)
+	p2, err := constructor(nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), created.Load())
+	assert.True(t, p1 == p2)
+}
+
+func TestNew_NonCloserIsNotWrapped(t *testing.T) {
+	type simpleProc struct{ beat.Processor }
+	inner := &simpleProc{}
+	constructor := shared.New(func(_ *config.C, _ *logp.Logger) (beat.Processor, error) { return inner, nil })
+
+	p, err := constructor(nil, nil)
+	require.NoError(t, err)
+	assert.True(t, p == inner)
+}
+
+func TestSharedProcessor_CloseUnderlyingWhenLastUserGone(t *testing.T) {
+	tests := []struct {
+		users, closesBeforeStop int
+		expectClosed            bool
+	}{
+		{2, 2, true},
+		{3, 2, false},
+		{3, 3, true},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("users=%d closes=%d", tc.users, tc.closesBeforeStop), func(t *testing.T) {
+			fp := &fakeProcessor{}
+			constructor := shared.New(newFakeConstructor(fp))
+			cfg := config.MustNewConfigFrom(map[string]interface{}{"k": "v"})
+
+			procs := make([]beat.Processor, tc.users)
+			for i := range procs {
+				p, err := constructor(cfg, nil)
+				require.NoError(t, err)
+				procs[i] = p
+			}
+			for i := 0; i < tc.closesBeforeStop; i++ {
+				require.NoError(t, processors.Close(procs[i]))
+			}
+
+			if tc.expectClosed {
+				assert.Equal(t, int64(1), fp.closeCalls.Load())
+			} else {
+				assert.Equal(t, int64(0), fp.closeCalls.Load())
+			}
+		})
+	}
+}
+
+func TestSharedProcessor_DoubleCloseIsHarmless(t *testing.T) {
+	fp := &fakeProcessor{}
+	constructor := shared.New(newFakeConstructor(fp))
+	cfg := config.MustNewConfigFrom(map[string]interface{}{"k": "v"})
+
+	p1, err := constructor(cfg, nil)
+	require.NoError(t, err)
+	p2, err := constructor(cfg, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, processors.Close(p1))
+	require.NoError(t, processors.Close(p2))
+	require.NoError(t, processors.Close(p2))
+	assert.Equal(t, int64(1), fp.closeCalls.Load())
+}
+
+func TestNew_ConcurrentSameConfig_NoRace(t *testing.T) {
+	const goroutines = 50
+	var created atomic.Int32
+	constructor := shared.New(func(_ *config.C, _ *logp.Logger) (beat.Processor, error) {
+		created.Add(1)
+		return &fakeProcessor{}, nil
+	})
+	cfg := config.MustNewConfigFrom(map[string]interface{}{"concurrent": true})
+
+	results := make([]beat.Processor, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			p, err := constructor(cfg, nil)
+			if err != nil {
+				t.Errorf("goroutine %d: %v", i, err)
+				return
+			}
+			results[i] = p
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), created.Load())
+	for i, p := range results {
+		assert.True(t, p == results[0], "goroutine %d got different instance", i)
+	}
+}
+
+func TestSharedProcessor_ConcurrentRun_NoRace(t *testing.T) {
+	const goroutines = 100
+	fp := &fakeProcessor{}
+	proc, err := shared.New(newFakeConstructor(fp))(nil, nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			out, err := proc.Run(newEvent(i))
+			if err != nil {
+				t.Errorf("goroutine %d: %v", i, err)
+				return
+			}
+			if out.Fields["id"] != i {
+				t.Errorf("goroutine %d: id mismatch: got %v", i, out.Fields["id"])
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int64(goroutines), fp.runCalls.Load())
+}
+
+func TestSharedProcessor_ConcurrentClose_NoRace(t *testing.T) {
+	const users = 20
+	fp := &fakeProcessor{}
+	constructor := shared.New(newFakeConstructor(fp))
+	cfg := config.MustNewConfigFrom(map[string]interface{}{"cc": true})
+
+	procs := make([]beat.Processor, users)
+	for i := range procs {
+		p, err := constructor(cfg, nil)
+		require.NoError(t, err)
+		procs[i] = p
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(users)
+	for i := 0; i < users; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			if err := processors.Close(procs[i]); err != nil {
+				t.Errorf("goroutine %d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int64(1), fp.closeCalls.Load())
+}
+
+func TestSharedProcessor_ConcurrentRunAndClose_NoRace(t *testing.T) {
+	const runners, closers = 40, 10
+	fp := &fakeProcessor{}
+	constructor := shared.New(newFakeConstructor(fp))
+
+	procs := make([]beat.Processor, closers+1)
+	for i := range procs {
+		p, err := constructor(nil, nil)
+		require.NoError(t, err)
+		procs[i] = p
+	}
+
+	stop := make(chan struct{})
+
+	var runWg sync.WaitGroup
+	runWg.Add(runners)
+	for i := 0; i < runners; i++ {
+		i := i
+		go func() {
+			defer runWg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = procs[0].Run(newEvent(i))
+				}
+			}
+		}()
+	}
+
+	var closeWg sync.WaitGroup
+	closeWg.Add(closers)
+	for i := 0; i < closers; i++ {
+		i := i
+		go func() {
+			defer closeWg.Done()
+			if err := processors.Close(procs[i+1]); err != nil {
+				t.Errorf("closer %d: %v", i, err)
+			}
+		}()
+	}
+	closeWg.Wait()
+	close(stop)
+	runWg.Wait()
+}
+
+func TestSharedProcessor_RunEventIsolation(t *testing.T) {
+	proc, err := shared.New(func(_ *config.C, _ *logp.Logger) (beat.Processor, error) {
+		return &fakeProcessor{}, nil
+	})(nil, nil)
+	require.NoError(t, err)
+
+	e1, err := proc.Run(newEvent(1))
+	require.NoError(t, err)
+	e2, err := proc.Run(newEvent(2))
+	require.NoError(t, err)
+
+	e1.Fields["injected"] = "mutation"
+	assert.NotContains(t, e2.Fields, "injected")
+	assert.Equal(t, 2, e2.Fields["id"])
+}


### PR DESCRIPTION
## Proposed commit message

Right now, per input processors are instantiated for every new harvester created. https://github.com/elastic/beats/blob/c37e794745210a3567eec5881406fa08cf5457e7/filebeat/channel/runner.go#L136-L150

In environments with a large number of log files, this will lead to excessive memory usage and can cause memory exhaustion/OOM issues.

Fix this by adding a shared processor wrapper, that will create one processor instance for a given config, no matter how many times it was instantiated. 


## Why is it important

Processors interested in using a "shared" state can opt-in by wrapping their constructors:

Before:

```go
processors.RegisterPlugin("add_kubernetes_metadata", New)
```

After:

```go
processors.RegisterPlugin("add_kubernetes_metadata", shared.New(New))
```

This will result in much less memory allocation over long term.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

You can test this with following config:

```
filebeat.inputs:

- type: filestream
  id: my-filestream-id1
  enabled: true
  paths:
    - /path/to/logs/*.log
  processors:
    - add_kubernetes_metadata

output.console:
  enabled: true
  # path: "/tmp/filebeat"
logging.level: debug
```

With new files being created, the memory increase will still be there, but slow and steady. Without my changes, the usage is drastic.
It is more drastic if you're testing this in k8s environment with `add_kubernetes_metadata` processor.

## Related issues

- Related https://github.com/elastic/integrations/issues/17250
