### PR TITLE
Propagate osquery live-query space IDs

### DIFF
--- a/changelog/fragments/1779275680-propagate-osquery-live-query-space-ids.yaml
+++ b/changelog/fragments/1779275680-propagate-osquery-live-query-space-ids.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Propagate osquery live-query space IDs to action response events.
+
+component: osquerybeat

--- a/x-pack/osquerybeat/internal/pub/publisher.go
+++ b/x-pack/osquerybeat/internal/pub/publisher.go
@@ -291,7 +291,7 @@ func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID s
 }
 
 func actionResultToEvent(req, res map[string]interface{}) map[string]interface{} {
-	m := make(map[string]interface{}, 8)
+	m := make(map[string]interface{}, 9)
 
 	copyKey := func(key string, src, dst map[string]interface{}) {
 		if v, ok := src[key]; ok {
@@ -322,6 +322,8 @@ func actionResultToEvent(req, res map[string]interface{}) map[string]interface{}
 	if v, ok := req["data"]; ok {
 		m["action_data"] = v
 	}
+
+	copyKey("space_id", req, m)
 
 	return m
 }

--- a/x-pack/osquerybeat/internal/pub/publisher_test.go
+++ b/x-pack/osquerybeat/internal/pub/publisher_test.go
@@ -186,6 +186,40 @@ func TestActionResultToEvent(t *testing.T) {
 				}
 			  }`),
 		},
+		{
+			name: "successful with space id",
+			req: toMap(t, `{
+				"data": {
+					"id": "a72d65d8-200a-4b43-8dbd-7bc0e9ce8e65",
+					"query": "select * from osquery_info"
+				},
+				"id": "5c433f88-ab0d-41e2-af76-6ff16ae3ced8",
+				"input_type": "osquery",
+				"space_id": "production",
+				"type": "INPUT_ACTION"
+			}`),
+			res: toMap(t, `{
+				"completed_at": "2024-04-18T19:39:39.740162Z",
+				"count": 1,
+				"started_at": "2024-04-18T19:39:39.532125Z"
+			} `),
+			want: toMap(t, `{
+				"completed_at": "2024-04-18T19:39:39.740162Z",
+				"action_response": {
+					"osquery": {
+						"count": 1
+					}
+				},
+				"action_id": "5c433f88-ab0d-41e2-af76-6ff16ae3ced8",
+				"started_at": "2024-04-18T19:39:39.532125Z",
+				"action_input_type": "osquery",
+				"action_data": {
+					"id": "a72d65d8-200a-4b43-8dbd-7bc0e9ce8e65",
+					"query": "select * from osquery_info"
+				},
+				"space_id": "production"
+			}`),
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Proposed commit message

Propagate osquery live-query space IDs

Live-query action response events now copy `space_id` from the Fleet action request when Kibana provides it. Kibana's osquery read paths filter action responses by `space_id`, so preserving the field lets space-scoped live-query responses be found instead of remaining effectively invisible to status/count queries.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None expected. This only adds `space_id` to osquery live-query action response events when the request already contains it, matching the scheduled-query response behavior.

## How to test this PR locally

```bash
go test ./x-pack/osquerybeat/internal/pub
```

## Related issues

- Closes https://github.com/elastic/security-team/issues/17489

## Use cases

When a live osquery action originates from a non-default Kibana space, osquerybeat should preserve that `space_id` on the corresponding `action.responses` event so Kibana can include the completed response in space-scoped status and listing queries.

## Screenshots

N/A

## Logs

```text
ok  	github.com/elastic/beats/v7/x-pack/osquerybeat/internal/pub	0.026s
```