### PR TITLE
x-pack/filebeat/input/{cel,httpjson}: strip sensitive headers on cross-origin redirects

### DIFF
--- a/changelog/fragments/1782163090-strip-sensitive-headers-cross-origin-redirect.yaml
+++ b/changelog/fragments/1782163090-strip-sensitive-headers-cross-origin-redirect.yaml
@@ -1,0 +1,9 @@
+kind: bug-fix
+summary: Strip sensitive headers on cross-origin redirects in httpjson and CEL inputs.
+description: |
+  When redirect.forward_headers is true, the Authorization, Proxy-Authorization,
+  and Cookie headers are now automatically removed on redirects that cross to a
+  different host or downgrade from HTTPS to HTTP. A new redirect.sensitive_headers
+  configuration option controls which headers are stripped; set it to [] to restore
+  the previous behaviour of forwarding all headers unconditionally.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-cel.md
+++ b/docs/reference/filebeat/filebeat-input-cel.md
@@ -1120,12 +1120,23 @@ The maximum time to wait before a retry is attempted. Default: `60s`.
 
 ### `resource.redirect.forward_headers` [_resource_redirect_forward_headers]
 
-When set to `true` request headers are forwarded in case of a redirect. Default: `false`.
+When set to `true` request headers are forwarded in case of a redirect. Headers listed in `redirect.sensitive_headers` are removed automatically on cross-origin or HTTPS-to-HTTP redirects. Default: `false`.
 
 
 ### `resource.redirect.headers_ban_list` [_resource_redirect_headers_ban_list]
 
 When `redirect.forward_headers` is set to `true`, all headers *except* the ones defined in this list will be forwarded. Default: `[]`.
+
+
+### `resource.redirect.sensitive_headers` [_resource_redirect_sensitive_headers]
+
+```{applies_to}
+stack: ga 9.3+
+```
+
+A list of header names that are automatically removed when a redirect crosses to a different host or downgrades from HTTPS to HTTP. This prevents credential leakage to unintended origins. Default: `["Authorization", "Proxy-Authorization", "Cookie"]`.
+
+Set to `[]` to disable cross-origin header stripping and forward all headers regardless of the redirect target (not recommended unless the target shares the same authentication domain).
 
 
 ### `resource.redirect.max_redirects` [_resource_redirect_max_redirects]

--- a/docs/reference/filebeat/filebeat-input-httpjson.md
+++ b/docs/reference/filebeat/filebeat-input-httpjson.md
@@ -735,12 +735,23 @@ The maximum time to wait before a retry is attempted. Default: `60s`.
 
 ### `request.redirect.forward_headers` [_request_redirect_forward_headers]
 
-When set to `true` request headers are forwarded in case of a redirect. Default: `false`.
+When set to `true` request headers are forwarded in case of a redirect. Headers listed in `redirect.sensitive_headers` are removed automatically on cross-origin or HTTPS-to-HTTP redirects. Default: `false`.
 
 
 ### `request.redirect.headers_ban_list` [_request_redirect_headers_ban_list]
 
 When `redirect.forward_headers` is set to `true`, all headers *except* the ones defined in this list will be forwarded. Default: `[]`.
+
+
+### `request.redirect.sensitive_headers` [_request_redirect_sensitive_headers]
+
+```{applies_to}
+stack: ga 9.3+
+```
+
+A list of header names that are automatically removed when a redirect crosses to a different host or downgrades from HTTPS to HTTP. This prevents credential leakage to unintended origins. Default: `["Authorization", "Proxy-Authorization", "Cookie"]`.
+
+Set to `[]` to disable cross-origin header stripping and forward all headers regardless of the redirect target (not recommended unless the target shares the same authentication domain).
 
 
 ### `request.redirect.max_redirects` [_request_redirect_max_redirects]

--- a/x-pack/filebeat/input/cel/check_redirect_test.go
+++ b/x-pack/filebeat/input/cel/check_redirect_test.go
@@ -1,0 +1,136 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cel
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+func TestCheckRedirectSensitiveHeaders(t *testing.T) {
+	log := logptest.NewTestingLogger(t, "")
+
+	tests := []struct {
+		name             string
+		prevURL          string
+		reqURL           string
+		sensitiveHeaders []string
+		wantAuth         bool
+		wantProxyAuth    bool
+		wantCookie       bool
+		wantCustom       bool
+	}{
+		{
+			name:             "same_origin_preserves_all_headers",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "https://api.example.com/v1/other",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         true,
+			wantProxyAuth:    true,
+			wantCookie:       true,
+			wantCustom:       true,
+		},
+		{
+			name:             "cross-origin_strips_sensitive_headers",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "https://evil.example.net/capture",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         false,
+			wantProxyAuth:    false,
+			wantCookie:       false,
+			wantCustom:       true,
+		},
+		{
+			name:             "scheme_downgrade_strips_sensitive_headers",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "http://api.example.com/v1/data",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         false,
+			wantProxyAuth:    false,
+			wantCookie:       false,
+			wantCustom:       true,
+		},
+		{
+			name:             "empty_sensitive_headers_preserves_all_cross-origin",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "https://other.example.net/resource",
+			sensitiveHeaders: []string{},
+			wantAuth:         true,
+			wantProxyAuth:    true,
+			wantCookie:       true,
+			wantCustom:       true,
+		},
+		{
+			name:             "scheme_upgrade_same_host_preserves_headers",
+			prevURL:          "http://api.example.com/v1/data",
+			reqURL:           "https://api.example.com/v1/secure",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         true,
+			wantProxyAuth:    true,
+			wantCookie:       true,
+			wantCustom:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &ResourceConfig{
+				RedirectForwardHeaders:   true,
+				RedirectSensitiveHeaders: test.sensitiveHeaders,
+				RedirectMaxRedirects:     10,
+			}
+
+			prev := &http.Request{
+				URL: mustParseURL(t, test.prevURL),
+				Header: http.Header{
+					"Authorization":       {"Bearer secret"},
+					"Proxy-Authorization": {"Basic proxy-creds"},
+					"Cookie":              {"session=abc123"},
+					"X-Custom":            {"keep-me"},
+				},
+			}
+
+			req := &http.Request{
+				URL:    mustParseURL(t, test.reqURL),
+				Header: http.Header{},
+			}
+
+			fn := checkRedirect(cfg, log)
+			err := fn(req, []*http.Request{prev})
+			if err != nil {
+				t.Fatalf("checkRedirect returned error: %v", err)
+			}
+
+			check(t, req.Header, "Authorization", test.wantAuth)
+			check(t, req.Header, "Proxy-Authorization", test.wantProxyAuth)
+			check(t, req.Header, "Cookie", test.wantCookie)
+			check(t, req.Header, "X-Custom", test.wantCustom)
+		})
+	}
+}
+
+func check(t *testing.T, h http.Header, key string, wantPresent bool) {
+	t.Helper()
+	_, got := h[key]
+	if got != wantPresent {
+		if wantPresent {
+			t.Errorf("expected header %s to be present, but it was stripped", key)
+		} else {
+			t.Errorf("expected header %s to be stripped, but it is present with value %q", key, h.Get(key))
+		}
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("failed to parse URL %q: %v", raw, err)
+	}
+	return u
+}

--- a/x-pack/filebeat/input/cel/config.go
+++ b/x-pack/filebeat/input/cel/config.go
@@ -189,9 +189,10 @@ func defaultConfig() config {
 				WaitMin:     &waitMin,
 				WaitMax:     &waitMax,
 			},
-			RedirectForwardHeaders: false,
-			RedirectMaxRedirects:   10,
-			Transport:              transport,
+			RedirectForwardHeaders:   false,
+			RedirectSensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			RedirectMaxRedirects:     10,
+			Transport:                transport,
 		},
 	}
 }
@@ -283,15 +284,16 @@ func (c keepAlive) settings() httpcommon.WithKeepaliveSettings {
 }
 
 type ResourceConfig struct {
-	URL                    *urlConfig       `config:"url" validate:"required"`
-	Headers                http.Header      `config:"headers"`
-	Retry                  retryConfig      `config:"retry"`
-	RedirectForwardHeaders bool             `config:"redirect.forward_headers"`
-	RedirectHeadersBanList []string         `config:"redirect.headers_ban_list"`
-	RedirectMaxRedirects   int              `config:"redirect.max_redirects"`
-	MaxBodySize            int64            `config:"max_body_size"`
-	RateLimit              *rateLimitConfig `config:"rate_limit"`
-	KeepAlive              keepAlive        `config:"keep_alive"`
+	URL                      *urlConfig       `config:"url" validate:"required"`
+	Headers                  http.Header      `config:"headers"`
+	Retry                    retryConfig      `config:"retry"`
+	RedirectForwardHeaders   bool             `config:"redirect.forward_headers"`
+	RedirectHeadersBanList   []string         `config:"redirect.headers_ban_list"`
+	RedirectSensitiveHeaders []string         `config:"redirect.sensitive_headers"`
+	RedirectMaxRedirects     int              `config:"redirect.max_redirects"`
+	MaxBodySize              int64            `config:"max_body_size"`
+	RateLimit                *rateLimitConfig `config:"rate_limit"`
+	KeepAlive                keepAlive        `config:"keep_alive"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`
 

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1386,6 +1386,13 @@ func checkRedirect(cfg *ResourceConfig, log *logp.Logger) func(*http.Request, []
 		log.Debugf("http client: forwarding headers from previous request: %#v", prev.Header)
 		req.Header = prev.Header.Clone()
 
+		if req.URL.Host != prev.URL.Host || (prev.URL.Scheme == "https" && req.URL.Scheme == "http") {
+			for _, k := range cfg.RedirectSensitiveHeaders {
+				log.Debugf("http client: cross-origin redirect to %s: removing sensitive header %s", req.URL.Host, k)
+				req.Header.Del(k)
+			}
+		}
+
 		for _, k := range cfg.RedirectHeadersBanList {
 			log.Debugf("http client: ban header %v", k)
 			req.Header.Del(k)

--- a/x-pack/filebeat/input/httpjson/check_redirect_test.go
+++ b/x-pack/filebeat/input/httpjson/check_redirect_test.go
@@ -1,0 +1,136 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package httpjson
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+func TestCheckRedirectSensitiveHeaders(t *testing.T) {
+	log := logptest.NewTestingLogger(t, "")
+
+	tests := []struct {
+		name             string
+		prevURL          string
+		reqURL           string
+		sensitiveHeaders []string
+		wantAuth         bool
+		wantProxyAuth    bool
+		wantCookie       bool
+		wantCustom       bool
+	}{
+		{
+			name:             "same_origin_preserves_all_headers",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "https://api.example.com/v1/other",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         true,
+			wantProxyAuth:    true,
+			wantCookie:       true,
+			wantCustom:       true,
+		},
+		{
+			name:             "cross-origin_strips_sensitive_headers",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "https://evil.example.net/capture",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         false,
+			wantProxyAuth:    false,
+			wantCookie:       false,
+			wantCustom:       true,
+		},
+		{
+			name:             "scheme_downgrade_strips_sensitive_headers",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "http://api.example.com/v1/data",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         false,
+			wantProxyAuth:    false,
+			wantCookie:       false,
+			wantCustom:       true,
+		},
+		{
+			name:             "empty_sensitive_headers_preserves_all_cross-origin",
+			prevURL:          "https://api.example.com/v1/data",
+			reqURL:           "https://other.example.net/resource",
+			sensitiveHeaders: []string{},
+			wantAuth:         true,
+			wantProxyAuth:    true,
+			wantCookie:       true,
+			wantCustom:       true,
+		},
+		{
+			name:             "scheme_upgrade_same_host_preserves_headers",
+			prevURL:          "http://api.example.com/v1/data",
+			reqURL:           "https://api.example.com/v1/secure",
+			sensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			wantAuth:         true,
+			wantProxyAuth:    true,
+			wantCookie:       true,
+			wantCustom:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &requestConfig{
+				RedirectForwardHeaders:   true,
+				RedirectSensitiveHeaders: test.sensitiveHeaders,
+				RedirectMaxRedirects:     10,
+			}
+
+			prev := &http.Request{
+				URL: mustParseURL(t, test.prevURL),
+				Header: http.Header{
+					"Authorization":       {"Bearer secret"},
+					"Proxy-Authorization": {"Basic proxy-creds"},
+					"Cookie":              {"session=abc123"},
+					"X-Custom":            {"keep-me"},
+				},
+			}
+
+			req := &http.Request{
+				URL:    mustParseURL(t, test.reqURL),
+				Header: http.Header{},
+			}
+
+			fn := checkRedirect(cfg, log)
+			err := fn(req, []*http.Request{prev})
+			if err != nil {
+				t.Fatalf("checkRedirect returned error: %v", err)
+			}
+
+			check(t, req.Header, "Authorization", test.wantAuth)
+			check(t, req.Header, "Proxy-Authorization", test.wantProxyAuth)
+			check(t, req.Header, "Cookie", test.wantCookie)
+			check(t, req.Header, "X-Custom", test.wantCustom)
+		})
+	}
+}
+
+func check(t *testing.T, h http.Header, key string, wantPresent bool) {
+	t.Helper()
+	_, got := h[key]
+	if got != wantPresent {
+		if wantPresent {
+			t.Errorf("expected header %s to be present, but it was stripped", key)
+		} else {
+			t.Errorf("expected header %s to be stripped, but it is present with value %q", key, h.Get(key))
+		}
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("failed to parse URL %q: %v", raw, err)
+	}
+	return u
+}

--- a/x-pack/filebeat/input/httpjson/config.go
+++ b/x-pack/filebeat/input/httpjson/config.go
@@ -74,9 +74,10 @@ func defaultConfig() config {
 				WaitMin:     &waitMin,
 				WaitMax:     &waitMax,
 			},
-			RedirectForwardHeaders: false,
-			RedirectMaxRedirects:   10,
-			Transport:              transport,
+			RedirectForwardHeaders:   false,
+			RedirectSensitiveHeaders: []string{"Authorization", "Proxy-Authorization", "Cookie"},
+			RedirectMaxRedirects:     10,
+			Transport:                transport,
 		},
 		Response: &responseConfig{},
 	}

--- a/x-pack/filebeat/input/httpjson/config_request.go
+++ b/x-pack/filebeat/input/httpjson/config_request.go
@@ -128,17 +128,18 @@ func (u *urlConfig) Unpack(in string) error {
 }
 
 type requestConfig struct {
-	URL                    *urlConfig       `config:"url" validate:"required"`
-	Method                 string           `config:"method" validate:"required"`
-	Body                   *mapstr.M        `config:"body"`
-	EncodeAs               string           `config:"encode_as"`
-	Retry                  retryConfig      `config:"retry"`
-	RedirectForwardHeaders bool             `config:"redirect.forward_headers"`
-	RedirectHeadersBanList []string         `config:"redirect.headers_ban_list"`
-	RedirectMaxRedirects   int              `config:"redirect.max_redirects"`
-	RateLimit              *rateLimitConfig `config:"rate_limit"`
-	KeepAlive              keepAlive        `config:"keep_alive"`
-	Transforms             transformsConfig `config:"transforms"`
+	URL                      *urlConfig       `config:"url" validate:"required"`
+	Method                   string           `config:"method" validate:"required"`
+	Body                     *mapstr.M        `config:"body"`
+	EncodeAs                 string           `config:"encode_as"`
+	Retry                    retryConfig      `config:"retry"`
+	RedirectForwardHeaders   bool             `config:"redirect.forward_headers"`
+	RedirectHeadersBanList   []string         `config:"redirect.headers_ban_list"`
+	RedirectSensitiveHeaders []string         `config:"redirect.sensitive_headers"`
+	RedirectMaxRedirects     int              `config:"redirect.max_redirects"`
+	RateLimit                *rateLimitConfig `config:"rate_limit"`
+	KeepAlive                keepAlive        `config:"keep_alive"`
+	Transforms               transformsConfig `config:"transforms"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`
 

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -487,6 +487,13 @@ func checkRedirect(config *requestConfig, log *logp.Logger) func(*http.Request, 
 		log.Debugf("http client: forwarding headers from previous request: %#v", prev.Header)
 		req.Header = prev.Header.Clone()
 
+		if req.URL.Host != prev.URL.Host || (prev.URL.Scheme == "https" && req.URL.Scheme == "http") {
+			for _, k := range config.RedirectSensitiveHeaders {
+				log.Debugf("http client: cross-origin redirect to %s: removing sensitive header %s", req.URL.Host, k)
+				req.Header.Del(k)
+			}
+		}
+
 		for _, k := range config.RedirectHeadersBanList {
 			log.Debugf("http client: ban header %v", k)
 			req.Header.Del(k)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/{cel,httpjson}: strip sensitive headers on cross-origin redirects

When redirect.forward_headers is true, Authorization, Proxy-Authorization,
and Cookie headers are now removed automatically on redirects that cross
to a different host or downgrade from HTTPS to HTTP. This matches the
behaviour of Go's net/http default redirect policy and prevents credential
leakage to unintended origins via a compromised upstream server.

A new redirect.sensitive_headers configuration option (defaulting to
["Authorization", "Proxy-Authorization", "Cookie"]) controls which headers
are stripped. Operators who need cross-origin credential forwarding can
set it to [] to restore the previous behaviour.

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
