### PR TITLE
osquery extension: serialize integer zero values as "0" in table output

### DIFF
--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/README.md
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/README.md
@@ -1,358 +1,76 @@
-# Generator Examples
+# This file is generated! See ext/osquery-extension/cmd/gentables.
+<!-- DO NOT EDIT MANUALLY. Update specs/templates and re-run gentables. -->
 
-This directory contains sample table and view specifications to demonstrate the gentables code generator.
+# Osquery Extension for Elastic
 
-## Sample Files
+This osquery extension provides additional custom tables that enhance osquery's capabilities with Elastic-specific functionality. The extension is designed to work seamlessly with Osquerybeat and provides deep system insights across Linux, macOS, and Windows platforms.
 
-- `tables/sample_table.yaml` - Example table specification with multiple columns and comprehensive documentation
-- `views/sample_view.yaml` - Example view specification demonstrating UNION ALL, CASE expressions, and date calculations
+## Overview
 
-**Note:** The generator accepts both `.yaml` and `.yml` file extensions. You can use whichever you prefer, and both can coexist in the same directory.
+The extension adds several custom tables to osquery that provide:
+- Browser history analysis across multiple browsers
+- Host system information access from containers (groups, users, processes)
+- Deep file analysis and security auditing on macOS
+- Windows Amcache inventory and normalized application view
+- Windows Jump List parsing for recent and pinned entries
 
-## Testing the Generator
+## Supported Platforms
 
-To test the generator with these samples, you have two options:
+| Name | Type | Linux | macOS | Windows |
+|------|------|-------|-------|---------|
+| `sample_combined_resources` | view | ✅ | ✅ | ✅ |
+| `sample_custom_table` | table | ✅ | ✅ | ✅ |
+| `sample_jumplists` | table | ❌ | ❌ | ✅ |
+| `sample_recent_files` | table | ❌ | ❌ | ✅ |
 
-### Option 1: From the gentables directory
+---
+
+## Tables
+- [sample_custom_table](docs/tables/sample_custom_table.md)
+- [sample_jumplists](docs/tables/sample_jumplists.md)
+- [sample_recent_files](docs/tables/sample_recent_files.md)
+
+## Views
+- [sample_combined_resources](docs/views/sample_combined_resources.md)
+
+---
+
+## Building and Installation
+
+### Build the Extension
+
+From the osquerybeat directory:
 
 ```bash
-cd /path/to/cmd/gentables
+# Build for current platform
+mage buildext
 
-go run . \
-  -spec-dir examples/tables,examples/views \
-  -out-dir examples/tables/generated \
-  -docs-dir examples/docs \
-  -views-out-dir examples/views/generated \
-  -views-docs-dir examples/docs \
-  -verbose
+# The extension binary will be created at:
+# Linux: ext/osquery-extension/build/linux/osquery-extension
+# macOS: ext/osquery-extension/build/darwin/osquery-extension
+# Windows: ext/osquery-extension/build/windows/osquery-extension.ext
 ```
 
-### Option 2: From the examples directory
+### Using with Osquery
+
+The extension is automatically loaded by Osquerybeat. To use it manually with osquery:
 
 ```bash
-cd /path/to/cmd/gentables/examples
+# Start osquery with the extension
+osqueryi --extension /path/to/osquery-extension [--allow-unsafe]
 
-go run ../main.go \
-  -spec-dir tables,views \
-  -out-dir tables/generated \
-  -docs-dir tables/docs \
-  -views-out-dir views/generated \
-  -views-docs-dir views/docs \
-  -verbose
+# Verify tables are loaded
+osqueryi> .tables
+  => elastic_browser_history
+
+# Query the tables
+osqueryi> SELECT * FROM elastic_browser_history LIMIT 10;
 ```
 
-### What Gets Generated
+---
 
-The generator will create:
-- `tables/generated/` - Table code packages
-  - `sample_custom_table/sample_custom_table.go` - Generated table code
-  - `registry_*.go` - Platform-specific registries
-- `views/generated/` - View code packages
-  - `sample_combined_resources/sample_combined_resources.go` - Generated view code
-  - `registry_*.go` - Platform-specific registries
-- `tables/docs/` - Table documentation
-  - `sample_custom_table.md` - Generated table documentation
-- `views/docs/` - View documentation
-  - `sample_combined_resources.md` - Generated view documentation
+## Additional Resources
 
-**Note**: Import paths in the generated platform files are calculated automatically based on the output directory locations and the module path detected from `go.mod`.
-
-## Unified Spec Format
-
-Tables and views use **identical YAML format**, differentiated only by the `type` field and the presence of the `query` field for views.
-
-### Specification Format
-
-```yaml
-type: table|view                    # Required: "table" or "view"
-name: spec_name                     # Required: table or view name
-description: Brief description      # Required: brief description
-platforms: [linux, darwin, windows] # Optional: defaults to all platforms
-implementation_package: pkg/path    # Required for tables: import path of package that registers this table
-group: my_group                     # Optional: scopes shared types for this spec
-
-columns:                            # Required: column definitions
-  - name: column_name               # Required: column name
-    type: TEXT|INTEGER|BIGINT|DOUBLE # Required: osquery column type
-    description: Column description # Required: column description
-    go_type: string|int32|int64|float64|time.Time # Optional: override Go type
-    format: unix|rfc3339            # Optional: format hint for struct tags
-    timezone: UTC                   # Optional: timezone hint for struct tags
-
-documentation:                      # Required: documentation
-  description: Detailed description # Required: detailed description
-  examples:                         # Required: at least one SQL query example
-    - title: Example title
-      query: SELECT * FROM spec_name;
-  notes:                            # Required: at least one note
-    - Note text
-  related_tables:                   # Optional: defaults to empty list
-    - other_table
-
-# View-specific fields:
-required_tables:                    # Optional: tables this view depends on
-  - table_name
-
-query: |                            # Required for views only
-  SELECT column_name FROM table_name;
-```
-
-### Key Differences
-
-- **Tables** (`type: table`): Must NOT have a `query` field
-- **Views** (`type: view`): Must have a `query` field containing only the SELECT statement(s)
-
-**Note**: The `query` field should contain only the SELECT statement(s). The tool automatically wraps it with `CREATE VIEW ... AS` in the generated code.
-
-## Generated Output
-
-The generator creates individual packages for each table/view with better encapsulation:
-
-### Directory Structure
-```
-pkg/tables/
-├── registry.go                    # STATIC - registry of all tables
-└── generated/
-    └── sample_custom_table/           # Directory: descriptive with underscores
-        └── sample_custom_table.go     # Package: samplecustomtable (idiomatic)
-
-pkg/views/
-├── registry.go                    # STATIC - registry of all views
-└── generated/
-    └── sample_combined_resources/     # Directory: descriptive with underscores
-        └── sample_combined_resources.go  # Package: samplecombinedresources (idiomatic)
-```
-
-**Package Naming Convention:**
-- **Directory names**: Use the original table/view name with underscores (e.g., `sample_custom_table`)
-- **Package names**: Idiomatic Go style - lowercase without underscores (e.g., `samplecustomtable`)
-
-This follows Go best practices where package names should be short, lowercase, and without underscores, while directory names can remain descriptive.
-
-### Generated Files
-Each table/view package includes:
-- `Result` struct with osquery tags
-- `Columns()` function (tables) or `View()` function (views)
-- `TableName` constant (tables only)
-
-### Usage
-```go
-// Import using descriptive directory path, idiomatic package alias
-import samplecustomtable "github.com/.../pkg/tables/generated/sample_custom_table"
-
-// Access the types and functions
-var result samplecustomtable.Result
-columns := samplecustomtable.Columns()
-name := samplecustomtable.TableName
-```
-
-**Registry registration is automatic via generated registry files:**
-- Tables are registered in `pkg/tables/generated/registry.go`
-- Views are registered in `pkg/views/generated/registry.go`
-- No `init()` functions or manual registration needed
-
-## Automatic Registration
-
-### implementation_package Field (Tables Only, Required)
-
-Every table must specify `implementation_package`: the import path of the Go package that registers the table (via `RegisterGenerateFunc()` in `init()`). This guarantees each table has a single, explicit registration point.
-
-**Example 1 – dedicated implementation package** (implementation lives in a separate package):
-
-```yaml
-type: table
-name: my_table
-platforms: [linux, darwin, windows]
-
-implementation_package: github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/myimpl
-
-columns:
-  - name: id
-    type: BIGINT
-    description: Unique identifier
-  # ... more columns
-```
-
-**Example 2 – implementation in generated package** (implementation lives alongside generated code in the same package):
-
-```yaml
-type: table
-name: sample_jumplists
-group: jumplists
-
-implementation_package: github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/jumplists/sample_jumplists
-
-columns:
-  # ...
-```
-
-**How it works:**
-
-1. **Generator creates platform import files** – Imports `implementation_package` in `registry_linux.go`, etc.
-2. **Package init() registers** – That package’s `init()` calls `RegisterGenerateFunc()`
-3. **Static registry registers tables** – Generated `registry.go` calls all table registrations
-4. **Main.go calls registry** – Calls `tables.RegisterTables()` and `views.RegisterViews()`
-
-## Osquery Struct Tags
-
-The generator automatically creates `Result` structs with osquery tags for proper serialization:
-
-### Basic Tags
-All columns get an osquery tag with their column name:
-```go
-type Result struct {
-    Id   int64  `osquery:"id"`   // Basic column
-    Name string `osquery:"name"` // Text column
-}
-```
-
-### Format and Timezone Tags
-Use the optional `format` and `timezone` fields in your column specs to add additional tags:
-
-**YAML Spec:**
-```yaml
-columns:
-  - name: created_time
-    type: BIGINT
-    description: Creation timestamp
-    format: unix      # Adds format:"unix" tag
-    timezone: UTC     # Adds tz:"UTC" tag
-```
-
-**Generated Go:**
-```go
-type Result struct {
-    CreatedTime int64 `osquery:"created_time" format:"unix" tz:"UTC"`
-}
-```
-
-### Supported Format Values
-- `unix` - UNIX epoch timestamp (seconds since 1970-01-01)
-- `rfc3339` - RFC3339 formatted timestamp (ISO 8601)
-
-### Timezone Values
-- `UTC` - Coordinated Universal Time
-- Any IANA timezone name (e.g., `America/New_York`)
-
-These tags are used by the osquery encoding package for proper serialization and deserialization of query results.
-
-### Using time.Time in Result Structs
-
-For timestamp fields, you can use `go_type: time.Time` to generate `time.Time` fields instead of int64/string:
-
-**YAML Spec:**
-```yaml
-columns:
-  - name: timestamp
-    type: BIGINT
-    description: Event timestamp
-    go_type: time.Time    # Override default int64 with time.Time
-    format: unix
-    timezone: UTC
-```
-
-**Generated Go:**
-```go
-type Result struct {
-    Timestamp time.Time `osquery:"timestamp" format:"unix" tz:"UTC"`
-}
-```
-
-The encoding package automatically converts between `time.Time` and the appropriate format based on the tags.
-
-## Column Documentation for Views
-
-Both tables and views must document their columns in the spec. For views, this is especially important because:
-
-1. **Clear Documentation** - Users can see what columns are available without analyzing the SQL
-2. **Type Information** - Explicit type declarations help users understand data types
-3. **Schema Validation** - Column specs document the expected schema of the view
-4. **Better IDE Support** - Generated code includes column information in comments
-
-The `columns` field must list all columns that the view returns, matching the SELECT statement in the query.
-
-### Validation
-
-The generator uses pingcap SQL parser to validate view specifications:
-
-- **SQL Syntax Validation** - The SELECT statement must be syntactically valid SQL
-- **Column Matching** - All specified columns must match the SELECT's output schema
-- **Bidirectional Check** - Validates that specified columns exist in the output, and all output columns are documented
-- **UNION Support** - Validates UNION and UNION ALL queries by extracting columns from the first SELECT
-- **SELECT * Handling** - Views using `SELECT *` skip validation with a warning (assumes columns are correct)
-
-**Alias Requirements:**
-
-The following **do NOT require** an `AS` alias:
-- Simple column references: `SELECT id, name FROM table`
-- Qualified columns: `SELECT t.id, t.name FROM table t`
-- Wildcards: `SELECT *` or `SELECT t.*`
-
-The following **REQUIRE** an `AS` alias:
-- Aggregate functions: `COUNT(*)` → `COUNT(*) AS total_count`
-- Scalar functions: `UPPER(name)` → `UPPER(name) AS name_upper`
-- CASE expressions: `CASE WHEN ... END` → `CASE WHEN ... END AS status_label`
-- Arithmetic expressions: `value * 2` → `value * 2 AS doubled_value`
-- Any complex expression that isn't a plain column reference
-
-**How it works:**
-1. Parses the SELECT statement into an Abstract Syntax Tree (AST)
-2. Extracts output column names from the AST
-3. Simple columns use their name; complex expressions require explicit aliases
-4. Compares the extracted columns with the specified columns
-
-**Advantages:**
-- No database needed - purely static analysis
-- Works for any valid SQL regardless of source table schemas
-- Fast and reliable validation
-- Forces explicit, intentional column naming for complex expressions
-
-**Note:** 
-- The `query` field should contain ONLY the SELECT statement
-- The generator automatically wraps it in `CREATE VIEW view_name AS` when generating code
-- This validates SQL syntax and output schema, but not source table column existence (verified at runtime by osquery)
-
-## Defaults
-
-The generator applies sensible defaults for commonly omitted fields:
-
-- **`platforms`**: Defaults to `["linux", "darwin", "windows"]` if not specified
-- **`documentation.related_tables`**: Defaults to empty array if not specified
-
-This allows you to write minimal specs for cross-platform tables/views without repetitive boilerplate.
-
-## Required vs Optional Fields Summary
-
-### Required for ALL specs (tables and views):
-- ✅ `type` - Must be "table" or "view"
-- ✅ `name` - Spec name
-- ✅ `description` - Brief description
-- ✅ `columns` - At least one column with:
-  - ✅ `name` - Column name
-  - ✅ `type` - Column type (TEXT, INTEGER, BIGINT, DOUBLE, BOOLEAN)
-  - ✅ `description` - Column description
-- ✅ `documentation.description` - Detailed description
-- ✅ `documentation.examples` - At least one example query
-- ✅ `documentation.notes` - At least one note
-
-### Required for TABLES only:
-- ✅ `implementation_package` - Import path of the package that registers this table (via `RegisterGenerateFunc()` in `init()`)
-
-### Optional for ALL specs:
-- ⚪ `platforms` - Defaults to `["linux", "darwin", "windows"]`
-- ⚪ `columns[].go_type` - Explicit Go type override (for example, "time.Time")
-- ⚪ `columns[].format` - Format hint for osquery tags (for example, "unix", "rfc3339")
-- ⚪ `columns[].timezone` - Timezone hint for osquery tags (for example, "UTC")
-- ⚪ `documentation.related_tables` - Defaults to empty array
-- ⚪ `required_tables` - Only applies to views; optional
-- ⚪ `group` - Required if `shared_types` is set
-
-### View-specific required:
-- ✅ `query` - Must contain SELECT statement(s) only
-
-### Table-specific rules:
-- ❌ `query` - Must NOT be present
-
-## Notes
-
-These examples are for demonstration purposes only and are not processed by the actual build. They are kept separate from the real table/view specs in `../../specs/`.
+- **Table Documentation**: [docs/](docs/) - Detailed documentation for each table including configuration, examples, and security considerations
+- **Development**: See the main [beats documentation](https://github.com/elastic/beats)
+- **Osquery**: [osquery.io](https://osquery.io/)

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/tables/sample_custom_table.md
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/tables/sample_custom_table.md
@@ -1,0 +1,82 @@
+% This file is generated! See ext/osquery-extension/cmd/gentables.
+
+# sample_custom_table
+
+Example table showing the generator capabilities with multiple data types
+
+## Platforms
+
+- ✅ Linux
+- ✅ macOS
+- ✅ Windows
+
+## Description
+
+This table demonstrates the code generator's capabilities with various data types
+and comprehensive examples. It serves as a reference for creating new table
+specifications and showcases proper documentation practices.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `BIGINT` | Unique identifier for the resource |
+| `name` | `TEXT` | Resource name or label |
+| `status` | `TEXT` | Current status (active, inactive, pending, archived) |
+| `created_time` | `BIGINT` | Creation timestamp in UNIX epoch seconds |
+| `updated_time` | `BIGINT` | Last update timestamp in UNIX epoch seconds |
+| `value` | `DOUBLE` | Associated numeric value or metric |
+| `enabled` | `INTEGER` | Whether the resource is enabled (1=yes, 0=no) |
+| `category` | `TEXT` | Resource category (system, user, application) |
+| `priority` | `INTEGER` | Priority level (1=low, 2=medium, 3=high, 4=critical) |
+
+## Examples
+### List all active resources sorted by priority
+
+```sql
+SELECT id, name, priority, created_time
+FROM sample_custom_table
+WHERE status = 'active'
+ORDER BY priority DESC, created_time DESC;
+```
+### Count resources by status and category
+
+```sql
+SELECT status, category, COUNT(*) as count
+FROM sample_custom_table
+GROUP BY status, category
+ORDER BY status, category;
+```
+### Find high-priority enabled resources updated recently
+
+```sql
+SELECT name, priority, value, updated_time
+FROM sample_custom_table
+WHERE enabled = 1 
+  AND priority >= 3
+  AND updated_time > (strftime('%s', 'now') - 86400)
+ORDER BY priority DESC;
+```
+### Calculate average value by category for active resources
+
+```sql
+SELECT category, 
+       COUNT(*) as total_count,
+       AVG(value) as avg_value,
+       MAX(value) as max_value
+FROM sample_custom_table
+WHERE status = 'active'
+GROUP BY category;
+```
+
+## Notes
+- This is a sample table to demonstrate the code generator's capabilities
+- The generator creates Go code with column definitions and table metadata
+- Platform-specific build tags are automatically added based on the platforms field
+- All timestamps are stored as UNIX epoch seconds for cross-platform compatibility
+- Status values should be validated at query time using WHERE clauses
+
+## Related Tables
+- `sample_resource_history`
+- `sample_resource_tags`
+- `system_info`

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/tables/sample_jumplists.md
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/tables/sample_jumplists.md
@@ -1,0 +1,61 @@
+% This file is generated! See ext/osquery-extension/cmd/gentables.
+
+# sample_jumplists
+
+Windows Jump Lists containing recently accessed files and pinned items
+
+## Platforms
+
+- ❌ Linux
+- ❌ macOS
+- ✅ Windows
+
+## Description
+
+Windows Jump Lists are a feature that provides quick access to recently
+accessed files and common tasks for applications. This table parses both
+custom destinations (pinned items) and automatic destinations (recent items).
+
+Jump lists are stored per-user in the Recent folder and contain embedded
+LNK (shortcut) file data with rich forensic information.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `application_id` | `TEXT` | The application ID (hash of the application path) |
+| `application_name` | `TEXT` | The resolved application name from known IDs |
+| `username` | `TEXT` | The username |
+| `domain` | `TEXT` | The domain or computer name |
+| `sid` | `TEXT` | The Windows Security Identifier (SID) |
+| `local_path` | `TEXT` | Target local path |
+| `file_size` | `INTEGER` | Target file size in bytes |
+| `hot_key` | `TEXT` | Assigned hotkey combination |
+| `command_line_arguments` | `TEXT` | Command line arguments for the target |
+| `icon_location` | `TEXT` | Path to the icon file |
+| `volume_serial_number` | `TEXT` | Volume serial number (format XXXX-XXXX) |
+| `volume_label` | `TEXT` | Volume label |
+| `jumplist_type` | `TEXT` | Type of jumplist (custom or automatic) |
+| `source_file_path` | `TEXT` | Path to the jumplist file |
+| `entry_index` | `INTEGER` | Index of the entry within the jumplist |
+
+## Examples
+### Find all jumplist entries for a specific application
+
+```sql
+SELECT application_name, local_path, username, jumplist_type
+FROM sample_jumplists
+WHERE application_id = '590aee7bdd69b59b';
+```
+### List recent file accesses by user
+
+```sql
+SELECT username, application_name, local_path, source_file_path
+FROM sample_jumplists
+ORDER BY username, application_name;
+```
+
+## Notes
+- Uses shared types from shared_types.yaml for ApplicationID, UserProfile, and LnkMetadata
+- Custom destinations contain user-pinned items
+- Automatic destinations contain recently accessed files

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/tables/sample_recent_files.md
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/tables/sample_recent_files.md
@@ -1,0 +1,63 @@
+% This file is generated! See ext/osquery-extension/cmd/gentables.
+
+# sample_recent_files
+
+Windows Recent Files tracking user file access history
+
+## Platforms
+
+- ❌ Linux
+- ❌ macOS
+- ✅ Windows
+
+## Description
+
+Windows maintains LNK files in the Recent folder to track recently accessed
+files for each user. This table parses these LNK files to provide forensic
+information about file access history.
+
+This table shares the UserProfile and LnkMetadata types with sample_jumplists,
+demonstrating how shared types enable consistent column definitions across
+related tables.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `username` | `TEXT` | The username |
+| `domain` | `TEXT` | The domain or computer name |
+| `sid` | `TEXT` | The Windows Security Identifier (SID) |
+| `local_path` | `TEXT` | Target local path |
+| `file_size` | `INTEGER` | Target file size in bytes |
+| `hot_key` | `TEXT` | Assigned hotkey combination |
+| `command_line_arguments` | `TEXT` | Command line arguments for the target |
+| `icon_location` | `TEXT` | Path to the icon file |
+| `volume_serial_number` | `TEXT` | Volume serial number (format XXXX-XXXX) |
+| `volume_label` | `TEXT` | Volume label |
+| `created_time` | `BIGINT` | File creation timestamp |
+| `modified_time` | `BIGINT` | File modification timestamp |
+| `accessed_time` | `BIGINT` | File last access timestamp |
+| `lnk_file_path` | `TEXT` | Path to the LNK file in the Recent folder |
+| `target_exists` | `INTEGER` | Whether the target file still exists (1=yes, 0=no) |
+
+## Examples
+### Find recent files accessed by a user
+
+```sql
+SELECT username, local_path, modified_time
+FROM sample_recent_files
+WHERE username = 'john.doe'
+ORDER BY modified_time DESC;
+```
+### Find files accessed from removable drives
+
+```sql
+SELECT username, local_path, volume_serial_number, volume_label
+FROM sample_recent_files
+WHERE volume_label LIKE '%USB%';
+```
+
+## Notes
+- Shares UserProfile and LnkMetadata types with sample_jumplists table
+- Uses FileTimestamps for standard timestamp fields
+- LNK files persist even after the target file is deleted

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/views/sample_combined_resources.md
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/docs/views/sample_combined_resources.md
@@ -1,0 +1,124 @@
+% This file is generated! See ext/osquery-extension/cmd/gentables.
+
+# sample_combined_resources
+
+View combining active and archived resources with calculated fields and UNION
+
+## Platforms
+
+- ✅ Linux
+- ✅ macOS
+- ✅ Windows
+
+## Description
+
+This view demonstrates advanced SQL features including:
+- UNION ALL for combining multiple query results
+- CASE expressions with explicit aliases for calculated fields
+- Date calculations using strftime for age and modification tracking
+- Complex WHERE conditions with multiple criteria
+- Arithmetic expressions with proper aliasing
+
+The view combines active enabled resources with recently archived resources
+(archived within the last 30 days), providing a unified view of current and
+recent resources with human-readable priority levels and calculated age fields.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `BIGINT` | Unique identifier |
+| `name` | `TEXT` | Resource name |
+| `status` | `TEXT` | Current status |
+| `category` | `TEXT` | Resource category |
+| `priority_level` | `TEXT` | Human-readable priority level |
+| `age_days` | `INTEGER` | Age in days since creation |
+| `last_modified_days` | `INTEGER` | Days since last modification |
+| `value` | `DOUBLE` | Associated numeric value |
+
+## Required Tables
+
+This view requires the following tables to be available:
+- `sample_custom_table`
+
+## View Definition
+
+```sql
+CREATE VIEW sample_combined_resources AS
+SELECT 
+  id,
+  name,
+  status,
+  category,
+  CASE priority
+    WHEN 4 THEN 'critical'
+    WHEN 3 THEN 'high'
+    WHEN 2 THEN 'medium'
+    ELSE 'low'
+  END AS priority_level,
+  (strftime('%s', 'now') - created_time) / 86400 AS age_days,
+  (strftime('%s', 'now') - updated_time) / 86400 AS last_modified_days,
+  value
+FROM sample_custom_table
+WHERE status = 'active' AND enabled = 1
+
+UNION ALL
+
+SELECT 
+  id,
+  name,
+  status,
+  category,
+  CASE priority
+    WHEN 4 THEN 'critical'
+    WHEN 3 THEN 'high'
+    WHEN 2 THEN 'medium'
+    ELSE 'low'
+  END AS priority_level,
+  (strftime('%s', 'now') - created_time) / 86400 AS age_days,
+  (strftime('%s', 'now') - updated_time) / 86400 AS last_modified_days,
+  value
+FROM sample_custom_table
+WHERE status = 'archived' AND updated_time > (strftime('%s', 'now') - 2592000);
+```
+
+## Examples
+### Find critical resources requiring attention
+
+```sql
+SELECT name, category, priority_level, last_modified_days
+FROM sample_combined_resources
+WHERE priority_level = 'critical'
+  AND last_modified_days > 7
+ORDER BY last_modified_days DESC;
+```
+### Analyze resource distribution by category and priority
+
+```sql
+SELECT category, priority_level, COUNT(*) as count, AVG(value) as avg_value
+FROM sample_combined_resources
+GROUP BY category, priority_level
+ORDER BY category, priority_level;
+```
+### Identify aging resources by status
+
+```sql
+SELECT status, 
+       COUNT(*) as total,
+       AVG(age_days) as avg_age,
+       MAX(age_days) as oldest
+FROM sample_combined_resources
+GROUP BY status;
+```
+
+## Notes
+- This view uses UNION ALL to combine active and recently archived resources
+- CASE expressions require explicit AS aliases for column names
+- All date calculations are performed using SQLite date functions
+- The view automatically updates when the underlying table changes
+- Archived resources older than 30 days are excluded to keep results focused
+- Priority levels are converted to human-readable text for easier interpretation
+
+## Related Tables
+- `sample_custom_table`
+- `sample_resource_history`

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/jumplists/sample_jumplists/sample_jumplists.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/jumplists/sample_jumplists/sample_jumplists.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/osquery/osquery-go/plugin/table"
 
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/client"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 
@@ -23,13 +24,13 @@ import (
 )
 
 var (
-	generateFunc func(context.Context, table.QueryContext, *logger.Logger) ([]Result, error)
+	generateFunc func(context.Context, table.QueryContext, *logger.Logger, *client.ResilientClient) ([]Result, error)
 	registerOnce sync.Once
 )
 
 // RegisterGenerateFunc registers the generate function for this table.
 // This should be called once from the implementation package's init() function.
-func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Logger) ([]Result, error)) {
+func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Logger, *client.ResilientClient) ([]Result, error)) {
 	registerOnce.Do(func() {
 		generateFunc = f
 	})
@@ -37,20 +38,22 @@ func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Lo
 
 // GetGenerateFunc returns the osquery table.GenerateFunc for this table.
 // It wraps the registered generate function and handles marshaling of results.
-func GetGenerateFunc(log *logger.Logger) (table.GenerateFunc, error) {
+func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.GenerateFunc, error) {
 	if generateFunc == nil {
 		return nil, errors.New("generate function not registered for sample_jumplists")
 	}
 	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-		results, err := generateFunc(ctx, queryContext, log)
+		results, err := generateFunc(ctx, queryContext, log, client)
 		if err != nil {
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/jumplists/sample_recent_files/sample_recent_files.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/jumplists/sample_recent_files/sample_recent_files.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/osquery/osquery-go/plugin/table"
 
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/client"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 
@@ -23,13 +24,13 @@ import (
 )
 
 var (
-	generateFunc func(context.Context, table.QueryContext, *logger.Logger) ([]Result, error)
+	generateFunc func(context.Context, table.QueryContext, *logger.Logger, *client.ResilientClient) ([]Result, error)
 	registerOnce sync.Once
 )
 
 // RegisterGenerateFunc registers the generate function for this table.
 // This should be called once from the implementation package's init() function.
-func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Logger) ([]Result, error)) {
+func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Logger, *client.ResilientClient) ([]Result, error)) {
 	registerOnce.Do(func() {
 		generateFunc = f
 	})
@@ -37,20 +38,22 @@ func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Lo
 
 // GetGenerateFunc returns the osquery table.GenerateFunc for this table.
 // It wraps the registered generate function and handles marshaling of results.
-func GetGenerateFunc(log *logger.Logger) (table.GenerateFunc, error) {
+func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.GenerateFunc, error) {
 	if generateFunc == nil {
 		return nil, errors.New("generate function not registered for sample_recent_files")
 	}
 	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-		results, err := generateFunc(ctx, queryContext, log)
+		results, err := generateFunc(ctx, queryContext, log, client)
 		if err != nil {
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/registry_darwin.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/registry_darwin.go
@@ -15,16 +15,17 @@ import (
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/client"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 	samplecustomtable "github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/sample_custom_table"
 )
 
 // RegisterTables registers all generated tables with the osquery extension server.
 // This function is called from main.go after all init() functions have run.
-func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger) {
+func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger, client *client.ResilientClient) {
 	{
 		// Example table showing the generator capabilities with multiple data types
-		genFunc, err := samplecustomtable.GetGenerateFunc(log)
+		genFunc, err := samplecustomtable.GetGenerateFunc(log, client)
 		if err != nil {
 			log.Errorf("Failed to get generate function for sample_custom_table: %v", err)
 		} else {

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/registry_linux.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/registry_linux.go
@@ -15,16 +15,17 @@ import (
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/client"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 	samplecustomtable "github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/sample_custom_table"
 )
 
 // RegisterTables registers all generated tables with the osquery extension server.
 // This function is called from main.go after all init() functions have run.
-func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger) {
+func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger, client *client.ResilientClient) {
 	{
 		// Example table showing the generator capabilities with multiple data types
-		genFunc, err := samplecustomtable.GetGenerateFunc(log)
+		genFunc, err := samplecustomtable.GetGenerateFunc(log, client)
 		if err != nil {
 			log.Errorf("Failed to get generate function for sample_custom_table: %v", err)
 		} else {

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/registry_windows.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/registry_windows.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/client"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 	samplejumplists "github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/jumplists/sample_jumplists"
 	samplerecentfiles "github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/jumplists/sample_recent_files"
@@ -23,10 +24,10 @@ import (
 
 // RegisterTables registers all generated tables with the osquery extension server.
 // This function is called from main.go after all init() functions have run.
-func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger) {
+func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger, client *client.ResilientClient) {
 	{
 		// Example table showing the generator capabilities with multiple data types
-		genFunc, err := samplecustomtable.GetGenerateFunc(log)
+		genFunc, err := samplecustomtable.GetGenerateFunc(log, client)
 		if err != nil {
 			log.Errorf("Failed to get generate function for sample_custom_table: %v", err)
 		} else {
@@ -36,7 +37,7 @@ func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger) 
 	}
 	{
 		// Windows Jump Lists containing recently accessed files and pinned items
-		genFunc, err := samplejumplists.GetGenerateFunc(log)
+		genFunc, err := samplejumplists.GetGenerateFunc(log, client)
 		if err != nil {
 			log.Errorf("Failed to get generate function for sample_jumplists: %v", err)
 		} else {
@@ -46,7 +47,7 @@ func RegisterTables(server *osquery.ExtensionManagerServer, log *logger.Logger) 
 	}
 	{
 		// Windows Recent Files tracking user file access history
-		genFunc, err := samplerecentfiles.GetGenerateFunc(log)
+		genFunc, err := samplerecentfiles.GetGenerateFunc(log, client)
 		if err != nil {
 			log.Errorf("Failed to get generate function for sample_recent_files: %v", err)
 		} else {

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/sample_custom_table/sample_custom_table.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/tables/generated/sample_custom_table/sample_custom_table.go
@@ -16,18 +16,19 @@ import (
 
 	"github.com/osquery/osquery-go/plugin/table"
 
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/client"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 )
 
 var (
-	generateFunc func(context.Context, table.QueryContext, *logger.Logger) ([]Result, error)
+	generateFunc func(context.Context, table.QueryContext, *logger.Logger, *client.ResilientClient) ([]Result, error)
 	registerOnce sync.Once
 )
 
 // RegisterGenerateFunc registers the generate function for this table.
 // This should be called once from the implementation package's init() function.
-func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Logger) ([]Result, error)) {
+func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Logger, *client.ResilientClient) ([]Result, error)) {
 	registerOnce.Do(func() {
 		generateFunc = f
 	})
@@ -35,20 +36,22 @@ func RegisterGenerateFunc(f func(context.Context, table.QueryContext, *logger.Lo
 
 // GetGenerateFunc returns the osquery table.GenerateFunc for this table.
 // It wraps the registered generate function and handles marshaling of results.
-func GetGenerateFunc(log *logger.Logger) (table.GenerateFunc, error) {
+func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.GenerateFunc, error) {
 	if generateFunc == nil {
 		return nil, errors.New("generate function not registered for sample_custom_table")
 	}
 	return func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-		results, err := generateFunc(ctx, queryContext, log)
+		results, err := generateFunc(ctx, queryContext, log, client)
 		if err != nil {
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/registry_darwin.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/registry_darwin.go
@@ -22,10 +22,10 @@ func RegisterViews(hookManager *hooks.HookManager, log *logger.Logger) {
 		// View combining active and archived resources with calculated fields and UNION
 		hooksFunc, err := samplecombinedresources.GetHooksFunc()
 		if err != nil {
-			log.Errorf("Failed to get hooks function for sample_combined_resources: %v", err)
+			samplecombinedresources.RegisterDefaultViewHook(hookManager)
 		} else {
 			hooksFunc(hookManager)
-			log.Infof("Registered view: sample_combined_resources")
 		}
+		log.Infof("Registered view: sample_combined_resources")
 	}
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/registry_linux.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/registry_linux.go
@@ -22,10 +22,10 @@ func RegisterViews(hookManager *hooks.HookManager, log *logger.Logger) {
 		// View combining active and archived resources with calculated fields and UNION
 		hooksFunc, err := samplecombinedresources.GetHooksFunc()
 		if err != nil {
-			log.Errorf("Failed to get hooks function for sample_combined_resources: %v", err)
+			samplecombinedresources.RegisterDefaultViewHook(hookManager)
 		} else {
 			hooksFunc(hookManager)
-			log.Infof("Registered view: sample_combined_resources")
 		}
+		log.Infof("Registered view: sample_combined_resources")
 	}
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/registry_windows.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/registry_windows.go
@@ -22,10 +22,10 @@ func RegisterViews(hookManager *hooks.HookManager, log *logger.Logger) {
 		// View combining active and archived resources with calculated fields and UNION
 		hooksFunc, err := samplecombinedresources.GetHooksFunc()
 		if err != nil {
-			log.Errorf("Failed to get hooks function for sample_combined_resources: %v", err)
+			samplecombinedresources.RegisterDefaultViewHook(hookManager)
 		} else {
 			hooksFunc(hookManager)
-			log.Infof("Registered view: sample_combined_resources")
 		}
+		log.Infof("Registered view: sample_combined_resources")
 	}
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/sample_combined_resources/sample_combined_resources.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/examples/views/generated/sample_combined_resources/sample_combined_resources.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/hooks"
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
 )
 
 var (
@@ -19,8 +20,33 @@ var (
 	registerOnce sync.Once
 )
 
+func createViewHook(socket *string, log *logger.Logger, hookData any) error {
+	v, ok := hookData.(*hooks.View)
+	if !ok {
+		return fmt.Errorf("hook data is not a view")
+	}
+	return v.Create(socket, log)
+}
+
+func deleteViewHook(socket *string, log *logger.Logger, hookData any) error {
+	v, ok := hookData.(*hooks.View)
+	if !ok {
+		return fmt.Errorf("hook data is not a view")
+	}
+	return v.Delete(socket, log)
+}
+
+// RegisterDefaultViewHook registers only the create/delete view hook with the hook manager.
+// To add extra hooks, call RegisterHooksFunc with a function that calls RegisterDefaultViewHook(hm)
+// then registers additional hooks on hm.
+func RegisterDefaultViewHook(hm *hooks.HookManager) {
+	hm.Register(hooks.NewHook("CreateSampleCombinedResourcesView", createViewHook, deleteViewHook, View()))
+}
+
 // RegisterHooksFunc registers the hooks function for this view (optional).
-// This can be called to register any hooks that should be set up for this view.
+// If called (e.g. from an implementation package), that function runs instead of the default.
+// To add extra hooks while keeping the default view hook, pass a function that calls
+// RegisterDefaultViewHook(hm) then registers additional hooks.
 func RegisterHooksFunc(f func(*hooks.HookManager)) {
 	registerOnce.Do(func() {
 		hooksFunc = f

--- a/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/templates/table.tmpl
+++ b/x-pack/osquerybeat/ext/osquery-extension/cmd/gentables/templates/table.tmpl
@@ -43,10 +43,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_application/elastic_amcache_application.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_application/elastic_amcache_application.go
@@ -48,10 +48,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_application_file/elastic_amcache_application_file.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_application_file/elastic_amcache_application_file.go
@@ -48,10 +48,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_application_shortcut/elastic_amcache_application_shortcut.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_application_shortcut/elastic_amcache_application_shortcut.go
@@ -48,10 +48,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_device_pnp/elastic_amcache_device_pnp.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_device_pnp/elastic_amcache_device_pnp.go
@@ -48,10 +48,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_driver_binary/elastic_amcache_driver_binary.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_driver_binary/elastic_amcache_driver_binary.go
@@ -48,10 +48,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_driver_package/elastic_amcache_driver_package.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/amcache/elastic_amcache_driver_package/elastic_amcache_driver_package.go
@@ -48,10 +48,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_browser_history/elastic_browser_history.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_browser_history/elastic_browser_history.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_file_analysis/elastic_file_analysis.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_file_analysis/elastic_file_analysis.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_host_groups/elastic_host_groups.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_host_groups/elastic_host_groups.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_host_processes/elastic_host_processes.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_host_processes/elastic_host_processes.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_host_users/elastic_host_users.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/elastic_host_users/elastic_host_users.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/jumplists/elastic_jumplists/elastic_jumplists.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/jumplists/elastic_jumplists/elastic_jumplists.go
@@ -48,10 +48,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/ntfs/elastic_ntfs_file/elastic_ntfs_file.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/ntfs/elastic_ntfs_file/elastic_ntfs_file.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/ntfs/elastic_ntfs_partitions/elastic_ntfs_partitions.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/ntfs/elastic_ntfs_partitions/elastic_ntfs_partitions.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/ntfs/elastic_ntfs_volumes/elastic_ntfs_volumes.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/generated/ntfs/elastic_ntfs_volumes/elastic_ntfs_volumes.go
@@ -46,10 +46,12 @@ func GetGenerateFunc(log *logger.Logger, client *client.ResilientClient) (table.
 			return nil, err
 		}
 
-		// Convert results to maps
+		// Convert results to maps.
+		// EncodingFlagUseNumbersZeroValues ensures integer zero values are serialized as
+		// "0" rather than "" so that WHERE col = 0 constraints match in SQLite.
 		rows := make([]map[string]string, len(results))
 		for i, result := range results {
-			row, err := encoding.MarshalToMap(result)
+			row, err := encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Proposed commit message

Switches the `gentables` table template from `encoding.MarshalToMap` to
`encoding.MarshalToMapWithFlags(result, encoding.EncodingFlagUseNumbersZeroValues)`
so that integer zero values are serialized as `"0"` rather than `""` in
all extension table output.

**Why this matters:** `MarshalToMap` converts any integer `0` to an
empty string by design (matching osquery's wire-protocol convention for
optional fields). However, SQLite does not equate empty-string TEXT with
integer `0` during equality comparisons, so `WHERE col = 0` constraints
silently returned no rows for columns whose value was zero. The most
visible symptom was `WHERE ads = 0` on `elastic_ntfs_file` returning no
results for files without Alternate Data Streams (#20779).

All generated table packages were regenerated with `mage generate`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `changelog/fragments/` for this change

Fixes: https://github.com/elastic/endpoint-dev/issues/20779