### PR TITLE
docs: fix Google Workspace typo

### DIFF
--- a/x-pack/filebeat/module/google_workspace/admin/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/admin/config/config.yml
@@ -16,7 +16,7 @@ request.proxy_url: {{ .proxy_url }}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start

--- a/x-pack/filebeat/module/google_workspace/drive/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/drive/config/config.yml
@@ -16,7 +16,7 @@ request.proxy_url: {{ .proxy_url }}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start

--- a/x-pack/filebeat/module/google_workspace/groups/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/groups/config/config.yml
@@ -16,7 +16,7 @@ request.proxy_url: {{ .proxy_url }}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start

--- a/x-pack/filebeat/module/google_workspace/login/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/login/config/config.yml
@@ -16,7 +16,7 @@ request.proxy_url: {{ .proxy_url }}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start

--- a/x-pack/filebeat/module/google_workspace/saml/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/saml/config/config.yml
@@ -16,7 +16,7 @@ request.proxy_url: {{ .proxy_url }}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start

--- a/x-pack/filebeat/module/google_workspace/user_accounts/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/user_accounts/config/config.yml
@@ -16,7 +16,7 @@ request.proxy_url: {{ .proxy_url }}
 request.transforms:
   - set:
       target: url.params.startTime
-      # If last pagination cycle was finished successully
+      # If last pagination cycle was finished successfully
       # we move the startDate pointer forward
       # else we reprocess the last interval from the beginning.
       # If none of the values are in the cursor it means is a fresh start


### PR DESCRIPTION
## Summary

Fixes the repeated `successully` typo in the Google Workspace module config comments.

Closes #50334

## Verification

- `git diff --check`
- `rg -n 'successully' x-pack/filebeat/module/google_workspace` returns no matches
