### PR TITLE
Docs: Fix deprecation formatting in SSL config documentation

### DIFF
--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -635,7 +635,7 @@ have changed on disk. The default value is `5s`.
 [[exit_on_cert_change_enabled]]
 ==== `restart_on_cert_change.enabled`
 
-deprecated:[8.19.0, Use <<certificate_reload_enabled,`certificate_reload.enabled`>> instead. Certificates, keys, and CA certificates are now automatically reloaded on each TLS handshake without requiring a process restart.]
+deprecated::[8.19.0,"Use <<certificate_reload_enabled,`certificate_reload.enabled`>> instead. Certificates, keys, and CA certificates are now automatically reloaded on each TLS handshake without requiring a process restart."]
 
 If set to `true` {beatname_uc} will restart if any file listed by `key`,
 `certificate`, or `certificate_authorities` is modified.
@@ -651,7 +651,7 @@ you have a custom seccomp policy in place, make sure to allow for
 [[restart_on_cert_change_period]]
 ==== `restart_on_cert_change.period`
 
-deprecated:[8.19.0, Use <<certificate_reload_reload_interval,`certificate_reload.reload_interval`>> instead.]
+deprecated::[8.19.0,"Use <<certificate_reload_reload_interval,`certificate_reload.reload_interval`>> instead."]
 
 Specifies how often the files are checked for changes. Do not set the
 period to less than 1s because the modification time of files is often


### PR DESCRIPTION
Docs

## Proposed commit message

Fixes the formatting of the deprecation note.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
