### PR TITLE
[8.19] Set Google OIDC plugin for agentbeat jobs

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -201,6 +201,7 @@ steps:
           automatic:
             - limit: 1
         plugins:
+          - *google_oidc_plugin
           - *dockerhub_login_plugin
           - *docker_elastic_login_plugin
         artifact_paths:
@@ -385,6 +386,7 @@ steps:
         artifact_paths:
           - build/distributions/**/*
         plugins:
+          - *google_oidc_plugin
           - *dockerhub_login_plugin
           - *docker_elastic_login_plugin
 


### PR DESCRIPTION
Add the `google_oidc_plugin` to the `agentbeat` specific steps missed by https://github.com/elastic/beats/pull/50801.

9.3+ removed Agentbeat and explains why these declarations were missed initially.