### PR TITLE
docs: fix CLI and runtime text typos

### DIFF
--- a/docs/reference/auditbeat/configuration-ssl.md
+++ b/docs/reference/auditbeat/configuration-ssl.md
@@ -509,7 +509,7 @@ This feature is NOT supported on Windows. The default value is `false`.
 
 
 ::::{note}
-This feature requres the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
+This feature requires the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
 ::::
 
 

--- a/docs/reference/filebeat/command-line-options.md
+++ b/docs/reference/filebeat/command-line-options.md
@@ -264,7 +264,7 @@ filebeat [FLAGS]
 
 
 **`--system.hostfs MOUNT_POINT`**
-:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is depricated, and an alternate hostfs should be specified via the `hostfs` module config value.
+:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is deprecated, and an alternate hostfs should be specified via the `hostfs` module config value.
 
 Also see [Global flags](#global-flags).
 

--- a/docs/reference/filebeat/configuration-ssl.md
+++ b/docs/reference/filebeat/configuration-ssl.md
@@ -509,7 +509,7 @@ This feature is NOT supported on Windows. The default value is `false`.
 
 
 ::::{note}
-This feature requres the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
+This feature requires the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
 ::::
 
 

--- a/docs/reference/heartbeat/command-line-options.md
+++ b/docs/reference/heartbeat/command-line-options.md
@@ -191,7 +191,7 @@ heartbeat [FLAGS]
 :   Writes memory profile data to the specified output file. This option is useful for troubleshooting Heartbeat.
 
 **`--system.hostfs MOUNT_POINT`**
-:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is depricated, and an alternate hostfs should be specified via the `hostfs` module config value.
+:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is deprecated, and an alternate hostfs should be specified via the `hostfs` module config value.
 
 Also see [Global flags](#global-flags).
 

--- a/docs/reference/heartbeat/configuration-ssl.md
+++ b/docs/reference/heartbeat/configuration-ssl.md
@@ -522,7 +522,7 @@ This feature is NOT supported on Windows. The default value is `false`.
 
 
 ::::{note}
-This feature requres the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
+This feature requires the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
 ::::
 
 

--- a/docs/reference/metricbeat/command-line-options.md
+++ b/docs/reference/metricbeat/command-line-options.md
@@ -248,7 +248,7 @@ metricbeat [FLAGS]
 :   Writes memory profile data to the specified output file. This option is useful for troubleshooting Metricbeat.
 
 **`--system.hostfs MOUNT_POINT`**
-:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is depricated, and an alternate hostfs should be specified via the `hostfs` module config value.
+:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is deprecated, and an alternate hostfs should be specified via the `hostfs` module config value.
 
 Also see [Global flags](#global-flags).
 

--- a/docs/reference/metricbeat/configuration-ssl.md
+++ b/docs/reference/metricbeat/configuration-ssl.md
@@ -524,7 +524,7 @@ This feature is NOT supported on Windows. The default value is `false`.
 
 
 ::::{note}
-This feature requres the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
+This feature requires the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
 ::::
 
 

--- a/docs/reference/metricbeat/exported-fields-kubernetes.md
+++ b/docs/reference/metricbeat/exported-fields-kubernetes.md
@@ -69,7 +69,7 @@ Kubernetes API server metrics
 
 
 **`kubernetes.apiserver.request.dry_run`**
-:   Wether the request uses dry run
+:   Whether the request uses dry run
 
     type: keyword
 

--- a/docs/reference/packetbeat/command-line-options.md
+++ b/docs/reference/packetbeat/command-line-options.md
@@ -229,7 +229,7 @@ packetbeat [FLAGS]
 :   Writes memory profile data to the specified output file. This option is useful for troubleshooting Packetbeat.
 
 **`--system.hostfs MOUNT_POINT`**
-:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is depricated, and an alternate hostfs should be specified via the `hostfs` module config value.
+:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is deprecated, and an alternate hostfs should be specified via the `hostfs` module config value.
 
 **`-t`**
 :   Reads packets from the pcap file as fast as possible without sleeping. Use this option in combination with the `-I` option. The `-t` option is useful only for testing Packetbeat.

--- a/docs/reference/packetbeat/configuration-ssl.md
+++ b/docs/reference/packetbeat/configuration-ssl.md
@@ -509,7 +509,7 @@ This feature is NOT supported on Windows. The default value is `false`.
 
 
 ::::{note}
-This feature requres the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
+This feature requires the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
 ::::
 
 

--- a/docs/reference/winlogbeat/command-line-options.md
+++ b/docs/reference/winlogbeat/command-line-options.md
@@ -205,7 +205,7 @@ winlogbeat [FLAGS]
 :   Writes memory profile data to the specified output file. This option is useful for troubleshooting Winlogbeat.
 
 **`--system.hostfs MOUNT_POINT`**
-:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is depricated, and an alternate hostfs should be specified via the `hostfs` module config value.
+:   Specifies the mount point of the host’s filesystem for use in monitoring a host. This flag is deprecated, and an alternate hostfs should be specified via the `hostfs` module config value.
 
 Also see [Global flags](#global-flags).
 

--- a/docs/reference/winlogbeat/configuration-ssl.md
+++ b/docs/reference/winlogbeat/configuration-ssl.md
@@ -509,7 +509,7 @@ This feature is NOT supported on Windows. The default value is `false`.
 
 
 ::::{note}
-This feature requres the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
+This feature requires the `execve` system call to be enabled. If you have a custom seccomp policy in place, make sure to allow for `execve`.
 ::::
 
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -124,7 +124,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 
 	if b.API != nil {
 		if err = inputmon.AttachHandler(b.API.Router(), b.Monitoring.InputsRegistry()); err != nil {
-			return nil, fmt.Errorf("failed attach inputs api to monitoring endpoint server: %w", err)
+			return nil, fmt.Errorf("failed to attach input API to monitoring endpoint server: %w", err)
 		}
 	}
 

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -176,7 +176,7 @@ func newMetricbeat(b *beat.Beat, c *conf.C, registry *mb.Register, options ...Op
 
 	if b.API != nil {
 		if err := inputmon.AttachHandler(b.API.Router(), b.Monitoring.InputsRegistry()); err != nil {
-			return nil, fmt.Errorf("failed attach inputs api to monitoring endpoint server: %w", err)
+			return nil, fmt.Errorf("failed to attach input API to monitoring endpoint server: %w", err)
 		}
 	}
 	return metricbeat, nil

--- a/metricbeat/module/kubernetes/apiserver/_meta/fields.yml
+++ b/metricbeat/module/kubernetes/apiserver/_meta/fields.yml
@@ -39,7 +39,7 @@
     - name: request.dry_run
       type: keyword
       description: >
-        Wether the request uses dry run
+        Whether the request uses dry run
     - name: request.kind
       type: keyword
       description: >

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -150,7 +150,7 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 	if b.API != nil {
 		err := inputmon.AttachHandler(b.API.Router(), (b.Monitoring.InputsRegistry()))
 		if err != nil {
-			return fmt.Errorf("failed attach inputs api to monitoring endpoint server: %w", err)
+			return fmt.Errorf("failed to attach input API to monitoring endpoint server: %w", err)
 		}
 	}
 

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -162,7 +162,7 @@ func (eb *Winlogbeat) Run(b *beat.Beat) error {
 	if b.API != nil {
 		err := inputmon.AttachHandler(b.API.Router(), b.Monitoring.InputsRegistry())
 		if err != nil {
-			return fmt.Errorf("failed attach inputs api to monitoring endpoint server: %w", err)
+			return fmt.Errorf("failed to attach input API to monitoring endpoint server: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the typo and grammar families reported in #50319:

- `depricated` -> `deprecated`
- `requres` -> `requires`
- `Wether` -> `Whether`
- `failed attach inputs api...` -> `failed to attach input API...`

Closes #50319

## Verification

- `gofmt -w filebeat/beater/filebeat.go metricbeat/beater/metricbeat.go packetbeat/beater/packetbeat.go winlogbeat/beater/winlogbeat.go`
- `git diff --check`
- `rg -n 'depricated|requres|Wether|failed attach inputs api to monitoring endpoint server' .` returns no matches
