### PR TITLE
fix(metricbeat): improve input validation in graphite, prometheus and zookeeper metricsets

### DIFF
--- a/metricbeat/helper/prometheus/metric.go
+++ b/metricbeat/helper/prometheus/metric.go
@@ -437,7 +437,7 @@ func (o opLabelKeyPrefixRemover) Process(field string, value interface{}, labels
 		if len(k) < len(o.Prefix) {
 			continue
 		}
-		if k[:6] == o.Prefix {
+		if k[:len(o.Prefix)] == o.Prefix {
 			renameKeys = append(renameKeys, k)
 		}
 	}

--- a/metricbeat/helper/prometheus/metric_test.go
+++ b/metricbeat/helper/prometheus/metric_test.go
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+func TestOpLabelKeyPrefixRemover(t *testing.T) {
+	tests := []struct {
+		name           string
+		prefix         string
+		labels         mapstr.M
+		expectedLabels mapstr.M
+	}{
+		{
+			name:   "prefix removed from matching key",
+			prefix: "exported_",
+			labels: mapstr.M{
+				"exported_job": "myjob",
+				"instance":     "localhost:9090",
+			},
+			expectedLabels: mapstr.M{
+				"job":      "myjob",
+				"instance": "localhost:9090",
+			},
+		},
+		{
+			name:   "key shorter than prefix is left untouched",
+			prefix: "exported_",
+			labels: mapstr.M{
+				"job": "myjob",
+			},
+			expectedLabels: mapstr.M{
+				"job": "myjob",
+			},
+		},
+		{
+			name:   "prefix shorter than 6 chars with key longer than prefix but shorter than 6",
+			prefix: "ex_",
+			labels: mapstr.M{
+				"ex_j":        "myjob",
+				"ex_instance": "localhost",
+			},
+			expectedLabels: mapstr.M{
+				"j":        "myjob",
+				"instance": "localhost",
+			},
+		},
+		{
+			name:   "no matching keys leaves labels unchanged",
+			prefix: "exported_",
+			labels: mapstr.M{
+				"job":      "myjob",
+				"instance": "localhost:9090",
+			},
+			expectedLabels: mapstr.M{
+				"job":      "myjob",
+				"instance": "localhost:9090",
+			},
+		},
+		{
+			name:           "empty labels",
+			prefix:         "exported_",
+			labels:         mapstr.M{},
+			expectedLabels: mapstr.M{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			option := OpLabelKeyPrefixRemover(tt.prefix)
+			require.NotPanics(t, func() {
+				_, _, result := option.Process("", nil, tt.labels)
+				assert.Equal(t, tt.expectedLabels, result)
+			})
+		})
+	}
+}

--- a/metricbeat/module/graphite/server/data.go
+++ b/metricbeat/module/graphite/server/data.go
@@ -136,7 +136,7 @@ func (m *metricProcessor) splitMetric(metric string) (string, common.Time, float
 		} else {
 			ts, err := strconv.ParseFloat(parts[2], 64)
 			if err != nil {
-				return "", currentTime, 0, errors.New("Unable to parse timestamp")
+				return "", currentTime, 0, errors.New("unable to parse timestamp")
 			}
 
 			if ts != -1 {

--- a/metricbeat/module/graphite/server/data.go
+++ b/metricbeat/module/graphite/server/data.go
@@ -133,18 +133,18 @@ func (m *metricProcessor) splitMetric(metric string) (string, common.Time, float
 	if len(parts) == 3 {
 		if parts[2] == "N" {
 			timestamp = currentTime
-		}
-		ts, err := strconv.ParseFloat(parts[2], 64)
-		if err != nil {
-			return "", currentTime, 0, errors.New("Unable to parse timestamp")
-		}
-
-		if ts != -1 {
-			timestamp = common.Time(time.Unix(int64(ts), int64((ts-math.Floor(ts))*float64(time.Second))))
 		} else {
-			timestamp = currentTime
-		}
+			ts, err := strconv.ParseFloat(parts[2], 64)
+			if err != nil {
+				return "", currentTime, 0, errors.New("Unable to parse timestamp")
+			}
 
+			if ts != -1 {
+				timestamp = common.Time(time.Unix(int64(ts), int64((ts-math.Floor(ts))*float64(time.Second))))
+			} else {
+				timestamp = currentTime
+			}
+		}
 	} else {
 		timestamp = currentTime
 	}

--- a/metricbeat/module/graphite/server/data_test.go
+++ b/metricbeat/module/graphite/server/data_test.go
@@ -109,6 +109,23 @@ func TestMetricProcessorProcess(t *testing.T) {
 	assert.Equal(t, event["stats"], float64(42))
 }
 
+func TestMetricProcessorProcessNTimestamp(t *testing.T) {
+	processor := GetMetricProcessor()
+
+	before := time.Now()
+	event, err := processor.Process("test.localhost.bash.stats 42 N")
+	after := time.Now()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, event)
+	assert.Equal(t, event["stats"], float64(42))
+
+	ts, ok := event["@timestamp"].(common.Time)
+	require.True(t, ok, "expected @timestamp to be common.Time")
+	assert.False(t, time.Time(ts).Before(before), "timestamp should not be before the call")
+	assert.False(t, time.Time(ts).After(after), "timestamp should not be after the call")
+}
+
 func TestTemplateApply(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Proposed commit message

Fix hardcoded slice bound in opLabelKeyPrefixRemover that caused a runtime panic when label key length was between prefix length and 6.

Fix "N" timestamp handling in the Graphite server metricset where valid metrics were silently dropped due to a missing else branch.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).