### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/okta: fix OAuth2 jwk_json token refresh

### DIFF
--- a/changelog/fragments/1780465416-fix-okta-jwk-json-refresh.yaml
+++ b/changelog/fragments/1780465416-fix-okta-jwk-json-refresh.yaml
@@ -1,0 +1,38 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+summary: Fix Okta entity analytics OAuth2 jwk_json token refresh failure.
+
+description: |
+  The legacy Okta entity analytics provider did not store the JWK bytes when
+  oauth2.jwk_json was configured, causing token refresh to fail with
+  "error decoding JWK: unexpected end of JSON input". Also add a cached-token
+  validity check to avoid regenerating the JWT on every API request.
+
+component: filebeat
+
+issue: https://github.com/elastic/beats/issues/50949
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2.go
@@ -94,7 +94,8 @@ func (o *oAuth2Config) fetchOktaOauthClient(ctx context.Context, client *http.Cl
 				return nil, fmt.Errorf("failed to generate Okta JWT: %w", err)
 			}
 		case o.OktaJWKJSON != nil:
-			oktaJWT, err = generateOktaJWT(o.OktaJWKJSON, oauthConfig)
+			jwkData = []byte(o.OktaJWKJSON)
+			oktaJWT, err = generateOktaJWT(jwkData, oauthConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate Okta JWT: %w", err)
 			}
@@ -194,6 +195,10 @@ func (ts *oktaTokenSource) Token() (*oauth2.Token, error) {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 
+	if ts.token != nil && ts.token.Valid() {
+		return ts.token, nil
+	}
+
 	var oktaJWT string
 	var err error
 	if ts.oktaJWKPEM != "" {
@@ -208,6 +213,7 @@ func (ts *oktaTokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error exchanging Okta JWT for bearer token: %w", err)
 	}
+	ts.token = token
 
 	return token, nil
 }

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//nolint:gosec // There are no secrets in this file.
 package okta
 
 import (
@@ -445,5 +446,50 @@ func TestOktaTokenSource_Token(t *testing.T) {
 				t.Errorf("unexpected access token: got %q want %q", tok.AccessToken, "mock")
 			}
 		})
+	}
+}
+
+// TestFetchOktaOauthClient_JWKJSONRoundTrip exercises the full
+// fetchOktaOauthClient path with jwk_json to verify that the JWK
+// bytes survive into the token source for refresh. Previously
+// jwkData was only stored for the jwk_file case, causing token
+// refresh to fail with "unexpected end of JSON input".
+func TestFetchOktaOauthClient_JWKJSONRoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "mock-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/resource":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &oAuth2Config{
+		ClientID:    "test-client-id",
+		Scopes:      []string{"okta.users.read"},
+		TokenURL:    srv.URL + "/token",
+		OktaJWKJSON: common.JSONBlob(testOktaJWKJSON),
+	}
+
+	client, err := cfg.fetchOktaOauthClient(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatalf("fetchOktaOauthClient() error: %v", err)
+	}
+
+	resp, err := client.Get(srv.URL + "/resource") //nolint:noctx // No need for a context here.
+	if err != nil {
+		t.Fatalf("GET /resource error: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /resource status = %d; want %d", resp.StatusCode, http.StatusOK)
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics/provider/okta: fix OAuth2 jwk_json token refresh

The legacy Okta entity analytics provider did not store the JWK bytes
when oauth2.jwk_json was configured. The jwkData variable was only
assigned in the jwk_file branch, so the oktaTokenSource received nil
for its oktaJWK field. Combined with Token() unconditionally
regenerating the JWT on every call (rather than checking the cached
token), the first API request failed with "error decoding JWK:
unexpected end of JSON input".

Store the JWK bytes for the jwk_json case and add a token validity
check to avoid unnecessary JWT regeneration, matching the pattern
already used by clientSecretTokenSource and the entcollect
jwtTokenSource.

Fixes #50949

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #50949

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
