### PR TITLE
Add dynamic sizing to slabqueue and masked based slot assignment.

### DIFF
--- a/libbeat/publisher/pipeline/output_otel.go
+++ b/libbeat/publisher/pipeline/output_otel.go
@@ -55,10 +55,15 @@ type otelOutputController struct {
 
 	intakeQueueID string
 	queue         queue.Queue[publisher.Event]
+
 	// pool is non-nil whenever the receiver uses the slabqueue pool (i.e.
 	// queue.mem); it is nil when the receiver was configured with queue.disk
 	// and owns its queue outright via queueFactory.
 	pool *slabqueue.Pool[publisher.Event]
+
+	// sharedPoolQueue is this controller's connection to the shared pool, used
+	// to drop its budget contribution on release. Non-nil iff pool is non-nil.
+	sharedPoolQueue *slabqueue.Queue[publisher.Event]
 
 	consumer *eventConsumer
 
@@ -66,18 +71,24 @@ type otelOutputController struct {
 	workerChan chan publisher.Batch
 }
 
-// sharedPool tracks one slabqueue.Pool together with its connected
-// pipeline count, for ref-counted lifecycle of pools indexed by intake
-// queue ID.
+// sharedPool tracks one slabqueue.Pool together with a ref count, for
+// ref-counted lifecycle of pools indexed by intake queue ID.
+//
+// Connected receivers may ask for different queue.mem.events sizes (the
+// elastic-agent default leaves the intake queue ID empty, so receivers with
+// differing sizes all land in the global default pool). Rather than rejecting a
+// size mismatch, each receiver's own Queue is capped at its requested size
+// (Queue.SetTarget), and the pool sizes itself to the largest of those caps.
+// The registry therefore only refcounts the pool's lifetime; it does not size
+// it — the queues drive the pool size, so the two cannot drift.
 //
 // All fields are protected by allOTelPools.Mutex — sharedPool itself
 // carries no lock, and instances live only inside allOTelPools.lookup,
 // so a sharedPool value should never be touched outside a section that
 // holds the registry lock.
 type sharedPool struct {
-	pool     *slabqueue.Pool[publisher.Event]
-	settings memqueue.Settings // remembered so later joiners can be validated
-	refs     int
+	pool *slabqueue.Pool[publisher.Event]
+	refs int
 }
 
 // allOTelPools is the process-global registry of slabqueue.Pools keyed
@@ -109,13 +120,10 @@ func newOTelOutputController(
 	// we go through acquireOTelPool. Anything else (in practice
 	// diskqueue.Settings from an explicit queue.disk) opts out and builds
 	// its queue from the user-supplied queueFactory.
+	var sharedQueue *slabqueue.Queue[publisher.Event]
 	if settings, isMem := queueConfig.(memqueue.Settings); isMem {
-		var err error
-		pool, err = acquireOTelPool(intakeQueueID, settings, monitors)
-		if err != nil {
-			return nil, err
-		}
-		pipelineQueue = pool.Connect()
+		pool, sharedQueue = acquireOTelPool(intakeQueueID, settings, monitors)
+		pipelineQueue = sharedQueue
 	} else {
 		// Non-memory queue (e.g. queue.disk): sharing is meaningless because
 		// each receiver writes to its own on-disk path, so an intake queue
@@ -137,7 +145,9 @@ func newOTelOutputController(
 	})
 	if err != nil {
 		closePipelineQueue(pipelineQueue)
-		releaseOTelPool(intakeQueueID)
+		if sharedQueue != nil {
+			releaseOTelPool(intakeQueueID)
+		}
 		return nil, err
 	}
 
@@ -157,15 +167,16 @@ func newOTelOutputController(
 	})
 
 	return &otelOutputController{
-		beatInfo:      beatInfo,
-		logger:        beatInfo.Logger.Named("otelOutputController"),
-		monitors:      monitors,
-		intakeQueueID: intakeQueueID,
-		queue:         pipelineQueue,
-		pool:          pool,
-		consumer:      consumer,
-		workers:       workers,
-		workerChan:    workerChan,
+		beatInfo:        beatInfo,
+		logger:          beatInfo.Logger.Named("otelOutputController"),
+		monitors:        monitors,
+		intakeQueueID:   intakeQueueID,
+		queue:           pipelineQueue,
+		pool:            pool,
+		sharedPoolQueue: sharedQueue,
+		consumer:        consumer,
+		workers:         workers,
+		workerChan:      workerChan,
 	}, nil
 }
 
@@ -178,33 +189,44 @@ func closePipelineQueue(q queue.Queue[publisher.Event]) {
 	_ = q.Close(true)
 }
 
-// acquireOTelPool returns the slabqueue.Pool for the given intake queue ID,
-// creating it if necessary. The empty string is the global default ID:
-// every receiver started without an explicit intake queue ID joins the
-// same global pool. Settings mismatches against an already-registered ID
-// (including the global one) return an error.
-func acquireOTelPool(intakeQueueID string, settings memqueue.Settings, monitors Monitors) (*slabqueue.Pool[publisher.Event], error) {
-	poolSettings := slabqueue.Settings{Events: settings.Events}
-
+// acquireOTelPool returns the slabqueue.Pool for the given intake queue ID and
+// a fresh per-connection Queue into it, creating the pool if necessary. The
+// empty string is the global default ID: every receiver started without an
+// explicit intake queue ID joins the same global pool.
+//
+// Connections may request different event budgets. Instead of rejecting a
+// mismatch, this connection's own Queue is capped at its requested size, which
+// in turn sizes the shared pool to the largest cap among connected queues
+// (Queue.SetTarget drives the pool). A smaller receiver therefore cannot exceed
+// its own size even though the shared pool is larger, and the pool grows and
+// shrinks as receivers join and leave — keeping the shared global pool usable
+// even when, as in the elastic-agent default, receivers with differing
+// queue.mem.events values all land on the empty ID.
+func acquireOTelPool(intakeQueueID string, settings memqueue.Settings, monitors Monitors) (*slabqueue.Pool[publisher.Event], *slabqueue.Queue[publisher.Event]) {
 	allOTelPools.Lock()
 	defer allOTelPools.Unlock()
-	if existing, ok := allOTelPools.lookup[intakeQueueID]; ok {
-		if existing.settings.Events != settings.Events {
-			return nil, fmt.Errorf("shared intake queue %q already initialized with different queue settings", intakeQueueID)
-		}
-		existing.refs++
-		monitors.Logger.Debugf("newOTelOutputController: joining existing pool for intake queue ID %q (%v pipelines connected)", intakeQueueID, existing.refs)
-		return existing.pool, nil
+	entry, ok := allOTelPools.lookup[intakeQueueID]
+	if !ok {
+		pool := slabqueue.NewPool[publisher.Event](slabqueue.Settings{Events: settings.Events}, observerForMonitors(monitors))
+		entry = &sharedPool{pool: pool}
+		allOTelPools.lookup[intakeQueueID] = entry
+		monitors.Logger.Debugf("newOTelOutputController: created new pool for intake queue ID %q", intakeQueueID)
 	}
-	pool := slabqueue.NewPool[publisher.Event](poolSettings, observerForMonitors(monitors))
-	allOTelPools.lookup[intakeQueueID] = &sharedPool{pool: pool, settings: settings, refs: 1}
-	monitors.Logger.Debugf("newOTelOutputController: created new pool for intake queue ID %q", intakeQueueID)
-	return pool, nil
+	entry.refs++
+	q := entry.pool.Connect()
+	// Cap this connection's own queue at its requested budget. This also resizes
+	// the shared pool to the largest cap among connected queues, so the pool
+	// always tracks the queues and the two cannot drift.
+	q.SetTarget(settings.Events)
+	monitors.Logger.Debugf("newOTelOutputController: joined pool for intake queue ID %q (%v connections, pool budget %v)", intakeQueueID, entry.refs, entry.pool.Target())
+	return entry.pool, q
 }
 
-// releaseOTelPool decrements the ref count for the given intake queue ID and
-// shuts the pool down once the last connected pipeline leaves. The empty ID
-// is the global default pool and is treated the same as a named ID.
+// releaseOTelPool drops one reference to the pool for the given intake queue ID
+// and shuts the pool down once the last connected pipeline leaves. The pool's
+// size is not adjusted here: the connection's queue was already closed (which
+// resizes the pool to the remaining queues' caps). The empty ID is the global
+// default pool and is treated the same as a named ID.
 func releaseOTelPool(intakeQueueID string) {
 	allOTelPools.Lock()
 	defer allOTelPools.Unlock()
@@ -213,7 +235,7 @@ func releaseOTelPool(intakeQueueID string) {
 		return
 	}
 	entry.refs--
-	if entry.refs == 0 {
+	if entry.refs <= 0 {
 		entry.pool.Shutdown()
 		delete(allOTelPools.lookup, intakeQueueID)
 	}
@@ -249,8 +271,11 @@ func (c *otelOutputController) waitClose(ctx context.Context, _ bool) error {
 	}
 
 	// Release this pipeline's claim on the shared pool. When the last
-	// connected pipeline releases, the pool is shut down.
-	releaseOTelPool(c.intakeQueueID)
+	// connected pipeline releases, the pool is shut down. Receivers on the
+	// non-mem (disk) path own their queue outright and never joined a pool.
+	if c.sharedPoolQueue != nil {
+		releaseOTelPool(c.intakeQueueID)
+	}
 	return nil
 }
 

--- a/libbeat/publisher/pipeline/output_otel_test.go
+++ b/libbeat/publisher/pipeline/output_otel_test.go
@@ -170,7 +170,10 @@ func TestSharedPoolBudgetIsolatesPipelines(t *testing.T) {
 	assert.False(t, ok, "TryPublish should fail when the shared pool budget is exhausted")
 }
 
-func TestSharedIntakeQueueConfigMismatch(t *testing.T) {
+// TestSharedIntakeQueueGrowsToMax verifies that receivers requesting different
+// event budgets for the same intake queue ID no longer conflict: the shared
+// pool grows to the largest requested budget and every receiver connects.
+func TestSharedIntakeQueueGrowsToMax(t *testing.T) {
 	c1, err := newOTelOutputController(
 		beatInfoForTest(t),
 		monitorsForTest(),
@@ -182,7 +185,11 @@ func TestSharedIntakeQueueConfigMismatch(t *testing.T) {
 	require.NoError(t, err, "first output controller creation should succeed")
 	defer c1.waitClose(cancelledContext(), false)
 
-	_, err = newOTelOutputController(
+	require.Equal(t, 5, c1.poolForTest().Target(), "pool starts at the first receiver's budget")
+
+	// A second receiver asks for a larger budget on the same ID. Instead of
+	// erroring on the mismatch, the shared pool must grow to the maximum.
+	c2, err := newOTelOutputController(
 		beatInfoForTest(t),
 		monitorsForTest(),
 		nilObserver,
@@ -190,7 +197,95 @@ func TestSharedIntakeQueueConfigMismatch(t *testing.T) {
 		nil,
 		memqueue.Settings{Events: 10},
 	)
-	require.Error(t, err, "connecting to a shared intake queue with a different queue config should fail")
+	require.NoError(t, err, "a differing budget must grow the shared pool, not fail")
+	defer c2.waitClose(cancelledContext(), false)
+
+	require.Same(t, c1.poolForTest(), c2.poolForTest(), "both receivers share the pool")
+	assert.Equal(t, 10, c1.poolForTest().Target(), "pool grows to the largest requested budget")
+	assert.Equal(t, 10, c1.poolForTest().Capacity(), "growth is immediate")
+
+	// A smaller late joiner rides the larger pool without changing the budget.
+	c3, err := newOTelOutputController(
+		beatInfoForTest(t),
+		monitorsForTest(),
+		nilObserver,
+		"mismatchID",
+		nil,
+		memqueue.Settings{Events: 3},
+	)
+	require.NoError(t, err)
+	defer c3.waitClose(cancelledContext(), false)
+	assert.Equal(t, 10, c1.poolForTest().Target(), "a smaller joiner does not shrink the pool")
+}
+
+// TestSharedIntakeQueueShrinksWhenLargestLeaves verifies that when the receiver
+// holding the maximum budget leaves, the pool's target drops to the new running
+// maximum (shrink converges lazily under the hood).
+func TestSharedIntakeQueueShrinksWhenLargestLeaves(t *testing.T) {
+	c1, err := newOTelOutputController(
+		beatInfoForTest(t), monitorsForTest(), nilObserver, "shrinkID", nil,
+		memqueue.Settings{Events: 4},
+	)
+	require.NoError(t, err)
+	defer c1.waitClose(cancelledContext(), false)
+
+	c2, err := newOTelOutputController(
+		beatInfoForTest(t), monitorsForTest(), nilObserver, "shrinkID", nil,
+		memqueue.Settings{Events: 20},
+	)
+	require.NoError(t, err)
+
+	pool := c1.poolForTest()
+	require.Equal(t, 20, pool.Target(), "pool sized to the larger receiver")
+
+	// The larger receiver leaves; the budget must fall back to the smaller one.
+	require.NoError(t, c2.waitClose(cancelledContext(), false))
+	assert.Equal(t, 4, pool.Target(), "budget drops to the remaining receiver's request")
+	assert.Eventually(t, func() bool { return pool.Capacity() == 4 }, time.Second, time.Millisecond,
+		"capacity converges down to the new target once high slots are free")
+}
+
+// TestSharedIntakeQueueCapsPerReceiver verifies that, on a shared pool sized to
+// the largest receiver, each receiver's own queue is still capped at its own
+// requested size: the smaller receiver cannot use more than its budget even
+// though the pool has room.
+func TestSharedIntakeQueueCapsPerReceiver(t *testing.T) {
+	c1, err := newOTelOutputController(
+		beatInfoForTest(t), monitorsForTest(), nilObserver, "capID", nil,
+		memqueue.Settings{Events: 4},
+	)
+	require.NoError(t, err)
+	defer c1.waitClose(cancelledContext(), false)
+
+	c2, err := newOTelOutputController(
+		beatInfoForTest(t), monitorsForTest(), nilObserver, "capID", nil,
+		memqueue.Settings{Events: 8},
+	)
+	require.NoError(t, err)
+	defer c2.waitClose(cancelledContext(), false)
+
+	pool := c1.poolForTest()
+	require.Same(t, pool, c2.poolForTest())
+	require.Equal(t, 8, pool.Target(), "pool sized to the larger receiver")
+
+	// The small receiver (Events=4) must cap at 4 live events even though the
+	// pool has 8 slots.
+	p1 := c1.queueProducer(queue.ProducerConfig{})
+	for i := 0; i < 4; i++ {
+		_, ok := p1.TryPublish(testEvent(i))
+		require.True(t, ok, "publish %d within the small receiver's cap should succeed", i)
+	}
+	_, ok := p1.TryPublish(testEvent(99))
+	assert.False(t, ok, "the small receiver must cap at 4 even though the pool has room")
+	assert.Equal(t, 4, pool.Available(), "pool still has 4 free slots; only the per-queue cap blocked it")
+
+	// The larger receiver (Events=8) can use the remaining pool budget.
+	p2 := c2.queueProducer(queue.ProducerConfig{})
+	for i := 0; i < 4; i++ {
+		_, ok := p2.TryPublish(testEvent(i))
+		require.True(t, ok, "the larger receiver can use the rest of the shared pool")
+	}
+	assert.Equal(t, 0, pool.Available(), "pool now fully used: 4 + 4 = 8")
 }
 
 // TestNonMemQueueOptsOutOfPool verifies that a non-memory queue config

--- a/libbeat/publisher/queue/queuetest/queuetest.go
+++ b/libbeat/publisher/queue/queuetest/queuetest.go
@@ -276,6 +276,7 @@ func makeProducer(
 				log.Debug("publish event", i)
 				producer.Publish(MakeEvent(makeFields(i)))
 			}
+			producer.Close()
 
 			ackWG.Wait()
 		}

--- a/libbeat/publisher/queue/slabqueue/batch.go
+++ b/libbeat/publisher/queue/slabqueue/batch.go
@@ -51,7 +51,7 @@ func (b *batch[T]) Count() int { return len(b.indices) }
 
 // Entry returns the i-th event. Must not be called after FreeEntries.
 func (b *batch[T]) Entry(i int) T {
-	return b.queue.pool.storage[b.indices[i]].event
+	return b.queue.pool.slot(b.indices[i]).event
 }
 
 // FreeEntries clears the event field in each slot to allow the GC to collect
@@ -68,7 +68,7 @@ func (b *batch[T]) FreeEntries() {
 	}
 	var zero T
 	for _, i := range b.indices {
-		b.queue.pool.storage[i].event = zero
+		b.queue.pool.slot(i).event = zero
 	}
 	b.freed = true
 }
@@ -97,7 +97,7 @@ func (b *batch[T]) Done() {
 	b.ackProducers = b.ackProducers[:0]
 	b.ackCounts = b.ackCounts[:0]
 	for _, i := range b.indices {
-		s := &pool.storage[i]
+		s := pool.slot(i)
 		if s.producer != nil {
 			found := false
 			for j, p := range b.ackProducers {
@@ -123,9 +123,11 @@ func (b *batch[T]) Done() {
 	// producers can make progress regardless of where this batch is in
 	// the pending list.
 	pool.observer.RemoveEvents(len(b.indices), 0)
-	for _, i := range b.indices {
-		pool.free <- i
-	}
+	n := len(b.indices)
+	pool.releaseSlots(b.indices)
+	// These events left circulation; return their per-queue budget so producers
+	// blocked on this queue's cap can proceed.
+	b.queue.releaseLive(n)
 
 	q := b.queue
 	q.mu.Lock()
@@ -223,7 +225,7 @@ func (b *batch[T]) Release() {
 	// collection — we explicitly do not want to fire callbacks.
 	var zero T
 	for _, i := range b.indices {
-		s := &pool.storage[i]
+		s := pool.slot(i)
 		if !b.freed {
 			s.event = zero
 		}
@@ -231,12 +233,12 @@ func (b *batch[T]) Release() {
 		s.next = -1
 	}
 
-	// Return slots to the pool. pool.free's buffer is sized to the slot
-	// count so this never blocks.
+	// Return slots to the pool.
 	pool.observer.RemoveEvents(len(b.indices), 0)
-	for _, i := range b.indices {
-		pool.free <- i
-	}
+	n := len(b.indices)
+	pool.releaseSlots(b.indices)
+	// Return the per-queue budget for the abandoned events.
+	b.queue.releaseLive(n)
 
 	// Remove the batch from the pending FIFO if it's still there.
 	// Done's sweep relies on the per-batch `done` flag and walks from

--- a/libbeat/publisher/queue/slabqueue/freelist.go
+++ b/libbeat/publisher/queue/slabqueue/freelist.go
@@ -171,16 +171,15 @@ func (f *freeList) pushBatch(indices []int) {
 func (f *freeList) removeIndex(x int) bool {
 	sh := &f.shards[x&f.mask]
 	sh.mu.Lock()
+	defer sh.mu.Unlock()
 	for k := range sh.idx {
 		if sh.idx[k] == x {
 			last := len(sh.idx) - 1
 			sh.idx[k] = sh.idx[last]
 			sh.idx = sh.idx[:last]
-			sh.mu.Unlock()
 			return true
 		}
 	}
-	sh.mu.Unlock()
 	return false
 }
 

--- a/libbeat/publisher/queue/slabqueue/freelist.go
+++ b/libbeat/publisher/queue/slabqueue/freelist.go
@@ -1,0 +1,235 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package slabqueue
+
+import (
+	"runtime"
+	"slices"
+	"sync"
+	"sync/atomic"
+)
+
+// freeList is the pool's counting semaphore: it holds the indices of every
+// currently-free slot and bounds the number of live events at the pool's
+// capacity. It replaces the buffered `chan int` the pool used originally for
+// two reasons:
+//
+//   - A channel's buffer is fixed at creation, so it cannot back a resizable
+//     pool. The freeList's per-shard stacks grow and shrink freely.
+//   - Under multiple concurrent producers the single channel serializes every
+//     acquire and release on one lock. The freeList shards that traffic across
+//     K independent locks, which benchmarks show matches the channel at one
+//     producer and is ~2x faster at 2-8 producers in steady state.
+//
+// Routing: a slot index's "home" shard is i & mask, fixed for the life of the
+// pool and invariant under grow/shrink. release always returns an index to its
+// home shard regardless of which goroutine releases it, which keeps shards
+// balanced with no rebalancing. acquire takes a home *hint* (a per-producer
+// starting point) but scans every shard, so correctness never depends on the
+// hint — only contention does.
+//
+// Blocking: when every shard is empty (the pool is full and producers must
+// wait for backpressure to clear) acquirers park on a single shared cond. That
+// shared point is touched only on the slow path, so it is not a steady-state
+// contention source. Waking uses the re-check-after-register pattern (register
+// as a waiter, then re-scan the shards before parking) so a release that
+// happens between the failed scan and the park cannot be lost.
+type freeList struct {
+	shards []freeShard
+	mask   int // len(shards)-1; len(shards) is a power of two
+
+	// waiters counts parked acquirers. It is read without the lock on the
+	// release fast path (a racy "is anyone waiting?" check) and is also
+	// mutated and read under gmu where it is authoritative.
+	waiters atomic.Int64
+
+	gmu   sync.Mutex
+	gcond *sync.Cond
+}
+
+// freeShard is one independently-locked stack of free slot indices.
+type freeShard struct {
+	mu  sync.Mutex
+	idx []int
+}
+
+// newFreeList builds an empty free list. Indices are added by the pool (via
+// push/pushNoSignal) once their backing storage exists.
+func newFreeList() *freeList {
+	k := freeListShardCount()
+	f := &freeList{
+		shards: make([]freeShard, k),
+		mask:   k - 1,
+	}
+	f.gcond = sync.NewCond(&f.gmu)
+	return f
+}
+
+// freeListShardCount picks a fixed shard count from CPU parallelism, rounded up
+// to a power of two and floored at 4. It is intentionally independent of the
+// number of connected receivers: receivers come and go, but the shard count
+// (and therefore every index's home shard) must never change, or the routing
+// invariant would break.
+func freeListShardCount() int {
+	n := runtime.GOMAXPROCS(0)
+	k := 1
+	for k < n {
+		k <<= 1
+	}
+	if k < 4 {
+		k = 4
+	}
+	return k
+}
+
+// tryGrab pops a free index, scanning shards from the home hint. It never
+// blocks. The second return is false when every shard is empty.
+func (f *freeList) tryGrab(home int) (int, bool) {
+	for off := 0; off <= f.mask; off++ {
+		sh := &f.shards[(home+off)&f.mask]
+		sh.mu.Lock()
+		if n := len(sh.idx); n > 0 {
+			x := sh.idx[n-1]
+			sh.idx = sh.idx[:n-1]
+			sh.mu.Unlock()
+			return x, true
+		}
+		sh.mu.Unlock()
+	}
+	return 0, false
+}
+
+// push returns index i to its home shard and wakes one parked acquirer if any
+// might be waiting.
+func (f *freeList) push(i int) {
+	f.pushNoSignal(i)
+	f.signal()
+}
+
+// pushNoSignal returns index i to its home shard without waking acquirers. Used
+// by grow, which pushes a batch of new indices and then broadcasts once.
+func (f *freeList) pushNoSignal(i int) {
+	sh := &f.shards[i&f.mask]
+	sh.mu.Lock()
+	sh.idx = append(sh.idx, i)
+	sh.mu.Unlock()
+}
+
+// pushBatch returns a batch of indices to their home shards, locking each shard
+// at most once instead of once per index. For a large batch (e.g. acking a full
+// queue) this turns O(len) contended lock operations into O(shards). The slice
+// is reordered in place — callers must not rely on its order afterward, which
+// holds for every release path (the batch is recycled, the close list is
+// local). Holding each shard lock only for the contiguous bulk append keeps the
+// critical sections short, so it does not starve concurrent acquirers.
+func (f *freeList) pushBatch(indices []int) {
+	if len(indices) <= 1 {
+		if len(indices) == 1 {
+			f.pushNoSignal(indices[0])
+		}
+		return
+	}
+	// Sorting by the shard key clusters every shard's indices into a contiguous
+	// run; we then append each run under a single lock.
+	slices.SortFunc(indices, func(a, b int) int {
+		return (a & f.mask) - (b & f.mask)
+	})
+	for start := 0; start < len(indices); {
+		shard := indices[start] & f.mask
+		end := start + 1
+		for end < len(indices) && indices[end]&f.mask == shard {
+			end++
+		}
+		sh := &f.shards[shard]
+		sh.mu.Lock()
+		sh.idx = append(sh.idx, indices[start:end]...)
+		sh.mu.Unlock()
+		start = end
+	}
+}
+
+// removeIndex removes a specific free index from its home shard, returning
+// false if it is not currently free (i.e. it is live at a producer/consumer).
+// Used by the pool's top-down shrink to retire the highest slot once it is
+// free. The linear scan is bounded by the shard's length; shrink is rare and
+// off the hot path.
+func (f *freeList) removeIndex(x int) bool {
+	sh := &f.shards[x&f.mask]
+	sh.mu.Lock()
+	for k := range sh.idx {
+		if sh.idx[k] == x {
+			last := len(sh.idx) - 1
+			sh.idx[k] = sh.idx[last]
+			sh.idx = sh.idx[:last]
+			sh.mu.Unlock()
+			return true
+		}
+	}
+	sh.mu.Unlock()
+	return false
+}
+
+// signal wakes a single parked acquirer, but only if one might be waiting. The
+// fast unlocked read of waiters keeps the steady-state release path off the
+// shared cond lock entirely; the shard append in push happens-before this read,
+// and a parked acquirer increments waiters before re-scanning the shards, so if
+// an acquirer would miss the just-pushed index this read is guaranteed to
+// observe it as a waiter (see the freeList doc comment).
+func (f *freeList) signal() {
+	if f.waiters.Load() == 0 {
+		return
+	}
+	f.gmu.Lock()
+	if f.waiters.Load() > 0 {
+		f.gcond.Signal()
+	}
+	f.gmu.Unlock()
+}
+
+// wakeAll wakes every parked acquirer. Used on grow (new slots may satisfy
+// several blocked producers) and on close/shutdown (so parked producers can
+// observe the closed state and return).
+func (f *freeList) wakeAll() {
+	f.gmu.Lock()
+	f.gcond.Broadcast()
+	f.gmu.Unlock()
+}
+
+// maybeWakeAll wakes every parked acquirer, but only if one might be waiting.
+// Used by the bulk release path to coalesce many slot returns into one wake-up.
+// The unlocked waiters read is safe for the same reason signal's is.
+func (f *freeList) maybeWakeAll() {
+	if f.waiters.Load() == 0 {
+		return
+	}
+	f.wakeAll()
+}
+
+// available reports the number of free indices by summing the shards. It locks
+// each shard in turn, so it is meant for tests and observability, not the hot
+// path; keeping the count off the hot path avoids a single contended atomic on
+// every acquire and release.
+func (f *freeList) available() int {
+	n := 0
+	for s := range f.shards {
+		f.shards[s].mu.Lock()
+		n += len(f.shards[s].idx)
+		f.shards[s].mu.Unlock()
+	}
+	return n
+}

--- a/libbeat/publisher/queue/slabqueue/pool.go
+++ b/libbeat/publisher/queue/slabqueue/pool.go
@@ -420,14 +420,17 @@ func (p *Pool[T]) syncTargetToQueues() {
 	if p.isClosed() {
 		return
 	}
+	// Hold p.mu across both the scan and the apply so concurrent syncs serialize:
+	// otherwise two callers could each compute a max and then apply them out of
+	// order, letting a stale max overwrite a fresh one.
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	max := 0
 	for q := range p.queues {
 		if l := int(q.limit.Load()); l > max {
 			max = l
 		}
 	}
-	p.mu.Unlock()
 	if max > 0 {
 		p.setTarget(max)
 	}

--- a/libbeat/publisher/queue/slabqueue/pool.go
+++ b/libbeat/publisher/queue/slabqueue/pool.go
@@ -19,6 +19,7 @@ package slabqueue
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 )
@@ -35,15 +36,47 @@ type slot[T any] struct {
 }
 
 // Pool is the shared backing storage for events from multiple pipelines.
-// Slots are allocated from a free list (a buffered channel of indices),
-// which also functions as the counting semaphore that bounds the total
-// number of events live across all connected pipelines.
+// Slots are allocated from a free list, which also functions as the counting
+// semaphore that bounds the total number of events live across all connected
+// pipelines.
+//
+// The pool is resizable at any time, including while producers and consumers
+// are running: its two capacity-bounding structures are both growable. Storage
+// is a directory of non-moving chunks (see storage.go) and the free list is a
+// sharded semaphore (see freelist.go). The pool grows immediately and shrinks
+// lazily, retiring the highest slots as they fall out of circulation so live
+// events are never dropped. Its capacity is not set directly — it is derived
+// from the connected queues' per-queue caps (see syncTargetToQueues), so the
+// pool always tracks the largest queue and the two cannot drift.
+//
+// Capacity invariant: the in-circulation slot indices are always exactly
+// [0, capacity) with no holes. Growth appends indices at the top; shrink removes
+// only the current top index and only once it is free. capacity therefore
+// doubles as the storage high-water mark, which lets shrink reclaim whole
+// trailing chunks without ever invalidating a pointer to a live slot.
 type Pool[T any] struct {
-	settings Settings
 	observer queue.Observer
 
-	storage []slot[T]
-	free    chan int
+	// dir holds the slot storage as non-moving chunks; see storage.go. It is
+	// swapped (never mutated in place) under growMu when the pool grows or
+	// reclaims a trailing chunk, and loaded atomically on every slot access.
+	dir  atomic.Pointer[directory[T]]
+	free *freeList
+
+	// growMu serializes structural resize (capacity changes, directory swaps).
+	// capacity and target are stored under it but read lock-free as atomics.
+	//
+	//   capacity: current physical slot count == in-circulation high-water.
+	//   target:   desired budget. capacity == target in steady state; capacity
+	//             > target while a lazy shrink is converging.
+	growMu   sync.Mutex
+	capacity atomic.Int64
+	target   atomic.Int64
+
+	// homeCounter hands each producer a stable home shard for the free list,
+	// assigned once at producer creation. It keeps ticking as producers
+	// (receivers) come and go; the shard count never changes.
+	homeCounter atomic.Uint64
 
 	closeOnce sync.Once
 	closed    chan struct{}
@@ -83,19 +116,205 @@ func NewPool[T any](settings Settings, observer queue.Observer) *Pool[T] {
 	}
 
 	p := &Pool[T]{
-		settings: settings,
 		observer: observer,
-		storage:  make([]slot[T], settings.Events),
-		free:     make(chan int, settings.Events),
+		free:     newFreeList(),
 		closed:   make(chan struct{}),
 		queues:   make(map[*Queue[T]]struct{}),
 	}
 	p.batchPool.New = func() any { return &batch[T]{} }
+	p.dir.Store(newDirectory[T](settings.Events))
 	for i := 0; i < settings.Events; i++ {
-		p.free <- i
+		p.free.pushNoSignal(i)
 	}
+	p.capacity.Store(int64(settings.Events))
+	p.target.Store(int64(settings.Events))
 	p.observer.MaxEvents(settings.Events)
 	return p
+}
+
+// setTarget records n as the desired capacity and is safe to call while
+// producers and consumers are running. Growth is immediate: when n is above the
+// current capacity the new slots are allocated and become acquirable before
+// setTarget returns, and any producers blocked on a full pool are woken. Shrink
+// is lazy: when n is below the current capacity the target is lowered now and
+// the pool retires its highest slots as they are released, converging to n
+// without ever discarding a slot that still holds a live, unacked event. The
+// effective floor at any instant is the highest in-use slot index, so a
+// long-lived event at the top of the range holds the shrink until it drains.
+//
+// setTarget is unexported on purpose: the pool's capacity is not set directly
+// but derived from the per-queue caps via syncTargetToQueues, so callers size
+// the pool only by setting Queue.SetTarget and the two can never disagree.
+func (p *Pool[T]) setTarget(n int) {
+	if n < 1 {
+		n = 1
+	}
+	p.growMu.Lock()
+	defer p.growMu.Unlock()
+	prev := p.target.Load()
+	p.target.Store(int64(n))
+	if int64(n) != prev {
+		p.observer.MaxEvents(n)
+	}
+	switch {
+	case int64(n) > p.capacity.Load():
+		p.growLocked(n)
+	case int64(n) < p.capacity.Load():
+		p.shrinkLocked()
+	}
+}
+
+// growLocked raises capacity to n by allocating any missing chunks, publishing
+// the new directory, and pushing the new indices [old, n) to the free list. It
+// must be called with growMu held. Indices are published only after the
+// directory that backs them is stored, so a goroutine that later acquires one
+// always observes a directory containing its chunk.
+func (p *Pool[T]) growLocked(n int) {
+	old := int(p.capacity.Load())
+	if n <= old {
+		return
+	}
+	if need := numChunks(n); need > len(p.dir.Load().chunks) {
+		cur := p.dir.Load().chunks
+		nc := make([]*chunk[T], need)
+		copy(nc, cur)
+		for i := len(cur); i < need; i++ {
+			nc[i] = &chunk[T]{}
+		}
+		p.dir.Store(&directory[T]{chunks: nc})
+	}
+	for i := old; i < n; i++ {
+		p.free.pushNoSignal(i)
+	}
+	p.capacity.Store(int64(n))
+	// Wake every blocked producer: the added slots may satisfy more than one.
+	p.free.wakeAll()
+}
+
+// shrinkLocked retires free slots from the top of the index range toward the
+// current target. It removes only the highest index, and only while that index
+// is free; if the top index is currently live it stops and will be retried by
+// the next release. This keeps the in-circulation set contiguous ([0, capacity))
+// so trailing chunks can be reclaimed exactly. It must be called with growMu
+// held.
+func (p *Pool[T]) shrinkLocked() {
+	for {
+		cap := int(p.capacity.Load())
+		if cap <= int(p.target.Load()) {
+			return
+		}
+		top := cap - 1
+		if !p.free.removeIndex(top) {
+			// The top slot is still in use; it will be retired when released.
+			return
+		}
+		p.capacity.Store(int64(top))
+		// Reclaim any trailing chunk the shrink just emptied.
+		if want := numChunks(top); want < len(p.dir.Load().chunks) {
+			cur := p.dir.Load().chunks
+			nc := make([]*chunk[T], want)
+			copy(nc, cur[:want])
+			p.dir.Store(&directory[T]{chunks: nc})
+		}
+	}
+}
+
+// acquire takes a free slot index for a producer, blocking until one is
+// available, the queue closes (closeCh), or the pool shuts down. It returns
+// (0, false) when interrupted by close/shutdown. home is the producer's shard
+// hint.
+func (p *Pool[T]) acquire(home int, closeCh <-chan struct{}) (int, bool) {
+	// Mirror the original channel select: a publish racing with shutdown/close
+	// fails rather than grabbing a slot that would be immediately abandoned.
+	if p.isClosed() || chClosed(closeCh) {
+		return 0, false
+	}
+	if i, ok := p.free.tryGrab(home); ok {
+		return i, true
+	}
+	f := p.free
+	for {
+		f.gmu.Lock()
+		f.waiters.Add(1)
+		// Re-check after registering as a waiter: a push (or grow) between the
+		// failed tryGrab above and the Wait below would otherwise be lost.
+		if i, ok := f.tryGrab(home); ok {
+			f.waiters.Add(-1)
+			f.gmu.Unlock()
+			return i, true
+		}
+		if p.isClosed() || chClosed(closeCh) {
+			f.waiters.Add(-1)
+			f.gmu.Unlock()
+			return 0, false
+		}
+		f.gcond.Wait()
+		f.waiters.Add(-1)
+		f.gmu.Unlock()
+		if p.isClosed() || chClosed(closeCh) {
+			return 0, false
+		}
+		if i, ok := f.tryGrab(home); ok {
+			return i, true
+		}
+	}
+}
+
+// releaseSlot returns slot index i to the free list. If a lazy shrink is in
+// progress (capacity > target) it then attempts to retire the top slot(s) now
+// that this release may have freed the current high-water index. The shrink
+// check is a single atomic comparison, so the steady-state release path is just
+// a push.
+func (p *Pool[T]) releaseSlot(i int) {
+	p.free.push(i)
+	if p.capacity.Load() > p.target.Load() {
+		p.growMu.Lock()
+		p.shrinkLocked()
+		p.growMu.Unlock()
+	}
+}
+
+// releaseSlots returns a batch of slot indices to the free list, coalescing the
+// wake-up into a single broadcast rather than signaling once per slot. This is
+// the path batch completion and force-close use: acking a large batch while
+// producers are blocked would otherwise take the shared cond lock once per
+// slot. The single guarded broadcast is correct for the same reason signal is:
+// a parked producer registers as a waiter before re-scanning the shards, so if
+// it would miss every pushed slot the waiters count is guaranteed visible here.
+func (p *Pool[T]) releaseSlots(indices []int) {
+	if len(indices) == 0 {
+		return
+	}
+	p.free.pushBatch(indices)
+	if p.capacity.Load() > p.target.Load() {
+		p.growMu.Lock()
+		p.shrinkLocked()
+		p.growMu.Unlock()
+	}
+	p.free.maybeWakeAll()
+}
+
+// isClosed reports whether the pool has been shut down.
+func (p *Pool[T]) isClosed() bool {
+	select {
+	case <-p.closed:
+		return true
+	default:
+		return false
+	}
+}
+
+// chClosed is a non-blocking check for a closed signal channel.
+func chClosed(ch <-chan struct{}) bool {
+	if ch == nil {
+		return false
+	}
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
 }
 
 // getBatch returns a recycled or freshly allocated *batch[T]. Callers
@@ -144,6 +363,9 @@ func (p *Pool[T]) Connect() *Queue[T] {
 func (p *Pool[T]) Shutdown() {
 	p.closeOnce.Do(func() {
 		close(p.closed)
+		// Wake any producers parked on a full pool so they observe the closed
+		// state and return instead of blocking forever.
+		p.free.wakeAll()
 		p.mu.Lock()
 		queues := make([]*Queue[T], 0, len(p.queues))
 		for q := range p.queues {
@@ -159,12 +381,17 @@ func (p *Pool[T]) Shutdown() {
 	})
 }
 
-// Capacity returns the pool's total slot count.
-func (p *Pool[T]) Capacity() int { return p.settings.Events }
+// Capacity returns the pool's current physical slot count. While a lazy shrink
+// is converging this can exceed Target; in steady state they are equal.
+func (p *Pool[T]) Capacity() int { return int(p.capacity.Load()) }
+
+// Target returns the pool's desired capacity (the configured budget). Useful
+// for tests and observability.
+func (p *Pool[T]) Target() int { return int(p.target.Load()) }
 
 // Available returns the number of currently free slots. Useful for tests and
 // observability.
-func (p *Pool[T]) Available() int { return len(p.free) }
+func (p *Pool[T]) Available() int { return p.free.available() }
 
 // ConnectedQueues returns the number of Queue façades currently connected.
 func (p *Pool[T]) ConnectedQueues() int {
@@ -178,4 +405,30 @@ func (p *Pool[T]) disconnect(q *Queue[T]) {
 	p.mu.Lock()
 	delete(p.queues, q)
 	p.mu.Unlock()
+	// A departing queue may have held the largest per-queue cap; resize the pool
+	// to the new maximum so it tracks the connected queues.
+	p.syncTargetToQueues()
+}
+
+// syncTargetToQueues sizes the pool to the largest per-queue cap among the
+// connected queues, so the shared pool always tracks the queues rather than
+// being set independently (which could drift). It is the single place pool
+// capacity is derived: Queue.SetTarget and disconnect call it. Queues with no
+// per-queue cap (limit 0) do not contribute, so a pool of only uncapped queues
+// keeps whatever capacity it was created with.
+func (p *Pool[T]) syncTargetToQueues() {
+	if p.isClosed() {
+		return
+	}
+	p.mu.Lock()
+	max := 0
+	for q := range p.queues {
+		if l := int(q.limit.Load()); l > max {
+			max = l
+		}
+	}
+	p.mu.Unlock()
+	if max > 0 {
+		p.setTarget(max)
+	}
 }

--- a/libbeat/publisher/queue/slabqueue/producer.go
+++ b/libbeat/publisher/queue/slabqueue/producer.go
@@ -30,37 +30,48 @@ type producer[T any] struct {
 	queue *Queue[T]
 	cfg   queue.ProducerConfig
 
+	// home is this producer's free-list shard hint, assigned once at creation.
+	// It only steers where acquire starts scanning, so it never needs to change
+	// even as the pool grows or shrinks.
+	home int
+
 	nextID atomic.Uint64
 	closed atomic.Bool
 }
 
-// Publish adds an entry, blocking if the pool is empty until a slot is freed
-// or the queue/pool is closed.
+// Publish adds an entry, blocking until both this queue is under its per-queue
+// cap and the shared pool has a free slot, or the queue/pool is closed.
+//
+// The per-queue cap is reserved first, before acquiring a pool slot: a queue at
+// its cap must not consume pool slots it cannot keep, which would starve other
+// queues sharing the pool.
 func (p *producer[T]) Publish(entry T) (queue.EntryID, bool) {
 	if p.closed.Load() {
 		return 0, false
 	}
-	var slotIdx int
-	select {
-	case slotIdx = <-p.queue.pool.free:
-	case <-p.queue.closeCh:
+	if !p.queue.reserve() {
 		return 0, false
-	case <-p.queue.pool.closed:
+	}
+	slotIdx, ok := p.queue.pool.acquire(p.home, p.queue.closeCh)
+	if !ok {
+		p.queue.releaseLive(1)
 		return 0, false
 	}
 	return p.fill(entry, slotIdx)
 }
 
-// TryPublish adds an entry only if a slot is immediately available; it never
-// blocks.
+// TryPublish adds an entry only if this queue is under its per-queue cap and a
+// pool slot is immediately available; it never blocks.
 func (p *producer[T]) TryPublish(entry T) (queue.EntryID, bool) {
 	if p.closed.Load() {
 		return 0, false
 	}
-	var slotIdx int
-	select {
-	case slotIdx = <-p.queue.pool.free:
-	default:
+	if !p.queue.tryReserve() {
+		return 0, false
+	}
+	slotIdx, ok := p.queue.pool.free.tryGrab(p.home)
+	if !ok {
+		p.queue.releaseLive(1)
 		return 0, false
 	}
 	return p.fill(entry, slotIdx)
@@ -77,7 +88,7 @@ func (p *producer[T]) Close() { p.closed.Store(true) }
 func (p *producer[T]) fill(entry T, slotIdx int) (queue.EntryID, bool) {
 	id := p.nextID.Add(1)
 	pool := p.queue.pool
-	s := &pool.storage[slotIdx]
+	s := pool.slot(slotIdx)
 	s.event = entry
 	s.next = -1
 	s.producer = p
@@ -86,18 +97,20 @@ func (p *producer[T]) fill(entry T, slotIdx int) (queue.EntryID, bool) {
 	q := p.queue
 	q.mu.Lock()
 	if q.closing {
-		// Queue closed between acquire and fill. Return the slot.
+		// Queue closed between acquire and fill. Return the slot and the
+		// per-queue budget unit reserved for it.
 		var zero T
 		s.event = zero
 		s.producer = nil
 		q.mu.Unlock()
-		pool.free <- slotIdx
+		pool.releaseSlot(slotIdx)
+		q.releaseLive(1)
 		return 0, false
 	}
 	if q.tail == -1 {
 		q.head = slotIdx
 	} else {
-		pool.storage[q.tail].next = slotIdx
+		pool.slot(q.tail).next = slotIdx
 	}
 	q.tail = slotIdx
 	q.count++

--- a/libbeat/publisher/queue/slabqueue/queue.go
+++ b/libbeat/publisher/queue/slabqueue/queue.go
@@ -49,6 +49,25 @@ type Queue[T any] struct {
 	// notify wakes Get when new events arrive.
 	notify chan struct{}
 
+	// Per-queue live-event cap. This bounds the events live (published but not
+	// yet acked) on this one queue, independently of and in addition to the
+	// shared pool budget: a producer blocks when this queue reaches its limit
+	// even if the pool still has free slots. It is what lets several queues on
+	// one pool each enforce their own configured size while the pool is sized to
+	// the largest of them.
+	//
+	//   live:  events published to this queue but not yet released (FIFO +
+	//          in-flight). Maintained as an atomic so the reserve fast path is
+	//          lock-free, mirroring the pool free list.
+	//   limit: this queue's cap (0 = unlimited, bounded only by the pool).
+	//   limWaiters/limMu/limCond: park point for producers blocked on the cap,
+	//          touched only on the blocking slow path.
+	live       atomic.Int64
+	limit      atomic.Int64
+	limWaiters atomic.Int64
+	limMu      sync.Mutex
+	limCond    *sync.Cond
+
 	closeOnce sync.Once
 	closeCh   chan struct{} // closed on Close
 	doneOnce  sync.Once
@@ -57,7 +76,7 @@ type Queue[T any] struct {
 }
 
 func newQueue[T any](pool *Pool[T]) *Queue[T] {
-	return &Queue[T]{
+	q := &Queue[T]{
 		pool:    pool,
 		head:    -1,
 		tail:    -1,
@@ -65,11 +84,125 @@ func newQueue[T any](pool *Pool[T]) *Queue[T] {
 		closeCh: make(chan struct{}),
 		doneCh:  make(chan struct{}),
 	}
+	q.limCond = sync.NewCond(&q.limMu)
+	return q
 }
 
-// Producer returns a producer that publishes to this queue.
+// SetTarget sets this queue's per-queue live-event cap to n, and is safe to call
+// while the queue is in use. A producer blocks when this queue reaches n live
+// events even if the pool still has free slots. n <= 0 means uncapped (bounded
+// only by the pool). Lowering the cap takes effect lazily as in-flight events
+// drain; raising it immediately unblocks any producers parked on the old cap.
+//
+// Setting a queue's cap also resizes the shared pool to the largest cap among
+// the queues connected to it, so the pool always tracks its queues: a queue's
+// cap can never be larger than the pool that backs it, and the pool shrinks when
+// the queue holding the largest cap is lowered or leaves. The pool is therefore
+// driven entirely through the queues — callers set per-queue caps, not the pool
+// size directly.
+func (q *Queue[T]) SetTarget(n int) {
+	if n < 0 {
+		n = 0
+	}
+	q.limit.Store(int64(n))
+	// Resize the pool first (a raised cap grows the pool), then wake producers
+	// parked on the cap so they find both the budget and a pool slot available.
+	q.pool.syncTargetToQueues()
+	q.wakeLimitWaiters()
+}
+
+// tryReserve takes one unit of this queue's live-event budget if it is under the
+// cap, without blocking. It is the lock-free fast path: a CAS on the live
+// counter, with limit==0 meaning unlimited.
+func (q *Queue[T]) tryReserve() bool {
+	for {
+		lim := q.limit.Load()
+		if lim <= 0 {
+			q.live.Add(1)
+			return true
+		}
+		cur := q.live.Load()
+		if cur >= lim {
+			return false
+		}
+		if q.live.CompareAndSwap(cur, cur+1) {
+			return true
+		}
+	}
+}
+
+// reserve takes one unit of this queue's live-event budget, blocking until the
+// queue is under its cap or the queue is closed. It returns false only when the
+// queue is closing. Like the pool's acquire, it re-checks after registering as a
+// waiter so a release between the failed fast path and the park is not lost.
+func (q *Queue[T]) reserve() bool {
+	if q.tryReserve() {
+		return true
+	}
+	for {
+		q.limMu.Lock()
+		q.limWaiters.Add(1)
+		if q.tryReserve() {
+			q.limWaiters.Add(-1)
+			q.limMu.Unlock()
+			return true
+		}
+		if q.isClosing() {
+			q.limWaiters.Add(-1)
+			q.limMu.Unlock()
+			return false
+		}
+		q.limCond.Wait()
+		q.limWaiters.Add(-1)
+		q.limMu.Unlock()
+		if q.isClosing() {
+			return false
+		}
+		if q.tryReserve() {
+			return true
+		}
+	}
+}
+
+// releaseLive returns n units to this queue's live-event budget (called when
+// slots are released back to the pool) and wakes a producer parked on the cap.
+func (q *Queue[T]) releaseLive(n int) {
+	if n <= 0 {
+		return
+	}
+	q.live.Add(int64(-n))
+	q.wakeLimitWaiters()
+}
+
+// wakeLimitWaiters wakes producers parked on the per-queue cap, but only if one
+// might be waiting. The racy waiters read is safe for the same reason the pool's
+// signal is: a parked producer registers as a waiter before re-checking the cap.
+func (q *Queue[T]) wakeLimitWaiters() {
+	if q.limWaiters.Load() == 0 {
+		return
+	}
+	q.limMu.Lock()
+	q.limCond.Broadcast()
+	q.limMu.Unlock()
+}
+
+// isClosing reports whether Close has been called on this queue.
+func (q *Queue[T]) isClosing() bool {
+	select {
+	case <-q.closeCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// Producer returns a producer that publishes to this queue. Each producer is
+// given a stable home shard for the pool's free list, spread across shards by
+// a pool-global counter so concurrent producers tend to land on different
+// shards.
 func (q *Queue[T]) Producer(cfg queue.ProducerConfig) queue.Producer[T] {
-	return &producer[T]{queue: q, cfg: cfg}
+	home := int(q.pool.homeCounter.Add(1)-1) & q.pool.free.mask
+	return &producer[T]{queue: q, cfg: cfg, home: home}
 }
 
 // Get blocks until at least one event is available (or the queue is closed)
@@ -97,7 +230,7 @@ func (q *Queue[T]) Get(maxEvents int) (queue.Batch[T], error) {
 			cur := q.head
 			for i := 0; i < n; i++ {
 				b.indices = append(b.indices, cur)
-				cur = q.pool.storage[cur].next
+				cur = q.pool.slot(cur).next
 			}
 			q.head = cur
 			if cur == -1 {
@@ -164,7 +297,7 @@ func (q *Queue[T]) Close(force bool) error {
 			cur := q.head
 			for cur != -1 {
 				releaseIndices = append(releaseIndices, cur)
-				cur = q.pool.storage[cur].next
+				cur = q.pool.slot(cur).next
 			}
 			q.head = -1
 			q.tail = -1
@@ -182,21 +315,29 @@ func (q *Queue[T]) Close(force bool) error {
 	}
 	q.mu.Unlock()
 
-	// Wake any blocked Get.
-	q.closeOnce.Do(func() { close(q.closeCh) })
+	// Wake any blocked Get, and any producer parked waiting for a free slot on
+	// this queue so it can observe closeCh and return.
+	q.closeOnce.Do(func() {
+		close(q.closeCh)
+		q.pool.free.wakeAll()
+		// Wake producers parked on this queue's per-queue cap so they observe
+		// closeCh and return.
+		q.wakeLimitWaiters()
+	})
 	q.signal()
 
 	if len(releaseIndices) > 0 {
 		var zero T
 		for _, i := range releaseIndices {
-			q.pool.storage[i].event = zero
-			q.pool.storage[i].producer = nil
-			q.pool.storage[i].next = -1
+			s := q.pool.slot(i)
+			s.event = zero
+			s.producer = nil
+			s.next = -1
 		}
 		q.pool.observer.RemoveEvents(len(releaseIndices), 0)
-		for _, i := range releaseIndices {
-			q.pool.free <- i
-		}
+		q.pool.releaseSlots(releaseIndices)
+		// These FIFO events left circulation; return their per-queue budget.
+		q.releaseLive(len(releaseIndices))
 	}
 
 	if force {
@@ -224,10 +365,15 @@ func (q *Queue[T]) Done() <-chan struct{} { return q.doneCh }
 // QueueType identifies the implementation.
 func (q *Queue[T]) QueueType() string { return QueueType }
 
-// BufferConfig reports the pool's capacity. Note: this is the *shared* upper
-// bound across all queues connected to the same pool, not a per-queue cap.
+// BufferConfig reports this queue's effective maximum live events: the smaller
+// of its per-queue cap (if set) and the shared pool budget. With no per-queue
+// cap it is just the pool budget.
 func (q *Queue[T]) BufferConfig() queue.BufferConfig {
-	return queue.BufferConfig{MaxEvents: q.pool.settings.Events}
+	max := q.pool.Target()
+	if lim := int(q.limit.Load()); lim > 0 && lim < max {
+		max = lim
+	}
+	return queue.BufferConfig{MaxEvents: max}
 }
 
 // signal wakes a goroutine blocked in Get. Non-blocking: at most one pending

--- a/libbeat/publisher/queue/slabqueue/queue.go
+++ b/libbeat/publisher/queue/slabqueue/queue.go
@@ -201,7 +201,7 @@ func (q *Queue[T]) isClosing() bool {
 // a pool-global counter so concurrent producers tend to land on different
 // shards.
 func (q *Queue[T]) Producer(cfg queue.ProducerConfig) queue.Producer[T] {
-	home := int(q.pool.homeCounter.Add(1)-1) & q.pool.free.mask
+	home := int(q.pool.homeCounter.Add(1) & uint64(q.pool.free.mask)) //nolint:gosec // G115: masked by the shard count, always a small non-negative index
 	return &producer[T]{queue: q, cfg: cfg, home: home}
 }
 

--- a/libbeat/publisher/queue/slabqueue/queue.go
+++ b/libbeat/publisher/queue/slabqueue/queue.go
@@ -201,7 +201,7 @@ func (q *Queue[T]) isClosing() bool {
 // a pool-global counter so concurrent producers tend to land on different
 // shards.
 func (q *Queue[T]) Producer(cfg queue.ProducerConfig) queue.Producer[T] {
-	home := int(q.pool.homeCounter.Add(1) & uint64(q.pool.free.mask)) //nolint:gosec // G115: masked by the shard count, always a small non-negative index
+	home := int((q.pool.homeCounter.Add(1) - 1) & uint64(q.pool.free.mask)) //nolint:gosec // G115: masked by the shard count, always a small non-negative index
 	return &producer[T]{queue: q, cfg: cfg, home: home}
 }
 

--- a/libbeat/publisher/queue/slabqueue/queuetest_test.go
+++ b/libbeat/publisher/queue/slabqueue/queuetest_test.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package slabqueue_test
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/queuetest"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/slabqueue"
+)
+
+func makeTestQueue(sz int) queuetest.QueueFactory {
+	return func(t *testing.T) queue.Queue[publisher.Event] {
+		pool := slabqueue.NewPool[publisher.Event](slabqueue.Settings{Events: sz}, nil)
+		t.Cleanup(func() { pool.Shutdown() })
+		return pool.Connect()
+	}
+}
+
+func TestSlabQueueConformance(t *testing.T) {
+	events := 4096
+	batchSize := 100
+	bufferSize := 8192
+
+	// slabqueue's Queue façade is a single-consumer design: only one
+	// goroutine may call Get concurrently. TestMultiProducerConsumer
+	// includes cases with multiple concurrent consumers on the same
+	// queue, which violates that contract. Each pipeline gets its own
+	// façade in production, so concurrent consumers are not a supported
+	// use case.
+	t.Run("slabqueue", func(t *testing.T) {
+		t.Parallel()
+		queuetest.TestSingleProducerConsumer(t, events, batchSize, makeTestQueue(bufferSize))
+	})
+}

--- a/libbeat/publisher/queue/slabqueue/slabqueue.go
+++ b/libbeat/publisher/queue/slabqueue/slabqueue.go
@@ -20,11 +20,22 @@
 // receivers (always, when running with an in-memory queue config).
 // Storage is separated from FIFO ordering:
 //
-//   - A Pool owns a fixed-size backing array of slots and a free list.
-//     Publish acquires a slot; batch.Done returns it. The free list also
-//     serves as a counting semaphore: total live events across all
-//     pipelines is capped by Settings.Events. There is no per-pipeline cap
-//     — one pipeline may use the full budget while others are quiet.
+//   - A Pool owns the slot storage and a free list. Publish acquires a slot;
+//     batch.Done returns it. The free list also serves as a counting
+//     semaphore: total live events across all pipelines is capped by the
+//     pool's current capacity. The capacity is resizable at runtime
+//     (Pool.SetTarget) so a shared pool can grow to the largest budget its
+//     connected receivers request and shrink back as they leave, all while
+//     traffic flows; storage is a directory of non-moving chunks and the free
+//     list is sharded for concurrency (see storage.go / freelist.go).
+//   - Each Queue may additionally have its own per-queue cap (Queue.SetTarget),
+//     bounding the live events on that one pipeline independently of the shared
+//     pool. With several queues on one pool, each enforces its own configured
+//     size while the pool is sized to the largest of them: e.g. a 4096-cap
+//     queue and an 8192-cap queue share an 8192-slot pool, and the first can
+//     never exceed 4096 live events even when the pool has room. A queue with
+//     no per-queue cap is bounded only by the pool, so a single busy pipeline
+//     can still use the whole budget while others are quiet.
 //   - Each connected pipeline gets its own Queue (implementing
 //     queue.Queue[T]) with its own FIFO over the shared array. A slow or
 //     stalled consumer on one pipeline only holds its own in-flight slots;

--- a/libbeat/publisher/queue/slabqueue/slabqueue_test.go
+++ b/libbeat/publisher/queue/slabqueue/slabqueue_test.go
@@ -19,6 +19,7 @@ package slabqueue
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -651,9 +652,10 @@ func TestSlotMemoryClearedOnAck(t *testing.T) {
 	b.Done()
 
 	// The slot's event reference should now be nil so the GC can reclaim it.
-	for i := range pool.storage {
-		assert.Nil(t, pool.storage[i].event, "slot %d should have a nil event after Done", i)
-		assert.Nil(t, pool.storage[i].producer, "slot %d should have no producer after Done", i)
+	for i := 0; i < pool.Capacity(); i++ {
+		s := pool.slot(i)
+		assert.Nil(t, s.event, "slot %d should have a nil event after Done", i)
+		assert.Nil(t, s.producer, "slot %d should have no producer after Done", i)
 	}
 }
 
@@ -717,4 +719,475 @@ func TestConcurrentPublishersAndConsumers(t *testing.T) {
 	}
 
 	assert.Equal(t, poolSize, pool.Available(), "all slots should be released")
+}
+
+// TestSetTargetGrowsImmediately verifies raising the target adds capacity right
+// away.
+func TestSetTargetGrowsImmediately(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 2}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	p := q.Producer(queue.ProducerConfig{})
+
+	for i := 0; i < 2; i++ {
+		_, ok := p.TryPublish(i)
+		require.True(t, ok)
+	}
+	_, ok := p.TryPublish(99)
+	require.False(t, ok, "pool is full at its initial capacity")
+
+	pool.setTarget(4)
+	assert.Equal(t, 4, pool.Capacity())
+	assert.Equal(t, 4, pool.Target())
+
+	for i := 0; i < 2; i++ {
+		_, ok := p.TryPublish(100 + i)
+		require.True(t, ok, "the two slots added by the grow must be acquirable")
+	}
+	_, ok = p.TryPublish(102)
+	assert.False(t, ok, "pool is full again at the grown capacity")
+}
+
+// TestSetTargetGrowWakesBlockedProducer verifies a producer blocked on a full
+// pool is unblocked when a higher target adds a slot.
+func TestSetTargetGrowWakesBlockedProducer(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 1}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	p := q.Producer(queue.ProducerConfig{})
+
+	_, ok := p.TryPublish(1)
+	require.True(t, ok)
+	require.Equal(t, 0, pool.Available(), "pool is now full")
+
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := p.Publish(2) // blocks: no slot until the pool grows
+		done <- ok
+	}()
+
+	// Give the producer time to park, then grow.
+	require.Eventually(t, func() bool {
+		// waiters is incremented under gmu once the producer parks.
+		return pool.free.waiters.Load() == 1
+	}, time.Second, time.Millisecond, "producer should park on the full pool")
+
+	pool.setTarget(2)
+
+	select {
+	case ok := <-done:
+		assert.True(t, ok, "the blocked Publish should succeed once the grow adds a slot")
+	case <-time.After(time.Second):
+		t.Fatal("growing the pool did not wake the blocked producer")
+	}
+}
+
+// TestBlockedProducerWakesOnClose verifies a parked producer returns (0,false)
+// when its queue is closed rather than blocking forever.
+func TestBlockedProducerWakesOnClose(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 1}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	p := q.Producer(queue.ProducerConfig{})
+
+	_, ok := p.TryPublish(1)
+	require.True(t, ok)
+
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := p.Publish(2)
+		done <- ok
+	}()
+	require.Eventually(t, func() bool {
+		return pool.free.waiters.Load() == 1
+	}, time.Second, time.Millisecond)
+
+	q.Close(true)
+	select {
+	case ok := <-done:
+		assert.False(t, ok, "Publish must fail when the queue closes while blocked")
+	case <-time.After(time.Second):
+		t.Fatal("closing the queue did not wake the blocked producer")
+	}
+}
+
+// TestShrinkConvergesWhenFree verifies SetTarget shrinks immediately when all
+// slots are free.
+func TestShrinkConvergesWhenFree(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 8}, nil)
+	defer pool.Shutdown()
+
+	pool.setTarget(3)
+	assert.Equal(t, 3, pool.Target())
+	assert.Equal(t, 3, pool.Capacity(), "all slots free: shrink converges immediately")
+	assert.Equal(t, 3, pool.Available())
+}
+
+// TestShrinkFlooredByLiveEvents verifies the shrink cannot drop below the live
+// (unacked) events and converges once they drain.
+func TestShrinkFlooredByLiveEvents(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 8}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	p := q.Producer(queue.ProducerConfig{})
+
+	for i := 0; i < 8; i++ {
+		_, ok := p.TryPublish(i)
+		require.True(t, ok)
+	}
+	require.Equal(t, 0, pool.Available(), "pool full, all 8 live")
+
+	pool.setTarget(3)
+	assert.Equal(t, 3, pool.Target())
+	assert.Equal(t, 8, pool.Capacity(), "cannot retire slots while every slot is live")
+
+	// Draining the live events lets the shrink converge to the target.
+	drainOnce(t, q)
+	assert.Eventually(t, func() bool { return pool.Capacity() == 3 }, time.Second, time.Millisecond,
+		"capacity converges to target once the high slots are released")
+	assert.Equal(t, 3, pool.Available())
+}
+
+// TestShrinkConvergesUnderSustainedLoad guards the property that a shrink keeps
+// making progress while the pool is kept full by live traffic. The lazy shrink
+// retires only the top slot once it is free, and the free list hands slots back
+// out LIFO, so in principle a freed high slot could be re-acquired before the
+// shrink retires it. This test pins the pool full with several producers and a
+// draining consumer, then lowers the target and asserts the pool still
+// converges all the way down — i.e. the re-acquire window never stalls
+// convergence, because the shrink check runs on every release.
+func TestShrinkConvergesUnderSustainedLoad(t *testing.T) {
+	const (
+		poolSize  = 64
+		producers = 8
+		target    = 8
+	)
+	pool := NewPool[int](Settings{Events: poolSize}, nil)
+	q := pool.Connect()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Producers hammer the queue, blocking when the pool is full. With more
+	// producers than the single consumer can drain, the pool stays saturated.
+	for k := 0; k < producers; k++ {
+		p := q.Producer(queue.ProducerConfig{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, ok := p.Publish(0); !ok {
+					return
+				}
+			}
+		}()
+	}
+	// Consumer drains small batches continuously so slots keep being released
+	// (which is what drives the shrink) while the pool stays under pressure.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b, err := q.Get(4)
+			if err != nil {
+				return
+			}
+			b.Done()
+		}
+	}()
+
+	// Clean up regardless of assertion outcome: stop the workers, force the
+	// pool down to unblock anyone parked, and wait for the goroutines.
+	defer func() {
+		close(stop)
+		pool.Shutdown()
+		wg.Wait()
+	}()
+
+	// Make sure we are genuinely shrinking under load: wait until most of the
+	// pool is live before lowering the target, so the shrink must contend with
+	// live traffic rather than a near-empty pool.
+	require.Eventually(t, func() bool {
+		return pool.Capacity()-pool.Available() >= poolSize*3/4
+	}, 2*time.Second, time.Millisecond, "pool should be under load before shrinking")
+
+	pool.setTarget(target)
+
+	// Despite the pool being kept full, capacity must converge all the way to
+	// the target as live events drain. A generous bound keeps this robust on
+	// slow/loaded CI while still failing if convergence ever stalls.
+	require.Eventually(t, func() bool { return pool.Capacity() == target }, 10*time.Second, 5*time.Millisecond,
+		"capacity must converge to the target even under sustained load")
+	assert.Equal(t, target, pool.Target())
+}
+
+// TestTrailingChunkReclamation verifies that shrinking across a chunk boundary
+// drops the now-unused trailing chunk.
+func TestTrailingChunkReclamation(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 100}, nil)
+	defer pool.Shutdown()
+	require.Equal(t, 1, len(pool.dir.Load().chunks))
+
+	// Raise the target past one chunk so a second chunk is allocated.
+	pool.setTarget(slabChunkSize + 500)
+	require.Equal(t, 2, len(pool.dir.Load().chunks))
+
+	// Nothing is live, so shrinking back drops the trailing chunk.
+	pool.setTarget(100)
+	assert.Equal(t, 100, pool.Capacity())
+	assert.Equal(t, 1, len(pool.dir.Load().chunks), "trailing chunk must be reclaimed on shrink")
+}
+
+// TestPerQueueCapBlocksWhilePoolHasRoom verifies a queue's own cap blocks it
+// even when the pool still has free slots. A larger sibling queue keeps the
+// shared pool sized above the small queue's cap, so the small queue blocking at
+// its cap (not the pool) is observable.
+func TestPerQueueCapBlocksWhilePoolHasRoom(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 1}, nil)
+	defer pool.Shutdown()
+	// The pool is driven by the queues: max(8, 4) = 8.
+	qBig := pool.Connect()
+	qBig.SetTarget(8)
+	qSmall := pool.Connect()
+	qSmall.SetTarget(4)
+	require.Equal(t, 8, pool.Target(), "pool tracks the largest queue cap")
+
+	p := qSmall.Producer(queue.ProducerConfig{})
+	for i := 0; i < 4; i++ {
+		_, ok := p.TryPublish(i)
+		require.True(t, ok, "publish %d within the per-queue cap should succeed", i)
+	}
+	_, ok := p.TryPublish(99)
+	assert.False(t, ok, "publishing beyond the per-queue cap must fail even with pool slots free")
+	assert.Equal(t, 4, pool.Available(), "only the per-queue cap blocked; the pool still has 4 free slots")
+}
+
+// TestPerQueueCapsAreIndependent verifies two queues on one pool each enforce
+// their own cap while the pool is sized to the larger of them (the example from
+// the design: a 4-cap and an 8-cap queue share an 8-slot pool, not 12).
+func TestPerQueueCapsAreIndependent(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 1}, nil)
+	defer pool.Shutdown()
+	q1 := pool.Connect()
+	q1.SetTarget(4)
+	q2 := pool.Connect()
+	q2.SetTarget(8)
+	require.Equal(t, 8, pool.Target(), "pool is sized to the larger cap, not the sum")
+	p1 := q1.Producer(queue.ProducerConfig{})
+	p2 := q2.Producer(queue.ProducerConfig{})
+
+	// q1 caps at its own 4 regardless of pool room.
+	for i := 0; i < 4; i++ {
+		_, ok := p1.TryPublish(i)
+		require.True(t, ok)
+	}
+	_, ok := p1.TryPublish(99)
+	assert.False(t, ok, "q1 is capped at 4")
+
+	// q2 may use the rest of the shared 8-slot pool (4 slots remain), then the
+	// pool is full even though q2's own cap (8) is not reached.
+	for i := 0; i < 4; i++ {
+		_, ok := p2.TryPublish(i)
+		require.True(t, ok)
+	}
+	assert.Equal(t, 0, pool.Available(), "pool full: q1's 4 + q2's 4 = 8")
+	_, ok = p2.TryPublish(99)
+	assert.False(t, ok, "pool is full even though q2's own cap is not reached")
+}
+
+// TestPerQueueCapUnblocksOnDrain verifies a producer blocked on the per-queue
+// cap (while the pool still has room) resumes once an event on that queue is
+// acked.
+func TestPerQueueCapUnblocksOnDrain(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 1}, nil)
+	defer pool.Shutdown()
+	qBig := pool.Connect()
+	qBig.SetTarget(16) // keep the shared pool roomy
+	q := pool.Connect()
+	q.SetTarget(2)
+	p := q.Producer(queue.ProducerConfig{})
+	p.Publish(1)
+	p.Publish(2)
+
+	done := make(chan bool, 1)
+	go func() { _, ok := p.Publish(3); done <- ok }() // blocks: this queue at its cap
+
+	require.Eventually(t, func() bool { return q.limWaiters.Load() == 1 }, time.Second, time.Millisecond,
+		"producer should park on the per-queue cap, not the pool")
+	require.Greater(t, pool.Available(), 0, "the pool is not the constraint here")
+
+	// Ack one event on this queue: returns a per-queue budget unit.
+	b, err := q.Get(1)
+	require.NoError(t, err)
+	b.Done()
+
+	select {
+	case ok := <-done:
+		assert.True(t, ok, "blocked Publish should resume after an event drains")
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked on the per-queue cap did not unblock after a drain")
+	}
+}
+
+// TestQueueSetTargetRaiseUnblocks verifies raising a queue's cap immediately
+// unblocks a producer parked on the old cap (and grows the pool to match).
+func TestQueueSetTargetRaiseUnblocks(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 1}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	q.SetTarget(1)
+	p := q.Producer(queue.ProducerConfig{})
+	p.Publish(1)
+
+	done := make(chan bool, 1)
+	go func() { _, ok := p.Publish(2); done <- ok }()
+	require.Eventually(t, func() bool { return q.limWaiters.Load() == 1 }, time.Second, time.Millisecond)
+
+	q.SetTarget(2) // raises the cap and grows the pool to 2
+
+	select {
+	case ok := <-done:
+		assert.True(t, ok, "raising the cap should unblock the producer")
+	case <-time.After(time.Second):
+		t.Fatal("raising the per-queue cap did not unblock the producer")
+	}
+}
+
+// TestPerQueueCapWakesOnClose verifies a producer parked on the per-queue cap
+// returns (0,false) when the queue is closed.
+func TestPerQueueCapWakesOnClose(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 1}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	q.SetTarget(1)
+	p := q.Producer(queue.ProducerConfig{})
+	p.Publish(1)
+
+	done := make(chan bool, 1)
+	go func() { _, ok := p.Publish(2); done <- ok }()
+	require.Eventually(t, func() bool { return q.limWaiters.Load() == 1 }, time.Second, time.Millisecond)
+
+	q.Close(true)
+
+	select {
+	case ok := <-done:
+		assert.False(t, ok, "Publish blocked on the per-queue cap must fail when the queue closes")
+	case <-time.After(time.Second):
+		t.Fatal("closing did not wake the producer blocked on the per-queue cap")
+	}
+}
+
+// TestSetTargetGrowAcrossChunkBoundaryPreservesEvents verifies events published
+// before a grow are still readable after the directory swap (the chunked
+// storage must not move existing slots).
+func TestSetTargetGrowAcrossChunkBoundaryPreservesEvents(t *testing.T) {
+	pool := NewPool[int](Settings{Events: 4}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	p := q.Producer(queue.ProducerConfig{})
+
+	for i := 0; i < 4; i++ {
+		_, ok := p.TryPublish(i)
+		require.True(t, ok)
+	}
+	// Raise the target across the first chunk boundary while events are live.
+	pool.setTarget(slabChunkSize + 10)
+
+	b, err := q.Get(0)
+	require.NoError(t, err)
+	require.Equal(t, 4, b.Count())
+	for i := 0; i < 4; i++ {
+		assert.Equal(t, i, b.Entry(i), "event survives the grow/directory swap")
+	}
+	b.Done()
+}
+
+// TestResizeUnderConcurrentTraffic hammers SetTarget (growing and shrinking)
+// concurrently with live producers and consumers. Run with -race; the test
+// passes if every published event is delivered and the pool never deadlocks or
+// corrupts.
+func TestResizeUnderConcurrentTraffic(t *testing.T) {
+	const (
+		pipelines = 4
+		perPipe   = 2000
+	)
+	pool := NewPool[int](Settings{Events: 64}, nil)
+
+	var delivered atomic.Int64
+	var wg sync.WaitGroup
+
+	for i := 0; i < pipelines; i++ {
+		q := pool.Connect()
+		p := q.Producer(queue.ProducerConfig{})
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perPipe; j++ {
+				if _, ok := p.Publish(j); !ok {
+					return
+				}
+			}
+		}()
+		go func(q *Queue[int]) {
+			defer wg.Done()
+			got := 0
+			for got < perPipe {
+				b, err := q.Get(0)
+				if err != nil {
+					return
+				}
+				got += b.Count()
+				delivered.Add(int64(b.Count()))
+				b.Done()
+			}
+		}(q)
+	}
+
+	// Resizer: oscillate the budget while traffic flows.
+	stop := make(chan struct{})
+	resizerDone := make(chan struct{})
+	go func() {
+		defer close(resizerDone)
+		sizes := []int{16, 256, 32, slabChunkSize + 8, 48, 8}
+		k := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			pool.setTarget(sizes[k%len(sizes)])
+			k++
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	<-resizerDone
+
+	assert.Equal(t, int64(pipelines*perPipe), delivered.Load(),
+		"every published event must be delivered exactly once across resizes")
+	pool.Shutdown()
+}
+
+// drainOnce returns and acks all currently-queued events on q. It assumes at
+// least one event is available so Get does not block.
+func drainOnce[T any](t *testing.T, q *Queue[T]) int {
+	t.Helper()
+	b, err := q.Get(0)
+	require.NoError(t, err)
+	n := b.Count()
+	b.Done()
+	return n
 }

--- a/libbeat/publisher/queue/slabqueue/slabqueue_test.go
+++ b/libbeat/publisher/queue/slabqueue/slabqueue_test.go
@@ -936,16 +936,16 @@ func TestShrinkConvergesUnderSustainedLoad(t *testing.T) {
 func TestTrailingChunkReclamation(t *testing.T) {
 	pool := NewPool[int](Settings{Events: 100}, nil)
 	defer pool.Shutdown()
-	require.Equal(t, 1, len(pool.dir.Load().chunks))
+	require.Len(t, pool.dir.Load().chunks, 1)
 
 	// Raise the target past one chunk so a second chunk is allocated.
 	pool.setTarget(slabChunkSize + 500)
-	require.Equal(t, 2, len(pool.dir.Load().chunks))
+	require.Len(t, pool.dir.Load().chunks, 2)
 
 	// Nothing is live, so shrinking back drops the trailing chunk.
 	pool.setTarget(100)
 	assert.Equal(t, 100, pool.Capacity())
-	assert.Equal(t, 1, len(pool.dir.Load().chunks), "trailing chunk must be reclaimed on shrink")
+	assert.Len(t, pool.dir.Load().chunks, 1, "trailing chunk must be reclaimed on shrink")
 }
 
 // TestPerQueueCapBlocksWhilePoolHasRoom verifies a queue's own cap blocks it
@@ -1024,7 +1024,7 @@ func TestPerQueueCapUnblocksOnDrain(t *testing.T) {
 
 	require.Eventually(t, func() bool { return q.limWaiters.Load() == 1 }, time.Second, time.Millisecond,
 		"producer should park on the per-queue cap, not the pool")
-	require.Greater(t, pool.Available(), 0, "the pool is not the constraint here")
+	require.Positive(t, pool.Available(), "the pool is not the constraint here")
 
 	// Ack one event on this queue: returns a per-queue budget unit.
 	b, err := q.Get(1)

--- a/libbeat/publisher/queue/slabqueue/storage.go
+++ b/libbeat/publisher/queue/slabqueue/storage.go
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package slabqueue
+
+// The pool's slot storage is a directory of fixed-size chunks instead of a
+// single contiguous []slot. This is what makes the pool resizable while
+// producers and consumers are live: a chunk, once allocated, is never moved or
+// copied, so a goroutine holding `&pool.slot(i)` keeps a stable pointer even
+// while the pool grows or shrinks concurrently. Growing allocates new chunks
+// and publishes a new directory (a small slice of chunk pointers) behind an
+// atomic.Pointer; shrinking drops only trailing chunks whose slots are all out
+// of circulation. A plain []slot could not do this — append/realloc moves the
+// backing array, splitting a live producer's write and a reader's read across
+// two arrays.
+//
+// Index decomposition uses a power-of-two chunk size so slot lookup is a
+// shift + mask with no division.
+
+const (
+	// slabChunkShift sets the chunk size (1<<shift slots per chunk). 4096 keeps
+	// the per-chunk allocation modest (one chunk covers the default 3200-event
+	// pool) while keeping the directory small even for very large pools.
+	slabChunkShift = 12
+	slabChunkSize  = 1 << slabChunkShift
+	slabChunkMask  = slabChunkSize - 1
+)
+
+// chunk is a fixed block of slots. It is heap-allocated once and never moved,
+// so pointers into it (&c.slots[k]) stay valid for the chunk's lifetime.
+type chunk[T any] struct {
+	slots [slabChunkSize]slot[T]
+}
+
+// directory maps a flat slot index to its chunk. The slice of chunk pointers
+// is copied (cheaply) on grow/shrink and swapped atomically; the chunks it
+// points at are shared and never copied.
+type directory[T any] struct {
+	chunks []*chunk[T]
+}
+
+// numChunks returns how many chunks are needed to back `capacity` slots, never
+// fewer than one.
+func numChunks(capacity int) int {
+	if capacity <= 0 {
+		return 1
+	}
+	return (capacity + slabChunkSize - 1) >> slabChunkShift
+}
+
+// newDirectory allocates a directory whose chunks cover at least `capacity`
+// slots. All chunks are allocated eagerly.
+func newDirectory[T any](capacity int) *directory[T] {
+	n := numChunks(capacity)
+	d := &directory[T]{chunks: make([]*chunk[T], n)}
+	for i := range d.chunks {
+		d.chunks[i] = &chunk[T]{}
+	}
+	return d
+}
+
+// slot returns a stable pointer to slot i. The directory is loaded atomically
+// so this is safe to call concurrently with grow/shrink: any index a goroutine
+// legitimately holds (one it acquired from the free list, or reached by
+// following FIFO `next` links) is always covered by the directory it observes,
+// because indices are published to the free list only after the directory that
+// contains them has been stored.
+func (p *Pool[T]) slot(i int) *slot[T] {
+	d := p.dir.Load()
+	return &d.chunks[i>>slabChunkShift].slots[i&slabChunkMask]
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Add dynamic sizing to slabqueue and masked based slot assignment.

`SetTarget` is added to `Queue` and `Pool`, this sets the overall target size for the maximum slots in the slabqueue. When two queues have different size the larger of the two is set as the maximum number of slots in the `Pool` but its individual `Queue` is scoped to that limit. Growing the slabqueue is instant, but shrinking only happens once a chunk is no longer using any slots.

The `free chan` had to be removed because channels cannot be dynamic in size. To solve this a new `freeList` is implemented using a mask. A mask is computed for each `Queue` that defines its primary set of slots to use, but if all of its primary set of slots are used it will pull from other slots. This mask removes the contention on the hot path, only having contention when overflowing its own primary set of slots.

Benchmarks process 2,048 events/op (median of 8 runs, `go test -bench -benchmem`). `bytes/s = events/s × 8B`. Higher events/s is better.

| inputs / receivers | memqueue events/s | slabqueue events/s | speedup | memqueue bytes/s | slabqueue bytes/s | memqueue allocs/op | slabqueue allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|
| 1  | 1,293,112 | 14,463,175 | 11.2× | 10,344,897 | 115,705,398 | 80 | 0 |
| 4  |   704,483 | 11,833,225 | 16.8× |  5,635,867 |  94,665,804 | 80 | 0 |
| 8  |   554,873 | 16,673,180 | 30.0× |  4,438,984 | 133,385,437 | 80 | 0 |
| 16 |   657,335 | 19,953,429 | 30.4× |  5,258,680 | 159,627,432 | 80 | 0 |

This change sustains **14–20M events/s with zero allocations**, versus memqueue's **0.55–1.3M events/s at 80 allocs/op** — **11×–30× faster**. The gap widens with concurrency: memqueue degrades as inputs grow, while the slabqueue scales up.

Comparing this addition to the current slabqueue in main this is a roughly **3x faster**:

| inputs / receivers | pre-slabqueue events/s | this PR events/s | speedup | pre-slabqueue bytes/s | this PR bytes/s | allocs/op |
|---|---:|---:|:---:|---:|---:|:---:|
| 1  | 6,979,541 | 12,931,415 | 1.85× |  55,836,335 | 103,451,324 | 0 |
| 4  | 3,859,461 | 15,394,213 | 3.99× |  30,875,690 | 123,153,709 | 0 |
| 8  | 4,483,578 | 17,009,542 | 3.79× |  35,868,627 | 136,076,343 | 0 |
| 16 | 6,074,267 | 18,717,555 | 3.08× |  48,594,139 | 149,740,440 | 0 |

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None