### PR TITLE
filestream: fix data loss when a harvester closes at offset 0

### DIFF
--- a/changelog/fragments/1782902506-fix-filestream-offset-0-harvester-close.yaml
+++ b/changelog/fragments/1782902506-fix-filestream-offset-0-harvester-close.yaml
@@ -1,0 +1,28 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix filestream data loss when a harvester closes before ingesting any data
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  When a filestream harvester was closed before ingesting anything (for example
+  while still in its initial backoff), it reported an ingested offset of 0. The
+  file watcher could not distinguish this genuine 0 from "no offset reported",
+  so it fell back to the file size and never emitted a write event. As a result
+  no new harvester was started and the file's contents were never ingested,
+  causing silent data loss. The reported offset of 0 is now honored, so a new
+  harvester is started and the file is ingested.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat

--- a/filebeat/input/filestream/fswatch_integration_test.go
+++ b/filebeat/input/filestream/fswatch_integration_test.go
@@ -82,6 +82,40 @@ func TestFileWatcherNotifications(t *testing.T) {
 			}
 		},
 
+		"New file, harvester closed at offset 0": func(t *testing.T, fw *fileWatcher, evt loginp.FSEvent, dir, logFilePath string) {
+			// Reproduces the offset-0 harvester-close race:
+			//  - watch sees a new file, sends a create event (done in setup)
+			//  - the harvester is closed during the initial backoff before ingesting anything, so
+			//    it reports offset 0
+			//  - scan runs again, must use the 0 from the notification and send a write event so a
+			//    new harvester restarts and ingests the data
+
+			// Notify the harvester has closed at offset 0 (nothing ingested)
+			fw.processNotification(loginp.HarvesterStatus{
+				ID:   evt.SrcID,
+				Size: 0,
+			})
+
+			// Ensure closedHarvester is populated
+			if _, ok := fw.closedHarvesters[evt.SrcID]; !ok {
+				t.Fatal("closed harvester notification did not populate 'closedHarvesters'")
+			}
+
+			fw.watch(t.Context())
+			// Because the harvester reported offset 0 while the file has data, a write operation
+			// must be generated to restart ingestion.
+			if len(fw.events) == 0 {
+				t.Fatal("expecting a write event after offset-0 harvester close, got none (data loss)")
+			}
+			evt = <-fw.events
+			requireOperation(t, evt, loginp.OpWrite)
+
+			l := len(fw.closedHarvesters)
+			if l != 0 {
+				t.Fatalf("expecting 'closedHarvesters' to be empty, got %d items", l)
+			}
+		},
+
 		"Fully ingested file": func(t *testing.T, fw *fileWatcher, evt loginp.FSEvent, dir, logFilePath string) {
 			// Tests the default case of a harvester closing after fully
 			// ingesting the file. It also ensure entries in closedHarvesters

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -69,21 +69,24 @@ type FileDescriptor struct {
 	// GZIP indicates if the file is compressed with GZIP.
 	GZIP bool
 
-	// bytesIngested is the number of bytes already ingested by the harvester
-	// for this file
+	// bytesIngested is the number of bytes already ingested by the harvester for this file.
 	bytesIngested int64
+	// bytesIngestedSet distinguishes an explicit ingested offset of 0 (a harvester closed before
+	// ingesting anything) from bytesIngested never having been set.
+	bytesIngestedSet bool
 }
 
 // SetBytesIngested allows for setting a size that is different than the one in Info
 func (fd *FileDescriptor) SetBytesIngested(s int64) {
 	fd.bytesIngested = s
+	fd.bytesIngestedSet = true
 }
 
 // SizeOrBytesIngested returns the bytes ingested for the file or its size.
-// If [SetBytesIngested] has been called with a value other
-// than zero, the bytes ingested is returned, otherwise Info.Size() is returned.
+// If [SetBytesIngested] has been called, the bytes ingested is returned
+// (including a value of zero), otherwise Info.Size() is returned.
 func (fd FileDescriptor) SizeOrBytesIngested() int64 {
-	if fd.bytesIngested != 0 {
+	if fd.bytesIngestedSet {
 		return fd.bytesIngested
 	}
 


### PR DESCRIPTION
## Proposed commit message

```
When a harvester was closed before ingesting anything (for example while
still in its initial backoff) it reported an offset of 0. The watcher
could not tell this genuine 0 apart from "no offset reported", so
SizeOrBytesIngested returned the file size instead of 0. The write
comparison prevDesc.SizeOrBytesIngested() < fd.Info.Size() was then
false, no write event was emitted, no new harvester was started, and the
file's contents were never ingested, causing silent data loss.

Track whether an offset was set explicitly with a bytesIngestedSet flag
so an ingested offset of 0 is honored. The watcher now emits a write
event and restarts the harvester in this case.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

Run the filestream file-watcher integration tests, which now include the offset-0 harvester-close case:

```bash
cd filebeat
go test -race -tags integration -run 'TestFileWatcherNotifications/New_file,_harvester_closed_at_offset_0' ./input/filestream/...
```

## Related issues

- Relates #47247
