### PR TITLE
Make the storage extension support generic

### DIFF
--- a/changelog/fragments/1780677760-filebeat-receiver-otel-file-storage-extension.yaml
+++ b/changelog/fragments/1780677760-filebeat-receiver-otel-file-storage-extension.yaml
@@ -1,0 +1,13 @@
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add support for the OpenTelemetry file_storage extension as a state store in Filebeat receiver mode.
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "filebeat"
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+pr: https://github.com/elastic/beats/pull/50792

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -79,7 +79,7 @@ type Filebeat struct {
 
 type PluginFactory func(beat.Info, *logp.Logger, statestore.States) []v2.Plugin
 
-var _ backend.WithESStateStoreExtension = (*Filebeat)(nil)
+var _ backend.WithStorageExtension = (*Filebeat)(nil)
 
 // New creates a new Filebeat pointer instance.
 func New(plugins PluginFactory) beat.Creator {
@@ -219,8 +219,8 @@ func (fb *Filebeat) WithOtelFactoryWrapper(wrapper cfgfile.FactoryWrapper) {
 	fb.otelStatusFactoryWrapper = wrapper
 }
 
-func (fb *Filebeat) WithESStateStoreExtension(esStateStoreExtension backend.Registry) {
-	fb.config.Registry.ESStorageExtension = esStateStoreExtension
+func (fb *Filebeat) WithStorageExtension(storeExtension backend.Registry) {
+	fb.config.Registry.StorageExtension = storeExtension
 }
 
 // loadModulesPipelines is called when modules are configured to do the initial

--- a/filebeat/beater/store.go
+++ b/filebeat/beater/store.go
@@ -47,10 +47,10 @@ var (
 )
 
 type sharedRegistries struct {
-	refCount   int
-	registry   *statestore.Registry
-	esRegistry *statestore.Registry
-	notifier   *es.Notifier
+	refCount    int
+	registry    *statestore.Registry
+	extRegistry *statestore.Registry
+	notifier    *es.Notifier
 }
 
 type filebeatStore struct {
@@ -118,15 +118,15 @@ func openStateStore(ctx context.Context, info beat.Info, logger *logp.Logger, cf
 		}
 
 		if features.IsElasticsearchStateStoreEnabled() {
-			switch cfg.ESStorageExtension {
+			switch cfg.StorageExtension {
 			case nil:
 				// The notifier is a concurrency-safe pub/sub broadcaster shared between
 				// the es.Registry (subscriber) and all filebeatStore wrappers (publishers).
 				// Multiple Notify() calls are idempotent, so sharing across wrappers is safe.
 				shared.notifier = es.NewNotifier()
-				shared.esRegistry = statestore.NewRegistry(es.New(ctx, logger, shared.notifier))
+				shared.extRegistry = statestore.NewRegistry(es.New(ctx, logger, shared.notifier))
 			default:
-				shared.esRegistry = statestore.NewRegistry(cfg.ESStorageExtension)
+				shared.extRegistry = statestore.NewRegistry(cfg.StorageExtension)
 			}
 		}
 
@@ -151,8 +151,8 @@ func (s *filebeatStore) Close() {
 	s.shared.refCount--
 	if s.shared.refCount == 0 {
 		_ = s.shared.registry.Close()
-		if s.shared.esRegistry != nil {
-			_ = s.shared.esRegistry.Close()
+		if s.shared.extRegistry != nil {
+			_ = s.shared.extRegistry.Close()
 		}
 		delete(globalStores, s.storeKey)
 	}
@@ -160,8 +160,8 @@ func (s *filebeatStore) Close() {
 
 // StoreFor returns the storage registry depending on the type. Default is the file store.
 func (s *filebeatStore) StoreFor(typ string) (*statestore.Store, error) {
-	if features.IsElasticsearchStateStoreEnabledForInput(typ) && s.shared.esRegistry != nil {
-		return s.shared.esRegistry.Get(s.storeName)
+	if features.IsElasticsearchStateStoreEnabledForInput(typ) && s.shared.extRegistry != nil {
+		return s.shared.extRegistry.Get(s.storeName)
 	}
 	return s.shared.registry.Get(s.storeName)
 }

--- a/filebeat/config/config.go
+++ b/filebeat/config/config.go
@@ -55,8 +55,11 @@ type Registry struct {
 	// extension when Backend is "otel_file_storage". The map is decoded into
 	// filestorage.Config using confmap (which honours mapstructure tags) at registry
 	// creation time. If nil, factory defaults are used.
-	FileStorage        map[string]any   `config:"otel_file_storage"`
-	ESStorageExtension backend.Registry `config:"-"`
+	FileStorage map[string]any `config:"otel_file_storage"`
+	// StorageExtension is an external state store backend injected at runtime
+	// (e.g. by an OTel storage extension when Filebeat runs as a receiver). It
+	// is not user-configurable, hence config:"-".
+	StorageExtension backend.Registry `config:"-"`
 }
 
 var DefaultConfig = Config{

--- a/libbeat/statestore/backend/backend.go
+++ b/libbeat/statestore/backend/backend.go
@@ -74,6 +74,6 @@ type Store interface {
 	SetID(id string)
 }
 
-type WithESStateStoreExtension interface {
-	WithESStateStoreExtension(esStoreExtension Registry)
+type WithStorageExtension interface {
+	WithStorageExtension(storeExtension Registry)
 }

--- a/x-pack/libbeat/cmd/instance/receiver.go
+++ b/x-pack/libbeat/cmd/instance/receiver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/monitoring/report/log"
 	"github.com/elastic/beats/v7/libbeat/statestore/backend"
+	"github.com/elastic/beats/v7/libbeat/statestore/backend/otelstorage"
 	_ "github.com/elastic/beats/v7/x-pack/libbeat/include"
 	"github.com/elastic/beats/v7/x-pack/otel/otelmanager"
 	otelstatus "github.com/elastic/beats/v7/x-pack/otel/status"
@@ -27,6 +28,7 @@ import (
 	metricreport "github.com/elastic/elastic-agent-system-metrics/report"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.opentelemetry.io/collector/receiver"
 )
 
@@ -38,6 +40,11 @@ type BeatReceiver struct {
 	Logger              *logp.Logger
 	bridge              *oteltelemetry.RegistryBridge
 	releaseSystemBridge func()
+	// ctx and id are retained so a generic OTel storage.Extension can be
+	// adapted into a backend.Registry (which obtains a storage.Client scoped to
+	// this receiver) when the beat resolves its configured storage extension.
+	ctx context.Context
+	id  component.ID
 }
 
 // NewBeatReceiver creates a BeatReceiver.  This will also create the beater and start the monitoring server if configured
@@ -110,6 +117,8 @@ func NewBeatReceiver(ctx context.Context, b *instance.Beat, creator beat.Creator
 		Logger:              b.Info.Logger,
 		bridge:              bridge,
 		releaseSystemBridge: releaseSystem,
+		ctx:                 ctx,
+		id:                  receiverID,
 	}, nil
 }
 
@@ -145,17 +154,17 @@ func (br *BeatReceiver) Start(host component.Host) error {
 		}
 	}
 
-	if w, ok := br.beater.(backend.WithESStateStoreExtension); ok {
+	if w, ok := br.beater.(backend.WithStorageExtension); ok {
 		if present, err := br.beat.RawConfig.Has("storage", -1); present && err == nil {
 			storageID, err := br.beat.RawConfig.String("storage", -1)
 			if err != nil {
 				return fmt.Errorf("error reading storage extension from config: %w", err)
 			}
-			esStorageExtension, err := br.getESStateStoreExtension(host, storageID)
+			storageExtension, err := br.getStorageExtension(host, storageID)
 			if err != nil {
-				return fmt.Errorf("error getting ES state store extension: %w", err)
+				return fmt.Errorf("error getting storage extension: %w", err)
 			}
-			w.WithESStateStoreExtension(esStorageExtension)
+			w.WithStorageExtension(storageExtension)
 		}
 	}
 
@@ -235,19 +244,27 @@ func (br *BeatReceiver) stopMonitoring() error {
 	return nil
 }
 
-func (br *BeatReceiver) getESStateStoreExtension(host component.Host, storageExtension string) (backend.Registry, error) {
+func (br *BeatReceiver) getStorageExtension(host component.Host, storageExtensionID string) (backend.Registry, error) {
 	componentID := component.ID{}
-	err := componentID.UnmarshalText([]byte(storageExtension))
+	err := componentID.UnmarshalText([]byte(storageExtensionID))
 	if err != nil {
-		return nil, fmt.Errorf("invalid component id for ES state store extension (%v): %w", []byte(storageExtension), err)
+		return nil, fmt.Errorf("invalid component id for storage extension (%v): %w", []byte(storageExtensionID), err)
 	}
-	extension, ok := host.GetExtensions()[componentID]
+	ext, ok := host.GetExtensions()[componentID]
 	if !ok {
 		return nil, fmt.Errorf("extension with id %s not found", componentID.String())
 	}
-	reg, ok := extension.(backend.Registry)
-	if !ok {
-		return nil, fmt.Errorf("extension '%s' is not a backend.Registry", componentID.String())
+
+	// An extension can serve as a state store in two ways. If it natively
+	// implements backend.Registry (e.g. the Elasticsearch storage extension),
+	// use it directly. Otherwise, if it is a generic OTel storage extension
+	// (e.g. file_storage), adapt it into a backend.Registry.
+	switch e := ext.(type) {
+	case backend.Registry:
+		return e, nil
+	case storage.Extension:
+		return otelstorage.NewRegistryFromExtension(br.ctx, e, br.id), nil
+	default:
+		return nil, fmt.Errorf("extension %q is neither a backend.Registry nor an OTel storage.Extension", componentID.String())
 	}
-	return reg, nil
 }

--- a/x-pack/otel/distributions/beats-otel-collector/config.yaml
+++ b/x-pack/otel/distributions/beats-otel-collector/config.yaml
@@ -8,6 +8,7 @@ extensions:
     hosts:
       - http://localhost:9200
   kafkapartitioner:
+  file_storage:
 
 receivers:
   # Beats receivers

--- a/x-pack/otel/distributions/beats-otel-collector/config.yaml
+++ b/x-pack/otel/distributions/beats-otel-collector/config.yaml
@@ -117,7 +117,7 @@ exporters:
 connectors:
 
 service:
-  extensions: [health_check, pprof, beatsauth, elasticsearch_storage, kafkapartitioner]
+  extensions: [health_check, pprof, beatsauth, file_storage, elasticsearch_storage, kafkapartitioner]
   
   pipelines:
     logs:

--- a/x-pack/otel/oteltestcol/collector.go
+++ b/x-pack/otel/oteltestcol/collector.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
@@ -121,6 +122,7 @@ func getComponent() (otelcol.Factories, error) {
 	extensions, err := otelcol.MakeFactoryMap(
 		beatsauthextension.NewFactory(),
 		elasticsearchstorage.NewFactory(),
+		filestorage.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, nil //nolint:nilerr //ignoring this error

--- a/x-pack/otel/oteltestcol/collector_test.go
+++ b/x-pack/otel/oteltestcol/collector_test.go
@@ -6,11 +6,16 @@ package oteltestcol
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/features"
 )
 
 func TestNew(t *testing.T) {
@@ -215,4 +220,129 @@ service:
 		return col.ObservedLogs().
 			FilterMessageSnippet("Starting metrics logging every 30s").Len() > 0
 	}, 30*time.Second, 100*time.Millisecond, "Expected packetbeat receiver to start and log metrics")
+}
+
+// TestFilebeatReceiverFileStorage verifies that a Filebeat receiver can use the
+// OpenTelemetry file_storage extension as its state store. It ingests a file,
+// stops the collector, restarts it with the same storage directory, appends two
+// more lines, and asserts that only those two lines are read again (i.e. the
+// filestream offset was persisted to and restored from the file_storage
+// extension).
+func TestFilebeatReceiverFileStorage(t *testing.T) {
+	// The injected storage extension is only used by inputs for which the
+	// Elasticsearch state store feature is enabled. Enable it for filestream.
+	// Cleanup is registered before t.Setenv so it runs after the env is
+	// restored (cleanups run in LIFO order), re-reading the original value.
+	t.Cleanup(func() { features.ReinitForTest() })
+	t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "filestream")
+	features.ReinitForTest()
+
+	// Directories that must survive the collector restart.
+	workDir := t.TempDir()
+	homeDir := filepath.Join(workDir, "home")
+	storageDir := filepath.Join(workDir, "storage")
+	require.NoError(t, os.MkdirAll(homeDir, 0o700))
+	require.NoError(t, os.MkdirAll(storageDir, 0o700))
+	logFile := filepath.Join(workDir, "input.log")
+
+	cfg := fmt.Sprintf(`extensions:
+  file_storage:
+    directory: %[1]s
+    create_directory: true
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: filestream-filestorage-test
+          enabled: true
+          paths:
+            - %[2]s
+          file_identity.native: ~
+          prospector.scanner.fingerprint.enabled: false
+          prospector.scanner.check_interval: 100ms
+    path.home: %[3]s
+    storage: file_storage
+    queue.mem.flush.timeout: 0s
+    logging:
+      level: debug
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  extensions:
+    - file_storage
+  pipelines:
+    logs:
+      receivers:
+        - filebeatreceiver
+      exporters:
+        - debug
+  telemetry:
+    logs:
+      level: DEBUG
+    metrics:
+      level: none
+`, storageDir, logFile, homeDir)
+
+	// Ingest the first three lines.
+	appendLines(t, logFile, "line-1", "line-2", "line-3")
+
+	col1 := New(t, cfg)
+	require.NotNil(t, col1)
+
+	for _, line := range []string{"line-1", "line-2", "line-3"} {
+		require.Eventuallyf(t, func() bool {
+			return debugRecordCount(col1, line) > 0
+		}, 60*time.Second, 100*time.Millisecond, "expected %q in the debug output of the first run", line)
+	}
+
+	// Stop the collector; this releases the file_storage lock and persists the
+	// filestream offset.
+	col1.Shutdown()
+
+	// Restart the collector using the same storage directory, then append two
+	// more lines. Only these should be read.
+	col2 := New(t, cfg)
+	require.NotNil(t, col2)
+
+	appendLines(t, logFile, "line-4", "line-5")
+
+	for _, line := range []string{"line-4", "line-5"} {
+		require.Eventuallyf(t, func() bool {
+			return debugRecordCount(col2, line) > 0
+		}, 60*time.Second, 100*time.Millisecond, "expected %q in the debug output after restart", line)
+	}
+
+	// The previously ingested lines must not be read again after the restart,
+	// proving the offset was restored from the file_storage extension.
+	for _, line := range []string{"line-1", "line-2", "line-3"} {
+		assert.Zerof(t, debugRecordCount(col2, line),
+			"line %q was re-read after restart; the filestream offset was not restored from file_storage", line)
+	}
+}
+
+// appendLines appends the given lines (newline-terminated) to the file at path,
+// creating it if necessary, and flushes them to disk.
+func appendLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	require.NoErrorf(t, err, "could not open %s", path)
+	defer f.Close()
+	for _, line := range lines {
+		_, err := fmt.Fprintln(f, line)
+		require.NoErrorf(t, err, "could not write %q to %s", line, path)
+	}
+	require.NoErrorf(t, f.Sync(), "could not sync %s", path)
+}
+
+// debugRecordCount returns the number of detailed debug exporter log entries
+// whose body contains the given line. Filtering on "LogRecord #" restricts the
+// match to the debug exporter's marshaled output (which embeds the event body),
+// rather than Filebeat's own internal log lines.
+func debugRecordCount(col *Collector, line string) int {
+	return col.ObservedLogs().
+		FilterMessageSnippet("LogRecord #").
+		FilterMessageSnippet(line).
+		Len()
 }


### PR DESCRIPTION
## Proposed commit messagej

```
Make the storage extension support generic

From now on it's not specific to the Elasticsearch storage extension, it can use any OTel storage extension as an external registry.
```

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

You can find the collector configuration in the `TestFilebeatReceiverFileStorage` test (x-pack/otel/oteltestcol/collector_test.go) and it can be started following these instructions https://github.com/elastic/beats/tree/main/x-pack/otel/distributions/beats-otel-collector

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/50213
