### PR TITLE
Mount Git alternates in crossbuild containers

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -351,16 +351,6 @@ func (b GolangCrossBuilder) Build() error {
 		args = append(args, "-v", hostDir+":/go/pkg/mod:ro")
 	}
 
-	// Buildkite reference clones keep some objects in host-side alternates.
-	// Go's VCS stamping runs inside Docker, so those object dirs must be visible.
-	gitMounts, err := gitDockerVolumeMounts(repoInfo.RootDir, mountPoint)
-	if err != nil {
-		return err
-	}
-	for _, mount := range gitMounts {
-		args = append(args, "-v", mount.dockerArg())
-	}
-
 	if b.Platform == "darwin/amd64" {
 		fmt.Printf(">> %v: Forcing DEV=0 for %s: https://github.com/elastic/golang-crossbuild/issues/217\n", b.Target, b.Platform)
 		args = append(args, "--env", "DEV=0")
@@ -378,6 +368,16 @@ func (b GolangCrossBuilder) Build() error {
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 	)
+
+	// Buildkite reference clones keep some objects in host-side alternates.
+	// Go's VCS stamping runs inside Docker, so those object dirs must be visible.
+	gitMounts, err := gitDockerVolumeMounts(repoInfo.RootDir, mountPoint)
+	if err != nil {
+		return err
+	}
+	for _, mount := range gitMounts {
+		args = append(args, "-v", mount.dockerArg())
+	}
 
 	args = append(args,
 		image,

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -39,6 +39,12 @@ import (
 
 const defaultCrossBuildTarget = "golangCrossBuild"
 
+type dockerVolumeMount struct {
+	hostPath      string
+	containerPath string
+	readOnly      bool
+}
+
 // Platforms contains the set of target platforms for cross-builds. It can be
 // modified at runtime by setting the PLATFORMS environment variable.
 // See NewPlatformList for details about platform filtering expressions.
@@ -345,6 +351,16 @@ func (b GolangCrossBuilder) Build() error {
 		args = append(args, "-v", hostDir+":/go/pkg/mod:ro")
 	}
 
+	// Buildkite reference clones keep some objects in host-side alternates.
+	// Go's VCS stamping runs inside Docker, so those object dirs must be visible.
+	gitMounts, err := gitDockerVolumeMounts(repoInfo.RootDir, mountPoint)
+	if err != nil {
+		return err
+	}
+	for _, mount := range gitMounts {
+		args = append(args, "-v", mount.dockerArg())
+	}
+
 	if b.Platform == "darwin/amd64" {
 		fmt.Printf(">> %v: Forcing DEV=0 for %s: https://github.com/elastic/golang-crossbuild/issues/217\n", b.Target, b.Platform)
 		args = append(args, "--env", "DEV=0")
@@ -373,6 +389,103 @@ func (b GolangCrossBuilder) Build() error {
 	)
 
 	return dockerRun(args...)
+}
+
+func (m dockerVolumeMount) dockerArg() string {
+	arg := m.hostPath + ":" + m.containerPath
+	if m.readOnly {
+		arg += ":ro"
+	}
+	return arg
+}
+
+func gitDockerVolumeMounts(repoRoot, containerRepoRoot string) ([]dockerVolumeMount, error) {
+	objectsDir, err := gitPath(repoRoot, "objects")
+	if err != nil {
+		log.Printf("crossBuild: skipping git alternate mounts: %v", err)
+		return nil, nil
+	}
+
+	alternatesPath, err := gitPath(repoRoot, "objects/info/alternates")
+	if err != nil {
+		log.Printf("crossBuild: skipping git alternate mounts: %v", err)
+		return nil, nil
+	}
+
+	alternates, err := os.ReadFile(alternatesPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read git alternates file %q: %w", alternatesPath, err)
+	}
+
+	containerObjectsDir := containerPathForHostPath(objectsDir, repoRoot, containerRepoRoot)
+	return gitAlternateObjectDirMounts(objectsDir, containerObjectsDir, alternates), nil
+}
+
+func gitPath(repoRoot, path string) (string, error) {
+	out, err := sh.Output("git", "-C", repoRoot, "rev-parse", "--git-path", path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve git path %q for %q: %w", path, repoRoot, err)
+	}
+
+	resolved := strings.TrimSpace(out)
+	if resolved == "" {
+		return "", fmt.Errorf("git path %q for %q resolved to an empty path", path, repoRoot)
+	}
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(repoRoot, resolved)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func gitAlternateObjectDirMounts(objectsDir, containerObjectsDir string, alternates []byte) []dockerVolumeMount {
+	var mounts []dockerVolumeMount
+	seen := map[string]struct{}{}
+
+	for _, line := range strings.Split(string(alternates), "\n") {
+		alternate := strings.TrimSpace(line)
+		if alternate == "" || strings.HasPrefix(alternate, "#") {
+			continue
+		}
+
+		hostPath := alternate
+		containerPath := alternate
+		if !filepath.IsAbs(alternate) {
+			hostPath = filepath.Join(objectsDir, alternate)
+			containerPath = filepath.Join(containerObjectsDir, filepath.ToSlash(alternate))
+		}
+
+		hostPath = filepath.Clean(hostPath)
+		containerPath = filepath.ToSlash(filepath.Clean(containerPath))
+		if _, found := seen[containerPath]; found {
+			continue
+		}
+
+		info, err := os.Stat(hostPath)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+
+		seen[containerPath] = struct{}{}
+		mounts = append(mounts, dockerVolumeMount{
+			hostPath:      hostPath,
+			containerPath: containerPath,
+			readOnly:      true,
+		})
+	}
+
+	return mounts
+}
+
+func containerPathForHostPath(hostPath, hostRepoRoot, containerRepoRoot string) string {
+	rel, err := filepath.Rel(hostRepoRoot, hostPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(filepath.Clean(hostPath))
+	}
+
+	return filepath.ToSlash(filepath.Join(containerRepoRoot, rel))
 }
 
 // DockerChown chowns files generated during build. EXEC_UID and EXEC_GID must

--- a/dev-tools/mage/crossbuild_test.go
+++ b/dev-tools/mage/crossbuild_test.go
@@ -1,0 +1,103 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitAlternateObjectDirMounts(t *testing.T) {
+	tmp := t.TempDir()
+	objectsDir := filepath.Join(tmp, "repo", ".git", "objects")
+	containerObjectsDir := "/go/src/github.com/elastic/beats/.git/objects"
+	absoluteAlternate := filepath.Join(tmp, "mirror.git", "objects")
+	relativeAlternate := filepath.Join(tmp, "other.git", "objects")
+	missingAlternate := filepath.Join(tmp, "missing.git", "objects")
+
+	require.NoError(t, os.MkdirAll(objectsDir, 0755), "objects dir setup must succeed")
+	require.NoError(t, os.MkdirAll(absoluteAlternate, 0755), "absolute alternate setup must succeed")
+	require.NoError(t, os.MkdirAll(relativeAlternate, 0755), "relative alternate setup must succeed")
+
+	relativeEntry, err := filepath.Rel(objectsDir, relativeAlternate)
+	require.NoError(t, err, "relative alternate path must be computed")
+	missingEntry, err := filepath.Rel(objectsDir, missingAlternate)
+	require.NoError(t, err, "missing alternate path must be computed")
+
+	mounts := gitAlternateObjectDirMounts(
+		objectsDir,
+		containerObjectsDir,
+		[]byte(absoluteAlternate+"\n"+relativeEntry+"\n"+missingEntry+"\n# comment\n\n"+absoluteAlternate+"\n"),
+	)
+
+	expectedRelativeContainerPath := filepath.ToSlash(filepath.Clean(filepath.Join(containerObjectsDir, relativeEntry)))
+	assert.Equal(
+		t,
+		[]dockerVolumeMount{
+			{
+				hostPath:      filepath.Clean(absoluteAlternate),
+				containerPath: filepath.ToSlash(filepath.Clean(absoluteAlternate)),
+				readOnly:      true,
+			},
+			{
+				hostPath:      filepath.Clean(relativeAlternate),
+				containerPath: expectedRelativeContainerPath,
+				readOnly:      true,
+			},
+		},
+		mounts,
+		"expected existing alternates to be mounted read-only without duplicates",
+	)
+}
+
+func TestContainerPathForHostPath(t *testing.T) {
+	repoRoot := filepath.Join(string(filepath.Separator), "tmp", "checkout")
+	containerRepoRoot := "/go/src/github.com/elastic/beats"
+
+	tests := []struct {
+		name     string
+		hostPath string
+		expected string
+	}{
+		{
+			name:     "inside repo",
+			hostPath: filepath.Join(repoRoot, ".git", "objects"),
+			expected: "/go/src/github.com/elastic/beats/.git/objects",
+		},
+		{
+			name:     "outside repo",
+			hostPath: filepath.Join(string(filepath.Separator), "opt", "git-mirrors", "beats.git", "objects"),
+			expected: "/opt/git-mirrors/beats.git/objects",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				tc.expected,
+				containerPathForHostPath(tc.hostPath, repoRoot, containerRepoRoot),
+				"expected host paths under the repo to map into the container checkout",
+			)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed commit message

Mount Git alternate object directories into golang-crossbuild Docker containers.

Buildkite checks out Beats using reference clones:

```text
Skipping update and using existing mirror for repository git@github.com:elastic/beats.git at /opt/git-mirrors/git-github-com-elastic-beats-git.
git clone -v --reference /opt/git-mirrors/git-github-com-elastic-beats-git -- git@github.com:elastic/beats.git .
```

That checkout shape leaves `.git/objects/info/alternates` pointing at object directories under `/opt/git-mirrors`. The checkout itself is valid on the Buildkite host, but the crossbuild path runs `go build` inside a golang-crossbuild Docker container. Before this change, the container only had the Beats checkout mounted, not the host-side mirror object directory.

Go VCS stamping (`-buildvcs`, enabled by default for module builds) shells out to Git while building. In a reference clone, those Git commands may need borrowed objects from the alternate object directory to resolve repository metadata. When the alternate directory exists on the host but is not visible in the container, the repository appears incomplete from inside Docker and the build can fail even though the checkout is healthy on the agent.

This also explains why the failures showed up across unrelated Filebeat Go integration test PRs. The affected builds were tied to the CI checkout/build environment, not to the PR code under test:

| Build | Step | PR |
| --- | --- | --- |
| [32590](https://buildkite.com/elastic/filebeat/builds/32590#019e3a89-a0af-4c66-bcd0-48ea6905a9b4) | Filebeat: Go Integration Tests | [#50552](https://github.com/elastic/beats/pull/50552) |
| [32486](https://buildkite.com/elastic/filebeat/builds/32486#019e2bd1-7978-4fad-ad0c-bc37c589741e) | Filebeat: Go Integration Tests | [#50680](https://github.com/elastic/beats/pull/50680) |
| [32484](https://buildkite.com/elastic/filebeat/builds/32484#019e2bae-3924-499f-9ea0-b79aad789bf9) | Filebeat: Go Integration Tests | [#50257](https://github.com/elastic/beats/pull/50257) |
| [32473](https://buildkite.com/elastic/filebeat/builds/32473#019e2ada-186b-4510-974a-f012ada5030f) | Filebeat: Go Integration Tests | [#49762](https://github.com/elastic/beats/pull/49762) |

The fix teaches `GolangCrossBuilder` to detect `.git/objects/info/alternates` and mount each existing alternate object directory read-only into the crossbuild container. Absolute alternates, such as Buildkite's `/opt/git-mirrors/.../objects`, are mounted at the same absolute path in the container, which matches the path recorded by Git. Relative alternates are resolved relative to the checkout's object directory and mapped into the corresponding container checkout path.

The behavior is intentionally narrow:

- No alternates file means no extra Docker mounts.
- Missing alternate directories are ignored, matching Git's tolerance for stale alternates while avoiding broken Docker volume arguments.
- Alternate mounts are read-only.
- Duplicate container paths are de-duplicated.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~


## Disruptive User Impact

None expected. This only affects crossbuild Docker invocations from repositories that use Git alternates. The additional mounts are read-only and are only added when `.git/objects/info/alternates` exists.

## How to test this PR locally

Run the focused unit tests for the new helper behavior:

```shell
go test ./dev-tools/mage -run 'Test(GitAlternateObjectDirMounts|ContainerPathForHostPath)$'
```

The end-to-end validation is to rerun a Buildkite `Filebeat: Go Integration Tests` job on an agent that checks out Beats with `git clone --reference /opt/git-mirrors/...`. In that environment, the crossbuild `docker run` command should include read-only volume mounts for the alternate object directories.

~~## Related issues~~
- Closes https://github.com/elastic/beats/issues/50789


## Use cases

Buildkite agents use reference clones to avoid re-fetching the full Beats repository for every job. This PR keeps that optimization while making crossbuild containers see the same Git object graph that the host checkout sees.

The same behavior also helps any local or CI environment using Git alternates with the Beats crossbuild path.

## Screenshots

Not applicable.

## Logs

The relevant checkout evidence from the failing Buildkite log:

```text
Skipping update and using existing mirror for repository git@github.com:elastic/beats.git at /opt/git-mirrors/git-github-com-elastic-beats-git.
git clone -v --reference /opt/git-mirrors/git-github-com-elastic-beats-git -- git@github.com:elastic/beats.git .
```

The error:

```text
>> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=gcc, CXX=g++, GOARCH=amd64, GOARM=, GOOS=linux, GOTOOLCHAIN=local, PLATFORM_ID=linux-amd64]
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
Error: running "go build -o build/golang-crossbuild/filebeat-linux-amd64 -buildmode pie -trimpath -ldflags -s -X github.com/elastic/beats/v7/libbeat/version.buildTime=2026-05-18T10:04:57Z -X github.com/elastic/beats/v7/libbeat/version.commit=a35628e6e0a2946c25b976c8cee5dec2db7d3cd9" failed with exit code 1
Error: failed building for linux/amd64: exit status 1
failed building for linux/amd64: exit status 1
```