### PR TITLE
Remove not needed url domain from aws elb tests

### DIFF
--- a/x-pack/filebeat/module/aws/elb/test/example-alb-http.log-expected.json
+++ b/x-pack/filebeat/module/aws/elb/test/example-alb-http.log-expected.json
@@ -382,7 +382,6 @@
             "forwarded"
         ],
         "trace.id": "-",
-        "url.domain": null,
         "url.original": "http://www.example.com:80-",
         "url.path": "",
         "url.scheme": "http",

--- a/x-pack/filebeat/module/aws/elb/test/example-http.log-expected.json
+++ b/x-pack/filebeat/module/aws/elb/test/example-http.log-expected.json
@@ -99,7 +99,6 @@
         "tags": [
             "forwarded"
         ],
-        "url.domain": null,
         "url.original": "http://www.example.com:80-",
         "url.path": "",
         "url.scheme": "http",


### PR DESCRIPTION
## Summary

Remove stale `"url.domain": null` entries from AWS ELB module tests.

`uri_parts` ingest processor omits `url.domain` entirely for malformed URLs (e.g. `http://www.example.com:80-`) instead of emitting `null`. This causes two integration test failures in `x-pack/filebeat/module/aws/elb`:
- `test_fileset_file_229_aws` (`example-alb-http.log`)
- `test_fileset_file_232_aws` (`example-http.log`)

Reported in [#48748](https://github.com/elastic/beats/pull/48748).

## Test plan

- [ ] CI passes `x-pack/filebeat` Python integration tests