### PR TITLE
docs: fix field and module text

### DIFF
--- a/auditbeat/module/auditd/_meta/docs.md
+++ b/auditbeat/module/auditd/_meta/docs.md
@@ -146,7 +146,7 @@ This module also supports the [standard configuration options](#module-standard-
 :   A string containing the audit rules that should be installed to the kernel. There should be one rule per line. Comments can be embedded in the string using `#` as a prefix. The format for rules is the same used by the Linux `auditctl` utility. Auditbeat supports adding file watches (`-w`) and syscall rules (`-a` or `-A`). For more information, see [Audit rules](#audit-rules).
 
 **`audit_rule_files`**
-:   A list of files to load audit rules from. This files are loaded after the rules declared in `audit_rules` are loaded. Wildcards are supported and will expand in lexicographical order. The format is the same as that of the `audit_rules` field.
+:   A list of files to load audit rules from. These files are loaded after the rules declared in `audit_rules` are loaded. Wildcards are supported and will expand in lexicographical order. The format is the same as that of the `audit_rules` field.
 
 **`ignore_errors`**
 :   This setting allows errors during rule loading and parsing to be ignored, but logged as warnings.

--- a/docs/extend/creating-metricbeat-module.md
+++ b/docs/extend/creating-metricbeat-module.md
@@ -98,7 +98,7 @@ To test a Metricbeat module manually, follow the steps below.
 
 First we have to build the Docker image which is available for the modules. The Dockerfile is located inside a `_meta` folder within each module folder. As an example let’s take MySQL module.
 
-This steps assume you have checked out the Beats repository from Github and are inside `beats` directory. First, we have to enter in the `_meta` folder mentioned above and build the Docker image called `metricbeat-mysql`:
+These steps assume you have checked out the Beats repository from Github and are inside `beats` directory. First, we have to enter in the `_meta` folder mentioned above and build the Docker image called `metricbeat-mysql`:
 
 ```bash
 $ cd metricbeat/module/mysql/_meta/

--- a/metricbeat/module/etcd/leader/_meta/docs.md
+++ b/metricbeat/module/etcd/leader/_meta/docs.md
@@ -1,1 +1,1 @@
-This is the leader metricset of the module etcd. This metrics is being read from the Etcd V2 endpoint and won’t show any activity regarding Etcd V3.
+This is the leader metricset of the module etcd. These metrics are being read from the Etcd V2 endpoint and won’t show any activity regarding Etcd V3.

--- a/metricbeat/module/etcd/metrics/_meta/docs.md
+++ b/metricbeat/module/etcd/metrics/_meta/docs.md
@@ -3,4 +3,4 @@ This functionality is in beta and is subject to change. The design and code is l
 ::::
 
 
-This is the metrics endpoint metricset of the etcd module. This metrics is being read from the Etcd V3 endpoint and won’t show any activity regarding Etcd V2.
+This is the metrics endpoint metricset of the etcd module. These metrics are being read from the Etcd V3 endpoint and won’t show any activity regarding Etcd V2.

--- a/metricbeat/module/etcd/self/_meta/docs.md
+++ b/metricbeat/module/etcd/self/_meta/docs.md
@@ -1,1 +1,1 @@
-This is the self metricset of the module etcd. This metrics is being read from the Etcd V2 endpoint and won’t show any activity regarding Etcd V3.
+This is the self metricset of the module etcd. These metrics are being read from the Etcd V2 endpoint and won’t show any activity regarding Etcd V3.

--- a/metricbeat/module/etcd/store/_meta/docs.md
+++ b/metricbeat/module/etcd/store/_meta/docs.md
@@ -1,1 +1,1 @@
-This is the store metricset of the module etcd. This metrics is being read from the Etcd V2 endpoint and won’t show any activity regarding Etcd V3.
+This is the store metricset of the module etcd. These metrics are being read from the Etcd V2 endpoint and won’t show any activity regarding Etcd V3.

--- a/metricbeat/module/memcached/stats/_meta/fields.yml
+++ b/metricbeat/module/memcached/stats/_meta/fields.yml
@@ -28,7 +28,7 @@
     - name: connections.total
       type: long
       description: >
-        Numer of successful connect attempts to this server since it has been started.
+        Number of successful connect attempts to this server since it has been started.
 
     - name: get.hits
       type: long

--- a/packetbeat/protos/pgsql/_meta/fields.yml
+++ b/packetbeat/protos/pgsql/_meta/fields.yml
@@ -22,11 +22,11 @@
 
         - name: num_fields
           description: >
-            If the SELECT query if successful, this field is set to the number
+            If the SELECT query is successful, this field is set to the number
             of fields returned.
 
         - name: num_rows
           description: >
-            If the SELECT query if successful, this field is set to the number
+            If the SELECT query is successful, this field is set to the number
             of rows returned.
 

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -108,7 +108,7 @@ func createContainer(ctx context.Context, cli *client.Client, arch string) error
 
 	buildContext, err := os.Open(tarPath)
 	if err != nil {
-		return fmt.Errorf("error opening temp dur: %w", err)
+		return fmt.Errorf("error opening temp dir: %w", err)
 	}
 	defer buildContext.Close()
 


### PR DESCRIPTION
Closes #51166.

## Summary
- fix clear user-facing typo and grammar issues in field/module docs and one Mage error message
- correct `Numer`, duplicated `if`, singular/plural agreement issues, and `temp dur`

## Verification
- `gofmt -w x-pack/dockerlogbeat/magefile.go`
- `git diff --check`
- `rg -n "Numer of successful connect attempts|If the SELECT query if successful|This steps|This files|This metrics|error opening temp dur" ...` returned no matches in the touched files