### PR TITLE
Fix data race in the elasticsearch_storage OTel extension.

### DIFF
--- a/changelog/fragments/1782324121-fix-elasticsearchstorage-extension-race.yaml
+++ b/changelog/fragments/1782324121-fix-elasticsearchstorage-extension-race.yaml
@@ -2,10 +2,11 @@ kind: bug-fix
 summary: Fix data race in the elasticsearch_storage OTel extension.
 description: |
   The `elasticsearch_storage` OTel extension shared a single
-  `eslegclient.Connection` across every store returned by `Access`, but
-  that connection is not thread-safe.  The extension now wraps each
-  returned store in a locking proxy that serializes the full
-  `Marshal → execRequest → HTTP.Do` path on a
-  per-extension mutex, preventing the buffer races.
+  `eslegclient.Connection` across every store returned from both the
+  `backend.Registry` (`Access`) and `entcollect.Registry` (`Store`)
+  factories, but that connection is not thread-safe.  The extension now
+  wraps every returned store — on both factory paths — in a locking
+  proxy that serializes the full `Marshal → execRequest → HTTP.Do` path
+  on a per-extension mutex, preventing the buffer races.
 component: elastic-agent
 pr: https://github.com/elastic/beats/pull/51501

--- a/changelog/fragments/1782324121-fix-elasticsearchstorage-extension-race.yaml
+++ b/changelog/fragments/1782324121-fix-elasticsearchstorage-extension-race.yaml
@@ -7,5 +7,5 @@ description: |
   returned store in a locking proxy that serializes the full
   `Marshal → execRequest → HTTP.Do` path on a
   per-extension mutex, preventing the buffer races.
-component: x-pack/otel
-#pr: https://github.com/owner/repo/1234
+component: elastic-agent
+pr: https://github.com/elastic/beats/pull/51501

--- a/changelog/fragments/1782324121-fix-elasticsearchstorage-extension-race.yaml
+++ b/changelog/fragments/1782324121-fix-elasticsearchstorage-extension-race.yaml
@@ -1,0 +1,11 @@
+kind: bug-fix
+summary: Fix data race in the elasticsearch_storage OTel extension.
+description: |
+  The `elasticsearch_storage` OTel extension shared a single
+  `eslegclient.Connection` across every store returned by `Access`, but
+  that connection is not thread-safe.  The extension now wraps each
+  returned store in a locking proxy that serializes the full
+  `Marshal → execRequest → HTTP.Do` path on a
+  per-extension mutex, preventing the buffer races.
+component: x-pack/otel
+#pr: https://github.com/owner/repo/1234

--- a/x-pack/otel/extension/elasticsearchstorage/entcollect.go
+++ b/x-pack/otel/extension/elasticsearchstorage/entcollect.go
@@ -17,8 +17,17 @@ var _ entcollect.Registry = (*elasticStorage)(nil)
 
 // Store returns an [entcollect.Store] backed by Elasticsearch. The
 // returned store is scoped to name, which determines the ES index.
+// The underlying [backend.Store] is obtained via Access so that the
+// entcollect path shares clientMu with the [backend.Registry] path —
+// both factories ultimately drive the same non-thread-safe
+// eslegclient.Connection, and concurrent users (e.g. an entcollect
+// provider running alongside Filebeat httpjson inputs) must serialize.
 func (e *elasticStorage) Store(name string) (entcollect.Store, error) {
-	return &entcollectStore{base: es.NewStore(e.ctx, e.logger, e.client, name)}, nil
+	base, err := e.Access(name)
+	if err != nil {
+		return nil, err
+	}
+	return &entcollectStore{base: base}, nil
 }
 
 // entcollectStore wraps a [backend.Store] as [entcollect.Store],
@@ -43,8 +52,7 @@ func (s *entcollectStore) Set(key string, value any) error {
 // requires that deleting an absent key is not an error, but the
 // underlying ES store returns an error on 404. We check Has first
 // to avoid that. The extra round trip is acceptable: Delete is
-// called rarely (IDSet shard cleanup on rehash) and only one
-// goroutine accesses the store.
+// called rarely (IDSet shard cleanup on rehash).
 func (s *entcollectStore) Delete(key string) error {
 	ok, err := s.base.Has(key)
 	if err != nil {

--- a/x-pack/otel/extension/elasticsearchstorage/extension.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension.go
@@ -51,11 +51,11 @@ func (e *elasticStorage) Start(ctx context.Context, host component.Host) error {
 }
 
 func (e *elasticStorage) Shutdown(ctx context.Context) error {
+	e.clientMu.Lock()
+	defer e.clientMu.Unlock()
 	if e.client == nil {
 		return nil
 	}
-	e.clientMu.Lock()
-	defer e.clientMu.Unlock()
 	return e.client.Close()
 }
 

--- a/x-pack/otel/extension/elasticsearchstorage/extension.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension.go
@@ -6,6 +6,7 @@ package elasticsearchstorage
 
 import (
 	"context"
+	"sync"
 
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/statestore/backend"
@@ -25,6 +26,12 @@ type elasticStorage struct {
 	ctx    context.Context
 	logger *logp.Logger
 	client *eslegclient.Connection
+
+	// clientMu serializes every operation that goes through client. The
+	// connection (and its body encoder + response buffer) is documented as
+	// not thread-safe, so all stores returned by Access must share this lock
+	// and hold it for the full Marshal → execRequest → HTTP.Do path.
+	clientMu sync.Mutex
 }
 
 func (e *elasticStorage) Start(ctx context.Context, host component.Host) error {
@@ -49,10 +56,65 @@ func (e *elasticStorage) Shutdown(ctx context.Context) error {
 }
 
 func (e *elasticStorage) Access(name string) (backend.Store, error) {
-	return es.NewStore(e.ctx, e.logger, e.client, name), nil
+	return &lockedStore{
+		inner: es.NewStore(e.ctx, e.logger, e.client, name),
+		mu:    &e.clientMu,
+	}, nil
 }
 
 func (e *elasticStorage) Close() error {
 	// no-op. Client will be close in Shutdown
 	return nil
+}
+
+// lockedStore serializes access to the underlying baseStore so that
+// concurrent callers cannot race on the shared eslegclient.Connection
+// (its body encoder reuses a single *bytes.Buffer, and its response
+// buffer is also shared). The mutex is owned by elasticStorage so that
+// every store returned by Access shares the same lock.
+type lockedStore struct {
+	inner backend.Store
+	mu    *sync.Mutex
+}
+
+func (s *lockedStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Close()
+}
+
+func (s *lockedStore) Has(key string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Has(key)
+}
+
+func (s *lockedStore) Get(key string, to interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Get(key, to)
+}
+
+func (s *lockedStore) Set(key string, value interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Set(key, value)
+}
+
+func (s *lockedStore) Remove(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Remove(key)
+}
+
+func (s *lockedStore) Each(fn func(string, backend.ValueDecoder) (bool, error)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inner.Each(fn)
+}
+
+func (s *lockedStore) SetID(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inner.SetID(id)
 }

--- a/x-pack/otel/extension/elasticsearchstorage/extension.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension.go
@@ -21,6 +21,7 @@ import (
 var (
 	_ extension.Extension = (*elasticStorage)(nil)
 	_ backend.Registry    = (*elasticStorage)(nil)
+	_ backend.Store       = (*lockedStore)(nil)
 )
 
 type elasticStorage struct {

--- a/x-pack/otel/extension/elasticsearchstorage/extension.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension.go
@@ -18,8 +18,10 @@ import (
 	"go.opentelemetry.io/collector/extension"
 )
 
-var _ extension.Extension = (*elasticStorage)(nil)
-var _ backend.Registry = (*elasticStorage)(nil)
+var (
+	_ extension.Extension = (*elasticStorage)(nil)
+	_ backend.Registry    = (*elasticStorage)(nil)
+)
 
 type elasticStorage struct {
 	cfg    *Config
@@ -52,6 +54,8 @@ func (e *elasticStorage) Shutdown(ctx context.Context) error {
 	if e.client == nil {
 		return nil
 	}
+	e.clientMu.Lock()
+	defer e.clientMu.Unlock()
 	return e.client.Close()
 }
 

--- a/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
@@ -41,8 +41,7 @@ import (
 //
 // This test stands up a fake ES (httptest.Server) and drives concurrent Set
 // and Each from multiple goroutines against multiple stores produced by one
-// extension. It is expected to FAIL today, and should pass once Access
-// returns stores that serialize access to the underlying connection.
+// extension.
 //
 // Under `go test -race` the data race is detected directly on the encoder's
 // shared *bytes.Buffer. Without -race the test still catches the bug

--- a/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
@@ -1,0 +1,205 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package elasticsearchstorage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+
+	"github.com/elastic/beats/v7/libbeat/statestore/backend"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+// TestElasticStorage_Access_Concurrent_Race documents and guards against the
+// data race in the elasticsearch_storage OTel extension: a single
+// eslegclient.Connection (with its single reused *bytes.Buffer body encoder)
+// is shared across every backend.Store returned by Access. Concurrent state
+// ops from different streams therefore race on the shared buffer, producing
+// either:
+//
+//   - "http: ContentLength=N with Body length M" (Go stdlib aborts the
+//     request locally — buffer was overwritten between
+//     http.NewRequestWithContext capturing ContentLength and the transport
+//     reading the live body), or
+//   - the wrong body landing on the wire, e.g. a {"v":...} state doc reaching
+//     the _search endpoint, which ES rejects with
+//     "Unknown key for a START_OBJECT in [v]".
+//
+// This test stands up a fake ES (httptest.Server) and drives concurrent Set
+// and Each from multiple goroutines against multiple stores produced by one
+// extension. It is expected to FAIL today, and should pass once Access
+// returns stores that serialize access to the underlying connection.
+//
+// Under `go test -race` the data race is detected directly on the encoder's
+// shared *bytes.Buffer. Without -race the test still catches the bug
+// functionally — the fake ES rejects bodies that don't match the path
+// (PUT must carry a {"v":...} state doc, _search must carry a match_all
+// query), and the Go transport's own ContentLength/body-length mismatch
+// surfaces as an error returned from Set/Each.
+func TestElasticStorage_Access_Concurrent_Race(t *testing.T) {
+	srv := newFakeES(t)
+	defer srv.Close()
+
+	cfg := &Config{
+		ElasticsearchConfig: map[string]interface{}{
+			"hosts":    []string{srv.URL},
+			"username": "elastic",
+			"password": "changeme",
+		},
+	}
+	ext := &elasticStorage{cfg: cfg, logger: logptest.NewTestingLogger(t, "")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, ext.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+
+	const (
+		numStores      = 4
+		opsPerStore    = 50
+		writersPerStore = 2 // one Each loop + one Set loop per store == higher race odds
+	)
+
+	stores := make([]backend.Store, numStores)
+	for i := 0; i < numStores; i++ {
+		s, err := ext.Access(fmt.Sprintf("stream-%d", i))
+		require.NoError(t, err)
+		stores[i] = s
+	}
+
+	var (
+		wg     sync.WaitGroup
+		failed atomic.Int64
+	)
+
+	report := func(op string, err error) {
+		// Any per-op error is sufficient to fail the test; capture the
+		// first one in detail and silence the rest to keep output sane.
+		if failed.Add(1) == 1 {
+			t.Errorf("concurrent %s failed: %v", op, err)
+		}
+	}
+
+	for i := 0; i < numStores; i++ {
+		s := stores[i]
+		key := fmt.Sprintf("cursor-%d", i)
+		for w := 0; w < writersPerStore; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < opsPerStore; j++ {
+					if err := s.Set(key, map[string]any{
+						"cursor":  nil,
+						"ttl":     0,
+						"updated": time.Now().UTC().Format(time.RFC3339Nano),
+					}); err != nil {
+						report("Set", err)
+						return
+					}
+				}
+			}()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < opsPerStore; j++ {
+					if err := s.Each(func(string, backend.ValueDecoder) (bool, error) {
+						return true, nil
+					}); err != nil {
+						report("Each", err)
+						return
+					}
+				}
+			}()
+		}
+	}
+
+	wg.Wait()
+
+	if failed.Load() != 0 {
+		t.Fatalf("%d concurrent ops returned errors (see first reported above) — likely the shared-encoder race in elasticStorage.Access", failed.Load())
+	}
+	if srvErrs := srv.errs(); len(srvErrs) > 0 {
+		t.Fatalf("fake ES detected corrupted request bodies (signature A/B): %v", srvErrs)
+	}
+}
+
+// fakeES is a minimal stand-in for Elasticsearch that:
+//   - answers Ping with a valid version response,
+//   - validates that PUT _doc bodies look like state docs ({"v":...}),
+//   - validates that _search bodies look like search queries (match_all),
+//   - records any body that arrives on the wrong endpoint (Signature A of
+//     the shared-buffer race) for the test to assert on.
+type fakeES struct {
+	*httptest.Server
+
+	mu      sync.Mutex
+	corrupt []string
+}
+
+func newFakeES(t *testing.T) *fakeES {
+	t.Helper()
+	f := &fakeES{}
+	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"version":{"number":"8.10.0","build_flavor":"default"},"name":"fake"}`)
+
+		case strings.HasSuffix(r.URL.Path, "/_search"):
+			body, _ := io.ReadAll(r.Body)
+			if !bytes.Contains(body, []byte(`match_all`)) {
+				f.record(fmt.Sprintf("search got non-search body on %s: %q", r.URL.Path, body))
+				http.Error(w, `{"error":{"type":"parsing_exception","reason":"Unknown key for a START_OBJECT in [v]"}}`, http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"took":1,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}`)
+
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/_doc/"):
+			body, _ := io.ReadAll(r.Body)
+			// A correctly-marshalled state doc starts with {"v":
+			trimmed := bytes.TrimSpace(body)
+			if !bytes.HasPrefix(trimmed, []byte(`{"v":`)) {
+				f.record(fmt.Sprintf("PUT got non-state-doc body on %s: %q", r.URL.Path, body))
+				http.Error(w, `{"error":"bad body"}`, http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"result":"created"}`)
+
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{}`)
+		}
+	}))
+	return f
+}
+
+func (f *fakeES) record(msg string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.corrupt = append(f.corrupt, msg)
+}
+
+func (f *fakeES) errs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.corrupt))
+	copy(out, f.corrupt)
+	return out
+}

--- a/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 
+	"github.com/elastic/entcollect"
+
 	"github.com/elastic/beats/v7/libbeat/statestore/backend"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
@@ -131,6 +133,150 @@ func TestElasticStorage_Access_Concurrent_Race(t *testing.T) {
 
 	if failed.Load() != 0 {
 		t.Fatalf("%d concurrent ops returned errors (see first reported above) — likely the shared-encoder race in elasticStorage.Access", failed.Load())
+	}
+	if srvErrs := srv.errs(); len(srvErrs) > 0 {
+		t.Fatalf("fake ES detected corrupted request bodies (signature A/B): %v", srvErrs)
+	}
+}
+
+// TestElasticStorage_MixedRegistry_Concurrent_Race covers the cross-path
+// race between the two registry interfaces the extension implements:
+// backend.Registry (used by Filebeat inputs via Access → *lockedStore) and
+// entcollect.Registry (used by entcollect providers via Store →
+// *entcollectStore). Both factories return stores backed by the same
+// e.client, but only *lockedStore takes the extension's clientMu. When
+// the two paths are exercised on the same extension instance, the mutex
+// on the Access side does not protect against unsynchronized ops from the
+// Store side — both still hit the shared encoder buffer, response
+// buffer, and JSON visitor state on eslegclient.Connection.
+//
+// This is the realistic deployment shape: an EDOT/hybrid agent runs
+// Filebeat httpjson streams (Access path) alongside entcollect identity
+// providers (Store path), pointing at the same elasticsearch_storage
+// extension. The test fails on the current code (only *lockedStore is
+// locked) and should pass once both factories share clientMu.
+func TestElasticStorage_MixedRegistry_Concurrent_Race(t *testing.T) {
+	srv := newFakeES(t)
+	defer srv.Close()
+
+	cfg := &Config{
+		ElasticsearchConfig: map[string]interface{}{
+			"hosts":    []string{srv.URL},
+			"username": "elastic",
+			"password": "changeme",
+		},
+	}
+	ext := &elasticStorage{cfg: cfg, logger: logptest.NewTestingLogger(t, "")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, ext.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+
+	// Compile-time check that the extension still satisfies the two
+	// registry interfaces this test exercises.
+	var (
+		_ backend.Registry    = ext
+		_ entcollect.Registry = ext
+	)
+
+	const (
+		numStores   = 4
+		opsPerStore = 50
+	)
+
+	beatStores := make([]backend.Store, numStores)
+	entStores := make([]entcollect.Store, numStores)
+	for i := 0; i < numStores; i++ {
+		bs, err := ext.Access(fmt.Sprintf("stream-%d", i))
+		require.NoError(t, err)
+		beatStores[i] = bs
+
+		es, err := ext.Store(fmt.Sprintf("provider-%d", i))
+		require.NoError(t, err)
+		entStores[i] = es
+	}
+
+	var (
+		wg     sync.WaitGroup
+		failed atomic.Int64
+	)
+	report := func(op string, err error) {
+		if failed.Add(1) == 1 {
+			t.Errorf("concurrent %s failed: %v", op, err)
+		}
+	}
+
+	for i := 0; i < numStores; i++ {
+		bs := beatStores[i]
+		es := entStores[i]
+		key := fmt.Sprintf("cursor-%d", i)
+
+		// Access path: Set + Each, same shape as the original test.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerStore; j++ {
+				if err := bs.Set(key, map[string]any{
+					"cursor":  nil,
+					"ttl":     0,
+					"updated": time.Now().UTC().Format(time.RFC3339Nano),
+				}); err != nil {
+					report("Access.Set", err)
+					return
+				}
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerStore; j++ {
+				if err := bs.Each(func(string, backend.ValueDecoder) (bool, error) {
+					return true, nil
+				}); err != nil {
+					report("Access.Each", err)
+					return
+				}
+			}
+		}()
+
+		// Store path: same op pattern via entcollect.Store. These
+		// goroutines do not hold clientMu in the current code, so
+		// they race against the Access goroutines on the shared
+		// eslegclient.Connection.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerStore; j++ {
+				if err := es.Set(key, map[string]any{
+					"cursor":  nil,
+					"ttl":     0,
+					"updated": time.Now().UTC().Format(time.RFC3339Nano),
+				}); err != nil {
+					report("Store.Set", err)
+					return
+				}
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerStore; j++ {
+				if err := es.Each(func(string, func(any) error) (bool, error) {
+					return true, nil
+				}); err != nil {
+					report("Store.Each", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if failed.Load() != 0 {
+		t.Fatalf("%d concurrent ops returned errors (see first reported above) — the entcollect path does not share clientMu with the Access path", failed.Load())
 	}
 	if srvErrs := srv.errs(); len(srvErrs) > 0 {
 		t.Fatalf("fake ES detected corrupted request bodies (signature A/B): %v", srvErrs)

--- a/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
@@ -153,8 +153,7 @@ func TestElasticStorage_Access_Concurrent_Race(t *testing.T) {
 // This is the realistic deployment shape: an EDOT/hybrid agent runs
 // Filebeat httpjson streams (Access path) alongside entcollect identity
 // providers (Store path), pointing at the same elasticsearch_storage
-// extension. The test fails on the current code (only *lockedStore is
-// locked) and should pass once both factories share clientMu.
+// extension.
 func TestElasticStorage_MixedRegistry_Concurrent_Race(t *testing.T) {
 	srv := newFakeES(t)
 	defer srv.Close()

--- a/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension_race_test.go
@@ -70,8 +70,8 @@ func TestElasticStorage_Access_Concurrent_Race(t *testing.T) {
 	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
 
 	const (
-		numStores      = 4
-		opsPerStore    = 50
+		numStores       = 4
+		opsPerStore     = 50
 		writersPerStore = 2 // one Each loop + one Set loop per store == higher race odds
 	)
 


### PR DESCRIPTION
## Proposed commit message

 The `elasticsearch_storage` OTel extension shared a single `eslegclient.Connection` across every store returned by `Access`, but that connection is not thread-safe.  The extension now wraps each returned store in a locking proxy that serializes the full `Marshal → execRequest → HTTP.Do` path on a  per-extension mutex, preventing the buffer races.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

```
cd x-pack/otel/extension/elasticsearchstorage
go test . -race -run TestElasticStorage_Access_Concurrent_Race -count 1000
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
