### PR TITLE
remove settings.Processing override for heartbeat receiver

### DIFF
--- a/x-pack/heartbeat/hbreceiver/factory.go
+++ b/x-pack/heartbeat/hbreceiver/factory.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/elastic/beats/v7/heartbeat/beater"
 	"github.com/elastic/beats/v7/heartbeat/cmd"
-	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 
 	// Import OSS monitor types.
 	_ "github.com/elastic/beats/v7/heartbeat/monitors/active/http"
@@ -42,7 +41,6 @@ func createReceiver(ctx context.Context, set receiver.Settings, baseCfg componen
 		return nil, fmt.Errorf("could not convert otel config to heartbeat config")
 	}
 	settings := cmd.HeartbeatSettings()
-	settings.Processing = processing.MakeDefaultSupport(true, nil, processing.WithECS, processing.WithHost, processing.WithAgentMeta())
 	settings.ElasticLicensed = true
 
 	b, err := xpInstance.NewBeatForReceiver(settings, cfg.Beatconfig, consumer, set.ID.String(), set.Logger.Core())


### PR DESCRIPTION

## Proposed commit message

Remove settings.Processing override for heartbeat receiver

x-pack/heartbeat/cmd/root.go (heartbeatCfg) uses HeartbeatSettings() without any Processing override. The receiver was overriding settings.Processing with MakeDefaultSupport(..., WithECS, WithHost, WithAgentMeta()), which diverged from the process path in two ways:

- WithHost adds host.name as a builtin; process-mode heartbeat never emits this field because HeartbeatSettings() does not include WithHost.
- WithECS is functionally identical to the withECSVersion modifier already in HeartbeatSettings(), so the override was redundant after removing WithHost.

Dropping the override entirely makes the receiver use the same processing factory as the heartbeat command, restoring field parity between the two runtime modes.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/14552

