### PR TITLE
x-pack/libbeat/management: fix nil-pointer panic in reload with no output unit

### DIFF
--- a/changelog/fragments/1781341838-fix-managerv2-nil-output-unit-panic.yaml
+++ b/changelog/fragments/1781341838-fix-managerv2-nil-output-unit-panic.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix panic in the Elastic Agent V2 manager when reloading with no output unit.
+component: beats

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -706,15 +706,19 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*agentUnit) {
 		cm.logger.Errorw("could not start output", "error", err)
 
 		msg := fmt.Sprintf("could not start output: %s", err)
-		if err := outputUnit.UpdateState(status.Failed, msg, nil); err != nil {
-			cm.logger.Errorw("setting output state", "error", err)
+		if outputUnit != nil {
+			if err := outputUnit.UpdateState(status.Failed, msg, nil); err != nil {
+				cm.logger.Errorw("setting output state", "error", err)
+			}
 		}
 
 		return
 	}
 
-	if err := outputUnit.UpdateState(status.Running, "Healthy", nil); err != nil {
-		cm.logger.Errorw("setting output state", "error", err)
+	if outputUnit != nil {
+		if err := outputUnit.UpdateState(status.Running, "Healthy", nil); err != nil {
+			cm.logger.Errorw("setting output state", "error", err)
+		}
 	}
 
 	// reload APM tracing configuration

--- a/x-pack/libbeat/management/managerV2_test.go
+++ b/x-pack/libbeat/management/managerV2_test.go
@@ -810,6 +810,32 @@ func TestErrorPerUnit(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond, "desired state, was not reached")
 }
 
+// TestReloadNilOutputUnit verifies reload does not panic when no output unit is present.
+func TestReloadNilOutputUnit(t *testing.T) {
+	r := reload.NewRegistry()
+	output := &mockOutput{
+		ReloadFn: func(config *reload.ConfigWithMeta) error {
+			return nil
+		},
+	}
+	r.MustRegisterOutput(output)
+
+	m, err := NewV2AgentManagerWithClient(
+		&Config{Enabled: false},
+		r,
+		nil,
+		logptest.NewTestingLogger(t, ""),
+	)
+	require.NoError(t, err, "could not instantiate ManagerV2")
+
+	mm, ok := m.(*BeatV2Manager)
+	require.True(t, ok, "unexpected type for BeatV2Manager: %T", m)
+
+	require.NotPanics(t, func() {
+		mm.reload(map[unitKey]*agentUnit{})
+	}, "reload must not panic when there is no output unit")
+}
+
 type reloadable struct {
 	mx          sync.Mutex
 	config      *reload.ConfigWithMeta


### PR DESCRIPTION
## Proposed commit message

`reload` called `outputUnit.UpdateState` without a nil check, but `outputUnit` is nil when there is no active output unit (only inputs, the output is being stopped, or the units map is empty). Guard both calls, mirroring `reloadAPM`.

This is reachable from normal Elastic Agent behaviour: when a policy revision breaks the output config, the agent keeps inputs `HEALTHY` but sends the output unit as `STOPPED` in the same checkin, so the Beat reaches `outputUnit.UpdateState` with a nil unit and crashes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added an entry in `./changelog/fragments` using the changelog tool.
