### PR TITLE
docs: fix CyberArk and PostgreSQL typos

### DIFF
--- a/filebeat/docs/modules/cyberarkpas.asciidoc
+++ b/filebeat/docs/modules/cyberarkpas.asciidoc
@@ -80,7 +80,7 @@ protocol connections from all interfaces:
     #  key: /path/to/privatekey.pem
     #  key_passphrase: 'password for my key'
 
-    # Uncoment to keep the original syslog event under event.original.
+    # Uncomment to keep the original syslog event under event.original.
     # var.preserve_original_event: true
 
     # Set paths for the log files when file input is used.
@@ -110,7 +110,7 @@ to configure encrypted protocol in the Vault server and use `tcp` input with `va
       key: /path/to/privatekey.pem
       key_passphrase: 'password for my key'
 
-    # Uncoment to keep the original syslog event under event.original.
+    # Uncomment to keep the original syslog event under event.original.
     # var.preserve_original_event: true
 
     # Set paths for the log files when file input is used.

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -39,8 +39,8 @@ formatted in a determined way.
 
 There are some settings to take into account for the log format.
 
-Log lines should be preffixed with the timestamp in milliseconds, the process
-id, the user id and the database name. This uses to be the default in most
+Log lines should be prefixed with the timestamp in milliseconds, the process
+id, the user id and the database name. This used to be the default in most
 distributions, and is translated to this setting in the configuration file:
 
 ["source","sh"]

--- a/filebeat/module/postgresql/_meta/docs.md
+++ b/filebeat/module/postgresql/_meta/docs.md
@@ -40,7 +40,7 @@ This module can collect any logs from PostgreSQL servers, but to be able to bett
 
 There are some settings to take into account for the log format.
 
-Log lines should be preffixed with the timestamp in milliseconds, the process id, the user id and the database name. This uses to be the default in most distributions, and is translated to this setting in the configuration file:
+Log lines should be prefixed with the timestamp in milliseconds, the process id, the user id and the database name. This used to be the default in most distributions, and is translated to this setting in the configuration file:
 
 ```sh
 log_line_prefix = '%m [%p] %q%u@%d '

--- a/x-pack/filebeat/module/cyberarkpas/_meta/config.yml
+++ b/x-pack/filebeat/module/cyberarkpas/_meta/config.yml
@@ -16,7 +16,7 @@
     #  key: /path/to/privatekey.pem
     #  key_passphrase: 'password for my key'
 
-    # Uncoment to keep the original syslog event under event.original.
+    # Uncomment to keep the original syslog event under event.original.
     # var.preserve_original_event: true
 
     # Set paths for the log files when file input is used.

--- a/x-pack/filebeat/module/cyberarkpas/_meta/docs.md
+++ b/x-pack/filebeat/module/cyberarkpas/_meta/docs.md
@@ -78,7 +78,7 @@ Edit the `cyberarkpas.yml` configuration. The following sample configuration wil
     #  key: /path/to/privatekey.pem
     #  key_passphrase: 'password for my key'
 
-    # Uncoment to keep the original syslog event under event.original.
+    # Uncomment to keep the original syslog event under event.original.
     # var.preserve_original_event: true
 
     # Set paths for the log files when file input is used.
@@ -105,7 +105,7 @@ For encrypted communications, follow the [CyberArk documentation](https://docs.c
       key: /path/to/privatekey.pem
       key_passphrase: 'password for my key'
 
-    # Uncoment to keep the original syslog event under event.original.
+    # Uncomment to keep the original syslog event under event.original.
     # var.preserve_original_event: true
 
     # Set paths for the log files when file input is used.

--- a/x-pack/filebeat/modules.d/cyberarkpas.yml.disabled
+++ b/x-pack/filebeat/modules.d/cyberarkpas.yml.disabled
@@ -19,7 +19,7 @@
     #  key: /path/to/privatekey.pem
     #  key_passphrase: 'password for my key'
 
-    # Uncoment to keep the original syslog event under event.original.
+    # Uncomment to keep the original syslog event under event.original.
     # var.preserve_original_event: true
 
     # Set paths for the log files when file input is used.


### PR DESCRIPTION
## Summary

Fixes the CyberArk PAS and PostgreSQL docs typos reported in #50953:

- `Uncoment` -> `Uncomment`
- `preffixed` -> `prefixed`
- `uses to be` -> `used to be`

Closes #50953

## Verification

- `git diff --check`
- `rg -n 'Uncoment|preffixed|uses to be'` against the touched files returns no matches
