### PR TITLE
docs: fix runtime text typos

### DIFF
--- a/metricbeat/module/linux/memory/_meta/fields.yml
+++ b/metricbeat/module/linux/memory/_meta/fields.yml
@@ -70,7 +70,7 @@
           type: long
           format: number
           description: >
-            Number of overcommited huge pages.
+            Number of overcommitted huge pages.
         - name: default_size
           type: long
           format: bytes

--- a/x-pack/filebeat/module/snyk/vulnerabilities/_meta/fields.yml
+++ b/x-pack/filebeat/module/snyk/vulnerabilities/_meta/fields.yml
@@ -39,7 +39,7 @@
     - name: is_upgradable
       type: boolean
       description: >
-        If the vulnerability fixable by upgrading a dependency.
+        If the vulnerability is fixable by upgrading a dependency.
     - name: language
       type: keyword
       description: >

--- a/x-pack/otel/extension/kafkapartitionerextension/partitioner_test.go
+++ b/x-pack/otel/extension/kafkapartitionerextension/partitioner_test.go
@@ -58,7 +58,7 @@ func TestUnmarshalLogs(t *testing.T) {
 			name:        "json array",
 			input:       `["a","b"]`,
 			expectError: true,
-			errorMsg:    "shoud be a map",
+			errorMsg:    "should be a map",
 		},
 		{
 			name:        "json string",

--- a/x-pack/otel/extension/kafkapartitionerextension/unmarshaler.go
+++ b/x-pack/otel/extension/kafkapartitionerextension/unmarshaler.go
@@ -26,5 +26,5 @@ func unmarshalLogs(message []byte) (mapstr.M, error) {
 	case mapstr.M:
 		return v, nil
 	}
-	return nil, fmt.Errorf("unmarshaled value shoud be a map, found %T", val)
+	return nil, fmt.Errorf("unmarshaled value should be a map, found %T", val)
 }


### PR DESCRIPTION
## Summary

Fixes the three user-facing text issues reported in #51107:

- `shoud` -> `should` in a runtime error message
- `overcommited` -> `overcommitted` in Linux memory field metadata
- adds the missing `is` in the Snyk vulnerability field description

Closes #51107

## Verification

- `gofmt -w x-pack/otel/extension/kafkapartitionerextension/unmarshaler.go`
- `git diff --check`
- `rg -n 'shoud|overcommited|vulnerability fixable'` against the three touched files returns no matches
