### PR TITLE
x-pack/filebeat/input: validate request tracer and dump path regardless of enabled state

### DIFF
--- a/changelog/fragments/1782276173-fix-tracer-path-validation.yaml
+++ b/changelog/fragments/1782276173-fix-tracer-path-validation.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Validate request tracer path regardless of enabled state to prevent unintended file deletion.
+component: filebeat

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"maps"
 	"net"
 	"net/http"
@@ -59,7 +58,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent-libs/useragent"
@@ -188,15 +186,10 @@ func (i input) run(env v2.Context, src *source, cursor map[string]any, pub input
 	}
 	otelTracer := otelTracerProvider.Tracer(importPath)
 
-	if cfg.Resource.Tracer.enabled() {
-		id := httplog.SanitizeFileName(env.IDWithoutName)
-		path := strings.ReplaceAll(cfg.Resource.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(env.Agent.Paths, inputName, path)
+	if cfg.Resource.Tracer != nil {
+		resolved, err := httplog.ResolveTraceFilename(env.Agent.Paths, inputName, env.IDWithoutName, cfg.Resource.Tracer.Filename)
 		if err != nil {
 			return err
-		}
-		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, env.Agent.Paths.Resolve(paths.Logs, inputName))
 		}
 		cfg.Resource.Tracer.Filename = resolved
 	}
@@ -1116,11 +1109,6 @@ func getLimit(which string, rateLimit map[string]any, log *logp.Logger) (limit r
 	return limit, true
 }
 
-// lumberjackTimestamp is a glob expression matching the time format string used
-// by lumberjack when rolling over logs, "2006-01-02T15-04-05.000".
-// https://github.com/natefinch/lumberjack/blob/4cb27fcfbb0f35cb48c542c5ea80b7c1d18933d0/lumberjack.go#L39
-const lumberjackTimestamp = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9].[0-9][0-9][0-9]"
-
 func newClient(ctx context.Context, cfg config, log *logp.Logger, reg *monitoring.Registry, env v2.Context, tp *sdktrace.TracerProvider) (*http.Client, *httplog.LoggingRoundTripper, *otelCELMetrics, *otel.ContextInjector, error) {
 	c, err := cfg.Resource.Transport.Client(clientOptions(cfg.Resource.URL.URL, cfg.Resource.KeepAlive.settings(), log)...)
 	if err != nil {
@@ -1176,42 +1164,12 @@ func newClient(ctx context.Context, cfg config, log *logp.Logger, reg *monitorin
 	} else if cfg.Resource.Tracer != nil {
 		// We have a trace log name, but we are not enabled,
 		// so remove all trace logs we own.
-		err = os.Remove(cfg.Resource.Tracer.Filename)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Errorw("failed to remove request trace log", "path", cfg.Resource.Tracer.Filename, "error", err)
-		}
-		ext := filepath.Ext(cfg.Resource.Tracer.Filename)
-		base := strings.TrimSuffix(cfg.Resource.Tracer.Filename, ext)
-		paths, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
-		if err != nil {
-			log.Errorw("failed to collect request trace log path names", "error", err)
-		}
-		for _, p := range paths {
-			err = os.Remove(p)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				log.Errorw("failed to remove request trace log", "path", p, "error", err)
-			}
-		}
+		httplog.CleanTraceFiles(cfg.Resource.Tracer.Filename, log)
 	}
 	if !cfg.FailureDump.enabled() && cfg.FailureDump != nil && cfg.FailureDump.Filename != "" {
 		// We have a fail-dump name, but we are not enabled,
 		// so remove all dumps we own.
-		err = os.Remove(cfg.FailureDump.Filename)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Errorw("failed to remove request trace log", "path", cfg.FailureDump.Filename, "error", err)
-		}
-		ext := filepath.Ext(cfg.FailureDump.Filename)
-		base := strings.TrimSuffix(cfg.FailureDump.Filename, ext)
-		paths, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
-		if err != nil {
-			log.Errorw("failed to collect request trace log path names", "error", err)
-		}
-		for _, p := range paths {
-			err = os.Remove(p)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				log.Errorw("failed to remove request trace log", "path", p, "error", err)
-			}
-		}
+		httplog.CleanTraceFiles(cfg.FailureDump.Filename, log)
 	}
 
 	// inside the otel RoundTripper

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -193,6 +193,13 @@ func (i input) run(env v2.Context, src *source, cursor map[string]any, pub input
 		}
 		cfg.Resource.Tracer.Filename = resolved
 	}
+	if cfg.FailureDump != nil {
+		resolved, err := httplog.ResolveTraceFilename(env.Agent.Paths, inputName, env.IDWithoutName, cfg.FailureDump.Filename)
+		if err != nil {
+			return err
+		}
+		cfg.FailureDump.Filename = resolved
+	}
 
 	client, trace, otelMetrics, contextInjector, err := newClient(ctx, cfg, log, reg, env, otelTracerProvider)
 	if err != nil {

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -2189,7 +2189,7 @@ var inputTests = []struct {
 			},
 		},
 		time:       func() time.Time { return time.Date(2010, 2, 8, 0, 0, 0, 0, time.UTC) },
-		wantNoFile: filepath.Join("failure_dumps", "dump-2010-02-08T00-00-00.000.json"),
+		wantNoFile: filepath.Join("cel", "failure_dumps", "dump-2010-02-08T00-00-00.000.json"),
 		want: []map[string]interface{}{{
 			"message": map[string]interface{}{
 				"value": "division by zero",
@@ -2211,7 +2211,7 @@ var inputTests = []struct {
 			},
 		},
 		time:     func() time.Time { return time.Date(2010, 2, 9, 0, 0, 0, 0, time.UTC) },
-		wantFile: filepath.Join("failure_dumps", "dump-2010-02-09T00-00-00.000.json"), // One day after the no dump case.
+		wantFile: filepath.Join("cel", "failure_dumps", "dump-2010-02-09T00-00-00.000.json"), // One day after the no dump case.
 		want: []map[string]interface{}{
 			{
 				"error": map[string]interface{}{
@@ -2239,13 +2239,13 @@ var inputTests = []struct {
 		time: func() time.Time { return time.Date(2010, 2, 9, 0, 0, 0, 0, time.UTC) },
 		prepare: func() error {
 			// Make a file that the configuration should delete.
-			err := os.MkdirAll("failure_dumps", 0o700)
+			err := os.MkdirAll(filepath.Join("cel", "failure_dumps"), 0o700)
 			if err != nil {
 				return err
 			}
-			return os.WriteFile(filepath.Join("failure_dumps", "dump-2010-02-09T00-00-00.000.json"), nil, 0o600)
+			return os.WriteFile(filepath.Join("cel", "failure_dumps", "dump-2010-02-09T00-00-00.000.json"), nil, 0o600)
 		},
-		wantNoFile: filepath.Join("failure_dumps", "dump-2010-02-09T00-00-00.000.json"), // One day after the no dump case.
+		wantNoFile: filepath.Join("cel", "failure_dumps", "dump-2010-02-09T00-00-00.000.json"), // One day after the no dump case.
 		want: []map[string]interface{}{
 			{
 				"error": map[string]interface{}{
@@ -2349,7 +2349,7 @@ func TestInput(t *testing.T) {
 	os.Setenv("CELTESTENVVAR", "TESTVALUE")
 	os.Setenv("DISALLOWEDCELTESTENVVAR", "DISALLOWEDTESTVALUE")
 
-	err := os.RemoveAll("failure_dumps")
+	err := os.RemoveAll(filepath.Join("cel", "failure_dumps"))
 	if err != nil {
 		t.Fatalf("failed to remove failure_dumps directory: %v", err)
 	}

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -1503,56 +1504,22 @@ var inputTests = []struct {
 		},
 		wantNoFile: filepath.Join("cel", "logs", "http-request-trace-test_id_tracer_filename_sanitization_disabled*"),
 	},
-	// Path containment for enabled tracers is tested in
-	// x-pack/filebeat/input/internal/httplog.TestResolvePathInLogsFor.
-	// The input-level test only verifies that a disabled tracer does
-	// not reject an out-of-tree path (next case below).
+	// Path containment is enforced regardless of whether the tracer is
+	// enabled. The enabled case is tested in
+	// httplog.TestResolveTraceFilename; the test harness here rewrites
+	// enabled tracer filenames into a temp dir, so only the disabled
+	// case can exercise an out-of-tree path at the input level.
 	{
-		name: "tracer_disabled_escaping_logs",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-			server := httptest.NewServer(h)
-			config["resource.url"] = server.URL
-			t.Cleanup(server.Close)
-		},
+		name:   "tracer_disabled_escaping_logs",
+		server: newTestServer(httptest.NewServer),
 		config: map[string]interface{}{
 			"interval":                 1,
 			"resource.tracer.enabled":  false,
 			"resource.tracer.filename": "/var/log/http-request-trace-*.ndjson",
-			"state": map[string]interface{}{
-				"fake_now": "2002-10-02T15:00:00Z",
-			},
-			"program": `
-	// Use terse non-standard check for presence of timestamp. The standard
-	// alternative is to use has(state.cursor) && has(state.cursor.timestamp).
-	(!is_error(state.cursor.timestamp) ?
-		state.cursor.timestamp
-	:
-		timestamp(state.fake_now)-duration('10m')
-	).as(time_cursor,
-	string(state.url).parse_url().with_replace({
-		"RawQuery": {"$filter": ["alertCreationTime ge "+string(time_cursor)]}.format_query()
-	}).format_url().as(url, bytes(get(url).Body)).decode_json().as(event, {
-		"events": [event],
-		// Get the timestamp from the event if it exists, otherwise advance a little to break a request loop.
-		// Due to the name of the @timestamp field, we can't use has(), so use is_error().
-		"cursor": [{"timestamp": !is_error(event["@timestamp"]) ? event["@timestamp"] : time_cursor+duration('1s')}],
-
-		// Just for testing, cycle this back into the next state.
-		"fake_now": state.fake_now
-	}))
-	`,
+			"program":                  `bytes(get(state.url).Body).as(body, {"events": [body.decode_json()]})`,
 		},
-		handler: dateCursorHandler(),
-		want: []map[string]interface{}{
-			{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
-			{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
-			{"@timestamp": "2002-10-02T15:00:02Z", "foo": "bar"},
-		},
-		wantCursor: []map[string]interface{}{
-			{"timestamp": "2002-10-02T15:00:00Z"},
-			{"timestamp": "2002-10-02T15:00:01Z"},
-			{"timestamp": "2002-10-02T15:00:02Z"},
-		},
+		handler: defaultHandler(http.MethodGet, ""),
+		wantErr: errors.New("request tracer path"),
 	},
 	{
 		name:   "pagination_cursor_object",
@@ -2470,7 +2437,7 @@ func TestInput(t *testing.T) {
 				}
 			}
 			err = input{time: test.time}.run(v2Ctx, src, test.persistCursor, &client, &v2Ctx)
-			if fmt.Sprint(err) != fmt.Sprint(test.wantErr) {
+			if !sameErrorOrContains(err, test.wantErr) {
 				t.Errorf("unexpected error from running input: got:%v want:%v", err, test.wantErr)
 			}
 			if test.wantFile != "" {
@@ -3075,5 +3042,18 @@ func TestRedactor(t *testing.T) {
 				t.Errorf("unexpected redaction:\n--- got\n--- want\n%s", cmp.Diff(got, test.wantRedact))
 			}
 		})
+	}
+}
+
+// sameErrorOrContains reports whether got matches want: both nil, or got's
+// message contains want's message.
+func sameErrorOrContains(got, want error) bool {
+	switch {
+	case got == nil && want == nil:
+		return true
+	case got == nil, want == nil:
+		return false
+	default:
+		return strings.Contains(got.Error(), want.Error())
 	}
 }

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
@@ -13,11 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -463,15 +460,10 @@ func New(ctx context.Context, id string, cfg *config.C, logger *logp.Logger, aut
 		return nil, fmt.Errorf("unable to unpack Graph API Fetcher config: %w", err)
 	}
 
-	if c.Tracer.enabled() {
-		id = httplog.SanitizeFileName(id)
-		path := strings.ReplaceAll(c.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(p, inputName, path)
+	if c.Tracer != nil {
+		resolved, err := httplog.ResolveTraceFilename(p, inputName, id, c.Tracer.Filename)
 		if err != nil {
 			return nil, err
-		}
-		if !ok {
-			return nil, fmt.Errorf("request tracer path %q must be within %q path", path, p.Resolve(paths.Logs, inputName))
 		}
 		c.Tracer.Filename = resolved
 	}
@@ -540,11 +532,6 @@ func New(ctx context.Context, id string, cfg *config.C, logger *logp.Logger, aut
 	return &f, nil
 }
 
-// lumberjackTimestamp is a glob expression matching the time format string used
-// by lumberjack when rolling over logs, "2006-01-02T15-04-05.000".
-// https://github.com/natefinch/lumberjack/blob/4cb27fcfbb0f35cb48c542c5ea80b7c1d18933d0/lumberjack.go#L39
-const lumberjackTimestamp = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9].[0-9][0-9][0-9]"
-
 // requestTrace decorates cli with an httplog.LoggingRoundTripper if cfg.Tracer
 // is non-nil.
 func requestTrace(ctx context.Context, cli *http.Client, cfg graphConf, log *logp.Logger) *http.Client {
@@ -554,22 +541,7 @@ func requestTrace(ctx context.Context, cli *http.Client, cfg graphConf, log *log
 	if !cfg.Tracer.enabled() {
 		// We have a trace log name, but we are not enabled,
 		// so remove all trace logs we own.
-		err := os.Remove(cfg.Tracer.Filename)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Errorw("failed to remove request trace log", "path", cfg.Tracer.Filename, "error", err)
-		}
-		ext := filepath.Ext(cfg.Tracer.Filename)
-		base := strings.TrimSuffix(cfg.Tracer.Filename, ext)
-		paths, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
-		if err != nil {
-			log.Errorw("failed to collect request trace log path names", "error", err)
-		}
-		for _, p := range paths {
-			err = os.Remove(p)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				log.Errorw("failed to remove request trace log", "path", p, "error", err)
-			}
-		}
+		httplog.CleanTraceFiles(cfg.Tracer.Filename, log)
 		return cli
 	}
 

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
@@ -11,13 +11,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -113,15 +109,10 @@ func (p *jamfInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	syncTimer := time.NewTimer(syncWaitTime)
 	updateTimer := time.NewTimer(updateWaitTime)
 
-	if p.cfg.Tracer.enabled() {
-		id := httplog.SanitizeFileName(inputCtx.IDWithoutName)
-		path := strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(inputCtx.Agent.Paths, Name, path)
+	if p.cfg.Tracer != nil {
+		resolved, err := httplog.ResolveTraceFilename(inputCtx.Agent.Paths, Name, inputCtx.IDWithoutName, p.cfg.Tracer.Filename)
 		if err != nil {
 			return err
-		}
-		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, inputCtx.Agent.Paths.Resolve(paths.Logs, Name))
 		}
 		p.cfg.Tracer.Filename = resolved
 	}
@@ -207,11 +198,6 @@ func newClient(ctx context.Context, cfg conf, log *logp.Logger) (*http.Client, e
 	return client.StandardClient(), nil
 }
 
-// lumberjackTimestamp is a glob expression matching the time format string used
-// by lumberjack when rolling over logs, "2006-01-02T15-04-05.000".
-// https://github.com/natefinch/lumberjack/blob/4cb27fcfbb0f35cb48c542c5ea80b7c1d18933d0/lumberjack.go#L39
-const lumberjackTimestamp = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9].[0-9][0-9][0-9]"
-
 // requestTrace decorates cli with an httplog.LoggingRoundTripper if cfg.Tracer
 // is non-nil.
 func requestTrace(ctx context.Context, cli *http.Client, cfg conf, log *logp.Logger) *http.Client {
@@ -221,22 +207,7 @@ func requestTrace(ctx context.Context, cli *http.Client, cfg conf, log *logp.Log
 	if !cfg.Tracer.enabled() {
 		// We have a trace log name, but we are not enabled,
 		// so remove all trace logs we own.
-		err := os.Remove(cfg.Tracer.Filename)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Errorw("failed to remove request trace log", "path", cfg.Tracer.Filename, "error", err)
-		}
-		ext := filepath.Ext(cfg.Tracer.Filename)
-		base := strings.TrimSuffix(cfg.Tracer.Filename, ext)
-		paths, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
-		if err != nil {
-			log.Errorw("failed to collect request trace log path names", "error", err)
-		}
-		for _, p := range paths {
-			err = os.Remove(p)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				log.Errorw("failed to remove request trace log", "path", p, "error", err)
-			}
-		}
+		httplog.CleanTraceFiles(cfg.Tracer.Filename, log)
 		return cli
 	}
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -12,11 +12,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -118,15 +115,10 @@ func (p *oktaInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 	// Allow a single fetch operation to obtain limits from the API.
 	p.lim = okta.NewRateLimiter(p.cfg.LimitWindow, p.cfg.LimitFixed)
 
-	if p.cfg.Tracer.enabled() {
-		id := httplog.SanitizeFileName(inputCtx.IDWithoutName)
-		path := strings.ReplaceAll(p.cfg.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(inputCtx.Agent.Paths, Name, path)
+	if p.cfg.Tracer != nil {
+		resolved, err := httplog.ResolveTraceFilename(inputCtx.Agent.Paths, Name, inputCtx.IDWithoutName, p.cfg.Tracer.Filename)
 		if err != nil {
 			return err
-		}
-		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, inputCtx.Agent.Paths.Resolve(paths.Logs, Name))
 		}
 		p.cfg.Tracer.Filename = resolved
 	}
@@ -222,11 +214,6 @@ func newClient(ctx context.Context, cfg conf, log *logp.Logger) (*http.Client, e
 	return client.StandardClient(), nil
 }
 
-// lumberjackTimestamp is a glob expression matching the time format string used
-// by lumberjack when rolling over logs, "2006-01-02T15-04-05.000".
-// https://github.com/natefinch/lumberjack/blob/4cb27fcfbb0f35cb48c542c5ea80b7c1d18933d0/lumberjack.go#L39
-const lumberjackTimestamp = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9].[0-9][0-9][0-9]"
-
 // requestTrace decorates cli with an httplog.LoggingRoundTripper if cfg.Tracer
 // is non-nil.
 func requestTrace(ctx context.Context, cli *http.Client, cfg conf, log *logp.Logger) *http.Client {
@@ -236,22 +223,7 @@ func requestTrace(ctx context.Context, cli *http.Client, cfg conf, log *logp.Log
 	if !cfg.Tracer.enabled() {
 		// We have a trace log name, but we are not enabled,
 		// so remove all trace logs we own.
-		err := os.Remove(cfg.Tracer.Filename)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Errorw("failed to remove request trace log", "path", cfg.Tracer.Filename, "error", err)
-		}
-		ext := filepath.Ext(cfg.Tracer.Filename)
-		base := strings.TrimSuffix(cfg.Tracer.Filename, ext)
-		paths, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
-		if err != nil {
-			log.Errorw("failed to collect request trace log path names", "error", err)
-		}
-		for _, p := range paths {
-			err = os.Remove(p)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				log.Errorw("failed to remove request trace log", "path", p, "error", err)
-			}
-		}
+		httplog.CleanTraceFiles(cfg.Tracer.Filename, log)
 		return cli
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -15,13 +15,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -43,7 +40,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/elastic-agent-libs/monitoring/adapter"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
@@ -116,15 +112,10 @@ func (e *httpEndpoint) Run(ctx v2.Context, pipeline beat.Pipeline) error {
 
 	metrics := newInputMetrics(ctx.MetricsRegistry, ctx.Logger)
 
-	if e.config.Tracer.enabled() {
-		id := httplog.SanitizeFileName(ctx.IDWithoutName)
-		path := strings.ReplaceAll(e.config.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(ctx.Agent.Paths, inputName, path)
+	if e.config.Tracer != nil {
+		resolved, err := httplog.ResolveTraceFilename(ctx.Agent.Paths, inputName, ctx.IDWithoutName, e.config.Tracer.Filename)
 		if err != nil {
 			return err
-		}
-		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, ctx.Agent.Paths.Resolve(paths.Logs, inputName))
 		}
 		e.config.Tracer.Filename = resolved
 	}
@@ -580,22 +571,7 @@ func newHandler(ctx context.Context, c config, prg *program, pub func(beat.Event
 	} else if c.Tracer != nil {
 		// We have a trace log name, but we are not enabled,
 		// so remove all trace logs we own.
-		err := os.Remove(c.Tracer.Filename)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Errorw("failed to remove request trace log", "path", c.Tracer.Filename, "error", err)
-		}
-		ext := filepath.Ext(c.Tracer.Filename)
-		base := strings.TrimSuffix(c.Tracer.Filename, ext)
-		paths, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
-		if err != nil {
-			log.Errorw("failed to collect request trace log path names", "error", err)
-		}
-		for _, p := range paths {
-			err = os.Remove(p)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				log.Errorw("failed to remove request trace log", "path", p, "error", err)
-			}
-		}
+		httplog.CleanTraceFiles(c.Tracer.Filename, log)
 	}
 	return h
 }
@@ -603,11 +579,6 @@ func newHandler(ctx context.Context, c config, prg *program, pub func(beat.Event
 type noopReporter struct{}
 
 func (noopReporter) UpdateStatus(status.Status, string) {}
-
-// lumberjackTimestamp is a glob expression matching the time format string used
-// by lumberjack when rolling over logs, "2006-01-02T15-04-05.000".
-// https://github.com/natefinch/lumberjack/blob/4cb27fcfbb0f35cb48c542c5ea80b7c1d18933d0/lumberjack.go#L39
-const lumberjackTimestamp = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9].[0-9][0-9][0-9]"
 
 func htmlEscape(s string) string {
 	var buf bytes.Buffer

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -11,12 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -42,7 +39,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
-	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/elastic-agent-libs/transport"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/elastic/elastic-agent-libs/useragent"
@@ -184,25 +180,22 @@ func run(ctx v2.Context, cfg config, pub inputcursor.Publisher, crsr *inputcurso
 	log := ctx.Logger.With("input_url", cfg.Request.URL)
 	stdCtx := ctxtool.FromCanceller(ctx.Cancelation)
 
-	if cfg.Request.Tracer.enabled() {
-		id := httplog.SanitizeFileName(ctx.IDWithoutName)
-		path := strings.ReplaceAll(cfg.Request.Tracer.Filename, "*", id)
-		resolved, ok, err := httplog.ResolvePathInLogsFor(ctx.Agent.Paths, inputName, path)
+	if cfg.Request.Tracer != nil {
+		resolved, err := httplog.ResolveTraceFilename(ctx.Agent.Paths, inputName, ctx.IDWithoutName, cfg.Request.Tracer.Filename)
 		if err != nil {
 			return err
 		}
-		if !ok {
-			return fmt.Errorf("request tracer path %q must be within %q path", path, ctx.Agent.Paths.Resolve(paths.Logs, inputName))
-		}
 		cfg.Request.Tracer.Filename = resolved
 
-		// Propagate tracer behaviour to all chain children.
-		for i, c := range cfg.Chain {
-			if c.Step != nil { // Request is validated as required.
-				cfg.Chain[i].Step.Request.Tracer = cfg.Request.Tracer
-			}
-			if c.While != nil { // Request is validated as required.
-				cfg.Chain[i].While.Request.Tracer = cfg.Request.Tracer
+		if cfg.Request.Tracer.enabled() {
+			// Propagate tracer behaviour to all chain children.
+			for i, c := range cfg.Chain {
+				if c.Step != nil { // Request is validated as required.
+					cfg.Chain[i].Step.Request.Tracer = cfg.Request.Tracer
+				}
+				if c.While != nil { // Request is validated as required.
+					cfg.Chain[i].While.Request.Tracer = cfg.Request.Tracer
+				}
 			}
 		}
 	}
@@ -363,11 +356,6 @@ func newHTTPClient(ctx context.Context, authCfg *authConfig, requestCfg *request
 	return &httpClient{client: client, limiter: limiter}, nil
 }
 
-// lumberjackTimestamp is a glob expression matching the time format string used
-// by lumberjack when rolling over logs, "2006-01-02T15-04-05.000".
-// https://github.com/natefinch/lumberjack/blob/4cb27fcfbb0f35cb48c542c5ea80b7c1d18933d0/lumberjack.go#L39
-const lumberjackTimestamp = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9].[0-9][0-9][0-9]"
-
 func newNetHTTPClient(ctx context.Context, cfg *requestConfig, log *logp.Logger, reg *monitoring.Registry) (*http.Client, error) {
 	netHTTPClient, err := cfg.Transport.Client(clientOptions(cfg.URL.URL, cfg.KeepAlive.settings(), log)...)
 	if err != nil {
@@ -393,22 +381,7 @@ func newNetHTTPClient(ctx context.Context, cfg *requestConfig, log *logp.Logger,
 	} else if cfg.Tracer != nil {
 		// We have a trace log name, but we are not enabled,
 		// so remove all trace logs we own.
-		err = os.Remove(cfg.Tracer.Filename)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Errorw("failed to remove request trace log", "path", cfg.Tracer.Filename, "error", err)
-		}
-		ext := filepath.Ext(cfg.Tracer.Filename)
-		base := strings.TrimSuffix(cfg.Tracer.Filename, ext)
-		paths, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
-		if err != nil {
-			log.Errorw("failed to collect request trace log path names", "error", err)
-		}
-		for _, p := range paths {
-			err = os.Remove(p)
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				log.Errorw("failed to remove request trace log", "path", p, "error", err)
-			}
-		}
+		httplog.CleanTraceFiles(cfg.Tracer.Filename, log)
 	}
 
 	if reg != nil {

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -199,6 +199,22 @@ func run(ctx v2.Context, cfg config, pub inputcursor.Publisher, crsr *inputcurso
 			}
 		}
 	}
+	for i, c := range cfg.Chain {
+		if c.Step != nil && c.Step.Request.Tracer != nil { // Request is validated as required.
+			resolved, err := httplog.ResolveTraceFilename(ctx.Agent.Paths, inputName, ctx.IDWithoutName, c.Step.Request.Tracer.Filename)
+			if err != nil {
+				return err
+			}
+			cfg.Chain[i].Step.Request.Tracer.Filename = resolved
+		}
+		if c.While != nil && c.While.Request.Tracer != nil { // Request is validated as required.
+			resolved, err := httplog.ResolveTraceFilename(ctx.Agent.Paths, inputName, ctx.IDWithoutName, c.While.Request.Tracer.Filename)
+			if err != nil {
+				return err
+			}
+			cfg.Chain[i].While.Request.Tracer.Filename = resolved
+		}
+	}
 
 	metrics := newInputMetrics(reg, ctx.Logger)
 	client, err := newHTTPClient(stdCtx, cfg.Auth, cfg.Request, ctx, log, reg, nil)

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -6,6 +6,7 @@ package httpjson
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -446,49 +447,26 @@ var testCases = []struct {
 		},
 		expectedNoFile: filepath.Join("httpjson", "logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi*"),
 	},
-	// Path containment for enabled tracers is tested in
-	// x-pack/filebeat/input/internal/httplog.TestResolvePathInLogsFor.
-	// The input-level test only verifies that a disabled tracer does
-	// not reject an out-of-tree path (next case below).
+	// Path containment is enforced regardless of whether the tracer is
+	// enabled. The enabled case is tested in
+	// httplog.TestResolveTraceFilename; the test harness here rewrites
+	// enabled tracer filenames into a temp dir, so only the disabled
+	// case can exercise an out-of-tree path at the input level.
 	{
 		name: "tracer_disabled_escaping_logs",
 		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
-			timeNow = func() time.Time {
-				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
-				return t
-			}
-
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
-			t.Cleanup(func() { timeNow = time.Now })
 		},
 		baseConfig: map[string]interface{}{
-			"interval":       1,
-			"request.method": http.MethodGet,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
-						"target":  "url.params.$filter",
-						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
-						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
-					},
-				},
-			},
-			"cursor": map[string]interface{}{
-				"timestamp": map[string]interface{}{
-					"value": `[[index .last_response.body "@timestamp"]]`,
-				},
-			},
+			"interval":                1,
+			"request.method":          http.MethodGet,
 			"request.tracer.enabled":  false,
 			"request.tracer.filename": "/var/log/http-request-trace-*.ndjson",
 		},
-		handler: dateCursorHandler(),
-		expected: []string{
-			`{"@timestamp":"2002-10-02T15:00:00Z","foo":"bar"}`,
-			`{"@timestamp":"2002-10-02T15:00:01Z","foo":"bar"}`,
-			`{"@timestamp":"2002-10-02T15:00:02Z","foo":"bar"}`,
-		},
+		handler: defaultHandler(http.MethodGet, "", ""),
+		wantErr: errors.New("request tracer path"),
 	},
 	{
 		name: "pagination",
@@ -1729,7 +1707,10 @@ func TestInput(t *testing.T) {
 					t.Errorf("unexpected event: %v", got)
 				}
 				cancel()
-				assert.NoError(t, g.Wait())
+				err = g.Wait()
+				if !sameErrorOrContains(err, test.wantErr) {
+					t.Errorf("unexpected error from running input: got:%v want:%v", err, test.wantErr)
+				}
 				return
 			}
 
@@ -2139,5 +2120,18 @@ func paginationArrayHandler() http.HandlerFunc {
 			_, _ = w.Write([]byte(`[{"foo":"bar"}]`))
 		}
 		count += 1
+	}
+}
+
+// sameErrorOrContains reports whether got matches want: both nil, or got's
+// message contains want's message.
+func sameErrorOrContains(got, want error) bool {
+	switch {
+	case got == nil && want == nil:
+		return true
+	case got == nil, want == nil:
+		return false
+	default:
+		return strings.Contains(got.Error(), want.Error())
 	}
 }

--- a/x-pack/filebeat/input/internal/httplog/roundtripper.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper.go
@@ -43,6 +43,52 @@ func ResolvePathInLogsFor(p *paths.Path, input, path string) (resolved string, o
 	return path, ok, err
 }
 
+// ResolveTraceFilename sanitises id and substitutes it into the tracer
+// filename's "*" placeholder, then resolves and validates the result against
+// the input's logs directory. It returns the resolved filename and an error
+// if the path escapes the permitted directory.
+func ResolveTraceFilename(p *paths.Path, input, id, filename string) (string, error) {
+	if filename == "" {
+		return "", nil
+	}
+	id = SanitizeFileName(id)
+	path := strings.ReplaceAll(filename, "*", id)
+	resolved, ok, err := ResolvePathInLogsFor(p, input, path)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("request tracer path %q must be within %q path", path, p.Resolve(paths.Logs, input))
+	}
+	return resolved, nil
+}
+
+// lumberjackTimestamp is a glob expression matching the time format string used
+// by lumberjack when rolling over logs, "2006-01-02T15-04-05.000".
+// https://github.com/natefinch/lumberjack/blob/4cb27fcfbb0f35cb48c542c5ea80b7c1d18933d0/lumberjack.go#L39
+const lumberjackTimestamp = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9].[0-9][0-9][0-9]"
+
+// CleanTraceFiles removes the primary trace log file and any lumberjack-
+// rotated variants. Errors are logged but not returned.
+func CleanTraceFiles(filename string, log *logp.Logger) {
+	err := os.Remove(filename)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		log.Errorw("failed to remove request trace log", "path", filename, "error", err)
+	}
+	ext := filepath.Ext(filename)
+	base := strings.TrimSuffix(filename, ext)
+	matches, err := filepath.Glob(base + "-" + lumberjackTimestamp + ext)
+	if err != nil {
+		log.Errorw("failed to collect request trace log path names", "error", err)
+	}
+	for _, p := range matches {
+		err = os.Remove(p)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			log.Errorw("failed to remove request trace log", "path", p, "error", err)
+		}
+	}
+}
+
 // isRooted reports whether path begins with a path separator, i.e. it is
 // rooted at the filesystem root even if it is not absolute (no drive letter
 // on Windows). Such paths must not be joined to a base directory.

--- a/x-pack/filebeat/input/internal/httplog/roundtripper_test.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
 
@@ -360,6 +361,140 @@ func TestResolvePathInLogsFor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveTraceFilename(t *testing.T) {
+	logsDir := filepath.Join(t.TempDir(), "logs")
+	p := &paths.Path{Logs: logsDir}
+
+	const input = "cel"
+	root := filepath.Join(logsDir, input)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		id       string
+		filename string
+		wantOK   bool
+	}{
+		{
+			name:     "empty_filename",
+			id:       "test",
+			filename: "",
+			wantOK:   true,
+		},
+		{
+			name:     "relative_with_star",
+			id:       "my:input:id",
+			filename: "http-request-trace-*.ndjson",
+			wantOK:   true,
+		},
+		{
+			name:     "integration_pattern",
+			id:       "cel-test-1",
+			filename: "../../logs/cel/http-request-trace-*.ndjson",
+			wantOK:   true,
+		},
+		{
+			name:     "absolute_outside",
+			id:       "test",
+			filename: "/var/log/evil.ndjson",
+			wantOK:   false,
+		},
+		{
+			name:     "relative_escape",
+			id:       "test",
+			filename: "../../../etc/passwd",
+			wantOK:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, err := ResolveTraceFilename(p, input, tt.id, tt.filename)
+			if tt.wantOK {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if tt.filename == "" {
+					if resolved != "" {
+						t.Errorf("empty filename should resolve to empty, got %q", resolved)
+					}
+					return
+				}
+				ok, err := IsPathIn(root, resolved)
+				if err != nil {
+					t.Fatalf("IsPathIn error: %v", err)
+				}
+				if !ok {
+					t.Errorf("resolved path %q is not within root %q", resolved, root)
+				}
+				if filepath.Ext(resolved) == "" {
+					t.Errorf("resolved path %q lost its extension", resolved)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error for path %q escaping logs dir, got resolved=%q", tt.filename, resolved)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveTraceFilenameSanitisesID(t *testing.T) {
+	logsDir := filepath.Join(t.TempDir(), "logs")
+	p := &paths.Path{Logs: logsDir}
+
+	const input = "cel"
+	root := filepath.Join(logsDir, input)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := ResolveTraceFilename(p, input, "has:colon:chars", "trace-*.ndjson")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(root, "trace-has_colon_chars.ndjson")
+	if resolved != want {
+		t.Errorf("unexpected resolved path:\n got: %q\nwant: %q", resolved, want)
+	}
+}
+
+func TestCleanTraceFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	primary := filepath.Join(dir, "trace.ndjson")
+	rotated := filepath.Join(dir, "trace-2026-01-02T15-04-05.000.ndjson")
+	unrelated := filepath.Join(dir, "other.log")
+
+	for _, f := range []string{primary, rotated, unrelated} {
+		if err := os.WriteFile(f, []byte("data"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	log := logptest.NewTestingLogger(t, "test")
+	CleanTraceFiles(primary, log)
+
+	if _, err := os.Stat(primary); err == nil {
+		t.Error("primary trace file should have been removed")
+	}
+	if _, err := os.Stat(rotated); err == nil {
+		t.Error("rotated trace file should have been removed")
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Error("unrelated file should not have been removed")
+	}
+}
+
+func TestCleanTraceFilesNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "does-not-exist.ndjson")
+
+	log := logptest.NewTestingLogger(t, "test")
+	CleanTraceFiles(primary, log)
 }
 
 func sameError(a, b error) bool {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input: validate request tracer and dump path regardless of enabled state

When the request tracer was configured but disabled, path validation
was skipped. A misconfigured tracer filename outside the permitted
logs directory would be passed to os.Remove during cleanup, deleting
unintended files.

Lift path resolution and validation above the enabled check in all
six inputs that use httplog, so the tracer filename is always
validated. Factor the duplicated resolution and cleanup logic into
httplog.ResolveTraceFilename and httplog.CleanTraceFiles.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #49691

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
