### PR TITLE
filebeat: nil-check UDP RemoteAddr before formatting in debug log

### DIFF
--- a/changelog/fragments/1779131096-fix-udp-input-nil-remote-addr-panic.yaml
+++ b/changelog/fragments/1779131096-fix-udp-input-nil-remote-addr-panic.yaml
@@ -1,6 +1,6 @@
 kind: bug-fix
 
-summary: Stop the UDP input panicking on Windows when the conn returns a truncated datagram with a nil RemoteAddr.
+summary: Fixes UDP input crashes on Windows when oversized datagrams are received.
 
 component: filebeat
 

--- a/changelog/fragments/1779131096-fix-udp-input-nil-remote-addr-panic.yaml
+++ b/changelog/fragments/1779131096-fix-udp-input-nil-remote-addr-panic.yaml
@@ -1,0 +1,7 @@
+kind: bug-fix
+
+summary: Stop the UDP input panicking on Windows when the conn returns a truncated datagram with a nil RemoteAddr.
+
+component: filebeat
+
+issue: https://github.com/elastic/beats/issues/50718

--- a/filebeat/input/net/udp/input.go
+++ b/filebeat/input/net/udp/input.go
@@ -103,10 +103,17 @@ func (s *server) Run(ctx input.Context, evtChan chan<- netinput.DataMetadata, me
 	server := udp.New(&s.Config, func(data []byte, metadata inputsource.NetworkMetadata) {
 		now := time.Now()
 		metrics.EventReceived(len(data), now)
+		// On Windows the conn returns a nil RemoteAddr for truncated
+		// datagrams (WSAEMSGSIZE); calling .String() on it would
+		// panic and kill the input. See #50718.
+		remoteAddr := ""
+		if metadata.RemoteAddr != nil {
+			remoteAddr = metadata.RemoteAddr.String()
+		}
 		logger.Debugw(
 			"Data received",
 			"bytes", len(data),
-			"remote_address", metadata.RemoteAddr.String(),
+			"remote_address", remoteAddr,
 			"truncated", metadata.Truncated)
 
 		evtChan <- netinput.DataMetadata{

--- a/filebeat/input/net/udp/input_test.go
+++ b/filebeat/input/net/udp/input_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -106,4 +107,61 @@ func TestInput(t *testing.T) {
 	default:
 		// No more events on the channel, test passed
 	}
+}
+
+// TestInputOversizedDatagram sends a datagram larger than max_message_size and
+// checks the input keeps running. On Windows an oversized read returns a nil
+// RemoteAddr, which used to panic the input while formatting the debug log
+// (#50718). A panic here would crash the test binary, so simply reaching the
+// end of the test is the assertion.
+func TestInputOversizedDatagram(t *testing.T) {
+	serverAddr := "127.0.0.1:9043"
+	wg := sync.WaitGroup{}
+	inp, err := configure(conf.MustNewConfigFrom(map[string]any{
+		"host":             serverAddr,
+		"max_message_size": 64,
+	}))
+	if err != nil {
+		t.Fatalf("cannot create input: %s", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	v2Ctx := v2.Context{
+		ID:              t.Name(),
+		Cancelation:     ctx,
+		Logger:          logp.NewNopLogger(),
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+
+	metrics := inp.InitMetrics("udp", v2Ctx.MetricsRegistry, v2Ctx.Logger)
+	c := make(chan netinput.DataMetadata, 10)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := inp.Run(v2Ctx, c, metrics); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("input exited with error: %s", err)
+			}
+		}
+	}()
+
+	// Allow the UDP server to start
+	runtime.Gosched()
+
+	// A datagram several times larger than max_message_size. It is sent a few
+	// times so a dropped packet on a slow runner doesn't leave the truncation
+	// path unexercised.
+	oversized := strings.Repeat("x", 256)
+	nettest.RunUDPClient(t, serverAddr, []string{oversized, oversized, oversized})
+
+	select {
+	case <-c:
+		// The oversized datagram was processed without panicking.
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the oversized datagram to be processed")
+	}
+
+	cancel()
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes #50718. The v2 UDP input crashes on Windows when a datagram exceeds `max_message_size`: `conn.ReadFrom` returns a nil `addr` (the known `WSAEMSGSIZE` behavior), the dgram handler passes that through to the callback, and the callback unconditionally calls `metadata.RemoteAddr.String()` for a debug log. That panics, the input tries to rebind, Windows hasn't released the port yet, and the input exits fatally.

The non-v2 input had the same bug fixed in #33837 (Nov 2022); the regression slipped in with #41059 (Oct 2024) when the debug log moved into the v2 callback path.

The fix is the same shape: guard `.String()` against a nil `RemoteAddr` and log an empty string instead. Truncated-datagram detection upstream is unchanged.

Fixes #50718