### PR TITLE
winlogbeat: fix XML rendering on Windows arm64

### DIFF
--- a/changelog/fragments/1780393903-fix-winlog-xml-rendering-on-windows-arm64.yaml
+++ b/changelog/fragments/1780393903-fix-winlog-xml-rendering-on-windows-arm64.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix winlog XML rendering on Windows arm64
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: winlogbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -469,7 +469,7 @@ func offset(buffer []byte, reader io.Reader) (uint64, error) {
 	switch runtime.GOARCH {
 	default:
 		return 0, fmt.Errorf("unhandled architecture: %s", runtime.GOARCH)
-	case "amd64":
+	case "amd64", "arm64":
 		err = binary.Read(reader, binary.LittleEndian, &dataPtr)
 		if err != nil {
 			return 0, err

--- a/winlogbeat/sys/wineventlog/wineventlog_windows_test.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows_test.go
@@ -19,6 +19,7 @@ package wineventlog
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/xml"
 	"flag"
 	"fmt"
@@ -26,11 +27,14 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
 )
@@ -145,6 +149,24 @@ func TestWinEventLog(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestOffsetSupportsWindowsPointerArchitectures(t *testing.T) {
+	buffer := make([]byte, 16)
+	ptr := uintptr(unsafe.Pointer(&buffer[8]))
+	reader := &bytes.Buffer{}
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+		require.NoError(t, binary.Write(reader, binary.LittleEndian, uint64(ptr)), "write 64-bit pointer")
+	case "386":
+		require.NoError(t, binary.Write(reader, binary.LittleEndian, uint32(ptr)), "write 32-bit pointer")
+	default:
+		t.Skipf("unsupported Windows test architecture %q", runtime.GOARCH)
+	}
+
+	got, err := offset(buffer, reader)
+	require.NoError(t, err, "offset should support %s pointer layout", runtime.GOARCH)
+	assert.Equal(t, uint64(8), got, "offset should point inside the render buffer")
 }
 
 // unmarshalXMLEvents unmarshals a complete set of events from the XML data


### PR DESCRIPTION
## Proposed commit message

winlogbeat: fix XML rendering on Windows arm64

Treat Windows arm64 as a 64-bit pointer architecture when decoding rendered Windows Event Log values. This prevents XML rendering from reporting `unhandled architecture: arm64` and emitting degraded winlog events with rendering errors.

Assisted-By: Cursor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

No disruptive user impact is expected. This only extends existing 64-bit pointer decoding to Windows arm64.

## How to test this PR locally

```bash
GOOS=windows GOARCH=arm64 go test -c -o /tmp/wineventlog-pr.test.exe ./winlogbeat/sys/wineventlog
```

Runtime validation was performed on a Windows 11 arm64 host with paired `winlog` Security inputs using `include_xml: false` and `include_xml: true`. Before the fix, XML-mode events included `unhandled architecture: arm64` and `failed in EvtFormatMessage`; after the fix, Security events rendered successfully with no matches for those errors.

## Related issues

-

## Use cases

Users running winlog collection on native Windows arm64 can enable XML inclusion without provider-name rendering failing due to unsupported architecture handling.

## Screenshots

N/A

## Logs

Post-fix debug output showed `EvtNext` returning Security records and XML-rendered events with `render_error:false`; output contained no `unhandled architecture: arm64` or `failed in EvtFormatMessage` entries.