### PR TITLE
ci: include `.go-version` file as trigger for linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,7 @@ on:
       - '**/*.go'
       - '**/go.mod'
       - '**/go.sum'
+      - '.go-version'
       - '.golangci.yml'
       - '.github/workflows/golangci-lint.yml'
 


### PR DESCRIPTION
Changing Go version should trigger linter.

Suggested by CodeRabbit [here](https://github.com/elastic/elastic-agent-autodiscover/pull/164#discussion_r3494079045).