### PR TITLE
Enable status reporting for heartbeat receiver

### DIFF
--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -54,12 +54,12 @@ type Heartbeat struct {
 	config             *config.Config
 	scheduler          *scheduler.Scheduler
 	monitorReloader    *cfgfile.Reloader
-	monitorFactory     *monitors.RunnerFactory
+	monitorFactory     cfgfile.RunnerFactory
 	autodiscover       *autodiscover.Autodiscover
 	replaceStateLoader func(sl monitorstate.StateLoader)
 	trace              tracer.Tracer
 
-	otelStatusFactoryWrapper cfgfile.FactoryWrapper
+	otelStatusFactoryWrapper func(cfgfile.RunnerFactory) cfgfile.RunnerFactory
 }
 
 // New creates a new heartbeat.
@@ -165,6 +165,10 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 	logp.L().Info("heartbeat is running! Hit CTRL-C to stop it.")
 	groups, _ := syscall.Getgroups()
 	logp.L().Infof("Effective user/group ids: %d/%d, with groups: %v", syscall.Geteuid(), syscall.Getegid(), groups)
+
+	if bt.otelStatusFactoryWrapper != nil {
+		bt.monitorFactory = bt.otelStatusFactoryWrapper(bt.monitorFactory)
+	}
 
 	waitMonitors := monitors.NewSignalWait()
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -52,6 +52,7 @@ type Heartbeat struct {
 	stopOnce sync.Once
 	// config is used for iterating over elements of the config.
 	config             *config.Config
+	logger             *logp.Logger
 	scheduler          *scheduler.Scheduler
 	monitorReloader    *cfgfile.Reloader
 	monitorFactory     cfgfile.RunnerFactory
@@ -125,6 +126,7 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 	bt := &Heartbeat{
 		done:               make(chan struct{}),
 		config:             parsedConfig,
+		logger:             b.Info.Logger,
 		scheduler:          sched,
 		replaceStateLoader: replaceStateLoader,
 		// monitorFactory is the factory used for creating all monitor instances,
@@ -143,7 +145,7 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 	if parsedConfig.RunFrom != nil {
 		runFromID = parsedConfig.RunFrom.ID
 	}
-	logp.L().Infof("heartbeat starting, running from: %v", runFromID)
+	bt.logger.Infof("heartbeat starting, running from: %v", runFromID)
 	return bt, nil
 }
 
@@ -162,9 +164,9 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 		pipelineWrapper = sync
 	}
 
-	logp.L().Info("heartbeat is running! Hit CTRL-C to stop it.")
+	bt.logger.Info("heartbeat is running! Hit CTRL-C to stop it.")
 	groups, _ := syscall.Getgroups()
-	logp.L().Infof("Effective user/group ids: %d/%d, with groups: %v", syscall.Geteuid(), syscall.Getegid(), groups)
+	bt.logger.Infof("Effective user/group ids: %d/%d, with groups: %v", syscall.Geteuid(), syscall.Getegid(), groups)
 
 	if bt.otelStatusFactoryWrapper != nil {
 		bt.monitorFactory = bt.otelStatusFactoryWrapper(bt.monitorFactory)
@@ -200,7 +202,7 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 	}
 	// Configure the beats Manager to start after all the reloadable hooks are initialized
 	// and shutdown when the function return.
-	if err := b.Manager.Start(); err != nil { //nolint:staticcheck
+	if err := b.Manager.Start(); err != nil { //nolint:staticcheck // b.Manager.Start is deprecated in favour of PreInit/PostInit; refactor is deferred
 		return err
 	}
 
@@ -220,7 +222,7 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 	waitMonitors.AddChan(bt.done)
 	waitMonitors.Wait()
 
-	logp.L().Info("Shutting down, waiting for output to complete")
+	bt.logger.Info("Shutting down, waiting for output to complete")
 
 	// Due to defer's LIFO execution order, waitPublished.Wait() has to be
 	// located _after_ b.Manager.Stop() or else it will exit early
@@ -231,7 +233,7 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 	waitPublished.AddChan(bt.done)
 	waitPublished.Add(monitors.WithLog(pipelineWrapper.Wait, "shutdown: finished publishing events."))
 	if bt.config.PublishTimeout > 0 {
-		logp.L().Infof("shutdown: output timer started. Waiting for max %v.", bt.config.PublishTimeout)
+		bt.logger.Infof("shutdown: output timer started. Waiting for max %v.", bt.config.PublishTimeout)
 		waitPublished.Add(monitors.WithLog(monitors.WaitDuration(bt.config.PublishTimeout),
 			"shutdown: timed out waiting for pipeline to publish events."))
 	}
@@ -246,7 +248,7 @@ func (bt *Heartbeat) RunStaticMonitors(b *beat.Beat, pipeline beat.Pipeline) (st
 		created, err := bt.monitorFactory.Create(pipeline, cfg)
 		if err != nil {
 			if errors.Is(err, monitors.ErrMonitorDisabled) {
-				logp.L().Infof("skipping disabled monitor: %s", err)
+				bt.logger.Infof("skipping disabled monitor: %s", err)
 				continue // don't stop loading monitors just because they're disabled
 			}
 
@@ -282,7 +284,7 @@ func (bt *Heartbeat) RunCentralMgmtMonitors(b *beat.Beat) {
 		// Backoff panics with 0 duration, set to smallest unit
 		esClient, err := makeESClient(context.TODO(), outCfg.Config(), 1, 1*time.Nanosecond, b.Info.Logger)
 		if err != nil {
-			logp.L().Warnf("skipping monitor state management during managed reload: %v", err)
+			bt.logger.Warnf("skipping monitor state management during managed reload: %v", err)
 		} else {
 			bt.replaceStateLoader(monitorstate.MakeESLoader(esClient, monitorstate.DefaultDataStreams, bt.config.RunFrom))
 		}
@@ -298,7 +300,7 @@ func (bt *Heartbeat) RunCentralMgmtMonitors(b *beat.Beat) {
 func (bt *Heartbeat) RunReloadableMonitors() (err error) {
 	// Check monitor configs
 	if err := bt.monitorReloader.Check(bt.monitorFactory); err != nil {
-		logp.L().Error(fmt.Errorf("error loading reloadable monitors: %w", err))
+		bt.logger.Error(fmt.Errorf("error loading reloadable monitors: %w", err))
 	}
 
 	// Execute the monitor

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -76,12 +76,12 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 	if stConfig != nil {
 		// Note this, intentionally, blocks until connected to the trace endpoint
 		var err error
-		logp.L().Infof("Setting up sock tracer at %s (wait: %s)", stConfig.Path, stConfig.Wait)
+		b.Info.Logger.Infof("Setting up sock tracer at %s (wait: %s)", stConfig.Path, stConfig.Wait)
 		sockTrace, err := tracer.NewSockTracer(stConfig.Path, stConfig.Wait)
 		if err == nil {
 			trace = sockTrace
 		} else {
-			logp.L().Warnf("could not connect to socket trace at path %s after %s timeout: %v", stConfig.Path, stConfig.Wait, err)
+			b.Info.Logger.Warnf("could not connect to socket trace at path %s after %s timeout: %v", stConfig.Path, stConfig.Wait, err)
 		}
 	}
 
@@ -90,13 +90,13 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 	if b.Config.Output.Name() == "elasticsearch" && !b.Manager.Enabled() {
 		// Connect to ES and setup the State loader if the output is not managed by agent
 		// Note this, intentionally, blocks until connected or max attempts reached
-		esClient, err := makeESClient(context.TODO(), b.Config.Output.Config(), 3, 2*time.Second)
+		esClient, err := makeESClient(context.TODO(), b.Config.Output.Config(), 3, 2*time.Second, b.Info.Logger)
 		if err != nil {
 			if parsedConfig.RunOnce {
 				trace.Abort()
 				return nil, fmt.Errorf("run_once mode fatal error: %w", err)
 			} else {
-				logp.L().Warnf("skipping monitor state management: %v", err)
+				b.Info.Logger.Warnf("skipping monitor state management: %v", err)
 			}
 		} else {
 			replaceStateLoader(monitorstate.MakeESLoader(esClient, monitorstate.DefaultDataStreams, parsedConfig.RunFrom))
@@ -200,7 +200,7 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 	}
 	// Configure the beats Manager to start after all the reloadable hooks are initialized
 	// and shutdown when the function return.
-	if err := b.Manager.Start(); err != nil {
+	if err := b.Manager.Start(); err != nil { //nolint:staticcheck
 		return err
 	}
 
@@ -280,7 +280,7 @@ func (bt *Heartbeat) RunCentralMgmtMonitors(b *beat.Beat) {
 		}
 
 		// Backoff panics with 0 duration, set to smallest unit
-		esClient, err := makeESClient(context.TODO(), outCfg.Config(), 1, 1*time.Nanosecond)
+		esClient, err := makeESClient(context.TODO(), outCfg.Config(), 1, 1*time.Nanosecond, b.Info.Logger)
 		if err != nil {
 			logp.L().Warnf("skipping monitor state management during managed reload: %v", err)
 		} else {
@@ -326,7 +326,7 @@ func (bt *Heartbeat) WithOtelFactoryWrapper(wrapper cfgfile.FactoryWrapper) {
 }
 
 // makeESClient establishes an ES connection meant to load monitors' state
-func makeESClient(ctx context.Context, cfg *conf.C, attempts int, wait time.Duration) (*eslegclient.Connection, error) {
+func makeESClient(ctx context.Context, cfg *conf.C, attempts int, wait time.Duration, logger *logp.Logger) (*eslegclient.Connection, error) {
 	var (
 		esClient *eslegclient.Connection
 		err      error
@@ -355,8 +355,7 @@ func makeESClient(ctx context.Context, cfg *conf.C, attempts int, wait time.Dura
 	}
 
 	for i := 0; i < attempts; i++ {
-		// TODO: use local logger here
-		esClient, err = eslegclient.NewConnectedClient(ctx, newCfg, "Heartbeat", logp.NewLogger(""))
+		esClient, err = eslegclient.NewConnectedClient(ctx, newCfg, "Heartbeat", logger)
 		if err == nil {
 			connectDelay.Reset()
 			return esClient, nil

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -60,7 +60,7 @@ type Heartbeat struct {
 	replaceStateLoader func(sl monitorstate.StateLoader)
 	trace              tracer.Tracer
 
-	otelStatusFactoryWrapper func(cfgfile.RunnerFactory) cfgfile.RunnerFactory
+	otelStatusFactoryWrapper cfgfile.FactoryWrapper
 }
 
 // New creates a new heartbeat.

--- a/heartbeat/beater/heartbeat_test.go
+++ b/heartbeat/beater/heartbeat_test.go
@@ -41,7 +41,7 @@ func TestMakeESClient(t *testing.T) {
 		anyAttempt := 1
 		anyDuration := 1 * time.Second
 
-		_, _ = makeESClient(context.Background(), origCfg, anyAttempt, anyDuration, logp.NewLogger("test"))
+		_, _ = makeESClient(context.Background(), origCfg, anyAttempt, anyDuration, logp.NewNopLogger())
 
 		timeout, err := origCfg.Int("timeout", -1)
 		require.NoError(t, err)

--- a/heartbeat/beater/heartbeat_test.go
+++ b/heartbeat/beater/heartbeat_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func TestMakeESClient(t *testing.T) {
@@ -40,7 +41,7 @@ func TestMakeESClient(t *testing.T) {
 		anyAttempt := 1
 		anyDuration := 1 * time.Second
 
-		_, _ = makeESClient(context.Background(), origCfg, anyAttempt, anyDuration)
+		_, _ = makeESClient(context.Background(), origCfg, anyAttempt, anyDuration, logp.NewLogger("test"))
 
 		timeout, err := origCfg.Int("timeout", -1)
 		require.NoError(t, err)

--- a/x-pack/heartbeat/hbreceiver/status_test.go
+++ b/x-pack/heartbeat/hbreceiver/status_test.go
@@ -1,0 +1,70 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package hbreceiver
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/elastic/beats/v7/x-pack/otel/oteltest"
+)
+
+func TestReceiverStatus(t *testing.T) {
+	// Use a TCP monitor with a long schedule so the first check never fires
+	// during the test. Monitor.Start() still calls updateStatus(Running)
+	// immediately, producing the StatusOK event we assert below.
+	monitorID := "test-tcp"
+	inputStatusAttributes := func(state string, msg string) pcommon.Map {
+		eventAttributes := pcommon.NewMap()
+		inputStatuses := eventAttributes.PutEmptyMap("inputs")
+		monitorStatus := inputStatuses.PutEmptyMap(monitorID)
+		monitorStatus.PutStr("status", state)
+		monitorStatus.PutStr("error", msg)
+		return eventAttributes
+	}
+
+	testCases := []struct {
+		name   string
+		status *componentstatus.Event
+	}{
+		{
+			name: "running monitor",
+			status: componentstatus.NewEvent(componentstatus.StatusOK,
+				componentstatus.WithAttributes(inputStatusAttributes(componentstatus.StatusOK.String(), ""))),
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			config := Config{
+				Beatconfig: map[string]any{
+					"heartbeat": map[string]any{
+						"monitors": []map[string]any{{
+							"type": "tcp", "id": monitorID,
+							"schedule": "@every 30s", "timeout": "3s",
+							"hosts": []string{"localhost:0"},
+						}},
+					},
+					"queue.mem.flush.timeout": "0s",
+					"path.home":               t.TempDir(),
+				},
+			}
+			oteltest.CheckReceivers(oteltest.CheckReceiversParams{
+				T: t,
+				Receivers: []oteltest.ReceiverConfig{
+					{
+						Name:    "r1",
+						Beat:    "heartbeat",
+						Config:  &config,
+						Factory: NewFactoryWithSettings(Settings{Home: t.TempDir()}),
+					},
+				},
+				Status: test.status,
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Proposed commit message

Enable status reporting for heartbeat receiver.

`heartbeat.WithOtelFactoryWrapper()` stored the wrapper but `Run()` used `bt.monitorFactory` directly without applying it, so component status events were never delivered to the OTel host. This mirrors the pattern already used in filebeat and metricbeat: apply the wrapper in `Run()` before loading any monitors so that each `Monitor.Start()` call reaches `componentstatus.ReportStatus()` through the sub-reporter chain.

This was originally a 3-line change in heartbeat.go that the linter has since balooned into a small logging refactor. I can pull that out into a separate PR if need be, though it's pretty straightforward.

Not adding a changelog entry because this hasn't been released yet and is only intended for 9.5.0.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

Running the unit test is simplest. You can also start the test otel distro and try a heartbeat receiver there with a healthcheck extension wired up.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/14552

