### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/azuread: add minimal-state adapter

### DIFF
--- a/changelog/fragments/1779159472-entityanalytics-entraid-minimal-state.yaml
+++ b/changelog/fragments/1779159472-entityanalytics-entraid-minimal-state.yaml
@@ -1,0 +1,33 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+summary: Add minimal-state mode for the EntraID entity analytics provider.
+description: |
+  The EntraID (Azure AD) entity analytics provider now supports
+  use_minimal_state: true, replacing persistent entity and group graph
+  storage with delta-query-based sync and in-memory transitive group
+  membership computation.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.4.1
 	github.com/cilium/ebpf v0.21.0
 	github.com/coder/websocket v1.8.14
-	github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d
+	github.com/elastic/entcollect v0.0.0-20260525234839-d7d7a2bf1510
 	github.com/elastic/gokrb5/v8 v8.0.0-20251105095404-23cc45e6a102
 	github.com/jimlambrt/gldap v0.1.14
 	github.com/mattn/go-sqlite3 v1.14.32

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/elastic/elastic-agent-system-metrics v0.14.3 h1:v867kcgCVguOX3AYIHEVn
 github.com/elastic/elastic-agent-system-metrics v0.14.3/go.mod h1:JNfnZrC0viAjlJRUzQKKuMpDlXgjXBn4WdWEXQF7jcA=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
 github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d h1:eKAtaQ8G4w9j3LctyOaSoYXnxfSGAcnix8y81esjtJs=
-github.com/elastic/entcollect v0.0.0-20260514013106-6d4034497b3d/go.mod h1:geO9V37Ibo+caL/8JpeqUE5ZJd8jzHjvOcEvAGEaZgI=
+github.com/elastic/entcollect v0.0.0-20260525234839-d7d7a2bf1510 h1:UOtItuwg13cYHSHaK6iIMaBlw9hWIFPWb/xVbYYBnK8=
+github.com/elastic/entcollect v0.0.0-20260525234839-d7d7a2bf1510/go.mod h1:geO9V37Ibo+caL/8JpeqUE5ZJd8jzHjvOcEvAGEaZgI=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQVCpGSRXmLqjEHpJKbR60rxh1nQZY4=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/fsnotify v1.6.1-0.20240920222514-49f82bdbc9e3 h1:UyNbxdkQiSfyipwsOCWAlO+ju3xXC61Z4prx/HBTtFk=

--- a/x-pack/filebeat/input/entityanalytics/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/conf_test.go
@@ -40,12 +40,11 @@ func TestConf_Validate(t *testing.T) {
 			},
 			WantErr: ErrProviderUnknown.Error(),
 		},
-		"err-minimal-state-legacy-only-provider": {
+		"ok-minimal-state-provider-azure": {
 			In: conf{
 				Provider:        azuread.Name,
 				UseMinimalState: true,
 			},
-			WantErr: ErrProviderUnknown.Error(),
 		},
 	}
 

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/equivalence_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/equivalence_test.go
@@ -1,0 +1,563 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package azuread
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/entcollect"
+	ecentraid "github.com/elastic/entcollect/provider/entraid"
+
+	mockauth "github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider/azuread/authenticator/mock"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher"
+	mockfetcher "github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/mock"
+)
+
+// TestEquivalence_FullSync runs both the legacy and minimal-state EntraID
+// providers against the same fixture data and asserts that the azure_ad.*
+// payloads are structurally equivalent.
+//
+// Scope: FullSync only. Incremental sync divergences — especially group
+// membership invisibility (user delta endpoints do not report group membership
+// changes) — are not covered.
+//
+// Input asymmetry: the legacy side reads Go structs from fetcher/mock (no HTTP,
+// no JSON parsing); the entcollect side unmarshals JSON from an httptest Graph
+// API mock. This test proves alignment on a shared logical dataset, not that
+// both providers produce identical output from live Graph API responses. JSON
+// parsing fidelity is tested separately in entcollect/provider/entraid.
+//
+// Intentional differences between the two providers (documented here):
+//   - Legacy emits start/end marker events; minimal-state does not.
+//   - Legacy stores entities, groups, and UUIDTree between syncs;
+//     minimal-state stores only delta URLs.
+//   - Legacy uses group delta queries for incremental group changes;
+//     minimal-state re-fetches all groups each sync.
+//   - Legacy puts MFA under azure_ad.mfa (fetcher.MFARegistrationDetails);
+//     entcollect puts MFA under user.risk.mfa (ecentraid.MFADetails).
+//     MFA user-ID coverage is compared; field values are not.
+//   - event.kind: asset present only in minimal-state (set by adapter).
+//   - event.action format differs: legacy uses "user-discovered" etc.;
+//     minimal-state uses entcollect.ActionDiscovered.
+//   - Device ownership: legacy resolves from state store (cloned full user
+//     objects with user.id); entcollect fetches via live API (raw
+//     []map[string]any). Output shapes differ structurally, so ownership
+//     is excluded from comparison. httptest serves empty ownership responses.
+//     Users migrating configs will see different ownership document shapes
+//     in production.
+func TestEquivalence_FullSync(t *testing.T) {
+	legacyUsers, legacyDevices, legacyUserGroups, legacyDeviceGroups, legacyMFAUserIDs := runLegacyFetch(t)
+
+	srv := startEquivGraphServer(t)
+	minimalDocs := runMinimalFullSync(t, srv)
+
+	minimalUsers := filterDocsByKind(minimalDocs, entcollect.KindUser)
+	minimalDevices := filterDocsByKind(minimalDocs, entcollect.KindDevice)
+
+	if len(legacyUsers) != len(minimalUsers) {
+		t.Fatalf("user count: legacy=%d, minimal=%d", len(legacyUsers), len(minimalUsers))
+	}
+	if len(legacyDevices) != len(minimalDevices) {
+		t.Fatalf("device count: legacy=%d, minimal=%d", len(legacyDevices), len(minimalDevices))
+	}
+
+	compareSortedEntries(t, "user", legacyUsers, minimalUsers)
+	compareSortedEntries(t, "device", legacyDevices, minimalDevices)
+
+	compareGroups(t, "user", legacyUserGroups, minimalUsers, "user.group")
+	compareGroups(t, "device", legacyDeviceGroups, minimalDevices, "device.group")
+
+	compareMFACoverage(t, legacyMFAUserIDs, minimalUsers)
+
+	// Sanity: verify we actually compared non-trivial data.
+	if len(legacyUsers) == 0 {
+		t.Error("sanity: no legacy users")
+	}
+	if len(legacyDevices) == 0 {
+		t.Error("sanity: no legacy devices")
+	}
+	if len(legacyUserGroups) == 0 {
+		t.Error("sanity: no legacy user groups")
+	}
+	if len(legacyDeviceGroups) == 0 {
+		t.Error("sanity: no legacy device groups")
+	}
+	if len(legacyMFAUserIDs) == 0 {
+		t.Error("sanity: no legacy MFA user IDs")
+	}
+}
+
+// runLegacyFetch runs the legacy doFetch path with the mock fetcher and
+// extracts entity payloads, group memberships, and MFA user-ID coverage.
+func runLegacyFetch(t *testing.T) (
+	users, devices []idPayload,
+	userGroups, deviceGroups map[string][]groupECS,
+	mfaUserIDs []string,
+) {
+	t.Helper()
+	a := azure{
+		conf:    conf{Dataset: "all", EnrichWith: []string{"mfa"}},
+		logger:  logptest.NewTestingLogger(t, "test-legacy"),
+		auth:    mockauth.New(""),
+		fetcher: mockfetcher.New(),
+	}
+	ss := &stateStore{
+		users:   make(map[uuid.UUID]*fetcher.User),
+		devices: make(map[uuid.UUID]*fetcher.Device),
+		groups:  make(map[uuid.UUID]*fetcher.Group),
+	}
+
+	_, _, err := a.doFetch(context.Background(), ss, true)
+	if err != nil {
+		t.Fatalf("legacy doFetch: %v", err)
+	}
+
+	userGroups = make(map[string][]groupECS)
+	for _, u := range ss.users {
+		b, err := json.Marshal(u.Fields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		users = append(users, idPayload{id: u.ID.String(), payload: b})
+
+		var groups []groupECS
+		u.TransitiveMemberOf.ForEach(func(gID uuid.UUID) {
+			g, ok := ss.groups[gID]
+			if !ok {
+				return
+			}
+			groups = append(groups, groupECS{ID: g.ID.String(), Name: g.Name})
+		})
+		if len(groups) > 0 {
+			userGroups[u.ID.String()] = groups
+		}
+
+		if u.MFA != nil {
+			mfaUserIDs = append(mfaUserIDs, u.ID.String())
+		}
+	}
+
+	deviceGroups = make(map[string][]groupECS)
+	for _, d := range ss.devices {
+		b, err := json.Marshal(d.Fields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		devices = append(devices, idPayload{id: d.ID.String(), payload: b})
+
+		var groups []groupECS
+		d.TransitiveMemberOf.ForEach(func(gID uuid.UUID) {
+			g, ok := ss.groups[gID]
+			if !ok {
+				return
+			}
+			groups = append(groups, groupECS{ID: g.ID.String(), Name: g.Name})
+		})
+		if len(groups) > 0 {
+			deviceGroups[d.ID.String()] = groups
+		}
+	}
+
+	return users, devices, userGroups, deviceGroups, mfaUserIDs
+}
+
+// runMinimalFullSync runs the entcollect FullSync path against the httptest
+// server and collects the published documents.
+func runMinimalFullSync(t *testing.T, srv *httptest.Server) []entcollect.Document {
+	t.Helper()
+
+	cfg := ecentraid.DefaultConfig()
+	cfg.TenantID = "test-tenant"
+	cfg.ClientID = "test-client"
+	cfg.ClientSecret = "test-secret"
+	cfg.LoginEndpoint = srv.URL
+	cfg.APIEndpoint = srv.URL + "/v1.0"
+	cfg.Dataset = "all"
+	cfg.EnrichWith = []string{"mfa"}
+
+	p := ecentraid.NewWithClient(cfg, srv.Client())
+
+	store := newEquivMemStore()
+	var docs []entcollect.Document
+	pub := func(_ context.Context, doc entcollect.Document) error {
+		docs = append(docs, doc)
+		return nil
+	}
+
+	log := slog.New(slog.NewTextHandler(&testWriter{t}, nil))
+	if err := p.FullSync(context.Background(), store, pub, log); err != nil {
+		t.Fatalf("minimal FullSync: %v", err)
+	}
+	return docs
+}
+
+// startEquivGraphServer starts an httptest server that serves Graph API
+// responses derived from the fetcher/mock fixture data. Responses use
+// proper delta envelopes with @odata.deltaLink and @odata.type annotations,
+// following the patterns from entcollect's testGraphMux.
+func startEquivGraphServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	var srvURL string
+	mux := http.NewServeMux()
+
+	deltaLink := func(path string) string {
+		return srvURL + path
+	}
+
+	// OAuth token endpoint.
+	mux.HandleFunc("POST /test-tenant/oauth2/v2.0/token", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+
+	// Users delta — always full (first call in FullSync after clearing cursors).
+	mux.HandleFunc("GET /v1.0/users/delta", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"@odata.deltaLink": deltaLink("/v1.0/users/delta?$deltatoken=full"),
+			"value":            mockUsersAsGraphJSON(),
+		})
+	})
+
+	// Devices delta — always full.
+	mux.HandleFunc("GET /v1.0/devices/delta", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"@odata.deltaLink": deltaLink("/v1.0/devices/delta?$deltatoken=full"),
+			"value":            mockDevicesAsGraphJSON(),
+		})
+	})
+
+	// Groups list.
+	groups := mockfetcher.GroupResponse
+	mux.HandleFunc("GET /v1.0/groups", func(w http.ResponseWriter, _ *http.Request) {
+		var groupList []map[string]any
+		for _, g := range groups {
+			groupList = append(groupList, map[string]any{
+				"id":          g.ID.String(),
+				"displayName": g.Name,
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": groupList})
+	})
+
+	// Group members — route /v1.0/groups/{id}/members.
+	groupMembers := buildGroupMembersMap()
+	mux.HandleFunc("GET /v1.0/groups/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		if len(parts) < 5 || parts[4] != "members" {
+			http.NotFound(w, r)
+			return
+		}
+		groupID := parts[3]
+		members := groupMembers[groupID]
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": members})
+	})
+
+	// Device registered owners/users — serve empty responses.
+	mux.HandleFunc("GET /v1.0/devices/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		if len(parts) < 5 {
+			http.NotFound(w, r)
+			return
+		}
+		relation := parts[4]
+		if relation != "registeredOwners" && relation != "registeredUsers" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	})
+
+	// MFA registration details.
+	mux.HandleFunc("GET /v1.0/reports/authenticationMethods/userRegistrationDetails", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": mockMFAAsGraphJSON()})
+	})
+
+	srv := httptest.NewServer(mux)
+	srvURL = srv.URL
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// mockUsersAsGraphJSON converts mock fetcher users into Graph API delta
+// response entries with "id" field injected back into the object.
+func mockUsersAsGraphJSON() []map[string]any {
+	var result []map[string]any
+	for _, u := range mockfetcher.UserResponse {
+		entry := make(map[string]any, len(u.Fields)+1)
+		entry["id"] = u.ID.String()
+		maps.Copy(entry, u.Fields)
+		result = append(result, entry)
+	}
+	return result
+}
+
+// mockDevicesAsGraphJSON converts mock fetcher devices into Graph API delta
+// response entries with "id" field injected back into the object.
+func mockDevicesAsGraphJSON() []map[string]any {
+	var result []map[string]any
+	for _, d := range mockfetcher.DeviceResponse {
+		entry := make(map[string]any, len(d.Fields)+1)
+		entry["id"] = d.ID.String()
+		maps.Copy(entry, d.Fields)
+		result = append(result, entry)
+	}
+	return result
+}
+
+// buildGroupMembersMap builds a map of group ID → []member for the httptest
+// server, using @odata.type annotations as the real Graph API does.
+func buildGroupMembersMap() map[string][]map[string]any {
+	result := make(map[string][]map[string]any)
+	for _, g := range mockfetcher.GroupResponse {
+		var members []map[string]any
+		for _, m := range g.Members {
+			var odataType string
+			switch m.Type {
+			case fetcher.MemberUser:
+				odataType = "#microsoft.graph.user"
+			case fetcher.MemberDevice:
+				odataType = "#microsoft.graph.device"
+			case fetcher.MemberGroup:
+				odataType = "#microsoft.graph.group"
+			}
+			members = append(members, map[string]any{
+				"id":          m.ID.String(),
+				"@odata.type": odataType,
+			})
+		}
+		result[g.ID.String()] = members
+	}
+	return result
+}
+
+// mockMFAAsGraphJSON converts mock fetcher MFA data into Graph API response
+// entries with the user "id" field included.
+func mockMFAAsGraphJSON() []map[string]any {
+	var result []map[string]any
+	for userID, mfa := range mockfetcher.MFAResponse {
+		entry := map[string]any{
+			"id":                    userID.String(),
+			"isMfaCapable":          mfa.IsMFACapable,
+			"isMfaRegistered":       mfa.IsMFARegistered,
+			"isPasswordlessCapable": mfa.IsPasswordlessCapable,
+			"isSsprCapable":         mfa.IsSsprCapable,
+			"isSsprEnabled":         mfa.IsSsprEnabled,
+			"isSsprRegistered":      mfa.IsSsprRegistered,
+			"methodsRegistered":     mfa.MethodsRegistered,
+			"userPreferredMethodForSecondaryAuthentication": mfa.UserPreferredMethodForSecondaryAuthentication,
+			"userType": mfa.UserType,
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// idPayload pairs an entity ID with its JSON-serialized azure_ad field blob.
+// Used to carry payloads from both the legacy and minimal-state paths into
+// compareSortedEntries.
+type idPayload struct {
+	id      string
+	payload json.RawMessage
+}
+
+// groupECS mirrors the ECS group shape emitted by both providers
+// (fetcher.GroupECS on the legacy side, ecentraid.GroupECS on the
+// entcollect side). JSON tags match the wire format so we can
+// unmarshal entcollect's group slices directly into this type.
+type groupECS struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// compareSortedEntries compares azure_ad field blobs between legacy and
+// minimal-state providers. Both sides are sorted by entity ID, then each
+// payload is round-tripped through map[string]any to normalize key ordering
+// before byte-level comparison. kind is "user" or "device" for error messages.
+func compareSortedEntries(t *testing.T, kind string, legacy []idPayload, minimalDocs []entcollect.Document) {
+	t.Helper()
+
+	slices.SortFunc(legacy, func(a, b idPayload) int { return cmp.Compare(a.id, b.id) })
+
+	minimalByID := make([]idPayload, 0, len(minimalDocs))
+	for _, doc := range minimalDocs {
+		adField := doc.Fields["azure_ad"]
+		raw, err := json.Marshal(adField)
+		if err != nil {
+			t.Fatal(err)
+		}
+		minimalByID = append(minimalByID, idPayload{id: doc.ID, payload: raw})
+	}
+	slices.SortFunc(minimalByID, func(a, b idPayload) int { return cmp.Compare(a.id, b.id) })
+
+	for i := range legacy {
+		if legacy[i].id != minimalByID[i].id {
+			t.Errorf("%s[%d] ID mismatch: legacy=%q, minimal=%q", kind, i, legacy[i].id, minimalByID[i].id)
+			continue
+		}
+
+		var legacyMap, minimalMap map[string]any
+		if err := json.Unmarshal(legacy[i].payload, &legacyMap); err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(minimalByID[i].payload, &minimalMap); err != nil {
+			t.Fatal(err)
+		}
+
+		legacyNorm, _ := json.Marshal(legacyMap)
+		minimalNorm, _ := json.Marshal(minimalMap)
+		if string(legacyNorm) != string(minimalNorm) {
+			t.Errorf("%s %q payload mismatch:\n  legacy:  %s\n  minimal: %s",
+				kind, legacy[i].id, legacyNorm, minimalNorm)
+		}
+	}
+}
+
+// compareGroups verifies that each entity's transitive group membership
+// matches between legacy and minimal-state. legacyGroups is keyed by entity
+// ID; minimalDocs are the entcollect documents. fieldKey is the document field
+// to extract groups from ("user.group" or "device.group"). Both sides are
+// sorted by group ID before element-wise comparison.
+func compareGroups(t *testing.T, kind string, legacyGroups map[string][]groupECS, minimalDocs []entcollect.Document, fieldKey string) {
+	t.Helper()
+
+	for _, doc := range minimalDocs {
+		legacyG := legacyGroups[doc.ID]
+		slices.SortFunc(legacyG, func(a, b groupECS) int { return cmp.Compare(a.ID, b.ID) })
+
+		var minimalG []groupECS
+		if raw, ok := doc.Fields[fieldKey]; ok {
+			b, err := json.Marshal(raw)
+			if err != nil {
+				t.Fatalf("%s %q: marshal minimal groups: %v", kind, doc.ID, err)
+			}
+			if err := json.Unmarshal(b, &minimalG); err != nil {
+				t.Fatalf("%s %q: unmarshal minimal groups: %v", kind, doc.ID, err)
+			}
+		}
+		slices.SortFunc(minimalG, func(a, b groupECS) int { return cmp.Compare(a.ID, b.ID) })
+
+		if len(legacyG) != len(minimalG) {
+			t.Errorf("%s %q group count mismatch: legacy=%d, minimal=%d", kind, doc.ID, len(legacyG), len(minimalG))
+			continue
+		}
+		for j := range legacyG {
+			if legacyG[j].ID != minimalG[j].ID || legacyG[j].Name != minimalG[j].Name {
+				t.Errorf("%s %q group[%d] mismatch: legacy=%+v, minimal=%+v",
+					kind, doc.ID, j, legacyG[j], minimalG[j])
+			}
+		}
+	}
+}
+
+// compareMFACoverage checks that the same set of user IDs received MFA
+// enrichment on both sides. It does not compare MFA field values because
+// the two providers use different struct types (fetcher.MFARegistrationDetails
+// vs ecentraid.MFADetails) at different field paths (azure_ad.mfa vs
+// user.risk.mfa).
+func compareMFACoverage(t *testing.T, legacyMFAUserIDs []string, minimalUsers []entcollect.Document) {
+	t.Helper()
+
+	slices.Sort(legacyMFAUserIDs)
+
+	var minimalMFAUserIDs []string
+	for _, doc := range minimalUsers {
+		if _, ok := doc.Fields["user.risk.mfa"]; ok {
+			minimalMFAUserIDs = append(minimalMFAUserIDs, doc.ID)
+		}
+	}
+	slices.Sort(minimalMFAUserIDs)
+
+	if len(legacyMFAUserIDs) != len(minimalMFAUserIDs) {
+		t.Errorf("MFA user-ID count mismatch: legacy=%d, minimal=%d", len(legacyMFAUserIDs), len(minimalMFAUserIDs))
+		return
+	}
+	for i := range legacyMFAUserIDs {
+		if legacyMFAUserIDs[i] != minimalMFAUserIDs[i] {
+			t.Errorf("MFA user-ID[%d] mismatch: legacy=%q, minimal=%q", i, legacyMFAUserIDs[i], minimalMFAUserIDs[i])
+		}
+	}
+}
+
+// filterDocsByKind returns only the documents matching the given EntityKind.
+func filterDocsByKind(docs []entcollect.Document, kind entcollect.EntityKind) []entcollect.Document {
+	var out []entcollect.Document
+	for _, d := range docs {
+		if d.Kind == kind {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// testWriter adapts testing.T for use as an io.Writer, routing all
+// output through t.Log so it appears in verbose test output.
+type testWriter struct{ t *testing.T }
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+// equivMemStore is a minimal in-memory implementation of entcollect.Store
+// for the equivalence test. It avoids the kvstore disk I/O that the legacy
+// provider's stateStore normally requires.
+type equivMemStore struct {
+	data map[string]json.RawMessage
+}
+
+func newEquivMemStore() *equivMemStore {
+	return &equivMemStore{data: make(map[string]json.RawMessage)}
+}
+
+func (m *equivMemStore) Get(key string, dst any) error {
+	raw, ok := m.data[key]
+	if !ok {
+		return entcollect.ErrKeyNotFound
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+func (m *equivMemStore) Set(key string, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	m.data[key] = raw
+	return nil
+}
+
+func (m *equivMemStore) Delete(key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *equivMemStore) Each(fn func(string, func(any) error) (bool, error)) error {
+	for k, v := range m.data {
+		cont, err := fn(k, func(dst any) error { return json.Unmarshal(v, dst) })
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return nil
+		}
+	}
+	return nil
+}

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/minimal.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/minimal.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package azuread
+
+import (
+	"time"
+
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/entcollect"
+	ecentraid "github.com/elastic/entcollect/provider/entraid"
+)
+
+func init() {
+	err := provider.RegisterMinimalStateProvider(Name, minimalProvider)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func minimalProvider(cfg *config.C, _ *logp.Logger) (entcollect.Provider, time.Duration, time.Duration, error) {
+	// localConf mirrors ecentraid.Config with config:"" tags for ucfg
+	// Unpack. The config tag names match the legacy azuread provider's
+	// config namespace so that existing beats YAML works unchanged.
+	// If ecentraid.Config gains a new field, add it here and in the
+	// mapping below; TestMinimalConfigRoundTrip will catch any drift.
+	type selection struct {
+		Users   []string `config:"users"`
+		Groups  []string `config:"groups"`
+		Devices []string `config:"devices"`
+	}
+	type localConf struct {
+		TenantID string `config:"tenant_id" validate:"required"`
+		ClientID string `config:"client_id" validate:"required"`
+		Secret   string `config:"secret"    validate:"required"`
+
+		LoginEndpoint string   `config:"login_endpoint"`
+		LoginScopes   []string `config:"login_scopes"`
+		APIEndpoint   string   `config:"api_endpoint"`
+
+		Dataset    string   `config:"dataset"`
+		EnrichWith []string `config:"enrich_with"`
+
+		Select selection `config:"select"`
+
+		SyncInterval   time.Duration `config:"sync_interval"`
+		UpdateInterval time.Duration `config:"update_interval"`
+	}
+
+	d := ecentraid.DefaultConfig()
+	lc := localConf{
+		LoginEndpoint: d.LoginEndpoint,
+		LoginScopes:   d.LoginScopes,
+		APIEndpoint:   d.APIEndpoint,
+		Dataset:       d.Dataset,
+		EnrichWith:    d.EnrichWith,
+		Select: selection{
+			Users:   d.SelectUsers,
+			Groups:  d.SelectGroups,
+			Devices: d.SelectDevices,
+		},
+		SyncInterval:   d.SyncInterval,
+		UpdateInterval: d.UpdateInterval,
+	}
+	if err := cfg.Unpack(&lc); err != nil {
+		return nil, 0, 0, err
+	}
+
+	ec := ecentraid.Config{
+		TenantID:       lc.TenantID,
+		ClientID:       lc.ClientID,
+		ClientSecret:   lc.Secret,
+		LoginEndpoint:  lc.LoginEndpoint,
+		LoginScopes:    lc.LoginScopes,
+		APIEndpoint:    lc.APIEndpoint,
+		Dataset:        lc.Dataset,
+		EnrichWith:     lc.EnrichWith,
+		SelectUsers:    lc.Select.Users,
+		SelectGroups:   lc.Select.Groups,
+		SelectDevices:  lc.Select.Devices,
+		SyncInterval:   lc.SyncInterval,
+		UpdateInterval: lc.UpdateInterval,
+	}
+
+	if err := ec.Validate(); err != nil {
+		return nil, 0, 0, err
+	}
+	return ecentraid.New(ec), ec.SyncInterval, ec.UpdateInterval, nil
+}

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/minimal_test.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package azuread
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	ecentraid "github.com/elastic/entcollect/provider/entraid"
+)
+
+// TestMinimalConfigRoundTrip verifies that every exported field of
+// ecentraid.Config is represented in the localConf mirror inside
+// minimalProvider. It does this in two ways:
+//
+//  1. Field-count assertion — if ecentraid.Config gains a field, the
+//     count check fails, forcing the developer to update localConf
+//     and this test.
+//  2. Functional round-trip — all fields are set to non-default sentinel
+//     values; the returned sync intervals must match, confirming that
+//     at least the duration fields are wired through end-to-end.
+func TestMinimalConfigRoundTrip(t *testing.T) {
+	const wantFields = 13
+	if got := reflect.TypeOf(ecentraid.Config{}).NumField(); got != wantFields {
+		t.Fatalf("ecentraid.Config has %d exported fields, want %d; "+
+			"update localConf inside minimalProvider and this test", got, wantFields)
+	}
+
+	wantSync := 48 * time.Hour
+	wantUpdate := 30 * time.Minute
+
+	cfg := config.MustNewConfigFrom(map[string]any{
+		"tenant_id":       "test-tenant",
+		"client_id":       "test-client",
+		"secret":          "test-secret",
+		"login_endpoint":  "https://login.example.com",
+		"login_scopes":    []string{"https://graph.example.com/.default"},
+		"api_endpoint":    "https://graph.example.com/v1.0",
+		"dataset":         "users",
+		"enrich_with":     []string{"mfa"},
+		"select.users":    []string{"displayName", "mail"},
+		"select.groups":   []string{"displayName"},
+		"select.devices":  []string{"displayName", "operatingSystem"},
+		"sync_interval":   wantSync.String(),
+		"update_interval": wantUpdate.String(),
+	})
+
+	_, gotSync, gotUpdate, err := minimalProvider(cfg, nil)
+	if err != nil {
+		t.Fatalf("minimalProvider returned unexpected error: %v", err)
+	}
+	if gotSync != wantSync {
+		t.Errorf("sync_interval: got %v, want %v", gotSync, wantSync)
+	}
+	if gotUpdate != wantUpdate {
+		t.Errorf("update_interval: got %v, want %v", gotUpdate, wantUpdate)
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics/provider/azuread: add minimal-state adapter

Register a MinimalStateProvider for the azure-ad entity analytics
provider. When use_minimal_state is enabled, the input delegates to
entcollect's EntraID provider instead of the legacy kvstore-based
implementation.

The localConf struct mirrors the existing beats config tags (including
"secret" and nested "select.*" fields) and maps them to the entcollect
ecentraid.Config. A field-count guard in TestMinimalConfigRoundTrip
detects config drift between the two structs.

For #49161

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #49161
- Depends elastic/entcollect#9

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
