### PR TITLE
otel(processors): implement PdataProcessor for add_cloud_metadata, add_host_metadata

### DIFF
--- a/libbeat/processors/actions/addfields/add_fields.go
+++ b/libbeat/processors/actions/addfields/add_fields.go
@@ -25,10 +25,13 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
+	"github.com/elastic/beats/v7/libbeat/processors"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
+
+var _ processors.PdataProcessor = (*addFields)(nil)
 
 type addFields struct {
 	fields    mapstr.M

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -23,7 +23,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor/registry"
 	cfg "github.com/elastic/elastic-agent-libs/config"
@@ -43,6 +46,8 @@ func init() {
 	processors.RegisterPlugin("add_cloud_metadata", New)
 	jsprocessor.RegisterPlugin("AddCloudMetadata", New)
 }
+
+var _ processors.PdataProcessor = (*addCloudMetadata)(nil)
 
 type addCloudMetadata struct {
 	baseCtx       context.Context
@@ -148,6 +153,26 @@ func (p *addCloudMetadata) Close() error {
 	p.baseCtxCancel()
 	p.initOnce.Do(func() {})
 	return nil
+}
+
+// RunPdata enriches the given pcommon.Map directly with cloud metadata,
+// avoiding the round-trip conversion to/from mapstr.M used by the standard Run path.
+func (p *addCloudMetadata) RunPdata(body pcommon.Map) (bool, error) {
+	meta := p.getMeta()
+	if len(meta) == 0 {
+		return false, nil
+	}
+	for key, metaVal := range meta {
+		if !p.initData.overwrite {
+			if _, exists := otelmap.GetAtPath(key, body); exists {
+				continue
+			}
+		}
+		if err := otelmap.PutAtPath(key, metaVal, body); err != nil {
+			return false, err
+		}
+	}
+	return false, nil
 }
 
 func (p *addCloudMetadata) addMeta(event *beat.Event, meta mapstr.M) error {

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata_parity_test.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata_parity_test.go
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package add_cloud_metadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+// newPreloadedProcessor builds an addCloudMetadata with metadata already set,
+// bypassing the network fetch. initDone is closed so getMeta returns immediately.
+func newPreloadedProcessor(t *testing.T, meta mapstr.M, overwrite bool) *addCloudMetadata {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	p := &addCloudMetadata{
+		baseCtx:       ctx,
+		baseCtxCancel: cancel,
+		initData:      &initData{overwrite: overwrite},
+		initDone:      make(chan struct{}),
+		metadata:      meta,
+		logger:        logptest.NewTestingLogger(t, ""),
+	}
+	// Consume initOnce so getMeta → init() is a no-op: init() never runs, so
+	// it never closes initDone or fetches from the network.
+	p.initOnce.Do(func() {})
+	return p
+}
+
+// TestRunPdata verifies that Run and RunPdata produce identical output for the
+// overwrite=false and overwrite=true cases, using a preloaded processor that
+// bypasses the network fetch.
+func TestRunPdata(t *testing.T) {
+	cases := []struct {
+		name      string
+		meta      mapstr.M
+		input     mapstr.M
+		overwrite bool
+	}{
+		{
+			name: "overwrite=false preserves existing field and adds absent field",
+			meta: mapstr.M{
+				"cloud.provider":    "aws",
+				"cloud.instance.id": "i-12345",
+			},
+			input:     mapstr.M{"cloud": mapstr.M{"provider": "existing-provider"}},
+			overwrite: false,
+		},
+		{
+			name:      "overwrite=true replaces existing field",
+			meta:      mapstr.M{"cloud.provider": "aws"},
+			input:     mapstr.M{"cloud": mapstr.M{"provider": "existing-provider"}},
+			overwrite: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newPreloadedProcessor(t, tc.meta, tc.overwrite)
+
+			// Legacy Run path.
+			out, err := p.Run(&beat.Event{Fields: tc.input.Clone()})
+			require.NoError(t, err)
+			require.NotNil(t, out)
+
+			// RunPdata path.
+			body := pcommon.NewMap()
+			require.NoError(t, otelmap.FromMapstr(body, tc.input))
+			drop, err := p.RunPdata(body)
+			require.NoError(t, err)
+			require.False(t, drop)
+
+			// Normalize Run output through pdata so nested map types match.
+			legacyNorm := pcommon.NewMap()
+			require.NoError(t, otelmap.FromMapstr(legacyNorm, out.Fields))
+			assert.Equal(t, otelmap.ToMapstr(legacyNorm), otelmap.ToMapstr(body),
+				"Run and RunPdata must produce identical output")
+		})
+	}
+}

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -139,7 +138,6 @@ var genericInstanceIDResponse getInstanceIDFunc = func(ctx context.Context, para
 }
 
 func TestMain(m *testing.M) {
-	logp.TestingSetup()
 	code := m.Run()
 	os.Exit(code)
 }
@@ -536,7 +534,7 @@ func Test_getTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tags := getTags(ctx, tt.imdsClient, tt.ec2Client, instanceId, logger)
-			assert.Equal(t, tags, tt.want)
+			assert.Equal(t, tt.want, tags)
 		})
 	}
 }

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -31,8 +31,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
+	"github.com/elastic/beats/v7/libbeat/processors"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
@@ -420,11 +424,29 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 				t.Fatalf("error creating new metadata processor: %s", err.Error())
 			}
 
-			actual, err := cmp.Run(&beat.Event{Fields: tc.previousEvent})
+			// Clone before Run: addMeta mutates event.Fields in place, which
+			// would corrupt tc.previousEvent before the RunPdata body is seeded.
+			inputForRun := tc.previousEvent.Clone()
+			inputForPdata := tc.previousEvent.Clone()
+
+			actual, err := cmp.Run(&beat.Event{Fields: inputForRun})
 			if err != nil {
 				t.Fatalf("error running processor: %s", err.Error())
 			}
 			assert.Equal(t, tc.expectedEvent, actual.Fields)
+
+			// RunPdata path: assert Run == RunPdata.
+			pp, ok := cmp.(processors.PdataProcessor)
+			require.True(t, ok, "processor must implement PdataProcessor")
+			body := pcommon.NewMap()
+			require.NoError(t, otelmap.FromMapstr(body, inputForPdata))
+			drop, err := pp.RunPdata(body)
+			require.NoError(t, err)
+			require.False(t, drop)
+			legacyNorm := pcommon.NewMap()
+			require.NoError(t, otelmap.FromMapstr(legacyNorm, actual.Fields))
+			assert.Equal(t, otelmap.ToMapstr(legacyNorm), otelmap.ToMapstr(body),
+				"Run and RunPdata must produce identical output")
 		})
 	}
 }

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -23,12 +23,15 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/go-sysinfo"
 	"github.com/elastic/go-sysinfo/types"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/features"
+	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor/registry"
 	"github.com/elastic/beats/v7/libbeat/processors/util"
@@ -51,6 +54,8 @@ func init() {
 
 	reg = monitoring.Default.GetOrCreateRegistry(logName, monitoring.DoNotReport)
 }
+
+var _ processors.PdataProcessor = (*addHostMetadata)(nil)
 
 type metrics struct {
 	FQDNLookupFailed *monitoring.Int
@@ -238,6 +243,40 @@ func (p *addHostMetadata) fetchData(useFQDN bool) (mapstr.M, error) {
 	}
 
 	return data, nil
+}
+
+// RunPdata enriches the given pcommon.Map directly with host metadata, avoiding
+// the round-trip conversion to/from mapstr.M used by the standard Run path.
+func (p *addHostMetadata) RunPdata(body pcommon.Map) (bool, error) {
+	if !p.config.ReplaceFields && skipAddingHostMetadataPdata(body) {
+		return false, nil
+	}
+
+	data, err := p.loadData(features.FQDN())
+	if err != nil {
+		return false, fmt.Errorf("error loading data during event update: %w", err)
+	}
+
+	if err := otelmap.MergeMapstrIntoPdata(data, body, true); err != nil {
+		return false, fmt.Errorf("error merging host metadata: %w", err)
+	}
+
+	if len(p.geoData) > 0 {
+		if err := otelmap.MergeMapstrIntoPdata(p.geoData, body, true); err != nil {
+			return false, fmt.Errorf("error merging geo data: %w", err)
+		}
+	}
+	return false, nil
+}
+
+func skipAddingHostMetadataPdata(body pcommon.Map) bool {
+	hostVal, ok := body.Get("host")
+	if !ok || hostVal.Type() != pcommon.ValueTypeMap {
+		return false
+	}
+	hostMap := hostVal.Map()
+	_, hasName := hostMap.Get("name")
+	return hostMap.Len() > 0 && (!hasName || hostMap.Len() != 1)
 }
 
 func (p *addHostMetadata) String() string {

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -29,7 +29,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
+	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
+	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/util"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
@@ -90,6 +93,18 @@ func TestConfigDefault(t *testing.T) {
 	v, err = newEvent.GetValue("host.os.type")
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
+
+	// RunPdata path: assert Run == RunPdata.
+	pp, ok := p.(processors.PdataProcessor)
+	require.True(t, ok, "processor must implement PdataProcessor")
+	body := pcommon.NewMap()
+	drop, err := pp.RunPdata(body)
+	require.NoError(t, err)
+	require.False(t, drop)
+	legacyNorm := pcommon.NewMap()
+	require.NoError(t, otelmap.FromMapstr(legacyNorm, newEvent.Fields))
+	assert.Equal(t, otelmap.ToMapstr(legacyNorm), otelmap.ToMapstr(body),
+		"Run and RunPdata must produce identical output")
 }
 
 func TestConfigNetInfoDisabled(t *testing.T) {
@@ -137,6 +152,18 @@ func TestConfigNetInfoDisabled(t *testing.T) {
 	v, err = newEvent.GetValue("host.os.type")
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
+
+	// RunPdata path: assert Run == RunPdata.
+	pp, ok := p.(processors.PdataProcessor)
+	require.True(t, ok, "processor must implement PdataProcessor")
+	body := pcommon.NewMap()
+	drop, err := pp.RunPdata(body)
+	require.NoError(t, err)
+	require.False(t, drop)
+	legacyNorm := pcommon.NewMap()
+	require.NoError(t, otelmap.FromMapstr(legacyNorm, newEvent.Fields))
+	assert.Equal(t, otelmap.ToMapstr(legacyNorm), otelmap.ToMapstr(body),
+		"Run and RunPdata must produce identical output")
 }
 
 func TestConfigName(t *testing.T) {

--- a/libbeat/processors/conditionals.go
+++ b/libbeat/processors/conditionals.go
@@ -47,6 +47,9 @@ func NewConditional(
 	}
 }
 
+var _ PdataProcessor = (*WhenProcessor)(nil)
+var _ PdataProcessor = (*ClosingWhenProcessor)(nil)
+
 // WhenProcessor is a tuple of condition plus a Processor.
 type WhenProcessor struct {
 	condition conditions.Condition


### PR DESCRIPTION
## Proposed commit message

Both processors implement RunPdata, which merges metadata directly into the pcommon.Map via MergeMapstrIntoPdata, avoiding the round-trip conversion to/from mapstr.M. Parity tests verify Run and RunPdata produce identical output for both overwrite=true and overwrite=false.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

- Relates https://github.com/elastic/beats/pull/51272
- For https://github.com/elastic/beats/issues/50744