### PR TITLE
[Metricbeat] Add data_stream field to node_index_shards

### DIFF
--- a/changelog/fragments/1780660834-4453_add_data_stream.yaml
+++ b/changelog/fragments/1780660834-4453_add_data_stream.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add `data_stream` field alongside `aliases` in cat_shards resolved_indices for metricbeat autoops_es module
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cache.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cache.go
@@ -124,6 +124,7 @@ func enrichIndexMetadata(nodeIndexShards *NodeIndexShards, indexMetadata map[str
 	if metadata, found := indexMetadata[nodeIndexShards.Index]; found {
 		nodeIndexShards.Aliases = metadata.aliases
 		nodeIndexShards.Attributes = metadata.attributes
+		nodeIndexShards.DataStream = metadata.dataStream
 		nodeIndexShards.IndexType = &metadata.indexType
 		nodeIndexShards.IsHidden = &metadata.hidden
 		nodeIndexShards.IsOpen = &metadata.open

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cache_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cache_test.go
@@ -118,6 +118,7 @@ func getIndexMetadata() map[string]IndexMetadata {
 	return map[string]IndexMetadata{
 		"my-index": {
 			aliases:    []string{"alias1", "alias2"},
+			dataStream: "data-stream1",
 			attributes: []string{"attribute1"},
 			indexType:  "index",
 			hidden:     false,
@@ -161,6 +162,7 @@ func TestEnrichNodeIndexShardsWithoutCache(t *testing.T) {
 		require.Nil(t, nodeIndexShards.SearchLatencyInMillis)
 		// unknown index metadata
 		require.Nil(t, nodeIndexShards.Aliases)
+		require.Equal(t, "", nodeIndexShards.DataStream)
 		require.Nil(t, nodeIndexShards.Attributes)
 		require.Nil(t, nodeIndexShards.IndexType)
 		require.Nil(t, nodeIndexShards.IsHidden)
@@ -193,6 +195,7 @@ func TestEnrichNodeIndexShardsWithoutCachedValues(t *testing.T) {
 		require.Nil(t, nodeIndexShards.SearchLatencyInMillis)
 		// unknown index metadata
 		require.Nil(t, nodeIndexShards.Aliases)
+		require.Equal(t, "", nodeIndexShards.DataStream)
 		require.Nil(t, nodeIndexShards.Attributes)
 		require.Nil(t, nodeIndexShards.IndexType)
 		require.Nil(t, nodeIndexShards.IsHidden)
@@ -242,6 +245,7 @@ func TestEnrichNodeIndexShardsWithCachedValues(t *testing.T) {
 		metadata := indexMetadata[nodeIndexShards.Index]
 
 		require.ElementsMatch(t, metadata.aliases, nodeIndexShards.Aliases)
+		require.Equal(t, metadata.dataStream, nodeIndexShards.DataStream)
 		require.ElementsMatch(t, metadata.attributes, nodeIndexShards.Attributes)
 		require.Equal(t, metadata.indexType, *nodeIndexShards.IndexType)
 		require.Equal(t, metadata.hidden, *nodeIndexShards.IsHidden)
@@ -320,6 +324,7 @@ func TestEnrichNodeIndexShardsWithCachedValuesWithNoChange(t *testing.T) {
 		metadata := indexMetadata[nodeIndexShards.Index]
 
 		require.ElementsMatch(t, metadata.aliases, nodeIndexShards.Aliases)
+		require.Equal(t, metadata.dataStream, nodeIndexShards.DataStream)
 		require.ElementsMatch(t, metadata.attributes, nodeIndexShards.Attributes)
 		require.Equal(t, metadata.indexType, *nodeIndexShards.IndexType)
 		require.Equal(t, metadata.hidden, *nodeIndexShards.IsHidden)
@@ -387,6 +392,7 @@ func TestEnrichNodeIndexShardsWithCachedValuesWithHoles(t *testing.T) {
 		metadata := indexMetadata[nodeIndexShards.Index]
 
 		require.ElementsMatch(t, metadata.aliases, nodeIndexShards.Aliases)
+		require.Equal(t, metadata.dataStream, nodeIndexShards.DataStream)
 		require.ElementsMatch(t, metadata.attributes, nodeIndexShards.Attributes)
 		require.Equal(t, metadata.indexType, *nodeIndexShards.IndexType)
 		require.Equal(t, metadata.hidden, *nodeIndexShards.IsHidden)
@@ -445,6 +451,7 @@ func TestEnrichNodeIndexShardsWithCachedValuesWithNewNodeAndIndex(t *testing.T) 
 			metadata := indexMetadata[nodeIndexShards.Index]
 
 			require.ElementsMatch(t, metadata.aliases, nodeIndexShards.Aliases)
+			require.Equal(t, metadata.dataStream, nodeIndexShards.DataStream)
 			require.ElementsMatch(t, metadata.attributes, nodeIndexShards.Attributes)
 			require.Equal(t, metadata.indexType, *nodeIndexShards.IndexType)
 			require.Equal(t, metadata.hidden, *nodeIndexShards.IsHidden)
@@ -462,6 +469,7 @@ func TestEnrichNodeIndexShardsWithCachedValuesWithNewNodeAndIndex(t *testing.T) 
 			require.Nil(t, nodeIndexShards.SearchLatencyInMillis)
 			// unknown index metadata
 			require.Nil(t, nodeIndexShards.Aliases)
+			require.Equal(t, "", nodeIndexShards.DataStream)
 			require.Nil(t, nodeIndexShards.Attributes)
 			require.Nil(t, nodeIndexShards.IndexType)
 			require.Nil(t, nodeIndexShards.IsHidden)
@@ -573,6 +581,7 @@ func TestConvertToNodeIndexShardsUncached(t *testing.T) {
 	require.Equal(t, YELLOW, *yellowNode2.IndexStatus)
 	require.Nil(t, yellowNode2.IndexType)
 	require.Nil(t, yellowNode2.Aliases)
+	require.Equal(t, "", yellowNode2.DataStream)
 	require.Nil(t, yellowNode2.Attributes)
 	require.Nil(t, yellowNode2.IsHidden)
 	require.Nil(t, yellowNode2.IsOpen)
@@ -631,6 +640,7 @@ func TestConvertToNodeIndexShardsUncached(t *testing.T) {
 	require.Equal(t, RED, *redIndex.IndexStatus)
 	require.Nil(t, redIndex.IndexType)
 	require.Nil(t, redIndex.Aliases)
+	require.Equal(t, "", redIndex.DataStream)
 	require.Nil(t, redIndex.Attributes)
 	require.Nil(t, redIndex.IsHidden)
 	require.Nil(t, redIndex.IsOpen)
@@ -705,6 +715,7 @@ func TestConvertToNodeIndexShardsWithCache(t *testing.T) {
 	require.Equal(t, GREEN, *myIndexNode1.IndexStatus)
 	require.Equal(t, "index", *myIndexNode1.IndexType)
 	require.ElementsMatch(t, []string{"alias1", "alias2"}, myIndexNode1.Aliases)
+	require.Equal(t, "data-stream1", myIndexNode1.DataStream)
 	require.ElementsMatch(t, []string{"attribute1"}, myIndexNode1.Attributes)
 	require.Equal(t, false, *myIndexNode1.IsHidden)
 	require.Equal(t, true, *myIndexNode1.IsOpen)
@@ -763,6 +774,7 @@ func TestConvertToNodeIndexShardsWithCache(t *testing.T) {
 	require.Equal(t, GREEN, *myIndexNode3.IndexStatus)
 	require.Equal(t, "index", *myIndexNode3.IndexType)
 	require.ElementsMatch(t, []string{"alias1", "alias2"}, myIndexNode3.Aliases)
+	require.Equal(t, "data-stream1", myIndexNode3.DataStream)
 	require.ElementsMatch(t, []string{"attribute1"}, myIndexNode3.Attributes)
 	require.Equal(t, false, *myIndexNode3.IsHidden)
 	require.Equal(t, true, *myIndexNode3.IsOpen)

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/index_shards.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/index_shards.go
@@ -51,6 +51,7 @@ type UnassignedShard struct {
 type IndexMetadata struct {
 	indexType  string
 	aliases    []string
+	dataStream string
 	hidden     bool
 	system     bool
 	open       bool
@@ -66,6 +67,7 @@ type NodeIndexShards struct {
 	IndexType                *string           `json:"index_type"`
 	Aliases                  []string          `json:"aliases"`
 	Attributes               []string          `json:"attributes"`
+	DataStream               string            `json:"data_stream"`
 	IsHidden                 *bool             `json:"is_hidden"`
 	IsOpen                   *bool             `json:"is_open"`
 	IsSystem                 *bool             `json:"is_system"`

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/resolved_indices.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/resolved_indices.go
@@ -76,6 +76,7 @@ func parseResolvedIndicesResponse(response *resolvedApiResponse) map[string]Inde
 			system:     isSystem,
 			hidden:     isHidden,
 			aliases:    dataStreamAndAliasesCombined(index.DataStream, index.Aliases, maxAliasesPerIndex),
+			dataStream: index.DataStream,
 			attributes: attributes,
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
[Metricbeat] Add data_stream field to node_index_shards
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally
1. updated existing tests to run locally

2. Attaching example output of cat_shards

 ```
# metricbeat.yaml 
# ...
metricbeat.modules:
- module: autoops_es
  metricsets:
    - cat_shards
  period: 10s
  hosts: ["http://localhost:9210"]

```
example output:
<img width="794" height="783" alt="image" src="https://github.com/user-attachments/assets/0ac1b107-42d2-4d3a-81ee-21768ecc11be" />



<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
