### PR TITLE
[Metricbeat][Elasticsearch] Remove local=true from Metricbeat elasticsearch module HTTP calls

### DIFF
--- a/changelog/fragments/1778848622-metricbeat-elasticsearch-cluster-state-no-local.yaml
+++ b/changelog/fragments/1778848622-metricbeat-elasticsearch-cluster-state-no-local.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+summary: Elasticsearch module cluster state requests no longer append local=true.
+component: metricbeat
+pr: https://github.com/elastic/beats/pull/50723
+issue: https://github.com/elastic/beats/issues/50722

--- a/changelog/fragments/1778848622-metricbeat-elasticsearch-cluster-state-no-local.yaml
+++ b/changelog/fragments/1778848622-metricbeat-elasticsearch-cluster-state-no-local.yaml
@@ -1,4 +1,4 @@
-kind: enhancement
+kind: bug-fix
 summary: Elasticsearch module cluster state requests no longer append local=true.
 component: metricbeat
 pr: https://github.com/elastic/beats/pull/50723

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -251,7 +251,15 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string, filte
 		queryParams = append(queryParams, filterPathQueryParam)
 	}
 
-	queryString := strings.Join(queryParams, "&")
+	queryString := ""
+	clusterStateURI := "_cluster/state"
+	if len(metrics) > 0 {
+		clusterStateURI += "/" + strings.Join(metrics, ",")
+	}
+
+	if len(filterPaths) > 0 {
+		queryString = "filter_path=" + strings.Join(filterPaths, ",")
+	}
 
 	content, err := fetchPath(http, resetURI, clusterStateURI, queryString)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -265,7 +265,7 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string, filte
 
 func GetIndexSettings(http *helper.HTTP, resetURI string, indexPattern string, filterPaths []string) (mapstr.M, error) {
 
-	queryParams := []string{"expand_wildcards=hidden,all"}
+	queryParams := []string{"local=true", "expand_wildcards=hidden,all"}
 	indicesSettingsURI := indexPattern + "/_settings"
 
 	if len(filterPaths) > 0 {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -161,7 +161,7 @@ func getNodeName(http *helper.HTTP, uri string) (string, error) {
 }
 
 func getMasterName(http *helper.HTTP, uri string) (string, error) {
-	content, err := fetchPath(http, uri, "_cluster/state/master_node", "local=true")
+	content, err := fetchPath(http, uri, "_cluster/state/master_node", "")
 	if err != nil {
 		return "", err
 	}
@@ -240,7 +240,7 @@ func GetLicense(http *helper.HTTP, resetURI string) (*License, error) {
 
 // GetClusterState returns cluster state information.
 func GetClusterState(http *helper.HTTP, resetURI string, metrics []string, filterPaths []string) (mapstr.M, error) {
-	queryParams := []string{"local=true"}
+	queryParams := []string{}
 	clusterStateURI := "_cluster/state"
 	if len(metrics) > 0 {
 		clusterStateURI += "/" + strings.Join(metrics, ",")
@@ -265,7 +265,7 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string, filte
 
 func GetIndexSettings(http *helper.HTTP, resetURI string, indexPattern string, filterPaths []string) (mapstr.M, error) {
 
-	queryParams := []string{"local=true", "expand_wildcards=hidden,all"}
+	queryParams := []string{"expand_wildcards=hidden,all"}
 	indicesSettingsURI := indexPattern + "/_settings"
 
 	if len(filterPaths) > 0 {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -240,19 +240,9 @@ func GetLicense(http *helper.HTTP, resetURI string) (*License, error) {
 
 // GetClusterState returns cluster state information.
 func GetClusterState(http *helper.HTTP, resetURI string, metrics []string, filterPaths []string) (mapstr.M, error) {
-	queryParams := []string{}
-	clusterStateURI := "_cluster/state"
-	if len(metrics) > 0 {
-		clusterStateURI += "/" + strings.Join(metrics, ",")
-	}
-
-	if len(filterPaths) > 0 {
-		filterPathQueryParam := "filter_path=" + strings.Join(filterPaths, ",")
-		queryParams = append(queryParams, filterPathQueryParam)
-	}
-
 	queryString := ""
 	clusterStateURI := "_cluster/state"
+
 	if len(metrics) > 0 {
 		clusterStateURI += "/" + strings.Join(metrics, ",")
 	}

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -59,7 +59,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return nil
 	}
 
-	content, err := m.HTTP.FetchContent()
+	content, err := m.FetchContent()
 	if err != nil {
 		return err
 	}

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 const (
-	statePath = "/_cluster/state/version,nodes,master_node,routing_table?local=true"
+	statePath = "/_cluster/state/version,nodes,master_node,routing_table"
 )
 
 // MetricSet type defines all fields of the MetricSet


### PR DESCRIPTION
## Summary

- Drop the `local=true` query string from cluster state requests (`getMasterName`, `GetClusterState`, and the `shard` metricset `_cluster/state/...` path).

Closes #50722

## Test plan

- [x] `go test ./metricbeat/module/elasticsearch/...`