### PR TITLE
x-pack/filebeat/input/entityanalytics: add AD, Okta, and EntraID integration tests

### DIFF
--- a/x-pack/filebeat/input/entityanalytics/integration_ad_test.go
+++ b/x-pack/filebeat/input/entityanalytics/integration_ad_test.go
@@ -1,0 +1,368 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package entityanalytics
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jimlambrt/gldap"
+
+	ecad "github.com/elastic/entcollect/provider/ad"
+)
+
+func TestADIntegration_FullLifecycle(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := &adFixture{
+		users: []adEntry{
+			{
+				dn: "cn=alice,dc=example,dc=com",
+				attrs: map[string][]string{
+					"cn":                {"alice"},
+					"distinguishedName": {"cn=alice,dc=example,dc=com"},
+					"mail":              {"alice@example.com"},
+					"whenChanged":       {"20260101120000.0Z"},
+				},
+			},
+			{
+				dn: "cn=bob,dc=example,dc=com",
+				attrs: map[string][]string{
+					"cn":                {"bob"},
+					"distinguishedName": {"cn=bob,dc=example,dc=com"},
+					"mail":              {"bob@example.com"},
+					"whenChanged":       {"20260101130000.0Z"},
+				},
+			},
+		},
+		devices: []adEntry{
+			{
+				dn: "cn=workstation1,dc=example,dc=com",
+				attrs: map[string][]string{
+					"cn":                {"workstation1"},
+					"distinguishedName": {"cn=workstation1,dc=example,dc=com"},
+					"whenChanged":       {"20260101140000.0Z"},
+				},
+			},
+		},
+	}
+
+	serverURL := startADIntegLDAPServer(t, fix)
+
+	newProvider := func() *ecad.Provider {
+		cfg := ecad.DefaultConfig()
+		cfg.URL = serverURL
+		cfg.BaseDN = "DC=example,DC=com"
+		cfg.User = "cn=admin,dc=example,dc=com"
+		cfg.Password = "pass"
+		p, err := ecad.New(cfg)
+		if err != nil {
+			t.Fatalf("new AD provider: %v", err)
+		}
+		return p
+	}
+
+	// Run 1: full sync discovers all entities.
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "activedirectory", newProvider(), client1); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+
+	events1 := client1.Events()
+	if got := len(events1); got != 3 {
+		t.Errorf("first sync: got %d events, want 3", got)
+	}
+	if got := countByAction(events1, "user-discovered"); got != 2 {
+		t.Errorf("first sync: got %d user-discovered, want 2", got)
+	}
+	if got := countByAction(events1, "device-discovered"); got != 1 {
+		t.Errorf("first sync: got %d device-discovered, want 1", got)
+	}
+
+	// Assert bbolt state keys after first run.
+	assertBboltKey(t, tmpDir, "activedirectory", "ad.cursor.when_changed")
+	assertBboltKey(t, tmpDir, "activedirectory", "ad.users.idset.meta")
+	assertBboltKey(t, tmpDir, "activedirectory", "ad.devices.idset.meta")
+
+	// Run 2: remove bob, restart with same bbolt.
+	fix.users = []adEntry{
+		{
+			dn: "cn=alice,dc=example,dc=com",
+			attrs: map[string][]string{
+				"cn":                {"alice"},
+				"distinguishedName": {"cn=alice,dc=example,dc=com"},
+				"mail":              {"alice@example.com"},
+				"whenChanged":       {"20260101120000.0Z"},
+			},
+		},
+	}
+
+	client2 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "activedirectory", newProvider(), client2); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	events2 := client2.Events()
+	if got := len(events2); got != 3 {
+		t.Errorf("second sync: got %d events, want 3 (1 user-modified + 1 device-modified + 1 user-deleted)", got)
+	}
+	if got := countByAction(events2, "user-modified"); got != 1 {
+		t.Errorf("second sync: got %d user-modified, want 1", got)
+	}
+	if got := countByAction(events2, "device-modified"); got != 1 {
+		t.Errorf("second sync: got %d device-modified, want 1", got)
+	}
+	if got := countByAction(events2, "user-deleted"); got != 1 {
+		t.Errorf("second sync: got %d user-deleted, want 1", got)
+	}
+
+	deletedID := ""
+	for _, e := range events2 {
+		action, _ := e.Fields.GetValue("event.action")
+		if action == "user-deleted" {
+			id, _ := e.Fields.GetValue("user.id")
+			deletedID, _ = id.(string)
+		}
+	}
+	if deletedID != "cn=bob,dc=example,dc=com" {
+		t.Errorf("deleted user ID = %q, want %q", deletedID, "cn=bob,dc=example,dc=com")
+	}
+}
+
+func TestADIntegration_CursorRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := &adFixture{
+		users: []adEntry{
+			{
+				dn: "cn=alice,dc=example,dc=com",
+				attrs: map[string][]string{
+					"cn":                {"alice"},
+					"distinguishedName": {"cn=alice,dc=example,dc=com"},
+					"whenChanged":       {"20260101120000.0Z"},
+				},
+			},
+		},
+	}
+
+	serverURL := startADIntegLDAPServer(t, fix)
+
+	cfg := ecad.DefaultConfig()
+	cfg.URL = serverURL
+	cfg.BaseDN = "DC=example,DC=com"
+	cfg.User = "cn=admin,dc=example,dc=com"
+	cfg.Password = "pass"
+
+	newProvider := func() *ecad.Provider {
+		p, err := ecad.New(cfg)
+		if err != nil {
+			t.Fatalf("new AD provider: %v", err)
+		}
+		return p
+	}
+
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "activedirectory", newProvider(), client1); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	if got := len(client1.Events()); got != 1 {
+		t.Fatalf("first sync: got %d events, want 1", got)
+	}
+
+	// Second run: same fixture, same bbolt -> cursor round-trip proves
+	// "modified" instead of "discovered".
+	client2 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "activedirectory", newProvider(), client2); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	events := client2.Events()
+	if len(events) != 1 {
+		t.Fatalf("second sync: got %d events, want 1", len(events))
+	}
+	action, _ := events[0].Fields.GetValue("event.action")
+	if action != "user-modified" {
+		t.Errorf("second sync action = %v, want %q (proves cursor roundtrip)", action, "user-modified")
+	}
+}
+
+// TestADIntegration_MissingCursor verifies that deleting the AD cursor
+// from bbolt causes the incremental sync to treat it as a zero-time
+// cursor and still emit entities. This tests the adapter-level recovery
+// path — the provider falls back to fetching everything when the cursor
+// is missing.
+func TestADIntegration_MissingCursor(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := &adFixture{
+		users: []adEntry{
+			{
+				dn: "cn=alice,dc=example,dc=com",
+				attrs: map[string][]string{
+					"cn":                {"alice"},
+					"distinguishedName": {"cn=alice,dc=example,dc=com"},
+					"whenChanged":       {"20260101120000.0Z"},
+				},
+			},
+		},
+	}
+
+	serverURL := startADIntegLDAPServer(t, fix)
+
+	cfg := ecad.DefaultConfig()
+	cfg.URL = serverURL
+	cfg.BaseDN = "DC=example,DC=com"
+	cfg.User = "cn=admin,dc=example,dc=com"
+	cfg.Password = "pass"
+
+	newProvider := func() *ecad.Provider {
+		p, err := ecad.New(cfg)
+		if err != nil {
+			t.Fatalf("new AD provider: %v", err)
+		}
+		return p
+	}
+
+	// Run 1: full sync to populate bbolt with cursor and idset.
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "activedirectory", newProvider(), client1); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	if got := len(client1.Events()); got != 1 {
+		t.Fatalf("first sync: got %d events, want 1", got)
+	}
+	assertBboltKey(t, tmpDir, "activedirectory", "ad.cursor.when_changed")
+
+	// Delete the cursor from bbolt. The provider should treat the
+	// missing cursor as zero time and fetch all entities.
+	deleteBboltKey(t, tmpDir, "activedirectory", "ad.cursor.when_changed")
+
+	// Run incremental sync with missing cursor.
+	client2 := &fakeClient{}
+	if err := runIncrementalOnce(t, tmpDir, "activedirectory", newProvider(), client2); err != nil {
+		t.Fatalf("incremental with missing cursor failed: %v", err)
+	}
+
+	events := client2.Events()
+	if len(events) == 0 {
+		t.Error("incremental sync with missing cursor produced no events; want at least 1")
+	}
+}
+
+// AD test infrastructure
+
+type adFixture struct {
+	users   []adEntry
+	devices []adEntry
+	groups  []adEntry
+}
+
+type adEntry struct {
+	dn    string
+	attrs map[string][]string
+}
+
+type adLDAPServer struct {
+	fix *adFixture
+}
+
+func startADIntegLDAPServer(t *testing.T, fix *adFixture) string {
+	t.Helper()
+
+	srv := &adLDAPServer{fix: fix}
+
+	s, err := gldap.NewServer()
+	if err != nil {
+		t.Fatalf("gldap new server: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Stop() })
+
+	mux, err := gldap.NewMux()
+	if err != nil {
+		t.Fatalf("gldap new mux: %v", err)
+	}
+
+	if err := mux.Bind(func(w *gldap.ResponseWriter, r *gldap.Request) {
+		resp := r.NewBindResponse()
+		resp.SetResultCode(gldap.ResultSuccess)
+		_ = w.Write(resp)
+	}); err != nil {
+		t.Fatalf("mux bind: %v", err)
+	}
+
+	if err := mux.Search(srv.searchHandler(t)); err != nil {
+		t.Fatalf("mux search: %v", err)
+	}
+
+	if err := mux.Unbind(func(w *gldap.ResponseWriter, r *gldap.Request) {}); err != nil {
+		t.Fatalf("mux unbind: %v", err)
+	}
+
+	if err := s.Router(mux); err != nil {
+		t.Fatalf("gldap router: %v", err)
+	}
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	go func() { _ = s.Run(addr) }()
+	for i := 0; i < 100; i++ {
+		if s.Ready() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !s.Ready() {
+		t.Fatal("gldap server not ready")
+	}
+
+	return "ldap://" + addr
+}
+
+func (s *adLDAPServer) searchHandler(t *testing.T) gldap.HandlerFunc {
+	t.Helper()
+	return func(w *gldap.ResponseWriter, r *gldap.Request) {
+		msg, err := r.GetSearchMessage()
+		if err != nil {
+			t.Errorf("get search message: %v", err)
+			return
+		}
+
+		filter := msg.Filter
+		fix := s.fix
+
+		var results []adEntry
+
+		switch {
+		case strings.Contains(filter, "objectClass=group"):
+			results = fix.groups
+		case strings.Contains(filter, "objectClass=computer"):
+			results = fix.devices
+		case strings.Contains(filter, "objectCategory=person"):
+			results = fix.users
+		default:
+			t.Logf("unhandled filter: %s", filter)
+		}
+
+		for _, entry := range results {
+			e := r.NewSearchResponseEntry(entry.dn)
+			for name, vals := range entry.attrs {
+				e.AddAttribute(name, vals)
+			}
+			_ = w.Write(e)
+		}
+
+		done := r.NewSearchDoneResponse()
+		done.SetResultCode(gldap.ResultSuccess)
+		_ = w.Write(done)
+	}
+}

--- a/x-pack/filebeat/input/entityanalytics/integration_entraid_test.go
+++ b/x-pack/filebeat/input/entityanalytics/integration_entraid_test.go
@@ -1,0 +1,344 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package entityanalytics
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	ecentraid "github.com/elastic/entcollect/provider/entraid"
+)
+
+// TestEntraidIntegration_FullLifecycle exercises the EntraID adapter end-to-end.
+//
+// Run 1: full sync discovers users and devices.
+// Run 2: full sync with one @removed user → remaining discovered + removed deleted.
+func TestEntraidIntegration_FullLifecycle(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := newEntraidFixture()
+	fix.set(entraidData{
+		users: []map[string]any{
+			{"id": "u1", "userPrincipalName": "alice@example.com", "displayName": "Alice"},
+			{"id": "u2", "userPrincipalName": "bob@example.com", "displayName": "Bob"},
+		},
+		devices: []map[string]any{
+			{"id": "d1", "displayName": "Workstation-1", "operatingSystem": "Windows"},
+		},
+	})
+
+	srv := startEntraidIntegServer(t, fix)
+
+	newProvider := func() *ecentraid.Provider {
+		cfg := ecentraid.DefaultConfig()
+		cfg.TenantID = "test-tenant"
+		cfg.ClientID = "test-client"
+		cfg.ClientSecret = "test-secret"
+		cfg.LoginEndpoint = srv.URL
+		cfg.APIEndpoint = srv.URL + "/v1.0"
+		cfg.Dataset = "all"
+		return ecentraid.NewWithClient(cfg, srv.Client())
+	}
+
+	// Run 1: full sync discovers all entities.
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "azure-ad", newProvider(), client1); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+
+	events1 := client1.Events()
+	if got := len(events1); got != 3 {
+		t.Errorf("first sync: got %d events, want 3 (2 users + 1 device)", got)
+	}
+	if got := countByAction(events1, "user-discovered"); got != 2 {
+		t.Errorf("first sync: got %d user-discovered, want 2", got)
+	}
+	if got := countByAction(events1, "device-discovered"); got != 1 {
+		t.Errorf("first sync: got %d device-discovered, want 1", got)
+	}
+
+	// Assert delta link keys are written.
+	assertBboltKey(t, tmpDir, "azure-ad", "entraid.cursor.users_delta")
+	assertBboltKey(t, tmpDir, "azure-ad", "entraid.cursor.devices_delta")
+
+	// Run 2: @removed user, full sync → remaining discovered + removed deleted.
+	fix.set(entraidData{
+		users: []map[string]any{
+			{"id": "u1", "userPrincipalName": "alice@example.com", "displayName": "Alice"},
+			{"id": "u2", "@removed": map[string]any{"reason": "deleted"}},
+		},
+		devices: []map[string]any{
+			{"id": "d1", "displayName": "Workstation-1", "operatingSystem": "Windows"},
+		},
+	})
+
+	client2 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "azure-ad", newProvider(), client2); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	events2 := client2.Events()
+	if got := len(events2); got != 3 {
+		t.Errorf("second sync: got %d events, want 3 (1 user-discovered + 1 user-deleted + 1 device-discovered)", got)
+	}
+	if got := countByAction(events2, "user-discovered"); got != 1 {
+		t.Errorf("second sync: got %d user-discovered, want 1", got)
+	}
+	if got := countByAction(events2, "user-deleted"); got != 1 {
+		t.Errorf("second sync: got %d user-deleted, want 1", got)
+	}
+	if got := countByAction(events2, "device-discovered"); got != 1 {
+		t.Errorf("second sync: got %d device-discovered, want 1", got)
+	}
+
+	deletedID := ""
+	for _, e := range events2 {
+		action, _ := e.Fields.GetValue("event.action")
+		if action == "user-deleted" {
+			id, _ := e.Fields.GetValue("user.id")
+			deletedID, _ = id.(string)
+		}
+	}
+	if deletedID != "u2" {
+		t.Errorf("deleted user ID = %q, want %q", deletedID, "u2")
+	}
+}
+
+// TestEntraidIntegration_IncrementalDeltaLink verifies that delta links
+// stored in bbolt by full sync are read back and used by incremental
+// sync. Entities arrive as *-modified (IncrementalSync), proving the
+// delta link was round-tripped through bbolt.
+func TestEntraidIntegration_IncrementalDeltaLink(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := newEntraidFixture()
+	fix.set(entraidData{
+		users: []map[string]any{
+			{"id": "u1", "userPrincipalName": "alice@example.com", "displayName": "Alice"},
+		},
+		devices: []map[string]any{
+			{"id": "d1", "displayName": "Workstation-1", "operatingSystem": "Windows"},
+		},
+		deltaUsers: []map[string]any{
+			{"id": "u1", "displayName": "Alice Updated"},
+		},
+		deltaDevices: []map[string]any{
+			{"id": "d1", "displayName": "Workstation-1 Updated"},
+		},
+	})
+
+	srv := startEntraidIntegServer(t, fix)
+
+	newProvider := func() *ecentraid.Provider {
+		cfg := ecentraid.DefaultConfig()
+		cfg.TenantID = "test-tenant"
+		cfg.ClientID = "test-client"
+		cfg.ClientSecret = "test-secret"
+		cfg.LoginEndpoint = srv.URL
+		cfg.APIEndpoint = srv.URL + "/v1.0"
+		cfg.Dataset = "all"
+		return ecentraid.NewWithClient(cfg, srv.Client())
+	}
+
+	// Seed: full sync stores delta links.
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "azure-ad", newProvider(), client1); err != nil {
+		t.Fatalf("seed run failed: %v", err)
+	}
+	assertBboltKey(t, tmpDir, "azure-ad", "entraid.cursor.users_delta")
+	assertBboltKey(t, tmpDir, "azure-ad", "entraid.cursor.devices_delta")
+
+	// Incremental sync: delta link from bbolt → delta data.
+	client2 := &fakeClient{}
+	if err := runIncrementalOnce(t, tmpDir, "azure-ad", newProvider(), client2); err != nil {
+		t.Fatalf("incremental run failed: %v", err)
+	}
+
+	events := client2.Events()
+	if got := len(events); got != 2 {
+		t.Errorf("incremental sync: got %d events, want 2 (1 user + 1 device)", got)
+	}
+	if got := countByAction(events, "user-modified"); got != 1 {
+		t.Errorf("incremental sync: got %d user-modified, want 1", got)
+	}
+	if got := countByAction(events, "device-modified"); got != 1 {
+		t.Errorf("incremental sync: got %d device-modified, want 1", got)
+	}
+}
+
+// TestEntraidIntegration_DeltaRecovery verifies that an expired delta
+// link (HTTP 410) causes the provider to fall back to a full re-fetch
+// within IncrementalSync. Entities still arrive as *-modified.
+func TestEntraidIntegration_DeltaRecovery(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := newEntraidFixture()
+	fix.set(entraidData{
+		users: []map[string]any{
+			{"id": "u1", "userPrincipalName": "alice@example.com", "displayName": "Alice"},
+		},
+		devices: []map[string]any{
+			{"id": "d1", "displayName": "Workstation-1", "operatingSystem": "Windows"},
+		},
+	})
+
+	srv := startEntraidIntegServer(t, fix)
+
+	newProvider := func() *ecentraid.Provider {
+		cfg := ecentraid.DefaultConfig()
+		cfg.TenantID = "test-tenant"
+		cfg.ClientID = "test-client"
+		cfg.ClientSecret = "test-secret"
+		cfg.LoginEndpoint = srv.URL
+		cfg.APIEndpoint = srv.URL + "/v1.0"
+		cfg.Dataset = "all"
+		return ecentraid.NewWithClient(cfg, srv.Client())
+	}
+
+	// Seed: full sync stores delta links.
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "azure-ad", newProvider(), client1); err != nil {
+		t.Fatalf("seed run failed: %v", err)
+	}
+
+	// Expire the delta links: mock returns 410 for delta-token requests.
+	fix.setDeltaStatus(http.StatusGone)
+
+	// Incremental sync with expired delta → provider falls back to full fetch.
+	client2 := &fakeClient{}
+	if err := runIncrementalOnce(t, tmpDir, "azure-ad", newProvider(), client2); err != nil {
+		t.Fatalf("delta recovery run failed: %v", err)
+	}
+
+	events := client2.Events()
+	if len(events) == 0 {
+		t.Fatal("delta recovery: no events produced; want entities from fallback fetch")
+	}
+	// IncrementalSync emits ActionModified even after recovery.
+	if got := countByAction(events, "user-modified"); got != 1 {
+		t.Errorf("delta recovery: got %d user-modified, want 1", got)
+	}
+	if got := countByAction(events, "device-modified"); got != 1 {
+		t.Errorf("delta recovery: got %d device-modified, want 1", got)
+	}
+}
+
+// EntraID test infrastructure
+
+type entraidData struct {
+	users        []map[string]any
+	devices      []map[string]any
+	deltaUsers   []map[string]any // served for delta-token requests; nil → use users
+	deltaDevices []map[string]any // served for delta-token requests; nil → use devices
+}
+
+type entraidFixture struct {
+	mu          sync.Mutex
+	data        entraidData
+	deltaStatus int // if non-zero, return this status for delta-token requests
+}
+
+func newEntraidFixture() *entraidFixture {
+	return &entraidFixture{}
+}
+
+func (f *entraidFixture) set(d entraidData) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data = d
+	f.deltaStatus = 0
+}
+
+func (f *entraidFixture) setDeltaStatus(status int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deltaStatus = status
+}
+
+func (f *entraidFixture) get() (entraidData, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.data, f.deltaStatus
+}
+
+func startEntraidIntegServer(t *testing.T, fix *entraidFixture) *httptest.Server {
+	t.Helper()
+
+	var srvURL string
+	mux := http.NewServeMux()
+
+	deltaLink := func(path string) string {
+		return srvURL + path
+	}
+
+	// OAuth token endpoint.
+	mux.HandleFunc("POST /test-tenant/oauth2/v2.0/token", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+
+	// Users delta.
+	mux.HandleFunc("GET /v1.0/users/delta", func(w http.ResponseWriter, r *http.Request) {
+		d, status := fix.get()
+		isDelta := r.URL.Query().Has("$deltatoken")
+
+		if isDelta && status != 0 {
+			w.WriteHeader(status)
+			return
+		}
+
+		users := d.users
+		if isDelta && d.deltaUsers != nil {
+			users = d.deltaUsers
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"@odata.deltaLink": deltaLink("/v1.0/users/delta?$deltatoken=test"),
+			"value":            users,
+		})
+	})
+
+	// Devices delta.
+	mux.HandleFunc("GET /v1.0/devices/delta", func(w http.ResponseWriter, r *http.Request) {
+		d, status := fix.get()
+		isDelta := r.URL.Query().Has("$deltatoken")
+
+		if isDelta && status != 0 {
+			w.WriteHeader(status)
+			return
+		}
+
+		devices := d.devices
+		if isDelta && d.deltaDevices != nil {
+			devices = d.deltaDevices
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"@odata.deltaLink": deltaLink("/v1.0/devices/delta?$deltatoken=test"),
+			"value":            devices,
+		})
+	})
+
+	// Groups list — empty, not testing group enrichment.
+	mux.HandleFunc("GET /v1.0/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	})
+
+	// Device registered owners/users — empty.
+	mux.HandleFunc("GET /v1.0/devices/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+	})
+
+	srv := httptest.NewServer(mux)
+	srvURL = srv.URL
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/x-pack/filebeat/input/entityanalytics/integration_okta_test.go
+++ b/x-pack/filebeat/input/entityanalytics/integration_okta_test.go
@@ -1,0 +1,255 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package entityanalytics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	ecokta "github.com/elastic/entcollect/provider/okta"
+)
+
+func TestOktaIntegration_FullLifecycle(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := newOktaFixture()
+	fix.set(oktaData{
+		users: `[
+			{"id":"u1","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Smith"}},
+			{"id":"u2","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"bob@example.com","email":"bob@example.com","firstName":"Bob","lastName":"Jones"}},
+			{"id":"u3","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"charlie@example.com","email":"charlie@example.com","firstName":"Charlie","lastName":"Brown"}}
+		]`,
+		groups: `[
+			{"id":"g1","profile":{"name":"Staff","description":"All staff"}},
+			{"id":"g2","profile":{"name":"Engineering","description":"Engineering team"}}
+		]`,
+		groupMembers: map[string]string{
+			"g1": `[{"id":"u1"},{"id":"u2"},{"id":"u3"}]`,
+			"g2": `[{"id":"u1"}]`,
+		},
+		devices: `[
+			{"id":"d1","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","status":"ACTIVE","profile":{"displayName":"Alice Laptop"},"resourceID":"d1","resourceType":"UDDevice"}
+		]`,
+		deviceUsers: map[string]string{
+			"d1": `[{"created":"2026-01-01T12:00:00.000Z","managementStatus":"NOT_MANAGED","screenLockType":"NONE","user":{"id":"u1","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Smith"}}}]`,
+		},
+	})
+
+	srv := startOktaIntegServer(t, fix)
+
+	limitFixed := 1000
+	newProvider := func() *ecokta.Provider {
+		cfg := ecokta.DefaultConfig()
+		cfg.Domain = strings.TrimPrefix(srv.URL, "https://")
+		cfg.Token = "test-token"
+		cfg.EnrichWith = []string{"groups"}
+		cfg.LimitFixed = &limitFixed
+		return ecokta.NewWithClient(cfg, srv.Client())
+	}
+
+	// Run 1: full sync discovers all entities.
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "okta", newProvider(), client1); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+
+	events1 := client1.Events()
+	if got := len(events1); got != 4 {
+		t.Errorf("first sync: got %d events, want 4 (3 users + 1 device)", got)
+	}
+	if got := countByAction(events1, "user-discovered"); got != 3 {
+		t.Errorf("first sync: got %d user-discovered, want 3", got)
+	}
+	if got := countByAction(events1, "device-discovered"); got != 1 {
+		t.Errorf("first sync: got %d device-discovered, want 1", got)
+	}
+
+	// Assert bbolt state keys.
+	assertBboltKey(t, tmpDir, "okta", "okta.cursor.user.last_sync")
+	assertBboltKey(t, tmpDir, "okta", "okta.users.idset.meta")
+	assertBboltKey(t, tmpDir, "okta", "okta.cursor.device.last_sync")
+	assertBboltKey(t, tmpDir, "okta", "okta.devices.idset.meta")
+
+	// Run 2: remove u3, restart with same bbolt.
+	fix.set(oktaData{
+		users: `[
+			{"id":"u1","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Smith"}},
+			{"id":"u2","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"bob@example.com","email":"bob@example.com","firstName":"Bob","lastName":"Jones"}}
+		]`,
+		groups: `[
+			{"id":"g1","profile":{"name":"Staff","description":"All staff"}},
+			{"id":"g2","profile":{"name":"Engineering","description":"Engineering team"}}
+		]`,
+		groupMembers: map[string]string{
+			"g1": `[{"id":"u1"},{"id":"u2"}]`,
+			"g2": `[{"id":"u1"}]`,
+		},
+		devices: `[
+			{"id":"d1","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","status":"ACTIVE","profile":{"displayName":"Alice Laptop"},"resourceID":"d1","resourceType":"UDDevice"}
+		]`,
+		deviceUsers: map[string]string{
+			"d1": `[{"created":"2026-01-01T12:00:00.000Z","managementStatus":"NOT_MANAGED","screenLockType":"NONE","user":{"id":"u1","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Smith"}}}]`,
+		},
+	})
+
+	client2 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "okta", newProvider(), client2); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	events2 := client2.Events()
+	if got := len(events2); got != 4 {
+		t.Errorf("second sync: got %d events, want 4 (2 user-modified + 1 device-modified + 1 user-deleted)", got)
+	}
+	if got := countByAction(events2, "user-modified"); got != 2 {
+		t.Errorf("second sync: got %d user-modified, want 2", got)
+	}
+	if got := countByAction(events2, "device-modified"); got != 1 {
+		t.Errorf("second sync: got %d device-modified, want 1", got)
+	}
+	if got := countByAction(events2, "user-deleted"); got != 1 {
+		t.Errorf("second sync: got %d user-deleted, want 1", got)
+	}
+
+	deletedID := ""
+	for _, e := range events2 {
+		action, _ := e.Fields.GetValue("event.action")
+		if action == "user-deleted" {
+			id, _ := e.Fields.GetValue("user.id")
+			deletedID, _ = id.(string)
+		}
+	}
+	if deletedID != "u3" {
+		t.Errorf("deleted user ID = %q, want %q", deletedID, "u3")
+	}
+}
+
+func TestOktaIntegration_CursorRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fix := newOktaFixture()
+	fix.set(oktaData{
+		users: `[
+			{"id":"u1","status":"ACTIVE","created":"2026-01-01T12:00:00.000Z","lastUpdated":"2026-01-02T12:00:00.000Z","profile":{"login":"alice@example.com","email":"alice@example.com","firstName":"Alice","lastName":"Smith"}}
+		]`,
+		groups:       `[]`,
+		groupMembers: map[string]string{},
+		devices:      `[]`,
+		deviceUsers:  map[string]string{},
+	})
+
+	srv := startOktaIntegServer(t, fix)
+
+	limitFixed := 1000
+	cfg := ecokta.DefaultConfig()
+	cfg.Domain = strings.TrimPrefix(srv.URL, "https://")
+	cfg.Token = "test-token"
+	cfg.EnrichWith = []string{"groups"}
+	cfg.LimitFixed = &limitFixed
+
+	client1 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "okta", ecokta.NewWithClient(cfg, srv.Client()), client1); err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	if got := len(client1.Events()); got != 1 {
+		t.Fatalf("first sync: got %d events, want 1", got)
+	}
+
+	// Second run: same fixture, same bbolt -> cursor proves modified.
+	client2 := &fakeClient{}
+	if err := runInputOnce(t, tmpDir, "okta", ecokta.NewWithClient(cfg, srv.Client()), client2); err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	events := client2.Events()
+	if len(events) != 1 {
+		t.Fatalf("second sync: got %d events, want 1", len(events))
+	}
+	action, _ := events[0].Fields.GetValue("event.action")
+	if action != "user-modified" {
+		t.Errorf("second sync action = %v, want %q (proves cursor roundtrip)", action, "user-modified")
+	}
+}
+
+// Okta test infrastructure
+
+type oktaData struct {
+	users        string
+	groups       string
+	groupMembers map[string]string // groupID -> JSON members array
+	devices      string
+	deviceUsers  map[string]string // deviceID -> JSON device-users array
+}
+
+type oktaFixture struct {
+	mu   sync.Mutex
+	data oktaData
+}
+
+func newOktaFixture() *oktaFixture {
+	return &oktaFixture{}
+}
+
+func (f *oktaFixture) set(d oktaData) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data = d
+}
+
+func (f *oktaFixture) get() oktaData {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.data
+}
+
+func startOktaIntegServer(t *testing.T, fix *oktaFixture) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fix.get().users))
+	})
+
+	mux.HandleFunc("GET /api/v1/groups", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fix.get().groups))
+	})
+
+	mux.HandleFunc("GET /api/v1/groups/{groupID}/users", func(w http.ResponseWriter, r *http.Request) {
+		groupID := r.PathValue("groupID")
+		d := fix.get()
+		members, ok := d.groupMembers[groupID]
+		if !ok {
+			members = "[]"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(members))
+	})
+
+	mux.HandleFunc("GET /api/v1/devices", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fix.get().devices))
+	})
+
+	mux.HandleFunc("GET /api/v1/devices/{deviceID}/users", func(w http.ResponseWriter, r *http.Request) {
+		deviceID := r.PathValue("deviceID")
+		d := fix.get()
+		users, ok := d.deviceUsers[deviceID]
+		if !ok {
+			users = "[]"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(users))
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/x-pack/filebeat/input/entityanalytics/integration_test.go
+++ b/x-pack/filebeat/input/entityanalytics/integration_test.go
@@ -8,9 +8,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -19,8 +21,10 @@ import (
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/internal/kvstore"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/paths"
+	"github.com/elastic/entcollect"
 	ecjamf "github.com/elastic/entcollect/provider/jamf"
 )
 
@@ -54,7 +58,7 @@ func TestJamfIntegration_FullLifecycle(t *testing.T) {
 	// Phase 1: first sync discovers all computers.
 
 	client1 := &fakeClient{}
-	err1 := runInputOnce(t, tmpDir, newProvider(), client1)
+	err1 := runInputOnce(t, tmpDir, "jamf", newProvider(), client1)
 	if err1 != nil {
 		t.Fatalf("first run failed: %v", err1)
 	}
@@ -75,7 +79,7 @@ func TestJamfIntegration_FullLifecycle(t *testing.T) {
 	))
 
 	client2 := &fakeClient{}
-	err2 := runInputOnce(t, tmpDir, newProvider(), client2)
+	err2 := runInputOnce(t, tmpDir, "jamf", newProvider(), client2)
 	if err2 != nil {
 		t.Fatalf("second run failed: %v", err2)
 	}
@@ -121,7 +125,7 @@ func TestJamfIntegration_CursorRoundTrip(t *testing.T) {
 	cfg.Password = "testpass"
 
 	client1 := &fakeClient{}
-	if err := runInputOnce(t, tmpDir, ecjamf.NewWithClient(cfg, srv.Client()), client1); err != nil {
+	if err := runInputOnce(t, tmpDir, "jamf", ecjamf.NewWithClient(cfg, srv.Client()), client1); err != nil {
 		t.Fatalf("first run failed: %v", err)
 	}
 	if got := len(client1.Events()); got != 1 {
@@ -131,7 +135,7 @@ func TestJamfIntegration_CursorRoundTrip(t *testing.T) {
 	// Second run: same fixture, same bbolt → cursor should be read back.
 	// The device was already seen, so action should be "modified" not "discovered".
 	client2 := &fakeClient{}
-	if err := runInputOnce(t, tmpDir, ecjamf.NewWithClient(cfg, srv.Client()), client2); err != nil {
+	if err := runInputOnce(t, tmpDir, "jamf", ecjamf.NewWithClient(cfg, srv.Client()), client2); err != nil {
 		t.Fatalf("second run failed: %v", err)
 	}
 
@@ -147,13 +151,13 @@ func TestJamfIntegration_CursorRoundTrip(t *testing.T) {
 
 // runInputOnce starts a minimalStateInput, waits for the first full sync to
 // complete (events arrive), and stops it. It returns the Run error.
-func runInputOnce(t *testing.T, dataDir string, p *ecjamf.Provider, client *fakeClient) error {
+func runInputOnce(t *testing.T, dataDir string, providerName string, p entcollect.Provider, client *fakeClient) error {
 	t.Helper()
 	log := logptest.NewTestingLogger(t, "integ")
 
 	mi := &minimalStateInput{
 		provider:         p,
-		providerName:     "jamf",
+		providerName:     providerName,
 		fullSyncInterval: time.Hour,
 		incrSyncInterval: time.Hour,
 		logger:           log,
@@ -170,7 +174,7 @@ func runInputOnce(t *testing.T, dataDir string, p *ecjamf.Provider, client *fake
 		done <- mi.Run(
 			v2.Context{
 				Logger:      log,
-				ID:          "integ-jamf",
+				ID:          "integ-" + providerName,
 				Cancelation: v2.GoContextFromCanceler(ctx),
 			},
 			connector,
@@ -205,6 +209,98 @@ func runInputOnce(t *testing.T, dataDir string, p *ecjamf.Provider, client *fake
 		t.Fatal("Run did not return after cancel")
 		return nil
 	}
+}
+
+// runIncrementalOnce opens the bbolt store written by a previous
+// runInputOnce and runs a single incremental sync via runSync. This
+// bypasses the timer loop in Run(), which always fires a full sync
+// first and cannot reliably trigger incremental-only execution.
+func runIncrementalOnce(t *testing.T, dataDir string, providerName string, p entcollect.Provider, client *fakeClient) error {
+	t.Helper()
+	log := logptest.NewTestingLogger(t, "integ-incr")
+
+	dbPath := filepath.Join(dataDir, "kvstore", "integ-"+providerName+".db")
+	store, err := kvstore.NewStore(log, dbPath, 0600)
+	if err != nil {
+		t.Fatalf("open bbolt for incremental: %v", err)
+	}
+	defer store.Close()
+
+	mi := &minimalStateInput{
+		provider:         p,
+		providerName:     providerName,
+		fullSyncInterval: time.Hour,
+		incrSyncInterval: time.Hour,
+		logger:           log,
+		path:             &paths.Path{Data: dataDir},
+	}
+
+	acking := &ackingClient{inner: client}
+	ctx := context.Background()
+	slogger := slog.New(slog.NewTextHandler(&testLogWriter{t}, nil))
+
+	return mi.runSync(
+		v2.Context{
+			Logger:      log,
+			ID:          "integ-" + providerName,
+			Cancelation: v2.GoContextFromCanceler(ctx),
+		},
+		store,
+		acking,
+		slogger,
+		"entcollect."+providerName,
+		false,
+	)
+}
+
+// assertBboltKey verifies that a key exists in the bbolt bucket used by
+// runInputOnce. It opens the store read-only and reads the key.
+func assertBboltKey(t *testing.T, dataDir, providerName, key string) {
+	t.Helper()
+	log := logptest.NewTestingLogger(t, "assert-bbolt")
+	dbPath := filepath.Join(dataDir, "kvstore", "integ-"+providerName+".db")
+	store, err := kvstore.NewStore(log, dbPath, 0600)
+	if err != nil {
+		t.Fatalf("open bbolt for assertion: %v", err)
+	}
+	defer store.Close()
+
+	bucket := "entcollect." + providerName
+	err = store.RunTransaction(false, func(tx *kvstore.Transaction) error {
+		_, err := tx.GetBytes([]byte(bucket), []byte(key))
+		return err
+	})
+	if err != nil {
+		t.Errorf("bbolt key %q not found in bucket %q: %v", key, bucket, err)
+	}
+}
+
+// deleteBboltKey removes a key from the bbolt bucket. Used by
+// corruption/recovery tests to simulate missing state.
+func deleteBboltKey(t *testing.T, dataDir, providerName, key string) {
+	t.Helper()
+	log := logptest.NewTestingLogger(t, "delete-bbolt")
+	dbPath := filepath.Join(dataDir, "kvstore", "integ-"+providerName+".db")
+	store, err := kvstore.NewStore(log, dbPath, 0600)
+	if err != nil {
+		t.Fatalf("open bbolt for deletion: %v", err)
+	}
+	defer store.Close()
+
+	bucket := "entcollect." + providerName
+	err = store.RunTransaction(true, func(tx *kvstore.Transaction) error {
+		return tx.Delete([]byte(bucket), []byte(key))
+	})
+	if err != nil {
+		t.Fatalf("delete bbolt key %q in bucket %q: %v", key, bucket, err)
+	}
+}
+
+type testLogWriter struct{ t *testing.T }
+
+func (w *testLogWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
 }
 
 // atomicFixture holds a mutable API response body that can be swapped


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics: add AD, Okta, and EntraID integration tests

Extend the integration test suite from Session 6a (Jamf only) to
cover all four providers through the full adapter chain:
minimalStateInput.Run -> bbolt kvstore -> entcollect.Provider ->
publisher -> pipeline ACK -> Buffer.Commit.

Generalize runInputOnce to accept entcollect.Provider instead of
*ecjamf.Provider, and add runIncrementalOnce which calls runSync
directly to bypass the timer loop that always fires a full sync
first.

AD tests (gldap mock): FullLifecycle with deletion via idset,
CursorRoundTrip proving whenChanged persistence, and MissingCursor
verifying incremental recovery with a deleted cursor key.

Okta tests (httptest TLS mock): FullLifecycle with user deletion
and group enrichment, CursorRoundTrip proving last_sync persistence.

EntraID tests (httptest Graph mock): FullLifecycle with @removed
deletion, IncrementalDeltaLink proving delta link round-trip through
bbolt, and DeltaRecovery verifying 410 fallback within incremental
sync.

Each provider's FullLifecycle test asserts bbolt state keys after
the first sync, confirming state survives the transaction commit
path.

For #50774

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #50774

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
