### PR TITLE
x-pack/filebeat/input/httpjson: validate pagination URL origin

### DIFF
--- a/changelog/fragments/1782167932-httpjson-pagination-origin-validation.yaml
+++ b/changelog/fragments/1782167932-httpjson-pagination-origin-validation.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Validate that HTTPJSON pagination URLs share the configured request URL origin.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-httpjson.md
+++ b/docs/reference/filebeat/filebeat-input-httpjson.md
@@ -1018,6 +1018,22 @@ Nested split operation. Split operations can be nested at will. An event won’t
 If set to true, the values in `request.body` are sent for pagination requests. Default: `false`.
 
 
+### `response.pagination_allowed_hosts` [response-pagination-allowed-hosts]
+
+An optional list of additional origins that pagination URLs are allowed to target. By default, pagination URLs derived from API responses (via `set` with `target: url.value`) must share the same hostname as the configured `request.url`. If a remote API legitimately returns pagination URLs on a different host (for example, a CDN), list those origins here.
+
+Each entry must include both a scheme and a host. Example:
+
+```yaml
+response:
+  pagination_allowed_hosts:
+    - "https://cdn.provider.com"
+    - "https://api-secondary.provider.com:8443"
+```
+
+Default: empty (only URLs matching the configured `request.url` hostname are accepted).
+
+
 ### `response.pagination` [response-pagination]
 
 List of transforms that will be applied to the response to every new page request. All the transforms from `request.transform` will be executed and then `response.pagination` will be added to modify the next request as needed. For subsequent responses, the usual [response.transforms](#response-transforms) and [response.split](#response-split) will be executed normally.

--- a/docs/reference/filebeat/filebeat-input-httpjson.md
+++ b/docs/reference/filebeat/filebeat-input-httpjson.md
@@ -1020,9 +1020,9 @@ If set to true, the values in `request.body` are sent for pagination requests. D
 
 ### `response.pagination_allowed_hosts` [response-pagination-allowed-hosts]
 
-An optional list of additional origins that pagination URLs are allowed to target. By default, pagination URLs derived from API responses (via `set` with `target: url.value`) must share the same hostname as the configured `request.url`. If a remote API legitimately returns pagination URLs on a different host (for example, a CDN), list those origins here.
+An optional list of additional origins that pagination URLs are allowed to target. By default, pagination URLs derived from API responses (via `set` with `target: url.value`) must share the same origin (scheme, hostname, and port) as the configured `request.url`. If a remote API legitimately returns pagination URLs on a different origin (for example, a CDN), list those origins here.
 
-Each entry must include both a scheme and a host. Example:
+Each entry must include a scheme and a host, and may include a port. Example:
 
 ```yaml
 response:
@@ -1031,7 +1031,7 @@ response:
     - "https://api-secondary.provider.com:8443"
 ```
 
-Default: empty (only URLs matching the configured `request.url` hostname are accepted).
+Default: empty (only URLs matching the configured `request.url` origin are accepted).
 
 
 ### `response.pagination` [response-pagination]

--- a/x-pack/filebeat/input/httpjson/config_response.go
+++ b/x-pack/filebeat/input/httpjson/config_response.go
@@ -6,6 +6,7 @@ package httpjson
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -21,6 +22,7 @@ type responseConfig struct {
 	RequestBodyOnPagination bool             `config:"request_body_on_pagination"`
 	Transforms              transformsConfig `config:"transforms"`
 	Pagination              transformsConfig `config:"pagination"`
+	PaginationAllowedHosts  []string         `config:"pagination_allowed_hosts"`
 	Split                   *splitConfig     `config:"split"`
 	SaveFirstResponse       bool             `config:"save_first_response"`
 }
@@ -42,6 +44,15 @@ func (c *responseConfig) Validate() error {
 	}
 	if _, err := newBasicTransformsFromConfig(registeredTransforms, c.Pagination, paginationNamespace, noopReporter{}, nil); err != nil {
 		return err
+	}
+	for _, origin := range c.PaginationAllowedHosts {
+		u, err := url.Parse(origin)
+		if err != nil {
+			return fmt.Errorf("invalid pagination_allowed_hosts entry %q: %w", origin, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return fmt.Errorf("pagination_allowed_hosts entry %q must have both a scheme and a host", origin)
+		}
 	}
 	if c.DecodeAs != "" {
 		if _, found := registeredDecoders[c.DecodeAs]; !found {

--- a/x-pack/filebeat/input/httpjson/config_test.go
+++ b/x-pack/filebeat/input/httpjson/config_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -692,6 +693,52 @@ LNV/bIgMHOMoxiGrwyjAhg==
 			case c.expectedErr != "":
 				if err == nil || err.Error() != c.expectedErr {
 					t.Fatalf("Configuration validation failed. expecting %q error but got %q", c.expectedErr, err)
+				}
+			}
+		})
+	}
+}
+
+func TestPaginationAllowedHostsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		hosts   []interface{}
+		wantErr string
+	}{
+		{
+			name:  "valid_entries",
+			hosts: []interface{}{"https://cdn.example.com", "https://api.other.com:8443"},
+		},
+		{
+			name:    "missing_scheme",
+			hosts:   []interface{}{"cdn.example.com"},
+			wantErr: `pagination_allowed_hosts entry "cdn.example.com" must have both a scheme and a host`,
+		},
+		{
+			name:    "missing_host",
+			hosts:   []interface{}{"https://"},
+			wantErr: `pagination_allowed_hosts entry "https://" must have both a scheme and a host`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := map[string]interface{}{
+				"request.url":                       "https://localhost",
+				"response.pagination_allowed_hosts": test.hosts,
+			}
+			cfg := conf.MustNewConfigFrom(m)
+			c := defaultConfig()
+			err := cfg.Unpack(&c)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", test.wantErr)
+				}
+				if !strings.Contains(err.Error(), test.wantErr) {
+					t.Errorf("Unpack() error = %q; want substring %q", err, test.wantErr)
 				}
 			}
 		})

--- a/x-pack/filebeat/input/httpjson/pagination.go
+++ b/x-pack/filebeat/input/httpjson/pagination.go
@@ -50,6 +50,15 @@ func newPagination(config config, client *httpClient, stat status.StatusReporter
 		return &mapstr.M{}
 	}()
 
+	var allowedOrigins []*url.URL
+	for _, s := range config.Response.PaginationAllowedHosts {
+		u, err := url.Parse(s)
+		if err != nil {
+			continue // already validated by responseConfig.Validate
+		}
+		allowedOrigins = append(allowedOrigins, u)
+	}
+
 	requestFactory := newPaginationRequestFactory(
 		config.Request.Method,
 		config.Request.EncodeAs,
@@ -57,6 +66,7 @@ func newPagination(config config, client *httpClient, stat status.StatusReporter
 		body,
 		append(rts, pts...),
 		config.Auth,
+		allowedOrigins,
 		stat,
 		log,
 	)
@@ -64,15 +74,17 @@ func newPagination(config config, client *httpClient, stat status.StatusReporter
 	return pagination
 }
 
-func newPaginationRequestFactory(method, encodeAs string, url url.URL, body *mapstr.M, ts []basicTransform, authConfig *authConfig, stat status.StatusReporter, log *logp.Logger) *requestFactory {
+func newPaginationRequestFactory(method, encodeAs string, u url.URL, body *mapstr.M, ts []basicTransform, authConfig *authConfig, allowedOrigins []*url.URL, stat status.StatusReporter, log *logp.Logger) *requestFactory {
 	// config validation already checked for errors here
 	rf := &requestFactory{
-		url:        url,
-		method:     method,
-		body:       body,
-		transforms: ts,
-		log:        log,
-		encoder:    registeredEncoders[encodeAs],
+		url:            u,
+		method:         method,
+		body:           body,
+		transforms:     ts,
+		log:            log,
+		encoder:        registeredEncoders[encodeAs],
+		originURL:      &u,
+		allowedOrigins: allowedOrigins,
 	}
 	if authConfig != nil && authConfig.Basic.isEnabled() {
 		rf.user = authConfig.Basic.User

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -304,6 +304,13 @@ type requestFactory struct {
 	chainResponseProcessor *responseProcessor
 	saveFirstResponse      bool
 	log                    *logp.Logger
+
+	// originURL and allowedOrigins constrain the URL that transforms
+	// can produce. When originURL is non-nil, newHTTPRequest validates
+	// the post-transform URL against originURL and allowedOrigins. Set
+	// only on pagination factories.
+	originURL      *url.URL
+	allowedOrigins []*url.URL
 }
 
 func newRequestFactory(ctx context.Context, config config, stat status.StatusReporter, log *logp.Logger, metrics *inputMetrics, reg *monitoring.Registry) ([]*requestFactory, error) {
@@ -441,6 +448,16 @@ func (rf *requestFactory) newHTTPRequest(ctx context.Context, trCtx *transformCo
 		return nil, err
 	}
 
+	if rf.originURL != nil {
+		target := trReq.url()
+		if !allowedOrigin(rf.originURL, rf.allowedOrigins, &target) {
+			return nil, fmt.Errorf(
+				"pagination URL origin %q does not match configured origin %q",
+				target.Hostname(), rf.originURL.Hostname(),
+			)
+		}
+	}
+
 	var body []byte
 	if rf.method == http.MethodPost {
 		if rf.encoder != nil {
@@ -502,6 +519,35 @@ func (rf *requestFactory) newRequest(ctx *transformContext) (transformable, erro
 	rf.log.Debugw("new request", "req", redact{value: mapstrM(req), fields: []string{"header.Authorization"}})
 
 	return req, nil
+}
+
+// allowedOrigin returns true if target shares the same origin as base,
+// or if it matches any of the additional allowed origins. An allowed
+// origin only matches when the target also does not downgrade from the
+// base scheme, so an HTTP entry in the allowlist cannot bypass HTTPS
+// enforcement on the configured request URL.
+func allowedOrigin(base *url.URL, allowed []*url.URL, target *url.URL) bool {
+	if sameOrigin(base, target) {
+		return true
+	}
+	if base.Scheme == "https" && target.Scheme != "https" {
+		return false
+	}
+	for _, a := range allowed {
+		if sameOrigin(a, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// sameOrigin returns true when target does not downgrade from HTTPS to
+// HTTP and shares the same hostname as base.
+func sameOrigin(base, target *url.URL) bool {
+	if base.Scheme == "https" && target.Scheme != "https" {
+		return false
+	}
+	return base.Hostname() == target.Hostname()
 }
 
 type requester struct {

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -307,8 +307,7 @@ type requestFactory struct {
 
 	// originURL and allowedOrigins constrain the URL that transforms
 	// can produce. When originURL is non-nil, newHTTPRequest validates
-	// the post-transform URL against originURL and allowedOrigins. Set
-	// only on pagination factories.
+	// the post-transform URL against originURL and allowedOrigins.
 	originURL      *url.URL
 	allowedOrigins []*url.URL
 }
@@ -342,6 +341,14 @@ func newRequestFactory(ctx context.Context, config config, stat status.StatusRep
 		}
 	}
 	rfs = append(rfs, rf)
+	var chainAllowedOrigins []*url.URL
+	for _, s := range config.Response.PaginationAllowedHosts {
+		u, err := url.Parse(s)
+		if err != nil {
+			continue // already validated by responseConfig.Validate
+		}
+		chainAllowedOrigins = append(chainAllowedOrigins, u)
+	}
 	for _, ch := range config.Chain {
 		var rf *requestFactory
 		// chain calls requestFactory object
@@ -354,8 +361,9 @@ func newRequestFactory(ctx context.Context, config config, stat status.StatusRep
 			}
 
 			responseProcessor := newChainResponseProcessor(ch, client, xmlDetails, metrics, stat, log)
+			stepURL := ch.Step.Request.URL.URL
 			rf = &requestFactory{
-				url:                    *ch.Step.Request.URL.URL,
+				url:                    *stepURL,
 				method:                 ch.Step.Request.Method,
 				body:                   ch.Step.Request.Body,
 				transforms:             ts,
@@ -366,6 +374,10 @@ func newRequestFactory(ctx context.Context, config config, stat status.StatusRep
 				isChain:                true,
 				chainClient:            client,
 				chainResponseProcessor: responseProcessor,
+			}
+			if ch.Step.Replace == "" {
+				rf.originURL = stepURL
+				rf.allowedOrigins = chainAllowedOrigins
 			}
 			if ch.Step.Auth != nil && ch.Step.Auth.Basic.isEnabled() {
 				rf.user = ch.Step.Auth.Basic.User
@@ -381,8 +393,9 @@ func newRequestFactory(ctx context.Context, config config, stat status.StatusRep
 			}
 
 			responseProcessor := newChainResponseProcessor(ch, client, xmlDetails, metrics, stat, log)
+			whileURL := ch.While.Request.URL.URL
 			rf = &requestFactory{
-				url:                    *ch.While.Request.URL.URL,
+				url:                    *whileURL,
 				method:                 ch.While.Request.Method,
 				body:                   ch.While.Request.Body,
 				transforms:             ts,
@@ -394,6 +407,10 @@ func newRequestFactory(ctx context.Context, config config, stat status.StatusRep
 				isChain:                true,
 				chainClient:            client,
 				chainResponseProcessor: responseProcessor,
+			}
+			if ch.While.Replace == "" {
+				rf.originURL = whileURL
+				rf.allowedOrigins = chainAllowedOrigins
 			}
 			if ch.While.Auth != nil && ch.While.Auth.Basic.isEnabled() {
 				rf.user = ch.While.Auth.Basic.User
@@ -453,7 +470,7 @@ func (rf *requestFactory) newHTTPRequest(ctx context.Context, trCtx *transformCo
 		if !allowedOrigin(rf.originURL, rf.allowedOrigins, &target) {
 			return nil, fmt.Errorf(
 				"pagination URL origin %q does not match configured origin %q",
-				target.Hostname(), rf.originURL.Hostname(),
+				target.Host, rf.originURL.Host,
 			)
 		}
 	}
@@ -541,13 +558,30 @@ func allowedOrigin(base *url.URL, allowed []*url.URL, target *url.URL) bool {
 	return false
 }
 
-// sameOrigin returns true when target does not downgrade from HTTPS to
-// HTTP and shares the same hostname as base.
+// sameOrigin returns true when target shares the same origin (scheme,
+// hostname, and port) as base. HTTPS-to-HTTP downgrades are rejected
+// explicitly; scheme upgrades also fail because the default ports
+// differ (80 vs 443). Explicit default ports are normalised so that
+// https://example.com and https://example.com:443 are the same origin.
 func sameOrigin(base, target *url.URL) bool {
 	if base.Scheme == "https" && target.Scheme != "https" {
 		return false
 	}
-	return base.Hostname() == target.Hostname()
+	return base.Hostname() == target.Hostname() && portOrDefault(base) == portOrDefault(target)
+}
+
+func portOrDefault(u *url.URL) string {
+	if p := u.Port(); p != "" {
+		return p
+	}
+	switch u.Scheme {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 type requester struct {

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -350,6 +351,126 @@ func TestProcessExpression(t *testing.T) {
 	for _, test := range tests {
 		got := processExpression(test.in)
 		assert.Equal(t, test.want, got)
+	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   string
+		target string
+		want   bool
+	}{
+		{name: "same_host", base: "https://api.example.com/v1", target: "https://api.example.com/v2", want: true},
+		{name: "same_host_different_path", base: "https://api.example.com/events", target: "https://api.example.com/events?page=2", want: true},
+		{name: "different_host", base: "https://api.example.com", target: "https://evil.example.net", want: false},
+		{name: "different_subdomain", base: "https://api.example.com", target: "https://cdn.example.com", want: false},
+		{name: "scheme_downgrade", base: "https://api.example.com", target: "http://api.example.com", want: false},
+		{name: "scheme_upgrade", base: "http://api.example.com", target: "https://api.example.com", want: true},
+		{name: "same_ip", base: "https://192.168.1.1/api", target: "https://192.168.1.1/api?page=2", want: true},
+		{name: "different_ip", base: "https://192.168.1.1", target: "https://10.0.0.1", want: false},
+		{name: "same_hostname_ignores_port", base: "https://api.example.com:443", target: "https://api.example.com:8443", want: true},
+		{name: "same_host_explicit_vs_implicit_port", base: "https://api.example.com", target: "https://api.example.com:443", want: true},
+		{name: "metadata_ssrf", base: "https://api.provider.com", target: "http://169.254.169.254/latest/meta-data/", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := newURL(test.base)
+			target := newURL(test.target)
+			got := sameOrigin(base, target)
+			if got != test.want {
+				t.Errorf("sameOrigin(%q, %q) = %v, want %v", test.base, test.target, got, test.want)
+			}
+		})
+	}
+}
+
+func TestAllowedOrigin(t *testing.T) {
+	base := newURL("https://api.example.com")
+
+	tests := []struct {
+		name    string
+		allowed []string
+		target  string
+		want    bool
+	}{
+		{name: "same_as_base", target: "https://api.example.com/page/2", want: true},
+		{name: "cross_origin_no_allowlist", target: "https://cdn.example.net/page/2", want: false},
+		{
+			name:    "cross_origin_allowlisted",
+			allowed: []string{"https://cdn.example.net"},
+			target:  "https://cdn.example.net/page/2",
+			want:    true,
+		},
+		{
+			name:    "cross_origin_not_in_allowlist",
+			allowed: []string{"https://cdn.example.net"},
+			target:  "https://evil.example.org/page/2",
+			want:    false,
+		},
+		{
+			name:    "scheme_downgrade_despite_allowlist",
+			allowed: []string{"https://cdn.example.net"},
+			target:  "http://cdn.example.net/page/2",
+			want:    false,
+		},
+		{
+			name:    "http_allowlist_entry_cannot_bypass_https_base",
+			allowed: []string{"http://cdn.example.net"},
+			target:  "http://cdn.example.net/page/2",
+			want:    false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var allowed []*url.URL
+			for _, s := range test.allowed {
+				allowed = append(allowed, newURL(s))
+			}
+			target := newURL(test.target)
+			got := allowedOrigin(base, allowed, target)
+			if got != test.want {
+				t.Errorf("allowedOrigin(base, %v, %q) = %v, want %v", test.allowed, test.target, got, test.want)
+			}
+		})
+	}
+}
+
+func TestPaginationRejectsCrossOriginURL(t *testing.T) {
+	base := newURL("https://api.example.com/v1/events")
+	rf := &requestFactory{
+		url:        *base,
+		method:     "GET",
+		originURL:  base,
+		log:        logp.NewLogger("test"),
+		encoder:    registeredEncoders[""],
+		transforms: []basicTransform{},
+	}
+
+	trCtx := emptyTransformContext()
+	trCtx.lastResponse = &response{
+		url: *base,
+	}
+
+	// With no transforms mutating the URL, the request should succeed
+	// because the URL remains the same as the configured origin.
+	req, err := rf.newHTTPRequest(context.Background(), trCtx)
+	if err != nil {
+		t.Fatalf("same-origin request failed: %v", err)
+	}
+	if req.URL.Hostname() != "api.example.com" {
+		t.Fatalf("unexpected hostname: %s", req.URL.Hostname())
+	}
+
+	// Now simulate a transform that replaced the URL with a cross-origin one.
+	evil := newURL("https://evil.example.net/steal")
+	rf.url = *evil
+	_, err = rf.newHTTPRequest(context.Background(), trCtx)
+	if err == nil {
+		t.Fatal("expected error for cross-origin pagination URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not match configured origin") {
+		t.Errorf("newHTTPRequest() error = %q; want substring %q", err, "does not match configured origin")
 	}
 }
 

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -7,6 +7,7 @@ package httpjson
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -19,6 +20,7 @@ import (
 	beattest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -366,11 +368,15 @@ func TestSameOrigin(t *testing.T) {
 		{name: "different_host", base: "https://api.example.com", target: "https://evil.example.net", want: false},
 		{name: "different_subdomain", base: "https://api.example.com", target: "https://cdn.example.com", want: false},
 		{name: "scheme_downgrade", base: "https://api.example.com", target: "http://api.example.com", want: false},
-		{name: "scheme_upgrade", base: "http://api.example.com", target: "https://api.example.com", want: true},
+		{name: "scheme_upgrade", base: "http://api.example.com", target: "https://api.example.com", want: false},
 		{name: "same_ip", base: "https://192.168.1.1/api", target: "https://192.168.1.1/api?page=2", want: true},
 		{name: "different_ip", base: "https://192.168.1.1", target: "https://10.0.0.1", want: false},
-		{name: "same_hostname_ignores_port", base: "https://api.example.com:443", target: "https://api.example.com:8443", want: true},
-		{name: "same_host_explicit_vs_implicit_port", base: "https://api.example.com", target: "https://api.example.com:443", want: true},
+		{name: "different_port", base: "https://api.example.com:443", target: "https://api.example.com:8443", want: false},
+		{name: "explicit_default_port_matches_implicit", base: "https://api.example.com", target: "https://api.example.com:443", want: true},
+		{name: "explicit_non_default_port", base: "https://api.example.com:9200", target: "https://api.example.com:9200", want: true},
+		{name: "http_default_port_matches_implicit", base: "http://api.example.com", target: "http://api.example.com:80", want: true},
+		{name: "http_non_default_port", base: "http://api.example.com:8080", target: "http://api.example.com:8080", want: true},
+		{name: "http_different_port", base: "http://api.example.com:8080", target: "http://api.example.com:9090", want: false},
 		{name: "metadata_ssrf", base: "https://api.provider.com", target: "http://169.254.169.254/latest/meta-data/", want: false},
 	}
 	for _, test := range tests {
@@ -418,6 +424,18 @@ func TestAllowedOrigin(t *testing.T) {
 			name:    "http_allowlist_entry_cannot_bypass_https_base",
 			allowed: []string{"http://cdn.example.net"},
 			target:  "http://cdn.example.net/page/2",
+			want:    false,
+		},
+		{
+			name:    "allowlisted_with_matching_port",
+			allowed: []string{"https://cdn.example.net:8443"},
+			target:  "https://cdn.example.net:8443/page/2",
+			want:    true,
+		},
+		{
+			name:    "allowlisted_with_different_port",
+			allowed: []string{"https://cdn.example.net:8443"},
+			target:  "https://cdn.example.net:9443/page/2",
 			want:    false,
 		},
 	}
@@ -471,6 +489,75 @@ func TestPaginationRejectsCrossOriginURL(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not match configured origin") {
 		t.Errorf("newHTTPRequest() error = %q; want substring %q", err, "does not match configured origin")
+	}
+}
+
+func TestChainStepOriginValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		base        string
+		chainTarget string
+		allowed     []string
+		wantErr     error
+	}{
+		{
+			name:        "same_origin",
+			base:        "https://api.example.com/v1/details",
+			chainTarget: "https://api.example.com/v1/details",
+		},
+		{
+			name:        "cross_origin_rejected",
+			base:        "https://api.example.com/v1/details",
+			chainTarget: "https://evil.example.net/steal",
+			wantErr:     errors.New(`pagination URL origin "evil.example.net" does not match configured origin "api.example.com"`),
+		},
+		{
+			name:        "cross_origin_port_rejected",
+			base:        "https://api.example.com/v1/details",
+			chainTarget: "https://api.example.com:8443/steal",
+			wantErr:     errors.New(`pagination URL origin "api.example.com:8443" does not match configured origin "api.example.com"`),
+		},
+		{
+			name:        "allowlisted_origin",
+			base:        "https://api.example.com/v1/details",
+			chainTarget: "https://cdn.example.net/v1/details",
+			allowed:     []string{"https://cdn.example.net"},
+		},
+		{
+			name:        "not_in_allowlist",
+			base:        "https://api.example.com/v1/details",
+			chainTarget: "https://evil.example.org/steal",
+			allowed:     []string{"https://cdn.example.net"},
+			wantErr:     errors.New(`pagination URL origin "evil.example.org" does not match configured origin "api.example.com"`),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var allowed []*url.URL
+			for _, s := range test.allowed {
+				allowed = append(allowed, newURL(s))
+			}
+			base := newURL(test.base)
+			target := newURL(test.chainTarget)
+			rf := &requestFactory{
+				url:            *target,
+				method:         "GET",
+				originURL:      base,
+				allowedOrigins: allowed,
+				isChain:        true,
+				log:            logptest.NewTestingLogger(t, t.Name()),
+				encoder:        registeredEncoders[""],
+				transforms:     []basicTransform{},
+			}
+
+			trCtx := emptyTransformContext()
+			trCtx.lastResponse = &response{url: *base}
+
+			_, err := rf.newHTTPRequest(context.Background(), trCtx)
+			if !sameError(err, test.wantErr) {
+				t.Errorf("unexpected error: got=%q want=%q", err, test.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/httpjson: validate pagination URL origin

The setURLValue transform parses a response-derived string and sets
it as the next request URL without checking the origin. When
pagination uses target: url.value, a compromised upstream API can
redirect requests to arbitrary hosts; configured auth headers follow.

Validate that pagination URLs share the same hostname as the
configured request.url before issuing any request. HTTPS-to-HTTP
downgrades are also rejected. A response.pagination_allowed_hosts
config field provides an escape hatch for APIs that legitimately
return pagination URLs on a different host.

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
