### PR TITLE
fix(filestream): close done channel in task.Group.Stop to avoid goroutine leak

### DIFF
--- a/changelog/fragments/1779200000-filestream-task-group-stop-leak.yaml
+++ b/changelog/fragments/1779200000-filestream-task-group-stop-leak.yaml
@@ -1,0 +1,8 @@
+kind: bug-fix
+
+summary: Stop the filestream task group cleanly when the stop timeout elapses, fixing a goroutine leak on busy hosts.
+
+component: filebeat
+
+# pr: https://github.com/owner/repo/1234
+# issue: https://github.com/owner/repo/1234

--- a/filebeat/input/filestream/internal/task/group.go
+++ b/filebeat/input/filestream/internal/task/group.go
@@ -126,10 +126,16 @@ func (g *Group) Go(fn func(context.Context) error) error {
 func (g *Group) Stop() error {
 	g.cancelCtx()
 
+	// done has buffer 1 (or close) so the wait-goroutine always finishes
+	// even if the timeout branch is selected below. With an unbuffered
+	// channel and no reader, `done <- struct{}{}` blocks forever when
+	// stopTimeout elapses before all tasks finish, leaking the goroutine
+	// (and through it, references to g.wg, g.ctx, and anything the
+	// in-flight tasks close over).
 	done := make(chan struct{})
 	go func() {
 		g.wg.Wait()
-		done <- struct{}{}
+		close(done)
 	}()
 
 	timeout, cancel := context.WithTimeout(context.Background(), g.stopTimeout)

--- a/filebeat/input/filestream/internal/task/group_test.go
+++ b/filebeat/input/filestream/internal/task/group_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -355,5 +356,66 @@ func TestGroup_Stop(t *testing.T) {
 
 		err = g.Stop()
 		assert.NoError(t, err)
+	})
+
+	// Regression test for elastic/beats#50824. Before the fix, Stop's
+	// internal wait-goroutine sent to an unbuffered `done` channel. When
+	// the stop timeout fired first, the Stop call returned but the
+	// wait-goroutine remained blocked on its send forever, leaking the
+	// goroutine (and a reference to the task group) on every busy-host
+	// shutdown.
+	//
+	// The test triggers the timeout branch, then releases the in-flight
+	// task and confirms that the wait-goroutine count returns to its
+	// pre-Stop value within a short window. With the buggy code that
+	// count stays elevated indefinitely.
+	t.Run("does not leak the wait-goroutine after timeout", func(t *testing.T) {
+		// Quiet down any unrelated transient goroutines before measuring.
+		runtime.GC()
+		time.Sleep(20 * time.Millisecond)
+		runtime.GC()
+
+		baseline := runtime.NumGoroutine()
+
+		g := NewGroup(50, time.Millisecond, noopLogger{}, "")
+
+		// Block the task so Stop must hit the timeout branch.
+		taskRunning := make(chan struct{})
+		taskRelease := make(chan struct{})
+		err := g.Go(func(_ context.Context) error {
+			close(taskRunning)
+			<-taskRelease
+			return nil
+		})
+		require.NoError(t, err)
+		<-taskRunning
+
+		// Take the timeout path.
+		err = g.Stop()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+		// Release the in-flight task so g.wg.Wait() in the Stop
+		// wait-goroutine can return. With the unbuffered-send bug the
+		// wait-goroutine then tries `done <- struct{}{}` with no reader
+		// and blocks forever. With close(done) it just calls close and
+		// exits.
+		close(taskRelease)
+
+		// Allow the in-flight task goroutine and the Stop wait-goroutine
+		// to unwind. Use a poll loop instead of a fixed sleep so the test
+		// is robust against slow CI.
+		deadline := time.Now().Add(2 * time.Second)
+		var leaked int
+		for time.Now().Before(deadline) {
+			runtime.GC()
+			leaked = runtime.NumGoroutine() - baseline
+			if leaked <= 0 {
+				break
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		assert.LessOrEqual(t, leaked, 0,
+			"task group leaked %d goroutine(s) after Stop timeout", leaked)
 	})
 }


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

When `task.Group.Stop` hits the timeout branch, the internal wait-goroutine is left blocked forever on `done <- struct{}{}` once `g.wg.Wait()` finally returns, because the only reader (the `select` inside `Stop`) has already gone. That leaks the wait-goroutine and through it references to the group, its context, and anything the in-flight tasks close over, on every shutdown that hits the timeout.

Switching the send to `close(done)` makes the wait-goroutine exit cleanly regardless of which select arm `Stop` took. Both the buffered-channel and the `close()` approaches fix this, but `close()` matches the goroutine's "I'm done, signal once, exit" shape and reads more obviously.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added an entry in `./changelog/fragments`.

## Disruptive User Impact

None for correctly-behaved callers. Stop() returns the same values it did before for both branches; only the leak on the timeout path is fixed.

## How to test this PR locally

```
go test -race -run TestGroup_Stop ./filebeat/input/filestream/internal/task/
```

The new sub-test `does_not_leak_the_wait-goroutine_after_timeout` forces the timeout branch, releases the in-flight task, and then asserts `runtime.NumGoroutine` returns to the pre-Stop baseline. Reverting only the one-line `close(done)` change in `group.go` and re-running the test fails with `task group leaked 1 goroutine(s) after Stop timeout`.

## Related issues

- Closes #50824

## Logs

Before the fix, with the regression test reverted:

```
=== RUN   TestGroup_Stop/does_not_leak_the_wait-goroutine_after_timeout
    group_test.go:418:
        Error: "1" is not less than or equal to "0"
        Messages: task group leaked 1 goroutine(s) after Stop timeout
--- FAIL: TestGroup_Stop/does_not_leak_the_wait-goroutine_after_timeout (2.04s)
```

With the fix:

```
--- PASS: TestGroup_Stop/does_not_leak_the_wait-goroutine_after_timeout (0.02s)
```
