### PR TITLE
x-pack/filebeat/input/streaming: fix shutdown hang when server stalls

### DIFF
--- a/changelog/fragments/1781492627-fix-websocket-shutdown-read-hang.yaml
+++ b/changelog/fragments/1781492627-fix-websocket-shutdown-read-hang.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix WebSocket input hanging on shutdown when server stalls and keep_alive is disabled.
+component: filebeat

--- a/x-pack/filebeat/input/streaming/websocket.go
+++ b/x-pack/filebeat/input/streaming/websocket.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -50,6 +51,7 @@ type websocketStream struct {
 	tokenExpiry <-chan time.Time
 	time        func() time.Time
 	keepAlive   *keepAlive
+	conn        atomic.Pointer[websocket.Conn]
 }
 
 type loggingRoundTripper struct {
@@ -232,6 +234,7 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 		s.status.UpdateStatus(status.Failed, "failed to establish websocket connection: "+err.Error())
 		return err
 	}
+	s.conn.Store(c)
 	// Start the keep-alive routine if enabled and the connection is established successfully
 	// this is for the initial connection only, the keep-alive will be restarted during the reconnect
 	// logic/token refresh.
@@ -241,11 +244,25 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 
 	// ensures this is the last connection closed when the function returns
 	defer func() {
+		s.conn.Store(nil)
 		if c != nil {
 			if err := c.Close(); err != nil {
 				s.metrics.errorsTotal.Inc()
 				s.log.Errorw("encountered an error while closing the websocket connection", "error", err)
 			}
+		}
+	}()
+
+	// Force-close the connection when context is cancelled so that a
+	// blocked ReadMessage is unblocked. Without this, a stalled server
+	// with keep_alive disabled can prevent shutdown indefinitely.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.Close()
+		case <-stop:
 		}
 	}()
 
@@ -301,6 +318,7 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 				s.log.Errorw("failed to establish a new websocket connection on token refresh", "error", err)
 				return err
 			}
+			s.conn.Store(c)
 			// Restart the keep-alive routine on a token refresh if enabled and the
 			// connection is established successfully.
 			if s.keepAlive != nil {
@@ -314,6 +332,9 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 				// new connection via our reconnect logic.
 				if s.keepAlive != nil {
 					heartBeatCancel()
+				}
+				if err := ctx.Err(); err != nil {
+					return err
 				}
 				if !s.cfg.Retry.BlanketRetries && !isRetryableError(err) {
 					s.status.UpdateStatus(status.Failed, "failed to read websocket data: "+err.Error())
@@ -347,6 +368,7 @@ func (s *websocketStream) FollowStream(ctx context.Context) error {
 					s.log.Errorw("failed to reconnect websocket connection", "error", err)
 					return err
 				}
+				s.conn.Store(c)
 				// Restart the keep-alive routine if enabled after a successful reconnection.
 				if s.keepAlive != nil {
 					heartBeatCancel = s.keepAlive.heartBeat(ctx, c, s.now().In(time.UTC))
@@ -556,6 +578,10 @@ func (s *websocketStream) now() time.Time {
 }
 
 func (s *websocketStream) Close() error {
+	conn := s.conn.Swap(nil)
+	if conn != nil {
+		return conn.Close()
+	}
 	return nil
 }
 

--- a/x-pack/filebeat/input/streaming/websocket_test.go
+++ b/x-pack/filebeat/input/streaming/websocket_test.go
@@ -1,0 +1,105 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package streaming
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/testing/testutils"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestFollowStreamReturnsOnCancelWithStalledServer(t *testing.T) {
+	testutils.SkipIfFIPSOnly(t, "websocket uses SHA-1.")
+
+	// Server sends one message then goes silent. The client will
+	// successfully read and publish the first message, re-enter
+	// ReadMessage for the second read, and block. Cancelling at
+	// that point exercises the shutdown-while-blocked path.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{
+			CheckOrigin: func(*http.Request) bool { return true },
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Send one message so the client completes a full read cycle.
+		conn.WriteMessage(websocket.TextMessage, []byte(`{"ts":"2024-01-01T00:00:00Z","data":"hello"}`))
+		// Then go silent — hold the connection open until test cleanup.
+		<-r.Context().Done()
+		conn.Close()
+	}))
+	defer server.Close()
+
+	config := map[string]interface{}{
+		"url": "ws" + server.URL[4:] + "/stall",
+		"program": `
+			state.response.decode_json().as(body, {
+				"events": [body],
+			})`,
+	}
+	cfg := conf.MustNewConfigFrom(config)
+
+	c := defaultConfig()
+	c.Redact = &redact{}
+	if err := cfg.Unpack(&c); err != nil {
+		t.Fatalf("unexpected error unpacking config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	v2Ctx := v2.Context{
+		Logger:          logptest.NewTestingLogger(t, "websocket_shutdown_test"),
+		ID:              "test_id:stalled_shutdown",
+		Cancelation:     ctx,
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+
+	// Cancel after the first event is published. Publish sends on
+	// an unbuffered channel; by the time the test goroutine receives
+	// and calls cancel, the client has returned from processing and
+	// re-entered ReadMessage (a blocking syscall that yields the
+	// goroutine).
+	published := make(chan struct{})
+	var client publisher
+	client.done = func() {
+		select {
+		case published <- struct{}{}:
+		default:
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- input{}.run(v2Ctx, &source{c}, nil, &client)
+	}()
+
+	select {
+	case <-published:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first event publish")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil && err != context.Canceled { //nolint:errorlint // ctx.Err() is never wrapped
+			t.Errorf("input.run() error = %v; want nil or context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("input.run() did not return after context cancellation; ReadMessage is likely stuck")
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: fix shutdown hang when server stalls

The WebSocket input's FollowStream read loop can block indefinitely in
ReadMessage when the remote server stalls and keep_alive is disabled
(the default). Context cancellation is only checked between reads, so a
blocked read prevents shutdown.

Store the active connection in an atomic.Pointer and launch a goroutine
that closes it when the context is cancelled, unblocking ReadMessage.
Add a ctx.Err() check after read errors to exit immediately on
cancellation rather than attempting reconnect.

Fixed #51213

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #51213

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
