### PR TITLE
Fix winlog gap retry checkpoint recovery

### DIFF
--- a/changelog/fragments/1779785051-fix-winlog-gap-retry-checkpoint.yaml
+++ b/changelog/fragments/1779785051-fix-winlog-gap-retry-checkpoint.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix Winlogbeat record ID gap retries reopening from stale checkpoints.
+component: winlogbeat

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -34,6 +34,9 @@ type EventLog interface {
 	// from the first event specify a zero-valued EventLogState.
 	Open(state checkpoint.EventLogState, metricsRegistry *monitoring.Registry) error
 
+	// Checkpoint returns the last successfully read event state.
+	Checkpoint() checkpoint.EventLogState
+
 	// Read records from the event log. If io.EOF is returned you should stop
 	// reading and close the log.
 	Read() ([]Record, error)

--- a/winlogbeat/eventlog/runner.go
+++ b/winlogbeat/eventlog/runner.go
@@ -34,6 +34,13 @@ import (
 	"github.com/elastic/go-concert/timed"
 )
 
+var (
+	isRecoverable         = IsRecoverable
+	openRetryInitialDelay = 5 * time.Second
+	readRetryInitialDelay = 5 * time.Second
+	retryMaxDelay         = time.Minute
+)
+
 type Publisher interface {
 	Publish(records []Record) error
 }
@@ -73,7 +80,7 @@ func Run(
 		openChannelNotFoundErrDetected = true
 	}
 
-	openErrHandler := newExponentialLimitedBackoff(log, 5*time.Second, time.Minute, func(err error) bool {
+	openErrHandler := newExponentialLimitedBackoff(log, openRetryInitialDelay, retryMaxDelay, func(err error) bool {
 		if mustIgnoreError(err, api) {
 			if isChannelNotFound(err) {
 				logChannelNotFoundOpenRetry(err)
@@ -82,7 +89,7 @@ func Run(
 			}
 			return true
 		}
-		if !IsRecoverable(err, api.IsFile()) {
+		if !isRecoverable(err, api.IsFile()) {
 			return false
 		}
 		reporter.UpdateStatus(status.Degraded, fmt.Sprintf("Retrying to open %s: %v", api.Channel(), err))
@@ -94,7 +101,7 @@ func Run(
 		return true
 	})
 
-	readErrHandler := newExponentialLimitedBackoff(log, 5*time.Second, time.Minute, func(err error) bool {
+	readErrHandler := newExponentialLimitedBackoff(log, readRetryInitialDelay, retryMaxDelay, func(err error) bool {
 		if mustIgnoreError(err, api) {
 			log.Warnw("ignoring read error", "error", err, "channel", api.Channel())
 			if resetErr := api.Reset(); resetErr != nil {
@@ -102,7 +109,7 @@ func Run(
 			}
 			return true
 		}
-		if !IsRecoverable(err, api.IsFile()) {
+		if !isRecoverable(err, api.IsFile()) {
 			return false
 		}
 		reporter.UpdateStatus(status.Degraded, fmt.Sprintf("Retrying to read from %s: %v", api.Channel(), err))
@@ -113,9 +120,10 @@ func Run(
 		return true
 	})
 
+	currentCheckpoint := evtCheckpoint
 runLoop:
 	for cancelCtx.Err() == nil {
-		openErr := api.Open(evtCheckpoint, metricsRegistry)
+		openErr := api.Open(currentCheckpoint, metricsRegistry)
 		if openErr != nil {
 			if openErrHandler.backoff(cancelCtx, openErr) {
 				continue runLoop
@@ -141,6 +149,7 @@ runLoop:
 					return err
 				}
 			}
+			currentCheckpoint = api.Checkpoint()
 
 			if readErr != nil {
 				// io.EOF signals a clean end of stream (e.g. no_more_events: stop).

--- a/winlogbeat/eventlog/runner_test.go
+++ b/winlogbeat/eventlog/runner_test.go
@@ -24,11 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/winlogbeat/checkpoint"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
-	"github.com/stretchr/testify/require"
 )
 
 var errRepeatedRecordIDGap = errors.New("repeated record ID gap")

--- a/winlogbeat/eventlog/runner_test.go
+++ b/winlogbeat/eventlog/runner_test.go
@@ -1,0 +1,178 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eventlog
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/beats/v7/winlogbeat/checkpoint"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/stretchr/testify/require"
+)
+
+var errRepeatedRecordIDGap = errors.New("repeated record ID gap")
+
+func TestRunReopensFromLatestCheckpointAfterRecoverableGap(t *testing.T) {
+	const (
+		originalCheckpoint = 3599
+		lastBeforeGap      = 3600
+		firstAfterGap      = 3636
+		gapRetryLimit      = 3
+	)
+
+	restore := stubRecoverableForTest(errRepeatedRecordIDGap)
+	defer restore()
+
+	api := &replayingGapEventLog{
+		t:                  t,
+		lastBeforeGap:      lastBeforeGap,
+		firstAfterGap:      firstAfterGap,
+		gapRetryLimit:      gapRetryLimit,
+		maxOpenInvocations: gapRetryLimit + 2,
+	}
+
+	err := Run(
+		noOpStatusReporter{},
+		context.Background(),
+		monitoring.NewRegistry(),
+		api,
+		checkpoint.EventLogState{Name: "System", RecordNumber: originalCheckpoint},
+		noOpPublisher{},
+		logp.NewLogger("eventlog_runner_test"),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]uint64{originalCheckpoint, lastBeforeGap, lastBeforeGap, lastBeforeGap},
+		api.openedFromRecordNumbers,
+		"recoverable gap retries must reopen from the latest in-memory checkpoint, not the original checkpoint")
+	require.True(t, api.gapAccepted, "gap should be accepted after repeated retries")
+	require.Equal(t, uint64(firstAfterGap), api.Checkpoint().RecordNumber)
+}
+
+func stubRecoverableForTest(recoverableErr error) func() {
+	originalIsRecoverable := isRecoverable
+	originalOpenDelay := openRetryInitialDelay
+	originalReadDelay := readRetryInitialDelay
+	originalMaxDelay := retryMaxDelay
+
+	isRecoverable = func(err error, _ bool) bool {
+		return errors.Is(err, recoverableErr)
+	}
+	openRetryInitialDelay = time.Nanosecond
+	readRetryInitialDelay = time.Nanosecond
+	retryMaxDelay = time.Nanosecond
+
+	return func() {
+		isRecoverable = originalIsRecoverable
+		openRetryInitialDelay = originalOpenDelay
+		readRetryInitialDelay = originalReadDelay
+		retryMaxDelay = originalMaxDelay
+	}
+}
+
+type replayingGapEventLog struct {
+	t *testing.T
+
+	checkpoint              checkpoint.EventLogState
+	openedFromRecordNumbers []uint64
+
+	lastBeforeGap uint64
+	firstAfterGap uint64
+
+	gapRetryCount      int
+	gapRetryLimit      int
+	gapAccepted        bool
+	maxOpenInvocations int
+}
+
+func (l *replayingGapEventLog) Open(state checkpoint.EventLogState, _ *monitoring.Registry) error {
+	l.openedFromRecordNumbers = append(l.openedFromRecordNumbers, state.RecordNumber)
+	require.LessOrEqual(l.t, len(l.openedFromRecordNumbers), l.maxOpenInvocations,
+		"gap retry loop reopened too many times without accepting the gap")
+
+	l.checkpoint = state
+	return nil
+}
+
+func (l *replayingGapEventLog) Checkpoint() checkpoint.EventLogState {
+	return l.checkpoint
+}
+
+func (l *replayingGapEventLog) Read() ([]Record, error) {
+	if l.gapAccepted {
+		return nil, io.EOF
+	}
+
+	if l.checkpoint.RecordNumber < l.lastBeforeGap {
+		// Simulate replaying a successfully processed or filtered event before
+		// hitting the same gap again. winEventLog resets the gap retry counter
+		// after each successful event.
+		l.gapRetryCount = 0
+		l.checkpoint.RecordNumber = l.lastBeforeGap
+	}
+
+	l.gapRetryCount++
+	if l.gapRetryCount <= l.gapRetryLimit {
+		return nil, errRepeatedRecordIDGap
+	}
+
+	l.checkpoint.RecordNumber = l.firstAfterGap
+	l.gapAccepted = true
+	return nil, io.EOF
+}
+
+func (l *replayingGapEventLog) Reset() error {
+	return nil
+}
+
+func (l *replayingGapEventLog) Close() error {
+	return nil
+}
+
+func (l *replayingGapEventLog) Name() string {
+	return "System"
+}
+
+func (l *replayingGapEventLog) Channel() string {
+	return "System"
+}
+
+func (l *replayingGapEventLog) IsFile() bool {
+	return false
+}
+
+func (l *replayingGapEventLog) IgnoreMissingChannel() bool {
+	return false
+}
+
+type noOpPublisher struct{}
+
+func (noOpPublisher) Publish([]Record) error {
+	return nil
+}
+
+type noOpStatusReporter struct{}
+
+func (noOpStatusReporter) UpdateStatus(status.Status, string) {}

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -247,6 +247,10 @@ func (l *winEventLog) Open(state checkpoint.EventLogState, metricsRegistry *moni
 	return err
 }
 
+func (l *winEventLog) Checkpoint() checkpoint.EventLogState {
+	return l.lastRead
+}
+
 func (l *winEventLog) open(state checkpoint.EventLogState) (win.EvtHandle, error) {
 	var bookmark win.Bookmark
 	if len(state.Bookmark) > 0 {


### PR DESCRIPTION
## Proposed commit message

Fix winlog gap retry checkpoint recovery

Recoverable winlog read errors now reopen from the latest in-memory checkpoint instead of the original checkpoint passed into the runner. This prevents record ID gap recovery from replaying pre-gap records, resetting the gap retry counter, and looping indefinitely before the gap circuit breaker can accept a persistent gap.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None expected. This avoids repeated retry loops for persistent Winlogbeat/Filebeat winlog input record ID gaps without skipping unpublished records.

## How to test this PR locally

```sh
go test ./winlogbeat/eventlog
```

## Related issues

-

## Use cases

When a Windows Event Log channel has a persistent record ID gap, recoverable retry should reopen from the latest successfully read event. This lets the repeated gap remain consecutive so the retry circuit breaker can accept the gap instead of replaying earlier records and resetting retry state forever.

## Screenshots

N/A

## Logs

```sh
ok  	github.com/elastic/beats/v7/winlogbeat/eventlog	(cached)
```