### PR TITLE
add_process_metadata: use synctest for cache eviction test

### DIFF
--- a/libbeat/processors/add_process_metadata/cache_test.go
+++ b/libbeat/processors/add_process_metadata/cache_test.go
@@ -18,7 +18,7 @@
 package add_process_metadata
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -97,11 +97,10 @@ func TestCacheEviction(t *testing.T) {
 		// The cache expires entries based on time.Now. Run each case in its own synctest bubble so those sleeps
 		// advance a fake clock instead of real time.
 		synctest.Test(t, func(t *testing.T) {
-			rnd := rand.New(rand.NewSource(1))
 			c := newProcessCache(test.expire, test.cap, test.effort, emptyProvider{})
 
 			for i := 0; i < test.iters; i++ {
-				pid := rnd.Intn(test.maxPID)
+				pid := rand.IntN(test.maxPID)
 				_, err := c.GetProcessMetadata(pid)
 				require.NoError(t, err)
 				if len(c.cache) > test.cap {

--- a/libbeat/processors/add_process_metadata/cache_test.go
+++ b/libbeat/processors/add_process_metadata/cache_test.go
@@ -20,6 +20,7 @@ package add_process_metadata
 import (
 	"math/rand"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -93,19 +94,23 @@ var cacheEvictionTests = []struct {
 
 func TestCacheEviction(t *testing.T) {
 	for _, test := range cacheEvictionTests {
-		rnd := rand.New(rand.NewSource(1))
-		c := newProcessCache(test.expire, test.cap, test.effort, emptyProvider{})
+		// The cache expires entries based on time.Now. Run each case in its own synctest bubble so those sleeps
+		// advance a fake clock instead of real time.
+		synctest.Test(t, func(t *testing.T) {
+			rnd := rand.New(rand.NewSource(1))
+			c := newProcessCache(test.expire, test.cap, test.effort, emptyProvider{})
 
-		for i := 0; i < test.iters; i++ {
-			pid := rnd.Intn(test.maxPID)
-			_, err := c.GetProcessMetadata(pid)
-			require.NoError(t, err)
-			if len(c.cache) > test.cap {
-				t.Errorf("cache overflow for %s after %d iterations", test.name, i)
-				break
+			for i := 0; i < test.iters; i++ {
+				pid := rnd.Intn(test.maxPID)
+				_, err := c.GetProcessMetadata(pid)
+				require.NoError(t, err)
+				if len(c.cache) > test.cap {
+					t.Errorf("cache overflow for %s after %d iterations", test.name, i)
+					break
+				}
+				time.Sleep(test.delay)
 			}
-			time.Sleep(test.delay)
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
NOTE: easy to review ignoring whitespace: https://github.com/elastic/beats/pull/51447/changes?w=1

## Proposed commit message

```
libbeat/add_process_metadata: use testing/synctest for cache eviction test

TestCacheEviction exercises the process cache's time-based eviction by
sleeping between accesses so entries age past their expiration. Across the
table cases this slept for several seconds of real time, and the eviction
timing was at the mercy of wall-clock scheduling.

Run each case in a testing/synctest bubble. The cache expires entries via
time.Now, so against the bubble's fake clock the time.Sleep calls advance
time instantly and deterministically while preserving the eviction
behavior under test. The test now completes in a fraction of a second.
```

### Measured impact

Per-test execution time (`go test -v`, excludes compilation, n=5):

```
main:  --- PASS: TestCacheEviction (27.15s)   # range 26.96s–27.32s
fix:   --- PASS: TestCacheEviction (0.07s)
```

That is roughly a 27s reduction per run, and the test is now deterministic in its timing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~ — not applicable, test-only change
- ~~I have made corresponding change to the default configuration files~~ — not applicable, test-only change
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~I have added an entry in `./changelog/fragments`~~ — not applicable, test-only change with no user-facing impact (`skip-changelog`)

## How to test this PR locally

```bash
go test -race -count=1 -v -run '^TestCacheEviction$' ./libbeat/processors/add_process_metadata/
```