### PR TITLE
x-pack/filebeat/input/httpjson: ensure response body is mapstr.M in template values

### DIFF
--- a/changelog/fragments/1782697626-i19811-httpjson.yaml
+++ b/changelog/fragments/1782697626-i19811-httpjson.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix type loss in HTTP JSON template transform handling.
+component: filebeat

--- a/x-pack/filebeat/input/httpjson/response.go
+++ b/x-pack/filebeat/input/httpjson/response.go
@@ -93,6 +93,10 @@ func (resp *response) templateValues() mapstr.M {
 	if resp == nil {
 		return mapstr.M{}
 	}
+	body := resp.body
+	if m, ok := body.(map[string]interface{}); ok {
+		body = mapstr.M(m)
+	}
 	return mapstr.M{
 		"header": resp.header.Clone(),
 		"page":   resp.page,
@@ -100,7 +104,7 @@ func (resp *response) templateValues() mapstr.M {
 			"value":  resp.url.String(),
 			"params": resp.url.Query(),
 		},
-		"body": resp.body,
+		"body": body,
 	}
 }
 

--- a/x-pack/filebeat/input/httpjson/response_test.go
+++ b/x-pack/filebeat/input/httpjson/response_test.go
@@ -47,6 +47,29 @@ func TestTemplateValues(t *testing.T) {
 	assert.Equal(t, 0, len(vals))
 }
 
+func TestTemplateValuesBodyType(t *testing.T) {
+	// When the body is a plain map[string]interface{} (as produced by
+	// json.Unmarshal), templateValues must convert it to mapstr.M so
+	// that the String method produces valid JSON for use in templates
+	// with value_type: json. See elastic/beats#50384.
+	resp := &response{
+		body: map[string]interface{}{
+			"key": "value",
+		},
+	}
+
+	vals := resp.templateValues()
+
+	body := vals["body"]
+	m, ok := body.(mapstr.M)
+	if !ok {
+		t.Fatalf("body type = %T, want mapstr.M", body)
+	}
+	if m.String() != `{"key":"value"}` {
+		t.Errorf("body.String() = %s, want %s", m.String(), `{"key":"value"}`)
+	}
+}
+
 var asTransformablesTests = []struct {
 	name                   string
 	message                string


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/httpjson: ensure response body is mapstr.M in template values

Commit 02410fab8a removed response cloning in valueTpl.Execute to
reduce allocations. A side effect was that the response body, which
json.Unmarshal produces as map[string]interface{}, was no longer
converted to mapstr.M by the clone path. When a template renders
the entire body (e.g. [[.last_response.body]]) the Go default
string representation "map[...]" is produced instead of JSON,
breaking value_type: json parsing.

Convert map[string]interface{} to mapstr.M in templateValues so
that mapstr.M.String (which calls json.Marshal) is used. This is a
type conversion, and since maps are pointer-backed, the interface
re-boxing introduces no additional heap allocation.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes elastic/integrations#18754
- Fixes elastic/integrations#19767
- Fixes elastic/integrations#19774

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
