### PR TITLE
[ci][FIPS] `google_oidc_plugin` also needed on FIPS steps

### DIFF
--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -282,6 +282,7 @@ steps:
         artifact_paths:
           - build/distributions/**/*
         plugins:
+          - *google_oidc_plugin
           - *dockerhub_login_plugin
           - *docker_elastic_login_plugin
 
@@ -471,6 +472,7 @@ steps:
         artifact_paths:
           - build/distributions/**/*
         plugins:
+          - *google_oidc_plugin
           - *dockerhub_login_plugin
           - *docker_elastic_login_plugin
 


### PR DESCRIPTION
Missed setting `google_oidc_plugin` on the FIPS specific steps in https://github.com/elastic/beats/pull/50994.