### PR TITLE
fix panic when logging.metrics.period is 0

### DIFF
--- a/changelog/fragments/1782231377-fix-panic-with-logging.metrics.period-is-0.yaml
+++ b/changelog/fragments/1782231377-fix-panic-with-logging.metrics.period-is-0.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix panic when logging.metrics.period is 0
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: all
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/51462
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -142,6 +142,10 @@ func (r *Reporter) Stop() {
 }
 
 func (r *Reporter) snapshotLoop() {
+	if r.Period == 0 {
+		r.logger.Infof("Skipping metrics logging")
+		return
+	}
 	r.logger.Infof("Starting metrics logging every %v", r.Period)
 	defer r.logger.Infof("Stopping metrics logging.")
 	defer func() {

--- a/libbeat/monitoring/report/log/log_test.go
+++ b/libbeat/monitoring/report/log/log_test.go
@@ -171,7 +171,11 @@ func TestZeroPeriodConfig(t *testing.T) {
 	}
 	defer rep.Stop()
 
-	assert.Equal(t, time.Duration(0), rep.(*Reporter).Period)
+	reporter, ok := rep.(*Reporter)
+	if !ok {
+		t.Fatal("MakeReporter did not return a *Reporter")
+	}
+	assert.Equal(t, time.Duration(0), reporter.Period)
 }
 
 func assertMapHas(t *testing.T, m map[string]any, key string, expectedValue any) {
@@ -180,5 +184,5 @@ func assertMapHas(t *testing.T, m map[string]any, key string, expectedValue any)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.EqualValues(t, expectedValue, v) //nolint:testifylint // we don't care if types are different
+	assert.EqualValues(t, expectedValue, v)
 }

--- a/libbeat/monitoring/report/log/log_test.go
+++ b/libbeat/monitoring/report/log/log_test.go
@@ -19,6 +19,7 @@ package log
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -112,6 +113,65 @@ func TestReporterLog(t *testing.T) {
 		assertMapHas(t, logs[0].ContextMap(), "monitoring.metrics.new", 1)
 		assert.Contains(t, logs[1].Message, "Uptime: ")
 	}
+}
+
+func TestZeroPeriodSkipsLogging(t *testing.T) {
+	logger, zapLogs := logptest.NewTestingLoggerWithObserver(t, "")
+
+	r := &Reporter{
+		config:     config{Period: 0},
+		done:       make(chan struct{}),
+		logger:     logger.Named("monitoring"),
+		registries: map[string]*monitoring.Registry{},
+	}
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		r.snapshotLoop()
+	}()
+
+	// The goroutine should exit immediately when Period == 0.
+	exited := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(exited)
+	}()
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("snapshotLoop goroutine did not exit within 5s for zero period")
+	}
+
+	// No periodic metrics log lines should have been emitted.
+	for _, log := range zapLogs.TakeAll() {
+		assert.NotContains(t, log.Message, "Starting metrics logging")
+		assert.NotContains(t, log.Message, "Non-zero metrics")
+		assert.NotContains(t, log.Message, "No non-zero metrics")
+		assert.NotContains(t, log.Message, "Total metrics")
+		assert.Contains(t, log.Message, "Skipping metrics logging")
+	}
+}
+
+// TestZeroPeriodConfig verifies that a config with period=0 does not panic
+// (time.NewTicker panics on a zero duration) and that Period is parsed as 0.
+func TestZeroPeriodConfig(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
+
+	cfg, err := conf.NewConfigFrom(map[string]interface{}{
+		"period": "0s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := MakeReporter(beat.Info{Logger: logger}, cfg, beatmonitoring.NewGlobalMonitoring())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rep.Stop()
+
+	assert.Equal(t, time.Duration(0), rep.(*Reporter).Period)
 }
 
 func assertMapHas(t *testing.T, m map[string]any, key string, expectedValue any) {


### PR DESCRIPTION
## Proposed commit message

fix panic when `logging.metrics.period` is 0

Problem

Setting `logging.metrics.period: 0` in the beat configuration caused a panic. The snapshotLoop goroutine passed the zero duration directly to time.NewTicker, which panics on any non-positive argument.

Fix

Add an early-return guard at the top of snapshotLoop: if Period is zero, log a single "Skipping metrics logging" message and return immediately, bypassing the ticker entirely.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.  Setting `logging.metrics.period: 0` in the configuration file
will no longer cause a panic

## How to test this PR locally

Set `logging.metrics.period: 0` in configuration file, before PR
panic, after no panic and no "Non-zero metrics in the last 30s" logs

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
