### PR TITLE
x-pack/filebeat/input/entityanalytics: add Jamf equivalence and integration tests

### DIFF
--- a/x-pack/filebeat/input/entityanalytics/integration_test.go
+++ b/x-pack/filebeat/input/entityanalytics/integration_test.go
@@ -1,0 +1,351 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package entityanalytics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/paths"
+	ecjamf "github.com/elastic/entcollect/provider/jamf"
+)
+
+// TestJamfIntegration_FullLifecycle exercises the minimal-state Jamf input
+// end-to-end: real entcollect provider → minimalStateInput.Run → bbolt →
+// fakeClient. No external services required (httptest only).
+//
+// Phase 1: first sync discovers 3 computers.
+// Phase 2: one computer removed from the API; restart with same bbolt.
+//
+//	Expects 2 modified + 1 deleted.
+func TestJamfIntegration_FullLifecycle(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fixture := newAtomicFixture(makeComputersJSON(t,
+		testComputer{Name: "dev-laptop", UDID: "AAA-111", Managed: true},
+		testComputer{Name: "staging-server", UDID: "BBB-222", Managed: true},
+		testComputer{Name: "to-remove", UDID: "CCC-333", Managed: true},
+	))
+	srv := startJamfIntegServer(t, fixture)
+	host := hostFromURL(t, srv.URL)
+
+	newProvider := func() *ecjamf.Provider {
+		cfg := ecjamf.DefaultConfig()
+		cfg.TenantID = host
+		cfg.Username = "testuser"
+		cfg.Password = "testpass"
+		return ecjamf.NewWithClient(cfg, srv.Client())
+	}
+
+	// Phase 1: first sync discovers all computers.
+
+	client1 := &fakeClient{}
+	err1 := runInputOnce(t, tmpDir, newProvider(), client1)
+	if err1 != nil {
+		t.Fatalf("first run failed: %v", err1)
+	}
+
+	events1 := client1.Events()
+	if got := len(events1); got != 3 {
+		t.Errorf("first sync: got %d events, want 3", got)
+	}
+	if got := countByAction(events1, "device-discovered"); got != 3 {
+		t.Errorf("first sync: got %d discovered, want 3", got)
+	}
+
+	// Phase 2: remove one computer, restart with same bbolt.
+
+	fixture.set(makeComputersJSON(t,
+		testComputer{Name: "dev-laptop", UDID: "AAA-111", Managed: true},
+		testComputer{Name: "staging-server", UDID: "BBB-222", Managed: true},
+	))
+
+	client2 := &fakeClient{}
+	err2 := runInputOnce(t, tmpDir, newProvider(), client2)
+	if err2 != nil {
+		t.Fatalf("second run failed: %v", err2)
+	}
+
+	events2 := client2.Events()
+	if got := len(events2); got != 3 {
+		t.Errorf("second sync: got %d events, want 3 (2 modified + 1 deleted)", got)
+	}
+	if got := countByAction(events2, "device-modified"); got != 2 {
+		t.Errorf("second sync: got %d modified, want 2", got)
+	}
+	if got := countByAction(events2, "device-deleted"); got != 1 {
+		t.Errorf("second sync: got %d deleted, want 1", got)
+	}
+
+	deletedID := ""
+	for _, e := range events2 {
+		action, _ := e.Fields.GetValue("event.action")
+		if action == "device-deleted" {
+			id, _ := e.Fields.GetValue("device.id")
+			deletedID, _ = id.(string)
+		}
+	}
+	if deletedID != "CCC-333" {
+		t.Errorf("deleted device ID = %q, want %q", deletedID, "CCC-333")
+	}
+}
+
+// TestJamfIntegration_CursorRoundTrip verifies that the entcollect cursor
+// keys survive a restart via bbolt and are visible to the provider.
+func TestJamfIntegration_CursorRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fixture := newAtomicFixture(makeComputersJSON(t,
+		testComputer{Name: "laptop", UDID: "CURSOR-TEST", Managed: true},
+	))
+	srv := startJamfIntegServer(t, fixture)
+	host := hostFromURL(t, srv.URL)
+
+	cfg := ecjamf.DefaultConfig()
+	cfg.TenantID = host
+	cfg.Username = "testuser"
+	cfg.Password = "testpass"
+
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, ecjamf.NewWithClient(cfg, srv.Client()), client1); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	if got := len(client1.Events()); got != 1 {
+		t.Fatalf("first sync: got %d events, want 1", got)
+	}
+
+	// Second run: same fixture, same bbolt → cursor should be read back.
+	// The device was already seen, so action should be "modified" not "discovered".
+	client2 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, ecjamf.NewWithClient(cfg, srv.Client()), client2); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	events := client2.Events()
+	if len(events) != 1 {
+		t.Fatalf("second sync: got %d events, want 1", len(events))
+	}
+	action, _ := events[0].Fields.GetValue("event.action")
+	if action != "device-modified" {
+		t.Errorf("second sync action = %v, want %q (proves cursor roundtrip)", action, "device-modified")
+	}
+}
+
+// runInputOnce starts a minimalStateInput, waits for the first full sync to
+// complete (events arrive), and stops it. It returns the Run error.
+func runInputOnce(t *testing.T, dataDir string, p *ecjamf.Provider, client *fakeClient) error {
+	t.Helper()
+	log := logptest.NewTestingLogger(t, "integ")
+
+	mi := &minimalStateInput{
+		provider:         p,
+		providerName:     "jamf",
+		fullSyncInterval: time.Hour,
+		incrSyncInterval: time.Hour,
+		logger:           log,
+		path:             &paths.Path{Data: dataDir},
+	}
+
+	acking := &ackingClient{inner: client}
+	connector := &fakeConnector{client: acking}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mi.Run(
+			v2.Context{
+				Logger:      log,
+				ID:          "integ-jamf",
+				Cancelation: v2.GoContextFromCanceler(ctx),
+			},
+			connector,
+		)
+	}()
+
+	// Wait for at least one event (the sync fires at timer 0).
+	deadline := time.After(10 * time.Second)
+	for len(client.Events()) == 0 {
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("timed out waiting for events from first sync")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Events are published during FullSync, but the cursor and idset
+	// state are committed to bbolt after FullSync returns (runSync
+	// calls buf.Commit then tx.Commit). Canceling before that commit
+	// causes runSync to discard the buffer via ctx.Err(), losing the
+	// cursor. There is no external signal for commit completion, so
+	// we wait long enough for the remaining events and the bbolt
+	// write to finish.
+	time.Sleep(500 * time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+		return nil
+	}
+}
+
+// atomicFixture holds a mutable API response body that can be swapped
+// between test phases while the httptest server is running.
+type atomicFixture struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+// newAtomicFixture returns an atomicFixture initialised with data.
+func newAtomicFixture(data []byte) *atomicFixture {
+	return &atomicFixture{data: data}
+}
+
+func (f *atomicFixture) get() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.data
+}
+
+func (f *atomicFixture) set(data []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data = data
+}
+
+// startJamfIntegServer returns a TLS httptest server that serves Jamf
+// token and computer-list endpoints backed by the given fixture.
+func startJamfIntegServer(t *testing.T, fixture *atomicFixture) *httptest.Server {
+	t.Helper()
+
+	var tokenMu sync.Mutex
+	var currentToken string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/auth/token", func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "testuser" || pass != "testpass" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		tokenMu.Lock()
+		currentToken = uuid.Must(uuid.NewV4()).String()
+		tok := currentToken
+		tokenMu.Unlock()
+
+		expires := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+		fmt.Fprintf(w, `{"token":%q,"expires":%q}`, tok, expires)
+	})
+	mux.HandleFunc("/api/preview/computers", func(w http.ResponseWriter, r *http.Request) {
+		tokenMu.Lock()
+		tok := currentToken
+		tokenMu.Unlock()
+
+		if tok == "" || r.Header.Get("Authorization") != "Bearer "+tok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture.get())
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// testComputer describes a minimal Jamf computer for fixture generation.
+type testComputer struct {
+	Name    string
+	UDID    string
+	Managed bool
+}
+
+// makeComputersJSON marshals computers into a Jamf API response body.
+func makeComputersJSON(t *testing.T, computers ...testComputer) []byte {
+	t.Helper()
+
+	type result struct {
+		Location         struct{} `json:"location"`
+		Name             *string  `json:"name"`
+		UDID             *string  `json:"udid"`
+		IsManaged        *bool    `json:"isManaged"`
+		LastContactDate  string   `json:"lastContactDate"`
+		LastReportDate   string   `json:"lastReportDate"`
+		LastEnrolledDate string   `json:"lastEnrolledDate"`
+	}
+
+	results := make([]result, len(computers))
+	for i, c := range computers {
+		name := c.Name
+		udid := c.UDID
+		managed := c.Managed
+		results[i] = result{
+			Name:             &name,
+			UDID:             &udid,
+			IsManaged:        &managed,
+			LastContactDate:  "2024-01-01T00:00:00Z",
+			LastReportDate:   "2024-01-01T00:00:00Z",
+			LastEnrolledDate: "2024-01-01T00:00:00Z",
+		}
+	}
+
+	body := struct {
+		TotalCount int      `json:"totalCount"`
+		Results    []result `json:"results"`
+	}{
+		TotalCount: len(results),
+		Results:    results,
+	}
+
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshalling fixture: %v", err)
+	}
+	return b
+}
+
+// hostFromURL extracts the host:port from a URL string.
+func hostFromURL(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parsing server URL: %v", err)
+	}
+	return u.Host
+}
+
+// countByAction returns how many events have the given event.action value.
+func countByAction(events []beat.Event, action string) int {
+	n := 0
+	for _, e := range events {
+		a, _ := e.Fields.GetValue("event.action")
+		if a == action {
+			n++
+		}
+	}
+	return n
+}

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/equivalence_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/equivalence_test.go
@@ -1,0 +1,329 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package jamf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider/jamf/internal/jamf"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/entcollect"
+	ecjamf "github.com/elastic/entcollect/provider/jamf"
+)
+
+// TestEquivalence_FullSync runs both the legacy and minimal-state Jamf
+// providers against the same httptest mock and asserts that the jamf.*
+// payloads are structurally equivalent.
+//
+// Intentional differences between the two providers (documented here):
+//   - Legacy stores full Computer records in bbolt; minimal-state uses
+//     idset + cursor keys only.
+//   - Legacy IsManaged check has a bug (c.IsManaged != nil should be
+//     == nil) that marks managed devices as Deleted on update;
+//     minimal-state fixes this. First-sync output is unaffected because
+//     all devices take the "not previously seen" path.
+//   - Legacy emits start/end marker events; minimal-state does not.
+//   - event.kind: "asset" only in minimal-state.
+//   - event.action format differs: legacy uses "device-discovered" etc.;
+//     minimal-state uses entcollect.ActionDiscovered.
+//   - Minimal-state detects API absences as deletions via idset; legacy
+//     has no equivalent detection on incremental.
+func TestEquivalence_FullSync(t *testing.T) {
+	tenant, username, password, client, cleanup := startEquivServer(t)
+	defer cleanup()
+
+	legacyPayloads := runLegacyFetch(t, tenant, username, password, client)
+	minimalDocs := runMinimalFullSync(t, tenant, username, password, client)
+	minimalDevices := filterDocsByKind(minimalDocs, entcollect.KindDevice)
+
+	if len(legacyPayloads) == 0 {
+		t.Fatal("legacy returned no devices; fixture may be empty")
+	}
+	if len(legacyPayloads) != len(minimalDevices) {
+		t.Fatalf("device count: legacy=%d, minimal=%d", len(legacyPayloads), len(minimalDevices))
+	}
+	compareSortedEntries(t, legacyPayloads, minimalDevices)
+}
+
+// TestEquivalence_DeviceTypes unmarshals the shared fixture into both the
+// legacy (internal/jamf.Computer) and entcollect (provider/jamf.Computer)
+// types, then marshals each back to JSON and compares. This catches struct
+// tag drift between the two type definitions.
+func TestEquivalence_DeviceTypes(t *testing.T) {
+	var legacy jamf.Computers
+	if err := json.Unmarshal(computers, &legacy); err != nil {
+		t.Fatalf("unmarshal legacy: %v", err)
+	}
+	var ec ecjamf.Computers
+	if err := json.Unmarshal(computers, &ec); err != nil {
+		t.Fatalf("unmarshal entcollect: %v", err)
+	}
+
+	if len(legacy.Results) != len(ec.Results) {
+		t.Fatalf("count mismatch: legacy=%d, entcollect=%d",
+			len(legacy.Results), len(ec.Results))
+	}
+
+	for i := range legacy.Results {
+		legacyJSON, err := json.Marshal(legacy.Results[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		ecJSON, err := json.Marshal(ec.Results[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(legacyJSON) != string(ecJSON) {
+			t.Errorf("computer[%d] type mismatch:\n  legacy:     %s\n  entcollect: %s",
+				i, legacyJSON, ecJSON)
+		}
+	}
+}
+
+// runLegacyFetch exercises the legacy doFetchComputers path and returns the
+// raw JSON payload for each computer found.
+func runLegacyFetch(t *testing.T, tenant, username, password string, client *http.Client) []json.RawMessage {
+	t.Helper()
+
+	dbFile := t.TempDir() + "/equiv-legacy.db"
+	store := testSetupStore(t, dbFile)
+	t.Cleanup(func() { testCleanupStore(store, dbFile) })
+
+	a := jamfInput{
+		cfg: conf{
+			JamfTenant:   tenant,
+			JamfUsername: username,
+			JamfPassword: password,
+		},
+		client: client,
+		logger: logptest.NewTestingLogger(t, "test-legacy"),
+	}
+
+	ss, err := newStateStore(store)
+	if err != nil {
+		t.Fatalf("newStateStore: %v", err)
+	}
+	defer ss.close(false)
+
+	_, err = a.doFetchComputers(context.Background(), ss, true)
+	if err != nil {
+		t.Fatalf("legacy doFetchComputers: %v", err)
+	}
+
+	payloads := make([]json.RawMessage, 0, len(ss.computers))
+	for _, c := range ss.computers {
+		raw, err := json.Marshal(c.Computer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payloads = append(payloads, raw)
+	}
+	return payloads
+}
+
+// runMinimalFullSync exercises the entcollect FullSync path and returns the
+// published documents.
+func runMinimalFullSync(t *testing.T, tenant, username, password string, client *http.Client) []entcollect.Document {
+	t.Helper()
+
+	cfg := ecjamf.DefaultConfig()
+	cfg.TenantID = tenant
+	cfg.Username = username
+	cfg.Password = password
+
+	p := ecjamf.NewWithClient(cfg, client)
+
+	store := newEquivMemStore()
+	var docs []entcollect.Document
+	pub := func(_ context.Context, doc entcollect.Document) error {
+		docs = append(docs, doc)
+		return nil
+	}
+
+	log := slog.New(slog.NewTextHandler(&testWriter{t}, nil))
+	if err := p.FullSync(context.Background(), store, pub, log); err != nil {
+		t.Fatalf("minimal FullSync: %v", err)
+	}
+	return docs
+}
+
+// compareSortedEntries sorts legacy and minimal payloads by UDID and asserts
+// that the normalised JSON for each pair is identical.
+func compareSortedEntries(t *testing.T, legacy []json.RawMessage, minimalDocs []entcollect.Document) {
+	t.Helper()
+
+	type idPayload struct {
+		id      string
+		payload json.RawMessage
+	}
+
+	legacyByID := make([]idPayload, 0, len(legacy))
+	for _, raw := range legacy {
+		var c struct {
+			Udid *string `json:"udid"`
+		}
+		if err := json.Unmarshal(raw, &c); err != nil {
+			t.Fatal(err)
+		}
+		id := ""
+		if c.Udid != nil {
+			id = *c.Udid
+		}
+		legacyByID = append(legacyByID, idPayload{id: id, payload: raw})
+	}
+	sort.Slice(legacyByID, func(i, j int) bool { return legacyByID[i].id < legacyByID[j].id })
+
+	minimalByID := make([]idPayload, 0, len(minimalDocs))
+	for _, doc := range minimalDocs {
+		raw, err := json.Marshal(doc.Fields["jamf"])
+		if err != nil {
+			t.Fatal(err)
+		}
+		minimalByID = append(minimalByID, idPayload{id: doc.ID, payload: raw})
+	}
+	sort.Slice(minimalByID, func(i, j int) bool { return minimalByID[i].id < minimalByID[j].id })
+
+	for i := range legacyByID {
+		if legacyByID[i].id != minimalByID[i].id {
+			t.Errorf("device[%d] ID mismatch: legacy=%q, minimal=%q",
+				i, legacyByID[i].id, minimalByID[i].id)
+			continue
+		}
+
+		var legacyMap, minimalMap map[string]any
+		if err := json.Unmarshal(legacyByID[i].payload, &legacyMap); err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(minimalByID[i].payload, &minimalMap); err != nil {
+			t.Fatal(err)
+		}
+
+		legacyNorm, _ := json.Marshal(legacyMap)
+		minimalNorm, _ := json.Marshal(minimalMap)
+		if string(legacyNorm) != string(minimalNorm) {
+			t.Errorf("device %q payload mismatch:\n  legacy:  %s\n  minimal: %s",
+				legacyByID[i].id, legacyNorm, minimalNorm)
+		}
+	}
+}
+
+// filterDocsByKind returns only the documents matching the given entity kind.
+func filterDocsByKind(docs []entcollect.Document, kind entcollect.EntityKind) []entcollect.Document {
+	var out []entcollect.Document
+	for _, d := range docs {
+		if d.Kind == kind {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// startEquivServer returns a TLS httptest server that serves Jamf token and
+// computer-list endpoints using the package-level computers fixture.
+func startEquivServer(t *testing.T) (tenant, username, password string, client *http.Client, cleanup func()) {
+	t.Helper()
+
+	username = "testuser"
+	password = "testpassword"
+
+	var tok jamf.Token
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/auth/token", func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != username || pass != password {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		tok.Token = uuid.Must(uuid.NewV4()).String()
+		tok.Expires = time.Now().UTC().Add(time.Hour)
+		fmt.Fprintf(w, `{"token":%q,"expires":%q}`,
+			tok.Token, tok.Expires.Format(time.RFC3339))
+	})
+	mux.HandleFunc("/api/preview/computers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+tok.Token || !tok.IsValidFor(0) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(computers)
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		srv.Close()
+		t.Fatal(err)
+	}
+	return u.Host, username, password, srv.Client(), srv.Close
+}
+
+// testWriter adapts a *testing.T into an io.Writer for slog output.
+type testWriter struct{ t *testing.T }
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+// equivMemStore is an in-memory implementation of entcollect.Store for tests.
+type equivMemStore struct {
+	data map[string]json.RawMessage
+}
+
+// newEquivMemStore returns an empty equivMemStore.
+func newEquivMemStore() *equivMemStore {
+	return &equivMemStore{data: make(map[string]json.RawMessage)}
+}
+
+func (m *equivMemStore) Get(key string, dst any) error {
+	raw, ok := m.data[key]
+	if !ok {
+		return entcollect.ErrKeyNotFound
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+func (m *equivMemStore) Set(key string, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	m.data[key] = raw
+	return nil
+}
+
+func (m *equivMemStore) Delete(key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *equivMemStore) Each(fn func(string, func(any) error) (bool, error)) error {
+	for k, v := range m.data {
+		v := v
+		cont, err := fn(k, func(dst any) error { return json.Unmarshal(v, dst) })
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return nil
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics: add Jamf equivalence and integration tests

Add equivalence tests comparing legacy doFetchComputers output with
entcollect FullSync, verifying structural parity of Jamf device
payloads and detecting struct tag drift between the two Computer
type definitions.

Add integration tests exercising the full minimalStateInput lifecycle
with a real entcollect Jamf provider against an httptest server:
initial discovery, deletion detection via mutable fixtures, cursor
persistence across bbolt restarts.

For #50774

Assisted-By: Cursor
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #50774

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
