### PR TITLE
docs: align Go setup with go.mod

### DIFF
--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -24,7 +24,7 @@ In the pull request, describe what your changes do and mention any bugs/issues r
 
 ## Setting Up Your Dev Environment [setting-up-dev-environment]
 
-The Beats are Go programs, so install the 1.22.10 version of [Go](http://golang.org/) which is being used for Beats development.
+The Beats are Go programs, so install the [Go](http://golang.org/) version declared in `go.mod`, which is used for Beats development.
 
 After [installing Go](https://golang.org/doc/install), set the [GOPATH](https://golang.org/doc/code.md#GOPATH) environment variable to point to your workspace location, and make sure `$GOPATH/bin` is in your PATH.
 
@@ -34,8 +34,9 @@ One deterministic manner to install the proper Go version to work with Beats is 
 
 
 ```shell
-gvm use 1.22.10
-eval $(gvm 1.22.10)
+GO_VERSION=$(curl -fsSL https://raw.githubusercontent.com/elastic/beats/main/go.mod | awk '/^go / {print $2}')
+gvm use "${GO_VERSION}"
+eval "$(gvm "${GO_VERSION}")"
 ```
 
 Then you can clone Beats git repository:
@@ -193,6 +194,4 @@ The following packages are required to run `go generate`:
 ## Changelog [changelog]
 
 To keep up to date with changes to the official Beats for community developers, follow the developer changelog [here](https://github.com/elastic/beats/blob/main/CHANGELOG-developer.next.asciidoc).
-
-
 


### PR DESCRIPTION
Closes #49067.

## Summary
- Replace the outdated hardcoded Go version in contributor setup docs with a reference to `go.mod`.
- Update the GVM example to derive the version from upstream `go.mod` instead of hardcoding `1.22.10`.

## Verification
- `git diff --check`
- `rg -n '1\\.22\\.10|GO_VERSION|raw.githubusercontent.com/elastic/beats/main/go.mod' docs/extend/index.md` confirms the old version is gone and the setup uses `go.mod`