### PR TITLE
libbeat: fix data race in add_cloud_metadata TLS config

### DIFF
--- a/changelog/fragments/1781613127-fix-add-cloud-metadata-tls-config-race.yaml
+++ b/changelog/fragments/1781613127-fix-add-cloud-metadata-tls-config-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix data race in add_cloud_metadata processor when fetching metadata from multiple providers concurrently.
+component: libbeat

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -166,10 +166,21 @@ func (p *addCloudMetadata) fetchMetadata(ctx context.Context) *result {
 
 	results := make(chan result)
 	for _, fetcher := range p.initData.fetchers {
-		// Each fetcher needs its own client; see newHTTPClient for why sharing
-		// one across the concurrent goroutines below would be a data race.
-		client := p.newHTTPClient()
 		go func() {
+			// Create an HTTP client with our timeouts and keep-alive disabled. We cannot share the client: net/http
+			// mutates the Transport's *tls.Config on first use, racing the concurrent fetchers.
+			client := http.Client{
+				Timeout: p.initData.timeout,
+				Transport: &http.Transport{
+					DisableKeepAlives: true,
+					DialContext: (&net.Dialer{
+						Timeout:   p.initData.timeout,
+						KeepAlive: 0,
+					}).DialContext,
+					TLSClientConfig: p.initData.tlsConfig.ToConfig(),
+				},
+			}
+
 			select {
 			case <-ctx.Done():
 			case results <- fetcher.fetchMetadata(ctx, client, p.logger):
@@ -178,27 +189,6 @@ func (p *addCloudMetadata) fetchMetadata(ctx context.Context) *result {
 	}
 
 	return acceptFirstPriorityResult(ctx, p.logger, start, results)
-}
-
-// newHTTPClient returns a metadata-fetching HTTP client with keep-alives
-// disabled. A new client, backed by its own Transport and a freshly built
-// *tls.Config, is returned on every call: net/http lazily mutates a Transport's
-// TLSClientConfig on first use (e.g. appending "h2" to NextProtos for HTTP/2),
-// and Transport.Clone — used by the AWS SDK — triggers that mutation too. So
-// sharing one *tls.Config across the concurrent fetchers would let one mutate
-// it while another reads it, which is a data race.
-func (p *addCloudMetadata) newHTTPClient() http.Client {
-	return http.Client{
-		Timeout: p.initData.timeout,
-		Transport: &http.Transport{
-			DisableKeepAlives: true,
-			DialContext: (&net.Dialer{
-				Timeout:   p.initData.timeout,
-				KeepAlive: 0,
-			}).DialContext,
-			TLSClientConfig: p.initData.tlsConfig.ToConfig(),
-		},
-	}
 }
 
 func acceptFirstPriorityResult(

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -160,8 +160,35 @@ func (p *addCloudMetadata) fetchMetadata(ctx context.Context) *result {
 		p.logger.Debugf("add_cloud_metadata: fetchMetadata ran for %v", time.Since(start))
 	}()
 
-	// Create HTTP client with our timeouts and keep-alive disabled.
-	client := http.Client{
+	// Create context to enable explicit cancellation of the http requests.
+	ctx, cancel := context.WithTimeout(ctx, p.initData.timeout)
+	defer cancel()
+
+	results := make(chan result)
+	for _, fetcher := range p.initData.fetchers {
+		// Each fetcher needs its own client; see newHTTPClient for why sharing
+		// one across the concurrent goroutines below would be a data race.
+		client := p.newHTTPClient()
+		go func() {
+			select {
+			case <-ctx.Done():
+			case results <- fetcher.fetchMetadata(ctx, client, p.logger):
+			}
+		}()
+	}
+
+	return acceptFirstPriorityResult(ctx, p.logger, start, results)
+}
+
+// newHTTPClient returns a metadata-fetching HTTP client with keep-alives
+// disabled. A new client, backed by its own Transport and a freshly built
+// *tls.Config, is returned on every call: net/http lazily mutates a Transport's
+// TLSClientConfig on first use (e.g. appending "h2" to NextProtos for HTTP/2),
+// and Transport.Clone — used by the AWS SDK — triggers that mutation too. So
+// sharing one *tls.Config across the concurrent fetchers would let one mutate
+// it while another reads it, which is a data race.
+func (p *addCloudMetadata) newHTTPClient() http.Client {
+	return http.Client{
 		Timeout: p.initData.timeout,
 		Transport: &http.Transport{
 			DisableKeepAlives: true,
@@ -172,23 +199,6 @@ func (p *addCloudMetadata) fetchMetadata(ctx context.Context) *result {
 			TLSClientConfig: p.initData.tlsConfig.ToConfig(),
 		},
 	}
-
-	// Create context to enable explicit cancellation of the http requests.
-	ctx, cancel := context.WithTimeout(ctx, p.initData.timeout)
-	defer cancel()
-
-	results := make(chan result)
-	for _, fetcher := range p.initData.fetchers {
-		fetcher := fetcher
-		go func() {
-			select {
-			case <-ctx.Done():
-			case results <- fetcher.fetchMetadata(ctx, client, p.logger):
-			}
-		}()
-	}
-
-	return acceptFirstPriorityResult(ctx, p.logger, start, results)
 }
 
 func acceptFirstPriorityResult(

--- a/libbeat/processors/add_cloud_metadata/providers_test.go
+++ b/libbeat/processors/add_cloud_metadata/providers_test.go
@@ -20,12 +20,14 @@ package add_cloud_metadata
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
@@ -122,6 +124,29 @@ func TestProvidersFilter(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		})
 	}
+}
+
+// TestNewHTTPClientIsolatesTLSConfig guards the invariant behind the data-race
+// fix: each fetcher must get its own Transport and *tls.Config (see
+// newHTTPClient), so concurrent fetchers never share a mutable config.
+func TestNewHTTPClientIsolatesTLSConfig(t *testing.T) {
+	// tlsConfig is intentionally nil: ToConfig handles a nil receiver and must
+	// still hand out a distinct *tls.Config on every call.
+	p := &addCloudMetadata{initData: &initData{timeout: time.Second}}
+
+	c1 := p.newHTTPClient()
+	c2 := p.newHTTPClient()
+
+	tr1, ok := c1.Transport.(*http.Transport)
+	require.True(t, ok, "expected an *http.Transport")
+	tr2, ok := c2.Transport.(*http.Transport)
+	require.True(t, ok, "expected an *http.Transport")
+
+	assert.NotSame(t, tr1, tr2, "each fetcher must use its own *http.Transport")
+	require.NotNil(t, tr1.TLSClientConfig, "TLSClientConfig must be set")
+	require.NotNil(t, tr2.TLSClientConfig, "TLSClientConfig must be set")
+	assert.NotSame(t, tr1.TLSClientConfig, tr2.TLSClientConfig,
+		"each fetcher must use its own *tls.Config to avoid a data race on lazy HTTP/2 setup")
 }
 
 func Test_priorityResult(t *testing.T) {

--- a/libbeat/processors/add_cloud_metadata/providers_test.go
+++ b/libbeat/processors/add_cloud_metadata/providers_test.go
@@ -20,14 +20,12 @@ package add_cloud_metadata
 import (
 	"context"
 	"errors"
-	"net/http"
 	"os"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
@@ -124,29 +122,6 @@ func TestProvidersFilter(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		})
 	}
-}
-
-// TestNewHTTPClientIsolatesTLSConfig guards the invariant behind the data-race
-// fix: each fetcher must get its own Transport and *tls.Config (see
-// newHTTPClient), so concurrent fetchers never share a mutable config.
-func TestNewHTTPClientIsolatesTLSConfig(t *testing.T) {
-	// tlsConfig is intentionally nil: ToConfig handles a nil receiver and must
-	// still hand out a distinct *tls.Config on every call.
-	p := &addCloudMetadata{initData: &initData{timeout: time.Second}}
-
-	c1 := p.newHTTPClient()
-	c2 := p.newHTTPClient()
-
-	tr1, ok := c1.Transport.(*http.Transport)
-	require.True(t, ok, "expected an *http.Transport")
-	tr2, ok := c2.Transport.(*http.Transport)
-	require.True(t, ok, "expected an *http.Transport")
-
-	assert.NotSame(t, tr1, tr2, "each fetcher must use its own *http.Transport")
-	require.NotNil(t, tr1.TLSClientConfig, "TLSClientConfig must be set")
-	require.NotNil(t, tr2.TLSClientConfig, "TLSClientConfig must be set")
-	assert.NotSame(t, tr1.TLSClientConfig, tr2.TLSClientConfig,
-		"each fetcher must use its own *tls.Config to avoid a data race on lazy HTTP/2 setup")
 }
 
 func Test_priorityResult(t *testing.T) {

--- a/x-pack/otel/oteltestcol/collector.go
+++ b/x-pack/otel/oteltestcol/collector.go
@@ -62,7 +62,7 @@ func New(tb testing.TB, configYAML string) *Collector {
 	var zapBuf zaptest.Buffer
 	zapCore := zapcore.NewCore(
 		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
-		&zapBuf,
+		zapcore.Lock(zapcore.AddSync(&zapBuf)),
 		zapcore.DebugLevel,
 	)
 	observed, observer := observer.New(zapcore.DebugLevel)


### PR DESCRIPTION
## Proposed commit message

```
libbeat: fix data race in add_cloud_metadata TLS config

The add_cloud_metadata processor created a single http.Client in
fetchMetadata and passed it by value to every provider fetcher goroutine.
Because http.Client.Transport is a pointer, all goroutines shared the same
*http.Transport and the same *tls.Config (built once via
tlsConfig.ToConfig()).

net/http lazily mutates a Transport's TLSClientConfig on first use (for
example appending h2 to NextProtos to negotiate HTTP/2), and
Transport.Clone runs that same onceSetNextProtoDefaults mutation on the
source transport before copying. The AWS EC2 fetcher copies the shared
*tls.Config pointer into the AWS SDK transport (provider_aws_ec2.go), and
the SDK clones that transport via GetTransport, mutating the config.
Meanwhile, the same config is being read which fails TestMetricbeatOTelE2E
under -race.

The fix moves client construction inside the fetcher goroutine loop, so
every concurrent goroutine builds its own http.Client with its own
*http.Transport and a freshly built *tls.Config: ToConfig() returns a new
*tls.Config on every call.

The same test also surfaces a separate, unrelated race in the oteltestcol which
is fixed in this commit for convenience.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).


## How to test this PR locally

Run the processor's unit tests with the race detector:

```bash
go test -race ./libbeat/processors/add_cloud_metadata/...
```

The race originally surfaced in the `TestMetricbeatOTelE2E` integration test once `-race` was enabled for integration tests (#51282). Stressing that test under `-race` no longer reports the `add_cloud_metadata` race — 23 runs, 0 failures:

```bash
script/stresstest.sh --race --tags integration \
  ./x-pack/metricbeat/tests/integration '^TestMetricbeatOTelE2E$' -p 1
```

Before the fix, running the cloud-metadata path with multiple providers (including AWS) under `-race` could surface a `WARNING: DATA RACE` on `crypto/tls.(*Config).Clone` vs `net/http.http2configureTransports`. After the fix the race no longer occurs.

## Related issues

- Closes https://github.com/elastic/beats/issues/49827: The issue is extremely low-info. No logs, file numbers or anything. I am closing it in hoping that this PR fixes the underlying cause.
- Discovered in https://github.com/elastic/beats/pull/51282

## Logs

The race as reported (trimmed) shows the read in a non-AWS fetcher's TLS dial racing with the AWS fetcher's lazy HTTP/2 transport setup:

```text
WARNING: DATA RACE
Read at 0x00c0006aad88 by goroutine 49:
  crypto/tls.(*Config).Clone()
  net/http.cloneTLSConfig()
  net/http.(*persistConn).addTLS()
  net/http.(*Transport).dialConn()
  ...
  add_cloud_metadata.(*httpMetadataFetcher).fetchRaw()
  add_cloud_metadata.(*addCloudMetadata).fetchMetadata.func2()

Previous write at 0x00c0006aad88 by goroutine 40:
  net/http.http2configureTransports()
  net/http.(*Transport).onceSetNextProtoDefaults()
  ...
  aws-sdk-go-v2/aws/transport/http.(*BuildableClient).GetTransport()
  aws-sdk-go-v2/feature/ec2/imds.New()
  aws-sdk-go-v2/config.LoadDefaultConfig()
  add_cloud_metadata.fetchRawProviderMetadata()
  add_cloud_metadata.(*addCloudMetadata).fetchMetadata.func2()
```
