### PR TITLE
fix: prevent Filebeat from replaying events after a clean shutdown

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,7 +115,6 @@ linters:
               reason: Use one uuid library consistently across the codebase
     gosec:
       excludes:
-        - G115
         - G306
         - G404
         - G401

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,7 @@ linters:
               reason: Use one uuid library consistently across the codebase
     gosec:
       excludes:
+        - G115
         - G306
         - G404
         - G401

--- a/changelog/fragments/1782376956-fix-filebeat-duplicating-events-after-a-normal-shutdown-caused-by-a-race-in-the-registrar.yaml
+++ b/changelog/fragments/1782376956-fix-filebeat-duplicating-events-after-a-normal-shutdown-caused-by-a-race-in-the-registrar.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix Filebeat duplicating events after a normal shutdown caused by a race in the registrar
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/filebeat/registrar/migrate_bench_test.go
+++ b/filebeat/registrar/migrate_bench_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,7 +55,7 @@ func BenchmarkMigration0To1(b *testing.B) {
 					Id:     fmt.Sprintf("123455-%v", i),
 					Source: fmt.Sprintf("/path/to/test/file-%v.log", i),
 					FileStateOS: libfile.StateOS{
-						Inode:  uint64(i),
+						Inode:  uint64(i), //nolint:gosec // i is always non-negative (range index)
 						Device: 123455,
 					},
 				}
@@ -101,7 +100,7 @@ func tempDir(t testing.TB) string {
 		t.Fatal(err)
 	}
 
-	path, err := ioutil.TempDir(cwd, "")
+	path, err := os.MkdirTemp(cwd, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +120,7 @@ func mkDir(t testing.TB, path string) {
 }
 
 func clearDir(t testing.TB, path string) {
-	old, err := ioutil.ReadDir(path)
+	old, err := os.ReadDir(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +133,7 @@ func clearDir(t testing.TB, path string) {
 
 func writeFile(t testing.TB, path string, contents []byte) {
 	t.Helper()
-	err := ioutil.WriteFile(path, contents, 0o600)
+	err := os.WriteFile(path, contents, 0o600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filebeat/registrar/migrate_bench_test.go
+++ b/filebeat/registrar/migrate_bench_test.go
@@ -125,7 +125,7 @@ func clearDir(t testing.TB, path string) {
 		t.Fatal(err)
 	}
 	for _, info := range old {
-		if err := os.RemoveAll(info.Name()); err != nil {
+		if err := os.RemoveAll(filepath.Join(path, info.Name())); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/filebeat/registrar/migrate_bench_test.go
+++ b/filebeat/registrar/migrate_bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkMigration0To1(b *testing.B) {
 					Id:     fmt.Sprintf("123455-%v", i),
 					Source: fmt.Sprintf("/path/to/test/file-%v.log", i),
 					FileStateOS: libfile.StateOS{
-						Inode:  uint64(i), //nolint:gosec // i is always non-negative (range index)
+						Inode:  uint64(i),
 						Device: 123455,
 					},
 				}

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -160,6 +160,15 @@ func (r *Registrar) Run() {
 		select {
 		case <-r.done:
 			r.log.Info("Ending Registrar")
+			// Persist any pending batch on shutdown so its events are not replayed on restart.
+			// Channel has buffer=1, so it holds at most one pending batch. A single
+			// non-blocking receive is enough to drain it.
+			select {
+			case states := <-r.Channel:
+				r.onEvents(states)
+			default:
+			}
+			r.commitStateUpdates()
 			return
 
 		case states := <-directIn:

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -136,12 +136,6 @@ func (r *Registrar) Run() {
 
 	defer r.store.Close()
 
-	defer func() {
-		if err := writeStates(r.store, r.states.GetStates()); err != nil {
-			r.log.Errorf("Error writing stopping registrar state to statestore: %v", err)
-		}
-	}()
-
 	var (
 		timer  *time.Timer
 		flushC <-chan time.Time

--- a/filebeat/registrar/registrar_test.go
+++ b/filebeat/registrar/registrar_test.go
@@ -115,5 +115,52 @@ func TestRunEmptyChannelShutdown(t *testing.T) {
 		t.Fatalf("expected no states to be acked, got Published count %d", spy.n)
 	}
 }
+// TestRunConcurrentShutdownAndBatch runs Run in a background goroutine (via
+// Start), pre-loads a state into the channel, then calls Stop immediately.
+// Many iterations expose the scheduling race: the goroutine may not be
+// scheduled before r.done closes, so the select sees both channels ready
+// simultaneously — the exact case the shutdown drain must handle.
+func TestRunConcurrentShutdownAndBatch(t *testing.T) {
+       const iterations = 100
 
+       testCases := []struct {
+               name    string
+               timeout time.Duration
+       }{
+               {"directIn path", 0},
+               {"collectIn path", time.Second},
+       }
+
+       for _, tc := range testCases {
+               tc := tc
+               t.Run(tc.name, func(t *testing.T) {
+                       for i := 0; i < iterations; i++ {
+                               logger := logptest.NewTestingLogger(t, "")
+                               memBackend := storetest.NewMemoryStoreBackend()
+                               stateStore := &testStateStore{registry: statestore.NewRegistry(memBackend)}
+                               spy := &spyLogger{}
+                               r, err := New(stateStore, spy, tc.timeout, logger)
+                               if err != nil {
+                                       t.Fatalf("iter %d: New: %v", i, err)
+                               }
+
+                               state := file.State{Id: "test-id", Source: "/path/to/file.log", TTL: -1}
+
+                               // Pre-load the buffered channel before Run starts so that both
+                               // r.Channel and r.done can be ready in the first select evaluation.
+                               r.Channel <- []file.State{state}
+
+                               if err := r.Start(); err != nil {
+                                       t.Fatalf("iter %d: Start: %v", i, err)
+                               }
+                               // Immediately stop — races with the pre-loaded batch.
+                               r.Stop()
+
+                               if _, ok := memBackend.Stores[testStoreName].Table[fileStatePrefix+state.Id]; !ok {
+                                       t.Fatalf("iter %d (%s): state %q was not persisted", i, tc.name, state.Id)
+                               }
+                       }
+               })
+       }
+}
 var _ statestore.States = (*testStateStore)(nil)

--- a/filebeat/registrar/registrar_test.go
+++ b/filebeat/registrar/registrar_test.go
@@ -115,52 +115,54 @@ func TestRunEmptyChannelShutdown(t *testing.T) {
 		t.Fatalf("expected no states to be acked, got Published count %d", spy.n)
 	}
 }
+
 // TestRunConcurrentShutdownAndBatch runs Run in a background goroutine (via
 // Start), pre-loads a state into the channel, then calls Stop immediately.
 // Many iterations expose the scheduling race: the goroutine may not be
 // scheduled before r.done closes, so the select sees both channels ready
 // simultaneously — the exact case the shutdown drain must handle.
 func TestRunConcurrentShutdownAndBatch(t *testing.T) {
-       const iterations = 100
+	const iterations = 100
 
-       testCases := []struct {
-               name    string
-               timeout time.Duration
-       }{
-               {"directIn path", 0},
-               {"collectIn path", time.Second},
-       }
+	testCases := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"directIn path", 0},
+		{"collectIn path", time.Second},
+	}
 
-       for _, tc := range testCases {
-               tc := tc
-               t.Run(tc.name, func(t *testing.T) {
-                       for i := 0; i < iterations; i++ {
-                               logger := logptest.NewTestingLogger(t, "")
-                               memBackend := storetest.NewMemoryStoreBackend()
-                               stateStore := &testStateStore{registry: statestore.NewRegistry(memBackend)}
-                               spy := &spyLogger{}
-                               r, err := New(stateStore, spy, tc.timeout, logger)
-                               if err != nil {
-                                       t.Fatalf("iter %d: New: %v", i, err)
-                               }
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 0; i < iterations; i++ {
+				logger := logptest.NewTestingLogger(t, "")
+				memBackend := storetest.NewMemoryStoreBackend()
+				stateStore := &testStateStore{registry: statestore.NewRegistry(memBackend)}
+				spy := &spyLogger{}
+				r, err := New(stateStore, spy, tc.timeout, logger)
+				if err != nil {
+					t.Fatalf("iter %d: New: %v", i, err)
+				}
 
-                               state := file.State{Id: "test-id", Source: "/path/to/file.log", TTL: -1}
+				state := file.State{Id: "test-id", Source: "/path/to/file.log", TTL: -1}
 
-                               // Pre-load the buffered channel before Run starts so that both
-                               // r.Channel and r.done can be ready in the first select evaluation.
-                               r.Channel <- []file.State{state}
+				// Pre-load the buffered channel before Run starts so that both
+				// r.Channel and r.done can be ready in the first select evaluation.
+				r.Channel <- []file.State{state}
 
-                               if err := r.Start(); err != nil {
-                                       t.Fatalf("iter %d: Start: %v", i, err)
-                               }
-                               // Immediately stop — races with the pre-loaded batch.
-                               r.Stop()
+				if err := r.Start(); err != nil {
+					t.Fatalf("iter %d: Start: %v", i, err)
+				}
+				// Immediately stop — races with the pre-loaded batch.
+				r.Stop()
 
-                               if _, ok := memBackend.Stores[testStoreName].Table[fileStatePrefix+state.Id]; !ok {
-                                       t.Fatalf("iter %d (%s): state %q was not persisted", i, tc.name, state.Id)
-                               }
-                       }
-               })
-       }
+				if _, ok := memBackend.Stores[testStoreName].Table[fileStatePrefix+state.Id]; !ok {
+					t.Fatalf("iter %d (%s): state %q was not persisted", i, tc.name, state.Id)
+				}
+			}
+		})
+	}
 }
+
 var _ statestore.States = (*testStateStore)(nil)

--- a/filebeat/registrar/registrar_test.go
+++ b/filebeat/registrar/registrar_test.go
@@ -1,0 +1,119 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package registrar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/filebeat/input/file"
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+type spyLogger struct {
+	n int
+}
+
+func (s *spyLogger) Published(n int) bool {
+	s.n += n
+	return true
+}
+
+const testStoreName = "test"
+
+type testStateStore struct {
+	registry *statestore.Registry
+}
+
+func (s *testStateStore) StoreFor(string) (*statestore.Store, error) {
+	return s.registry.Get(testStoreName)
+}
+
+func (s *testStateStore) CleanupInterval() time.Duration {
+	return time.Second
+}
+
+// TestRunDrainsPendingBatchOnShutdown verifies the shutdown property: a state
+// already in the channel when done fires is persisted and acked, so it is not
+// replayed on restart.
+func TestRunDrainsPendingBatchOnShutdown(t *testing.T) {
+	testCases := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"directIn path", 0},
+		{"collectIn path", time.Second},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logptest.NewTestingLogger(t, "")
+			memBackend := storetest.NewMemoryStoreBackend()
+			stateStore := &testStateStore{registry: statestore.NewRegistry(memBackend)}
+
+			spy := &spyLogger{}
+			r, err := New(stateStore, spy, tc.timeout, logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			state := file.State{Id: "test-id", Source: "/path/to/file.log", TTL: -1}
+
+			r.Channel <- []file.State{state}
+			close(r.done)
+
+			r.Run()
+
+			table := memBackend.Stores[testStoreName].Table
+			if _, ok := table[fileStatePrefix+state.Id]; !ok {
+				t.Fatalf("expected drained state %q to be persisted, store has: %v", state.Id, table)
+			}
+
+			if spy.n != 1 {
+				t.Fatalf("expected commitStateUpdates to ack the single drained state once, got Published count %d", spy.n)
+			}
+		})
+	}
+}
+
+// TestRunEmptyChannelShutdown verifies that Run returns without deadlock when
+// done fires and the channel is empty. This exercises the default branch of the
+// drain select.
+func TestRunEmptyChannelShutdown(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
+	memBackend := storetest.NewMemoryStoreBackend()
+	stateStore := &testStateStore{registry: statestore.NewRegistry(memBackend)}
+
+	spy := &spyLogger{}
+	r, err := New(stateStore, spy, 0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	close(r.done)
+
+	r.Run()
+
+	if spy.n != 0 {
+		t.Fatalf("expected no states to be acked, got Published count %d", spy.n)
+	}
+}
+
+var _ statestore.States = (*testStateStore)(nil)


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

When Filebeat shuts down cleanly, it occasionally re-sends events it already indexed on the next start.

The registrar goroutine tracks file offsets. On shutdown, it races between two signals that can arrive at the same moment: the stop signal and a final batch of offset updates from the pipeline. Go picks one at random. If the stop signal wins, the offset update is lost — Filebeat saves a stale position and re-reads from it next time.

The fix ensures the pending offset update is always processed before the goroutine exits, so the saved position is always accurate.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

```bash
go test -race -count=20 ./filebeat/registrar/...
```

The original symptom is also exercised by `TestFilebeatReceiverLogAsFilestream` in the elastic-agent integration suite.

## Related issues

- Closes #51490

## Use cases

Filebeat is stopped normally (SIGTERM) while the last batch of events is being acknowledged. Without this fix the registry occasionally saves a stale offset and the events are re-sent on the next start. With this fix the pending offset is always saved correctly on shutdown.

## Screenshots

N/A

## Logs

N/A
