### PR TITLE
docs: fix typo families in docs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7893,7 +7893,7 @@ https://github.com/elastic/beats/compare/v7.2.0\...v7.3.0[View commits]
 
 *Filebeat*
 
-- `convert_timezone` option is removed and locale is always added to the event so timezone is used when parsing the timestamp, this behaviour can be overriden with processors. {pull}12410[12410]
+- `convert_timezone` option is removed and locale is always added to the event so timezone is used when parsing the timestamp, this behaviour can be overridden with processors. {pull}12410[12410]
 
 ==== Bugfixes
 

--- a/metricbeat/module/kafka/README.md
+++ b/metricbeat/module/kafka/README.md
@@ -79,7 +79,7 @@ Here is how the config should look like (in a MAC):
 
 #### Starting extra Producers/Consumers
 In order to create more stats for the Kafka Module, one could create more Producer/Consumer pairs (or combinations).
-For this we will reuse the scripts that are used withing the Docker container to bring up a Producer/Consumer pair for the testing.
+For this we will reuse the scripts that are used within the Docker container to bring up a Producer/Consumer pair for the testing.
 See the [source](https://github.com/elastic/beats/blob/87c49acb60b277a24c60c3956e9b4e23a644bce8/metricbeat/module/kafka/_meta/run.sh#L75).
 
 Here are the commands:

--- a/metricbeat/module/kubernetes/state_resourcequota/README.md
+++ b/metricbeat/module/kubernetes/state_resourcequota/README.md
@@ -41,7 +41,7 @@ https://github.com/elastic/beats/tree/master/metricbeat/module/kubernetes/_meta/
 It will create
 
 - named `rqtest` namespace, which will be assigned the resource quotas
-- named `resources` resource quota, which will limit the ammount of CPU and memory that can be assigned to the namespace. (This settings won't be put to test) 
+- named `resources` resource quota, which will limit the amount of CPU and memory that can be assigned to the namespace. (This settings won't be put to test)
 - `objects` resource quota, which will limit the quantity of objects that can be created at this namespace:
   - 3 Pods
   - 1 Configmap

--- a/x-pack/filebeat/input/azureeventhub/README.md
+++ b/x-pack/filebeat/input/azureeventhub/README.md
@@ -389,7 +389,7 @@ I see we have the following folder:
 filebeat-activitylogs-zmoog-0005 / mbranca-general.servicebus.windows.net / eventhubsdkupgrade / $Default / checkpoint
 ```
 
-The folder containts four blobs `0`, `1`, `2`, and `3`
+The folder contains four blobs `0`, `1`, `2`, and `3`
 
 The metadata of blobs `0`, `2`, and `3`:
 

--- a/x-pack/filebeat/module/aws/elb/README.md
+++ b/x-pack/filebeat/module/aws/elb/README.md
@@ -49,7 +49,7 @@ services.
 
 Configuration files can be found in `_meta/terraform`, and deployed with
 `terraform apply`. It will get credentials from your configuration, some
-settings can be overriden using Terraform variables (see `vars.tf` file).
+settings can be overridden using Terraform variables (see `vars.tf` file).
 
 Once deployed, information about the resources can be queried with `terraform
 output`, for example to query the different load balancers: 


### PR DESCRIPTION
## Summary

Fixes the text-auditor typos reported in #50235:

- `withing` -> `within`
- `containts` -> `contains`
- `ammount` -> `amount`
- `overriden` -> `overridden`

Closes #50235

## Verification

- `git diff --check`
- `rg -n 'withing|containts|ammount|overriden'` against the five touched files returns no matches
