### PR TITLE
docs: fix Kibana default port

### DIFF
--- a/docs/reference/auditbeat/command-line-options.md
+++ b/docs/reference/auditbeat/command-line-options.md
@@ -63,7 +63,7 @@ $$$dashboard-subcommand$$$**`dashboard`**
 
     To load the dashboard, copy the generated `dashboard.json` file into the `kibana/6/dashboard` directory of Auditbeat, and run `auditbeat setup --dashboards` to import the dashboard.
 
-    If {{kib}} is not running on `localhost:5061`, you must also adjust the Auditbeat configuration under `setup.kibana`.
+    If {{kib}} is not running on `localhost:5601`, you must also adjust the Auditbeat configuration under `setup.kibana`.
 
 
 $$$template-subcommand$$$**`template`**

--- a/docs/reference/filebeat/command-line-options.md
+++ b/docs/reference/filebeat/command-line-options.md
@@ -64,7 +64,7 @@ $$$dashboard-subcommand$$$**`dashboard`**
 
     To load the dashboard, copy the generated `dashboard.json` file into the `kibana/6/dashboard` directory of Filebeat, and run `filebeat setup --dashboards` to import the dashboard.
 
-    If {{kib}} is not running on `localhost:5061`, you must also adjust the Filebeat configuration under `setup.kibana`.
+    If {{kib}} is not running on `localhost:5601`, you must also adjust the Filebeat configuration under `setup.kibana`.
 
 
 $$$template-subcommand$$$**`template`**

--- a/docs/reference/metricbeat/command-line-options.md
+++ b/docs/reference/metricbeat/command-line-options.md
@@ -64,7 +64,7 @@ $$$dashboard-subcommand$$$**`dashboard`**
 
     To load the dashboard, copy the generated `dashboard.json` file into the `kibana/6/dashboard` directory of Metricbeat, and run `metricbeat setup --dashboards` to import the dashboard.
 
-    If {{kib}} is not running on `localhost:5061`, you must also adjust the Metricbeat configuration under `setup.kibana`.
+    If {{kib}} is not running on `localhost:5601`, you must also adjust the Metricbeat configuration under `setup.kibana`.
 
 
 $$$template-subcommand$$$**`template`**

--- a/docs/reference/packetbeat/command-line-options.md
+++ b/docs/reference/packetbeat/command-line-options.md
@@ -63,7 +63,7 @@ $$$dashboard-subcommand$$$**`dashboard`**
 
     To load the dashboard, copy the generated `dashboard.json` file into the `kibana/6/dashboard` directory of Packetbeat, and run `packetbeat setup --dashboards` to import the dashboard.
 
-    If {{kib}} is not running on `localhost:5061`, you must also adjust the Packetbeat configuration under `setup.kibana`.
+    If {{kib}} is not running on `localhost:5601`, you must also adjust the Packetbeat configuration under `setup.kibana`.
 
 
 $$$template-subcommand$$$**`template`**

--- a/docs/reference/winlogbeat/command-line-options.md
+++ b/docs/reference/winlogbeat/command-line-options.md
@@ -54,7 +54,7 @@ $$$dashboard-subcommand$$$**`dashboard`**
 
     To load the dashboard, copy the generated `dashboard.json` file into the `kibana/6/dashboard` directory of Winlogbeat, and run `winlogbeat setup --dashboards` to import the dashboard.
 
-    If {{kib}} is not running on `localhost:5061`, you must also adjust the Winlogbeat configuration under `setup.kibana`.
+    If {{kib}} is not running on `localhost:5601`, you must also adjust the Winlogbeat configuration under `setup.kibana`.
 
 
 $$$template-subcommand$$$**`template`**


### PR DESCRIPTION
Closes #51123.

## Summary
- update the Kibana default port in Beat command-line dashboard docs from `localhost:5061` to `localhost:5601`
- apply the correction across Auditbeat, Filebeat, Metricbeat, Packetbeat, and Winlogbeat reference docs

## Verification
- `git diff --check`
- `rg -n "localhost:5061" docs/reference/*beat/command-line-options.md` returned no matches
- `rg -n "localhost:5601" docs/reference/*beat/command-line-options.md` confirmed the five updated entries