### PR TITLE
docs: fix duplicate words and CLI text

### DIFF
--- a/docs/reference/filebeat/filebeat-input-container.md
+++ b/docs/reference/filebeat/filebeat-input-container.md
@@ -12,7 +12,7 @@ applies_to:
 ::::{warning}
 The container input is just a preset for the [`log`](/reference/filebeat/filebeat-input-log.md) input. The `log` input is deprecated in version 7.16 and disabled in version 9.0.
 
-Please use the the [`filestream`](/reference/filebeat/filebeat-input-filestream.md) input with its [`container`](/reference/filebeat/filebeat-input-filestream.md#filebeat-input-filestream-parsers-container) parser instead. Follow [our official guide](/reference/filebeat/migrate-to-filestream.md) to migrate existing `log`/`container` inputs to `filestream` inputs.
+Please use the [`filestream`](/reference/filebeat/filebeat-input-filestream.md) input with its [`container`](/reference/filebeat/filebeat-input-filestream.md#filebeat-input-filestream-parsers-container) parser instead. Follow [our official guide](/reference/filebeat/migrate-to-filestream.md) to migrate existing `log`/`container` inputs to `filestream` inputs.
 
 After deprecation it’s possible to use this input type (e.g. for migration to `filestream`) only in combination with the `allow_deprecated_use: true` setting as a part of the input configuration.
 

--- a/docs/reference/filebeat/filebeat-input-http_endpoint.md
+++ b/docs/reference/filebeat/filebeat-input-http_endpoint.md
@@ -10,7 +10,7 @@ applies_to:
 # HTTP Endpoint input [filebeat-input-http_endpoint]
 
 
-The HTTP Endpoint input initializes a listening HTTP server that collects incoming HTTP POST requests containing a JSON body. The body must be either an object or an array of objects, otherwise a Common Expression Language expression that converts the the JSON body to these types can be provided. Any other data types will result in an HTTP 400 (Bad Request) response. For arrays, one document is created for each object in the array.
+The HTTP Endpoint input initializes a listening HTTP server that collects incoming HTTP POST requests containing a JSON body. The body must be either an object or an array of objects, otherwise a Common Expression Language expression that converts the JSON body to these types can be provided. Any other data types will result in an HTTP 400 (Bad Request) response. For arrays, one document is created for each object in the array.
 
 gzip encoded request bodies are supported if a `Content-Encoding: gzip` header is sent with the request.
 
@@ -541,5 +541,4 @@ Example value: `"%{[agent.name]}-myindex-%{+yyyy.MM.dd}"` might expand to `"file
 #### `publisher_pipeline.disable_host` [_publisher_pipeline_disable_host_12]
 
 By default, all events contain `host.name`. This option can be set to `true` to disable the addition of this field to all events. The default value is `false`.
-
 

--- a/docs/reference/filebeat/filebeat-input-log.md
+++ b/docs/reference/filebeat/filebeat-input-log.md
@@ -12,7 +12,7 @@ applies_to:
 ::::{warning}
 The `log` input is deprecated in version 7.16 and disabled in version 9.0.
 
-Please use the the [`filestream`](/reference/filebeat/filebeat-input-filestream.md) input for sending log files to outputs. Follow [our official guide](/reference/filebeat/migrate-to-filestream.md) to migrate existing `log` inputs to `filestream` inputs.
+Please use the [`filestream`](/reference/filebeat/filebeat-input-filestream.md) input for sending log files to outputs. Follow [our official guide](/reference/filebeat/migrate-to-filestream.md) to migrate existing `log` inputs to `filestream` inputs.
 
 After deprecation it’s possible to use this input type (e.g. for migration to `filestream`) only in combination with the `allow_deprecated_use: true` setting as a part of the input configuration.
 ::::

--- a/libbeat/cmd/export/ilm_policy.go
+++ b/libbeat/cmd/export/ilm_policy.go
@@ -47,7 +47,7 @@ func GenGetILMPolicyCmd(settings instance.Settings) *cobra.Command {
 			// is connected to. Might not be a problem since a user who doesn't have any custom lifecycle config has nothing to export?
 			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Config.LifecycleConfig)
 			if err != nil {
-				fatalf("error creating file handler: %s", err)
+				fatalf("Error creating file handler: %s", err)
 			}
 			idxManager := b.IdxSupporter.Manager(clientHandler, idxmgmt.BeatsAssets(b.Fields))
 			if err := idxManager.Setup(idxmgmt.LoadModeDisabled, idxmgmt.LoadModeForce); err != nil {

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -49,7 +49,7 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 
 			clientHandler, err := idxmgmt.NewFileClientHandler(newIdxmgmtClient(dir, version), b.Info, b.Config.LifecycleConfig)
 			if err != nil {
-				fatalf("error creating file handler: %s", err)
+				fatalf("Error creating file handler: %s", err)
 			}
 			idxManager := b.IdxSupporter.Manager(clientHandler, idxmgmt.BeatsAssets(b.Fields))
 			if err := idxManager.Setup(idxmgmt.LoadModeForce, idxmgmt.LoadModeDisabled); err != nil {


### PR DESCRIPTION
Closes #49267.

## Summary
- remove duplicated `the` in Filebeat input docs
- remove duplicated `the` from the HTTP endpoint input description
- capitalize two export command fatal error messages for consistency

## Verification
- `gofmt -w libbeat/cmd/export/template.go libbeat/cmd/export/ilm_policy.go`
- `git diff --check`
- `rg -n "the the|error creating file handler" ...` returned no matches in the touched files

Note: the other #49267 items (`of of`, `by the moment`) are already fixed on current main and no longer reproduce.