### PR TITLE
docs: update Logstash exporter README to reflect reality

### DIFF
--- a/x-pack/otel/exporter/logstashexporter/README.md
+++ b/x-pack/otel/exporter/logstashexporter/README.md
@@ -1,24 +1,47 @@
 # Logstash Exporter
 
 | Status    |                     |
-|-----------|---------------------|
+| --------- | ------------------- |
 | Stability | [development]: logs |
 
 [development]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#development
 
-> [!NOTE]
-> This component is currently in development and no functionality is implemented.
-> Including it in a pipeline is a no-op.
-> The documentation describes the intended state after the functionality is implemented.
-
-The Logstash exporter (`logstash`) is an OpenTelemetry Collector exporter that wraps the Beats [Logstash output] and allows
-you to send data to Logstash by using the lumberjack protocol, which runs over TCP.
+The Logstash exporter (`logstash`) is an OpenTelemetry Collector exporter that wraps the Beats [Logstash output] and sends
+log data to Logstash using the lumberjack protocol over TCP.
 
 > [!NOTE]
-> This component is highly coupled with the Beats ecosystem, and is not designed to be used with
-> the native OpenTelemetry Collector.
+> This component is only expected to work correctly with data from the Beat receivers: [Filebeat receiver], [Metricbeat receiver].
+> Using it with data coming from other components is not recommended and may result in unexpected behavior.
 
 ## Configuration options
 
+The exporter accepts the same configuration options as the Beats [Logstash output]. At minimum, `hosts` is required.
+
+See the [Logstash output] documentation for the full list of options and their defaults.
+
+## Example
+
+```yaml
+service:
+  pipelines:
+    logs:
+      receivers: [filebeatreceiver]
+      exporters: [logstash]
+
+receivers:
+  filebeatreceiver:
+    filebeat:
+      inputs:
+        - type: filestream
+          id: host-logs
+          paths:
+            - /var/log/*.log
+
+exporters:
+  logstash:
+    hosts: ["localhost:5044"]
+```
 
 [Logstash output]: https://www.elastic.co/docs/reference/beats/filebeat/logstash-output
+[Filebeat receiver]: ../../../filebeat/fbreceiver
+[Metricbeat receiver]: ../../../metricbeat/mbreceiver


### PR DESCRIPTION
The Logstash exporter is implemented. Including it in a pipeline is NOT no-op.

## Checklist

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [ ] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~
- ~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~

## How to test this PR locally

1. Prepare Logstash config `logstash.conf`:

```conf
input {
  beats {
    port => 1234
    host => "0.0.0.0"
    ssl_enabled => false
  }
}

output {
  stdout {
    codec => rubydebug
  }
}
```

2. Prepare Elastic Agent OTel config `agent.yaml` and input file `/tmp/log1k.log` with at least 1024 bytes of data:

```yaml
agent:
  grpc:
    port: 0
service:
  pipelines:
    logs:
      receivers:
        - filebeatreceiver
      exporters:
        - debug
        - logstash
receivers:
  filebeatreceiver:
    filebeat:
      inputs:
        - type: filestream
          id: filestream1
          paths:
            - /tmp/log1k.log
    path.data: /tmp/0625/data
    path.logs: /tmp/0625/logs
    queue.mem:
      flush.timeout: 0
exporters:
  debug:
    verbosity: normal
  logstash:
    hosts:
      - localhost:1234
```

3. Run Logstash

```console
docker run --rm -it -p 1234:1234 -v /path/to/logstash.conf:/usr/share/logstash/pipeline/logstash.conf docker.elastic.co/logstash/logstash-oss:9.4.2
```

4. Run Elastic Agent:

```console
~/Downloads/elastic-agent-9.4.2-darwin-aarch64/elastic-agent -e -c /path/to/agent.yaml
```
