### PR TITLE
x-pack/filebeat/input/streaming: validate CrowdStrike resource URL origins

### DIFF
--- a/changelog/fragments/1782164854-crowdstrike-streaming-validate-resource-origins.yaml
+++ b/changelog/fragments/1782164854-crowdstrike-streaming-validate-resource-origins.yaml
@@ -1,0 +1,34 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Validate CrowdStrike streaming resource URL origins against the configured discover URL.
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/docs/reference/filebeat/filebeat-input-streaming.md
+++ b/docs/reference/filebeat/filebeat-input-streaming.md
@@ -34,6 +34,8 @@ The `streaming` input websocket handler does not currently support XML messages.
 
 The Crowdstrike streaming input requires OAuth2.0 as described in the Crowdstrike documentation for the API. When using the Crowdstrike streaming type, the `crowdstrike_app_id` configuration field must be set. This field specifies the `appId` parameter sent to the Crowdstrike API. See the Crowdstrike documentation for details.
 
+The feed and refresh URLs returned by the Crowdstrike discover endpoint are validated against the configured URL's origin before any request is made. By default, both URLs must share the same registrable domain (e.g. `crowdstrike.com`) as the configured `url`. If the discover response returns URLs on a different domain, you can allowlist additional origins with the `resource_origins` option.
+
 The `stream_type` configuration field specifies which type of streaming input to use, "websocket" or "crowdstrike". If it is not set, the input defaults to websocket streaming  .
 
 ## Execution [_execution_3]
@@ -241,6 +243,20 @@ The `streaming` input supports the following configuration options plus the [Com
 ### `stream_type` [stream_type-streaming]
 
 The flavor of streaming to use. This may be either "websocket", "crowdstrike", or unset. If the field is unset, websocket streaming is used.
+
+
+### `resource_origins` [resource-origins-streaming]
+
+An optional list of additional origins (scheme and host) to accept for CrowdStrike resource URLs. This only applies when `stream_type` is `crowdstrike`.
+
+By default, the `dataFeedURL` and `refreshActiveSessionURL` returned by the discover endpoint must share the same registrable domain as the configured `url` (for example, both `api.crowdstrike.com` and `firehose.crowdstrike.com` share the registrable domain `crowdstrike.com`). HTTPS-to-HTTP scheme downgrades are always rejected.
+
+If CrowdStrike returns resource URLs on a different registrable domain, add them here to allow those origins without waiting for a code change. Each entry must include a scheme and host.
+
+```yaml
+resource_origins:
+  - "https://firehose.newdomain.com"
+```
 
 
 ### `program` [program-streaming]

--- a/x-pack/filebeat/input/streaming/config.go
+++ b/x-pack/filebeat/input/streaming/config.go
@@ -56,6 +56,13 @@ type config struct {
 	// appId request parameter in the FalconHose stream
 	// discovery request.
 	CrowdstrikeAppID string `config:"crowdstrike_app_id"`
+	// ResourceOrigins is an optional allowlist of additional
+	// origins (scheme+host) that may appear in the discover
+	// response's dataFeedURL or refreshActiveSessionURL fields.
+	// By default, resource URLs must share the same registrable
+	// domain as the configured URL. Entries here extend the set
+	// of accepted origins.
+	ResourceOrigins []string `config:"resource_origins"`
 }
 
 type redact struct {
@@ -186,6 +193,15 @@ func (c config) Validate() error {
 	if c.Auth.OAuth2.isEnabled() {
 		if c.Auth.OAuth2.AuthStyle != authStyleInHeader && c.Auth.OAuth2.AuthStyle != authStyleInParams && c.Auth.OAuth2.AuthStyle != "" {
 			return fmt.Errorf("unsupported auth style: %s", c.Auth.OAuth2.AuthStyle)
+		}
+	}
+	for i, raw := range c.ResourceOrigins {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return fmt.Errorf("invalid resource_origins[%d]: %w", i, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return fmt.Errorf("resource_origins[%d] must have a scheme and host: %q", i, raw)
 		}
 	}
 	return nil

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/net/publicsuffix"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 
@@ -36,10 +37,11 @@ type falconHoseStream struct {
 
 	status status.StatusReporter
 
-	creds         *clientcredentials.Config
-	authTransport *rateLimitTransport
-	discoverURL   string
-	plainClient   *http.Client
+	creds          *clientcredentials.Config
+	authTransport  *rateLimitTransport
+	discoverURL    string
+	allowedOrigins []*url.URL
+	plainClient    *http.Client
 
 	time func() time.Time
 }
@@ -73,6 +75,57 @@ func runRefreshLoopWithAfter(ctx context.Context, wait time.Duration, after func
 				return
 			}
 		}
+	}
+}
+
+// sameOrigin reports whether target shares the same origin as base. It returns
+// true when the hostnames are identical or when both resolve to the same
+// registrable domain (eTLD+1). It rejects HTTPS-to-HTTP scheme downgrades.
+// For IP addresses or hosts where the registrable domain is undefined, only
+// an exact hostname match is accepted.
+func sameOrigin(base, target *url.URL) bool {
+	if base.Scheme == "https" && target.Scheme != "https" {
+		return false
+	}
+	bh := base.Hostname()
+	th := target.Hostname()
+	if bh == th {
+		return true
+	}
+	bd, bErr := publicsuffix.EffectiveTLDPlusOne(bh)
+	td, tErr := publicsuffix.EffectiveTLDPlusOne(th)
+	if bErr != nil || tErr != nil {
+		return false
+	}
+	return bd == td
+}
+
+// allowedOrigin reports whether target is permitted given the discover URL's
+// origin and an optional set of explicitly allowed origins. The target is
+// accepted when sameOrigin(base, target) is true or when the target's
+// scheme, hostname, and port match any entry in allowed. Absent ports are
+// normalised to the scheme default (443 for HTTPS, 80 for HTTP).
+func allowedOrigin(base *url.URL, allowed []*url.URL, target *url.URL) bool {
+	if sameOrigin(base, target) {
+		return true
+	}
+	for _, a := range allowed {
+		if a.Scheme == target.Scheme && a.Hostname() == target.Hostname() && portOrDefault(a) == portOrDefault(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func portOrDefault(u *url.URL) string {
+	if p := u.Port(); p != "" {
+		return p
+	}
+	switch u.Scheme {
+	case "https", "wss":
+		return "443"
+	default:
+		return "80"
 	}
 }
 
@@ -132,6 +185,16 @@ func NewFalconHoseFollower(ctx context.Context, env v2.Context, cfg config, curs
 	query := url.Values{"appId": []string{cfg.CrowdstrikeAppID}}
 	u.RawQuery = query.Encode()
 	s.discoverURL = u.String()
+
+	for _, raw := range cfg.ResourceOrigins {
+		o, err := url.Parse(raw)
+		if err != nil {
+			err = fmt.Errorf("failed to parse resource_origins entry %q: %w", raw, err)
+			stat.UpdateStatus(status.Failed, err.Error())
+			return nil, err
+		}
+		s.allowedOrigins = append(s.allowedOrigins, o)
+	}
 
 	// Build the auth transport before zeroing timeouts for the streaming
 	// client. The oauth2 token endpoint needs normal request timeouts;
@@ -295,11 +358,31 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	}
 	s.log.Debugw("stream discover metadata", logp.Namespace(s.ns), "meta", mapstr.M(body.Meta))
 
+	discoverOrigin, err := url.Parse(s.discoverURL)
+	if err != nil {
+		return state, fmt.Errorf("failed to parse discover url for origin check: %w", err)
+	}
+
 	cursors, _ := state["cursor"].(map[string]any)
 	// Clean up state feed annotation. This unfortunate code placement
 	// is in order to avoid allocating defers in a loop.
 	defer delete(state, "feed")
 	for _, r := range body.Resources {
+		feedURL, err := url.Parse(r.FeedURL)
+		if err != nil {
+			return state, fmt.Errorf("failed to parse feed url: %w", err)
+		}
+		if !allowedOrigin(discoverOrigin, s.allowedOrigins, feedURL) {
+			return nil, hardError{fmt.Errorf("feed url origin %q does not match discover origin %q", feedURL.Host, discoverOrigin.Host)}
+		}
+		refreshURL, err := url.Parse(r.RefreshURL)
+		if err != nil {
+			return state, fmt.Errorf("failed to parse refresh url: %w", err)
+		}
+		if !allowedOrigin(discoverOrigin, s.allowedOrigins, refreshURL) {
+			return nil, hardError{fmt.Errorf("refresh url origin %q does not match discover origin %q", refreshURL.Host, discoverOrigin.Host)}
+		}
+
 		feedName := r.FeedURL // Retain this since we will mutate it to set the offset.
 		var offset int
 		if cursor, ok := cursors[feedName].(map[string]any); ok {
@@ -340,10 +423,6 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 		}()
 
 		if offset > 0 {
-			feedURL, err := url.Parse(r.FeedURL)
-			if err != nil {
-				return state, fmt.Errorf("failed to parse feed url: %w", err)
-			}
 			feedQuery, err := url.ParseQuery(feedURL.RawQuery)
 			if err != nil {
 				return state, fmt.Errorf("failed to parse feed query: %w", err)

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -7,6 +7,7 @@ package streaming
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -411,6 +413,275 @@ func TestFollowStreamCancelsRefreshOnReconnect(t *testing.T) {
 	if growth >= totalSessions/2 {
 		t.Errorf("goroutine growth = %d; want < %d (samples: %v)",
 			growth, totalSessions/2, samples)
+	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		base string
+		tgt  string
+		want bool
+	}{
+		{
+			name: "same_host",
+			base: "https://api.crowdstrike.com/sensors",
+			tgt:  "https://api.crowdstrike.com/other",
+			want: true,
+		},
+		{
+			name: "same_registrable_domain_different_subdomains",
+			base: "https://api.crowdstrike.com/sensors",
+			tgt:  "https://firehose.crowdstrike.com/feed",
+			want: true,
+		},
+		{
+			name: "different_registrable_domain",
+			base: "https://api.crowdstrike.com/sensors",
+			tgt:  "https://evil.example.com/capture",
+			want: false,
+		},
+		{
+			name: "scheme_downgrade_https_to_http",
+			base: "https://api.crowdstrike.com/sensors",
+			tgt:  "http://api.crowdstrike.com/sensors",
+			want: false,
+		},
+		{
+			name: "scheme_upgrade_http_to_https",
+			base: "http://api.crowdstrike.com/sensors",
+			tgt:  "https://api.crowdstrike.com/sensors",
+			want: true,
+		},
+		{
+			name: "same_IP_address",
+			base: "https://192.168.1.1:8080/api",
+			tgt:  "https://192.168.1.1:9090/feed",
+			want: true,
+		},
+		{
+			name: "different_IP_addresses",
+			base: "https://192.168.1.1:8080/api",
+			tgt:  "https://10.0.0.1:8080/api",
+			want: false,
+		},
+		{
+			name: "regional_subdomains_same_domain",
+			base: "https://api.us-2.crowdstrike.com/sensors",
+			tgt:  "https://firehose.us-2.crowdstrike.com/feed",
+			want: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			base, err := url.Parse(test.base)
+			if err != nil {
+				t.Fatalf("failed to parse base URL: %v", err)
+			}
+			tgt, err := url.Parse(test.tgt)
+			if err != nil {
+				t.Fatalf("failed to parse target URL: %v", err)
+			}
+			if got := sameOrigin(base, tgt); got != test.want {
+				t.Errorf("sameOrigin(%q, %q) = %v, want %v", test.base, test.tgt, got, test.want)
+			}
+		})
+	}
+}
+
+func TestAllowedOrigin(t *testing.T) {
+	t.Parallel()
+
+	parse := func(t *testing.T, raw string) *url.URL {
+		t.Helper()
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("failed to parse URL %q: %v", raw, err)
+		}
+		return u
+	}
+
+	tests := []struct {
+		name    string
+		base    string
+		allowed []string
+		tgt     string
+		want    bool
+	}{
+		{
+			name: "same_origin_no_allowlist",
+			base: "https://api.crowdstrike.com",
+			tgt:  "https://firehose.crowdstrike.com/feed",
+			want: true,
+		},
+		{
+			name: "different_origin_no_allowlist",
+			base: "https://api.crowdstrike.com",
+			tgt:  "https://evil.example.com/capture",
+			want: false,
+		},
+		{
+			name:    "different_origin_allowed_by_allowlist",
+			base:    "https://api.crowdstrike.com",
+			allowed: []string{"https://evil.example.com"},
+			tgt:     "https://evil.example.com/capture",
+			want:    true,
+		},
+		{
+			name:    "allowlist_scheme_mismatch",
+			base:    "https://api.crowdstrike.com",
+			allowed: []string{"https://streaming.newdomain.com"},
+			tgt:     "http://streaming.newdomain.com/feed",
+			want:    false,
+		},
+		{
+			name:    "allowlist_host_mismatch",
+			base:    "https://api.crowdstrike.com",
+			allowed: []string{"https://streaming.newdomain.com"},
+			tgt:     "https://other.newdomain.com/feed",
+			want:    false,
+		},
+		{
+			name:    "allowlist_matches_with_explicit_default_port",
+			base:    "https://api.crowdstrike.com",
+			allowed: []string{"https://streaming.newdomain.com"},
+			tgt:     "https://streaming.newdomain.com:443/feed",
+			want:    true,
+		},
+		{
+			name:    "allowlist_rejects_non_default_port",
+			base:    "https://api.crowdstrike.com",
+			allowed: []string{"https://streaming.newdomain.com"},
+			tgt:     "https://streaming.newdomain.com:8443/feed",
+			want:    false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			base := parse(t, test.base)
+			tgt := parse(t, test.tgt)
+			allowed := make([]*url.URL, len(test.allowed))
+			for i, a := range test.allowed {
+				allowed[i] = parse(t, a)
+			}
+			if got := allowedOrigin(base, allowed, tgt); got != test.want {
+				t.Errorf("allowedOrigin(%q, %v, %q) = %v, want %v", test.base, test.allowed, test.tgt, got, test.want)
+			}
+		})
+	}
+}
+
+func TestFollowSessionRejectsCrossOriginResourceURLs(t *testing.T) {
+	t.Parallel()
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"tok","token_type":"bearer","expires_in":3600}`)
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	tests := []struct {
+		name       string
+		feedHost   string
+		refreshURL string
+		wantErr    string
+	}{
+		{
+			name:     "cross_origin_feed_URL",
+			feedHost: "https://evil.example.com",
+			wantErr:  "feed url origin",
+		},
+		{
+			name:       "cross_origin_refresh_URL",
+			refreshURL: "https://evil.example.com/refresh",
+			wantErr:    "refresh url origin",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"metadata":{"offset":1,"eventType":"test"}}`)
+			}))
+			defer feedSrv.Close()
+
+			refreshSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer refreshSrv.Close()
+
+			feedURL := feedSrv.URL
+			if test.feedHost != "" {
+				feedURL = test.feedHost + "/feed"
+			}
+			refreshURL := refreshSrv.URL
+			if test.refreshURL != "" {
+				refreshURL = test.refreshURL
+			}
+
+			discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{
+					"resources": [{
+						"dataFeedURL": %q,
+						"sessionToken": {"token": "tok", "expiration": "2099-01-01T00:00:00Z"},
+						"refreshActiveSessionURL": %q,
+						"refreshActiveSessionInterval": 30
+					}],
+					"meta": {}
+				}`, feedURL, refreshURL)
+			}))
+			defer discoverSrv.Close()
+
+			u, err := url.Parse(discoverSrv.URL)
+			if err != nil {
+				t.Fatalf("failed to parse discover URL: %v", err)
+			}
+			cfg := config{
+				Type: "crowdstrike",
+				URL:  &urlConfig{u},
+				Auth: authConfig{
+					OAuth2: oAuth2Config{
+						ClientID:     "id",
+						ClientSecret: "secret",
+						TokenURL:     tokenSrv.URL,
+					},
+				},
+				CrowdstrikeAppID: "test",
+				Retry:            &retry{MaxAttempts: 1, WaitMin: time.Millisecond, WaitMax: time.Millisecond},
+				Program:          `state.response.decode_json().as(body, {"events": [body]})`,
+			}
+
+			log := logptest.NewTestingLogger(t, "origin")
+			env := v2.Context{
+				ID:              "origin_test",
+				MetricsRegistry: monitoring.NewRegistry(),
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			s, err := NewFalconHoseFollower(ctx, env, cfg, nil, &testPublisher{log}, nil, log, time.Now)
+			if err != nil {
+				t.Fatalf("failed to construct follower: %v", err)
+			}
+
+			err = s.FollowStream(ctx)
+			if err == nil {
+				t.Fatal("expected FollowStream to fail with origin mismatch, but it succeeded")
+			}
+			if !errors.Is(err, hardError{}) {
+				t.Errorf("expected hardError, got: %v", err)
+			}
+			if got := err.Error(); !strings.Contains(got, test.wantErr) {
+				t.Errorf("error %q does not contain %q", got, test.wantErr)
+			}
+		})
 	}
 }
 

--- a/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
@@ -42,10 +42,9 @@ func TestFollowSession_FirehoseHTTPError(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			discoverResp := discoverResponse(t, srv.URL+"/firehose")
 			discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, discoverResp)
+				fmt.Fprint(w, discoverResponse(t, srv.URL+"/firehose", srv.URL+"/refresh"))
 			}))
 			defer discoverSrv.Close()
 
@@ -104,10 +103,9 @@ func TestFollowSession_NonObjectMessage(t *testing.T) {
 			}))
 			defer firehoseSrv.Close()
 
-			discoverResp := discoverResponse(t, firehoseSrv.URL+"/firehose")
 			discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, discoverResp)
+				fmt.Fprint(w, discoverResponse(t, firehoseSrv.URL+"/firehose", firehoseSrv.URL+"/refresh"))
 			}))
 			defer discoverSrv.Close()
 
@@ -125,7 +123,7 @@ func TestFollowSession_NonObjectMessage(t *testing.T) {
 	}
 }
 
-func discoverResponse(t *testing.T, feedURL string) string {
+func discoverResponse(t *testing.T, feedURL, refreshURL string) string {
 	t.Helper()
 	resp := map[string]any{
 		"resources": []map[string]any{
@@ -135,7 +133,7 @@ func discoverResponse(t *testing.T, feedURL string) string {
 					"token":      "test-token",
 					"expiration": "2099-01-01T00:00:00Z",
 				},
-				"refreshActiveSessionURL":      "http://localhost/refresh",
+				"refreshActiveSessionURL":      refreshURL,
 				"refreshActiveSessionInterval": 1800,
 			},
 		},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: validate CrowdStrike resource URL origins

The CrowdStrike streaming input follows dataFeedURL and
refreshActiveSessionURL from the discover response without checking
that they point to the same place as the configured URL. Add origin
validation using registrable domain (eTLD+1) comparison via
golang.org/x/net/publicsuffix. This allows CrowdStrike's
cross-subdomain setup (api.crowdstrike.com to
firehose.crowdstrike.com) while rejecting URLs on unrelated domains.
HTTPS-to-HTTP scheme downgrades are also rejected. Mismatches
terminate the input with a hard error.

A resource_origins config option provides an escape hatch for
environments where CrowdStrike moves infrastructure to a different
registrable domain, avoiding the need for a code release.

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
