### PR TITLE
docs: fix Filebeat build path

### DIFF
--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -59,7 +59,7 @@ make mage
 Then you can compile a particular Beat by using Mage. For example, for Filebeat:
 
 ```shell
-cd beats/filebeat
+cd filebeat
 mage build
 ```
 
@@ -193,6 +193,5 @@ The following packages are required to run `go generate`:
 ## Changelog [changelog]
 
 To keep up to date with changes to the official Beats for community developers, follow the developer changelog [here](https://github.com/elastic/beats/blob/main/CHANGELOG-developer.next.asciidoc).
-
 
 


### PR DESCRIPTION
Closes #49810.

## Summary
- Update the Filebeat Mage build example to `cd filebeat`, which exists from the repository root.

## Verification
- `git diff --check`
- `rg -n 'cd beats/filebeat|cd filebeat' docs/extend/index.md` shows only `cd filebeat`