### PR TITLE
[libbeat/output/kafka]: fix data race and panic on Publish during Close

### DIFF
--- a/changelog/fragments/1782287808-fix-kafka-output-publish-close-race.yaml
+++ b/changelog/fragments/1782287808-fix-kafka-output-publish-close-race.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix panic in the Kafka output during shutdown
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: libbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -53,7 +53,7 @@ type client struct {
 	done     chan struct{}
 
 	producerMux sync.RWMutex
-	producer sarama.AsyncProducer
+	producer    sarama.AsyncProducer
 
 	recordHeaders []sarama.RecordHeader
 

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -52,6 +52,7 @@ type client struct {
 	mux      sync.Mutex
 	done     chan struct{}
 
+	producerMux sync.RWMutex
 	producer sarama.AsyncProducer
 
 	recordHeaders []sarama.RecordHeader
@@ -161,8 +162,15 @@ func (c *client) Close() error {
 		return nil
 	}
 
+	// Releases any Publish goroutine blocked on a channel send.
 	close(c.done)
+
+	// Take the write lock so AsyncClose, which closes the input channel, waits
+	// for in-flight sends to finish instead of racing with them; see send.
+	c.producerMux.Lock()
 	c.producer.AsyncClose()
+	c.producerMux.Unlock()
+
 	c.wg.Wait()
 	c.producer = nil
 	return nil
@@ -193,16 +201,35 @@ func (c *client) Publish(_ context.Context, batch publisher.Batch) error {
 
 		msg.ref = ref
 		msg.initProducerMessage()
-		select {
-		case <-c.done:
+		if !c.send(ch, &msg.msg) {
 			c.log.Errorf("output closing, dropping event")
 			ref.done()
 			c.observer.PermanentErrors(1)
-		case ch <- &msg.msg:
 		}
 	}
 
 	return nil
+}
+
+// send delivers msg to the producer's input channel, returning false if the
+// client is closing and the message was dropped instead.
+func (c *client) send(ch chan<- *sarama.ProducerMessage, msg *sarama.ProducerMessage) bool {
+	c.producerMux.RLock()
+	defer c.producerMux.RUnlock()
+
+	// Check if `ch` is still open (closed by producer.AsyncClose).
+	select {
+	case <-c.done:
+		return false
+	default:
+	}
+
+	select {
+	case <-c.done:
+		return false
+	case ch <- msg:
+		return true
+	}
 }
 
 func (c *client) String() string {


### PR DESCRIPTION
<!-- Suggested label: Bug -->

## Proposed commit message

`Close` closes `c.done` and then calls `producer.AsyncClose()`, which closes the producer's input channel. If `Publish` picks the send case on an already-closed channel, it produces a data race (`chansend` vs `closechan`) and panic.

This PR serializes sends against the channel close using a `sync.RWMutex`:

- `Publish` delivers each event through a new `send` helper that holds the read lock and performs a non-blocking `c.done` check before the blocking `select`.
- `Close` closes `c.done` (to release any blocked send) and then takes the write lock around `AsyncClose`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~ I have made corresponding changes to the documentation~~
- ~~ I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

```bash
# Reproduces the data race / panic on main, passes with this PR.
./script/stresstest.sh --race ./libbeat/outputs/kafka '^TestClientShutdownPanic$' -p 28 -timeout 30s

# Without the race detector (exercises the actual "send on closed channel" panic).
./script/stresstest.sh ./libbeat/outputs/kafka '^TestClientShutdownPanic$' -p 28 -timeout 30s
```

With this change both profiles ran with zero failures (2158 runs under `-race`, 62828 runs without). On `main` the `--race` profile reports `WARNING: DATA RACE` within seconds.

## Related issues

- Relates #46109
- Relates #46446
