### PR TITLE
docs: fix occurred and colon-separated typos

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -939,7 +939,7 @@ include::CHANGELOG.asciidoc[tags=known-issue-8.19-filestream-clean-inactive-1]
 *Filebeat*
 
 - Fix endpoint path typo in the Okta entity analytics provider. {pull}44147[44147]
-- Fix a WebSocket panic scenario that occured after exhausting the maximum number of retries. {pull}44342[44342]
+- Fix a WebSocket panic scenario that occurred after exhausting the maximum number of retries. {pull}44342[44342]
 
 *Osquerybeat*
 
@@ -1237,7 +1237,7 @@ include::CHANGELOG.asciidoc[tags=known-issue-8.19-filestream-clean-inactive-1]
 
 *Filebeat*
 
-- Fix a WebSocket panic scenario that occured after exhausting the maximum number of retries. {pull}44342[44342]
+- Fix a WebSocket panic scenario that occurred after exhausting the maximum number of retries. {pull}44342[44342]
 
 ==== Added
 

--- a/docs/reference/filebeat/exported-fields-cef.md
+++ b/docs/reference/filebeat/exported-fields-cef.md
@@ -221,7 +221,7 @@ Collection of key-value pairs carried in the CEF extension field.
 
 
 **`cef.extensions.destinationMacAddress`**
-:   Six colon-seperated hexadecimal numbers.
+:   Six colon-separated hexadecimal numbers.
 
     type: keyword
 

--- a/docs/reference/metricbeat/exported-fields-oracle.md
+++ b/docs/reference/metricbeat/exported-fields-oracle.md
@@ -128,7 +128,7 @@ Opened cursors statistic
 
 ## parse [_parse]
 
-Parses statistic information that occured in the current session
+Parses statistic information that occurred in the current session
 
 **`oracle.performance.cursors.parse.real`**
 :   Real number of parses that occurred: session cursor cache hits - parse count (total)

--- a/docs/release-notes/_snippets/9.0.2/index.md
+++ b/docs/release-notes/_snippets/9.0.2/index.md
@@ -33,7 +33,7 @@
 **Filebeat**
 
 - Fix endpoint path typo in the Okta entity analytics provider. [44147]({{beats-pull}}44147)
-- Fix a WebSocket panic scenario that occured after exhausting the maximum number of retries. [44342]({{beats-pull}}44342)
+- Fix a WebSocket panic scenario that occurred after exhausting the maximum number of retries. [44342]({{beats-pull}}44342)
 
 **Metricbeat**
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -3935,7 +3935,7 @@ type: keyword
 *`cef.extensions.destinationMacAddress`*::
 +
 --
-Six colon-seperated hexadecimal numbers.
+Six colon-separated hexadecimal numbers.
 
 type: keyword
 

--- a/x-pack/filebeat/processors/decode_cef/_meta/fields.yml
+++ b/x-pack/filebeat/processors/decode_cef/_meta/fields.yml
@@ -159,7 +159,7 @@
 
             - name: destinationMacAddress
               type: keyword
-              description: Six colon-seperated hexadecimal numbers.
+              description: Six colon-separated hexadecimal numbers.
 
             - name: destinationNtDomain
               type: keyword

--- a/x-pack/metricbeat/module/oracle/performance/_meta/fields.yml
+++ b/x-pack/metricbeat/module/oracle/performance/_meta/fields.yml
@@ -66,7 +66,7 @@
               description: Total number of cursors opened since the instance started
         - name: parse
           type: group
-          description: Parses statistic information that occured in the current session
+          description: Parses statistic information that occurred in the current session
           fields:
             - name: real
               type: long


### PR DESCRIPTION
Closes #49847.

## Summary
- fix `occured` -> `occurred` in Oracle field docs, release notes, and changelog entries
- fix `colon-seperated` -> `colon-separated` in CEF field docs

## Verification
- `git diff --check`
- `rg -n "occured|colon-seperated" ...` returned no matches in the touched files