### PR TITLE
fix task group stop goroutine leak

### DIFF
--- a/changelog/fragments/1779367798-fix-goroutine-leak-in-filestream-task-group.yaml
+++ b/changelog/fragments/1779367798-fix-goroutine-leak-in-filestream-task-group.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix goroutine leak in filestream task group.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/50839
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/50824

--- a/filebeat/input/filestream/internal/task/group.go
+++ b/filebeat/input/filestream/internal/task/group.go
@@ -20,6 +20,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -72,7 +73,11 @@ func NewGroup(limit uint64, stopTimeout time.Duration, log Logger, errPrefix str
 
 	var sem *semaphore.Weighted
 	if limit > 0 {
-		sem = semaphore.NewWeighted(int64(limit))
+		n := int64(limit)
+		if limit > math.MaxInt64 {
+			n = math.MaxInt64
+		}
+		sem = semaphore.NewWeighted(n)
 	}
 
 	return &Group{

--- a/filebeat/input/filestream/internal/task/group.go
+++ b/filebeat/input/filestream/internal/task/group.go
@@ -73,11 +73,7 @@ func NewGroup(limit uint64, stopTimeout time.Duration, log Logger, errPrefix str
 
 	var sem *semaphore.Weighted
 	if limit > 0 {
-		n := int64(limit)
-		if limit > math.MaxInt64 {
-			n = math.MaxInt64
-		}
-		sem = semaphore.NewWeighted(n)
+		sem = semaphore.NewWeighted(int64(min(limit, math.MaxInt64)))
 	}
 
 	return &Group{

--- a/filebeat/input/filestream/internal/task/group.go
+++ b/filebeat/input/filestream/internal/task/group.go
@@ -56,7 +56,7 @@ type Logger interface {
 func NewGroup(limit uint64, stopTimeout time.Duration, log Logger, errPrefix string) *Group {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var logErr = func(error) {}
+	logErr := func(error) {}
 	if log != nil {
 		var format string
 		if errPrefix == "" {
@@ -129,7 +129,7 @@ func (g *Group) Stop() error {
 	done := make(chan struct{})
 	go func() {
 		g.wg.Wait()
-		done <- struct{}{}
+		close(done)
 	}()
 
 	timeout, cancel := context.WithTimeout(context.Background(), g.stopTimeout)

--- a/filebeat/input/filestream/internal/task/group_test.go
+++ b/filebeat/input/filestream/internal/task/group_test.go
@@ -48,6 +48,7 @@ func (tl *testLogger) Errorf(format string, args ...interface{}) {
 	tl.b.WriteString(fmt.Sprintf(format, args...))
 	tl.b.WriteString("\n")
 }
+
 func (tl *testLogger) String() string {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
@@ -57,12 +58,12 @@ func (tl *testLogger) String() string {
 func TestNewGroup(t *testing.T) {
 	limit := 10
 	timeout := time.Second
-	g := NewGroup(uint64(limit), timeout, noopLogger{}, "")
+	g := NewGroup(uint64(limit), timeout, noopLogger{}, "") //nolint:gosec //limit is 10 no overflow
 	require.NotNil(t, g, "NewGroup returned a nil group, it cannot be nil")
 
 	require.NotNil(t, g.sem)
 
-	err := g.sem.Acquire(context.Background(), int64(limit-1))
+	err := g.sem.Acquire(context.Background(), int64(limit-1)) //nolint:gosec //limit is 10 no overflow
 	require.NoError(t, err, "semaphore Acquire failed")
 	assert.True(t, g.sem.TryAcquire(1),
 		"semaphore should have 1 place left, there is none")
@@ -262,7 +263,6 @@ func TestGroup_Go(t *testing.T) {
 		assert.Contains(t, logs, wantErr.Error())
 		assert.Contains(t, logs, "[2]")
 		assert.Contains(t, logs, "[1]")
-
 	})
 
 	t.Run("some workloads return an error", func(t *testing.T) {

--- a/filebeat/input/filestream/internal/task/group_test.go
+++ b/filebeat/input/filestream/internal/task/group_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -333,7 +334,6 @@ func TestGroup_Stop(t *testing.T) {
 		done := make(chan struct{})
 		wg := sync.WaitGroup{}
 		wg.Add(1)
-		defer func() { close(done) }()
 		err := g.Go(func(_ context.Context) error {
 			wg.Done() // signal that the goroutine is running
 			<-done
@@ -342,9 +342,57 @@ func TestGroup_Stop(t *testing.T) {
 		require.NoError(t, err, "could not launch goroutine")
 		wg.Wait() // wait for the goroutine to start
 
+		goroutinesBefore := runtime.NumGoroutine()
 		err = g.Stop()
 		require.Error(t, err, "Stop should return a timeout error")
 		assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+		// Unblock the task and give the waiter goroutine time to exit.
+		close(done)
+		assert.Eventually(t,
+			func() bool { return runtime.NumGoroutine() <= goroutinesBefore },
+			time.Second, 10*time.Millisecond,
+			"waiter goroutine leaked after Stop timeout")
+	})
+
+	t.Run("no goroutine leak on repeated stop timeout", func(t *testing.T) {
+		// Each iteration: start a group with a blocking task, force Stop()
+		// to time out, then unblock the task. The waiter goroutine spawned
+		// inside Stop() must exit after the task finishes — not block forever
+		// trying to send on an unread channel.
+		const iterations = 20
+
+		// Establish a baseline before the loop.
+		baseline := runtime.NumGoroutine()
+
+		for i := 0; i < iterations; i++ {
+			g := NewGroup(1, time.Millisecond, noopLogger{}, "")
+
+			taskRunning := make(chan struct{})
+			taskBlock := make(chan struct{})
+
+			err := g.Go(func(_ context.Context) error {
+				close(taskRunning)
+				<-taskBlock
+				return nil
+			})
+			require.NoError(t, err)
+			<-taskRunning // ensure the task is running before Stop
+
+			err = g.Stop()
+			require.ErrorIs(t, err, context.DeadlineExceeded,
+				"iteration %d: Stop should time out", i)
+
+			// Unblock the task so the waiter goroutine can exit.
+			close(taskBlock)
+		}
+
+		// Allow all waiter goroutines to finish.
+		assert.Eventually(t,
+			func() bool { return runtime.NumGoroutine() <= baseline+2 },
+			2*time.Second, 10*time.Millisecond,
+			"goroutine count grew after %d stop-timeout iterations (baseline %d, now %d)",
+			iterations, baseline, runtime.NumGoroutine())
 	})
 
 	t.Run("all goroutine finish before timeout", func(t *testing.T) {


### PR DESCRIPTION
## Proposed commit message

task.Group.Stop` leaks a goroutine on every timeout.**

`Stop` spawns an internal waiter goroutine that calls `g.wg.Wait()` and then sends on a `done` channel. When `Stop` returns early because the stop-timeout fires, nobody reads from `done`. After the blocked tasks eventually finish and `g.wg.Wait()` returns, the waiter goroutine blocks forever on the send — one leaked goroutine per timed-out `Stop` call.

The fix is a one-line change: replace the blocking channel send with `close(done)`. Closing a channel is non-blocking, so the waiter goroutine always exits promptly regardless of whether `Stop` has already returned.

## Changes

- **`group.go`**: replace `done <- struct{}{}` with `close(done)` in the waiter goroutine inside `Stop`.
- **`group_test.go`**:
  - `TestGroup_Stop/timeout`: removed the `defer close(done)` that was silently papering over the leak; instead, the test now explicitly unblocks the task after `Stop` returns and asserts via `runtime.NumGoroutine` that the waiter goroutine exits within 1 s.
  - `TestGroup_Stop/no_goroutine_leak_on_repeated_stop_timeout`: new regression test that runs 20 stop-timeout cycles (start group → block task → force timeout → unblock task) and asserts the goroutine count does not grow across iterations.


## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None

## How to test this PR locally

1. Revert the change to `group.go`
2. run `go test . -v` to run the unit test that shows the go leak

## Related issues

- Closes #50824

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

Researched with Claude