### PR TITLE
Fix journald translated field names in reference docs

### DIFF
--- a/docs/reference/filebeat/filebeat-input-journald.md
+++ b/docs/reference/filebeat/filebeat-input-journald.md
@@ -444,6 +444,12 @@ You can use the following translated names in filter expressions to reference jo
 `COREDUMP_USER_UNIT`
 :   `journald.coredump.user_unit`
 
+`MESSAGE`
+:   `message`
+
+`MESSAGE_ID`
+:   `message_id`
+
 `OBJECT_AUDIT_LOGINUID`
 :   `journald.object.audit.login_uid`
 
@@ -451,13 +457,13 @@ You can use the following translated names in filter expressions to reference jo
 :   `journald.object.audit.session`
 
 `OBJECT_CMDLINE`
-:   `journald.object.cmd`
+:   `journald.object.process.command_line`
 
 `OBJECT_COMM`
-:   `journald.object.name`
+:   `journald.object.process.name`
 
 `OBJECT_EXE`
-:   `journald.object.executable`
+:   `journald.object.process.executable`
 
 `OBJECT_GID`
 :   `journald.object.gid`
@@ -480,41 +486,56 @@ You can use the following translated names in filter expressions to reference jo
 `OBJECT_UID`
 :   `journald.object.uid`
 
+`PRIORITY`
+:   `log.syslog.priority`
+
+`SYSLOG_FACILITY`
+:   `log.syslog.facility.code`
+
+`SYSLOG_IDENTIFIER`
+:   `log.syslog.appname`
+
+`SYSLOG_PID`
+:   `log.syslog.procid`
+
+`UNIT`
+:   `journald.unit`
+
 `_AUDIT_LOGINUID`
-:   `process.audit.login_uid`
+:   `journald.audit.login_uid`
 
 `_AUDIT_SESSION`
-:   `process.audit.session`
+:   `journald.audit.session`
 
 `_BOOT_ID`
-:   `host.boot_id`
+:   `journald.host.boot_id`
 
 `_CAP_EFFECTIVE`
-:   `process.capabilites`
+:   `journald.process.capabilities`
 
 `_CMDLINE`
-:   `process.cmd`
+:   `journald.process.command_line`
 
-`_CODE_FILE`
+`CODE_FILE`
 :   `journald.code.file`
 
-`_CODE_FUNC`
+`CODE_FUNC`
 :   `journald.code.func`
 
-`_CODE_LINE`
+`CODE_LINE`
 :   `journald.code.line`
 
 `_COMM`
-:   `process.name`
+:   `journald.process.name`
 
 `_EXE`
-:   `process.executable`
+:   `journald.process.executable`
 
 `_GID`
-:   `process.uid`
+:   `journald.gid`
 
 `_HOSTNAME`
-:   `host.name`
+:   `host.hostname`
 
 `_KERNEL_DEVICE`
 :   `journald.kernel.device`
@@ -525,23 +546,8 @@ You can use the following translated names in filter expressions to reference jo
 `_MACHINE_ID`
 :   `host.id`
 
-`_MESSAGE`
-:   `message`
-
 `_PID`
-:   `process.pid`
-
-`_PRIORITY`
-:   `logs.syslog.priority`
-
-`_SYSLOG_FACILITY`
-:   `logs.syslog.facility.code`
-
-`_SYSLOG_IDENTIFIER`
-:   `logs.syslog.identifier.appname`
-
-`_SYSLOG_PID`
-:   `log.syslog.procid`
+:   `journald.pid`
 
 `_SYSTEMD_CGROUP`
 :   `systemd.cgroup`
@@ -580,7 +586,7 @@ You can use the following translated names in filter expressions to reference jo
 :   `journald.kernel.device_name`
 
 `_UID`
-:   `process.uid`
+:   `journald.uid`
 
 The following translated fields for [Docker](https://docs.docker.com/config/containers/logging/journald/) are also available:
 


### PR DESCRIPTION
<!-- Type of change: Docs -->

## Proposed commit message

```
Fix journald translated field names in reference docs

The "Translated field names" table in the journald input reference had
drifted out of sync with the field conversion map in
filebeat/input/journald/pkg/journalfield/default.go. Because these names
are what users put into include_matches/filter expressions, the stale
table meant expressions copied from the docs would silently fail to
match any events.

Reconcile the entire table with default.go:
- correct ~14 wrong target names (e.g. _CMDLINE -> journald.process.command_line,
  _GID -> journald.gid, _HOSTNAME -> host.hostname, _BOOT_ID -> journald.host.boot_id,
  _PID -> journald.pid, _UID -> journald.uid, the OBJECT_* process fields, the
  _AUDIT_* fields, and the process.capabilites typo -> journald.process.capabilities);
- fix keys that carried an erroneous leading underscore (CODE_FILE/FUNC/LINE,
  MESSAGE, PRIORITY, SYSLOG_*) since these are systemd user fields, not trusted
  underscore-prefixed fields, and drop the stray "logs.syslog" prefix;
- add the missing MESSAGE_ID and UNIT entries.

The table now matches default.go one-to-one.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the changelog tool.~~ Docs-only change; merged with the `skip-changelog` label.

## Disruptive User Impact

This is a documentation-only change and does not alter any code, configuration, or event output.

## How to test this PR locally

Cross-check every entry in the "Translated field names" table against the conversion map. The two must match exactly (Docker and ignored fields excepted):

```bash
python3 - <<'PY'
import re
go = {}
for line in open('filebeat/input/journald/pkg/journalfield/default.go'):
    m = re.match(r'\s*"([^"]+)":\s*(?:text|integer)\("([^"]+)"\)', line)
    if m: go[m.group(1)] = m.group(2)
doc, lines = {}, open('docs/reference/filebeat/filebeat-input-journald.md').read().splitlines()
for i, l in enumerate(lines):
    mk = re.match(r'^`([^`]+)`$', l)
    if mk and i+1 < len(lines):
        mv = re.match(r'^:   `([^`]+)`$', lines[i+1])
        if mv: doc[mk.group(1)] = mv.group(1)
docker = {'CONTAINER_ID_FULL','CONTAINER_NAME','IMAGE_NAME','CONTAINER_PARTIAL_MESSAGE'}
bad = [(k, doc.get(k), v) for k, v in go.items() if k not in docker and doc.get(k) != v]
print("MISMATCHES:", bad or "none")
PY
```

Optionally, run Filebeat with the `journald` input on a Linux host and confirm an `include_matches` expression using a corrected name (for example `journald.process.command_line`) matches as documented.

## Related issues

- Relates #51419
- Relates #51512