### PR TITLE
libbeat/otel: avoid importing receivertest from production code

### DIFF
--- a/libbeat/otel/otelconsumer/otelconsumer.go
+++ b/libbeat/otel/otelconsumer/otelconsumer.go
@@ -41,12 +41,16 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 const (
 	// esDocumentIDAttribute is the attribute key used to store the document ID in the log record.
 	esDocumentIDAttribute = "elasticsearch.document_id"
+
+	// receivertestUniqueIDAttrName mirrors receivertest.UniqueIDAttrName.
+	// It is duplicated here to avoid importing the receivertest package
+	// (and pulling its testify/testing deps) into production binaries.
+	receivertestUniqueIDAttrName = "test_id"
 
 	retryBackoffInit = 1 * time.Second
 	retryBackoffMax  = 60 * time.Second
@@ -147,7 +151,7 @@ func (out *otelConsumer) logsPublish(ctx context.Context, batch publisher.Batch)
 				// When receivertest allows this to be customized we can remove this condition.
 				// See https://github.com/open-telemetry/opentelemetry-collector/issues/12003.
 				if out.isReceiverTest {
-					logRecord.Attributes().PutStr(receivertest.UniqueIDAttrName, id)
+					logRecord.Attributes().PutStr(receivertestUniqueIDAttrName, id)
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed commit message

`libbeat/otel/otelconsumer` is production code that ships in every Beat binary, yet it imported `go.opentelemetry.io/collector/receiver/receivertest` solely to read its constant `UniqueIDAttrName` (`"test_id"`). `receivertest` is explicitly a test-only helper package and pulls in `github.com/stretchr/testify/{assert,require}`, `componenttest`, the `testing` stdlib, and large parts of the OTel SDK alongside it. As a result every Beat binary linked the OTel test scaffolding even though no production code path needs it.

Inline the constant locally with a comment pointing at the upstream issue that tracks making it customizable (https://github.com/open-telemetry/opentelemetry-collector/issues/12003). Once that is addressed the duplication can be dropped.

This removes 21 packages from filebeat's link graph — including `receivertest`, `componenttest`, `xconsumer`, `xreceiver` and the `otel/sdk/{,metric,trace}` subtrees — and shrinks the linked filebeat binary by ~135 KB; metricbeat sees a comparable reduction.

The existing `otelconsumer_test.go` still imports `receivertest` (where it is appropriate) to verify that the inlined value matches upstream, so any drift in the upstream constant will be caught by CI.

## Why

We should not be linking OTel test scaffolding into production Beats.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~ I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

The existing `otelconsumer` unit tests cover the receivertest doc-id attribute path and are unchanged; they still import `receivertest` to assert that the inlined constant matches the upstream one. Re-ran them with `-race`:

```
cd libbeat && go test -race ./otel/otelconsumer/...
ok  	github.com/elastic/beats/v7/libbeat/otel/otelconsumer
```

## Disruptive User Impact

None. No behavioural change; the inlined value is identical to the upstream constant and an existing test pins them together.

## How to test this PR locally

```bash
# build and observe link graph
cd filebeat && DEV=true mage build
go list -deps . | grep -E 'receivertest|componenttest|otel/sdk'
# (should produce no output on this branch)

# unit tests
cd ../libbeat && go test -race ./otel/otelconsumer/...
```

## Related issues

- Relates https://github.com/open-telemetry/opentelemetry-collector/issues/12003