### PR TITLE
[filebeat] azure module: guard event.original rename to prevent duplicate field error

### DIFF
--- a/changelog/fragments/1781544098-filebeat-azure-event-original-guard.yaml
+++ b/changelog/fragments/1781544098-filebeat-azure-event-original-guard.yaml
@@ -1,0 +1,7 @@
+kind: bug-fix
+
+summary: Guard event.original rename in azure module ingest pipelines to prevent "field already exists" error when the field is pre-populated
+
+component: filebeat
+
+pr: https://github.com/elastic/beats/pull/51271

--- a/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
@@ -29,6 +29,10 @@ processors:
 - rename:
     field: message
     target_field: event.original
+    if: 'ctx.event?.original == null'
+- remove:
+    field: message
+    ignore_missing: true
 - remove:
     field: azure.activitylogs.time
     ignore_missing: true

--- a/x-pack/filebeat/module/azure/auditlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/ingest/pipeline.yml
@@ -42,6 +42,10 @@ processors:
 - rename:
     field: message
     target_field: event.original
+    if: 'ctx.event?.original == null'
+- remove:
+    field: message
+    ignore_missing: true
 - remove:
     field: azure.auditlogs.time
     ignore_missing: true

--- a/x-pack/filebeat/module/azure/platformlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/platformlogs/ingest/pipeline.yml
@@ -37,6 +37,10 @@ processors:
 - rename:
     field: message
     target_field: event.original
+    if: 'ctx.event?.original == null'
+- remove:
+    field: message
+    ignore_missing: true
 - remove:
     field: azure.platformlogs.time
     ignore_missing: true

--- a/x-pack/filebeat/module/azure/signinlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/ingest/pipeline.yml
@@ -55,6 +55,10 @@ processors:
   - rename:
       field: message
       target_field: event.original
+      if: 'ctx.event?.original == null'
+  - remove:
+      field: message
+      ignore_missing: true
   - rename:
       field: azure.signinlogs.resource_id
       target_field: azure.resource_id


### PR DESCRIPTION
## Summary

- All four Azure module ingest pipelines (`activitylogs`, `auditlogs`, `platformlogs`, `signinlogs`) had an unconditional `rename: message → event.original` processor.
- Elasticsearch's `rename` processor throws **"field [event.original] already exists"** when the field is already populated — e.g. when running under Elastic Agent (whose base pipeline pre-sets `event.original`), when a custom `@custom` pipeline runs first, or during re-indexing.
- Fix: add `if: 'ctx.event?.original == null'` guard to each rename, plus a follow-up `remove: message, ignore_missing: true` to ensure `message` is always cleaned up regardless of which path was taken (three of the four pipelines have subsequent processors that rename other fields into `message`, which would fail if the original `message` field remained).

Mirrors the fix applied to the Elastic Agent azure integration in elastic/integrations#5361.

## Test plan

- [ ] Run existing pipeline unit tests: `mage -d x-pack/filebeat filebeatIntegTest` (or the equivalent module test target for the azure module)
- [ ] Verify pipeline tests for all four sub-modules still pass (`.log-expected.json` fixtures should remain unchanged since the normal path — `event.original` not pre-set — is unaffected)
- [ ] Manually verify with an Elasticsearch ingest pipeline simulate API call that sets `event.original` before running the pipeline, confirming no error is thrown
- [ ] Verify the re-indexing scenario: run the pipeline on a document that already has `event.original` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)