### PR TITLE
harvester: Clean up panic handling

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -230,8 +230,7 @@ func startHarvester(
 	return func(canceler context.Context) (err error) {
 		defer func() {
 			if v := recover(); v != nil {
-				err := fmt.Errorf("harvester panic with: %+v\n%s", v, debug.Stack())
-				ctx.Logger.Errorf("Harvester crashed with: %+v", err)
+				err = fmt.Errorf("harvester panic for source %q: %+v\n%s", srcID, v, debug.Stack())
 				hg.readers.remove(srcID)
 			}
 

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -92,7 +92,7 @@ func (inp *managedInput) Run(
 			inp.harvesterLimit,
 			harvesterGroupStopTimeout,
 			ctx.Logger,
-			"harvester:"),
+			"harvester"),
 		metrics: metrics,
 		inputID: inp.id,
 	}


### PR DESCRIPTION
## Proposed commit message

```text
Clean up filestream harvester panic handling

`err` was incorrectly shadowed before and no error was returned.

Return recovered harvester panics to the task group so panic recovery follows
the same error path as other harvester failures.

The recover block no longer logs directly, avoiding duplicate panic logs, and
the task group prefix no longer includes a trailing colon so the parent log
line is formatted cleanly.
```

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None

## How to test this PR locally

```sh
go test -race ./filebeat/input/filestream/...
```
