### PR TITLE
slabqueue: simplify dynamic-sizing plumbing

### DIFF
--- a/libbeat/publisher/pipeline/output_otel.go
+++ b/libbeat/publisher/pipeline/output_otel.go
@@ -58,12 +58,9 @@ type otelOutputController struct {
 
 	// pool is non-nil whenever the receiver uses the slabqueue pool (i.e.
 	// queue.mem); it is nil when the receiver was configured with queue.disk
-	// and owns its queue outright via queueFactory.
+	// and owns its queue outright via queueFactory. It therefore also marks
+	// whether this controller joined a shared pool that must be released.
 	pool *slabqueue.Pool[publisher.Event]
-
-	// sharedPoolQueue is this controller's connection to the shared pool, used
-	// to drop its budget contribution on release. Non-nil iff pool is non-nil.
-	sharedPoolQueue *slabqueue.Queue[publisher.Event]
 
 	consumer *eventConsumer
 
@@ -120,8 +117,8 @@ func newOTelOutputController(
 	// we go through acquireOTelPool. Anything else (in practice
 	// diskqueue.Settings from an explicit queue.disk) opts out and builds
 	// its queue from the user-supplied queueFactory.
-	var sharedQueue *slabqueue.Queue[publisher.Event]
 	if settings, isMem := queueConfig.(memqueue.Settings); isMem {
+		var sharedQueue *slabqueue.Queue[publisher.Event]
 		pool, sharedQueue = acquireOTelPool(intakeQueueID, settings, monitors)
 		pipelineQueue = sharedQueue
 	} else {
@@ -145,7 +142,7 @@ func newOTelOutputController(
 	})
 	if err != nil {
 		closePipelineQueue(pipelineQueue)
-		if sharedQueue != nil {
+		if pool != nil {
 			releaseOTelPool(intakeQueueID)
 		}
 		return nil, err
@@ -167,16 +164,15 @@ func newOTelOutputController(
 	})
 
 	return &otelOutputController{
-		beatInfo:        beatInfo,
-		logger:          beatInfo.Logger.Named("otelOutputController"),
-		monitors:        monitors,
-		intakeQueueID:   intakeQueueID,
-		queue:           pipelineQueue,
-		pool:            pool,
-		sharedPoolQueue: sharedQueue,
-		consumer:        consumer,
-		workers:         workers,
-		workerChan:      workerChan,
+		beatInfo:      beatInfo,
+		logger:        beatInfo.Logger.Named("otelOutputController"),
+		monitors:      monitors,
+		intakeQueueID: intakeQueueID,
+		queue:         pipelineQueue,
+		pool:          pool,
+		consumer:      consumer,
+		workers:       workers,
+		workerChan:    workerChan,
 	}, nil
 }
 
@@ -273,7 +269,7 @@ func (c *otelOutputController) waitClose(ctx context.Context, _ bool) error {
 	// Release this pipeline's claim on the shared pool. When the last
 	// connected pipeline releases, the pool is shut down. Receivers on the
 	// non-mem (disk) path own their queue outright and never joined a pool.
-	if c.sharedPoolQueue != nil {
+	if c.pool != nil {
 		releaseOTelPool(c.intakeQueueID)
 	}
 	return nil

--- a/libbeat/publisher/pipeline/output_otel_test.go
+++ b/libbeat/publisher/pipeline/output_otel_test.go
@@ -52,6 +52,22 @@ func beatInfoForTest(t *testing.T) beat.Info {
 	return beat.Info{Logger: logp.NewNopLogger(), LogConsumer: nopLogConsumer(t)}
 }
 
+// beatInfoNoDrain returns a beat.Info whose LogConsumer blocks until its
+// context is cancelled (which the output worker does on Close). This keeps the
+// controller's background consumer and workers from acking events while a test
+// inspects the queue or pool budget: nopLogConsumer acks almost immediately,
+// which races budget assertions and makes them flaky. Published events stay
+// live until cleanup, where waitClose cancels the worker context to release it.
+func beatInfoNoDrain(t *testing.T) beat.Info {
+	t.Helper()
+	c, err := consumer.NewLogs(func(ctx context.Context, _ plog.Logs) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	require.NoError(t, err)
+	return beat.Info{Logger: logp.NewNopLogger(), LogConsumer: c}
+}
+
 // monitorsForTest returns a fresh Monitors with its own metrics registry. Each
 // controller must get its own registry because loadOutput registers stats
 // under fixed names that would collide if reused.
@@ -131,7 +147,7 @@ func TestSharedPoolBudgetIsolatesPipelines(t *testing.T) {
 	}
 
 	c1, err := newOTelOutputController(
-		beatInfoForTest(t),
+		beatInfoNoDrain(t),
 		monitorsForTest(),
 		nilObserver,
 		"sharedID",
@@ -142,7 +158,7 @@ func TestSharedPoolBudgetIsolatesPipelines(t *testing.T) {
 	defer c1.waitClose(cancelledContext(), false)
 
 	c2, err := newOTelOutputController(
-		beatInfoForTest(t),
+		beatInfoNoDrain(t),
 		monitorsForTest(),
 		nilObserver,
 		"sharedID",
@@ -251,14 +267,14 @@ func TestSharedIntakeQueueShrinksWhenLargestLeaves(t *testing.T) {
 // though the pool has room.
 func TestSharedIntakeQueueCapsPerReceiver(t *testing.T) {
 	c1, err := newOTelOutputController(
-		beatInfoForTest(t), monitorsForTest(), nilObserver, "capID", nil,
+		beatInfoNoDrain(t), monitorsForTest(), nilObserver, "capID", nil,
 		memqueue.Settings{Events: 4},
 	)
 	require.NoError(t, err)
 	defer c1.waitClose(cancelledContext(), false)
 
 	c2, err := newOTelOutputController(
-		beatInfoForTest(t), monitorsForTest(), nilObserver, "capID", nil,
+		beatInfoNoDrain(t), monitorsForTest(), nilObserver, "capID", nil,
 		memqueue.Settings{Events: 8},
 	)
 	require.NoError(t, err)

--- a/libbeat/publisher/queue/slabqueue/batch.go
+++ b/libbeat/publisher/queue/slabqueue/batch.go
@@ -92,12 +92,15 @@ func (b *batch[T]) Done() {
 	// Walk slots: collect per-producer counts, clear slot state. Most
 	// batches come from a single producer so the linear search stays
 	// small. Reuse b's own slice backing arrays (set by Get from a
-	// recycled batch) to avoid allocating per Done.
+	// recycled batch) to avoid allocating per Done. The directory only
+	// grows under growMu and always covers an index this batch holds, so
+	// load it once instead of per slot.
 	var zero T
 	b.ackProducers = b.ackProducers[:0]
 	b.ackCounts = b.ackCounts[:0]
+	d := pool.dir.Load()
 	for _, i := range b.indices {
-		s := pool.slot(i)
+		s := d.slot(i)
 		if s.producer != nil {
 			found := false
 			for j, p := range b.ackProducers {
@@ -129,68 +132,46 @@ func (b *batch[T]) Done() {
 	// blocked on this queue's cap can proceed.
 	b.queue.releaseLive(n)
 
+	// Mark this batch done and drain the now-ready prefix of the pending FIFO.
+	// forced is read under the same lock so the snapshot is consistent with the
+	// drain. Slots are already back in the pool; the only work left is firing
+	// the drained prefix's ACK callbacks (in publish order) and recycling them.
 	q := b.queue
 	q.mu.Lock()
 	b.done = true
-	// Walk the pending FIFO from the head, peeling off every batch that
-	// has completed. toAck holds the prefix to ACK in publish order
-	// outside the lock. Anything from a not-yet-done batch onward stays
-	// in the list. Batches in toAck are no longer reachable from the
-	// queue once they're spliced out, so it's safe to recycle them
-	// after callbacks fire.
-	var toAckHead, toAckTail *batch[T]
-	for q.pendingHead != nil && q.pendingHead.done {
-		ready := q.pendingHead
-		q.pendingHead = ready.next
-		ready.next = nil
-		if toAckTail == nil {
-			toAckHead = ready
-		} else {
-			toAckTail.next = ready
-		}
-		toAckTail = ready
-	}
-	if q.pendingHead == nil {
-		q.pendingTail = nil
-	}
-	q.maybeMarkDone()
+	toAck := q.drainReadyLocked()
 	forced := q.forced.Load()
 	q.mu.Unlock()
 
-	// Slots are already back in the pool above; the remaining work is
-	// invoking producer ACK callbacks for any batches whose turn in the
-	// publish-order FIFO has come up.
-	//
-	// Suppress ACK callbacks once the queue has been force-closed.
-	// Force-close means the caller explicitly abandoned in-flight events
-	// (Close(true) released FIFO slots without acking them); reporting
-	// ACKs for the parallel set of in-flight batches that were already
-	// out at workers would be inconsistent and could mislead
-	// order-sensitive consumers (e.g. filestream's registry tracker).
-	// This matches memqueue's behaviour: its ackLoop exits on force-
-	// close and no further producer ACK callbacks fire.
+	pool.fireAndRecycle(toAck, forced)
+}
+
+// fireAndRecycle invokes producer ACK callbacks for each batch in the
+// publish-order list, then returns the batches to the recycle pool. The list
+// comes from Queue.drainReadyLocked and is no longer reachable from the queue,
+// so visiting it after q.mu is released is safe; a callback that re-publishes
+// through the queue is free to take the pool/queue locks without deadlocking.
+//
+// ACK callbacks are suppressed once the queue has been force-closed: the caller
+// explicitly abandoned in-flight events (Close(true) released FIFO slots without
+// acking them), so reporting ACKs for the parallel set of batches already out at
+// workers would be inconsistent and could mislead order-sensitive consumers
+// (e.g. filestream's registry tracker). This matches memqueue, whose ackLoop
+// exits on force-close and fires no further callbacks.
+func (p *Pool[T]) fireAndRecycle(head *batch[T], forced bool) {
 	if !forced {
-		// Invoke ACK callbacks outside the lock in publish (Get) order.
-		// A callback that re-publishes through this queue will be free
-		// to take the pool/queue locks without deadlocking us. The
-		// drained batches are no longer reachable from the queue, so
-		// visiting them here is safe.
-		for ab := toAckHead; ab != nil; ab = ab.next {
-			for i, p := range ab.ackProducers {
-				if p.cfg.ACK != nil {
-					p.cfg.ACK(ab.ackCounts[i])
+		for ab := head; ab != nil; ab = ab.next {
+			for i, pr := range ab.ackProducers {
+				if pr.cfg.ACK != nil {
+					pr.cfg.ACK(ab.ackCounts[i])
 				}
 			}
 		}
 	}
-
-	// Recycle every swept batch back to the batch pool now that no one
-	// else holds a reference (sweep took them out of pendingHead, and
-	// callbacks have been delivered). We capture next before putBatch
-	// because putBatch clears the .next field.
-	for ab := toAckHead; ab != nil; {
+	// Capture next before putBatch clears the .next field.
+	for ab := head; ab != nil; {
 		next := ab.next
-		pool.putBatch(ab)
+		p.putBatch(ab)
 		ab = next
 	}
 }
@@ -220,12 +201,12 @@ func (b *batch[T]) Release() {
 	}
 	pool := b.queue.pool
 
-	// Clear slot state and gather indices for release. Mirrors the
-	// slot-cleanup section of Done but skips the ackProducers/ackCounts
-	// collection — we explicitly do not want to fire callbacks.
+	// Clear slot state. Mirrors the slot-cleanup section of Done but skips the
+	// ackProducers/ackCounts collection — we explicitly do not fire callbacks.
 	var zero T
+	d := pool.dir.Load()
 	for _, i := range b.indices {
-		s := pool.slot(i)
+		s := d.slot(i)
 		if !b.freed {
 			s.event = zero
 		}
@@ -240,14 +221,12 @@ func (b *batch[T]) Release() {
 	// Return the per-queue budget for the abandoned events.
 	b.queue.releaseLive(n)
 
-	// Remove the batch from the pending FIFO if it's still there.
-	// Done's sweep relies on the per-batch `done` flag and walks from
-	// the head; for a Released batch we splice it out wherever it sits
-	// so the sweep can drain the prefix that's ready. After the splice,
-	// if any batches were already Done()'d but stuck behind us they
-	// must be drained here — otherwise a later Done() may never come
-	// to drain them and they would sit in pendingHead indefinitely,
-	// blocking q.Done() and leaking their ACK callbacks + batch object.
+	// Remove the batch from the pending FIFO if it's still there. Done's sweep
+	// relies on the per-batch `done` flag and walks from the head; for a Released
+	// batch we splice it out wherever it sits, then drain the now-exposed ready
+	// prefix exactly as Done would — otherwise completed-but-stalled successors
+	// behind us would sit in pendingHead indefinitely, blocking q.Done() and
+	// leaking their ACK callbacks + batch objects.
 	q := b.queue
 	q.mu.Lock()
 	var prev *batch[T]
@@ -266,51 +245,15 @@ func (b *batch[T]) Release() {
 		prev = cur
 	}
 	b.next = nil
-
-	// Drain the now-exposed head prefix of already-completed batches.
-	// Mirrors Done's sweep so a Release that unblocks a queue of
-	// completed-but-stalled successors gets them ACKed (or recycled
-	// under force-close) just as Done would have.
-	var toAckHead, toAckTail *batch[T]
-	for q.pendingHead != nil && q.pendingHead.done {
-		ready := q.pendingHead
-		q.pendingHead = ready.next
-		ready.next = nil
-		if toAckTail == nil {
-			toAckHead = ready
-		} else {
-			toAckTail.next = ready
-		}
-		toAckTail = ready
-	}
-	if q.pendingHead == nil {
-		q.pendingTail = nil
-	}
-	q.maybeMarkDone()
+	toAck := q.drainReadyLocked()
 	forced := q.forced.Load()
 	q.mu.Unlock()
 
-	// Fire ACK callbacks for the drained successors in publish order.
-	// Suppressed under force-close, matching Done's contract.
-	if !forced {
-		for ab := toAckHead; ab != nil; ab = ab.next {
-			for i, p := range ab.ackProducers {
-				if p.cfg.ACK != nil {
-					p.cfg.ACK(ab.ackCounts[i])
-				}
-			}
-		}
-	}
-
-	// Recycle each drained successor; capture next before putBatch
-	// clears the .next field.
-	for ab := toAckHead; ab != nil; {
-		next := ab.next
-		pool.putBatch(ab)
-		ab = next
-	}
+	pool.fireAndRecycle(toAck, forced)
 
 	// b itself is no longer reachable from the queue and the caller
-	// has released it — safe to recycle.
+	// has released it — safe to recycle. It is never part of toAck (it was
+	// spliced out above and never marked done), so it is recycled here without
+	// firing its producer callbacks, which is the whole point of Release.
 	pool.putBatch(b)
 }

--- a/libbeat/publisher/queue/slabqueue/pool.go
+++ b/libbeat/publisher/queue/slabqueue/pool.go
@@ -29,10 +29,9 @@ import (
 // live on each Queue; this struct just carries the "next" link plus the
 // producer needed for ACK callbacks.
 type slot[T any] struct {
-	event      T
-	next       int // index of the next slot in the owning pipeline's FIFO, or -1
-	producer   *producer[T]
-	producerID uint64
+	event    T
+	next     int // index of the next slot in the owning pipeline's FIFO, or -1
+	producer *producer[T]
 }
 
 // Pool is the shared backing storage for events from multiple pipelines.
@@ -164,6 +163,27 @@ func (p *Pool[T]) setTarget(n int) {
 	}
 }
 
+// setChunkCount swaps in a directory holding exactly n chunks, allocating fresh
+// trailing chunks when growing and dropping trailing chunks when shrinking; it
+// is a no-op if the directory already has n chunks. The chunks themselves are
+// shared with the previous directory (never moved or copied), so pointers into
+// surviving chunks stay valid. It must be called with growMu held, and the new
+// directory is published atomically. Grow must call this before pushing the
+// backing indices to the free list, so an acquirer always observes a directory
+// containing the chunk for any index it grabs.
+func (p *Pool[T]) setChunkCount(n int) {
+	cur := p.dir.Load().chunks
+	if n == len(cur) {
+		return
+	}
+	nc := make([]*chunk[T], n)
+	copy(nc, cur) // copies min(n, len(cur)) chunk pointers
+	for i := len(cur); i < n; i++ {
+		nc[i] = &chunk[T]{}
+	}
+	p.dir.Store(&directory[T]{chunks: nc})
+}
+
 // growLocked raises capacity to n by allocating any missing chunks, publishing
 // the new directory, and pushing the new indices [old, n) to the free list. It
 // must be called with growMu held. Indices are published only after the
@@ -174,15 +194,7 @@ func (p *Pool[T]) growLocked(n int) {
 	if n <= old {
 		return
 	}
-	if need := numChunks(n); need > len(p.dir.Load().chunks) {
-		cur := p.dir.Load().chunks
-		nc := make([]*chunk[T], need)
-		copy(nc, cur)
-		for i := len(cur); i < need; i++ {
-			nc[i] = &chunk[T]{}
-		}
-		p.dir.Store(&directory[T]{chunks: nc})
-	}
+	p.setChunkCount(numChunks(n))
 	for i := old; i < n; i++ {
 		p.free.pushNoSignal(i)
 	}
@@ -199,23 +211,18 @@ func (p *Pool[T]) growLocked(n int) {
 // held.
 func (p *Pool[T]) shrinkLocked() {
 	for {
-		cap := int(p.capacity.Load())
-		if cap <= int(p.target.Load()) {
+		curCap := int(p.capacity.Load())
+		if curCap <= int(p.target.Load()) {
 			return
 		}
-		top := cap - 1
+		top := curCap - 1
 		if !p.free.removeIndex(top) {
 			// The top slot is still in use; it will be retired when released.
 			return
 		}
 		p.capacity.Store(int64(top))
 		// Reclaim any trailing chunk the shrink just emptied.
-		if want := numChunks(top); want < len(p.dir.Load().chunks) {
-			cur := p.dir.Load().chunks
-			nc := make([]*chunk[T], want)
-			copy(nc, cur[:want])
-			p.dir.Store(&directory[T]{chunks: nc})
-		}
+		p.setChunkCount(numChunks(top))
 	}
 }
 
@@ -267,6 +274,13 @@ func (p *Pool[T]) acquire(home int, closeCh <-chan struct{}) (int, bool) {
 // a push.
 func (p *Pool[T]) releaseSlot(i int) {
 	p.free.push(i)
+	p.maybeShrink()
+}
+
+// maybeShrink converges a lazy shrink one step further if one is in progress
+// (capacity > target). The check is a single atomic comparison, so the
+// steady-state release path pays only that before returning.
+func (p *Pool[T]) maybeShrink() {
 	if p.capacity.Load() > p.target.Load() {
 		p.growMu.Lock()
 		p.shrinkLocked()
@@ -286,23 +300,12 @@ func (p *Pool[T]) releaseSlots(indices []int) {
 		return
 	}
 	p.free.pushBatch(indices)
-	if p.capacity.Load() > p.target.Load() {
-		p.growMu.Lock()
-		p.shrinkLocked()
-		p.growMu.Unlock()
-	}
+	p.maybeShrink()
 	p.free.maybeWakeAll()
 }
 
 // isClosed reports whether the pool has been shut down.
-func (p *Pool[T]) isClosed() bool {
-	select {
-	case <-p.closed:
-		return true
-	default:
-		return false
-	}
-}
+func (p *Pool[T]) isClosed() bool { return chClosed(p.closed) }
 
 // chClosed is a non-blocking check for a closed signal channel.
 func chClosed(ch <-chan struct{}) bool {
@@ -317,8 +320,9 @@ func chClosed(ch <-chan struct{}) bool {
 	}
 }
 
-// getBatch returns a recycled or freshly allocated *batch[T]. Callers
-// are responsible for populating it via fillBatch before exposing it.
+// getBatch returns a fully-reset *batch[T] (queue == nil, empty slices, flags
+// cleared) — either recycled via putBatch or freshly allocated. The caller only
+// needs to set queue and append indices before exposing it; see Queue.Get.
 func (p *Pool[T]) getBatch() *batch[T] {
 	b, _ := p.batchPool.Get().(*batch[T])
 	return b
@@ -425,13 +429,11 @@ func (p *Pool[T]) syncTargetToQueues() {
 	// order, letting a stale max overwrite a fresh one.
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	max := 0
+	largest := 0
 	for q := range p.queues {
-		if l := int(q.limit.Load()); l > max {
-			max = l
-		}
+		largest = max(largest, int(q.limit.Load()))
 	}
-	if max > 0 {
-		p.setTarget(max)
+	if largest > 0 {
+		p.setTarget(largest)
 	}
 }

--- a/libbeat/publisher/queue/slabqueue/producer.go
+++ b/libbeat/publisher/queue/slabqueue/producer.go
@@ -92,7 +92,6 @@ func (p *producer[T]) fill(entry T, slotIdx int) (queue.EntryID, bool) {
 	s.event = entry
 	s.next = -1
 	s.producer = p
-	s.producerID = id
 
 	q := p.queue
 	q.mu.Lock()

--- a/libbeat/publisher/queue/slabqueue/queue.go
+++ b/libbeat/publisher/queue/slabqueue/queue.go
@@ -187,14 +187,7 @@ func (q *Queue[T]) wakeLimitWaiters() {
 }
 
 // isClosing reports whether Close has been called on this queue.
-func (q *Queue[T]) isClosing() bool {
-	select {
-	case <-q.closeCh:
-		return true
-	default:
-		return false
-	}
-}
+func (q *Queue[T]) isClosing() bool { return chClosed(q.closeCh) }
 
 // Producer returns a producer that publishes to this queue. Each producer is
 // given a stable home shard for the pool's free list, spread across shards by
@@ -213,24 +206,20 @@ func (q *Queue[T]) Get(maxEvents int) (queue.Batch[T], error) {
 		q.mu.Lock()
 		if q.count > 0 {
 			n := q.count
-			if maxEvents > 0 && maxEvents < n {
-				n = maxEvents
+			if maxEvents > 0 {
+				n = min(n, maxEvents)
 			}
-			// Pull a recycled batch from the pool. Its slices retain
-			// their backing arrays from previous uses; we reset
-			// lengths and append into them. The batch is owned solely
-			// by this Queue/consumer/worker chain until Done/Release
-			// returns it to the pool.
+			// Pull a batch from the recycle pool (already fully reset; see
+			// getBatch) and append our slot indices into its retained backing
+			// array. The batch is owned solely by this Queue/consumer/worker
+			// chain until Done/Release returns it to the pool.
 			b := q.pool.getBatch()
 			b.queue = q
-			b.indices = b.indices[:0]
-			b.done = false
-			b.freed = false
-			b.next = nil
+			d := q.pool.dir.Load()
 			cur := q.head
 			for i := 0; i < n; i++ {
 				b.indices = append(b.indices, cur)
-				cur = q.pool.slot(cur).next
+				cur = d.slot(cur).next
 			}
 			q.head = cur
 			if cur == -1 {
@@ -286,14 +275,12 @@ func (q *Queue[T]) Close(force bool) error {
 		q.forced.Store(true)
 	}
 	q.mu.Lock()
-	if !q.closing {
-		q.closing = true
-	}
+	q.closing = true
 	var releaseIndices []int
 	if force {
 		if q.count > 0 {
 			// Walk the FIFO and gather the slots so we can release them back to
-			// the pool below (outside the lock, since pool.free is a channel).
+			// the pool below, outside the lock, to keep the critical section short.
 			cur := q.head
 			for cur != -1 {
 				releaseIndices = append(releaseIndices, cur)
@@ -369,11 +356,11 @@ func (q *Queue[T]) QueueType() string { return QueueType }
 // of its per-queue cap (if set) and the shared pool budget. With no per-queue
 // cap it is just the pool budget.
 func (q *Queue[T]) BufferConfig() queue.BufferConfig {
-	max := q.pool.Target()
-	if lim := int(q.limit.Load()); lim > 0 && lim < max {
-		max = lim
+	maxEvents := q.pool.Target()
+	if lim := int(q.limit.Load()); lim > 0 {
+		maxEvents = min(maxEvents, lim)
 	}
-	return queue.BufferConfig{MaxEvents: max}
+	return queue.BufferConfig{MaxEvents: maxEvents}
 }
 
 // signal wakes a goroutine blocked in Get. Non-blocking: at most one pending
@@ -397,4 +384,30 @@ func (q *Queue[T]) maybeMarkDone() {
 // markDone closes doneCh idempotently.
 func (q *Queue[T]) markDone() {
 	q.doneOnce.Do(func() { close(q.doneCh) })
+}
+
+// drainReadyLocked peels every already-Done() batch off the head of the pending
+// FIFO and returns them as a list in publish order, the prefix whose producer
+// ACK callbacks are now ready to fire. Anything from a not-yet-done batch onward
+// stays in the list. It also re-checks whether the queue is now fully drained.
+// Returned batches are no longer reachable from the queue, so the caller may ACK
+// and recycle them once it releases q.mu. Must be called with q.mu held.
+func (q *Queue[T]) drainReadyLocked() *batch[T] {
+	var head, tail *batch[T]
+	for q.pendingHead != nil && q.pendingHead.done {
+		ready := q.pendingHead
+		q.pendingHead = ready.next
+		ready.next = nil
+		if tail == nil {
+			head = ready
+		} else {
+			tail.next = ready
+		}
+		tail = ready
+	}
+	if q.pendingHead == nil {
+		q.pendingTail = nil
+	}
+	q.maybeMarkDone()
+	return head
 }

--- a/libbeat/publisher/queue/slabqueue/slabqueue.go
+++ b/libbeat/publisher/queue/slabqueue/slabqueue.go
@@ -23,11 +23,12 @@
 //   - A Pool owns the slot storage and a free list. Publish acquires a slot;
 //     batch.Done returns it. The free list also serves as a counting
 //     semaphore: total live events across all pipelines is capped by the
-//     pool's current capacity. The capacity is resizable at runtime
-//     (Pool.SetTarget) so a shared pool can grow to the largest budget its
-//     connected receivers request and shrink back as they leave, all while
-//     traffic flows; storage is a directory of non-moving chunks and the free
-//     list is sharded for concurrency (see storage.go / freelist.go).
+//     pool's current capacity. The capacity is resizable at runtime (driven by
+//     the connected queues' caps via Queue.SetTarget) so a shared pool can grow
+//     to the largest budget its connected receivers request and shrink back as
+//     they leave, all while traffic flows; storage is a directory of non-moving
+//     chunks and the free list is sharded for concurrency (see storage.go /
+//     freelist.go).
 //   - Each Queue may additionally have its own per-queue cap (Queue.SetTarget),
 //     bounding the live events on that one pipeline independently of the shared
 //     pool. With several queues on one pool, each enforces its own configured
@@ -67,11 +68,13 @@ import (
 // from a pipeline config (queue.slab) just like the other implementations.
 const QueueType = "slab"
 
-// Settings configures a Pool's capacity.
+// Settings configures a Pool's initial capacity.
 type Settings struct {
-	// Events is the total number of slots in the pool's backing array. It
-	// is the upper bound on events live (published but not yet ack'd) across
-	// every pipeline connected to the pool.
+	// Events is the pool's initial slot count: the starting bound on events
+	// live (published but not yet ack'd) across every pipeline connected to the
+	// pool. It is not a fixed ceiling — the pool is resizable at runtime, driven
+	// by the connected queues' caps (see Queue.SetTarget), and its storage grows
+	// and shrinks in chunks rather than being a single backing array.
 	Events int
 }
 

--- a/libbeat/publisher/queue/slabqueue/storage.go
+++ b/libbeat/publisher/queue/slabqueue/storage.go
@@ -73,6 +73,13 @@ func newDirectory[T any](capacity int) *directory[T] {
 	return d
 }
 
+// slot returns a stable pointer to slot i within this directory. Callers that
+// touch many slots in a loop (batch.Done, Queue.Get, ...) load the directory
+// once and call this, instead of reloading the atomic per slot.
+func (d *directory[T]) slot(i int) *slot[T] {
+	return &d.chunks[i>>slabChunkShift].slots[i&slabChunkMask]
+}
+
 // slot returns a stable pointer to slot i. The directory is loaded atomically
 // so this is safe to call concurrently with grow/shrink: any index a goroutine
 // legitimately holds (one it acquired from the free list, or reached by
@@ -80,6 +87,5 @@ func newDirectory[T any](capacity int) *directory[T] {
 // because indices are published to the free list only after the directory that
 // contains them has been stored.
 func (p *Pool[T]) slot(i int) *slot[T] {
-	d := p.dir.Load()
-	return &d.chunks[i>>slabChunkShift].slots[i&slabChunkMask]
+	return p.dir.Load().slot(i)
 }


### PR DESCRIPTION
<!-- Cleanup -->

## Proposed commit message

Internal cleanup of the slabqueue dynamic-sizing code, with no change in behavior, plus a fix for two flaky pipeline tests.

slabqueue:

- Drop the redundant `otelOutputController.sharedPoolQueue` field and use `pool != nil` as the single "joined a shared pool" marker.
- Deduplicate the batch-completion and chunk-directory resize paths: shared `Queue.drainReadyLocked` / `Pool.fireAndRecycle` helpers for `batch.Done`/`batch.Release`, and a shared `Pool.setChunkCount` for grow/shrink.
- Smaller tidy-ups: a `maybeShrink` helper, reuse of the existing `chClosed` helper, a `directory.slot` accessor in the hot loops, removal of the unused `slot.producerID` field, batch reset consolidated into `putBatch`, `min`/`max` builtins, and corrected stale comments.

pipeline:

- Fix flaky `TestSharedIntakeQueueCapsPerReceiver` and `TestSharedPoolBudgetIsolatesPipelines`. They asserted on the per-queue cap / shared pool budget while a published batch could be acked before the assertion ran. The tests now use a `LogConsumer` that blocks on the worker context so published events stay live during the assertions; `out.Close()` releases it on cleanup.

Benchmarks confirm the cleanup is performance-neutral with no allocation change (`orig-PR` = the base this branch builds on, `this-branch` = this PR; `go test -run=^$ -bench=. -benchmem -benchtime=1s -count=20 ./libbeat/publisher/queue/slabqueue/`):

```
goos: linux
goarch: amd64
pkg: github.com/elastic/beats/v7/libbeat/publisher/queue/slabqueue
cpu: Intel(R) Core(TM) Ultra 7 265U
                              │   orig-PR   │             this-branch             │
                              │   sec/op    │    sec/op     vs base               │
MemqueueShared/inputs=1-14      1.489m ± 2%   1.468m ±  2%       ~ (p=0.221 n=20)
MemqueueShared/inputs=4-14      1.761m ± 1%   1.736m ±  1%  -1.41% (p=0.007 n=20)
MemqueueShared/inputs=8-14      1.787m ± 1%   1.812m ±  2%  +1.37% (p=0.030 n=20)
MemqueueShared/inputs=16-14     1.859m ± 2%   1.892m ±  1%       ~ (p=0.056 n=20)
SlabQueuePool/receivers=1-14    155.3µ ± 1%   149.0µ ±  1%  -4.04% (p=0.000 n=20)
SlabQueuePool/receivers=4-14    102.7µ ± 4%   108.1µ ±  3%  +5.31% (p=0.028 n=20)
SlabQueuePool/receivers=8-14    68.89µ ± 1%   69.87µ ±  2%       ~ (p=0.183 n=20)
SlabQueuePool/receivers=16-14   57.43µ ± 4%   59.33µ ± 11%  +3.30% (p=0.001 n=20)
ProducerThroughput-14           86.42µ ± 6%   82.55µ ±  2%  -4.47% (p=0.021 n=20)
geomean                         330.8µ        331.4µ        +0.16%

                              │   orig-PR    │             this-branch              │
                              │  allocs/op   │ allocs/op   vs base                 │
MemqueueShared/inputs=1-14      80.00 ± 0%     80.00 ± 0%       ~ (p=1.000 n=20)
MemqueueShared/inputs=4-14      80.00 ± 0%     80.00 ± 0%       ~ (p=1.000 n=20)
MemqueueShared/inputs=8-14      80.00 ± 0%     80.00 ± 0%       ~ (p=1.000 n=20)
MemqueueShared/inputs=16-14     80.00 ± 0%     80.00 ± 0%       ~ (p=1.000 n=20)
SlabQueuePool/receivers=1-14    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
SlabQueuePool/receivers=4-14    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
SlabQueuePool/receivers=8-14    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
SlabQueuePool/receivers=16-14   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)
ProducerThroughput-14           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20)

                      │   orig-PR   │            this-branch             │
                      │  events/s   │  events/s    vs base               │
ProducerThroughput-14   8.833M ± 2%   8.932M ± 1%  +1.12% (p=0.009 n=20)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

```bash
go test -race -count=1 ./libbeat/publisher/queue/slabqueue/...
go test -race -count=10 -run 'TestSharedIntakeQueueCapsPerReceiver|TestSharedPoolBudgetIsolatesPipelines' ./libbeat/publisher/pipeline/
```

## Related issues

- Relates #51164
