### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/okta: fix dual-auth config rejection in minimal-state provider

### DIFF
--- a/changelog/fragments/1780464295-okta-minimal-dual-auth.yaml
+++ b/changelog/fragments/1780464295-okta-minimal-dual-auth.yaml
@@ -1,0 +1,47 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix Okta minimal-state provider to accept configs with both okta_token and oauth2.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+issue: https://github.com/elastic/beats/issues/51005
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/minimal.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/minimal.go
@@ -91,6 +91,7 @@ func minimalProvider(cfg *config.C, _ *logp.Logger) (entcollect.Provider, time.D
 	}
 
 	if lc.OAuth2.isEnabled() {
+		ec.Token = "" // OAuth2 takes precedence over okta_token.
 		jwk, err := resolveJWK(lc.OAuth2)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("oauth2 jwk: %w", err)

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/minimal_test.go
@@ -57,3 +57,23 @@ func TestMinimalConfigRoundTrip(t *testing.T) {
 		t.Errorf("update_interval: got %v, want %v", gotUpdate, wantUpdate)
 	}
 }
+
+func TestMinimalProvider_DualAuth(t *testing.T) {
+	cfg := config.MustNewConfigFrom(map[string]any{
+		"okta_domain":          "test.okta.com",
+		"okta_token":           "legacy-token", //nolint:gosec // This is not a secret.
+		"oauth2.enabled":       true,
+		"oauth2.client.id":     "client-id",
+		"oauth2.client.secret": "client-secret",
+		"oauth2.token_url":     "https://test.okta.com/oauth2/v1/token",
+		"oauth2.scopes":        []string{"okta.users.read"},
+		"sync_interval":        "24h",
+		"update_interval":      "15m",
+	})
+
+	_, _, _, err := minimalProvider(cfg, nil)
+	if err != nil {
+		t.Fatalf("minimalProvider rejected dual-auth config: %v — "+
+			"OAuth2 should take precedence over okta_token", err)
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics/provider/okta: fix dual-auth config rejection in minimal-state provider

The minimal-state provider rejected configurations specifying both
okta_token and oauth2, despite the legacy provider accepting them
with OAuth2 taking precedence. Clear the token when OAuth2 is
enabled so the adapter matches legacy behaviour before passing to
the entcollect library's stricter validator.

Fixes #51005

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #51005

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
