### PR TITLE
remove global paths from metricbeat

### DIFF
--- a/changelog/fragments/1782499306-remove-global-paths-from-metricbeat.yaml
+++ b/changelog/fragments/1782499306-remove-global-paths-from-metricbeat.yaml
@@ -18,9 +18,11 @@ summary: remove global paths from metricbeat
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
-description: Change paths definition from global paths to per beat
-instance paths.  Without this multiple metricbeat receivers could use
-the same data store.
+description: >
+  Change paths definition from global paths to per beat
+  instance paths.  Without this multiple metricbeat receivers could use
+  the same data store.
+
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # impact:
@@ -38,7 +40,7 @@ component: elastic-agent
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-# pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/beats/pull/51591
 
 # AUTOMATED
 # OPTIONAL to manually add other issue URLs

--- a/changelog/fragments/1782499306-remove-global-paths-from-metricbeat.yaml
+++ b/changelog/fragments/1782499306-remove-global-paths-from-metricbeat.yaml
@@ -1,0 +1,47 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: remove global paths from metricbeat
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Change paths definition from global paths to per beat
+instance paths.  Without this multiple metricbeat receivers could use
+the same data store.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/15154

--- a/changelog/fragments/1782499306-remove-global-paths-from-metricbeat.yaml
+++ b/changelog/fragments/1782499306-remove-global-paths-from-metricbeat.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: remove global paths from metricbeat
+summary: Fix registry corruption issue with multiple metricbeat receivers.
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change

--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -59,7 +59,7 @@ func NewModule(config *conf.C, r *Register, info beat.Info) (Module, []MetricSet
 		return nil, nil, ErrPathsRequired
 	}
 
-	bm, err := newBaseModuleFromConfig(config, info.Logger)
+	bm, err := newBaseModuleFromConfig(config, info.Logger, info.Paths)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -80,11 +80,12 @@ func NewModule(config *conf.C, r *Register, info beat.Info) (Module, []MetricSet
 
 // newBaseModuleFromConfig creates a new BaseModule from config. The returned
 // BaseModule's name will always be lower case.
-func newBaseModuleFromConfig(rawConfig *conf.C, logger *logp.Logger) (BaseModule, error) {
+func newBaseModuleFromConfig(rawConfig *conf.C, logger *logp.Logger, paths *paths.Path) (BaseModule, error) {
 	baseModule := BaseModule{
 		config:    DefaultModuleConfig(),
 		rawConfig: rawConfig,
 		Logger:    logger,
+		Paths:     paths,
 	}
 	err := rawConfig.Unpack(&baseModule.config)
 	if err != nil {
@@ -116,9 +117,7 @@ func createModule(r *Register, bm BaseModule) (Module, error) {
 }
 
 func initMetricSets(r *Register, m Module, p *paths.Path, logger *logp.Logger) ([]MetricSet, error) {
-	var (
-		errs []error
-	)
+	var errs []error
 
 	bms, err := newBaseMetricSets(r, m, p, logger)
 	if err != nil {

--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -115,11 +115,10 @@ func (m *LightMetricSet) baseModule(base BaseMetricSet) (*BaseModule, error) {
 	}
 
 	// Create the base module
-	baseModule, err := newBaseModuleFromConfig(rawConfig, base.Logger())
+	baseModule, err := newBaseModuleFromConfig(rawConfig, base.Logger(), base.GetPath())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base module: %w", err)
 	}
 	baseModule.name = m.Module
 	return &baseModule, nil
-
 }

--- a/metricbeat/mb/lightmetricset_test.go
+++ b/metricbeat/mb/lightmetricset_test.go
@@ -130,14 +130,14 @@ func baseModule(t *testing.T, r *Register, module, metricSet string) BaseMetricS
 	c.Query = QueryParams{"default": "foo"}
 	raw, err := conf.NewConfigFrom(c)
 	require.NoError(t, err)
-	baseModule, err := newBaseModuleFromConfig(raw, logptest.NewTestingLogger(t, ""))
+	baseModule, err := newBaseModuleFromConfig(raw, logptest.NewTestingLogger(t, ""), paths.New())
 	require.NoError(t, err)
 
 	bm := BaseMetricSet{ //nolint:exhaustruct // test only sets fields relevant to light module registration
 		name:         "bar",
 		module:       &baseModule,
 		registration: origRegistration,
-		paths:        paths.New(),
+		paths:        baseModule.Paths,
 	}
 	return bm
 }

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -82,6 +82,7 @@ type BaseModule struct {
 	statusReporter status.StatusReporter
 	userAgent      string
 	Logger         *logp.Logger
+	Paths          *paths.Path
 }
 
 func (m *BaseModule) String() string {
@@ -387,7 +388,7 @@ func (q QueryParams) String() (s string) {
 				u.Add(k, fmt.Sprintf("%v", innerValue))
 			}
 		} else {
-			//nil values in YAML shouldn't be stringified anyhow
+			// nil values in YAML shouldn't be stringified anyhow
 			if v == nil {
 				u.Add(k, "")
 			} else {

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -249,7 +249,7 @@ func TestNewBaseModuleFromModuleConfigStruct(t *testing.T) {
 
 	c := newConfig(t, moduleConf)
 
-	baseModule, err := newBaseModuleFromConfig(c, logptest.NewTestingLogger(t, ""))
+	baseModule, err := newBaseModuleFromConfig(c, logptest.NewTestingLogger(t, ""), paths.New())
 	assert.NoError(t, err)
 
 	assert.Equal(t, moduleName, baseModule.Name())

--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -103,25 +103,19 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 	}
 
 	cfg := (*config.C)(tmp)
-	if settings.Name == "filebeat" {
-		partialConfig := struct {
-			Path paths.Path `config:"path"`
-		}{}
+	partialConfig := struct {
+		Path paths.Path `config:"path"`
+	}{}
 
-		if err := cfg.Unpack(&partialConfig); err != nil {
-			return nil, fmt.Errorf("error extracting default paths: %w", err)
-		}
-		p := paths.New()
-		if err := p.InitPaths(&partialConfig.Path); err != nil {
-			return nil, fmt.Errorf("error initializing default paths: %w", err)
-		}
-		b.Info.Paths = p
-	} else {
-		if err := instance.InitPaths(cfg); err != nil {
-			return nil, fmt.Errorf("error initializing paths: %w", err)
-		}
-		b.Info.Paths = paths.Paths //nolint:forbidigo // to be fixed
+	if err := cfg.Unpack(&partialConfig); err != nil {
+		return nil, fmt.Errorf("error extracting default paths: %w", err)
 	}
+
+	p := paths.New()
+	if err := p.InitPaths(&partialConfig.Path); err != nil {
+		return nil, fmt.Errorf("error initializing default paths: %w", err)
+	}
+	b.Info.Paths = p
 
 	// We have to initialize the keystore before any unpack or merging the cloud
 	// options.

--- a/x-pack/metricbeat/module/sql/module.go
+++ b/x-pack/metricbeat/module/sql/module.go
@@ -11,7 +11,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/backend/memlog"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
 
@@ -122,7 +121,7 @@ func (m *module) GetCursorRegistry() (*statestore.Registry, error) {
 		return s.registry, s.err
 	}
 
-	logger := logp.NewLogger("sql.cursor")
+	logger := m.Logger.Named("sql.cursor")
 
 	reg, err := memlog.New(logger.Named("memlog"), memlog.Settings{
 		Root:     dataPath,

--- a/x-pack/metricbeat/module/sql/module.go
+++ b/x-pack/metricbeat/module/sql/module.go
@@ -41,11 +41,11 @@ type Module interface {
 // data path it was created for. All SQL module instances created by the same
 // ModuleBuilder share a single sharedRegistryState via pointer.
 //
-// Path-Aware Caching: In production, paths.Resolve(paths.Data, "sql-cursor")
+// Path-Aware Caching: In production, m.Paths.Resolve(paths.Data, "sql-cursor")
 // never changes, so the registry is created once and reused for the entire
 // lifetime of the Beat process — identical behaviour to sync.Once.
-// In integration tests, each test overrides paths.Paths.Data to a unique
-// t.TempDir(), causing the resolved path to change. When a path change is
+// In integration tests, each test uses a module whose per-instance data path is
+// a unique t.TempDir(), causing the resolved path to change. When a path change is
 // detected, a new registry is created at the new location, giving each test
 // an isolated cursor store without any cross-test state leakage.
 type sharedRegistryState struct {
@@ -97,7 +97,7 @@ func ModuleBuilder() mb.ModuleFactory {
 // should use registry.Get("cursor-state") to obtain a ref-counted Store handle.
 //
 // Path-aware caching: The method resolves the current data path via
-// paths.Resolve(paths.Data, "sql-cursor"). If the resolved path matches the
+// m.Paths.Resolve(paths.Data, "sql-cursor"). If the resolved path matches the
 // path used to create the cached registry, the cached registry is returned
 // immediately. If the path has changed (which only happens in tests), a new
 // registry is created at the new location.

--- a/x-pack/metricbeat/module/sql/module.go
+++ b/x-pack/metricbeat/module/sql/module.go
@@ -115,7 +115,7 @@ func (m *module) GetCursorRegistry() (*statestore.Registry, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	dataPath := paths.Resolve(paths.Data, "sql-cursor")
+	dataPath := m.Paths.Resolve(paths.Data, "sql-cursor")
 
 	// Return the cached registry if it was created for the same data path.
 	if s.registry != nil && s.dataPath == dataPath {

--- a/x-pack/metricbeat/module/sql/module_test.go
+++ b/x-pack/metricbeat/module/sql/module_test.go
@@ -5,6 +5,7 @@
 package sql
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
 
@@ -44,10 +46,10 @@ func TestGetCursorRegistryReturnsSamePointer(t *testing.T) {
 
 	factory := ModuleBuilder()
 
-	mod1, err := factory(mb.BaseModule{Paths: tmpPaths})
+	mod1, err := factory(mb.BaseModule{Logger: logp.NewNopLogger(), Paths: tmpPaths})
 	require.NoError(t, err)
 
-	mod2, err := factory(mb.BaseModule{Paths: tmpPaths})
+	mod2, err := factory(mb.BaseModule{Logger: logp.NewNopLogger(), Paths: tmpPaths})
 	require.NoError(t, err)
 
 	sqlMod1, ok := mod1.(Module)
@@ -81,10 +83,10 @@ func TestGetCursorRegistryPathChange(t *testing.T) {
 	tmpPaths2.Data = t.TempDir()
 
 	factory := ModuleBuilder()
-	mod1, err := factory(mb.BaseModule{Paths: tmpPaths1})
+	mod1, err := factory(mb.BaseModule{Logger: logp.NewNopLogger(), Paths: tmpPaths1})
 	require.NoError(t, err)
 
-	mod2, err := factory(mb.BaseModule{Paths: tmpPaths2})
+	mod2, err := factory(mb.BaseModule{Logger: logp.NewNopLogger(), Paths: tmpPaths2})
 	require.NoError(t, err)
 
 	sqlMod1, ok := mod1.(Module)
@@ -123,7 +125,7 @@ func TestGetCursorRegistryConcurrent(t *testing.T) {
 	const n = 20
 	modules := make([]mb.Module, n)
 	for i := range modules {
-		mod, err := factory(mb.BaseModule{Paths: tmpPaths})
+		mod, err := factory(mb.BaseModule{Logger: logp.NewNopLogger(), Paths: tmpPaths})
 		require.NoError(t, err)
 		modules[i] = mod
 	}
@@ -141,8 +143,17 @@ func TestGetCursorRegistryConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func(mod mb.Module) {
 			defer wg.Done()
-			reg, err := mod.(Module).GetCursorRegistry()
-			resultsCh <- result{reg: reg, err: err}
+			sqlMod, ok := mod.(Module)
+			if !ok {
+				resultsCh <- result{err: fmt.Errorf("module does not implement sql.Module")}
+				return
+			}
+			reg, err := sqlMod.GetCursorRegistry()
+			if err != nil {
+				resultsCh <- result{err: err}
+				return
+			}
+			resultsCh <- result{reg: reg}
 		}(modules[i])
 	}
 

--- a/x-pack/metricbeat/module/sql/module_test.go
+++ b/x-pack/metricbeat/module/sql/module_test.go
@@ -39,17 +39,15 @@ func TestModuleBuilderSharesState(t *testing.T) {
 // GetCursorRegistry return the exact same *statestore.Registry pointer when
 // the data path has not changed.
 func TestGetCursorRegistryReturnsSamePointer(t *testing.T) {
-	tmpDir := t.TempDir()
-	origData := paths.Paths.Data
-	paths.Paths.Data = tmpDir
-	t.Cleanup(func() { paths.Paths.Data = origData })
+	tmpPaths := paths.New()
+	tmpPaths.Data = t.TempDir()
 
 	factory := ModuleBuilder()
 
-	mod1, err := factory(mb.BaseModule{})
+	mod1, err := factory(mb.BaseModule{Paths: tmpPaths})
 	require.NoError(t, err)
 
-	mod2, err := factory(mb.BaseModule{})
+	mod2, err := factory(mb.BaseModule{Paths: tmpPaths})
 	require.NoError(t, err)
 
 	sqlMod1, ok := mod1.(Module)
@@ -77,63 +75,55 @@ func TestGetCursorRegistryReturnsSamePointer(t *testing.T) {
 // TestGetCursorRegistryPathChange verifies that changing paths.Paths.Data
 // causes GetCursorRegistry to create a new registry at the new location.
 func TestGetCursorRegistryPathChange(t *testing.T) {
-	tmpDir1 := t.TempDir()
-	tmpDir2 := t.TempDir()
-
-	origData := paths.Paths.Data
-	t.Cleanup(func() { paths.Paths.Data = origData })
+	tmpPaths1 := paths.New()
+	tmpPaths1.Data = t.TempDir()
+	tmpPaths2 := paths.New()
+	tmpPaths2.Data = t.TempDir()
 
 	factory := ModuleBuilder()
-	mod, err := factory(mb.BaseModule{})
+	mod1, err := factory(mb.BaseModule{Paths: tmpPaths1})
 	require.NoError(t, err)
 
-	sqlMod, ok := mod.(Module)
-	require.True(t, ok, "mod should implement sql.Module")
+	mod2, err := factory(mb.BaseModule{Paths: tmpPaths2})
+	require.NoError(t, err)
+
+	sqlMod1, ok := mod1.(Module)
+	require.True(t, ok, "mod1 should implement sql.Module")
+
+	sqlMod2, ok := mod2.(Module)
+	require.True(t, ok, "mod2 should implement sql.Module")
 
 	// First path
-	paths.Paths.Data = tmpDir1
-	reg1, err := sqlMod.GetCursorRegistry()
+	reg1, err := sqlMod1.GetCursorRegistry()
 	require.NoError(t, err)
 	require.NotNil(t, reg1)
 
 	// Same path - cached
-	reg1again, err := sqlMod.GetCursorRegistry()
+	reg1again, err := sqlMod1.GetCursorRegistry()
 	require.NoError(t, err)
 	assert.Same(t, reg1, reg1again)
 
-	// Change path - new registry expected
-	paths.Paths.Data = tmpDir2
-	reg2, err := sqlMod.GetCursorRegistry()
+	// Second path - new registry expected
+	reg2, err := sqlMod2.GetCursorRegistry()
 	require.NoError(t, err)
 	require.NotNil(t, reg2)
 	assert.NotSame(t, reg1, reg2,
 		"Changing the data path must produce a new registry")
-
-	// Revert to first path - yet another new registry (previous one is not cached)
-	paths.Paths.Data = tmpDir1
-	reg3, err := sqlMod.GetCursorRegistry()
-	require.NoError(t, err)
-	require.NotNil(t, reg3)
-	assert.NotSame(t, reg1, reg3,
-		"Reverting to a previous path creates a new registry (old cache was replaced)")
-	assert.NotSame(t, reg2, reg3)
 }
 
 // TestGetCursorRegistryConcurrent verifies that concurrent calls to
 // GetCursorRegistry from multiple goroutines are safe and all return
 // the same pointer.
 func TestGetCursorRegistryConcurrent(t *testing.T) {
-	tmpDir := t.TempDir()
-	origData := paths.Paths.Data
-	paths.Paths.Data = tmpDir
-	t.Cleanup(func() { paths.Paths.Data = origData })
+	tmpPaths := paths.New()
+	tmpPaths.Data = t.TempDir()
 
 	factory := ModuleBuilder()
 
 	const n = 20
 	modules := make([]mb.Module, n)
 	for i := range modules {
-		mod, err := factory(mb.BaseModule{})
+		mod, err := factory(mb.BaseModule{Paths: tmpPaths})
 		require.NoError(t, err)
 		modules[i] = mod
 	}

--- a/x-pack/metricbeat/module/sql/module_test.go
+++ b/x-pack/metricbeat/module/sql/module_test.go
@@ -74,8 +74,9 @@ func TestGetCursorRegistryReturnsSamePointer(t *testing.T) {
 		"Repeated calls on the same module must return cached registry")
 }
 
-// TestGetCursorRegistryPathChange verifies that changing paths.Paths.Data
-// causes GetCursorRegistry to create a new registry at the new location.
+// TestGetCursorRegistryPathChange verifies that using a module with a different
+// per-instance data path causes GetCursorRegistry to create a new registry at
+// the new location.
 func TestGetCursorRegistryPathChange(t *testing.T) {
 	tmpPaths1 := paths.New()
 	tmpPaths1.Data = t.TempDir()

--- a/x-pack/metricbeat/module/sql/query/cursor/store_test.go
+++ b/x-pack/metricbeat/module/sql/query/cursor/store_test.go
@@ -342,7 +342,7 @@ func newTestStore(t *testing.T, beatPaths *paths.Path, logger *logp.Logger) (*St
 	t.Helper()
 
 	if beatPaths == nil {
-		beatPaths = paths.Paths
+		beatPaths = paths.New()
 	}
 
 	dataPath := beatPaths.Resolve(paths.Data, "sql-cursor")

--- a/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
@@ -125,7 +125,7 @@ func TestMySQLCursor(t *testing.T) {
 	// First connect without database to create test database
 	db0, err := sql.Open("mysql", baseDSN)
 	require.NoError(t, err)
-	_, err = db0.Exec("CREATE DATABASE IF NOT EXISTS cursor_test")
+	_, err = db0.ExecContext(t.Context(), "CREATE DATABASE IF NOT EXISTS cursor_test")
 	require.NoError(t, err)
 	db0.Close()
 
@@ -136,7 +136,7 @@ func TestMySQLCursor(t *testing.T) {
 	db, err := sql.Open("mysql", dsn)
 	require.NoError(t, err)
 	defer db.Close()
-	defer func() { _, _ = db.Exec("DROP DATABASE IF EXISTS cursor_test") }()
+	defer func() { _, _ = db.ExecContext(t.Context(), "DROP DATABASE IF EXISTS cursor_test") }()
 
 	setupMySQLTestTable(t, db)
 
@@ -177,7 +177,7 @@ func insertTestData(t *testing.T, db *sql.DB, driver string, n int) {
 	}
 
 	for i := 0; i < n; i++ {
-		_, err := db.Exec(insertSQL, fmt.Sprintf("event-%d", i))
+		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i))
 		require.NoError(t, err)
 	}
 }
@@ -755,7 +755,7 @@ func TestOracleCursor(t *testing.T) {
 	// See: https://oracle.github.io/odpi/doc/installation.html
 	testDB, err := sql.Open("godror", "user/pass@localhost:1521/test")
 	if err == nil {
-		err = testDB.Ping()
+		err = testDB.PingContext(t.Context())
 		testDB.Close()
 	}
 	if err != nil && containsOracleClientError(err.Error()) {
@@ -938,7 +938,7 @@ func testOracleIntegerCursor(t *testing.T, dsn string) {
 	ms5 := newMetricSetWithPaths(t, cfg, testPaths)
 	events5, errs5 := fetchEvents(t, ms5)
 	require.Empty(t, errs5, "Fifth fetch should not have errors")
-	require.Len(t, events5, 0, "Fifth fetch should return 0 events (all consumed)")
+	require.Empty(t, events5, "Fifth fetch should return 0 events (all consumed)")
 	if closer, ok := ms5.(mb.Closer); ok {
 		require.NoError(t, closer.Close())
 	}
@@ -987,7 +987,7 @@ func testOracleIntegerCursorRestart(t *testing.T, dsn string) {
 	ms2 := newMetricSetWithPaths(t, cfg, testPaths)
 	events2, errs2 := fetchEvents(t, ms2)
 	require.Empty(t, errs2)
-	require.Len(t, events2, 0, "After restart, should get 0 rows (cursor loaded from persisted state)")
+	require.Empty(t, events2, "After restart, should get 0 rows (cursor loaded from persisted state)")
 	if closer, ok := ms2.(mb.Closer); ok {
 		require.NoError(t, closer.Close())
 	}
@@ -1067,7 +1067,7 @@ func testOracleTimestampCursorMultiBatch(t *testing.T, dsn string) {
 	ms5 := newMetricSetWithPaths(t, cfg, testPaths)
 	events5, errs5 := fetchEvents(t, ms5)
 	require.Empty(t, errs5, "Fifth timestamp fetch should not have errors")
-	require.Len(t, events5, 0, "Fifth timestamp fetch should return 0 events (all consumed)")
+	require.Empty(t, events5, "Fifth timestamp fetch should return 0 events (all consumed)")
 	if closer, ok := ms5.(mb.Closer); ok {
 		require.NoError(t, closer.Close())
 	}
@@ -1451,7 +1451,7 @@ func testOracleDriverTypeConversions(t *testing.T, db *sql.DB) {
 	})
 
 	// Query a row to inspect godror's type mapping for Oracle columns
-	rows, err := db.Query("SELECT id, created_at, event_date FROM cursor_test_events WHERE ROWNUM <= 1")
+	rows, err := db.QueryContext(t.Context(), "SELECT id, created_at, event_date FROM cursor_test_events WHERE ROWNUM <= 1")
 	require.NoError(t, err)
 	defer rows.Close()
 
@@ -1953,7 +1953,7 @@ func waitForMSSQLConnection(t *testing.T, host string) {
 	for i := 0; i < maxRetries; i++ {
 		db, err := sql.Open("sqlserver", dsn)
 		if err == nil {
-			err = db.Ping()
+			err = db.PingContext(t.Context())
 			db.Close()
 			if err == nil {
 				t.Log("MSSQL is ready")

--- a/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
@@ -190,7 +190,7 @@ func setupPostgresTestTable(t *testing.T, db *sql.DB) {
 	})
 
 	// Drop table if exists
-	_, err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName))
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName))
 	require.NoError(t, err)
 
 	// Create table with columns for all cursor types
@@ -203,7 +203,7 @@ func setupPostgresTestTable(t *testing.T, db *sql.DB) {
 			price NUMERIC(10,2)
 		)
 	`, testTableName)
-	_, err = db.Exec(createSQL)
+	_, err = db.ExecContext(t.Context(), createSQL)
 	require.NoError(t, err)
 
 	// Insert test data with values for all cursor types
@@ -212,7 +212,7 @@ func setupPostgresTestTable(t *testing.T, db *sql.DB) {
 	for i := 0; i < 5; i++ {
 		score := float64(i+1) * 1.5   // 1.5, 3.0, 4.5, 6.0, 7.5
 		price := float64(i+1) * 10.25 // 10.25, 20.50, 30.75, 41.00, 51.25
-		_, err := db.Exec(insertSQL, fmt.Sprintf("event-%d", i), now.Add(time.Duration(i)*time.Second), score, price)
+		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), now.Add(time.Duration(i)*time.Second), score, price)
 		require.NoError(t, err)
 	}
 }
@@ -225,7 +225,7 @@ func setupMySQLTestTable(t *testing.T, db *sql.DB) {
 	})
 
 	// Drop table if exists
-	_, err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName))
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName))
 	require.NoError(t, err)
 
 	// Create table with columns for all cursor types
@@ -237,7 +237,7 @@ func setupMySQLTestTable(t *testing.T, db *sql.DB) {
 			price DECIMAL(10,2)
 		)
 	`, testTableName)
-	_, err = db.Exec(createSQL)
+	_, err = db.ExecContext(t.Context(), createSQL)
 	require.NoError(t, err)
 
 	// Insert test data with values for all cursor types
@@ -245,14 +245,14 @@ func setupMySQLTestTable(t *testing.T, db *sql.DB) {
 	now := time.Now().UTC()
 	for i := 0; i < 5; i++ {
 		price := float64(i+1) * 10.25 // 10.25, 20.50, 30.75, 41.00, 51.25
-		_, err := db.Exec(insertSQL, fmt.Sprintf("event-%d", i), now.Add(time.Duration(i)*time.Second), price)
+		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), now.Add(time.Duration(i)*time.Second), price)
 		require.NoError(t, err)
 	}
 }
 
 func cleanupTestTable(t *testing.T, db *sql.DB, driver string) {
 	t.Helper()
-	_, err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName))
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE IF EXISTS %s", testTableName))
 	if err != nil {
 		t.Logf("Warning: failed to cleanup test table: %v", err)
 	}
@@ -659,10 +659,10 @@ func TestCursorNullValues(t *testing.T) {
 
 	// Create table with nullable timestamp
 	tableName := "cursor_null_test"
-	_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
 	require.NoError(t, err)
 
-	_, err = db.Exec(fmt.Sprintf(`
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`
 		CREATE TABLE %s (
 			id SERIAL PRIMARY KEY,
 			event_data TEXT,
@@ -670,15 +670,15 @@ func TestCursorNullValues(t *testing.T) {
 		)
 	`, tableName))
 	require.NoError(t, err)
-	defer func() { _, _ = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) }()
+	defer func() { _, _ = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) }()
 
 	// Insert data with NULL timestamps
 	now := time.Now().UTC()
-	_, err = db.Exec(fmt.Sprintf(`INSERT INTO %s (event_data, updated_at) VALUES ($1, $2)`, tableName), "event-1", now)
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`INSERT INTO %s (event_data, updated_at) VALUES ($1, $2)`, tableName), "event-1", now)
 	require.NoError(t, err)
-	_, err = db.Exec(fmt.Sprintf(`INSERT INTO %s (event_data, updated_at) VALUES ($1, NULL)`, tableName), "event-2-null")
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`INSERT INTO %s (event_data, updated_at) VALUES ($1, NULL)`, tableName), "event-2-null")
 	require.NoError(t, err)
-	_, err = db.Exec(fmt.Sprintf(`INSERT INTO %s (event_data, updated_at) VALUES ($1, $2)`, tableName), "event-3", now.Add(time.Second))
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`INSERT INTO %s (event_data, updated_at) VALUES ($1, $2)`, tableName), "event-3", now.Add(time.Second))
 	require.NoError(t, err)
 
 	// Set up temp paths for cursor store
@@ -837,7 +837,7 @@ func setupOracleTestTable(t *testing.T, db *sql.DB) {
 	})
 
 	// Drop table if exists (Oracle doesn't have IF EXISTS, so we ignore errors)
-	_, _ = db.Exec("DROP TABLE cursor_test_events")
+	_, _ = db.ExecContext(t.Context(), "DROP TABLE cursor_test_events")
 
 	// Create table with Oracle-specific syntax.
 	// Uses TIMESTAMP (not TIMESTAMP WITH TIME ZONE) and DATE to test
@@ -850,7 +850,7 @@ func setupOracleTestTable(t *testing.T, db *sql.DB) {
 			event_date DATE DEFAULT CURRENT_DATE
 		)
 	`
-	_, err := db.Exec(createSQL)
+	_, err := db.ExecContext(t.Context(), createSQL)
 	require.NoError(t, err, "Failed to create Oracle test table")
 
 	// Insert 10 rows with timestamps 1 second apart.
@@ -859,7 +859,7 @@ func setupOracleTestTable(t *testing.T, db *sql.DB) {
 	now := time.Now().UTC()
 	for i := 0; i < 10; i++ {
 		ts := now.Add(time.Duration(i) * time.Second)
-		_, err := db.Exec(insertSQL, fmt.Sprintf("event-%d", i), ts, ts)
+		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), ts, ts)
 		require.NoError(t, err, "Failed to insert Oracle test data row %d", i)
 	}
 	t.Log("Oracle test table created with 10 rows")
@@ -867,7 +867,7 @@ func setupOracleTestTable(t *testing.T, db *sql.DB) {
 
 func cleanupOracleTestTable(t *testing.T, db *sql.DB) {
 	t.Helper()
-	_, err := db.Exec("DROP TABLE cursor_test_events")
+	_, err := db.ExecContext(t.Context(), "DROP TABLE cursor_test_events")
 	if err != nil {
 		t.Logf("Warning: failed to cleanup Oracle test table: %v", err)
 	}
@@ -1121,7 +1121,7 @@ func testOracleTimestampTimezoneHandling(t *testing.T, dsn string) {
 	ms3 := newMetricSetWithPaths(t, cfg, testPaths)
 	events3, errs3 := fetchEvents(t, ms3)
 	require.Empty(t, errs3)
-	require.Len(t, events3, 0, "Third fetch should return 0 events (all consumed)")
+	require.Empty(t, events3, "Third fetch should return 0 events (all consumed)")
 	if closer, ok := ms3.(mb.Closer); ok {
 		require.NoError(t, closer.Close())
 	}
@@ -1191,8 +1191,8 @@ func testOracleDateCursor(t *testing.T, dsn string) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	_, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tableName))
-	_, err = db.Exec(fmt.Sprintf(`
+	_, _ = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s", tableName))
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`
 		CREATE TABLE %s (
 			id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
 			event_data VARCHAR2(255),
@@ -1200,14 +1200,14 @@ func testOracleDateCursor(t *testing.T, dsn string) {
 		)
 	`, tableName))
 	require.NoError(t, err, "Failed to create date cursor test table")
-	defer func() { _, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tableName)) }()
+	defer func() { _, _ = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s", tableName)) }()
 
 	// Insert 6 rows across 6 distinct dates (today-5 .. today), all at midnight
 	// so TO_DATE comparison works cleanly.
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 	for i := 0; i < 6; i++ {
 		d := today.AddDate(0, 0, i-5) // today-5, today-4, ..., today
-		_, err := db.Exec(
+		_, err := db.ExecContext(t.Context(),
 			fmt.Sprintf("INSERT INTO %s (event_data, event_date) VALUES (:1, :2)", tableName),
 			fmt.Sprintf("event-%d", i), d,
 		)
@@ -1273,9 +1273,9 @@ func testOracleNullHandling(t *testing.T, db *sql.DB, dsn string) {
 
 	// Create a separate table with NULL values
 	tableName := "cursor_null_test_oracle"
-	_, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tableName))
+	_, _ = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s", tableName))
 
-	_, err := db.Exec(fmt.Sprintf(`
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf(`
 		CREATE TABLE %s (
 			id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
 			event_data VARCHAR2(255),
@@ -1283,15 +1283,15 @@ func testOracleNullHandling(t *testing.T, db *sql.DB, dsn string) {
 		)
 	`, tableName))
 	require.NoError(t, err, "Failed to create NULL test table")
-	defer func() { _, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tableName)) }()
+	defer func() { _, _ = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s", tableName)) }()
 
 	// Insert rows: some with timestamps, some with NULL
 	now := time.Now().UTC()
-	_, err = db.Exec(fmt.Sprintf("INSERT INTO %s (event_data, updated_at) VALUES (:1, :2)", tableName), "event-1", now)
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("INSERT INTO %s (event_data, updated_at) VALUES (:1, :2)", tableName), "event-1", now)
 	require.NoError(t, err)
-	_, err = db.Exec(fmt.Sprintf("INSERT INTO %s (event_data, updated_at) VALUES (:1, NULL)", tableName), "event-2-null")
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("INSERT INTO %s (event_data, updated_at) VALUES (:1, NULL)", tableName), "event-2-null")
 	require.NoError(t, err)
-	_, err = db.Exec(fmt.Sprintf("INSERT INTO %s (event_data, updated_at) VALUES (:1, :2)", tableName), "event-3", now.Add(time.Second))
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf("INSERT INTO %s (event_data, updated_at) VALUES (:1, :2)", tableName), "event-3", now.Add(time.Second))
 	require.NoError(t, err)
 
 	testPaths := createTestPaths(t)
@@ -1355,7 +1355,7 @@ func testOracleEmptyResultSet(t *testing.T, dsn string) {
 	ms := newMetricSetWithPaths(t, cfg, testPaths)
 	events, errs := fetchEvents(t, ms)
 	require.Empty(t, errs, "Empty result set should not cause errors")
-	require.Len(t, events, 0, "Should return 0 events when cursor is in the far future")
+	require.Empty(t, events, "Should return 0 events when cursor is in the far future")
 
 	// Verify cursor remains unchanged after empty result
 	queryMs, ok := ms.(*MetricSet)
@@ -1584,8 +1584,8 @@ func testOracleTimestampCursorTimezoneMismatch(t *testing.T, host, port string) 
 	defer db.Close()
 
 	// Setup table
-	_, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tableName))
-	_, err = db.Exec(fmt.Sprintf(`
+	_, _ = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s", tableName))
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`
 		CREATE TABLE %s (
 			id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
 			event_data VARCHAR2(255),
@@ -1593,7 +1593,7 @@ func testOracleTimestampCursorTimezoneMismatch(t *testing.T, host, port string) 
 		)
 	`, tableName))
 	require.NoError(t, err, "Failed to create timezone test table")
-	defer func() { _, _ = db.Exec(fmt.Sprintf("DROP TABLE %s", tableName)) }()
+	defer func() { _, _ = db.ExecContext(t.Context(), fmt.Sprintf("DROP TABLE %s", tableName)) }()
 
 	// Insert 10 rows with timestamps 1 second apart.
 	// With params.Timezone=UTC, godror sends the raw UTC value and Oracle stores
@@ -1601,7 +1601,7 @@ func testOracleTimestampCursorTimezoneMismatch(t *testing.T, host, port string) 
 	now := time.Now().UTC()
 	for i := 0; i < 10; i++ {
 		ts := now.Add(time.Duration(i) * time.Second)
-		_, err := db.Exec(
+		_, err := db.ExecContext(t.Context(),
 			fmt.Sprintf("INSERT INTO %s (event_data, created_at) VALUES (:1, :2)", tableName),
 			fmt.Sprintf("event-%d", i), ts)
 		require.NoError(t, err, "Failed to insert row %d", i)
@@ -1612,7 +1612,7 @@ func testOracleTimestampCursorTimezoneMismatch(t *testing.T, host, port string) 
 	// insert and read use the same params.Timezone=UTC. The mismatch only
 	// manifests during comparison (WHERE clause with > operator).
 	var storedTS time.Time
-	err = db.QueryRow(fmt.Sprintf(
+	err = db.QueryRowContext(t.Context(), fmt.Sprintf(
 		"SELECT created_at FROM %s WHERE ROWNUM = 1 ORDER BY id", tableName)).Scan(&storedTS)
 	require.NoError(t, err)
 	t.Logf("Inserted Go time (UTC):  %s", now.Format(time.RFC3339Nano))
@@ -1623,7 +1623,7 @@ func testOracleTimestampCursorTimezoneMismatch(t *testing.T, host, port string) 
 	// Use a raw SQL query with a TIMESTAMP WITH TIME ZONE literal to show
 	// that Oracle converts stored TIMESTAMP using session TZ for comparison.
 	var countDirect int
-	err = db.QueryRow(fmt.Sprintf(
+	err = db.QueryRowContext(t.Context(), fmt.Sprintf(
 		"SELECT COUNT(*) FROM %s WHERE created_at > TO_TIMESTAMP(:1, 'YYYY-MM-DD\"T\"HH24:MI:SS.FF\"Z\"')",
 		tableName),
 		now.Add(-1*time.Hour).Format("2006-01-02T15:04:05.000000Z")).Scan(&countDirect)
@@ -1762,7 +1762,7 @@ func setupMSSQLTestTable(t *testing.T, db *sql.DB) {
 	})
 
 	// Drop table if exists
-	_, _ = db.Exec("DROP TABLE IF EXISTS cursor_test_events")
+	_, _ = db.ExecContext(t.Context(), "DROP TABLE IF EXISTS cursor_test_events")
 
 	// Create table with MSSQL-specific syntax
 	createSQL := `
@@ -1773,7 +1773,7 @@ func setupMSSQLTestTable(t *testing.T, db *sql.DB) {
 			event_date DATE DEFAULT CAST(GETUTCDATE() AS DATE)
 		)
 	`
-	_, err := db.Exec(createSQL)
+	_, err := db.ExecContext(t.Context(), createSQL)
 	require.NoError(t, err, "Failed to create MSSQL test table")
 
 	// Insert test data
@@ -1781,7 +1781,7 @@ func setupMSSQLTestTable(t *testing.T, db *sql.DB) {
 	now := time.Now().UTC()
 	for i := 0; i < 5; i++ {
 		ts := now.Add(time.Duration(i) * time.Second)
-		_, err := db.Exec(insertSQL, fmt.Sprintf("event-%d", i), ts, ts)
+		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), ts, ts)
 		require.NoError(t, err, "Failed to insert MSSQL test data")
 	}
 	t.Log("MSSQL test table created with 5 rows")
@@ -1789,7 +1789,7 @@ func setupMSSQLTestTable(t *testing.T, db *sql.DB) {
 
 func cleanupMSSQLTestTable(t *testing.T, db *sql.DB) {
 	t.Helper()
-	_, err := db.Exec("DROP TABLE IF EXISTS cursor_test_events")
+	_, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS cursor_test_events")
 	if err != nil {
 		t.Logf("Warning: failed to cleanup MSSQL test table: %v", err)
 	}
@@ -1841,7 +1841,7 @@ func testMSSQLIntegerCursor(t *testing.T, dsn string) {
 	ms3 := newMetricSetWithPaths(t, cfg, testPaths)
 	events3, errs3 := fetchEvents(t, ms3)
 	require.Empty(t, errs3, "Third fetch should not have errors")
-	require.Len(t, events3, 0, "Third fetch should return 0 events")
+	require.Empty(t, events3, "Third fetch should return 0 events")
 
 	if closer, ok := ms3.(mb.Closer); ok {
 		require.NoError(t, closer.Close())

--- a/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
@@ -40,18 +40,11 @@ import (
 const testTableName = "cursor_test_events"
 
 // newMetricSetWithPaths creates a MetricSet with custom paths for cursor storage.
-// It sets the global paths.Paths.Data to the test's data directory so that
-// GetCursorRegistry resolves to the correct temp path, and uses t.Cleanup
-// to restore the original value when the test completes.
+// The per-instance *paths.Path is passed straight to the module so cursor state
+// resolves under the per-test temp directory, without relying on any global
+// paths singleton.
 func newMetricSetWithPaths(t *testing.T, config map[string]interface{}, p *paths.Path) mb.MetricSet {
 	t.Helper()
-
-	// Override the global data path so GetCursorRegistry creates its
-	// registry under the per-test temp directory instead of the shared
-	// process-level path.
-	origData := paths.Paths.Data
-	paths.Paths.Data = p.Data
-	t.Cleanup(func() { paths.Paths.Data = origData })
 
 	c, err := conf.NewConfigFrom(config)
 	require.NoError(t, err)

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -230,7 +230,7 @@ func TestOracle(t *testing.T) {
 	// See: https://oracle.github.io/odpi/doc/installation.html
 	testDB, err := sql.Open("godror", "user/pass@localhost:1521/test")
 	if err == nil {
-		err = testDB.Ping()
+		err = testDB.PingContext(t.Context())
 		_ = testDB.Close()
 	}
 	if err != nil && containsOracleClientError(err.Error()) {
@@ -388,7 +388,7 @@ func waitForOracleConnection(t *testing.T, host, port string) {
 
 	for i := 0; i < maxRetries; i++ {
 		// First check if the port is open
-		conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 10*time.Second)
+		conn, err := (&net.Dialer{Timeout: 10 * time.Second}).DialContext(t.Context(), "tcp", net.JoinHostPort(host, port))
 		if err == nil {
 			conn.Close()
 			// Give Oracle a bit more time to fully initialize

--- a/x-pack/metricbeat/module/sql/query/query_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_test.go
@@ -105,9 +105,16 @@ func testMetricSetConfig(queryText string) map[string]interface{} {
 func newTestMetricSet(t *testing.T, cfg map[string]interface{}) *MetricSet {
 	t.Helper()
 
-	ms := mbtest.NewMetricSet(t, cfg)
-	qms, ok := ms.(*MetricSet)
-	require.Truef(t, ok, "expected *MetricSet, got %T", ms)
+	c, err := conf.NewConfigFrom(cfg)
+	require.NoError(t, err)
+	// Use a per-test data directory so cursor state stays isolated and the
+	// test does not depend on the (removed) global paths singleton.
+	beatPaths := &paths.Path{Data: t.TempDir()}
+	_, metricsets, err := mb.NewModule(c, mb.Registry, beatPaths, logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+	require.Len(t, metricsets, 1)
+	qms, ok := metricsets[0].(*MetricSet)
+	require.Truef(t, ok, "expected *MetricSet, got %T", metricsets[0])
 	return qms
 }
 
@@ -156,22 +163,13 @@ func withFakeDBClientFactory(t *testing.T, db dbClient) {
 	})
 }
 
-func withTempDataPath(t *testing.T) {
-	t.Helper()
-	origData := paths.Paths.Data
-	paths.Paths.Data = t.TempDir()
-	t.Cleanup(func() {
-		paths.Paths.Data = origData
-	})
-}
-
 func instantiateMetricSetWithConfig(t *testing.T, cfg map[string]interface{}) error {
 	t.Helper()
-	withTempDataPath(t)
 
 	c, err := conf.NewConfigFrom(cfg)
 	require.NoError(t, err)
-	_, metricsets, err := mb.NewModule(c, mb.Registry, beat.Info{Paths: paths.New(), Logger: logptest.NewTestingLogger(t, "")})
+	beatPaths := &paths.Path{Data: t.TempDir()}
+	_, metricsets, err := mb.NewModule(c, mb.Registry, beat.Info{Paths: beatPaths, Logger: logptest.NewTestingLogger(t, "")})
 	if err != nil {
 		return err
 	}
@@ -494,7 +492,6 @@ func TestFetch_VariableMode_MergeResultsSuccess(t *testing.T) {
 }
 
 func TestInitCursorAndClose(t *testing.T) {
-	withTempDataPath(t)
 	ms := newTestMetricSet(t, testMetricSetConfig("SELECT id FROM t WHERE id > :cursor ORDER BY id ASC"))
 	ms.Config.Cursor = cursor.Config{
 		Enabled: true,

--- a/x-pack/metricbeat/module/sql/query/query_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_test.go
@@ -864,5 +864,5 @@ func TestInferTypeFromMetricsAndDriverHelpers(t *testing.T) {
 	assert.NotEmpty(t, queryDBNames("mssql"))
 	assert.Empty(t, queryDBNames("postgres"))
 	assert.Equal(t, "USE [mydb];", dbSelector("sqlserver", "mydb"))
-	assert.Equal(t, "", dbSelector("postgres", "mydb"))
+	assert.Empty(t, dbSelector("postgres", "mydb"))
 }

--- a/x-pack/metricbeat/module/sql/query/query_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_test.go
@@ -110,7 +110,7 @@ func newTestMetricSet(t *testing.T, cfg map[string]interface{}) *MetricSet {
 	// Use a per-test data directory so cursor state stays isolated and the
 	// test does not depend on the (removed) global paths singleton.
 	beatPaths := &paths.Path{Data: t.TempDir()}
-	_, metricsets, err := mb.NewModule(c, mb.Registry, beatPaths, logptest.NewTestingLogger(t, ""))
+	_, metricsets, err := mb.NewModule(c, mb.Registry, beat.Info{Paths: beatPaths, Logger: logptest.NewTestingLogger(t, "")})
 	require.NoError(t, err)
 	require.Len(t, metricsets, 1)
 	qms, ok := metricsets[0].(*MetricSet)


### PR DESCRIPTION
## Proposed commit message
This change removes the use of global/singleton path state from Metricbeat and replaces it with per-instance paths, fixing a bug where multiple Metricbeat receivers could share the same data store.

Problem

Metricbeat was using global paths.Paths (a package-level singleton) when resolving file paths like the SQL cursor data store. In receiver mode, multiple Metricbeat instances share the same process, so they would all resolve to the same data path, causing them to share state incorrectly.

Changes

- metricbeat/mb/mb.go: Added a Paths *paths.Path field to BaseModule so each module carries its own path instance.
- metricbeat/mb/builders.go: Threaded the *paths.Path parameter through newBaseModuleFromConfig so it is assigned to the BaseModule at construction time.
- metricbeat/mb/lightmetricset.go: Updated LightMetricSet.baseModule() to pass the metric set's path to newBaseModuleFromConfig.
- x-pack/libbeat/cmd/instance/beat.go: Simplified NewBeatForReceiver by removing the filebeat-specific branch for path initialization — both filebeat and metricbeat now use the same path initialization path, constructing a fresh paths.Path instance per beat.
- x-pack/metricbeat/module/sql/module.go: Replaced paths.Resolve(paths.Data, "sql-cursor") (global) with m.Paths.Resolve(paths.Data, "sql-cursor") (per-instance), so each SQL module instance resolves its own data directory.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.  Stand alone Metricbeat will function as before, only metricbeat receiver will have multiple beat instances in the same process.  This change will allow the sql module to have unique data path per beat instance.

## How to test this PR locally

```
cd x-pack/metricbeat/module/sql
go test .
```

## Related issues

- Closes elastic/elastic-agent#15154

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
