### PR TITLE
Add workaround for non-standard datastream types in otelconsumer

### DIFF
--- a/libbeat/otel/otelconsumer/otelconsumer.go
+++ b/libbeat/otel/otelconsumer/otelconsumer.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -249,6 +251,8 @@ func fillLogRecordFromEvent(logRecord plog.LogRecord, event publisher.Event, bea
 				logRecord.Attributes().PutStr("data_stream."+sub, vStr)
 			}
 		}
+		// temporary workaround for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49337
+		applyNonStandardDataStreamIndex(logRecord, ds)
 	}
 
 	bodyMap := logRecord.Body().SetEmptyMap()
@@ -278,6 +282,49 @@ func fillLogRecordFromEvent(logRecord plog.LogRecord, event publisher.Event, bea
 		}
 	}
 	return nil
+}
+
+// applyNonStandardDataStreamIndex is a WORKAROUND: elasticsearchexporter's MappingBodyMap
+// mode only routes data_stream.type "logs" and "metrics" via data_stream.* attributes; other
+// types (e.g. "synthetics") are rejected. This sets elasticsearch.index directly to bypass
+// that restriction. Remove this function and sanitizeDataStreamField when upstream adds support.
+func applyNonStandardDataStreamIndex(logRecord plog.LogRecord, ds mapstr.M) {
+	const (
+		// esIndexAttribute matches elasticsearchexporter/internal/elasticsearch.IndexAttributeName.
+		esIndexAttribute = "elasticsearch.index"
+
+		// maxDataStreamBytes and disallowed* mirror the sanitisation constants in
+		// elasticsearchexporter so the computed index name matches exactly.
+		maxDataStreamBytes       = 100
+		disallowedNamespaceRunes = `\/*?"<>| ,#:`
+		disallowedDatasetRunes   = `-\/*?"<>| ,#:`
+	)
+	dsType, _ := ds["type"].(string)
+	if dsType == "" || dsType == "logs" || dsType == "metrics" {
+		return
+	}
+	dataset, _ := ds["dataset"].(string)
+	namespace, _ := ds["namespace"].(string)
+	sanitizedDataset := sanitizeDataStreamField(dataset, disallowedDatasetRunes)
+	sanitizedNamespace := sanitizeDataStreamField(namespace, disallowedNamespaceRunes)
+	logRecord.Attributes().PutStr(esIndexAttribute, fmt.Sprintf("%s-%s-%s", dsType, sanitizedDataset, sanitizedNamespace))
+}
+
+// sanitizeDataStreamField mirrors elasticsearchexporter's sanitizeDataStreamField:
+// it lower-cases the value, replaces disallowed runes with '_', and truncates to 100 bytes.
+// No suffix is appended (MappingBodyMap never adds one).
+func sanitizeDataStreamField(field, disallowed string) string {
+	const maxDataStreamBytes = 100
+	field = strings.Map(func(r rune) rune {
+		if strings.ContainsRune(disallowed, r) {
+			return '_'
+		}
+		return unicode.ToLower(r)
+	}, field)
+	if len(field) > maxDataStreamBytes {
+		field = field[:maxDataStreamBytes]
+	}
+	return field
 }
 
 func tryToMapStr(v interface{}) (mapstr.M, bool) {

--- a/libbeat/otel/otelconsumer/otelconsumer.go
+++ b/libbeat/otel/otelconsumer/otelconsumer.go
@@ -305,24 +305,23 @@ func applyNonStandardDataStreamIndex(logRecord plog.LogRecord, ds mapstr.M) {
 	}
 	dataset, _ := ds["dataset"].(string)
 	namespace, _ := ds["namespace"].(string)
-	sanitizedDataset := sanitizeDataStreamField(dataset, disallowedDatasetRunes)
-	sanitizedNamespace := sanitizeDataStreamField(namespace, disallowedNamespaceRunes)
+	sanitizedDataset := sanitizeDataStreamField(dataset, disallowedDatasetRunes, maxDataStreamBytes)
+	sanitizedNamespace := sanitizeDataStreamField(namespace, disallowedNamespaceRunes, maxDataStreamBytes)
 	logRecord.Attributes().PutStr(esIndexAttribute, fmt.Sprintf("%s-%s-%s", dsType, sanitizedDataset, sanitizedNamespace))
 }
 
 // sanitizeDataStreamField mirrors elasticsearchexporter's sanitizeDataStreamField:
 // it lower-cases the value, replaces disallowed runes with '_', and truncates to 100 bytes.
 // No suffix is appended (MappingBodyMap never adds one).
-func sanitizeDataStreamField(field, disallowed string) string {
-	const maxDataStreamBytes = 100
+func sanitizeDataStreamField(field, disallowed string, maxLength int) string {
 	field = strings.Map(func(r rune) rune {
 		if strings.ContainsRune(disallowed, r) {
 			return '_'
 		}
 		return unicode.ToLower(r)
 	}, field)
-	if len(field) > maxDataStreamBytes {
-		field = field[:maxDataStreamBytes]
+	if len(field) > maxLength {
+		field = field[:maxLength]
 	}
 	return field
 }

--- a/libbeat/otel/otelconsumer/otelconsumer_test.go
+++ b/libbeat/otel/otelconsumer/otelconsumer_test.go
@@ -743,6 +743,141 @@ func newMockES(t *testing.T, handler func(mockesapi.Action, []byte) int) *mockes
 	)
 }
 
+func TestSanitizeDataStreamField(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		disallowed string
+		want       string
+	}{
+		{
+			name:       "clean value unchanged",
+			input:      "http",
+			disallowed: `-\/*?"<>| ,#:`,
+			want:       "http",
+		},
+		{
+			name:       "uppercase lowercased",
+			input:      "HTTP",
+			disallowed: `-\/*?"<>| ,#:`,
+			want:       "http",
+		},
+		{
+			name:       "disallowed rune replaced with underscore",
+			input:      "my dataset",
+			disallowed: `-\/*?"<>| ,#:`,
+			want:       "my_dataset",
+		},
+		{
+			name:       "multiple disallowed runes replaced",
+			input:      "a*b?c",
+			disallowed: `-\/*?"<>| ,#:`,
+			want:       "a_b_c",
+		},
+		{
+			name:       "value truncated to maxDataStreamBytes",
+			input:      string(make([]byte, 110)),
+			disallowed: `-\/*?"<>| ,#:`,
+			want:       string(make([]byte, 100)),
+		},
+		{
+			name:       "namespace allows hyphen, dataset does not",
+			input:      "my-namespace",
+			disallowed: `\/*?"<>| ,#:`,
+			want:       "my-namespace",
+		},
+		{
+			name:       "dataset treats hyphen as disallowed",
+			input:      "my-dataset",
+			disallowed: `-\/*?"<>| ,#:`,
+			want:       "my_dataset",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeDataStreamField(tc.input, tc.disallowed)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestFillLogRecordSetsElasticsearchIndex(t *testing.T) {
+	logger := logp.NewNopLogger()
+	beatInfo := beat.Info{}
+
+	cases := []struct {
+		name      string
+		dsType    string
+		dataset   string
+		namespace string
+		wantIndex string // empty means attribute should not be set
+	}{
+		{
+			name:      "synthetics type sets elasticsearch.index",
+			dsType:    "synthetics",
+			dataset:   "http",
+			namespace: "default",
+			wantIndex: "synthetics-http-default",
+		},
+		{
+			name:      "traces type sets elasticsearch.index",
+			dsType:    "traces",
+			dataset:   "apm.transaction",
+			namespace: "default",
+			wantIndex: "traces-apm.transaction-default",
+		},
+		{
+			name:      "logs type does not set elasticsearch.index",
+			dsType:    "logs",
+			dataset:   "system.syslog",
+			namespace: "default",
+			wantIndex: "",
+		},
+		{
+			name:      "metrics type does not set elasticsearch.index",
+			dsType:    "metrics",
+			dataset:   "system.cpu",
+			namespace: "default",
+			wantIndex: "",
+		},
+		{
+			name:      "synthetics dataset sanitized",
+			dsType:    "synthetics",
+			dataset:   "http monitor",
+			namespace: "my-namespace",
+			wantIndex: "synthetics-http_monitor-my-namespace",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := publisher.Event{
+				Content: beat.Event{
+					Fields: mapstr.M{
+						"data_stream": mapstr.M{
+							"type":      tc.dsType,
+							"dataset":   tc.dataset,
+							"namespace": tc.namespace,
+						},
+					},
+				},
+			}
+			logRecord := plog.NewLogRecord()
+			err := fillLogRecordFromEvent(logRecord, event, beatInfo, logger, false)
+			require.NoError(t, err)
+
+			indexAttr, hasIndex := logRecord.Attributes().Get("elasticsearch.index")
+			if tc.wantIndex == "" {
+				assert.False(t, hasIndex, "elasticsearch.index should not be set for type %q", tc.dsType)
+			} else {
+				require.True(t, hasIndex, "elasticsearch.index should be set for type %q", tc.dsType)
+				assert.Equal(t, tc.wantIndex, indexAttr.Str())
+			}
+		})
+	}
+}
+
 // testIndexManager is a minimal outputs.IndexManager that always selects a fixed index name.
 type testIndexManager struct{}
 

--- a/libbeat/otel/otelconsumer/otelconsumer_test.go
+++ b/libbeat/otel/otelconsumer/otelconsumer_test.go
@@ -793,10 +793,10 @@ func TestSanitizeDataStreamField(t *testing.T) {
 			want:       "my_dataset",
 		},
 	}
-
+	const maxLength = 100
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := sanitizeDataStreamField(tc.input, tc.disallowed)
+			got := sanitizeDataStreamField(tc.input, tc.disallowed, maxLength)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Add workaround for non-standard datastream types in otelconsumer

Works around https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49337, allowing heartbeat receiver to be used with elasticsearch exporter. This is done by explicitly setting `elasticsearch.index`. If this is set, the exporter uses it instead of rejecting the events for not having a known `data_stream.type` value.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## How to test this PR locally

Build the test otel distribution and send data from heartbeat receiver to elasticsearch. The data shouldn't be rejected by the exporter.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/14552
