### PR TITLE
docs: fix remaining doc typos

### DIFF
--- a/docs/reference/filebeat/configuration-autodiscover.md
+++ b/docs/reference/filebeat/configuration-autodiscover.md
@@ -226,7 +226,7 @@ The `kubernetes` autodiscover provider has the following configuration settings:
 :   (Optional) Specify at what level autodiscover needs to be done at. `scope` can either take `node` or `cluster` as values. `node` scope allows discovery of resources in the specified node. `cluster` scope allows cluster wide discovery. Only `pod` and `node` resources can be discovered at node scope.
 
 `add_resource_metadata`
-:   (Optional) Specify filters and configration for the extra metadata, that will be added to the event. Configuration parameters:
+:   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
     * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name isn’t added, this can be enabled by setting `deployment: true`.

--- a/docs/reference/filebeat/filebeat-reference-yml.md
+++ b/docs/reference/filebeat/filebeat-reference-yml.md
@@ -684,7 +684,7 @@ filebeat.inputs:
   # To fetch all ".log" files from a specific level of subdirectories
   # /var/log/*/*.log can be used.
   # For each file found under this path, a harvester is started.
-  # Make sure not file is defined twice as this can lead to unexpected behaviour.
+  # Make sure no file is defined twice as this can lead to unexpected behaviour.
   paths:
     - /var/log/*.log
     #- c:\programdata\elasticsearch\logs\*
@@ -3064,4 +3064,3 @@ logging.files:
 #  fqdn:
 #    enabled: true
 ```
-

--- a/docs/reference/heartbeat/configuration-autodiscover.md
+++ b/docs/reference/heartbeat/configuration-autodiscover.md
@@ -127,7 +127,7 @@ The `kubernetes` autodiscover provider has the following configuration settings:
 :   (Optional) Specify at what level autodiscover needs to be done at. `scope` can either take `node` or `cluster` as values. `node` scope allows discovery of resources in the specified node. `cluster` scope allows cluster wide discovery. Only `pod` and `node` resources can be discovered at node scope.
 
 `add_resource_metadata`
-:   (Optional) Specify filters and configration for the extra metadata, that will be added to the event. Configuration parameters:
+:   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
     * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name isn’t added, this can be enabled by setting `deployment: true`.
@@ -578,6 +578,5 @@ aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@exam
 Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify the aws.yml config file with the new credentials. Unless [live reloading](/reference/metricbeat/_live_reloading.md) feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
 
 IAM policy is an entity that defines permissions to an object within your AWS environment. Specific permissions needs to be added into the IAM user’s policy to authorize Metricbeat to collect AWS monitoring metrics. Please see documentation under each metricset for required permissions.
-
 
 

--- a/docs/reference/metricbeat/configuration-autodiscover.md
+++ b/docs/reference/metricbeat/configuration-autodiscover.md
@@ -147,7 +147,7 @@ The `kubernetes` autodiscover provider has the following configuration settings:
 :   (Optional) Specify at what level autodiscover needs to be done at. `scope` can either take `node` or `cluster` as values. `node` scope allows discovery of resources in the specified node. `cluster` scope allows cluster wide discovery. Only `pod` and `node` resources can be discovered at node scope.
 
 `add_resource_metadata`
-:   (Optional) Specify filters and configration for the extra metadata, that will be added to the event. Configuration parameters:
+:   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
     * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name isn’t added, this can be enabled by setting `deployment: true`.

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -1727,7 +1727,7 @@ type: object
 *`dhcpv4.option.subnet_mask`*::
 +
 --
-The subnet mask that the client should use on the currnet
+The subnet mask that the client should use on the current
 network.
 
 


### PR DESCRIPTION
Closes #49496.

## Summary
- fix the remaining `configration` autodiscover docs typos on current main
- fix `not file` in Filebeat reference docs
- fix `currnet` in Packetbeat DHCPv4 field docs

## Verification
- `git diff --check`
- `rg -n "configration|not file|currnet" ...` returned no matches in the touched files

Note: the other #49496 typo families (`realtive`, `endponts`, `formated`, `recomended`) are already fixed on current main and no longer reproduce.