### PR TITLE
metricbeat: fix flaky TestTcpServer by binding to an ephemeral port

### DIFF
--- a/metricbeat/helper/server/tcp/tcp_test.go
+++ b/metricbeat/helper/server/tcp/tcp_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func GetTestTcpServer(host string, port int) (server.Server, error) {
-	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, strconv.Itoa(int(port))))
-
+func GetTestTcpServer(host string) (*TcpServer, error) {
+	// Listen on port 0 so the OS assigns a free ephemeral port.
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, "0"))
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,6 @@ func GetTestTcpServer(host string, port int) (server.Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("Started listening for TCP on: %s:%d", host, port)
 	return &TcpServer{
 		tcpAddr:           addr,
 		receiveBufferSize: 1024,
@@ -54,8 +53,7 @@ func GetTestTcpServer(host string, port int) (server.Server, error) {
 
 func TestTcpServer(t *testing.T) {
 	host := "127.0.0.1"
-	port := 2003
-	svc, err := GetTestTcpServer(host, port)
+	svc, err := GetTestTcpServer(host)
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -68,6 +66,9 @@ func TestTcpServer(t *testing.T) {
 	}
 
 	defer svc.Stop()
+
+	// Start() binds the listener, so the OS-assigned port is now known.
+	port := svc.listener.Addr().(*net.TCPAddr).Port
 	writeToServer(t, "test1\n", host, port)
 	msg := <-svc.GetEvents()
 


### PR DESCRIPTION
## Proposed commit message

`TestTcpServer` in `metricbeat/helper/server/tcp` bound the test server to a hardcoded port (`2003`). When the test runs in multiple parallel processes (for example under `stresstest.sh` with `-p`), the processes race to bind `127.0.0.1:2003` and all but one fail with `bind: address already in use`, so the test is flaky regardless of whether the race detector is enabled.

This change binds the test server to port `0` so the OS assigns a free ephemeral port, then reads the actual port back from the listener after `Start()` to connect the client. While here, the test helper is simplified: the now-unused `port` parameter is dropped, the helper returns the concrete `*TcpServer` (removing a type assertion at the call site), and a misleading log line that claimed the server was listening before `Start()` was called is removed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None.

## How to test this PR locally

```bash
script/stresstest.sh --race ./metricbeat/helper/server/tcp .
```
