### PR TITLE
libbeat/publisher/queue/slabqueue: add per-producer slot magazine to amortize free-list overhead

### DIFF
--- a/libbeat/publisher/queue/queuetest/queuetest.go
+++ b/libbeat/publisher/queue/queuetest/queuetest.go
@@ -276,6 +276,7 @@ func makeProducer(
 				log.Debug("publish event", i)
 				producer.Publish(MakeEvent(makeFields(i)))
 			}
+			producer.Close()
 
 			ackWG.Wait()
 		}

--- a/libbeat/publisher/queue/slabqueue/producer.go
+++ b/libbeat/publisher/queue/slabqueue/producer.go
@@ -23,12 +23,24 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
 
+// magazineMaxCap is the absolute upper bound on slots a single producer may
+// pre-claim from the shared depot regardless of pool capacity.
+const magazineMaxCap = 256
+
 // producer publishes events into one Queue. It acquires a slot from the
 // shared pool's free list (blocking when the pool is empty), writes the event
 // into that slot, and threads the slot onto its queue's per-pipeline FIFO.
+//
+// Each producer holds a magazine: a small pre-claimed stack of slot indices
+// (Bonwick & Adams §3.1). Publish pops from the magazine without touching the
+// shared depot; the depot is only accessed to bulk-refill when
+// the magazine runs dry.
 type producer[T any] struct {
-	queue *Queue[T]
-	cfg   queue.ProducerConfig
+	queue          *Queue[T]
+	cfg            queue.ProducerConfig
+	magazine       []int // pre-claimed slot indices; drained LIFO before touching pool.free
+	magazineCeiled int   // cached ceiling; recomputed when connectedQueues changes
+	cachedQueues   int   // connectedQueues value at last ceiling computation
 
 	nextID atomic.Uint64
 	closed atomic.Bool
@@ -40,15 +52,88 @@ func (p *producer[T]) Publish(entry T) (queue.EntryID, bool) {
 	if p.closed.Load() {
 		return 0, false
 	}
-	var slotIdx int
-	select {
-	case slotIdx = <-p.queue.pool.free:
-	case <-p.queue.closeCh:
-		return 0, false
-	case <-p.queue.pool.closed:
+	slotIdx, ok := p.acquireSlot()
+	if !ok {
 		return 0, false
 	}
 	return p.fill(entry, slotIdx)
+}
+
+// ceiling returns the maximum slots this producer may hold in its magazine:
+// pool.Capacity()/(2*connectedQueues), capped at magazineMaxCap. The result
+// is cached and only recomputed when the connected-queue count changes, so
+// the common path (stable receiver count) pays no lock overhead.
+func (p *producer[T]) ceiling() int {
+	pool := p.queue.pool
+	queues := pool.ConnectedQueues()
+	if queues == p.cachedQueues {
+		return p.magazineCeiled
+	}
+	p.cachedQueues = queues
+	if queues == 0 {
+		queues = 1
+	}
+	c := pool.Capacity() / (2 * queues)
+	if c > magazineMaxCap {
+		c = magazineMaxCap
+	}
+	if c < 1 {
+		c = 1
+	}
+	p.magazineCeiled = c
+	return c
+}
+
+// acquireSlot returns a slot index, refilling the magazine from pool.free when
+// it is empty. Returns false if the queue or pool is closed.
+//
+// Refill limit = min(len(pool.free)/2, ceiling()).
+func (p *producer[T]) acquireSlot() (int, bool) {
+	if len(p.magazine) > 0 {
+		idx := p.magazine[len(p.magazine)-1]
+		p.magazine = p.magazine[:len(p.magazine)-1]
+		return idx, true
+	}
+
+	// Magazine empty; bulk-fill from the depot. Limit to the smaller of
+	// half the currently visible free slots and the per-producer ceiling.
+	pool := p.queue.pool
+	limit := len(pool.free) / 2
+	if c := p.ceiling(); limit > c {
+		limit = c
+	}
+
+	if limit > 0 {
+		p.magazine = p.magazine[:cap(p.magazine)] // reuse pre-allocated backing array
+		filled := 0
+	fill:
+		for filled < limit {
+			select {
+			case idx := <-pool.free:
+				p.magazine[filled] = idx
+				filled++
+			default:
+				break fill
+			}
+		}
+		if filled > 0 {
+			p.magazine = p.magazine[:filled]
+			idx := p.magazine[filled-1]
+			p.magazine = p.magazine[:filled-1]
+			return idx, true
+		}
+		p.magazine = p.magazine[:0]
+	}
+
+	// Depot was empty — block until a slot is available or we close.
+	select {
+	case idx := <-pool.free:
+		return idx, true
+	case <-p.queue.closeCh:
+		return 0, false
+	case <-pool.closed:
+		return 0, false
+	}
 }
 
 // TryPublish adds an entry only if a slot is immediately available; it never
@@ -56,6 +141,12 @@ func (p *producer[T]) Publish(entry T) (queue.EntryID, bool) {
 func (p *producer[T]) TryPublish(entry T) (queue.EntryID, bool) {
 	if p.closed.Load() {
 		return 0, false
+	}
+	// Check the local magazine first before touching the shared channel.
+	if len(p.magazine) > 0 {
+		idx := p.magazine[len(p.magazine)-1]
+		p.magazine = p.magazine[:len(p.magazine)-1]
+		return p.fill(entry, idx)
 	}
 	var slotIdx int
 	select {
@@ -69,7 +160,14 @@ func (p *producer[T]) TryPublish(entry T) (queue.EntryID, bool) {
 // Close marks the producer as closed. Subsequent Publish/TryPublish return
 // (0, false). The queue may still deliver ACK callbacks for events this
 // producer published before Close was called.
-func (p *producer[T]) Close() { p.closed.Store(true) }
+func (p *producer[T]) Close() {
+	p.closed.Store(true)
+	// Return magazine slots to the pool
+	for _, idx := range p.magazine {
+		p.queue.pool.free <- idx
+	}
+	p.magazine = p.magazine[:0]
+}
 
 // fill stores entry in the given slot and threads it onto the queue's FIFO.
 // If the queue is already closing, the slot is returned to the pool and the
@@ -86,12 +184,17 @@ func (p *producer[T]) fill(entry T, slotIdx int) (queue.EntryID, bool) {
 	q := p.queue
 	q.mu.Lock()
 	if q.closing {
-		// Queue closed between acquire and fill. Return the slot.
+		// Queue closed between acquire and fill. Return the current slot and
+		// the entire magazine.
 		var zero T
 		s.event = zero
 		s.producer = nil
 		q.mu.Unlock()
 		pool.free <- slotIdx
+		for _, idx := range p.magazine {
+			pool.free <- idx
+		}
+		p.magazine = p.magazine[:0]
 		return 0, false
 	}
 	if q.tail == -1 {

--- a/libbeat/publisher/queue/slabqueue/queue.go
+++ b/libbeat/publisher/queue/slabqueue/queue.go
@@ -67,9 +67,11 @@ func newQueue[T any](pool *Pool[T]) *Queue[T] {
 	}
 }
 
-// Producer returns a producer that publishes to this queue.
+// Producer returns a producer that publishes to this queue. The caller must
+// call producer.Close() when done to return any pre-claimed magazine slots to
+// the pool; failing to do so leaks slots until the pool is shut down.
 func (q *Queue[T]) Producer(cfg queue.ProducerConfig) queue.Producer[T] {
-	return &producer[T]{queue: q, cfg: cfg}
+	return &producer[T]{queue: q, cfg: cfg, magazine: make([]int, 0, magazineMaxCap)}
 }
 
 // Get blocks until at least one event is available (or the queue is closed)

--- a/libbeat/publisher/queue/slabqueue/queuetest_test.go
+++ b/libbeat/publisher/queue/slabqueue/queuetest_test.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package slabqueue_test
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/queuetest"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/slabqueue"
+)
+
+func makeTestQueue(sz int) queuetest.QueueFactory {
+	return func(t *testing.T) queue.Queue[publisher.Event] {
+		pool := slabqueue.NewPool[publisher.Event](slabqueue.Settings{Events: sz}, nil)
+		t.Cleanup(func() { pool.Shutdown() })
+		return pool.Connect()
+	}
+}
+
+func TestSlabQueueConformance(t *testing.T) {
+	events := 4096
+	batchSize := 100
+	bufferSize := 8192
+
+	// slabqueue's Queue façade is a single-consumer design: only one
+	// goroutine may call Get concurrently. TestMultiProducerConsumer
+	// includes cases with multiple concurrent consumers on the same
+	// queue, which violates that contract. Each pipeline gets its own
+	// façade in production, so concurrent consumers are not a supported
+	// use case.
+	t.Run("slabqueue", func(t *testing.T) {
+		t.Parallel()
+		queuetest.TestSingleProducerConsumer(t, events, batchSize, makeTestQueue(bufferSize))
+	})
+}

--- a/libbeat/publisher/queue/slabqueue/recycle_test.go
+++ b/libbeat/publisher/queue/slabqueue/recycle_test.go
@@ -194,6 +194,9 @@ func TestDoubleDoneIsSafe(t *testing.T) {
 
 	p := q.Producer(queue.ProducerConfig{ACK: func(int) {}})
 	p.Publish(1)
+	// Close the producer to return any pre-claimed magazine slots before
+	// checking pool availability.
+	p.Close()
 	b, err := q.Get(0)
 	require.NoError(t, err)
 
@@ -264,6 +267,7 @@ func TestConcurrentRecycleNoCorruption(t *testing.T) {
 		wg.Add(2)
 		go func(p queue.Producer[int], base int) {
 			defer wg.Done()
+			defer p.Close()
 			for j := 0; j < eventsPerPipe; j++ {
 				if _, ok := p.Publish(base*1_000_000 + j); !ok {
 					return

--- a/libbeat/publisher/queue/slabqueue/slabqueue_test.go
+++ b/libbeat/publisher/queue/slabqueue/slabqueue_test.go
@@ -677,6 +677,7 @@ func TestConcurrentPublishersAndConsumers(t *testing.T) {
 		// Producer.
 		go func(p queue.Producer[int], base int) {
 			defer wg.Done()
+			defer p.Close()
 			for j := 0; j < eventsPerPipe; j++ {
 				_, ok := p.Publish(base*1000 + j)
 				if !ok {


### PR DESCRIPTION
## Proposed commit message

Each producer now pre-claims up to ceiling() slot indices from the depot in a single bulk receive. Subsequent Publish calls pop from the local slice (the magazine) without touching the shared channel, paying channel overhead once per refill instead of once per event.

The refill limit is `min(len(pool.free)/2, ceiling())` where ceiling is `pool.Capacity()/(2*connectedQueues)`, capped at magazineMaxCap=256.

Together this guarantees:
- at most half the currently free slots are claimed in one shot (fairness)
- the sum of all magazine caps never exceeds half the pool capacity (starvation prevention)
- the per-producer ceiling shrinks as producer count grows, so the magazine adapts to queue topology (§3.4 dynamic magazine sizing)
- short publish bursts are absorbed from local magazines (burst absorption)

The design follows the magazine layer described in Bonwick & Adams §3: each producer goroutine holds a loaded magazine; the shared pool.free channel acts as the depot.

Reference: Bonwick & Adams, "Magazines and Vmem", USENIX 2001, §3.4, §3.7. https://www.usenix.org/legacy/event/usenix01/full_papers/bonwick/bonwick_html

```
	goos: linux
	goarch: amd64
	pkg: github.com/elastic/beats/v7/libbeat/publisher/queue/slabqueue
	cpu: AMD Ryzen 9 9950X3D 16-Core Processor
	                              │    before    │              after               │
	                              │    sec/op    │   sec/op     vs base             │
	SlabQueuePool/receivers=1-32    220.2µ ±  5%   137.4µ ±  8%  -37.58% (p=0.002 n=6)
	SlabQueuePool/receivers=4-32    394.0µ ± 12%   140.2µ ±  1%  -64.41% (p=0.002 n=6)
	SlabQueuePool/receivers=8-32    385.2µ ±  6%   162.8µ ±  4%  -57.72% (p=0.002 n=6)
	SlabQueuePool/receivers=16-32   413.5µ ±  7%   204.3µ ±  8%  -50.58% (p=0.002 n=6)
	ProducerThroughput-32            20.29µ ± 12%   14.00µ ±  2%  -31.00% (p=0.002 n=6)
	geomean                          194.8µ          97.87µ        -49.75%

	                              │   events/s  │              after               │
	                              │   before    │  events/s    vs base             │
	ProducerThroughput-32           4.623M ± 6%   6.552M ± 6%  +41.73% (p=0.002 n=6)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

- Relates https://github.com/elastic/beats/pull/51047