### PR TITLE
docs: add `line_terminator` to `filestream` and `log` config docs

### DIFF
--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -741,11 +741,11 @@ The maximum number of bytes that a single log message can have. All bytes after 
 
 ### `line_terminator` [filebeat-input-filestream-line-terminator]
 
-The characters that separate lines in the input file. The default is `auto`.
+Specifies the characters used to separate lines in the input file. The default is `auto`.
 
 Valid values:
 
-* `auto`: Detects both LF and CR+LF line endings (U+000A and U+000D U+000A).
+* `auto`: Automatic detection of LF and CR+LF line endings (U+000A and U+000D U+000A).
 * `line_feed`: Line feed (LF, `\n`, U+000A).
 * `vertical_tab`: Vertical tab (VT, `\v`, U+000B).
 * `form_feed`: Form feed (FF, `\f`, U+000C).

--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -739,6 +739,23 @@ When set to `true`, enables GZIP file reading with auto-detection.
 
 The maximum number of bytes that a single log message can have. All bytes after `message_max_bytes` are discarded and not sent. The default is 10MB (10485760).
 
+### `line_terminator` [filebeat-input-filestream-line-terminator]
+
+The characters that separate lines in the input file. The default is `auto`.
+
+Valid values:
+
+* `auto`: Detects both LF and CR+LF line endings (U+000A and U+000D U+000A).
+* `line_feed`: Line feed (LF, `\n`, U+000A).
+* `vertical_tab`: Vertical tab (VT, `\v`, U+000B).
+* `form_feed`: Form feed (FF, `\f`, U+000C).
+* `carriage_return`: Carriage return (CR, `\r`, U+000D).
+* `carriage_return_line_feed`: Carriage return followed by line feed (CR+LF, `\r\n`, U+000D U+000A).
+* `next_line`: Next line (NEL, U+0085).
+* `line_separator`: Line separator (LS, U+2028).
+* `paragraph_separator`: Paragraph separator (PS, U+2029).
+* `null_terminator`: Null character (`\u0000`, U+0000).
+
 ### `parsers` [_parsers]
 
 This option expects a list of parsers that the log line has to go through.

--- a/docs/reference/filebeat/filebeat-input-log.md
+++ b/docs/reference/filebeat/filebeat-input-log.md
@@ -241,11 +241,11 @@ The maximum number of bytes that a single log message can have. All bytes after 
 
 #### `line_terminator` [filebeat-input-log-line-terminator]
 
-The characters that separate lines in the input file. The default is `auto`.
+Specifies the characters used to separate lines in the input file. The default is `auto`.
 
 Valid values:
 
-* `auto`: Detects both LF and CR+LF line endings (U+000A and U+000D U+000A).
+* `auto`: Automatic detection of LF and CR+LF line endings (U+000A and U+000D U+000A).
 * `line_feed`: Line feed (LF, `\n`, U+000A).
 * `vertical_tab`: Vertical tab (VT, `\v`, U+000B).
 * `form_feed`: Form feed (FF, `\f`, U+000C).

--- a/docs/reference/filebeat/filebeat-input-log.md
+++ b/docs/reference/filebeat/filebeat-input-log.md
@@ -239,6 +239,24 @@ The size in bytes of the buffer that each harvester uses when fetching a file. T
 The maximum number of bytes that a single log message can have. All bytes after `max_bytes` are discarded and not sent. This setting is especially useful for multiline log messages, which can get large. The default is 10MB (10485760).
 
 
+#### `line_terminator` [filebeat-input-log-line-terminator]
+
+The characters that separate lines in the input file. The default is `auto`.
+
+Valid values:
+
+* `auto`: Detects both LF and CR+LF line endings (U+000A and U+000D U+000A).
+* `line_feed`: Line feed (LF, `\n`, U+000A).
+* `vertical_tab`: Vertical tab (VT, `\v`, U+000B).
+* `form_feed`: Form feed (FF, `\f`, U+000C).
+* `carriage_return`: Carriage return (CR, `\r`, U+000D).
+* `carriage_return_line_feed`: Carriage return followed by line feed (CR+LF, `\r\n`, U+000D U+000A).
+* `next_line`: Next line (NEL, U+0085).
+* `line_separator`: Line separator (LS, U+2028).
+* `paragraph_separator`: Paragraph separator (PS, U+2029).
+* `null_terminator`: Null character (`\u0000`, U+0000).
+
+
 #### `json` [filebeat-input-log-config-json]
 
 These options make it possible for Filebeat to decode logs structured as JSON messages. Filebeat processes the logs line by line, so the JSON decoding only works if there is one JSON object per line.


### PR DESCRIPTION
The option has been implemented for years but apparently never made it into the docs, other than the [reference YAML docs](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-reference-yml).
