### PR TITLE
[ci][packaging] Update `vault-docker-login` plugin to v0.8.0

### DIFF
--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -40,9 +40,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/auditbeat/auditbeat-pipeline.yml
+++ b/.buildkite/auditbeat/auditbeat-pipeline.yml
@@ -39,10 +39,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -37,9 +37,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/filebeat/filebeat-pipeline.yml
+++ b/.buildkite/filebeat/filebeat-pipeline.yml
@@ -36,10 +36,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/heartbeat/heartbeat-pipeline.yml
+++ b/.buildkite/heartbeat/heartbeat-pipeline.yml
@@ -59,7 +59,7 @@ steps:
           useCustomGlobalHooks: true
         notify:
           - github_commit_status:
-              context: "hearbeat: check/update"
+              context: "heartbeat: check/update"
 
       - label: "Heartbeat: Run pre-commit"
         command: "pre-commit run --all-files"

--- a/.buildkite/heartbeat/heartbeat-pipeline.yml
+++ b/.buildkite/heartbeat/heartbeat-pipeline.yml
@@ -33,10 +33,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/heartbeat/heartbeat-pipeline.yml
+++ b/.buildkite/heartbeat/heartbeat-pipeline.yml
@@ -34,9 +34,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -40,9 +40,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/metricbeat/pipeline.yml
+++ b/.buildkite/metricbeat/pipeline.yml
@@ -39,10 +39,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/packaging.pipeline.yml
+++ b/.buildkite/packaging.pipeline.yml
@@ -17,11 +17,13 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
+        disable_logout: true
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
+        disable_logout: true
   - google_oidc_plugin: &google_oidc_plugin
       # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/elastic-agent/01-gcp-oidc.tf
       # This plugin authenticates to Google Cloud using the OIDC token.

--- a/.buildkite/packetbeat/pipeline.packetbeat.yml
+++ b/.buildkite/packetbeat/pipeline.packetbeat.yml
@@ -33,10 +33,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/packetbeat/pipeline.packetbeat.yml
+++ b/.buildkite/packetbeat/pipeline.packetbeat.yml
@@ -34,9 +34,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/winlogbeat/pipeline.winlogbeat.yml
+++ b/.buildkite/winlogbeat/pipeline.winlogbeat.yml
@@ -34,10 +34,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/winlogbeat/pipeline.winlogbeat.yml
+++ b/.buildkite/winlogbeat/pipeline.winlogbeat.yml
@@ -35,9 +35,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -40,10 +40,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.auditbeat.yml
@@ -41,9 +41,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
@@ -24,10 +24,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.dockerlogbeat.yml
@@ -25,9 +25,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -37,9 +37,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.filebeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.filebeat.yml
@@ -36,10 +36,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
@@ -37,9 +37,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
@@ -36,10 +36,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -40,9 +40,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.metricbeat.yml
@@ -39,10 +39,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.osquerybeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.osquerybeat.yml
@@ -32,9 +32,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.osquerybeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.osquerybeat.yml
@@ -31,10 +31,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
@@ -33,10 +33,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.packetbeat.yml
@@ -34,9 +34,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.winlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.winlogbeat.yml
@@ -30,10 +30,10 @@ env:
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
-      elastic/vault-docker-login#v0.6.4:
+      elastic/vault-docker-login#v0.8.0:
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:

--- a/.buildkite/x-pack/pipeline.xpack.winlogbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.winlogbeat.yml
@@ -31,9 +31,11 @@ env:
 common:
   - dockerhub_login_plugin: &dockerhub_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/observability-github-secrets/shared/docker/dockerhub/observabilityrobots'
   - docker_elastic_login_plugin: &docker_elastic_login_plugin
       elastic/vault-docker-login#v0.8.0:
+        disable_logout: true
         secret_path: 'kv/ci-shared/platform-ingest/elastic_docker_registry'
 
 steps:


### PR DESCRIPTION
### Summary

* Update all instances of `vault-docker-login` to use the newest available version, v0.8.0.
* Set the new `disable_logout: true` parameter for the Beats packaging pipeline config. 