### PR TITLE
[9.3](backport #50118) perf: harvester: Reduce logger clones

### DIFF
--- a/changelog/fragments/1777530175-orestisfl-reduce-harvester-logger-clones.yaml
+++ b/changelog/fragments/1777530175-orestisfl-reduce-harvester-logger-clones.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Optimize filestream logger performance
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -221,8 +221,7 @@ func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetada
 			}
 
 			src := p.identifier.GetSource(fe)
-			p.onFSEvent(loggerWithEvent(log, fe, src), ctx, fe, src, s, hg, ignoreInactiveSince)
-
+			p.onFSEvent(loggerWithEvent(log, fe), ctx, fe, src, s, hg, ignoreInactiveSince)
 		}
 		return nil
 	})
@@ -233,24 +232,17 @@ func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetada
 	}
 }
 
-func (p *copyTruncateFileProspector) onFSEvent(
-	log *logp.Logger,
-	ctx input.Context,
-	event loginp.FSEvent,
-	src loginp.Source,
-	updater loginp.StateMetadataUpdater,
-	group loginp.HarvesterGroup,
-	ignoreSince time.Time,
-) {
+func (p *copyTruncateFileProspector) onFSEvent(log *logp.Logger, ctx input.Context, event loginp.FSEvent, src loginp.Source, updater loginp.StateMetadataUpdater, group loginp.HarvesterGroup, ignoreSince time.Time) {
 	switch event.Op {
 	case loginp.OpCreate, loginp.OpWrite:
-		if event.Op == loginp.OpCreate {
+		switch event.Op {
+		case loginp.OpCreate:
 			log.Debugf("A new file %s has been found", event.NewPath)
-		} else if event.Op == loginp.OpWrite {
+		case loginp.OpWrite:
 			log.Debugf("File %s has been updated", event.NewPath)
 		}
 
-		if p.fileProspector.isFileIgnored(log, event, ignoreSince) {
+		if p.isFileIgnored(log, event, ignoreSince) {
 			return
 		}
 
@@ -287,7 +279,7 @@ func (p *copyTruncateFileProspector) onFSEvent(
 	case loginp.OpDelete:
 		log.Debugf("File %s has been removed", event.OldPath)
 
-		p.fileProspector.onRemove(log, event, src, updater, group)
+		p.onRemove(log, event, src, updater, group)
 
 	case loginp.OpRename:
 		log.Debugf("File %s has been renamed to %s", event.OldPath, event.NewPath)
@@ -299,10 +291,10 @@ func (p *copyTruncateFileProspector) onFSEvent(
 			p.onRotatedFile(log, ctx, event, src, group)
 		}
 
-		p.fileProspector.onRename(log, ctx, event, src, updater, group)
+		p.onRename(log, ctx, event, src, updater, group)
 
 	default:
-		log.Error("Unknown return value %v", event.Op)
+		log.Errorf("Unknown return value %v", event.Op)
 	}
 }
 
@@ -310,13 +302,7 @@ func (p *copyTruncateFileProspector) isRotated(event loginp.FSEvent) bool {
 	return p.rotatedSuffix.MatchString(event.NewPath)
 }
 
-func (p *copyTruncateFileProspector) onRotatedFile(
-	log *logp.Logger,
-	ctx input.Context,
-	fe loginp.FSEvent,
-	src loginp.Source,
-	hg loginp.HarvesterGroup,
-) {
+func (p *copyTruncateFileProspector) onRotatedFile(log *logp.Logger, ctx input.Context, fe loginp.FSEvent, src loginp.Source, hg loginp.HarvesterGroup) {
 	// Continue reading the rotated file from where we have left off with the original.
 	// The original will be picked up again when updated and read from the beginning.
 	originalPath := p.rotatedSuffix.ReplaceAllLiteralString(fe.NewPath, "")

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -311,14 +311,14 @@ func (w *fileWatcher) watch(ctx unison.Canceler) {
 		}
 	}
 
-	w.log.With(
+	w.log.Debugw("File scan complete",
 		"total", len(paths),
 		"written", writtenCount,
 		"truncated", truncatedCount,
 		"renamed", renamedCount,
 		"removed", removedCount,
 		"created", createdCount,
-	).Debugf("File scan complete")
+	)
 
 	w.prev = paths
 }

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"time"
 
+	"go.uber.org/zap"
 	"golang.org/x/text/transform"
 
 	"github.com/elastic/go-concert/ctxtool"
@@ -215,7 +216,7 @@ func (inp *filestream) Run(
 		return fmt.Errorf("not file source")
 	}
 
-	log := ctx.Logger.With("path", fs.newPath).With("state-id", src.Name())
+	log := ctx.Logger.WithLazy(zap.String("path", fs.newPath), zap.String("state-id", src.Name()))
 	state := initState(log, cursor, fs)
 	if state.EOF {
 		// TODO: change it to debug once GZIP isn't experimental anymore.
@@ -798,13 +799,17 @@ func (inp *filestream) readFromSource(
 func (inp *filestream) isDroppedLine(log *logp.Logger, line string) bool {
 	if len(inp.readerConfig.IncludeLines) > 0 {
 		if !matchAny(inp.readerConfig.IncludeLines, line) {
-			log.Debug("Drop line as it does not match any of the include patterns %s", line)
+			if log.IsDebug() {
+				log.Debug("Drop line as it does not match any of the include patterns %s", line)
+			}
 			return true
 		}
 	}
 	if len(inp.readerConfig.ExcludeLines) > 0 {
 		if matchAny(inp.readerConfig.ExcludeLines, line) {
-			log.Debug("Drop line as it does match one of the exclude patterns%s", line)
+			if log.IsDebug() {
+				log.Debug("Drop line as it does match one of the exclude patterns%s", line)
+			}
 			return true
 		}
 	}

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -49,7 +49,8 @@ import (
 )
 
 func BenchmarkFilestream(b *testing.B) {
-	logger := logp.NewNopLogger()
+	// Info level keeps per-line Debugf calls out of the hot path.
+	logger := logptest.NewTestingLogger(b, "", zap.IncreaseLevel(zap.InfoLevel))
 
 	cases := []struct {
 		name        string

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -33,10 +33,7 @@ import (
 	"github.com/elastic/go-concert/ctxtool"
 )
 
-var (
-	ErrHarvesterAlreadyRunning = errors.New("harvester is already running for file")
-	ErrHarvesterLimitReached   = errors.New("harvester limit reached")
-)
+var ErrHarvesterAlreadyRunning = errors.New("harvester is already running for file")
 
 type permanentHarvesterError struct {
 	err error
@@ -74,7 +71,7 @@ func newReaderGroup() *readerGroup {
 }
 
 // newContext creates a new context, cancel function and associates it with the given id within
-// the reader group. Using the cancel function does not remvoe the association.
+// the reader group. Using the cancel function does not remove the association.
 // An error is returned if the id is already associated with a context. The cancel
 // function is nil in that case and must not be called.
 //
@@ -179,13 +176,11 @@ func (hg *defaultHarvesterGroup) SetObserver(c chan HarvesterStatus) {
 // If the harvester limit has been reached, the harvester will wait until it can
 // be started. Start does not block.
 func (hg *defaultHarvesterGroup) Start(ctx inputv2.Context, src Source) {
-	sourceName := hg.identifier.ID(src)
-	ctx.Logger = ctx.Logger.With("source_file", sourceName)
-
 	fn := startHarvester(ctx, hg, src, false, hg.metrics, hg.inputID)
 	if fn == nil {
 		return
 	}
+
 	if err := hg.tg.Go(fn); err != nil {
 		ctx.Logger.Warnf(
 			"tried to start harvester for %s with task group already closed",
@@ -198,10 +193,7 @@ func (hg *defaultHarvesterGroup) Start(ctx inputv2.Context, src Source) {
 // If the harvester limit has been reached, the harvester will wait until it can
 // be started. Restart does not block.
 func (hg *defaultHarvesterGroup) Restart(ctx inputv2.Context, src Source) {
-	sourceName := hg.identifier.ID(src)
-
-	ctx.Logger = ctx.Logger.With("source_file", sourceName)
-	ctx.Logger.Debug("Restarting harvester for file")
+	ctx.Logger.Debugf("Restarting harvester for %s", src)
 
 	if err := hg.tg.Go(startHarvester(ctx, hg, src, true, hg.metrics, hg.inputID)); err != nil {
 		ctx.Logger.Warnf(
@@ -230,7 +222,7 @@ func startHarvester(
 		// until a slot is available. Without this early check, repeated file events
 		// would spawn goroutines that wait on the semaphore only to discover (after
 		// acquiring it) that a harvester is already running, causing a goroutine leak.
-		ctx.Logger.Debug("Harvester already running")
+		ctx.Logger.Debugf("Harvester already running for %s", srcID)
 		return nil
 	}
 
@@ -250,6 +242,9 @@ func startHarvester(
 				)
 			}
 		}()
+
+		// We clone the logger here where we need it to avoid redundant copies that increase memory pressure.
+		ctx.Logger = ctx.Logger.With("source_file", srcID)
 
 		if restart {
 			// stop previous harvester

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -18,29 +18,34 @@
 package filestream
 
 import (
+	"go.uber.org/zap"
+
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Source) *logp.Logger {
-	log := logger.With(
-		"operation", event.Op.String(),
-		"source_name", src.Name(),
+// loggerWithEvent returns a logger enriched with FS-event fields. Enrichment
+// is deferred via [logp.Logger.WithLazy], so the underlying core only pays
+// for the fields if a message is actually emitted.
+func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent) *logp.Logger {
+	fields := make([]zap.Field, 0, 6)
+	fields = append(fields,
+		zap.String("operation", event.Op.String()),
+		zap.String("source_file", event.SrcID),
 	)
 	if event.Descriptor.Fingerprint != "" {
-		log = log.With("fingerprint", event.Descriptor.Fingerprint)
+		fields = append(fields, zap.String("fingerprint", event.Descriptor.Fingerprint))
 	}
-	if event.Descriptor.Info != nil {
-		osID := event.Descriptor.Info.GetOSState().Identifier()
-		if osID != "" {
-			log = log.With("os_id", osID)
+	if info := event.Descriptor.Info; info != nil {
+		if osID := info.GetOSState().Identifier(); osID != "" {
+			fields = append(fields, zap.String("os_id", osID))
 		}
 	}
 	if event.NewPath != "" {
-		log = log.With("new_path", event.NewPath)
+		fields = append(fields, zap.String("new_path", event.NewPath))
 	}
 	if event.OldPath != "" {
-		log = log.With("old_path", event.OldPath)
+		fields = append(fields, zap.String("old_path", event.OldPath))
 	}
-	return log
+	return logger.WithLazy(fields...)
 }

--- a/filebeat/input/filestream/logger_test.go
+++ b/filebeat/input/filestream/logger_test.go
@@ -1,0 +1,122 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestLoggerWithEvent(t *testing.T) {
+	minimalEvent := loginp.FSEvent{Op: loginp.OpCreate, SrcID: "src-1"}
+	fullEvent := loginp.FSEvent{
+		Op:         loginp.OpRename,
+		SrcID:      "src-2",
+		NewPath:    "/var/log/new.log",
+		OldPath:    "/var/log/old.log",
+		Descriptor: loginp.FileDescriptor{Fingerprint: "abc123"},
+	}
+
+	cases := []struct {
+		name        string
+		event       loginp.FSEvent
+		loggerLevel zapcore.Level
+		emit        func(*logp.Logger)
+		wantEntries int
+		wantFields  map[string]string
+		wantAbsent  []string
+	}{
+		{
+			name:        "warnf with minimal event enriches and emits",
+			event:       minimalEvent,
+			loggerLevel: zapcore.InfoLevel,
+			emit:        func(l *logp.Logger) { l.Warnf("hello") },
+			wantEntries: 1,
+			wantFields:  map[string]string{"operation": "create", "source_file": "src-1"},
+			wantAbsent:  []string{"fingerprint", "os_id", "new_path", "old_path"},
+		},
+		{
+			name:        "warnf with all event fields populates every key",
+			event:       fullEvent,
+			loggerLevel: zapcore.InfoLevel,
+			emit:        func(l *logp.Logger) { l.Warnf("hello") },
+			wantEntries: 1,
+			wantFields: map[string]string{
+				"operation":   "rename",
+				"source_file": "src-2",
+				"fingerprint": "abc123",
+				"new_path":    "/var/log/new.log",
+				"old_path":    "/var/log/old.log",
+			},
+			wantAbsent: []string{"os_id"},
+		},
+		{
+			name:        "debugf is a no-op when debug logging is disabled",
+			event:       minimalEvent,
+			loggerLevel: zapcore.InfoLevel,
+			emit:        func(l *logp.Logger) { l.Debugf("noisy %d", 1) },
+			wantEntries: 0,
+		},
+		{
+			name:        "debugf enriches and emits when debug logging is enabled",
+			event:       minimalEvent,
+			loggerLevel: zapcore.DebugLevel,
+			emit:        func(l *logp.Logger) { l.Debugf("noisy %d", 1) },
+			wantEntries: 1,
+			wantFields:  map[string]string{"operation": "create", "source_file": "src-1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			core, observed := observer.New(tc.loggerLevel)
+			base, err := logp.NewZapLogger(zap.New(core))
+			require.NoError(t, err, "constructing zap logger")
+
+			log := loggerWithEvent(base, tc.event)
+			tc.emit(log)
+
+			entries := observed.All()
+			require.Lenf(t, entries, tc.wantEntries, "unexpected number of emitted entries")
+
+			for i, e := range entries {
+				fields := map[string]string{}
+				for _, f := range e.Context {
+					if f.Type == zapcore.StringType {
+						fields[f.Key] = f.String
+					}
+				}
+				for k, v := range tc.wantFields {
+					assert.Equalf(t, v, fields[k], "entry %d: field %q value mismatch", i, k)
+				}
+				for _, k := range tc.wantAbsent {
+					_, ok := fields[k]
+					assert.Falsef(t, ok, "entry %d: field %q must not be present", i, k)
+				}
+			}
+		})
+	}
+}

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -338,7 +338,7 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 			}
 
 			src := p.identifier.GetSource(fe)
-			p.onFSEvent(loggerWithEvent(p.logger, fe, src), ctx, fe, src, s, hg, ignoreInactiveSince)
+			p.onFSEvent(loggerWithEvent(p.logger, fe), ctx, fe, src, s, hg, ignoreInactiveSince)
 		}
 		return nil
 	})
@@ -360,8 +360,6 @@ func (p *fileProspector) onFSEvent(
 	group loginp.HarvesterGroup,
 	ignoreSince time.Time,
 ) {
-
-	log = log.With("source_file", event.SrcID)
 	switch event.Op {
 	case loginp.OpCreate, loginp.OpWrite, loginp.OpNotChanged:
 		switch event.Op {

--- a/libbeat/reader/readfile/line.go
+++ b/libbeat/reader/readfile/line.go
@@ -30,8 +30,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-const unlimited = 0
-
 // LineReader reads lines from underlying reader, decoding the input stream
 // using the configured codec. The reader keeps track of bytes consumed
 // from raw input stream for every decoded line.
@@ -78,7 +76,7 @@ func NewLineReader(input io.ReadCloser, config Config, logger *logp.Logger) (*Li
 		inBuffer:     streambuf.New(nil),
 		outBuffer:    streambuf.New(nil),
 		tempBuffer:   make([]byte, config.BufferSize),
-		logger:       logger.Named("reader_line"),
+		logger:       logger,
 	}, nil
 }
 

--- a/libbeat/reader/readfile/line_test.go
+++ b/libbeat/reader/readfile/line_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
+const unlimited = 0
+
 // Sample texts are from http://www.columbia.edu/~kermit/utf8.html
 type lineTestCase struct {
 	encoding       string


### PR DESCRIPTION
## Proposed commit message

```
perf: harvester: Reduce logger clones (#50118)

Reduce logger cloning overhead in the filestream input hot paths.

- Batch multiple `.With()` calls into one in `loggerWithEvent` and
  `filestream.Run()`. Remove the redundant `.Named("reader_line")` clone in
  `LineReader`.
- Switch the contextual loggers built per-event (`loggerWithEvent`) and
  per-harvester (`filestream.Run()`) to `logp.Logger.WithLazy`, so the field
  encoding into the underlying core is deferred until something actually logs
  on the child logger. On quiet files that only emit at info level the encoding
  cost is paid once at startup or never.
- Move the `source_file` logger clone in `Start()`/`Restart()` into
  `startHarvester`, after the early-return guard, so it only runs when a
  harvester actually starts.
- Wrap the per-line `Debugf` in `isDroppedLine` behind `log.IsDebug()`, which
  runs for every line read. Even without debug-logging enabled, this avoids
  interface boxing.

`logp.Logger.WithLazy` is the new primitive added in
elastic/elastic-agent-libs#420

(cherry picked from commit 201086bfc767f5a87f83ae115b8ec454e1a04ab5)
```

This is a **manual backport of #50118 to `9.3`**. The automatic Mergify backport
got stuck ("Waiting for conditions to match") and never produced a branch/PR.

### Backport notes (deviations from the original commit)

- **Dropped the `go.mod` / `go.sum` / `NOTICE.txt` bump** to
  `elastic-agent-libs v0.43.0`. `9.3` is already on `v0.43.1`, which provides
  `logp.Logger.WithLazy`, so no dependency change is needed.
- **`isDroppedLine` conflict resolved to preserve `9.3` behavior.** On `9.3`
  the signature is `line string` (not `[]byte`) and the body uses
  `log.Debug(...)` with the existing message strings. The `log.IsDebug()` guard
  from the PR was applied around those existing lines without changing the
  `Debug` call or message text (changing them would be an unrelated behavior
  change).

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added an entry in `./changelog/fragments` (carried over from the original PR).

## How to test this PR locally

```bash
cd filebeat
go test -count=1 ./input/filestream/... ../libbeat/reader/readfile/...
```

## Related issues

- Backport of #50118
- Relates #50137
