### PR TITLE
docs: fix duplicated words

### DIFF
--- a/docs/extend/build-dashboards.md
+++ b/docs/extend/build-dashboards.md
@@ -29,7 +29,7 @@ You can set a custom name (skip suffix) for visualization placed on a dashboard.
 ::::
 
 
-The naming convention rules can be verified with the the tool `mage check`. The command fails if it detects:
+The naming convention rules can be verified with the tool `mage check`. The command fails if it detects:
 
 * empty description on a dashboard
 * unexpected dashboard title format (missing prefix `[BeatName ModuleName]`)

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -562,7 +562,7 @@ filebeat.inputs:
 
   # Match can be set to "after" or "before". It is used to define if lines should be appended to a pattern
   # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-  # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+  # Note: After is the equivalent to previous and before is the equivalent to next in Logstash
   #multiline.match: after
 
   # The maximum number of lines that are combined into one event.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -412,7 +412,7 @@ metricbeat.modules:
   #paths:
   #  - path: "/foo"
   #    namespace: "foo"
-  #    fields: # added to the the response in root. overwrites existing fields
+  #    fields: # added to the response in root. overwrites existing fields
   #      key: "value"
 
 #------------------------------- Jolokia Module -------------------------------

--- a/metricbeat/module/linux/conntrack/_meta/fields.yml
+++ b/metricbeat/module/linux/conntrack/_meta/fields.yml
@@ -32,7 +32,7 @@
         - name: insert_failed
           type: long
           description: >
-            Number of entries where list insert insert failed 
+            Number of entries where list insert failed
         - name: invalid
           type: long
           description: > 

--- a/metricbeat/module/system/process/_meta/fields.yml
+++ b/metricbeat/module/system/process/_meta/fields.yml
@@ -657,7 +657,7 @@
               type: long
               format: bytes
               description: >
-                Size of memory-mapped mapped files, including tmpfs (shmem),
+                Size of memory-mapped files, including tmpfs (shmem),
                 in bytes.
 
             - name: stats.page_faults

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2262,7 +2262,7 @@ filebeat.inputs:
 
   # Match can be set to "after" or "before". It is used to define if lines should be appended to a pattern
   # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-  # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+  # Note: After is the equivalent to previous and before is the equivalent to next in Logstash
   #multiline.match: after
 
   # The maximum number of lines that are combined into one event.

--- a/x-pack/filebeat/module/google_workspace/drive/_meta/fields.yml
+++ b/x-pack/filebeat/module/google_workspace/drive/_meta/fields.yml
@@ -35,7 +35,7 @@
     - name: shared_drive_id
       type: keyword
       description: >
-        The unique identifier of the Team Drive. Only populated for for events relating to a Team Drive or item contained inside a Team Drive.
+        The unique identifier of the Team Drive. Only populated for events relating to a Team Drive or item contained inside a Team Drive.
     - name: visibility
       type: keyword
       description: >

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -791,7 +791,7 @@ metricbeat.modules:
   #paths:
   #  - path: "/foo"
   #    namespace: "foo"
-  #    fields: # added to the the response in root. overwrites existing fields
+  #    fields: # added to the response in root. overwrites existing fields
   #      key: "value"
 
 #-------------------------------- IBM MQ Module --------------------------------


### PR DESCRIPTION
## Summary

Removes the duplicated words reported in #51009 across docs, reference config comments, and field descriptions.

Closes #51009

## Verification

- `git diff --check`
- `rg -n 'the the|to to|insert insert|mapped mapped|for for'` against the touched files returns no matches
