### PR TITLE
docs: fix field description text

### DIFF
--- a/libbeat/autodiscover/providers/jolokia/_meta/fields.yml
+++ b/libbeat/autodiscover/providers/jolokia/_meta/fields.yml
@@ -12,7 +12,7 @@
       default_field: true
       type: keyword
       description: >
-        Each agent has a unique id which can be either provided during startup of the agent in form of a configuration parameter or being autodetected. If autodected, the id has several parts: The IP, the process id, hashcode of the agent and its type.
+        Each agent has a unique id which can be either provided during startup of the agent in form of a configuration parameter or being autodetected. If autodetected, the ID has several parts: The IP, the process id, hashcode of the agent and its type.
     - name: jolokia.server.product
       default_field: true
       type: keyword

--- a/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/fields.yml
@@ -1,7 +1,7 @@
 - name: node.stats
   type: group
   description: >
-    Statistics about each node in a Elasticsearch cluster
+    Statistics about each node in an Elasticsearch cluster
   release: ga
   fields:
     - name: ingest

--- a/packetbeat/protos/cassandra/_meta/fields.yml
+++ b/packetbeat/protos/cassandra/_meta/fields.yml
@@ -247,7 +247,7 @@
 
             - name: error
               type: group
-              description: Indicates an error processing a request. The body of the message will be an  error code followed by a error message. Then, depending on the exception, more content may follow.
+              description: Indicates an error processing a request. The body of the message will be an error code followed by an error message. Then, depending on the exception, more content may follow.
               fields:
                 - name: code
                   type: long
@@ -316,5 +316,4 @@
                     - name: arg_types
                       type: keyword
                       description:  One string for each argument type (as CQL type) of the failed function.
-
 

--- a/x-pack/filebeat/module/checkpoint/firewall/_meta/fields.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/_meta/fields.yml
@@ -864,7 +864,7 @@
       type: integer
       overwrite: true
       description: >
-        Number of files that were not  scanned due to an error.
+        Number of files that were not scanned due to an error.
 
     - name: next_scheduled_scan_date
       type: keyword

--- a/x-pack/filebeat/module/zoom/webhook/_meta/fields.yml
+++ b/x-pack/filebeat/module/zoom/webhook/_meta/fields.yml
@@ -611,8 +611,8 @@
     - name: old_values
       type: flattened
       description: >
-        Includes the old values when updating a object like user, meeting, account or webinar
+        Includes the old values when updating an object like user, meeting, account or webinar
     - name: settings
       type: flattened
       description: >
-        The current active settings related to a object like user, meeting, account or webinar
+        The current active settings related to an object like user, meeting, account or webinar

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/_meta/fields.yml
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/_meta/fields.yml
@@ -23,7 +23,7 @@
         - name: type
           type: keyword
           example: application
-          description: Whether this is an application or network loadbalancer
+          description: Whether this is an application or network load balancer
         - name: protocol
           type: keyword
           example: HTTP
@@ -67,5 +67,4 @@
           type: number
           example: 8080
           description: Port number for this listener
-
 

--- a/x-pack/metricbeat/module/gcp/dataproc/_meta/fields.yml
+++ b/x-pack/metricbeat/module/gcp/dataproc/_meta/fields.yml
@@ -65,7 +65,7 @@
     - name: cluster.operation.completion_time.value
       type: object
       object_type: histogram
-      description: The time operations took to complete from the time the user submits a operation to the time Dataproc reports it is completed.
+      description: The time operations took to complete from the time the user submits an operation to the time Dataproc reports it is completed.
     - name: cluster.operation.duration.value
       type: object
       object_type: histogram

--- a/x-pack/metricbeat/module/iis/website/_meta/fields.yml
+++ b/x-pack/metricbeat/module/iis/website/_meta/fields.yml
@@ -60,7 +60,7 @@
         - name: total_bytes_sent
           type: float
           description: >
-            The  total number of bytes sent.
+            The total number of bytes sent.
         - name: total_connection_attempts
           type: float
           description: >

--- a/x-pack/metricbeat/module/istio/mixer/_meta/fields.yml
+++ b/x-pack/metricbeat/module/istio/mixer/_meta/fields.yml
@@ -91,7 +91,7 @@
     - name: handler.name
       type: keyword
       description: >
-        The name of the daemon  handler
+        The name of the daemon handler
     - name: variety
       type: keyword
       description: >


### PR DESCRIPTION
Closes #50396.

## Summary
- fix article grammar issues, double-space typos, and spelling/terminology issues in field descriptions
- keep the ELB ARN `loadbalancer` example unchanged while updating the prose term to `load balancer`

## Verification
- `git diff --check`
- `rg -n "a error message|a operation|a object|a Elasticsearch cluster|an  error code|daemon  handler|not  scanned|The  total|autodected|network loadbalancer" ...` returned no matches in the touched files
- confirmed the ELB ARN example still contains `loadbalancer`