### PR TITLE
x-pack/filebeat/input/streaming: scope refresh goroutine to session lifetime

### DIFF
--- a/changelog/fragments/1779249109-fix-crowdstrike-refresh-goroutine-leak.yaml
+++ b/changelog/fragments/1779249109-fix-crowdstrike-refresh-goroutine-leak.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Make CrowdStrike streaming input cancel refresh goroutines on session reconnect.
+component: filebeat

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -238,7 +238,10 @@ func (s *falconHoseStream) FollowStream(ctx context.Context) error {
 // they are received. It always returns a valid state value unless the error
 // returned is a hardError.
 func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, state map[string]any) (map[string]any, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.discoverURL, nil)
+	sessionCtx, sessionCancel := context.WithCancel(ctx)
+	defer sessionCancel()
+
+	req, err := http.NewRequestWithContext(sessionCtx, http.MethodGet, s.discoverURL, nil)
 	if err != nil {
 		return state, fmt.Errorf("failed to prepare discover stream request: %w", err)
 	}
@@ -309,9 +312,9 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 		}
 		refreshAfter := time.Duration(r.RefreshAfter) * time.Second
 		go func() {
-			runRefreshLoopWithAfter(ctx, refreshSessionWait(refreshAfter), time.After, func() error {
+			runRefreshLoopWithAfter(sessionCtx, refreshSessionWait(refreshAfter), time.After, func() error {
 				s.log.Debugw("session refresh", "url", r.RefreshURL)
-				req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.RefreshURL, nil)
+				req, err := http.NewRequestWithContext(sessionCtx, http.MethodPost, r.RefreshURL, nil)
 				if err != nil {
 					s.metrics.errorsTotal.Inc()
 					s.status.UpdateStatus(status.Failed, "failed to prepare refresh stream request: "+err.Error())
@@ -351,7 +354,7 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 		}
 
 		s.log.Debugw("stream request", "url", r.FeedURL)
-		req, err := http.NewRequestWithContext(ctx, "GET", r.FeedURL, nil)
+		req, err := http.NewRequestWithContext(sessionCtx, "GET", r.FeedURL, nil)
 		if err != nil {
 			return state, fmt.Errorf("failed to make firehose request to %s: %w", r.FeedURL, err)
 		}

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -21,6 +23,7 @@ import (
 	cursor "github.com/elastic/beats/v7/filebeat/input/v2/input-cursor"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
@@ -289,6 +292,125 @@ func TestCrowdstrikeOAuthHTTPClientRespectsConfiguredTimeout(t *testing.T) {
 	}
 	if elapsed > tokenDelay {
 		t.Fatalf("expected FollowStream to fail before server delay %v, but it took %v: %v", tokenDelay, elapsed, err)
+	}
+}
+
+func TestFollowStreamCancelsRefreshOnReconnect(t *testing.T) {
+	const totalSessions = 10
+
+	var discoverCalls atomic.Int32
+
+	goroutineSamples := make(chan int, totalSessions)
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"tok","token_type":"bearer","expires_in":3600}`)
+	}))
+	defer tokenSrv.Close()
+
+	refreshSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer refreshSrv.Close()
+
+	// Each feed is one event and then an EOF, triggering a reconnect.
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, fmt.Sprintf(`{"metadata":{"offset":%d,"eventType":"test"}}`, discoverCalls.Load()))
+	}))
+	defer feedSrv.Close()
+
+	discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := discoverCalls.Add(1)
+		if n > 1 && n <= totalSessions {
+			// Give the previous session's canceled refresh goroutine
+			// time to observe ctx.Done() and exit before sampling.
+			time.Sleep(5 * time.Millisecond)
+			goroutineSamples <- runtime.NumGoroutine()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{
+			"resources": [{
+				"dataFeedURL": %q,
+				"sessionToken": {"token": "tok", "expiration": "2099-01-01T00:00:00Z"},
+				"refreshActiveSessionURL": %q,
+				"refreshActiveSessionInterval": 30
+			}],
+			"meta": {}
+		}`, feedSrv.URL, refreshSrv.URL)
+	}))
+	defer discoverSrv.Close()
+
+	u, err := url.Parse(discoverSrv.URL)
+	if err != nil {
+		t.Fatalf("failed to parse discover URL: %v", err)
+	}
+	cfg := config{
+		Type: "crowdstrike",
+		URL:  &urlConfig{u},
+		Auth: authConfig{
+			OAuth2: oAuth2Config{
+				ClientID:     "id",
+				ClientSecret: "secret",
+				TokenURL:     tokenSrv.URL,
+			},
+		},
+		CrowdstrikeAppID: "test",
+		Program:          `state.response.decode_json().as(body, {"events": [body]})`,
+	}
+
+	log := logptest.NewTestingLogger(t, "recon")
+	env := v2.Context{
+		ID:              "reconnect_test",
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s, err := NewFalconHoseFollower(ctx, env, cfg, nil, &testPublisher{log}, nil, log, time.Now)
+	if err != nil {
+		t.Fatalf("failed to construct follower: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.FollowStream(ctx)
+	}()
+
+	// Collect goroutine samples from sessions 2 through totalSessions.
+	// Session 1 has no predecessor, so skip it.
+	samples := make([]int, 0, totalSessions-1)
+	for i := range totalSessions - 1 {
+		select {
+		case n := <-goroutineSamples:
+			samples = append(samples, n)
+		case err := <-done:
+			t.Fatalf("FollowStream exited early after %d sessions: %v", i+1, err)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for session %d", i+2)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for FollowStream to return")
+	}
+
+	if len(samples) != totalSessions-1 {
+		t.Fatalf("collected %d goroutine samples; want %d", len(samples), totalSessions-1)
+	}
+
+	// With the fix, goroutine count stays roughly constant because each
+	// session's refresh goroutine exits when followSession returns. Without
+	// the fix, goroutines accumulate at one per session, giving growth ≈
+	// totalSessions-1. The threshold is set at half that to tolerate
+	// scheduling jitter while still catching the linear leak.
+	growth := samples[len(samples)-1] - samples[0]
+	if growth >= totalSessions/2 {
+		t.Errorf("goroutine growth = %d; want < %d (samples: %v)",
+			growth, totalSessions/2, samples)
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: scope refresh goroutine to session lifetime

The refresh goroutine started by followSession used the input-level
context, so it was only canceled when the entire input was shut down.
When a stream session ended and reconnected, the old refresh goroutine
kept running, accumulating one leaked goroutine per reconnect. Under
unstable connections this grows goroutine count, auth traffic, and
rate-limit pressure.

Create a per-session child context in followSession and defer its
cancellation. When the session ends for any reason, the refresh
goroutine sees ctx.Done() and exits.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #50564

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
