### PR TITLE
docs: fix validation error text

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -147,7 +147,7 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, optionalXpa
 		// Type cast the metricsets to a slice of strings
 		cfgdMetricsetsSlice, ok := cfgdMetricsets.([]interface{})
 		if !ok {
-			return nil, fmt.Errorf("configured metricsets are not an slice for module %s: %v", moduleName, cfgdMetricsets)
+			return nil, fmt.Errorf("configured metricsets are not a slice for module %s: %v", moduleName, cfgdMetricsets)
 		}
 
 		cfgdMetricsetsStrings := make([]string, 0, len(cfgdMetricsetsSlice))

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -121,7 +121,7 @@ func (c *config) Validate() error {
 	}
 
 	if c.QueueURL != "" && c.APITimeout < c.SQSWaitTime {
-		return fmt.Errorf("api_timeout <%v> must be greater than the sqs.wait_time <%v",
+		return fmt.Errorf("api_timeout <%v> must be greater than the sqs.wait_time <%v>",
 			c.APITimeout, c.SQSWaitTime)
 	}
 

--- a/x-pack/filebeat/input/cel/config_auth.go
+++ b/x-pack/filebeat/input/cel/config_auth.go
@@ -381,7 +381,7 @@ var findDefaultGoogleCredentials = google.FindDefaultCredentials
 func (o *oAuth2Config) validateGoogleProvider() error {
 	if o.TokenURL != "" || o.ClientID != "" || o.ClientSecret != nil ||
 		o.AzureTenantID != "" || o.AzureResource != "" || len(o.EndpointParams) != 0 {
-		return errors.New("none of token_url and client credentials can be used, use google.credentials_file, google.jwt_file, google.credentials_json or ADC instead")
+		return errors.New("token_url and client credentials cannot be used with the Google provider; use google.credentials_file, google.jwt_file, google.credentials_json, or ADC instead")
 	}
 
 	// credentials_json

--- a/x-pack/filebeat/input/cel/config_test.go
+++ b/x-pack/filebeat/input/cel/config_test.go
@@ -565,7 +565,7 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name:    "google_can't_have_token_url_or_client_credentials_set",
-		wantErr: errors.New("none of token_url and client credentials can be used, use google.credentials_file, google.jwt_file, google.credentials_json or ADC instead accessing 'auth.oauth2'"),
+		wantErr: errors.New("token_url and client credentials cannot be used with the Google provider; use google.credentials_file, google.jwt_file, google.credentials_json, or ADC instead accessing 'auth.oauth2'"),
 		input: map[string]interface{}{
 			"auth.oauth2": map[string]interface{}{
 				"provider": "google",

--- a/x-pack/filebeat/input/httpjson/config_auth.go
+++ b/x-pack/filebeat/input/httpjson/config_auth.go
@@ -328,7 +328,7 @@ var findDefaultGoogleCredentials = google.FindDefaultCredentialsWithParams
 func (o *oAuth2Config) validateGoogleProvider() error {
 	if o.TokenURL != "" || o.ClientID != "" || o.ClientSecret != nil ||
 		o.AzureTenantID != "" || o.AzureResource != "" || len(o.EndpointParams) != 0 {
-		return errors.New("none of token_url and client credentials can be used, use google.credentials_file, google.jwt_file, google.credentials_json or ADC instead")
+		return errors.New("token_url and client credentials cannot be used with the Google provider; use google.credentials_file, google.jwt_file, google.credentials_json, or ADC instead")
 	}
 
 	// credentials_json

--- a/x-pack/filebeat/input/httpjson/config_test.go
+++ b/x-pack/filebeat/input/httpjson/config_test.go
@@ -401,7 +401,7 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name:        "google can't have token_url or client credentials set",
-			expectedErr: "none of token_url and client credentials can be used, use google.credentials_file, google.jwt_file, google.credentials_json or ADC instead accessing 'auth.oauth2'",
+			expectedErr: "token_url and client credentials cannot be used with the Google provider; use google.credentials_file, google.jwt_file, google.credentials_json, or ADC instead accessing 'auth.oauth2'",
 			input: map[string]interface{}{
 				"auth.oauth2": map[string]interface{}{
 					"provider": "google",


### PR DESCRIPTION
Closes #49572.

## Summary
- fix the missing closing bracket in the S3 `api_timeout` validation error
- fix `an slice` grammar in the Metricbeat helper error
- clarify the Google OAuth validation error in both httpjson and cel inputs
- update matching httpjson/cel test expectations

## Verification
- `gofmt -w x-pack/filebeat/input/awss3/config.go metricbeat/helper/elastic/elastic.go x-pack/filebeat/input/httpjson/config_auth.go x-pack/filebeat/input/httpjson/config_test.go x-pack/filebeat/input/cel/config_auth.go x-pack/filebeat/input/cel/config_test.go`
- `git diff --check`
- `rg -n "api_timeout <.*sqs.wait_time <%v\"|not an slice|none of token_url and client credentials" ...` returned no matches in the touched files

## Test note
- `go test ./x-pack/filebeat/input/httpjson ./x-pack/filebeat/input/cel ./x-pack/filebeat/input/awss3 ./metricbeat/helper/elastic` could not run in the sparse checkout because required internal packages such as `libbeat/common`, `x-pack/libbeat/common/aws`, and `metricbeat/mb` were not present.