### PR TITLE
ci: fix golangci-lint deprecation warning and increase timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -54,7 +54,7 @@ jobs:
           # which can lead to some frustration from developers who would like to
           # fix a single line in an existing codebase and the linter would force them
           # into fixing all linting issues in the whole file instead
-          args: --timeout=60m --whole-files
+          args: --timeout=90m --whole-files
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -54,7 +54,7 @@ jobs:
           # which can lead to some frustration from developers who would like to
           # fix a single line in an existing codebase and the linter would force them
           # into fixing all linting issues in the whole file instead
-          args: --timeout=30m --whole-files
+          args: --timeout=60m --whole-files
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - exhaustruct
     - forbidigo
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - gosec
     - govet
     - importas
@@ -93,26 +93,25 @@ linters:
         - github.com/meraki/dashboard-api-go/v3
         - github.com/snowflakedb/gosnowflake
       replace-local: false
-    gomodguard:
+    gomodguard_v2:
       blocked:
-        modules:
-          - github.com/pkg/errors:
-              recommendations:
-                - errors
-                - fmt
-              reason: This package is deprecated, use `fmt.Errorf` with `%w` instead
-          - go.uber.org/multierr:
-              recommendations:
-                - errors
-              reason: This package is deprecated, use `errors.Join` instead
-          - gotest.tools/v3:
-              recommendations:
-                - github.com/stretchr/testify
-              reason: Use one assertion library consistently across the codebase
-          - github.com/google/uuid:
-              recommendations:
-                - github.com/gofrs/uuid/v5
-              reason: Use one uuid library consistently across the codebase
+        - module: github.com/pkg/errors
+          recommendations:
+            - errors
+            - fmt
+          reason: This package is deprecated, use `fmt.Errorf` with `%w` instead
+        - module: go.uber.org/multierr
+          recommendations:
+            - errors
+          reason: This package is deprecated, use `errors.Join` instead
+        - module: gotest.tools/v3
+          recommendations:
+            - github.com/stretchr/testify
+          reason: Use one assertion library consistently across the codebase
+        - module: github.com/google/uuid
+          recommendations:
+            - github.com/gofrs/uuid/v5
+          reason: Use one uuid library consistently across the codebase
     gosec:
       excludes:
         - G306


### PR DESCRIPTION
## Proposed commit message

Two small CI fixes for the golangci-lint workflow:

- Migrate `gomodguard` → `gomodguard_v2` to clear the deprecation warning introduced in golangci-lint v2.12.0. The config schema changed slightly (flat list instead of nested map).
- Increase the linter timeout from 30m to 90m. macOS runners consistently exceed the current limit when running with `--whole-files` on cold caches (observed finishing at 59m 3s with a 60m limit).

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `./changelog/fragments`~~

## Disruptive User Impact

None.

## How to test this PR locally

Run `golangci-lint run --timeout=90m --whole-files` — no deprecation warnings should appear.

## Context: cache situation

The golangci-lint timeout is closely tied to the state of the [GitHub Actions cache](https://github.com/elastic/beats/actions/caches).

**How caching works:** `golangci-lint-action` saves its analysis cache (~5-6 MB compressed) keyed by OS + `go.mod` hash. `actions/setup-go` separately saves the Go build and module cache (~750 MB–1.5 GB per entry). All entries share a **10 GB repository-wide limit**.

**Why release branches are slow:** Each active branch (`main`, `9.4`, `9.3`, `8.19`) has a different `go.mod` and therefore a separate cache. Release branches receive fewer PRs, so their caches expire or get evicted before the next lint run — every new PR against a release branch starts cold.

**The timeout problem:** macOS cold-start runs take ~60 min on this codebase, exceeding the 30 m limit. The golangci-lint analysis cache is ~6 MB compressed (normal — it compresses well) and is saved correctly even after a timeout, but it does not significantly speed up subsequent cold runs on its own. Increasing the timeout to 90 m ensures macOS runs complete reliably.

**Current cache state:** The 10 GB pool is at ~99% capacity, dominated by `setup-go` Go build caches (up to 1.5 GB each for macOS). macOS runners are currently resolving to both `arm64` and `x64` images, doubling the macOS cache footprint. Frequent dependency bumps also cause cache key churn across branches.

## Related issues

-

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A
