### PR TITLE
docs: fix CLI log and field text

### DIFF
--- a/auditbeat/cmd/root.go
+++ b/auditbeat/cmd/root.go
@@ -48,7 +48,7 @@ var RootCmd *cmd.BeatsRootCmd
 // ShowCmd to display extra information.
 var ShowCmd = &cobra.Command{
 	Use:   "show",
-	Short: "Show modules information",
+	Short: "Show module information",
 }
 
 // withECSVersion is a modifier that adds ecs.version to events.

--- a/libbeat/idxmgmt/index_support.go
+++ b/libbeat/idxmgmt/index_support.go
@@ -251,7 +251,7 @@ func (m *indexManager) Setup(loadTemplate, loadILM LoadMode) error {
 		return err
 	}
 	if withILM {
-		log.Info("Auto lifecycle enable success.")
+		log.Info("Auto lifecycle enabled successfully.")
 	}
 
 	// create feature objects for ILM and template setup

--- a/x-pack/filebeat/processors/decode_cef/_meta/fields.yml
+++ b/x-pack/filebeat/processors/decode_cef/_meta/fields.yml
@@ -740,7 +740,7 @@
 
             - name: categoryOutcome
               type: keyword
-              description: Outcome of the event (e.g. sucess, failure, or attempt).
+              description: Outcome of the event (e.g. success, failure, or attempt).
 
             - name: managerReceiptTime
               type: date


### PR DESCRIPTION
Closes #50439.

## Summary
- fix the CEF outcome field description typo
- update Auditbeat `show` command help grammar
- improve the auto lifecycle success log message

## Verification
- `gofmt -w auditbeat/cmd/root.go libbeat/idxmgmt/index_support.go`
- `git diff --check`
- `rg -n "sucess|Show modules information|Auto lifecycle enable success" ...` returned no matches in the touched files