### PR TITLE
docs: fix error message grammar

### DIFF
--- a/dev-tools/cmd/module_include_list/module_include_list.go
+++ b/dev-tools/cmd/module_include_list/module_include_list.go
@@ -234,7 +234,7 @@ func findModuleAndDatasets() ([]string, error) {
 			filepath.Join(moduleDir, "*/*/_meta"),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed finding modules and datasets: %w", err)
+			return nil, fmt.Errorf("failed to find modules and datasets: %w", err)
 		}
 
 		for _, metaDir := range metaDirs {

--- a/x-pack/osquerybeat/internal/osqd/osqueryd.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd.go
@@ -366,7 +366,7 @@ func prepareAutoloadFile(extensionAutoloadPath, mandatoryExtensionPath string, l
 
 	if rewrite {
 		if err := os.WriteFile(extensionAutoloadPath, []byte(mandatoryExtensionPath), 0600); err != nil {
-			return fmt.Errorf("failed write osquery extension autoload file, %w", err)
+			return fmt.Errorf("failed to write osquery extension autoload file: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #51185.

## Summary
- fix two user-facing runtime/CLI error messages with clearer grammar
- update `failed write ...` and `failed finding ...` phrasing

## Verification
- `gofmt -w dev-tools/cmd/module_include_list/module_include_list.go x-pack/osquerybeat/internal/osqd/osqueryd.go`
- `git diff --check`
- `rg -n "failed write osquery extension autoload file|failed finding modules and datasets" x-pack/osquerybeat/internal/osqd/osqueryd.go dev-tools/cmd/module_include_list/module_include_list.go` returned no matches