### PR TITLE
osquerybeat: fix data race on osquery runner cancel function

### DIFF
--- a/changelog/fragments/1782246918-fix-osquerybeat-runner-cancel-data-race.yaml
+++ b/changelog/fragments/1782246918-fix-osquerybeat-runner-cancel-data-race.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix a rare crash when osquery restarts after a configuration change
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: osquerybeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/osquerybeat/beater/osquery_runner.go
+++ b/x-pack/osquerybeat/beater/osquery_runner.go
@@ -46,11 +46,11 @@ func (r *osqueryRunner) Run(parentCtx context.Context, runfn osqueryRunFunc) err
 	var mx sync.Mutex
 	cancel := func() {
 		mx.Lock()
+		defer mx.Unlock()
 		if cn != nil {
 			cn()
 			cn = nil
 		}
-		defer mx.Unlock()
 	}
 
 	// Cleanup on exit
@@ -68,30 +68,33 @@ func (r *osqueryRunner) Run(parentCtx context.Context, runfn osqueryRunFunc) err
 		newFlags := config.GetOsqueryOptions(inputs)
 		newLogLevel := zapcore.LevelOf(r.log.Core())
 
+		// cn is cleared by the spawned goroutine's cancel() on exit, so guard it with mx.
+		mx.Lock()
+		running := cn != nil
+		mx.Unlock()
+
 		// If Osqueryd is running and flags are different or log level changed: stop osquery
-		if cn != nil && (!osqd.FlagsAreSame(flags, newFlags) || logLevel != newLogLevel) {
+		if running && (!osqd.FlagsAreSame(flags, newFlags) || logLevel != newLogLevel) {
 			r.log.Info("Osquery is running and options changed, stop osqueryd")
 
 			// Cancel context
 			cancel()
 
-			// Wait until osquery runner exists
+			// Wait until osquery runner exits
 			wg.Wait()
 		}
 
-		// Set the flags to use
-		flags = newFlags
-		logLevel = newLogLevel
-
+		mx.Lock()
 		// Start osqueryd if not running
 		if cn == nil {
 			r.log.Info("Start osqueryd")
+
+			flags = newFlags
+			logLevel = newLogLevel
 			inputCh = make(chan []config.InputConfig, 1)
 			ctx, cn = context.WithCancel(parentCtx)
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				err := runfn(ctx, flags, inputCh)
 
 				// Reset cancellable
@@ -100,8 +103,9 @@ func (r *osqueryRunner) Run(parentCtx context.Context, runfn osqueryRunFunc) err
 				// Forward error to main loop
 				r.log.Debugf("Forward osquery run error to the main runner loop: %v", err)
 				errCh <- err
-			}()
+			})
 		}
+		mx.Unlock()
 
 		select {
 		case inputCh <- inputs:


### PR DESCRIPTION
## Proposed commit message

```
osquerybeat: fix data race on osquery runner cancel function

The `process` closure in `osqueryRunner.Run` reads the `cn` (context cancel
function) variable without holding the mutex, while the goroutine running
osqueryd can concurrently set `cn = nil` through `cancel()`. This is a data
race that can cause a nil-pointer crash when osquery restarts after a
configuration change.

Fix by guarding every read and write of `cn` in `process` with the existing
mutex
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

```bash
script/stresstest.sh --race ./x-pack/osquerybeat/beater '^TestOsqueryRunner'
```
