### PR TITLE
docs: remove mage buildSystemTestBinary from Go test docs

### DIFF
--- a/docs/extend/testing.md
+++ b/docs/extend/testing.md
@@ -42,9 +42,6 @@ mage docker:composeBuild
 # Bring up all containers, wait until they are healthy, and put them in the background.
 mage docker:composeUp
 
-# Build the test binary
-mage buildSystemTestBinary
-
 # Run all integration tests.
 go test ./filebeat/...  -tags integration
 

--- a/filebeat/input/journald/README.md
+++ b/filebeat/input/journald/README.md
@@ -79,7 +79,6 @@ have to copy/clone it some VMs):
 ```
 cp -r /vagrant ./beats # Filebeat won't run correctly on the mounted volume
 cd ./beats/filebeat
-mage buildSystemTestBinary
 go test -count=1 -tags integration ./tests/integration -run TestJournaldInputReadsMessagesFromAllBoots -v
 ```
 
@@ -211,7 +210,7 @@ Then you can read the newly created file:
 root@vagrant-debian-12:~/filebeat# journalctl --file ./example.journal
 Oct 02 04:16:54 vagrant-debian-12 unknown[1908]: Hello Journal!
 Oct 02 04:17:50 vagrant-debian-12 my-test[1924]: Hello Journal!
-root@vagrant-debian-12:~/filebeat# 
+root@vagrant-debian-12:~/filebeat#
 ```
 
 Bear in mind that `systemd-journal-remote` will **append** to the


### PR DESCRIPTION
## Proposed commit message

```
docs: remove mage buildSystemTestBinary from Go test docs

The Go integration test framework builds the beat test binary
automatically since #49583.

Remove the obsolete step from the Go integration test docs. The 
references in the Python system test section are kept because they are
still required.
```

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Docs-only change, `skip-changelog` applied.

## Related issues

- Relates #49583
