### PR TITLE
filebeat/input/winlog: promote winlog input to GA

### DIFF
--- a/changelog/fragments/1782385200-winlog-input-ga.yaml
+++ b/changelog/fragments/1782385200-winlog-input-ga.yaml
@@ -1,0 +1,18 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Promote the `winlog` input to GA (generally available).
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-winlog.md
+++ b/docs/reference/filebeat/filebeat-input-winlog.md
@@ -3,7 +3,7 @@ navigation_title: "winlog"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-winlog.html
 applies_to:
-  stack: ga
+  stack: ga 9.5+
   serverless: ga
 ---
 

--- a/docs/reference/filebeat/filebeat-input-winlog.md
+++ b/docs/reference/filebeat/filebeat-input-winlog.md
@@ -3,17 +3,11 @@ navigation_title: "winlog"
 mapped_pages:
   - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-winlog.html
 applies_to:
-  stack: beta
-  serverless: beta
+  stack: ga
+  serverless: ga
 ---
 
 # winlog input [filebeat-input-winlog]
-
-
-::::{warning}
-This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
-::::
-
 
 Use the `winlog` input to read Windows event logs. It reads from one event log using Windows APIs, filters the events based on user-configured criteria, then sends the event data to the configured outputs. It watches the event log so that new event data is sent in a timely manner. The read position for the event log is persisted to disk to allow the input to resume after restarts.
 

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -57,7 +57,7 @@ type winlogInput struct{}
 func Plugin(log *logp.Logger, store statestore.States) input.Plugin {
 	return input.Plugin{
 		Name:       pluginName,
-		Stability:  feature.Beta,
+		Stability:  feature.Stable,
 		Deprecated: false,
 		Info:       "Windows Event Logs",
 		Doc:        "The winlog input collects logs from the local windows event log service",


### PR DESCRIPTION
## Proposed commit message

The `winlog` input has been available and stable for a long time, but its plugin stability was still declared as beta. This surfaced beta warnings in the reference documentation and `applies_to: beta` metadata, even though the input is production-ready and widely used.

This PR promotes the input to GA:
- WHAT: set the input plugin `Stability` to `feature.Stable` and update the reference docs (`applies_to` set to `ga` for stack and serverless, and remove the beta warning callout).
- WHY: align the declared stability with the actual maturity of the input and stop emitting beta warnings to users.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. This is a stability/documentation-level change only; the input behavior is unchanged.

## How to test this PR locally

Build Filebeat and confirm the `winlog` input no longer reports a beta stability:

```bash
cd filebeat
DEV=true mage build
```

The reference docs page (`docs/reference/filebeat/filebeat-input-winlog.md`) should now show `applies_to: ga` and no beta warning.

## Related issues

-