### PR TITLE
[8.19] fix: disable TLS certificate hot-reload by default

### DIFF
--- a/changelog/fragments/1780583553-disable-tls-certificate-hot-reload-by-default-on-patch-branches.yaml
+++ b/changelog/fragments/1780583553-disable-tls-certificate-hot-reload-by-default-on-patch-branches.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: "Disable TLS certificate hot-reload by default on patch branches"
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: beats
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/51105
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -153,7 +153,14 @@ type certReloadConfig struct {
 	Reload           cfgfile.Reload `config:"restart_on_cert_change" yaml:"restart_on_cert_change"`
 }
 
-func (c certReloadConfig) Validate() error {
+func (c *certReloadConfig) Validate() error {
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not activate silently in a patch release.
+	if c.CertificateReload.Enabled == nil {
+		enabled := false
+		c.CertificateReload.Enabled = &enabled
+	}
+
 	if c.Reload.Period < time.Second {
 		return errors.New("'restart_on_cert_change.period' must be equal or greather than 1s")
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -157,8 +157,7 @@ func (c *certReloadConfig) Validate() error {
 	// Certificate hot-reload was introduced after this branch was cut. Disable it
 	// by default so it does not activate silently in a patch release.
 	if c.CertificateReload.Enabled == nil {
-		enabled := false
-		c.CertificateReload.Enabled = &enabled
+		c.CertificateReload.Enabled = new(false)
 	}
 
 	if c.Reload.Period < time.Second {

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -96,5 +96,12 @@ func (c *ElasticsearchConfig) Validate() error {
 		return fmt.Errorf("cannot set both api_key and username/password")
 	}
 
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not activate silently in a patch release.
+	if c.Transport.TLS != nil && c.Transport.TLS.CertificateReload.Enabled == nil {
+		enabled := false
+		c.Transport.TLS.CertificateReload.Enabled = &enabled
+	}
+
 	return nil
 }

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -99,8 +99,7 @@ func (c *ElasticsearchConfig) Validate() error {
 	// Certificate hot-reload was introduced after this branch was cut. Disable it
 	// by default so it does not activate silently in a patch release.
 	if c.Transport.TLS != nil && c.Transport.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		c.Transport.TLS.CertificateReload.Enabled = &enabled
+		c.Transport.TLS.CertificateReload.Enabled = new(false)
 	}
 
 	return nil

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -201,8 +201,7 @@ func (c *KafkaConfig) Validate() error {
 	// Certificate hot-reload was introduced after this branch was cut. Disable it
 	// by default so it does not activate silently in a patch release.
 	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		c.TLS.CertificateReload.Enabled = &enabled
+		c.TLS.CertificateReload.Enabled = new(false)
 	}
 
 	return nil

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -198,6 +198,13 @@ func (c *KafkaConfig) Validate() error {
 		}
 	}
 
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not activate silently in a patch release.
+	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
+		enabled := false
+		c.TLS.CertificateReload.Enabled = &enabled
+	}
+
 	return nil
 }
 

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -69,6 +69,17 @@ func defaultConfig() Config {
 	}
 }
 
+// Validate applies backport-branch defaults.
+func (c *Config) Validate() error {
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not activate silently in a patch release.
+	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
+		enabled := false
+		c.TLS.CertificateReload.Enabled = &enabled
+	}
+	return nil
+}
+
 func readConfig(cfg *config.C, info beat.Info) (*Config, error) {
 	c := defaultConfig()
 

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -74,8 +74,7 @@ func (c *Config) Validate() error {
 	// Certificate hot-reload was introduced after this branch was cut. Disable it
 	// by default so it does not activate silently in a patch release.
 	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		c.TLS.CertificateReload.Enabled = &enabled
+		c.TLS.CertificateReload.Enabled = new(false)
 	}
 	return nil
 }

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -72,5 +72,12 @@ func (c *redisConfig) Validate() error {
 		return fmt.Errorf("redis data type %v not supported", c.DataType)
 	}
 
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not activate silently in a patch release.
+	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
+		enabled := false
+		c.TLS.CertificateReload.Enabled = &enabled
+	}
+
 	return nil
 }

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -75,8 +75,7 @@ func (c *redisConfig) Validate() error {
 	// Certificate hot-reload was introduced after this branch was cut. Disable it
 	// by default so it does not activate silently in a patch release.
 	if c.TLS != nil && c.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		c.TLS.CertificateReload.Enabled = &enabled
+		c.TLS.CertificateReload.Enabled = new(false)
 	}
 
 	return nil

--- a/x-pack/otel/extension/beatsauthextension/authenticator.go
+++ b/x-pack/otel/extension/beatsauthextension/authenticator.go
@@ -135,6 +135,13 @@ func getHttpClient(a *authenticator) (roundTripperProvider, error) {
 
 	applyRestartOnCertChangeAlias(parsedCfg, &beatAuthConfig, a.logger)
 
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not activate silently in a patch release.
+	if beatAuthConfig.Transport.TLS != nil && beatAuthConfig.Transport.TLS.CertificateReload.Enabled == nil {
+		enabled := false
+		beatAuthConfig.Transport.TLS.CertificateReload.Enabled = &enabled
+	}
+
 	client, err := beatAuthConfig.Transport.Client(a.getHTTPOptions(beatAuthConfig.Transport.IdleConnTimeout)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating http client: %w", err)

--- a/x-pack/otel/extension/beatsauthextension/authenticator.go
+++ b/x-pack/otel/extension/beatsauthextension/authenticator.go
@@ -138,8 +138,7 @@ func getHttpClient(a *authenticator) (roundTripperProvider, error) {
 	// Certificate hot-reload was introduced after this branch was cut. Disable it
 	// by default so it does not activate silently in a patch release.
 	if beatAuthConfig.Transport.TLS != nil && beatAuthConfig.Transport.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		beatAuthConfig.Transport.TLS.CertificateReload.Enabled = &enabled
+		beatAuthConfig.Transport.TLS.CertificateReload.Enabled = new(false)
 	}
 
 	client, err := beatAuthConfig.Transport.Client(a.getHTTPOptions(beatAuthConfig.Transport.IdleConnTimeout)...)

--- a/x-pack/otel/extension/beatsauthextension/authenticator_test.go
+++ b/x-pack/otel/extension/beatsauthextension/authenticator_test.go
@@ -425,6 +425,7 @@ func TestCertificateHotReload(t *testing.T) {
 
 		client, _ := startAuthClient(t, sslCfg(certPath, keyPath, map[string]any{
 			"certificate_reload": map[string]any{
+				"enabled":         true,
 				"reload_interval": "100ms",
 			},
 		}))

--- a/x-pack/otel/oteltranslate/tls_otel.go
+++ b/x-pack/otel/oteltranslate/tls_otel.go
@@ -52,8 +52,7 @@ func TLSCommonToOTel(output *config.C, logger *logp.Logger) (map[string]any, err
 	// Certificate hot-reload was introduced after this branch was cut. Disable it
 	// by default so it does not activate silently in a patch release.
 	if tlsCfg.TLS.CertificateReload.Enabled == nil {
-		enabled := false
-		tlsCfg.TLS.CertificateReload.Enabled = &enabled
+		tlsCfg.TLS.CertificateReload.Enabled = new(false)
 	}
 
 	tlscfg := tlsCfg.TLS

--- a/x-pack/otel/oteltranslate/tls_otel.go
+++ b/x-pack/otel/oteltranslate/tls_otel.go
@@ -49,6 +49,13 @@ func TLSCommonToOTel(output *config.C, logger *logp.Logger) (map[string]any, err
 		}, nil
 	}
 
+	// Certificate hot-reload was introduced after this branch was cut. Disable it
+	// by default so it does not activate silently in a patch release.
+	if tlsCfg.TLS.CertificateReload.Enabled == nil {
+		enabled := false
+		tlsCfg.TLS.CertificateReload.Enabled = &enabled
+	}
+
 	tlscfg := tlsCfg.TLS
 	// validate the beats config before proceeding
 	if err := tlscfg.Validate(); err != nil {


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

fix: disable TLS certificate hot-reload by default on 8.19 patch branch

WHAT: Adds explicit guards in `Validate()` methods across all output configs
(Elasticsearch, Logstash, Kafka, Redis), the beat's own TLS config, the OTel TLS
translation, and the beatsauth extension to set `CertificateReload.Enabled = false`
when the operator has not explicitly opted in.

WHY: Certificate hot-reload was introduced in elastic-agent-libs v0.43.0. Its
`IsEnabled()` method returns `true` when the config field is absent (nil pointer),
meaning the feature silently activates for any TLS connection on branches that pick up
v0.43.x. We want certificate hot-reload to be enabled by default in upcoming minor
releases, but disabled by default in patch releases where silently activating new
behaviour would be unexpected. This mirrors what elastic-agent did in
elastic/elastic-agent#14597 and follows the same pattern as elastic/fleet-server#7066.

Operators who want hot-reload can opt in by setting `ssl.certificate_reload.enabled: true`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/pull/50444
