### PR TITLE
docs: fix Kubernetes and threatintel text

### DIFF
--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -632,9 +632,9 @@ metricbeat.modules:
   metricsets:
     - event
   period: 10s
-  # Skip events older than Metricbeat's statup time is enabled by default.
+  # Skipping events older than Metricbeat's startup time is enabled by default.
   # Setting to false the skip_older setting will stop filtering older events.
-  # This setting is also useful went Event's timestamps are not populated properly.
+  # This setting is also useful when events' timestamps are not populated properly.
   #skip_older: false
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster

--- a/metricbeat/module/kubernetes/_meta/config.reference.yml
+++ b/metricbeat/module/kubernetes/_meta/config.reference.yml
@@ -110,9 +110,9 @@
   metricsets:
     - event
   period: 10s
-  # Skip events older than Metricbeat's statup time is enabled by default.
+  # Skipping events older than Metricbeat's startup time is enabled by default.
   # Setting to false the skip_older setting will stop filtering older events.
-  # This setting is also useful went Event's timestamps are not populated properly.
+  # This setting is also useful when events' timestamps are not populated properly.
   #skip_older: false
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -72,9 +72,9 @@
 #  metricsets:
 #    - event
 #  period: 10s
-#  # Skip events older than Metricbeat's statup time is enabled by default.
+#  # Skipping events older than Metricbeat's startup time is enabled by default.
 #  # Setting to false the skip_older setting will stop filtering older events.
-#  # This setting is also useful went Event's timestamps are not populated properly.
+#  # This setting is also useful when events' timestamps are not populated properly.
 #  skip_older: false
 #  # If kube_config is not set, KUBECONFIG environment variable will be checked
 #  # and if not present it will fall back to InCluster

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -75,9 +75,9 @@
 #  metricsets:
 #    - event
 #  period: 10s
-#  # Skip events older than Metricbeat's statup time is enabled by default.
+#  # Skipping events older than Metricbeat's startup time is enabled by default.
 #  # Setting to false the skip_older setting will stop filtering older events.
-#  # This setting is also useful went Event's timestamps are not populated properly.
+#  # This setting is also useful when events' timestamps are not populated properly.
 #  skip_older: false
 #  # If kube_config is not set, KUBECONFIG environment variable will be checked
 #  # and if not present it will fall back to InCluster

--- a/x-pack/filebeat/module/threatintel/abusemalware/_meta/fields.yml
+++ b/x-pack/filebeat/module/threatintel/abusemalware/_meta/fields.yml
@@ -11,7 +11,7 @@
   - name: signature
     type: keyword
     description: >
-      Malware familiy.
+      Malware family.
 
   - name: urlhaus_download
     type: keyword

--- a/x-pack/filebeat/module/threatintel/malwarebazaar/_meta/fields.yml
+++ b/x-pack/filebeat/module/threatintel/malwarebazaar/_meta/fields.yml
@@ -10,7 +10,7 @@
   - name: signature
     type: keyword
     description: >
-      Malware familiy.
+      Malware family.
   - name: tags
     type: keyword
     description: >

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1083,9 +1083,9 @@ metricbeat.modules:
   metricsets:
     - event
   period: 10s
-  # Skip events older than Metricbeat's statup time is enabled by default.
+  # Skipping events older than Metricbeat's startup time is enabled by default.
   # Setting to false the skip_older setting will stop filtering older events.
-  # This setting is also useful went Event's timestamps are not populated properly.
+  # This setting is also useful when events' timestamps are not populated properly.
   #skip_older: false
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster


### PR DESCRIPTION
Closes #50972.

## Summary
- fix Kubernetes event config comments for `startup`, `when`, and events' timestamp possessive wording
- fix `Malware familiy` field descriptions in two threatintel modules

## Verification
- `git diff --check`
- `rg -n "statup|went Event's timestamps|Malware familiy" ...` returned no matches in the touched files