### PR TITLE
ci(fragment-in-pr): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/fragment-in-pr.yml
+++ b/.github/workflows/fragment-in-pr.yml
@@ -3,6 +3,9 @@ name: fragment-in-pr
 on:
   pull_request:
     types: [ labeled, unlabeled, opened, reopened, synchronize ]
+permissions:
+  contents: read
+
 jobs:
   fragments:
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog') && !contains(github.event.pull_request.labels.*.name, 'backport')"


### PR DESCRIPTION
The `fragment-in-pr` workflow only validates changelog fragments on PRs. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.