### PR TITLE
Enhance ETW-backed file events documentation

### DIFF
--- a/auditbeat/module/file_integrity/_meta/docs.md
+++ b/auditbeat/module/file_integrity/_meta/docs.md
@@ -17,10 +17,10 @@ The operating system features that power this feature are as follows.
   * `ReadDirectoryChangesW` is used.
   * {applies_to}`stack: preview 9.2.0` Multiple backends are supported: `auto`, `fsnotify`, `etw`. By default, `fsnotify` is used, which utilizes the `ReadDirectoryChangesW` Windows API. The `etw` backend uses Event Tracing for Windows (ETW) to monitor file system activities at the kernel level, supporting enhanced process context information. It requires Administrator privileges.
 
-    :::{note}
+    :::{admonition} ETW backend behavior
     Process and user information attached to ETW-backed file events can vary depending on the underlying ETW event type.
 
-    Create or open operations may provide richer execution context, allowing Auditbeat to attach additional process metadata and user/security information. Update operations, such as file content writes or attribute changes, may use a lighter-weight event payload that only includes basic identifiers such as the process ID (PID).
+    Create and open operations typically include richer execution context, so Auditbeat can attach additional process metadata and user and security information. Update operations, such as file content writes or attribute changes, often use a smaller event payload that only includes basic identifiers like the process ID (PID).
     :::
 
 The file integrity module should not be used to monitor paths on network file systems.

--- a/auditbeat/module/file_integrity/_meta/docs.md
+++ b/auditbeat/module/file_integrity/_meta/docs.md
@@ -19,7 +19,7 @@ The operating system features that power this feature are as follows.
 
     :::{note}
     Process and user information attached to ETW-backed file events can vary depending on the underlying ETW event type.
-  
+
     Create or open operations may provide richer execution context, allowing Auditbeat to attach additional process metadata and user/security information. Update operations, such as file content writes or attribute changes, may use a lighter-weight event payload that only includes basic identifiers such as the process ID (PID).
     :::
 

--- a/auditbeat/module/file_integrity/_meta/docs.md
+++ b/auditbeat/module/file_integrity/_meta/docs.md
@@ -17,8 +17,13 @@ The operating system features that power this feature are as follows.
   * `ReadDirectoryChangesW` is used.
   * {applies_to}`stack: preview 9.2.0` Multiple backends are supported: `auto`, `fsnotify`, `etw`. By default, `fsnotify` is used, which utilizes the `ReadDirectoryChangesW` Windows API. The `etw` backend uses Event Tracing for Windows (ETW) to monitor file system activities at the kernel level, supporting enhanced process context information. It requires Administrator privileges.
 
-The file integrity module should not be used to monitor paths on network file systems.
+    :::{note}
+    Process and user information attached to ETW-backed file events can vary depending on the underlying ETW event type.
+  
+    Create or open operations may provide richer execution context, allowing Auditbeat to attach additional process metadata and user/security information. Update operations, such as file content writes or attribute changes, may use a lighter-weight event payload that only includes basic identifiers such as the process ID (PID).
+    :::
 
+The file integrity module should not be used to monitor paths on network file systems.
 
 ## Configuration options [_configuration_options_18]
 

--- a/docs/reference/auditbeat/auditbeat-module-file_integrity.md
+++ b/docs/reference/auditbeat/auditbeat-module-file_integrity.md
@@ -29,10 +29,10 @@ The operating system features that power this feature are as follows.
   * `ReadDirectoryChangesW` is used.
   * {applies_to}`stack: preview 9.2.0` Multiple backends are supported: `auto`, `fsnotify`, `etw`. By default, `fsnotify` is used, which utilizes the `ReadDirectoryChangesW` Windows API. The `etw` backend uses Event Tracing for Windows (ETW) to monitor file system activities at the kernel level, supporting enhanced process context information. It requires Administrator privileges.
 
-    :::{note}
+    :::{admonition} ETW backend behavior
     Process and user information attached to ETW-backed file events can vary depending on the underlying ETW event type.
 
-    Create or open operations may provide richer execution context, allowing Auditbeat to attach additional process metadata and user/security information. Update operations, such as file content writes or attribute changes, may use a lighter-weight event payload that only includes basic identifiers such as the process ID (PID).
+    Create and open operations typically include richer execution context, so Auditbeat can attach additional process metadata and user and security information. Update operations, such as file content writes or attribute changes, often use a smaller event payload that only includes basic identifiers like the process ID (PID).
     :::
 
 The file integrity module should not be used to monitor paths on network file systems.

--- a/docs/reference/auditbeat/auditbeat-module-file_integrity.md
+++ b/docs/reference/auditbeat/auditbeat-module-file_integrity.md
@@ -31,7 +31,7 @@ The operating system features that power this feature are as follows.
 
     :::{note}
     Process and user information attached to ETW-backed file events can vary depending on the underlying ETW event type.
-  
+
     Create or open operations may provide richer execution context, allowing Auditbeat to attach additional process metadata and user/security information. Update operations, such as file content writes or attribute changes, may use a lighter-weight event payload that only includes basic identifiers such as the process ID (PID).
     :::
 

--- a/docs/reference/auditbeat/auditbeat-module-file_integrity.md
+++ b/docs/reference/auditbeat/auditbeat-module-file_integrity.md
@@ -29,8 +29,13 @@ The operating system features that power this feature are as follows.
   * `ReadDirectoryChangesW` is used.
   * {applies_to}`stack: preview 9.2.0` Multiple backends are supported: `auto`, `fsnotify`, `etw`. By default, `fsnotify` is used, which utilizes the `ReadDirectoryChangesW` Windows API. The `etw` backend uses Event Tracing for Windows (ETW) to monitor file system activities at the kernel level, supporting enhanced process context information. It requires Administrator privileges.
 
-The file integrity module should not be used to monitor paths on network file systems.
+    :::{note}
+    Process and user information attached to ETW-backed file events can vary depending on the underlying ETW event type.
+  
+    Create or open operations may provide richer execution context, allowing Auditbeat to attach additional process metadata and user/security information. Update operations, such as file content writes or attribute changes, may use a lighter-weight event payload that only includes basic identifiers such as the process ID (PID).
+    :::
 
+The file integrity module should not be used to monitor paths on network file systems.
 
 ## Configuration options [_configuration_options_18]
 


### PR DESCRIPTION
Added note about process and user information variability for ETW-backed file events in documentation.

The content of the note comes from a discussion with Dev team in this https://github.com/elastic/sdh-beats/issues/7260
