### PR TITLE
docs: clarify Elasticsearch field metadata

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/_meta/fields.yml
@@ -2,6 +2,7 @@
   title: "Elasticsearch"
   description: >
     Elasticsearch module
+  # Keep this metadata near the module-level field aliases.
   release: ga
   settings: ["ssl", "http"]
   short_config: false


### PR DESCRIPTION
Small metadata comment cleanup for the Metricbeat Elasticsearch module.