### PR TITLE
filestream: Fix date sorter short path panic

### DIFF
--- a/changelog/fragments/1782459050-fix-filestream-copytruncate-date-sorter-panic.yaml
+++ b/changelog/fragments/1782459050-fix-filestream-copytruncate-date-sorter-panic.yaml
@@ -1,0 +1,27 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Avoid slice-bounds panic when sorting copytruncate rotated files by date
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  When the filestream copytruncate prospector sorts rotated files using a date
+  format, `dateSorter.GetTs` sliced the file path by the format length without
+  checking the path was long enough. A path shorter than the configured date
+  format triggered a "slice bounds out of range" panic inside a prospector
+  goroutine, crashing the process. GetTs now returns a zero time for paths
+  shorter than the format, mirroring the existing parse-failure path.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -136,6 +136,9 @@ func (s *dateSorter) GetTs(fi *rotatedFileInfo) time.Time {
 	if !fi.ts.IsZero() {
 		return fi.ts
 	}
+	if len(fi.path) < len(s.format) {
+		return time.Time{}
+	}
 	fileTs := fi.path[len(fi.path)-len(s.format):]
 
 	ts, err := time.Parse(s.format, fileTs)

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"regexp"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
@@ -269,4 +271,32 @@ func TestDateSorter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDateSorterShortPath(t *testing.T) {
+	// Regression test: a path shorter than the configured date format must not
+	// trigger a slice-bounds panic. GetTs runs inside sort.Slice in a prospector
+	// goroutine where such a panic would crash the whole process.
+	s := dateSorter{"-20060102"}
+
+	t.Run("GetTs returns zero time for a path shorter than the format", func(t *testing.T) {
+		fi := rotatedFileInfo{path: "a.log"}
+		var ts time.Time
+		require.NotPanics(t, func() {
+			ts = s.GetTs(&fi)
+		}, "GetTs must not panic when the path is shorter than the date format")
+		assert.True(t, ts.IsZero(),
+			"GetTs should return a zero time for a path shorter than the format")
+	})
+
+	t.Run("sort does not panic when a path is shorter than the format", func(t *testing.T) {
+		files := []rotatedFileInfo{
+			{path: "/path/to/apache.log-20140508"},
+			{path: "x"},
+			{path: "/path/to/apache.log-20140506"},
+		}
+		require.NotPanics(t, func() {
+			s.sort(files)
+		}, "sort must not panic when a path is shorter than the date format")
+	})
 }

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -122,8 +122,6 @@ func TestCopyTruncateProspector_Create(t *testing.T) {
 	}
 
 	for name, test := range testCases {
-		test := test
-
 		t.Run(name, func(t *testing.T) {
 			p := copyTruncateFileProspector{
 				fileProspector{
@@ -212,7 +210,6 @@ func TestNumericSorter(t *testing.T) {
 	sorter := newNumericSorter()
 
 	for name, test := range testCases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			sorter.sort(test.fileinfos)
 			for i, fi := range test.fileinfos {
@@ -263,7 +260,6 @@ func TestDateSorter(t *testing.T) {
 	sorter := dateSorter{"-20060102"}
 
 	for name, test := range testCases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			sorter.sort(test.fileinfos)
 			for i, fi := range test.fileinfos {


### PR DESCRIPTION
## Proposed commit message

```text
Fix filestream date sorter short path panic

Return a zero timestamp when a rotated file path is shorter than the configured
date format so copytruncate sorting cannot panic inside the prospector
goroutine.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None

## How to test this PR locally

```sh
go test -race ./filebeat/input/filestream/...
```

Real reproduction:

```sh
rm -rf /tmp/fbr /tmp/fbr-home-fixed
mkdir -p /tmp/fbr /tmp/fbr-home-fixed
python - <<'PY'
from pathlib import Path
base = Path('/tmp/fbr')
for name, prefix in [('a', 'original'), ('a-1', 'rotated-one'), ('a-2', 'rotated-two')]:
    with (base / name).open('w') as f:
        for i in range(140):
            f.write(f'{prefix} line {i:03d} abcdefghijklmnopqrstuvwxyz\n')
PY
cat >/tmp/fbr-filebeat.yml <<'YAML'
filebeat.inputs:
  - type: filestream
    id: repro-copytruncate-datesort
    paths:
      - /tmp/fbr/*
    prospector.scanner.check_interval: 1s
    rotation:
      external:
        strategy:
          copytruncate:
            suffix_regex: '-\d$'
            dateformat: '2006-01-02T15:04:05.000000Z07:00'

output.console:
  enabled: true
  codec.format:
    string: 'EVENT: %{[message]}'

logging.level: debug
logging.to_stderr: true

queue.mem:
  flush.timeout: 0s
YAML

timeout 5 /tmp/filebeat-fixed -e --strict.perms=false -c /tmp/fbr-filebeat.yml --path.home=/tmp/fbr-home-fixed > /tmp/fbr-fixed.log 2>&1
grep 'File /tmp/fbr/a-2 is rotated' /tmp/fbr-fixed.log
grep 'EVENT:' /tmp/fbr-fixed.log
grep -E 'panic|slice bounds out of range' /tmp/fbr-fixed.log
```

On an unpatched build, the same config exits with a panic after detecting `/tmp/fbr/a-2` as rotated:

```text
panic: runtime error: slice bounds out of range [-20:]
github.com/elastic/beats/v7/filebeat/input/filestream.(*dateSorter).GetTs
github.com/elastic/beats/v7/filebeat/input/filestream.(*dateSorter).sort
github.com/elastic/beats/v7/filebeat/input/filestream.rotatedFilestreams.addRotatedFile
github.com/elastic/beats/v7/filebeat/input/filestream.(*copyTruncateFileProspector).onRotatedFile
github.com/elastic/beats/v7/filebeat/input/filestream.(*copyTruncateFileProspector).onFSEvent
github.com/elastic/beats/v7/filebeat/input/filestream.(*copyTruncateFileProspector).Run.func2
github.com/elastic/go-concert/unison.(*MultiErrGroup).Go.func1
```
