### PR TITLE
x-pack/filebeat/input/streaming: fix TestInput failures under -count >1

### DIFF
--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -7,6 +7,7 @@ package streaming
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/testing/testutils"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
@@ -822,7 +822,6 @@ var urlEvalTests = []struct {
 }
 
 func TestURLEval(t *testing.T) {
-	logp.TestingSetup()
 	for _, test := range urlEvalTests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := conf.MustNewConfigFrom(test.config)
@@ -853,7 +852,7 @@ func TestURLEval(t *testing.T) {
 			if now == nil {
 				now = time.Now
 			}
-			response, err := getURL(ctx, "websocket", conf.URLProgram, conf.URL.String(), state, conf.Redact, logp.NewLogger("websocket_url_eval_test"), now)
+			response, err := getURL(ctx, "websocket", conf.URLProgram, conf.URL.String(), state, conf.Redact, logptest.NewTestingLogger(t, "websocket_url_eval_test"), now)
 			if err != nil && !errors.Is(err, context.Canceled) {
 				t.Errorf("unexpected error from running input: got:%v want:%v", err, nil)
 			}
@@ -867,20 +866,21 @@ func TestInput(t *testing.T) {
 	testutils.SkipIfFIPSOnly(t, "websocket setup requires SHA-1.")
 	// tests will ignore context cancelled errors, since they are expected
 	ctxCancelledError := fmt.Errorf("context canceled")
-	logp.TestingSetup()
 	for _, test := range inputTests {
 		t.Run(test.name, func(t *testing.T) {
+			testConfig := cloneConfig(t, test.config)
+
 			if test.oauth2Server != nil {
-				test.oauth2Server(t, test.oauth2Handler, test.config)
+				test.oauth2Server(t, test.oauth2Handler, testConfig)
 			}
 			if test.server != nil {
-				test.server(t, test.handler, test.config, test.response)
+				test.server(t, test.handler, testConfig, test.response)
 			}
 			if test.proxyServer != nil {
-				test.proxyServer(t, test.handler, test.config, test.response)
+				test.proxyServer(t, test.handler, testConfig, test.response)
 			}
 
-			cfg := conf.MustNewConfigFrom(test.config)
+			cfg := conf.MustNewConfigFrom(testConfig)
 
 			conf := config{}
 			conf.Redact = &redact{} // Make sure we pass the redact requirement.
@@ -907,7 +907,7 @@ func TestInput(t *testing.T) {
 			defer cancel()
 
 			v2Ctx := v2.Context{
-				Logger:          logp.NewLogger("websocket_test"),
+				Logger:          logptest.NewTestingLogger(t, "websocket_test"),
 				ID:              "test_id:" + test.name,
 				Cancelation:     ctx,
 				MetricsRegistry: monitoring.NewRegistry(),
@@ -927,18 +927,35 @@ func TestInput(t *testing.T) {
 				return
 			}
 
-			if len(client.published) < len(test.want) {
-				t.Errorf("unexpected number of published events: got:%d want at least:%d", len(client.published), len(test.want))
-				test.want = test.want[:len(client.published)]
+			want := test.want
+			if len(client.published) < len(want) {
+				t.Errorf("unexpected number of published events: got:%d want at least:%d", len(client.published), len(want))
+				want = want[:len(client.published)]
 			}
-			client.published = client.published[:len(test.want)]
+			client.published = client.published[:len(want)]
 			for i, got := range client.published {
-				if !reflect.DeepEqual(got.Fields, mapstr.M(test.want[i])) {
-					t.Errorf("unexpected result for event %d: got:- want:+\n%s", i, cmp.Diff(got.Fields, mapstr.M(test.want[i])))
+				if !reflect.DeepEqual(got.Fields, mapstr.M(want[i])) {
+					t.Errorf("unexpected result for event %d: got:- want:+\n%s", i, cmp.Diff(got.Fields, mapstr.M(want[i])))
 				}
 			}
 		})
 	}
+}
+
+// cloneConfig returns a deep copy of m via a JSON round-trip. This prevents
+// server factories from mutating the package-level inputTests table, which
+// would otherwise cause stale URLs and state when tests are run with -count >1.
+func cloneConfig(t *testing.T, m map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("failed to marshal config for deep copy: %v", err)
+	}
+	var clone map[string]interface{}
+	if err := json.Unmarshal(b, &clone); err != nil {
+		t.Fatalf("failed to unmarshal config for deep copy: %v", err)
+	}
+	return clone
 }
 
 // TestURLProgramReconnect verifies that url_program is re-evaluated before
@@ -1272,8 +1289,8 @@ func webSocketTestServerWithAuth(serve func(http.Handler) *httptest.Server) func
 
 // webSocketServerWithRetry returns a function that creates a WebSocket server that rejects the first two connection attempts and accepts the third.
 func webSocketServerWithRetry(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]interface{}, []string) {
-	var attempt int
 	return func(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) {
+		var attempt int
 		server := serve(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			attempt++
 			if attempt <= 2 {
@@ -1418,9 +1435,12 @@ func webSocketProxyHandler(targetURL string) http.HandlerFunc {
 // newWebSocketProxyTestServer creates a proxy server forwarding WebSocket traffic.
 func newWebSocketProxyTestServer(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) *httptest.Server {
 	backendServer := webSocketTestServer(t, handler, response)
+	t.Cleanup(backendServer.Close)
 	config["url"] = "ws" + backendServer.URL[4:]
 	config["proxy_url"] = "ws" + backendServer.URL[4:]
-	return httptest.NewServer(webSocketProxyHandler(config["url"].(string)))
+	proxy := httptest.NewServer(webSocketProxyHandler(config["url"].(string)))
+	t.Cleanup(proxy.Close)
+	return proxy
 }
 
 //nolint:errcheck // no point checking errors in test server.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: fix TestInput failures under -count >1

The inputTests table uses package-level config maps that server
factories mutate in place. On repeated runs (-count >1), stale
server URLs from the previous iteration survive into the next,
causing "connection refused" failures.

Deep-copy each test's config via a JSON round-trip before passing
it to server factories. Also fix test.want mutation (use a local
variable), move the retry attempt counter into the per-invocation
closure so it resets between runs, add t.Cleanup for the proxy
test's leaked servers, and replace the deprecated logp.TestingSetup
with logptest.

Identified while working on #50803.
```
> [!NOTE]
> No user-facing change, so no changelog.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Ref #50803

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
