### PR TITLE
[Doc] fix use_performance_counters documented default value as false

### DIFF
--- a/docs/reference/metricbeat/metricbeat-metricset-system-core.md
+++ b/docs/reference/metricbeat/metricbeat-metricset-system-core.md
@@ -27,7 +27,7 @@ This metricset is available on:
 :   This option controls what metrics are reported for each CPU core. The value is a list and two metric types are supported - `percentages` and `ticks`. The default value is `core.metrics: [percentages]`.
 
 **`use_performance_counters`**
-:   This option enables the use of performance counters to collect data for the CPU/core metricset. It is only effective on Windows. You should use this option if running beats on machins with more than 64 cores. The default value is `use_performance_counters: true`
+:   This option enables the use of performance counters to collect data for the CPU/core metricset. It is only effective on Windows. You should use this option if running beats on machines with more than 64 cores. The default value is `use_performance_counters: false`
 
     ```yaml
     metricbeat.modules:

--- a/metricbeat/module/system/core/_meta/docs.md
+++ b/metricbeat/module/system/core/_meta/docs.md
@@ -15,7 +15,7 @@ This metricset is available on:
 :   This option controls what metrics are reported for each CPU core. The value is a list and two metric types are supported - `percentages` and `ticks`. The default value is `core.metrics: [percentages]`.
 
 **`use_performance_counters`**
-:   This option enables the use of performance counters to collect data for the CPU/core metricset. It is only effective on Windows. You should use this option if running beats on machins with more than 64 cores. The default value is `use_performance_counters: false`
+:   This option enables the use of performance counters to collect data for the CPU/core metricset. It is only effective on Windows. You should use this option if running beats on machines with more than 64 cores. The default value is `use_performance_counters: false`
 
     ```yaml
     metricbeat.modules:

--- a/metricbeat/module/system/core/_meta/docs.md
+++ b/metricbeat/module/system/core/_meta/docs.md
@@ -15,7 +15,7 @@ This metricset is available on:
 :   This option controls what metrics are reported for each CPU core. The value is a list and two metric types are supported - `percentages` and `ticks`. The default value is `core.metrics: [percentages]`.
 
 **`use_performance_counters`**
-:   This option enables the use of performance counters to collect data for the CPU/core metricset. It is only effective on Windows. You should use this option if running beats on machins with more than 64 cores. The default value is `use_performance_counters: true`
+:   This option enables the use of performance counters to collect data for the CPU/core metricset. It is only effective on Windows. You should use this option if running beats on machins with more than 64 cores. The default value is `use_performance_counters: false`
 
     ```yaml
     metricbeat.modules:


### PR DESCRIPTION
## Proposed commit message

This is just fixing documentation about default value of `use_performance_counters` being `false` (since [8.16](https://github.com/elastic/beats/pull/42041)) and not true


## Disruptive User Impact

None

## How to test this PR locally

Doc change so no particular test needed

## Related issues

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A