### PR TITLE
docs: fix runtime and field text

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -524,7 +524,7 @@ func (s *store) Release() {
 
 func (s *store) close() {
 	if err := s.persistentStore.Close(); err != nil {
-		s.log.Errorf("Closing registry store did report an error: %+v", err)
+		s.log.Errorf("Closing registry store reported an error: %+v", err)
 	}
 }
 

--- a/filebeat/input/v2/input-cursor/store.go
+++ b/filebeat/input/v2/input-cursor/store.go
@@ -160,7 +160,7 @@ func (s *store) Release() {
 
 func (s *store) close() {
 	if err := s.persistentStore.Close(); err != nil {
-		s.log.Errorf("Closing registry store did report an error: %+v", err)
+		s.log.Errorf("Closing registry store reported an error: %+v", err)
 	}
 }
 

--- a/x-pack/filebeat/module/cisco/asa/_meta/fields.yml
+++ b/x-pack/filebeat/module/cisco/asa/_meta/fields.yml
@@ -129,12 +129,12 @@
   - name: privilege.old
     type: keyword
     description: >
-      When a users privilege is changed this is the old value
+      When a user's privilege is changed this is the old value
 
   - name: privilege.new
     type: keyword
     description: >
-      When a users privilege is changed this is the new value
+      When a user's privilege is changed this is the new value
 
   - name: burst.object
     type: keyword

--- a/x-pack/filebeat/module/zoom/webhook/_meta/fields.yml
+++ b/x-pack/filebeat/module/zoom/webhook/_meta/fields.yml
@@ -607,7 +607,7 @@
     - name: participant.sharing_details.source
       type: keyword
       description: >
-        The file source that was share
+        The file source that was shared
     - name: old_values
       type: flattened
       description: >

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -679,7 +679,7 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*agentUnit) {
 			inputUnits = append(inputUnits, unit)
 			healthyInputs[unit.ID()] = unit
 		} else {
-			cm.logger.Errorf("unit %s as an unknown type %+v", unit.ID(), unit.Type())
+			cm.logger.Errorf("unit %s has an unknown type %+v", unit.ID(), unit.Type())
 		}
 	}
 


### PR DESCRIPTION
Closes #51068.

## Summary
- fix the remaining runtime log and field-description text issues from #51068 that are not covered by #51074
- update registry close log wording, the unknown unit type log message, Zoom webhook field text, and Cisco ASA privilege descriptions

## Verification
- `gofmt -w filebeat/input/filestream/internal/input-logfile/store.go filebeat/input/v2/input-cursor/store.go x-pack/libbeat/management/managerV2.go`
- `git diff --check`
- `rg -n "unit %s as an unknown type|Closing registry store did report an error|The file source that was share$|When a users privilege" ...` returned no matches in the touched files

Note: #51074 already covers the docs/README entries from #51068, so this PR leaves those files untouched.