### PR TITLE
Fix test_modules to add more time with better event waiting

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -5,12 +5,19 @@ import os
 import unittest
 import glob
 import subprocess
+import time
 
 import json
 import logging
 from parameterized import parameterized
 from elasticsearch import Elasticsearch, NotFoundError
 from deepdiff import DeepDiff
+
+# Maximum time (seconds) Filebeat is allowed to ingest a module's test file.
+# Inputs started with --once exit as soon as the file is fully read; tailing
+# inputs (journald, filestream) never exit, so the test stops Filebeat once the
+# expected events have been indexed or this timeout elapses.
+MODULE_INGEST_TIMEOUT = 60
 
 # datasets for which @timestamp is removed due to date missing
 remove_timestamp = {
@@ -258,17 +265,18 @@ class Test(BaseTest):
                                     stdout=output,
                                     stderr=subprocess.STDOUT,
                                     bufsize=0)
-            # The journald input (used by some modules like 'system') does not
-            # support the --once flag, hence we run Filebeat for at most
-            # 15 seconds, if it does not finish, then kill the process.
-            # If for any reason the Filebeat process gets stuck, only SIGKILL
-            # will terminate it. We use SIGKILL to avoid leaking any running
-            # process that could interfere with other tests
-            try:
-                proc.wait(15)
-            except subprocess.TimeoutExpired:
-                # Send SIGKILL
-                proc.kill()
+            if "--once" in cmd:
+                # Process will exit on its own once the file is fully read. Wait the maximum time,
+                # if it doesn't exit by then, kill it to avoid leaking a process.
+                try:
+                    proc.wait(MODULE_INGEST_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+            else:
+                # The journald and filestream inputs do not support --once and
+                # tail the file forever. Stop filebeat once elasticsearch has
+                # indexed the expected number of events (or the timeout elapses).
+                self._wait_for_events_then_stop(proc, test_file, MODULE_INGEST_TIMEOUT)
 
         # List of errors to check in filebeat output logs
         errors = ["error loading pipeline for fileset"]
@@ -310,6 +318,35 @@ class Test(BaseTest):
                 self.assert_fields_are_documented(obj)
 
         self._test_expected_events(test_file, objects)
+
+    def _wait_for_events_then_stop(self, proc, test_file, timeout):
+        expected = self._expected_event_count(test_file)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                # Filebeat exited on its own; nothing left to stop.
+                return
+            if expected is not None and self._indexed_event_count() >= expected:
+                break
+            time.sleep(0.5)
+        # force cleanup
+        proc.kill()
+
+    def _expected_event_count(self, test_file):
+        if os.getenv("GENERATE"):
+            return None
+        try:
+            with open(test_file + "-expected.json", "r") as f:
+                return len(json.load(f))
+        except (FileNotFoundError, ValueError):
+            return None
+
+    def _indexed_event_count(self):
+        try:
+            self.es.indices.refresh(index=self.index_name)
+            return self.es.count(index=self.index_name)["count"]
+        except NotFoundError:
+            return 0
 
     def _test_expected_events(self, test_file, objects):
 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -272,6 +272,7 @@ class Test(BaseTest):
                     proc.wait(MODULE_INGEST_TIMEOUT)
                 except subprocess.TimeoutExpired:
                     proc.kill()
+                    proc.wait()
             else:
                 # The journald and filestream inputs do not support --once and
                 # tail the file forever. Stop filebeat once elasticsearch has
@@ -322,15 +323,18 @@ class Test(BaseTest):
     def _wait_for_events_then_stop(self, proc, test_file, timeout):
         expected = self._expected_event_count(test_file)
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if proc.poll() is not None:
-                # Filebeat exited on its own; nothing left to stop.
-                return
-            if expected is not None and self._indexed_event_count() >= expected:
-                break
-            time.sleep(0.5)
-        # force cleanup
-        proc.kill()
+        try:
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    # Filebeat exited on its own; nothing left to stop.
+                    return
+                if expected is not None and self._indexed_event_count() >= expected:
+                    break
+                time.sleep(0.5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+            proc.wait()
 
     def _expected_event_count(self, test_file):
         if os.getenv("GENERATE"):


### PR DESCRIPTION
## Proposed commit message

Fixes the test_modules.py to wait for the process in the `--once` case and wait for the indexed events in the non-once cases. Increases timeout to 60 seconds for slower workers.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #51146 
