### PR TITLE
x-pack/filebeat/input/http_endpoint: use constant-time comparison for auth checks

### DIFF
--- a/changelog/fragments/1782166371-http_endpoint-constant-time-auth.yaml
+++ b/changelog/fragments/1782166371-http_endpoint-constant-time-auth.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Use constant-time comparison for http_endpoint basic auth and secret header validation.
+component: filebeat

--- a/x-pack/filebeat/input/http_endpoint/validate.go
+++ b/x-pack/filebeat/input/http_endpoint/validate.go
@@ -9,6 +9,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -46,13 +47,15 @@ type apiValidator struct {
 func (v *apiValidator) validateRequest(r *http.Request) (status int, err error) {
 	if v.basicAuth {
 		username, password, _ := r.BasicAuth()
-		if v.username != username || v.password != password {
+		usernameMatch := subtle.ConstantTimeCompare([]byte(v.username), []byte(username))
+		passwordMatch := subtle.ConstantTimeCompare([]byte(v.password), []byte(password))
+		if usernameMatch&passwordMatch != 1 {
 			return http.StatusUnauthorized, errIncorrectUserOrPass
 		}
 	}
 
 	if v.secretHeader != "" && v.secretValue != "" {
-		if v.secretValue != r.Header.Get(v.secretHeader) {
+		if subtle.ConstantTimeCompare([]byte(v.secretValue), []byte(r.Header.Get(v.secretHeader))) != 1 {
 			return http.StatusUnauthorized, errIncorrectHeaderSecret
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/http_endpoint: use constant-time comparison for auth checks

Replace direct string comparison (!=) with crypto/subtle.ConstantTimeCompare
for basic auth and secret header validation. The adjacent HMAC validation
already used hmac.Equal (constant-time), so this brings the other two auth
paths into line.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
