### PR TITLE
filebeat: fix registry resource leak in filestream findCursorMeta

### DIFF
--- a/changelog/fragments/1781341755-fix-filestream-findcursormeta-leak.yaml
+++ b/changelog/fragments/1781341755-fix-filestream-findcursormeta-leak.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix filestream registry leak on file renames.
+component: filebeat

--- a/filebeat/input/filestream/internal/input-logfile/clean_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/clean_test.go
@@ -128,6 +128,33 @@ func TestGCStore(t *testing.T) {
 		checkEqualStoreState(t, want, backend.snapshot())
 	})
 
+	t.Run("old state is removed after findCursorMeta", func(t *testing.T) {
+		// findCursorMeta must release the reference acquired by states.Find,
+		// otherwise the resource is never gc'ed after its TTL expires.
+		const ttl = 60 * time.Second
+		started := time.Now().Add(-5 * ttl) // cleanup process is running for a while already
+
+		initState := map[string]state{
+			"test::key": {
+				TTL:     ttl,
+				Updated: started.Add(-ttl),
+				Meta:    testMeta{IdentifierName: "native"},
+			},
+		}
+
+		backend := createSampleStore(t, initState)
+		store := testOpenStore(t, "test", backend)
+		defer store.Release()
+
+		var meta testMeta
+		require.NoError(t, store.findCursorMeta("test::key", &meta))
+
+		// The expired resource must be removed by the gc.
+		gcStore(logptest.NewTestingLogger(t, ""), started, store)
+		want := map[string]state{}
+		checkEqualStoreState(t, want, backend.snapshot())
+	})
+
 	t.Run("old state but resource has pending updates", func(t *testing.T) {
 		const ttl = 60 * time.Second
 		started := time.Now().Add(-5 * ttl) // cleanup process is running for a while already

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -540,6 +540,7 @@ func (s *store) findCursorMeta(key string, to interface{}) error {
 	if resource == nil {
 		return fmt.Errorf("resource '%s' not found", key)
 	}
+	defer resource.Release()
 	return typeconv.Convert(to, resource.cursorMeta)
 }
 

--- a/filebeat/tests/integration/filestream_test.go
+++ b/filebeat/tests/integration/filestream_test.go
@@ -128,6 +128,123 @@ func TestFilestreamCleanInactive(t *testing.T) {
 	filebeat.WaitFileContains(registryFile, `"op":"remove"`, time.Second)
 }
 
+// filestreamCleanInactiveRenamedCfg is the config for
+// TestFilestreamCleanInactiveRenamed. clean_removed is disabled so that
+// clean_inactive is the only mechanism that can remove the registry entry,
+// which isolates the rename code path under test.
+var filestreamCleanInactiveRenamedCfg = `
+filebeat.inputs:
+  - type: filestream
+    id: "test-clean-inactive-renamed"
+    paths:
+      - %s
+
+    file_identity.native: ~
+    prospector.scanner.fingerprint.enabled: false
+    clean_inactive: 3.1s
+    ignore_older: 2s
+    clean_removed: false
+    close.on_state_change.inactive: 1s
+    prospector.scanner.check_interval: 1s
+
+filebeat.registry:
+  cleanup_interval: 5s
+  flush: 1s
+
+queue.mem:
+  events: 32
+  flush.min_events: 8
+  flush.timeout: 0.1s
+
+path.home: %s
+
+output.file:
+  path: ${path.home}
+  filename: "output-file"
+  rotate_every_kb: 10000
+
+logging:
+  level: debug
+  selectors:
+    - "input"
+    - "input.filestream"
+    - "input.filestream.file_watcher"
+    - "input.filestream.prospector"
+    - "input.filestream.scanner"
+  metrics:
+    enabled: false
+`
+
+// TestFilestreamCleanInactiveRenamed is a regression test for a registry
+// resource leak in store.findCursorMeta.
+//
+// When a file tracked by a file_identity that supports rename tracking (e.g.
+// native) is renamed, fileProspector.onRename calls FindCursorMeta to read the
+// previous metadata. FindCursorMeta acquires a reference on the in-memory
+// resource through states.Find. Before the fix that reference was never
+// released, so the resource stayed permanently active (pending > 0), the
+// registry GC could never collect it and the entry leaked forever, even after
+// clean_inactive expired.
+//
+// This test renames a harvested file, lets it become inactive and asserts the
+// registry entry is eventually garbage collected. Without the fix the entry is
+// never removed and the test times out.
+func TestFilestreamCleanInactiveRenamed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("renaming files while Filebeat is running is not supported on Windows")
+	}
+
+	filebeat := integration.NewBeat(
+		t,
+		"filebeat",
+		"../../filebeat.test",
+	)
+	tempDir := filebeat.TempDir()
+
+	// Harvest from a sub-folder so the configured glob keeps matching the file
+	// after it is renamed. path.home (registry + output) lives in tempDir, the
+	// glob only matches the logs sub-folder.
+	logsDir := filepath.Join(tempDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o700); err != nil {
+		t.Fatalf("cannot create logs directory: %s", err)
+	}
+	logFilePath := filepath.Join(logsDir, "log.log")
+	renamedLogFilePath := filepath.Join(logsDir, "log.log.renamed")
+
+	filebeat.WriteConfigFile(
+		fmt.Sprintf(filestreamCleanInactiveRenamedCfg, filepath.Join(logsDir, "*"), tempDir))
+	filebeat.Start()
+
+	integration.WriteLogFile(t, logFilePath, 10, false)
+	filebeat.WaitLogsContains(
+		fmt.Sprintf("A new file %s has been found", logFilePath),
+		10*time.Second,
+		"Filebeat did not start harvesting the log file")
+
+	// Renaming is what triggers fileProspector.onRename -> FindCursorMeta.
+	if err := os.Rename(logFilePath, renamedLogFilePath); err != nil {
+		t.Fatalf("cannot rename log file: %s", err)
+	}
+
+	// Guard: confirm the change was detected as a rename (not a removal),
+	// otherwise onRename/FindCursorMeta never ran and the test would silently
+	// stop exercising the leak.
+	filebeat.WaitLogsContains(
+		fmt.Sprintf("has been renamed to %s", renamedLogFilePath),
+		10*time.Second,
+		"Filebeat did not detect the rename")
+
+	// After clean_inactive expires the GC must collect the entry. With the leak
+	// the resource is never "finished", so this never happens.
+	filebeat.WaitLogsContains(
+		"1 entries removed",
+		30*time.Second,
+		"registry entry for the renamed file was not garbage collected")
+
+	registryFile := filepath.Join(tempDir, "data", "registry", "filebeat", "log.json")
+	filebeat.WaitFileContains(registryFile, `"op":"remove"`, time.Second)
+}
+
 func TestFilestreamValidationPreventsFilebeatStart(t *testing.T) {
 	duplicatedIDs := `
 filebeat.inputs:


### PR DESCRIPTION
## Proposed commit message

```
filebeat: fix registry resource leak in filestream findCursorMeta

findCursorMeta acquired a resource reference via states.Find but never released
it, so the resource stayed active (pending > 0) and the registry gc never reaped
the entry after its TTL. This leaked one reference per file rename
(prospector.onRename), growing the registry unbounded on hosts with frequent log
rotation. Add the missing defer resource.Release().

Covered by a store gc unit test and a binary-level integration test
(TestFilestreamCleanInactiveRenamed) that renames a harvested file to drive
onRename -> FindCursorMeta; both fail on main and pass with the fix.
```

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added an entry in `./changelog/fragments` using the changelog tool.

## How to test this change

### Automated

Both tests fail on `main` and pass with the fix.

```bash
# Unit test
go test -count=1 -run 'TestGCStore/old_state_is_removed_after_findCursorMeta' ./filebeat/input/filestream/internal/input-logfile/

# Integration test (renames a harvested file to drive onRename -> FindCursorMeta)
cd filebeat && mage buildSystemTestBinary
go test -count=1 -tags integration -run TestFilestreamCleanInactiveRenamed ./tests/integration/
```

### Manual, end-to-end with a config file

Run Filebeat against a rotating log and check whether the renamed file's registry entry is garbage collected. Use this `filebeat.yml` (a normal rotating-log config; short timers only make the leak observable quickly):

```yaml
filebeat.inputs:
  - type: filestream
    id: app-logs
    paths:
      - /tmp/fb-leak/logs/*.log*       # glob keeps matching after the rename
    file_identity.native: ~
    prospector.scanner.fingerprint.enabled: false
    prospector.scanner.check_interval: 1s
    ignore_older: 5s
    clean_inactive: 10s
    close.on_state_change.inactive: 2s

filebeat.registry:
  cleanup_interval: 3s
  flush: 1s

path.home: /tmp/fb-leak/home
output.file: { path: /tmp/fb-leak/home, filename: output }
logging.level: debug
```

```bash
mkdir -p /tmp/fb-leak/logs /tmp/fb-leak/home
./filebeat -e -c /tmp/fb-leak/filebeat.yml --strict.perms=false &

sleep 3; printf 'a\nb\nc\n' > /tmp/fb-leak/logs/app.log
sleep 3; mv /tmp/fb-leak/logs/app.log /tmp/fb-leak/logs/app.log.1   # inode preserved -> detected as a rename
sleep 20; kill %1

# Count registry GC removals:
grep -c '"op":"remove"' /tmp/fb-leak/home/data/registry/filebeat/log.json
```

| Binary | `"op":"remove"` count | Result |
|--------|-----------------------|--------|
| `main` (buggy) | `0` | renamed file's entry leaked, never GC'd |
| fixed | `1` | entry GC'd after `clean_inactive` |
