### PR TITLE
Update the golangci-lint to 2.12.2 to support Go 1.26

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -44,7 +44,7 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v2.5.0
+          version: v2.12.2
 
           # Give the job more time to execute.
           # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,


### PR DESCRIPTION
After updating Go to version 1.26 the linter stopped working with the error:

```
Error: can't load config: the Go language version (go1.25) used to
build golangci-lint is lower than the targeted Go version (1.26.3)
```

Related to https://github.com/elastic/beats/pull/50644
