### PR TITLE
Fix kafka integration test hang on publish failure

### DIFF
--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -311,7 +311,7 @@ func TestKafkaPublish(t *testing.T) {
 			// Wait until the output has finished handling every batch (not necessarily ACKed).
 			wg.Wait()
 			// Failed publishes signal BatchRetryEvents; only proceed to read the topic after ACK.
-			assertBatchesACKed(t, batches)
+			requiretBatchesACKed(t, batches)
 
 			expected := flatten(test.events)
 
@@ -646,8 +646,8 @@ readLoop:
 	return messages
 }
 
-// assertBatchesACKed fails if the kafka client finished the batch with retry/drop instead of ACK.
-func assertBatchesACKed(t *testing.T, batches []*outest.Batch) {
+// requiretBatchesACKed fails if the kafka client finished the batch with retry/drop instead of ACK.
+func requiretBatchesACKed(t *testing.T, batches []*outest.Batch) {
 	t.Helper()
 	for _, batch := range batches {
 		require.NotEmpty(t, batch.Signals, "expected publish batch to receive a signal")

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -291,10 +291,12 @@ func TestKafkaPublish(t *testing.T) {
 			assert.Equal(t, "testbeat", output.index)
 			defer output.Close()
 
-			// publish test events
+			// Publish asynchronously; OnSignal runs for any terminal outcome (ACK, retry, drop, ...).
 			var wg sync.WaitGroup
+			batches := make([]*outest.Batch, 0, len(test.events))
 			for i := range test.events {
 				batch := outest.NewBatch(test.events[i].events...)
+				batches = append(batches, batch)
 				batch.OnSignal = func(_ outest.BatchSignal) {
 					wg.Done()
 				}
@@ -306,8 +308,10 @@ func TestKafkaPublish(t *testing.T) {
 				}
 			}
 
-			// wait for all published batches to be ACKed
+			// Wait until the output has finished handling every batch (not necessarily ACKed).
 			wg.Wait()
+			// Failed publishes signal BatchRetryEvents; only proceed to read the topic after ACK.
+			assertBatchesACKed(t, batches)
 
 			expected := flatten(test.events)
 
@@ -424,7 +428,7 @@ func TestKafkaErrors(t *testing.T) {
 			}
 		}
 
-		// wait for all published batches to be ACKed
+		// Wait until handling completes; this test expects a drop/retry, not necessarily ACK.
 		wg.Wait()
 
 		t.Cleanup(func() {
@@ -581,6 +585,8 @@ func (m *topicOffsetMap) SetOffset(topic string, partition int32, offset int64) 
 
 var testTopicOffsets = topicOffsetMap{}
 
+// testReadFromKafkaTopic consumes up to nMessages from topic across all partitions.
+// Returns after timeout even when fewer than nMessages were read (caller must assert count).
 func testReadFromKafkaTopic(
 	t *testing.T, topic string, nMessages int,
 	timeout time.Duration,
@@ -626,17 +632,28 @@ func testReadFromKafkaTopic(
 	var messages []*sarama.ConsumerMessage
 	timer := time.After(timeout)
 
+readLoop:
 	for len(messages) < nMessages {
 		select {
 		case msg := <-msgs:
 			messages = append(messages, msg)
 		case <-timer:
-			break
+			break readLoop
 		}
 	}
 
 	close(done)
 	return messages
+}
+
+// assertBatchesACKed fails if the kafka client finished the batch with retry/drop instead of ACK.
+func assertBatchesACKed(t *testing.T, batches []*outest.Batch) {
+	t.Helper()
+	for _, batch := range batches {
+		require.NotEmpty(t, batch.Signals, "expected publish batch to receive a signal")
+		last := batch.Signals[len(batch.Signals)-1]
+		require.Equal(t, outest.BatchACK, last.Tag, "expected batch to be ACKed, got %v", last.Tag)
+	}
 }
 
 func flatten(infos []eventInfo) []beat.Event {


### PR DESCRIPTION
## Proposed commit message

```
When Kafka rejects a publish (e.g. leadership election on a new topic), the client signals BatchRetryEvents, not BatchACK. The test treated any OnSignal as success, then blocked in testReadFromKafkaTopic because a bare break only exited the select, not the receive loop—burning the full 15m package timeout.

Verify ACK before reading the topic, and use a labeled break so read timeout returns promptly.

Assisted-By: Cursor (Composer)

GenAI-Assisted: Yes
Human-Reviewed: Yes
Tool: Cursor, Model: Composer
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~

## How to test this PR locally

```
# Prerequisites: Kafka on localhost:9094 (libbeat docker-compose)
cd libbeat
mage docker:composeUp
# From libbeat/
go test -v -race -tags integration -run 'TestKafkaPublish' ./outputs/kafka/...
# Optional: all kafka integration tests in the package
go test -v -race -tags integration -run 'TestKafka' ./outputs/kafka/...
mage docker:composeDown
```

## Related issues

- Surfaced by https://github.com/elastic/beats/pull/50644

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~