### PR TITLE
x-pack/filebeat/input/streaming: fix websocket context cancellation handling with infinite retries

### DIFF
--- a/changelog/fragments/1781135498-fix-websocket-reconnect-context-cancellation.yaml
+++ b/changelog/fragments/1781135498-fix-websocket-reconnect-context-cancellation.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix WebSocket reconnect loop ignoring context cancellation with infinite retries.
+component: filebeat

--- a/x-pack/filebeat/input/streaming/websocket.go
+++ b/x-pack/filebeat/input/streaming/websocket.go
@@ -483,6 +483,9 @@ func connectWebSocket(ctx context.Context, cfg config, url string, stat status.S
 		retryConfig := cfg.Retry
 		if !retryConfig.InfiniteRetries {
 			for attempt := 1; attempt <= retryConfig.MaxAttempts; attempt++ {
+				if err = ctx.Err(); err != nil {
+					return nil, nil, err
+				}
 				conn, response, err = dialer.DialContext(ctx, url, headers)
 				if err == nil {
 					stat.UpdateStatus(status.Running, "")
@@ -501,7 +504,13 @@ func connectWebSocket(ctx context.Context, cfg config, url string, stat status.S
 					log.Errorf("attempt %d: webSocket connection failed with error %v and no response, retrying...\n", attempt, err)
 				}
 				waitTime := calculateWaitTime(retryConfig.WaitMin, retryConfig.WaitMax, attempt, retryConfig.MaxAttempts)
-				time.Sleep(waitTime)
+				timer := time.NewTimer(waitTime)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, nil, ctx.Err()
+				case <-timer.C:
+				}
 			}
 			if response == nil {
 				return nil, nil, fmt.Errorf("failed to establish WebSocket connection after %d attempts with error %w", retryConfig.MaxAttempts, err)
@@ -509,6 +518,9 @@ func connectWebSocket(ctx context.Context, cfg config, url string, stat status.S
 			return nil, nil, fmt.Errorf("failed to establish WebSocket connection after %d attempts with error %w and (status %d)", retryConfig.MaxAttempts, err, response.StatusCode)
 		} else {
 			for attempt := 1; ; attempt++ {
+				if err = ctx.Err(); err != nil {
+					return nil, nil, err
+				}
 				conn, response, err = dialer.DialContext(ctx, url, headers)
 				if err == nil {
 					stat.UpdateStatus(status.Running, "")
@@ -527,7 +539,13 @@ func connectWebSocket(ctx context.Context, cfg config, url string, stat status.S
 					log.Errorf("attempt %d: webSocket connection failed with error %v and no response, retrying...\n", attempt, err)
 				}
 				waitTime := calculateWaitTime(retryConfig.WaitMin, retryConfig.WaitMax, attempt, retryConfig.MaxAttempts)
-				time.Sleep(waitTime)
+				timer := time.NewTimer(waitTime)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, nil, ctx.Err()
+				case <-timer.C:
+				}
 			}
 		}
 	}

--- a/x-pack/filebeat/input/streaming/websocket_test.go
+++ b/x-pack/filebeat/input/streaming/websocket_test.go
@@ -6,8 +6,10 @@ package streaming
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -101,5 +103,55 @@ func TestFollowStreamReturnsOnCancelWithStalledServer(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("input.run() did not return after context cancellation; ReadMessage is likely stuck")
+	}
+}
+
+func TestConnectWebSocketRetriesHonorContextCancellation(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  retry
+	}{
+		{
+			name: "infinite retries",
+			cfg: retry{
+				InfiniteRetries: true,
+				WaitMin:         time.Second,
+				WaitMax:         10 * time.Second,
+			},
+		},
+		{
+			name: "finite retries",
+			cfg: retry{
+				MaxAttempts: 100,
+				WaitMin:     time.Second,
+				WaitMax:     10 * time.Second,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			log := logptest.NewTestingLogger(t, "")
+
+			// Cancel after a short delay so the first dial attempt
+			// fails and the backoff wait is interrupted.
+			time.AfterFunc(50*time.Millisecond, cancel)
+
+			cfg := config{
+				URL:   &urlConfig{URL: &url.URL{Scheme: "ws", Host: "localhost:0", Path: "/unreachable"}},
+				Retry: &tt.cfg,
+			}
+
+			start := time.Now()
+			_, _, err := connectWebSocket(ctx, cfg, cfg.URL.String(), noopReporter{}, log) //nolint:bodyclose // resp is always nil in this test
+			elapsed := time.Since(start)
+
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("connectWebSocket() error = %v; want context.Canceled", err)
+			}
+			if elapsed >= tt.cfg.WaitMin {
+				t.Errorf("connectWebSocket() took %v; want less than WaitMin (%v)", elapsed, tt.cfg.WaitMin)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```
x-pack/filebeat/input/streaming: fix websocket context cancellation handling with infinite retries

Previously a retry could fail to respond to input stopping if
retry.infinite_retries is set to true and the stop occurs during retry.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #51119

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
