### PR TITLE
docs: fix runtime text errors

### DIFF
--- a/libbeat/cmd/export/index_pattern.go
+++ b/libbeat/cmd/export/index_pattern.go
@@ -31,7 +31,7 @@ import (
 func GenIndexPatternConfigCmd(settings instance.Settings) *cobra.Command {
 	genTemplateConfigCmd := &cobra.Command{
 		Use:   "index-pattern",
-		Short: "Export kibana index pattern to stdout",
+		Short: "Export Kibana index pattern to stdout",
 		Run: func(cmd *cobra.Command, args []string) {
 			version, _ := cmd.Flags().GetString("es.version")
 

--- a/libbeat/statestore/error.go
+++ b/libbeat/statestore/error.go
@@ -57,7 +57,7 @@ func (e *ErrorClosed) Operation() string { return e.operation }
 
 // Error creates a descriptive error string.
 func (e *ErrorClosed) Error() string {
-	return fmt.Sprintf("can not executed %v operation on closed store '%v'", e.operation, e.name)
+	return fmt.Sprintf("cannot execute %v operation on closed store '%v'", e.operation, e.name)
 }
 
 // ErrorOperation is returned when a generic store operation failed.

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -307,7 +307,7 @@ func (m *MetricSet) fetch(ctx context.Context, db dbClient, reporter mb.Reporter
 			for _, ms := range mss {
 				if m.Config.MergeResults {
 					if len(mss) > 1 {
-						return ok, fmt.Errorf("cannot merge query resulting with more than one rows: %s", q)
+						return ok, fmt.Errorf("cannot merge query resulting in more than one row: %s", q)
 					} else {
 						for k, v := range ms {
 							_, ok := merged[k]

--- a/x-pack/metricbeat/module/sql/query/query_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_test.go
@@ -369,7 +369,7 @@ func TestFetch_MergeResultsRejectsMultipleRowsPerQuery(t *testing.T) {
 		{Query: "SELECT id FROM t", ResponseFormat: tableResponseFormat},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot merge query resulting with more than one rows")
+	assert.Contains(t, err.Error(), "cannot merge query resulting in more than one row")
 }
 
 func TestFetch_TableAndVariableErrorsAreWrapped(t *testing.T) {


### PR DESCRIPTION
Closes #49916.

## Summary
- fix three user-facing runtime/CLI text issues
- correct the closed-store error string, SQL merge error string, and Kibana CLI help capitalization

## Verification
- `gofmt -w libbeat/statestore/error.go x-pack/metricbeat/module/sql/query/query.go libbeat/cmd/export/index_pattern.go`
- `git diff --check`
- `rg -n "can not executed|cannot merge query resulting with more than one rows|Export kibana index pattern" ...` returned no matches in the touched files