### PR TITLE
x-pack/filebeat/input/entityanalytics: add ES-backed state store for agentless

### DIFF
--- a/changelog/fragments/1781211047-entity-analytics-es-state-store.yaml
+++ b/changelog/fragments/1781211047-entity-analytics-es-state-store.yaml
@@ -1,0 +1,38 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+summary: Add Elasticsearch-backed state store support for entity-analytics agentless deployments.
+
+description: |
+  The entity-analytics minimal-state input can now use an Elasticsearch-backed
+  state store when running in agentless mode. State is persisted to an
+  Elasticsearch index (agentless-state-<input-id>) instead of local bbolt,
+  enabling stateless pod scheduling. The store backend is selected automatically
+  based on the AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES environment
+  variable set by the agentless controller.
+
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/docs/reference/filebeat/filebeat-input-entity-analytics.md
+++ b/docs/reference/filebeat/filebeat-input-entity-analytics.md
@@ -31,7 +31,22 @@ The `entity-analytics` input supports the following configuration options plus t
 
 ### `provider` [_provider_2]
 
-The identity provider. Must be one of: `activedirectory`, `azure-ad` or `okta`.
+The identity provider. Must be one of: `activedirectory`, `azure-ad`, `jamf`, or `okta`.
+
+
+### `use_minimal_state` [_use_minimal_state]
+
+```{applies_to}
+stack: preview 9.5.0
+```
+
+When set to `true`, the input uses the minimal-state sync implementation. This mode uses significantly less local storage than the legacy implementation and supports Elasticsearch-backed state for agentless deployments.
+
+In agentless deployments, state is stored in Elasticsearch (index `agentless-state-<input-id>`) rather than on local disk, enabling stateless pod scheduling. The routing is automatic when the `AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES` environment variable includes `entity-analytics`.
+
+When running with a local file store (the default for non-agentless deployments), state is stored in a bbolt database under the Filebeat data directory.
+
+Defaults to `false`. In Fleet-managed agentless deployments, integration packages set this to `true` automatically.
 
 
 ## Common options [filebeat-input-entity-analytics-common-options]
@@ -1376,6 +1391,60 @@ This input exposes metrics under the [HTTP monitoring endpoint](/reference/fileb
 | `update_total` | The total number of incremental updates. |
 | `update_error` | The number of incremental updates that failed due to an error. |
 | `update_processing_time` | Histogram of the elapsed incremental updates times in nanoseconds (time of API contact to items sent to output). |
+
+## Operational limits [_operational_limits]
+
+```{applies_to}
+stack: preview 9.5.0
+```
+
+The following scaling guidance applies to the minimal-state implementation (`use_minimal_state: true`). The legacy implementation has different characteristics.
+
+### EntraID (azure-ad) group scaling
+
+EntraID is the most complex sync path due to group membership graph expansion. The primary scaling factor is **group count**, because each active incremental sync refetches all groups regardless of how many entities changed.
+
+| Groups | API calls per sync | Projected time at 50ms/call |
+| --- | --- | --- |
+| 100 | ~103 | ~5s |
+| 1,000 | ~1,003 | ~50s |
+| 5,000 | ~5,003 | ~250s |
+| 10,000 | ~10,003 | ~500s |
+
+The ceiling is determined by API call count multiplied by per-call latency. Graph CPU (membership expansion) is negligible relative to network time at all realistic scales. At the default `update_interval` of 15 minutes (900s):
+
+- At 10ms/call latency: supports ~90,000 groups
+- At 50ms/call latency: supports ~18,000 groups
+- At 100ms/call latency: supports ~9,000 groups
+
+If a sync cannot complete within `update_interval`, the system cannot converge. Increase `update_interval` for larger environments.
+
+### Scratch storage (EntraID)
+
+The EntraID membership graph is stored in a temporary file (bbolt) rather than in-memory. This bounds Go heap usage for large directories — the heap holds only the BFS working set, not the full adjacency data. The trade-off is ephemeral disk usage:
+
+- At 2.5M edges (5,000 groups × 500 members), the scratch file is approximately 103 MB.
+- Mmap'd pages are OS-reclaimable under memory pressure and do not contribute to OOM kills in cgroup-limited containers.
+- Build time is dominated by API call latency, not local I/O.
+
+The `scratch_dir` provider configuration option overrides the default temporary directory. Files use the prefix `entcollect-scratch-*`.
+
+### Rate limiting
+
+EntraID APIs may return 429 (Too Many Requests) with `Retry-After` headers. Throttle wait time is additive to baseline sync duration. For example, at 1,000 groups with a policy of one throttle per 50 requests, expect ~20 throttle events adding ~20s total.
+
+### Document size
+
+Average per-document payload size (before Elasticsearch indexing overhead):
+
+| Provider | Typical doc size |
+| --- | --- |
+| EntraID | 93–99 B (fixture baseline; real documents larger with full attributes) |
+| Active Directory | ~264 B |
+| Okta | ~280 B |
+| Jamf | ~524 B (includes hardware/OS inventory) |
+
+At 10,000 users with ~500 B average (realistic with full attributes), each full sync produces ~5 MB of uncompressed payload — modest for Elasticsearch at a 15-minute interval.
 
 ::::{note}
 This input is experimental and is under active developement. Configuration options and behaviors may change without warning. Use with caution and do not use in production environments.

--- a/x-pack/filebeat/input/entityanalytics/es_integration_test.go
+++ b/x-pack/filebeat/input/entityanalytics/es_integration_test.go
@@ -1,0 +1,279 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build integration
+
+package entityanalytics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/backend"
+	"github.com/elastic/beats/v7/libbeat/statestore/backend/es"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/internal/kvstore"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/entcollect"
+)
+
+func TestESIntegration_StateStoreAdapter_CRUD(t *testing.T) {
+	store, conn, indexName := newESStore(t)
+	a := kvstore.NewStateStoreAdapter(store)
+
+	// Set
+	if err := a.Set("cursor", "page-2"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := a.Set("users-count", 42); err != nil {
+		t.Fatalf("Set users-count: %v", err)
+	}
+
+	// ES is near-real-time; force refresh.
+	refreshIndex(t, conn, indexName)
+
+	// Get
+	var cursor string
+	if err := a.Get("cursor", &cursor); err != nil {
+		t.Fatalf("Get cursor: %v", err)
+	}
+	if cursor != "page-2" {
+		t.Errorf("cursor = %q; want %q", cursor, "page-2")
+	}
+
+	var count int
+	if err := a.Get("users-count", &count); err != nil {
+		t.Fatalf("Get users-count: %v", err)
+	}
+	if count != 42 {
+		t.Errorf("users-count = %d; want 42", count)
+	}
+
+	// Get missing key
+	var missing string
+	err := a.Get("nonexistent", &missing)
+	if !errors.Is(err, entcollect.ErrKeyNotFound) {
+		t.Fatalf("Get missing = %v; want ErrKeyNotFound", err)
+	}
+
+	// Delete present key
+	if err := a.Delete("cursor"); err != nil {
+		t.Fatalf("Delete cursor: %v", err)
+	}
+	refreshIndex(t, conn, indexName)
+	err = a.Get("cursor", &cursor)
+	if !errors.Is(err, entcollect.ErrKeyNotFound) {
+		t.Fatalf("Get after Delete = %v; want ErrKeyNotFound", err)
+	}
+
+	// Delete absent key (the Has-before-Remove guard)
+	if err := a.Delete("nonexistent"); err != nil {
+		t.Fatalf("Delete absent key should succeed; got %v", err)
+	}
+
+	// Each
+	seen := map[string]bool{}
+	err = a.Each(func(key string, decode func(any) error) (bool, error) {
+		seen[key] = true
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("Each: %v", err)
+	}
+	if !seen["users-count"] {
+		t.Errorf("Each did not visit 'users-count'; saw %v", seen)
+	}
+	if seen["cursor"] {
+		t.Errorf("Each visited deleted key 'cursor'")
+	}
+}
+
+func TestESIntegration_ESSyncer_RunSync(t *testing.T) {
+	store, conn, indexName := newESStore(t)
+
+	syncer := &esSyncer{store: store}
+	client := &fakeClient{}
+	ackClient := &ackingClient{inner: client}
+	slogger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	prov := &fakeProvider{
+		fullFunc: func(ctx context.Context, s entcollect.Store, pub entcollect.Publisher, log *slog.Logger) error {
+			if err := s.Set("sync-cursor", "full-done"); err != nil {
+				return err
+			}
+			return pub(ctx, entcollect.Document{
+				ID:        "user-1",
+				Kind:      entcollect.KindUser,
+				Action:    entcollect.ActionDiscovered,
+				Timestamp: time.Now(),
+				Fields:    map[string]any{"user.name": "alice"},
+			})
+		},
+	}
+
+	ctx := context.Background()
+	err := syncer.runSync(
+		v2.Context{
+			Logger:      logptest.NewTestingLogger(t, "es-integ"),
+			ID:          "es-integ-test",
+			Cancelation: v2.GoContextFromCanceler(ctx),
+		},
+		prov,
+		ackClient,
+		slogger,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("runSync: %v", err)
+	}
+
+	// Verify state was persisted.
+	refreshIndex(t, conn, indexName)
+	a := kvstore.NewStateStoreAdapter(store)
+	var cursor string
+	if err := a.Get("sync-cursor", &cursor); err != nil {
+		t.Fatalf("Get sync-cursor after runSync: %v", err)
+	}
+	if cursor != "full-done" {
+		t.Errorf("sync-cursor = %q; want %q", cursor, "full-done")
+	}
+
+	// Verify event was published.
+	events := client.Events()
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d; want 1", len(events))
+	}
+	action, _ := events[0].Fields.GetValue("event.action")
+	if action != "user-discovered" {
+		t.Errorf("event.action = %v; want user-discovered", action)
+	}
+
+	// Second sync (incremental) can read state from first.
+	prov.mu.Lock()
+	prov.incrFunc = func(ctx context.Context, s entcollect.Store, pub entcollect.Publisher, log *slog.Logger) error {
+		var c string
+		if err := s.Get("sync-cursor", &c); err != nil {
+			return fmt.Errorf("incremental could not read cursor: %w", err)
+		}
+		if c != "full-done" {
+			return fmt.Errorf("incremental cursor = %q; want %q", c, "full-done")
+		}
+		return s.Set("sync-cursor", "incr-done")
+	}
+	prov.mu.Unlock()
+
+	err = syncer.runSync(
+		v2.Context{
+			Logger:      logptest.NewTestingLogger(t, "es-integ"),
+			ID:          "es-integ-test",
+			Cancelation: v2.GoContextFromCanceler(ctx),
+		},
+		prov,
+		ackClient,
+		slogger,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("incremental runSync: %v", err)
+	}
+
+	refreshIndex(t, conn, indexName)
+	if err := a.Get("sync-cursor", &cursor); err != nil {
+		t.Fatalf("Get sync-cursor after incremental: %v", err)
+	}
+	if cursor != "incr-done" {
+		t.Errorf("sync-cursor = %q; want %q", cursor, "incr-done")
+	}
+}
+
+// newESStore creates a *statestore.Store backed by a real Elasticsearch
+// instance. It uses the ES_HOST/ES_PORT environment variables (defaults
+// to localhost:9200) with admin credentials. It also returns the
+// underlying connection and index name for use in refreshIndex.
+func newESStore(t *testing.T) (*statestore.Store, *eslegclient.Connection, string) {
+	t.Helper()
+
+	host := os.Getenv("ES_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := os.Getenv("ES_PORT")
+	if port == "" {
+		port = "9200"
+	}
+	user := os.Getenv("ES_SUPERUSER_USER")
+	if user == "" {
+		user = "admin"
+	}
+	pass := os.Getenv("ES_SUPERUSER_PASS")
+	if pass == "" {
+		pass = "testing"
+	}
+
+	esURL := fmt.Sprintf("http://%s:%s", host, port)
+	log := logptest.NewTestingLogger(t, "es-backend")
+
+	conn, err := eslegclient.NewConnection(eslegclient.ConnectionSettings{
+		URL:      esURL,
+		Username: user,
+		Password: pass,
+	}, log)
+	if err != nil {
+		t.Fatalf("NewConnection: %v", err)
+	}
+	if err := conn.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect to ES: %v", err)
+	}
+
+	inputID := fmt.Sprintf("integ-test-%d", time.Now().UnixNano())
+	indexName := "agentless-state-" + inputID
+
+	baseStore := es.NewStore(context.Background(), log, conn, inputID)
+	reg := statestore.NewRegistry(&singleStoreRegistry{store: baseStore})
+	t.Cleanup(func() { reg.Close() })
+
+	s, err := reg.Get("entity-analytics")
+	if err != nil {
+		t.Fatalf("registry Get: %v", err)
+	}
+	s.SetID(inputID)
+	t.Cleanup(func() {
+		s.Close()
+		// Clean up the test index.
+		conn.Request("DELETE", "/"+indexName, "", nil, nil) //nolint:errcheck // best-effort cleanup
+	})
+	return s, conn, indexName
+}
+
+// refreshIndex forces an ES index refresh so writes become visible.
+func refreshIndex(t *testing.T, conn *eslegclient.Connection, indexName string) {
+	t.Helper()
+	status, body, err := conn.Request("POST", "/"+indexName+"/_refresh", "", nil, nil)
+	if err != nil {
+		t.Fatalf("refresh index %q: %v", indexName, err)
+	}
+	if status >= 300 {
+		t.Fatalf("refresh index %q: status=%d body=%s", indexName, status, body)
+	}
+}
+
+// singleStoreRegistry wraps a single backend.Store for testing.
+type singleStoreRegistry struct {
+	store backend.Store
+}
+
+func (r *singleStoreRegistry) Access(string) (backend.Store, error) {
+	return r.store, nil
+}
+
+func (r *singleStoreRegistry) Close() error {
+	return r.store.Close()
+}

--- a/x-pack/filebeat/input/entityanalytics/input.go
+++ b/x-pack/filebeat/input/entityanalytics/input.go
@@ -96,6 +96,7 @@ func (m *manager) createMinimalStateInput(cfg *config.C, c *conf) (v2.Input, err
 		fullSyncInterval: fullSync,
 		incrSyncInterval: incrSync,
 		logger:           m.logger,
+		store:            m.store,
 		path:             m.path,
 	}, nil
 }

--- a/x-pack/filebeat/input/entityanalytics/integration_test.go
+++ b/x-pack/filebeat/input/entityanalytics/integration_test.go
@@ -151,12 +151,12 @@ func TestJamfIntegration_CursorRoundTrip(t *testing.T) {
 
 // runInputOnce starts a minimalStateInput, waits for the first full sync to
 // complete (events arrive), and stops it. It returns the Run error.
-func runInputOnce(t *testing.T, dataDir string, providerName string, p entcollect.Provider, client *fakeClient) error {
+func runInputOnce(t *testing.T, dataDir string, providerName string, prov entcollect.Provider, client *fakeClient) error {
 	t.Helper()
 	log := logptest.NewTestingLogger(t, "integ")
 
 	mi := &minimalStateInput{
-		provider:         p,
+		provider:         prov,
 		providerName:     providerName,
 		fullSyncInterval: time.Hour,
 		incrSyncInterval: time.Hour,
@@ -215,40 +215,31 @@ func runInputOnce(t *testing.T, dataDir string, providerName string, p entcollec
 // runInputOnce and runs a single incremental sync via runSync. This
 // bypasses the timer loop in Run(), which always fires a full sync
 // first and cannot reliably trigger incremental-only execution.
-func runIncrementalOnce(t *testing.T, dataDir string, providerName string, p entcollect.Provider, client *fakeClient) error {
+func runIncrementalOnce(t *testing.T, dataDir string, providerName string, prov entcollect.Provider, client *fakeClient) error {
 	t.Helper()
 	log := logptest.NewTestingLogger(t, "integ-incr")
 
 	dbPath := filepath.Join(dataDir, "kvstore", "integ-"+providerName+".db")
-	store, err := kvstore.NewStore(log, dbPath, 0600)
+	store, err := kvstore.NewStore(log, dbPath, 0o600)
 	if err != nil {
 		t.Fatalf("open bbolt for incremental: %v", err)
 	}
 	defer store.Close()
 
-	mi := &minimalStateInput{
-		provider:         p,
-		providerName:     providerName,
-		fullSyncInterval: time.Hour,
-		incrSyncInterval: time.Hour,
-		logger:           log,
-		path:             &paths.Path{Data: dataDir},
-	}
-
 	acking := &ackingClient{inner: client}
 	ctx := context.Background()
 	slogger := slog.New(slog.NewTextHandler(&testLogWriter{t}, nil))
+	s := &bboltSyncer{store: store, bucketName: "entcollect." + providerName}
 
-	return mi.runSync(
+	return s.runSync(
 		v2.Context{
 			Logger:      log,
 			ID:          "integ-" + providerName,
 			Cancelation: v2.GoContextFromCanceler(ctx),
 		},
-		store,
+		prov,
 		acking,
 		slogger,
-		"entcollect."+providerName,
 		false,
 	)
 }
@@ -259,7 +250,7 @@ func assertBboltKey(t *testing.T, dataDir, providerName, key string) {
 	t.Helper()
 	log := logptest.NewTestingLogger(t, "assert-bbolt")
 	dbPath := filepath.Join(dataDir, "kvstore", "integ-"+providerName+".db")
-	store, err := kvstore.NewStore(log, dbPath, 0600)
+	store, err := kvstore.NewStore(log, dbPath, 0o600)
 	if err != nil {
 		t.Fatalf("open bbolt for assertion: %v", err)
 	}
@@ -281,7 +272,7 @@ func deleteBboltKey(t *testing.T, dataDir, providerName, key string) {
 	t.Helper()
 	log := logptest.NewTestingLogger(t, "delete-bbolt")
 	dbPath := filepath.Join(dataDir, "kvstore", "integ-"+providerName+".db")
-	store, err := kvstore.NewStore(log, dbPath, 0600)
+	store, err := kvstore.NewStore(log, dbPath, 0o600)
 	if err != nil {
 		t.Fatalf("open bbolt for deletion: %v", err)
 	}

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/entcollect"
@@ -47,6 +48,11 @@ func (a *StateStoreAdapter) Set(key string, value any) error {
 	// preserve json.RawMessage semantics (it treats []byte as a byte
 	// array). Decode into a generic value so the encoder gets a
 	// proper Go type.
+	//
+	// Precision: the values stored via this path are cursor strings,
+	// ISO timestamps, []string ID sets, and small counters. No
+	// integers exceed 0x1p53, we only store shard index values here,
+	// so float64 round-trip is safe.
 	if raw, ok := value.(json.RawMessage); ok {
 		var decoded any
 		if err := json.Unmarshal(raw, &decoded); err != nil {
@@ -62,14 +68,10 @@ func (a *StateStoreAdapter) Set(key string, value any) error {
 }
 
 func (a *StateStoreAdapter) Delete(key string) error {
-	has, err := a.store.Has(key)
-	if err != nil {
-		return fmt.Errorf("state store delete check %q: %w", key, err)
-	}
-	if !has {
+	err := a.store.Remove(key)
+	if err != nil && isKeyUnknown(err) {
 		return nil
 	}
-	err = a.store.Remove(key)
 	if err != nil {
 		return fmt.Errorf("state store delete %q: %w", key, err)
 	}
@@ -83,13 +85,20 @@ func (a *StateStoreAdapter) Each(fn func(key string, decode func(any) error) (bo
 }
 
 // isKeyUnknown checks whether err represents a key-not-found from
-// any statestore backend. All backends (ES, memlog, otelstorage)
-// use "key unknown" as the error message for missing keys.
+// any statestore backend. The memlog and otelstorage backends use
+// "key unknown" as the error message for missing keys. The ES
+// backend's baseStore.Remove discards the HTTP status code and
+// propagates a formatted error containing "404 Not Found" (see
+// libbeat/statestore/backend/es/base.go Remove). We match both.
 func isKeyUnknown(err error) bool {
 	var opErr *statestore.ErrorOperation
 	if errors.As(err, &opErr) {
 		cause := opErr.Unwrap()
-		return cause != nil && cause.Error() == "key unknown"
+		if cause == nil {
+			return false
+		}
+		msg := cause.Error()
+		return msg == "key unknown" || strings.Contains(msg, "404 Not Found")
 	}
 	return false
 }

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter.go
@@ -1,0 +1,95 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kvstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/entcollect"
+)
+
+var _ entcollect.Store = (*StateStoreAdapter)(nil)
+
+// StateStoreAdapter wraps a *statestore.Store to satisfy the
+// entcollect.Store interface. It is used when the ES-backed state
+// store is enabled for agentless deployments.
+//
+// Callers must call store.SetID before constructing the adapter to
+// ensure per-input isolation in the ES backend.
+type StateStoreAdapter struct {
+	store *statestore.Store
+}
+
+// NewStateStoreAdapter returns an entcollect.Store backed by s.
+func NewStateStoreAdapter(s *statestore.Store) *StateStoreAdapter {
+	return &StateStoreAdapter{store: s}
+}
+
+func (a *StateStoreAdapter) Get(key string, dst any) error {
+	err := a.store.Get(key, dst)
+	if err != nil {
+		if isKeyUnknown(err) {
+			return fmt.Errorf("state store get %q: %w", key, entcollect.ErrKeyNotFound)
+		}
+		return fmt.Errorf("state store get %q: %w", key, err)
+	}
+	return nil
+}
+
+func (a *StateStoreAdapter) Set(key string, value any) error {
+	// entcollect.Buffer.Commit passes json.RawMessage to Set. The ES
+	// backend's encoder uses struct-to-map conversion which doesn't
+	// preserve json.RawMessage semantics (it treats []byte as a byte
+	// array). Decode into a generic value so the encoder gets a
+	// proper Go type.
+	if raw, ok := value.(json.RawMessage); ok {
+		var decoded any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return fmt.Errorf("state store set %q: decode raw: %w", key, err)
+		}
+		value = decoded
+	}
+	err := a.store.Set(key, value)
+	if err != nil {
+		return fmt.Errorf("state store set %q: %w", key, err)
+	}
+	return nil
+}
+
+func (a *StateStoreAdapter) Delete(key string) error {
+	has, err := a.store.Has(key)
+	if err != nil {
+		return fmt.Errorf("state store delete check %q: %w", key, err)
+	}
+	if !has {
+		return nil
+	}
+	err = a.store.Remove(key)
+	if err != nil {
+		return fmt.Errorf("state store delete %q: %w", key, err)
+	}
+	return nil
+}
+
+func (a *StateStoreAdapter) Each(fn func(key string, decode func(any) error) (bool, error)) error {
+	return a.store.Each(func(key string, dec statestore.ValueDecoder) (bool, error) {
+		return fn(key, dec.Decode)
+	})
+}
+
+// isKeyUnknown checks whether err represents a key-not-found from
+// any statestore backend. All backends (ES, memlog, otelstorage)
+// use "key unknown" as the error message for missing keys.
+func isKeyUnknown(err error) bool {
+	var opErr *statestore.ErrorOperation
+	if errors.As(err, &opErr) {
+		cause := opErr.Unwrap()
+		return cause != nil && cause.Error() == "key unknown"
+	}
+	return false
+}

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
@@ -270,6 +270,13 @@ func (r *strictRegistry) Access(_ string) (backend.Store, error) {
 
 func (r *strictRegistry) Close() error { return nil }
 
+// TestStateStoreAdapter_DeleteAbsent_StrictBackend is a regression test
+// for the ES backend's non-compliant Remove behaviour. The ES backend's
+// baseStore.Remove discards the (status, body) return from eslegclient
+// and propagates an opaque "404 Not Found: ..." error when deleting a
+// missing document, violating the storecompliance contract that says
+// Remove should not error on unknown keys. The adapter must detect this
+// error shape and return nil.
 func TestStateStoreAdapter_DeleteAbsent_StrictBackend(t *testing.T) {
 	store := newTestStoreStrict(t)
 	a := NewStateStoreAdapter(store)

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
@@ -1,0 +1,297 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kvstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/backend"
+	"github.com/elastic/entcollect"
+)
+
+func TestStateStoreAdapter_GetSet(t *testing.T) {
+	store := newTestStore(t)
+	a := NewStateStoreAdapter(store)
+
+	if err := a.Set("k1", "hello"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	var got string
+	if err := a.Get("k1", &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "hello" {
+		t.Errorf("Get = %q; want %q", got, "hello")
+	}
+}
+
+func TestStateStoreAdapter_GetMissing(t *testing.T) {
+	store := newTestStore(t)
+	a := NewStateStoreAdapter(store)
+
+	var got string
+	err := a.Get("nonexistent", &got)
+	if err == nil {
+		t.Fatal("Get on missing key should return error")
+	}
+	if !errors.Is(err, entcollect.ErrKeyNotFound) {
+		t.Fatalf("Get error = %v; want ErrKeyNotFound", err)
+	}
+}
+
+func TestStateStoreAdapter_Delete(t *testing.T) {
+	store := newTestStore(t)
+	a := NewStateStoreAdapter(store)
+
+	if err := a.Set("k1", "val"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := a.Delete("k1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	var got string
+	err := a.Get("k1", &got)
+	if !errors.Is(err, entcollect.ErrKeyNotFound) {
+		t.Fatalf("Get after Delete = %v; want ErrKeyNotFound", err)
+	}
+}
+
+func TestStateStoreAdapter_DeleteAbsent(t *testing.T) {
+	store := newTestStore(t)
+	a := NewStateStoreAdapter(store)
+
+	if err := a.Delete("nonexistent"); err != nil {
+		t.Fatalf("Delete of absent key should return nil; got %v", err)
+	}
+}
+
+func TestStateStoreAdapter_Each(t *testing.T) {
+	store := newTestStore(t)
+	a := NewStateStoreAdapter(store)
+
+	if err := a.Set("a", 1); err != nil {
+		t.Fatalf("Set a: %v", err)
+	}
+	if err := a.Set("b", 2); err != nil {
+		t.Fatalf("Set b: %v", err)
+	}
+
+	seen := map[string]int{}
+	err := a.Each(func(key string, decode func(any) error) (bool, error) {
+		var v int
+		if err := decode(&v); err != nil {
+			return false, err
+		}
+		seen[key] = v
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("Each: %v", err)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("Each visited %d keys; want 2", len(seen))
+	}
+	if seen["a"] != 1 || seen["b"] != 2 {
+		t.Errorf("Each values = %v; want {a:1, b:2}", seen)
+	}
+}
+
+func TestStateStoreAdapter_EachStopEarly(t *testing.T) {
+	store := newTestStore(t)
+	a := NewStateStoreAdapter(store)
+
+	if err := a.Set("a", 1); err != nil {
+		t.Fatalf("Set a: %v", err)
+	}
+	if err := a.Set("b", 2); err != nil {
+		t.Fatalf("Set b: %v", err)
+	}
+
+	count := 0
+	err := a.Each(func(key string, decode func(any) error) (bool, error) {
+		count++
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Each: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Each visited %d keys; want 1 (early stop)", count)
+	}
+}
+
+// newTestStore creates a *statestore.Store backed by an in-memory map.
+func newTestStore(t *testing.T) *statestore.Store {
+	t.Helper()
+	reg := statestore.NewRegistry(&testRegistry{stores: map[string]*testBackendStore{}})
+	t.Cleanup(func() { reg.Close() })
+	s, err := reg.Get("test")
+	if err != nil {
+		t.Fatalf("registry Get: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// testRegistry implements backend.Registry with in-memory stores.
+type testRegistry struct {
+	mu     sync.Mutex
+	stores map[string]*testBackendStore
+}
+
+func (r *testRegistry) Access(name string) (backend.Store, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.stores[name]; ok {
+		return s, nil
+	}
+	s := &testBackendStore{data: map[string][]byte{}}
+	r.stores[name] = s
+	return s, nil
+}
+
+func (r *testRegistry) Close() error { return nil }
+
+// testBackendStore is an in-memory backend.Store.
+type testBackendStore struct {
+	mu   sync.RWMutex
+	data map[string][]byte
+}
+
+func (s *testBackendStore) Close() error { return nil }
+
+func (s *testBackendStore) Has(key string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.data[key]
+	return ok, nil
+}
+
+func (s *testBackendStore) Get(key string, value interface{}) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	raw, ok := s.data[key]
+	if !ok {
+		return errors.New("key unknown")
+	}
+	return json.Unmarshal(raw, value)
+}
+
+func (s *testBackendStore) Set(key string, value interface{}) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = raw
+	return nil
+}
+
+func (s *testBackendStore) Remove(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *testBackendStore) Each(fn func(string, backend.ValueDecoder) (bool, error)) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for k, v := range s.data {
+		dec := &jsonDecoder{raw: v}
+		cont, err := fn(k, dec)
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *testBackendStore) SetID(_ string) {}
+
+type jsonDecoder struct {
+	raw []byte
+}
+
+func (d *jsonDecoder) Decode(to interface{}) error {
+	return json.Unmarshal(d.raw, to)
+}
+
+// testBackendStoreStrict is like testBackendStore but returns an error
+// from Remove when the key doesn't exist, mimicking the real ES
+// backend's behaviour (HTTP 404 → error instead of silent success).
+type testBackendStoreStrict struct {
+	testBackendStore
+}
+
+func (s *testBackendStoreStrict) Remove(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.data[key]; !ok {
+		return fmt.Errorf("404 Not Found: {\"found\":false,\"_id\":\"%s\"}", key)
+	}
+	delete(s.data, key)
+	return nil
+}
+
+// newTestStoreStrict creates a *statestore.Store backed by a strict
+// in-memory backend that errors on Remove for missing keys.
+func newTestStoreStrict(t *testing.T) *statestore.Store {
+	t.Helper()
+	strict := &testBackendStoreStrict{testBackendStore{data: map[string][]byte{}}}
+	reg := statestore.NewRegistry(&strictRegistry{store: strict})
+	t.Cleanup(func() { reg.Close() })
+	s, err := reg.Get("test")
+	if err != nil {
+		t.Fatalf("registry Get: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+type strictRegistry struct {
+	store *testBackendStoreStrict
+}
+
+func (r *strictRegistry) Access(_ string) (backend.Store, error) {
+	return r.store, nil
+}
+
+func (r *strictRegistry) Close() error { return nil }
+
+func TestStateStoreAdapter_DeleteAbsent_StrictBackend(t *testing.T) {
+	store := newTestStoreStrict(t)
+	a := NewStateStoreAdapter(store)
+
+	if err := a.Delete("nonexistent"); err != nil {
+		t.Fatalf("Delete should swallow missing-key error from strict backend; got %v", err)
+	}
+}
+
+func TestStateStoreAdapter_DeletePresent_StrictBackend(t *testing.T) {
+	store := newTestStoreStrict(t)
+	a := NewStateStoreAdapter(store)
+
+	if err := a.Set("k1", "val"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := a.Delete("k1"); err != nil {
+		t.Fatalf("Delete of present key should succeed; got %v", err)
+	}
+	var got string
+	err := a.Get("k1", &got)
+	if !errors.Is(err, entcollect.ErrKeyNotFound) {
+		t.Fatalf("Get after Delete = %v; want ErrKeyNotFound", err)
+	}
+}

--- a/x-pack/filebeat/input/entityanalytics/minimal.go
+++ b/x-pack/filebeat/input/entityanalytics/minimal.go
@@ -18,6 +18,8 @@ import (
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/features"
+	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/internal/kvstore"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
@@ -31,6 +33,7 @@ type minimalStateInput struct {
 	fullSyncInterval time.Duration
 	incrSyncInterval time.Duration
 	logger           *logp.Logger
+	store            statestore.States
 	path             *paths.Path
 }
 
@@ -62,22 +65,13 @@ func (n *minimalStateInput) Run(runCtx v2.Context, connector beat.PipelineConnec
 	}
 	defer client.Close()
 
-	dataDir := n.path.Resolve(paths.Data, "kvstore")
-	if err = os.MkdirAll(dataDir, 0700); err != nil {
-		return fmt.Errorf("kvstore: unable to make data directory: %w", err)
-	}
-	// TODO: bbolt is a stopgap; the OTel path uses the
-	// elasticsearchstorage extension and this will follow once
-	// ES-backed state is available to Beats inputs.
-	filename := filepath.Join(dataDir, runCtx.ID+".db")
-	store, err := kvstore.NewStore(log, filename, 0600)
+	syncer, err := n.newSyncer(runCtx, log)
 	if err != nil {
 		return err
 	}
-	defer store.Close()
+	defer syncer.close()
 
 	slogger := slogLogger(log)
-	bucketName := "entcollect." + n.providerName
 
 	syncTimer := time.NewTimer(0) // fire immediately on first run
 	incrTimer := time.NewTimer(n.incrSyncInterval)
@@ -93,7 +87,7 @@ func (n *minimalStateInput) Run(runCtx v2.Context, connector beat.PipelineConnec
 			return nil
 
 		case <-syncTimer.C:
-			if err := n.runSync(runCtx, store, client, slogger, bucketName, true); err != nil {
+			if err := syncer.runSync(runCtx, n.provider, client, slogger, true); err != nil {
 				log.Errorw("Error running full sync", "error", err)
 			}
 			syncTimer.Reset(n.fullSyncInterval)
@@ -108,7 +102,7 @@ func (n *minimalStateInput) Run(runCtx v2.Context, connector beat.PipelineConnec
 			incrTimer.Reset(n.incrSyncInterval)
 
 		case <-incrTimer.C:
-			if err := n.runSync(runCtx, store, client, slogger, bucketName, false); err != nil {
+			if err := syncer.runSync(runCtx, n.provider, client, slogger, false); err != nil {
 				log.Errorw("Error running incremental sync", "error", err)
 			}
 			incrTimer.Reset(n.incrSyncInterval)
@@ -117,31 +111,65 @@ func (n *minimalStateInput) Run(runCtx v2.Context, connector beat.PipelineConnec
 	}
 }
 
-func (n *minimalStateInput) runSync(
-	runCtx v2.Context,
-	store *kvstore.Store,
-	client beat.Client,
-	slogger *slog.Logger,
-	bucketName string,
-	full bool,
-) error {
+// syncer abstracts state storage for sync operations. The bbolt
+// implementation uses transactions for atomicity; the ES-backed
+// implementation relies on entcollect.Buffer for batching without
+// transactional guarantees.
+type syncer interface {
+	runSync(runCtx v2.Context, provider entcollect.Provider, client beat.Client, slogger *slog.Logger, full bool) error
+	close()
+}
+
+func (n *minimalStateInput) newSyncer(runCtx v2.Context, log *logp.Logger) (syncer, error) {
+	if features.IsElasticsearchStateStoreEnabledForInput(Name) {
+		if n.store == nil {
+			return nil, errors.New("ES state store enabled but no statestore was injected")
+		}
+		return n.newESSyncer(runCtx, log)
+	}
+	return n.newBBoltSyncer(runCtx, log)
+}
+
+// bboltSyncer uses local bbolt storage with transactional semantics.
+type bboltSyncer struct {
+	store      *kvstore.Store
+	bucketName string
+}
+
+func (n *minimalStateInput) newBBoltSyncer(runCtx v2.Context, log *logp.Logger) (*bboltSyncer, error) {
+	dataDir := n.path.Resolve(paths.Data, "kvstore")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return nil, fmt.Errorf("kvstore: unable to make data directory: %w", err)
+	}
+	filename := filepath.Join(dataDir, runCtx.ID+".db")
+	store, err := kvstore.NewStore(log, filename, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return &bboltSyncer{
+		store:      store,
+		bucketName: "entcollect." + n.providerName,
+	}, nil
+}
+
+func (s *bboltSyncer) runSync(runCtx v2.Context, provider entcollect.Provider, client beat.Client, slogger *slog.Logger, full bool) error {
 	ctx := v2.GoContextFromCanceler(runCtx.Cancelation)
-	tx, err := store.BeginTx(true)
+	tx, err := s.store.BeginTx(true)
 	if err != nil {
 		return fmt.Errorf("unable to begin transaction: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck // best-effort cleanup
 
-	es := kvstore.NewEntcollectStore(tx, bucketName)
+	es := kvstore.NewEntcollectStore(tx, s.bucketName)
 	buf := entcollect.NewBuffer(es)
 
 	tracker := kvstore.NewTxTracker(ctx)
 	pub := kvstore.NewPublisher(client, runCtx.ID, tracker)
 
 	if full {
-		err = n.provider.FullSync(ctx, buf, pub, slogger)
+		err = provider.FullSync(ctx, buf, pub, slogger)
 	} else {
-		err = n.provider.IncrementalSync(ctx, buf, pub, slogger)
+		err = provider.IncrementalSync(ctx, buf, pub, slogger)
 	}
 
 	// Always wait for in-flight events to be ACKed, even on error.
@@ -164,6 +192,66 @@ func (n *minimalStateInput) runSync(
 		return fmt.Errorf("unable to commit transaction: %w", err)
 	}
 	return nil
+}
+
+func (s *bboltSyncer) close() {
+	s.store.Close()
+}
+
+// esSyncer uses the Elasticsearch-backed state store for agentless
+// deployments. No transactional atomicity — entcollect.Buffer
+// provides application-level batching.
+type esSyncer struct {
+	store *statestore.Store
+}
+
+func (n *minimalStateInput) newESSyncer(runCtx v2.Context, log *logp.Logger) (*esSyncer, error) {
+	s, err := n.store.StoreFor(Name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open ES state store: %w", err)
+	}
+	s.SetID(runCtx.ID)
+	log.Infof("Using Elasticsearch-backed state store (index: agentless-state-%s)", runCtx.ID)
+	return &esSyncer{store: s}, nil
+}
+
+func (s *esSyncer) runSync(runCtx v2.Context, provider entcollect.Provider, client beat.Client, slogger *slog.Logger, full bool) error {
+	ctx := v2.GoContextFromCanceler(runCtx.Cancelation)
+
+	es := kvstore.NewStateStoreAdapter(s.store)
+	buf := entcollect.NewBuffer(es)
+
+	tracker := kvstore.NewTxTracker(ctx)
+	pub := kvstore.NewPublisher(client, runCtx.ID, tracker)
+
+	var err error
+	if full {
+		err = provider.FullSync(ctx, buf, pub, slogger)
+	} else {
+		err = provider.IncrementalSync(ctx, buf, pub, slogger)
+	}
+
+	// Always wait for in-flight events to be ACKed, even on error.
+	tracker.Wait()
+
+	if err != nil {
+		buf.Discard()
+		return err
+	}
+
+	if ctx.Err() != nil {
+		buf.Discard()
+		return ctx.Err()
+	}
+
+	if err := buf.Commit(); err != nil {
+		return fmt.Errorf("unable to commit buffer: %w", err)
+	}
+	return nil
+}
+
+func (s *esSyncer) close() {
+	s.store.Close()
 }
 
 // slogLogger bridges logp.Logger to *slog.Logger using zapslog.

--- a/x-pack/filebeat/input/entityanalytics/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/minimal_test.go
@@ -97,7 +97,7 @@ func TestMinimalInput_RunSync_FullCycle(t *testing.T) {
 	dbFile := filepath.Join(tmpDir, "test.db")
 
 	log := logptest.NewTestingLogger(t, "test")
-	store, err := kvstore.NewStore(log, dbFile, 0600)
+	store, err := kvstore.NewStore(log, dbFile, 0o600)
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
@@ -122,28 +122,21 @@ func TestMinimalInput_RunSync_FullCycle(t *testing.T) {
 		},
 	}
 
-	mi := &minimalStateInput{
-		provider:     prov,
-		providerName: "testprov",
-		logger:       log,
-		path:         paths.New(),
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	ackClient := &ackingClient{inner: client}
+	s := &bboltSyncer{store: store, bucketName: bucketName}
 
-	err = mi.runSync(
+	err = s.runSync(
 		v2.Context{
 			Logger:      log,
 			ID:          "test-input-1",
 			Cancelation: v2.GoContextFromCanceler(ctx),
 		},
-		store,
+		prov,
 		ackClient,
 		slogger,
-		bucketName,
 		true,
 	)
 	if err != nil {
@@ -179,7 +172,7 @@ func TestMinimalInput_RunSync_ErrorDiscardsBuffer(t *testing.T) {
 	dbFile := filepath.Join(tmpDir, "test-err.db")
 
 	log := logptest.NewTestingLogger(t, "test")
-	store, err := kvstore.NewStore(log, dbFile, 0600)
+	store, err := kvstore.NewStore(log, dbFile, 0o600)
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
@@ -206,24 +199,18 @@ func TestMinimalInput_RunSync_ErrorDiscardsBuffer(t *testing.T) {
 		},
 	}
 
-	mi := &minimalStateInput{
-		provider:     prov,
-		providerName: "testprov",
-		logger:       log,
-		path:         paths.New(),
-	}
-
 	ctx := context.Background()
-	err = mi.runSync(
+	s := &bboltSyncer{store: store, bucketName: bucketName}
+
+	err = s.runSync(
 		v2.Context{
 			Logger:      log,
 			ID:          "test-input-err",
 			Cancelation: v2.GoContextFromCanceler(ctx),
 		},
-		store,
+		prov,
 		ackClient,
 		slogger,
-		bucketName,
 		true,
 	)
 	if !errors.Is(err, syncErr) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics: add ES-backed state store for agentless

Add a StateStoreAdapter that bridges *statestore.Store to the
entcollect.Store interface, enabling the minimal-state entity
analytics input to use Elasticsearch for state persistence when
running in agentless mode. The store backend is selected at startup
based on the AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES
environment variable set by the agentless controller.

The minimal-state input is refactored into a syncer interface with
two implementations: bboltSyncer (local transactional storage) and
esSyncer (ES-backed, using entcollect.Buffer for batching). The
adapter handles json.RawMessage decoding from the buffer layer and
works around the ES backend's non-compliant Remove behaviour on
missing keys via a Has-before-Remove guard.

Documentation adds the use_minimal_state option and an operational
limits section with scaling data for EntraID group-graph sync.

For #50774

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #50774

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
