### PR TITLE
[beatreceiver] Remove global logger packetbeat 2/2

### DIFF
--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -199,6 +199,7 @@ func (p *processorFactory) create(pipeline beat.PipelineConnector, cfg *conf.C, 
 		config.IgnoreOutgoing,
 		config.Interfaces[0].File == "",
 		config.Interfaces[0].InternalNetworks,
+		p.logger,
 	)
 	if err != nil {
 		return 0, nil, nil, nil, nil, err
@@ -290,7 +291,7 @@ func setupSniffer(
 		interfaces = append(interfaces, iface)
 	}
 
-	logger.Named("main").Debug("Initializing protocol plugins")
+	logger.Debug("Initializing protocol plugins")
 	decoders := make(map[string]sniffer.Decoders)
 	var closers []func()
 	for i, iface := range interfaces {

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -35,11 +35,6 @@ import (
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
 )
 
-var (
-	debugf    = logp.MakeDebug("amqp")
-	detailedf = logp.MakeDebug("amqpdetailed")
-)
-
 type amqpPlugin struct {
 	ports                     []int
 	sendRequest               bool
@@ -54,7 +49,9 @@ type amqpPlugin struct {
 	watcher                   *procs.ProcessesWatcher
 
 	// map containing functions associated with different method numbers
-	methodMap map[codeClass]map[codeMethod]amqpMethod
+	methodMap                              map[codeClass]map[codeMethod]amqpMethod
+	logger, amqpLogger, amqpDetailedLogger *logp.Logger
+	isDebug, isDetailed                    bool
 }
 
 var (
@@ -74,6 +71,13 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &amqpPlugin{}
+	p.logger = logger
+	p.amqpLogger = logger.Named("amqp")
+	p.amqpDetailedLogger = logger.Named("amqpdetailed")
+
+	p.isDebug = p.amqpLogger.IsDebug()
+	p.isDetailed = p.amqpDetailedLogger.IsDebug()
+
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -85,6 +89,20 @@ func New(
 		return nil, err
 	}
 	return p, nil
+}
+
+//go:inline
+func (amqp *amqpPlugin) debugf(format string, args ...interface{}) {
+	if amqp.isDebug {
+		amqp.amqpLogger.Debugf(format, args...)
+	}
+}
+
+//go:inline
+func (amqp *amqpPlugin) detailedf(format string, args ...interface{}) {
+	if amqp.isDetailed {
+		amqp.amqpDetailedLogger.Debugf(format, args...)
+	}
 }
 
 func (amqp *amqpPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *amqpConfig) error {
@@ -204,7 +222,7 @@ func (amqp *amqpPlugin) ConnectionTimeout() time.Duration {
 func (amqp *amqpPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 	dir uint8, private protos.ProtocolData,
 ) protos.ProtocolData {
-	detailedf("Parse method triggered")
+	amqp.detailedf("Parse method triggered")
 
 	priv := amqpPrivateData{}
 	if private != nil {
@@ -219,12 +237,13 @@ func (amqp *amqpPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 		priv.data[dir] = &amqpStream{
 			data:    pkt.Payload,
 			message: &amqpMessage{ts: pkt.Ts},
+			logger:  amqp.amqpLogger,
 		}
 	} else {
 		// concatenate data bytes
 		priv.data[dir].data = append(priv.data[dir].data, pkt.Payload...)
 		if len(priv.data[dir].data) > tcp.TCPMaxDataInStream {
-			debugf("Stream data too large, dropping TCP stream")
+			amqp.debugf("Stream data too large, dropping TCP stream")
 			priv.data[dir] = nil
 			return priv
 		}
@@ -254,7 +273,7 @@ func (amqp *amqpPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 
 func (amqp *amqpPlugin) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
-	detailedf("GapInStream called")
+	amqp.detailedf("GapInStream called")
 	return private, true
 }
 
@@ -270,7 +289,7 @@ func (amqp *amqpPlugin) handleAmqpRequest(msg *amqpMessage) {
 	trans := amqp.getTransaction(tuple.Hashable())
 	if trans != nil {
 		if trans.amqp != nil {
-			debugf("Two requests without a Response. Dropping old request: %s", trans.amqp)
+			amqp.debugf("Two requests without a Response. Dropping old request: %s", trans.amqp)
 			unmatchedRequests.Add(1)
 		}
 	} else {
@@ -304,7 +323,7 @@ func (amqp *amqpPlugin) handleAmqpRequest(msg *amqpMessage) {
 	// any response and publish
 	if isAsynchronous(trans) {
 		amqp.publishTransaction(trans)
-		debugf("Amqp transaction completed")
+		amqp.debugf("Amqp transaction completed")
 		amqp.transactions.Delete(trans.tuple.Hashable())
 		return
 	}
@@ -319,7 +338,7 @@ func (amqp *amqpPlugin) handleAmqpResponse(msg *amqpMessage) {
 	tuple := msg.tcpTuple
 	trans := amqp.getTransaction(tuple.Hashable())
 	if trans == nil || trans.amqp == nil {
-		debugf("Response from unknown transaction. Ignoring.")
+		amqp.debugf("Response from unknown transaction. Ignoring.")
 		unmatchedResponses.Add(1)
 		return
 	}
@@ -339,7 +358,7 @@ func (amqp *amqpPlugin) handleAmqpResponse(msg *amqpMessage) {
 
 	amqp.publishTransaction(trans)
 
-	debugf("Amqp transaction completed")
+	amqp.debugf("Amqp transaction completed")
 
 	// remove from map
 	amqp.transactions.Delete(trans.tuple.Hashable())
@@ -349,7 +368,7 @@ func (amqp *amqpPlugin) handleAmqpResponse(msg *amqpMessage) {
 }
 
 func (amqp *amqpPlugin) expireTransaction(trans *amqpTransaction) {
-	debugf("Transaction expired")
+	amqp.debugf("Transaction expired")
 
 	// possibility of a connection.close or channel.close method that didn't get an
 	// ok answer. Let's publish it.
@@ -390,7 +409,7 @@ func (amqp *amqpPlugin) handlePublishing(client *amqpMessage) {
 
 	trans.amqp = client.fields
 	amqp.publishTransaction(trans)
-	debugf("Amqp transaction completed")
+	amqp.debugf("Amqp transaction completed")
 	// delete trans from map
 	amqp.transactions.Delete(trans.tuple.Hashable())
 }
@@ -428,7 +447,7 @@ func (amqp *amqpPlugin) handleDelivering(server *amqpMessage) {
 	trans.amqp = server.fields
 
 	amqp.publishTransaction(trans)
-	debugf("Amqp transaction completed")
+	amqp.debugf("Amqp transaction completed")
 	// delete trans from map
 	amqp.transactions.Delete(trans.tuple.Hashable())
 }

--- a/packetbeat/protos/amqp/amqp_fields.go
+++ b/packetbeat/protos/amqp/amqp_fields.go
@@ -30,11 +30,11 @@ import (
 
 // getTable updates fields with the table data at the given offset.
 // fields must be non_nil on entry.
-func getTable(fields mapstr.M, data []byte, offset uint32) (next uint32, err bool, exists bool) {
+func getTable(fields mapstr.M, data []byte, offset uint32, logger *logp.Logger) (next uint32, err bool, exists bool) {
 	offset64 := int64(offset)
 	dataLen64 := int64(len(data))
 	if offset64 > dataLen64 || 4 > dataLen64-offset64 {
-		logp.Debug("amqp", "Error while parsing a field table")
+		logger.Debug("Error while parsing a field table")
 		return 0, true, false
 	}
 	offsetInt := int(offset64)
@@ -53,9 +53,9 @@ func getTable(fields mapstr.M, data []byte, offset uint32) (next uint32, err boo
 		table := mapstr.M{}
 		tableStartInt := int(tableStart64)
 		tableEndInt := tableStartInt + int(length)
-		err := fieldUnmarshal(table, data[tableStartInt:tableEndInt], 0, length, -1)
+		err := fieldUnmarshal(table, data[tableStartInt:tableEndInt], 0, length, -1, logger)
 		if err {
-			logp.Debug("amqp", "Error while parsing a field table")
+			logger.Debug("Error while parsing a field table")
 			return 0, true, false
 		}
 		fields.Update(table)
@@ -65,10 +65,10 @@ func getTable(fields mapstr.M, data []byte, offset uint32) (next uint32, err boo
 
 // getTable updates fields with the array data at the given offset.
 // fields must be non_nil on entry.
-func getArray(fields mapstr.M, data []byte, offset uint32) (next uint32, err bool, exists bool) {
+func getArray(fields mapstr.M, data []byte, offset uint32, logger *logp.Logger) (next uint32, err bool, exists bool) {
 	length, err := getIntegerAt[uint32](data, offset)
 	if err {
-		logp.Debug("amqp", "Error while parsing a field table")
+		logger.Debug("Error while parsing a field table")
 		return 0, true, false
 	}
 	offset64 := int64(offset)
@@ -90,9 +90,9 @@ func getArray(fields mapstr.M, data []byte, offset uint32) (next uint32, err boo
 		array := mapstr.M{}
 		arrayStartInt := int(arrayStart64)
 		arrayEndInt := arrayStartInt + int(length)
-		err := fieldUnmarshal(array, data[arrayStartInt:arrayEndInt], 0, length, 0)
+		err := fieldUnmarshal(array, data[arrayStartInt:arrayEndInt], 0, length, 0, logger)
 		if err {
-			logp.Debug("amqp", "Error while parsing a field array")
+			logger.Debug("Error while parsing a field array")
 			return 0, true, false
 		}
 		fields.Update(array)
@@ -102,7 +102,7 @@ func getArray(fields mapstr.M, data []byte, offset uint32) (next uint32, err boo
 
 // The index parameter, when set at -1, indicates that the entry is a field table.
 // If it's set at 0, it is an array.
-func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, index int) (err bool) {
+func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, index int, logger *logp.Logger) (err bool) {
 	var name string
 
 	// Why is this returning false if attempting to offset past the length of the data?
@@ -112,9 +112,9 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	// get name of the field. If it's an array, it will be the index parameter as a
 	// string. If it's a table, it will be the name of the field.
 	if index < 0 {
-		fieldName, consumed, err := getLVString[uint8](data, offset)
+		fieldName, consumed, err := getLVString[uint8](data, offset, logger)
 		if err {
-			logp.Debug("amqp", "Failed to get short string in table")
+			logger.Debug("Failed to get short string in table")
 			return true
 		}
 		name = fieldName
@@ -135,7 +135,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case shortShortInt:
 		v, err := getIntegerAt[int8](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get int8 in table")
+			logger.Debug("Failed to get int8 in table")
 			return true
 		}
 		table[name] = v
@@ -143,7 +143,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case shortShortUint:
 		v, err := getIntegerAt[uint8](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get uint8 in table")
+			logger.Debug("Failed to get uint8 in table")
 			return true
 		}
 		table[name] = v
@@ -151,7 +151,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case shortInt:
 		v, err := getIntegerAt[int16](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get int16 in table")
+			logger.Debug("Failed to get int16 in table")
 			return true
 		}
 		table[name] = v
@@ -159,7 +159,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case shortUint:
 		v, err := getIntegerAt[uint16](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get uint16 in table")
+			logger.Debug("Failed to get uint16 in table")
 			return true
 		}
 		table[name] = v
@@ -167,7 +167,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case longInt:
 		v, err := getIntegerAt[int32](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get int32 in table")
+			logger.Debug("Failed to get int32 in table")
 			return true
 		}
 		table[name] = v
@@ -175,7 +175,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case longUint:
 		v, err := getIntegerAt[uint32](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get uint32 in table")
+			logger.Debug("Failed to get uint32 in table")
 			return true
 		}
 		table[name] = v
@@ -183,7 +183,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case longLongInt:
 		v, err := getIntegerAt[int64](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get int64 in table")
+			logger.Debug("Failed to get int64 in table")
 			return true
 		}
 		table[name] = v
@@ -191,7 +191,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case longLongUint:
 		v, err := getIntegerAt[uint64](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get uint64 in table")
+			logger.Debug("Failed to get uint64 in table")
 			return true
 		}
 		table[name] = v
@@ -199,7 +199,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case float:
 		v, err := getIntegerAt[uint32](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get float32 in table")
+			logger.Debug("Failed to get float32 in table")
 			return true
 		}
 		table[name] = math.Float32frombits(v)
@@ -207,14 +207,14 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case double:
 		v, err := getIntegerAt[uint64](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get float64 in table")
+			logger.Debug("Failed to get float64 in table")
 			return true
 		}
 		table[name] = math.Float64frombits(v)
 		offset += 9
 	case decimal:
 		if len(data) < int(offset)+6 {
-			logp.Debug("amqp", "Failed to get decimal in table")
+			logger.Debug("Failed to get decimal in table")
 			return true
 		}
 		scale := data[offset+1]
@@ -231,24 +231,24 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 		table[name] = strings.Join(ret, "")
 		offset += 6
 	case shortString:
-		s, consumed, err := getLVString[uint8](data, offset+1)
+		s, consumed, err := getLVString[uint8](data, offset+1, logger)
 		if err {
-			logp.Debug("amqp", "Failed to get short string in table")
+			logger.Debug("Failed to get short string in table")
 			return true
 		}
 		table[name] = s
 		offset += consumed + 1
 	case longString:
-		s, consumed, err := getLVString[uint32](data, offset+1)
+		s, consumed, err := getLVString[uint32](data, offset+1, logger)
 		if err {
-			logp.Debug("amqp", "Failed to get long string in table")
+			logger.Debug("Failed to get long string in table")
 			return true
 		}
 		table[name] = s
 		offset += consumed + 1
 	case fieldArray:
 		newMap := mapstr.M{}
-		next, err, _ := getArray(newMap, data, offset+1)
+		next, err, _ := getArray(newMap, data, offset+1, logger)
 		if err {
 			return true
 		}
@@ -257,7 +257,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case timestamp:
 		ts, err := getIntegerAt[int64](data, offset+1)
 		if err {
-			logp.Debug("amqp", "Failed to get timestamp in table")
+			logger.Debug("Failed to get timestamp in table")
 			return true
 		}
 		t := time.Unix(ts, 0)
@@ -265,7 +265,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 		offset += 9
 	case fieldTable:
 		newMap := mapstr.M{}
-		next, err, _ := getTable(newMap, data, offset+1)
+		next, err, _ := getTable(newMap, data, offset+1, logger)
 		if err {
 			return true
 		}
@@ -277,7 +277,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 	case byteArray:
 		size, err := getIntegerAt[uint32](data, offset+1)
 		if err || len(data) < int(offset+5+size) {
-			logp.Debug("amqp", "Failed to get byte array in table")
+			logger.Debug("Failed to get byte array in table")
 			return true
 		}
 		table[name] = bodyToByteArray(data[offset+5 : offset+5+size])
@@ -287,7 +287,7 @@ func fieldUnmarshal(table mapstr.M, data []byte, offset uint32, length uint32, i
 		return true
 	}
 	// advance to next field recursively
-	return fieldUnmarshal(table, data, offset, length, index)
+	return fieldUnmarshal(table, data, offset, length, index, logger)
 }
 
 // function to convert a body slice into a byte array

--- a/packetbeat/protos/amqp/amqp_methods.go
+++ b/packetbeat/protos/amqp/amqp_methods.go
@@ -31,29 +31,29 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-func connectionStartMethod(m *amqpMessage, args []byte) (bool, bool) {
+func connectionStartMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	if len(args) < 2 {
-		logp.Debug("amqp", "Unexpected end of data")
+		logger.Debug("Unexpected end of data")
 		return false, false
 	}
 	major := args[0]
 	minor := args[1]
 	properties := make(mapstr.M)
-	next, err, exists := getTable(properties, args, 2)
+	next, err, exists := getTable(properties, args, 2, logger)
 	if err {
 		// failed to get de peer-properties, size may be wrong, let's quit
-		logp.Debug("amqp", "Failed to parse server properties in connection.start method")
+		logger.Debug("Failed to parse server properties in connection.start method")
 		return false, false
 	}
-	mechanisms, consumed, err := getLVString[uint32](args, next)
+	mechanisms, consumed, err := getLVString[uint32](args, next, logger)
 	next += consumed
 	if err {
-		logp.Debug("amqp", "Failed to get connection mechanisms")
+		logger.Debug("Failed to get connection mechanisms")
 		return false, false
 	}
-	locales, _, err := getLVString[uint32](args, next)
+	locales, _, err := getLVString[uint32](args, next, logger)
 	if err {
-		logp.Debug("amqp", "Failed to get connection locales")
+		logger.Debug("Failed to get connection locales")
 		return false, false
 	}
 	m.method = "connection.start"
@@ -71,29 +71,29 @@ func connectionStartMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func connectionStartOkMethod(m *amqpMessage, args []byte) (bool, bool) {
+func connectionStartOkMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	properties := make(mapstr.M)
-	next, err, exists := getTable(properties, args, 0)
+	next, err, exists := getTable(properties, args, 0, logger)
 	if err {
 		// failed to get de peer-properties, size may be wrong, let's quit
-		logp.Debug("amqp", "Failed to parse server properties in connection.start method")
+		logger.Debug("Failed to parse server properties in connection.start method")
 		return false, false
 	}
-	mechanism, consumed, err := getLVString[uint8](args, next)
+	mechanism, consumed, err := getLVString[uint8](args, next, logger)
 	next += consumed
 	if err {
-		logp.Debug("amqp", "Failed to get connection mechanism from client")
+		logger.Debug("Failed to get connection mechanism from client")
 		return false, false
 	}
-	_, consumed, err = getLVString[uint32](args, next)
+	_, consumed, err = getLVString[uint32](args, next, logger)
 	next += consumed
 	if err {
-		logp.Debug("amqp", "Failed to get connection response from client")
+		logger.Debug("Failed to get connection response from client")
 		return false, false
 	}
-	locale, _, err := getLVString[uint8](args, next)
+	locale, _, err := getLVString[uint8](args, next, logger)
 	if err {
-		logp.Debug("amqp", "Failed to get connection locale from client")
+		logger.Debug("Failed to get connection locale from client")
 		return false, false
 	}
 	m.isRequest = false
@@ -108,7 +108,7 @@ func connectionStartOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func connectionTuneMethod(m *amqpMessage, args []byte) (bool, bool) {
+func connectionTuneMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	m.isRequest = true
 	m.method = "connection.tune"
 	// parameters are not parsed here, they are further negotiated by the server
@@ -116,7 +116,7 @@ func connectionTuneMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func connectionTuneOkMethod(m *amqpMessage, args []byte) (bool, bool) {
+func connectionTuneOkMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	channelMax, err := getIntegerAt[uint16](args, 0)
 	if err {
 		return false, false
@@ -137,20 +137,20 @@ func connectionTuneOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func connectionOpenMethod(m *amqpMessage, args []byte) (bool, bool) {
+func connectionOpenMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	m.isRequest = true
 	m.method = "connection.open"
-	host, _, err := getLVString[uint8](args, 0)
+	host, _, err := getLVString[uint8](args, 0, logger)
 	if err {
-		logp.Debug("amqp", "Failed to get virtual host from client")
+		logger.Debug("Failed to get virtual host from client")
 		return false, false
 	}
 	m.fields = mapstr.M{"virtual-host": host}
 	return true, true
 }
 
-func connectionCloseMethod(m *amqpMessage, args []byte) (bool, bool) {
-	err := getCloseInfo(args, m)
+func connectionCloseMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
+	err := getCloseInfo(args, m, logger)
 	if err {
 		return false, false
 	}
@@ -159,19 +159,19 @@ func connectionCloseMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func channelOpenMethod(m *amqpMessage, args []byte) (bool, bool) {
+func channelOpenMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	m.method = "channel.open"
 	m.isRequest = true
 	return true, true
 }
 
-func channelFlowMethod(m *amqpMessage, args []byte) (bool, bool) {
+func channelFlowMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	m.method = "channel.flow"
 	m.isRequest = true
 	return true, true
 }
 
-func channelFlowOkMethod(m *amqpMessage, args []byte) (bool, bool) {
+func channelFlowOkMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	params, err := getBitParamsAt(args, 0)
 	if err {
 		return false, false
@@ -180,10 +180,10 @@ func channelFlowOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func channelCloseMethod(m *amqpMessage, args []byte) (bool, bool) {
+func channelCloseMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	m.method = "channel.close"
 	m.isRequest = true
-	err := getCloseInfo(args, m)
+	err := getCloseInfo(args, m, logger)
 	if err {
 		return false, false
 	}
@@ -191,26 +191,26 @@ func channelCloseMethod(m *amqpMessage, args []byte) (bool, bool) {
 }
 
 // function to fetch fields from channel close and connection close
-func getCloseInfo(args []byte, m *amqpMessage) bool {
+func getCloseInfo(args []byte, m *amqpMessage, logger *logp.Logger) bool {
 	code, err := getIntegerAt[uint16](args, 0)
 	if err {
-		logp.Debug("amqp", "Failed to get close info code")
+		logger.Debug("Failed to get close info code")
 		return err
 	}
 	m.isRequest = true
-	replyText, consumed, err := getLVString[uint8](args, 2)
+	replyText, consumed, err := getLVString[uint8](args, 2, logger)
 	if err {
-		logp.Debug("amqp", "Failed to get close info reply text")
+		logger.Debug("Failed to get close info reply text")
 		return err
 	}
 	classID, err := getIntegerAt[uint16](args, consumed+2)
 	if err {
-		logp.Debug("amqp", "Failed to get close info class-id")
+		logger.Debug("Failed to get close info class-id")
 		return err
 	}
 	methodID, err := getIntegerAt[uint16](args, consumed+4)
 	if err {
-		logp.Debug("amqp", "Failed to get close info method-id")
+		logger.Debug("Failed to get close info method-id")
 		return err
 	}
 
@@ -223,19 +223,19 @@ func getCloseInfo(args []byte, m *amqpMessage) bool {
 	return false
 }
 
-func queueDeclareMethod(m *amqpMessage, args []byte) (bool, bool) {
+func queueDeclareMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	name, consumed, err := getLVString[uint8](args, offset)
+	name, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue declaration")
+		logger.Debug("Error getting name of queue in queue declaration")
 		return false, false
 	}
 	m.isRequest = true
 	m.method = "queue.declare"
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in queue declaration")
+		logger.Debug("Error getting params in queue declaration")
 		return false, false
 	}
 	m.request = name
@@ -248,12 +248,12 @@ func queueDeclareMethod(m *amqpMessage, args []byte) (bool, bool) {
 		"no-wait":     params[4],
 	}
 	if len(args) <= int(offset+1) {
-		logp.Debug("amqp", "Expected end of frame or arguments in queue declaration")
+		logger.Debug("Expected end of frame or arguments in queue declaration")
 		return false, false
 	}
 	if args[offset+1] != frameEndOctet && m.parseArguments {
 		arguments := make(mapstr.M)
-		_, err, exists := getTable(arguments, args, offset+1)
+		_, err, exists := getTable(arguments, args, offset+1, logger)
 		if !err && exists {
 			m.fields["arguments"] = arguments
 		} else if err {
@@ -263,10 +263,10 @@ func queueDeclareMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func queueDeclareOkMethod(m *amqpMessage, args []byte) (bool, bool) {
-	name, offset, err := getLVString[uint8](args, 0)
+func queueDeclareOkMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
+	name, offset, err := getLVString[uint8](args, 0, logger)
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue confirmation")
+		logger.Debug("Error getting name of queue in queue confirmation")
 		return false, false
 	}
 	messageCount, err := getIntegerAt[uint32](args, offset)
@@ -286,30 +286,30 @@ func queueDeclareOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func queueBindMethod(m *amqpMessage, args []byte) (bool, bool) {
+func queueBindMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	queue, consumed, err := getLVString[uint8](args, offset)
+	queue, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue bind")
+		logger.Debug("Error getting name of queue in queue bind")
 		return false, false
 	}
 	m.isRequest = true
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue bind")
+		logger.Debug("Error getting name of queue in queue bind")
 		return false, false
 	}
-	routingKey, consumed, err := getLVString[uint8](args, offset)
+	routingKey, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue bind")
+		logger.Debug("Error getting name of queue in queue bind")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in queue bind")
+		logger.Debug("Error getting params in queue bind")
 		return false, false
 	}
 	m.method = "queue.bind"
@@ -323,12 +323,12 @@ func queueBindMethod(m *amqpMessage, args []byte) (bool, bool) {
 		m.fields["exchange"] = exchange
 	}
 	if len(args) <= int(offset+1) {
-		logp.Debug("amqp", "Expected end of frame or arguments in queue bind")
+		logger.Debug("Expected end of frame or arguments in queue bind")
 		return false, false
 	}
 	if args[offset+1] != frameEndOctet && m.parseArguments {
 		arguments := make(mapstr.M)
-		_, err, exists := getTable(arguments, args, offset+1)
+		_, err, exists := getTable(arguments, args, offset+1, logger)
 		if !err && exists {
 			m.fields["arguments"] = arguments
 		} else if err {
@@ -338,24 +338,24 @@ func queueBindMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func queueUnbindMethod(m *amqpMessage, args []byte) (bool, bool) {
+func queueUnbindMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	queue, consumed, err := getLVString[uint8](args, offset)
+	queue, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue unbind")
+		logger.Debug("Error getting name of queue in queue unbind")
 		return false, false
 	}
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue unbind")
+		logger.Debug("Error getting name of queue in queue unbind")
 		return false, false
 	}
-	routingKey, consumed, err := getLVString[uint8](args, offset)
+	routingKey, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue unbind")
+		logger.Debug("Error getting name of queue in queue unbind")
 		return false, false
 	}
 	m.isRequest = true
@@ -369,12 +369,12 @@ func queueUnbindMethod(m *amqpMessage, args []byte) (bool, bool) {
 		m.fields["exchange"] = exchange
 	}
 	if len(args) <= int(offset+1) {
-		logp.Debug("amqp", "Expected end of frame or arguments in queue unbind")
+		logger.Debug("Expected end of frame or arguments in queue unbind")
 		return false, false
 	}
 	if args[offset+1] != frameEndOctet && m.parseArguments {
 		arguments := make(mapstr.M)
-		_, err, exists := getTable(arguments, args, offset+1)
+		_, err, exists := getTable(arguments, args, offset+1, logger)
 		if !err && exists {
 			m.fields["arguments"] = arguments
 		} else if err {
@@ -384,18 +384,18 @@ func queueUnbindMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func queuePurgeMethod(m *amqpMessage, args []byte) (bool, bool) {
+func queuePurgeMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	queue, consumed, err := getLVString[uint8](args, offset)
+	queue, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue purge")
+		logger.Debug("Error getting name of queue in queue purge")
 		return false, false
 	}
 	m.isRequest = true
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in queue purge")
+		logger.Debug("Error getting params in queue purge")
 		return false, false
 	}
 	m.method = "queue.purge"
@@ -407,7 +407,7 @@ func queuePurgeMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func queuePurgeOkMethod(m *amqpMessage, args []byte) (bool, bool) {
+func queuePurgeOkMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	messageCount, err := getIntegerAt[uint32](args, 0)
 	if err {
 		return false, false
@@ -419,18 +419,18 @@ func queuePurgeOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func queueDeleteMethod(m *amqpMessage, args []byte) (bool, bool) {
+func queueDeleteMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	queue, consumed, err := getLVString[uint8](args, offset)
+	queue, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in queue delete")
+		logger.Debug("Error getting name of queue in queue delete")
 		return false, false
 	}
 	m.isRequest = true
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in queue delete")
+		logger.Debug("Error getting params in queue delete")
 		return false, false
 	}
 	m.method = "queue.delete"
@@ -444,7 +444,7 @@ func queueDeleteMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func queueDeleteOkMethod(m *amqpMessage, args []byte) (bool, bool) {
+func queueDeleteOkMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	messageCount, err := getIntegerAt[uint32](args, 0)
 	if err {
 		return false, false
@@ -456,23 +456,23 @@ func queueDeleteOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func exchangeDeclareMethod(m *amqpMessage, args []byte) (bool, bool) {
+func exchangeDeclareMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of exchange in exchange declare")
+		logger.Debug("Error getting name of exchange in exchange declare")
 		return false, false
 	}
-	exchangeType, consumed, err := getLVString[uint8](args, offset)
+	exchangeType, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of routing key in exchange declare")
+		logger.Debug("Error getting name of routing key in exchange declare")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in exchange declare")
+		logger.Debug("Error getting params in exchange declare")
 		return false, false
 	}
 	m.method = "exchange.declare"
@@ -489,12 +489,12 @@ func exchangeDeclareMethod(m *amqpMessage, args []byte) (bool, bool) {
 		"no-wait":       params[4],
 	}
 	if len(args) <= int(offset+1) {
-		logp.Debug("amqp", "Error getting name of routing key in exchange declare")
+		logger.Debug("Error getting name of routing key in exchange declare")
 		return false, false
 	}
 	if args[offset+1] != frameEndOctet && m.parseArguments {
 		arguments := make(mapstr.M)
-		_, err, exists := getTable(arguments, args, offset+1)
+		_, err, exists := getTable(arguments, args, offset+1, logger)
 		if !err && exists {
 			m.fields["arguments"] = arguments
 		} else if err {
@@ -504,19 +504,19 @@ func exchangeDeclareMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func exchangeDeleteMethod(m *amqpMessage, args []byte) (bool, bool) {
+func exchangeDeleteMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of exchange in exchange delete")
+		logger.Debug("Error getting name of exchange in exchange delete")
 		return false, false
 	}
 	m.method = "exchange.delete"
 	m.isRequest = true
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in exchange delete")
+		logger.Debug("Error getting params in exchange delete")
 		return false, false
 	}
 	m.request = exchange
@@ -529,9 +529,9 @@ func exchangeDeleteMethod(m *amqpMessage, args []byte) (bool, bool) {
 }
 
 // this is a method exclusive to RabbitMQ
-func exchangeBindMethod(m *amqpMessage, args []byte) (bool, bool) {
+func exchangeBindMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	m.method = "exchange.bind"
-	err := exchangeBindUnbindInfo(m, args)
+	err := exchangeBindUnbindInfo(m, args, logger)
 	if err {
 		return false, false
 	}
@@ -539,39 +539,39 @@ func exchangeBindMethod(m *amqpMessage, args []byte) (bool, bool) {
 }
 
 // this is a method exclusive to RabbitMQ
-func exchangeUnbindMethod(m *amqpMessage, args []byte) (bool, bool) {
+func exchangeUnbindMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	m.method = "exchange.unbind"
-	err := exchangeBindUnbindInfo(m, args)
+	err := exchangeBindUnbindInfo(m, args, logger)
 	if err {
 		return false, false
 	}
 	return true, true
 }
 
-func exchangeBindUnbindInfo(m *amqpMessage, args []byte) bool {
+func exchangeBindUnbindInfo(m *amqpMessage, args []byte, logger *logp.Logger) bool {
 	offset := uint32(2)
-	destination, consumed, err := getLVString[uint8](args, offset)
+	destination, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of destination in exchange bind/unbind")
+		logger.Debug("Error getting name of destination in exchange bind/unbind")
 		return true
 	}
-	source, consumed, err := getLVString[uint8](args, offset)
+	source, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of source in exchange bind/unbind")
+		logger.Debug("Error getting name of source in exchange bind/unbind")
 		return true
 	}
-	routingKey, consumed, err := getLVString[uint8](args, offset)
+	routingKey, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of routing-key in exchange bind/unbind")
+		logger.Debug("Error getting name of routing-key in exchange bind/unbind")
 		return true
 	}
 	m.isRequest = true
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in exchange bind/unbind")
+		logger.Debug("Error getting params in exchange bind/unbind")
 		return true
 	}
 	m.request = strings.Join([]string{source, destination}, " ")
@@ -583,12 +583,12 @@ func exchangeBindUnbindInfo(m *amqpMessage, args []byte) bool {
 	}
 
 	if len(args) <= int(offset+1) {
-		logp.Debug("amqp", "Error getting args in exchange bind/unbind")
+		logger.Debug("Error getting args in exchange bind/unbind")
 		return true
 	}
 	if args[offset+1] != frameEndOctet && m.parseArguments {
 		arguments := make(mapstr.M)
-		_, err, exists := getTable(arguments, args, offset+1)
+		_, err, exists := getTable(arguments, args, offset+1, logger)
 		if !err && exists {
 			m.fields["arguments"] = arguments
 		} else if err {
@@ -598,20 +598,20 @@ func exchangeBindUnbindInfo(m *amqpMessage, args []byte) bool {
 	return false
 }
 
-func basicQosMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicQosMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	prefetchSize, err := getIntegerAt[uint32](args, 0)
 	if err {
-		logp.Debug("amqp", "Error getting prefetch-size in basic qos")
+		logger.Debug("Error getting prefetch-size in basic qos")
 		return false, false
 	}
 	prefetchCount, err := getIntegerAt[uint16](args, 4)
 	if err {
-		logp.Debug("amqp", "Error getting prefetch-count in basic qos")
+		logger.Debug("Error getting prefetch-count in basic qos")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, 6)
 	if err {
-		logp.Debug("amqp", "Error getting params in basic qos")
+		logger.Debug("Error getting params in basic qos")
 		return false, false
 	}
 	m.isRequest = true
@@ -624,23 +624,23 @@ func basicQosMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicConsumeMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicConsumeMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	queue, consumed, err := getLVString[uint8](args, offset)
+	queue, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in basic consume")
+		logger.Debug("Error getting name of queue in basic consume")
 		return false, false
 	}
-	consumerTag, consumed, err := getLVString[uint8](args, offset)
+	consumerTag, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of consumer tag in basic consume")
+		logger.Debug("Error getting name of consumer tag in basic consume")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in basic consume")
+		logger.Debug("Error getting params in basic consume")
 		return false, false
 	}
 	m.method = "basic.consume"
@@ -655,12 +655,12 @@ func basicConsumeMethod(m *amqpMessage, args []byte) (bool, bool) {
 		"no-wait":      params[3],
 	}
 	if len(args) <= int(offset+1) {
-		logp.Debug("amqp", "Expected end of frame or arguments in basic consume")
+		logger.Debug("Expected end of frame or arguments in basic consume")
 		return false, false
 	}
 	if args[offset+1] != frameEndOctet && m.parseArguments {
 		arguments := make(mapstr.M)
-		_, err, exists := getTable(arguments, args, offset+1)
+		_, err, exists := getTable(arguments, args, offset+1, logger)
 		if !err && exists {
 			m.fields["arguments"] = arguments
 		} else if err {
@@ -670,10 +670,10 @@ func basicConsumeMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicConsumeOkMethod(m *amqpMessage, args []byte) (bool, bool) {
-	consumerTag, _, err := getLVString[uint8](args, 0)
+func basicConsumeOkMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
+	consumerTag, _, err := getLVString[uint8](args, 0, logger)
 	if err {
-		logp.Debug("amqp", "Error getting name of queue in basic consume")
+		logger.Debug("Error getting name of queue in basic consume")
 		return false, false
 	}
 	m.method = "basic.consume-ok"
@@ -683,10 +683,10 @@ func basicConsumeOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicCancelMethod(m *amqpMessage, args []byte) (bool, bool) {
-	consumerTag, offset, err := getLVString[uint8](args, 0)
+func basicCancelMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
+	consumerTag, offset, err := getLVString[uint8](args, 0, logger)
 	if err {
-		logp.Debug("amqp", "Error getting consumer tag in basic cancel")
+		logger.Debug("Error getting consumer tag in basic cancel")
 		return false, false
 	}
 	m.method = "basic.cancel"
@@ -694,7 +694,7 @@ func basicCancelMethod(m *amqpMessage, args []byte) (bool, bool) {
 	m.request = consumerTag
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in basic cancel")
+		logger.Debug("Error getting params in basic cancel")
 		return false, false
 	}
 	m.fields = mapstr.M{
@@ -704,10 +704,10 @@ func basicCancelMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicCancelOkMethod(m *amqpMessage, args []byte) (bool, bool) {
-	consumerTag, _, err := getLVString[uint8](args, 0)
+func basicCancelOkMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
+	consumerTag, _, err := getLVString[uint8](args, 0, logger)
 	if err {
-		logp.Debug("amqp", "Error getting consumer tag in basic cancel ok")
+		logger.Debug("Error getting consumer tag in basic cancel ok")
 		return false, false
 	}
 	m.method = "basic.cancel-ok"
@@ -717,23 +717,23 @@ func basicCancelOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicPublishMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicPublishMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting exchange in basic publish")
+		logger.Debug("Error getting exchange in basic publish")
 		return false, false
 	}
-	routingKey, consumed, err := getLVString[uint8](args, offset)
+	routingKey, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting routing key in basic publish")
+		logger.Debug("Error getting routing key in basic publish")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Error getting params in basic publish")
+		logger.Debug("Error getting params in basic publish")
 		return false, false
 	}
 	m.method = "basic.publish"
@@ -749,10 +749,10 @@ func basicPublishMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, false
 }
 
-func basicReturnMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicReturnMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	code, err := getIntegerAt[uint16](args, 0)
 	if err {
-		logp.Debug("amqp", "Error getting code in basic return")
+		logger.Debug("Error getting code in basic return")
 		return false, false
 	}
 	if code < 300 {
@@ -760,21 +760,21 @@ func basicReturnMethod(m *amqpMessage, args []byte) (bool, bool) {
 		return true, false
 	}
 	offset := uint32(2)
-	replyText, consumed, err := getLVString[uint8](args, offset)
+	replyText, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of reply text in basic return")
+		logger.Debug("Error getting name of reply text in basic return")
 		return false, false
 	}
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Error getting name of exchange in basic return")
+		logger.Debug("Error getting name of exchange in basic return")
 		return false, false
 	}
-	routingKey, _, err := getLVString[uint8](args, offset)
+	routingKey, _, err := getLVString[uint8](args, offset, logger)
 	if err {
-		logp.Debug("amqp", "Error getting name of routing key in basic return")
+		logger.Debug("Error getting name of routing key in basic return")
 		return false, false
 	}
 	m.method = "basic.return"
@@ -787,29 +787,29 @@ func basicReturnMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, false
 }
 
-func basicDeliverMethod(m *amqpMessage, args []byte) (bool, bool) {
-	consumerTag, offset, err := getLVString[uint8](args, 0)
+func basicDeliverMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
+	consumerTag, offset, err := getLVString[uint8](args, 0, logger)
 	if err {
-		logp.Debug("amqp", "Failed to get consumer tag in basic deliver")
+		logger.Debug("Failed to get consumer tag in basic deliver")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, offset+8)
 	if err {
-		logp.Debug("amqp", "Failed to get params in basic deliver")
+		logger.Debug("Failed to get params in basic deliver")
 		return false, false
 	}
 	// Saving the len check since this is before params in the args so it's guaranteed to be in bounds
 	deliveryTag := binary.BigEndian.Uint64(args[offset : offset+8])
 	offset = offset + 9
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Failed to get exchange in basic deliver")
+		logger.Debug("Failed to get exchange in basic deliver")
 		return false, false
 	}
-	routingKey, _, err := getLVString[uint8](args, offset)
+	routingKey, _, err := getLVString[uint8](args, offset, logger)
 	if err {
-		logp.Debug("amqp", "Failed to get routing key in basic deliver")
+		logger.Debug("Failed to get routing key in basic deliver")
 		return false, false
 	}
 	m.method = "basic.deliver"
@@ -826,18 +826,18 @@ func basicDeliverMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, false
 }
 
-func basicGetMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicGetMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	offset := uint32(2)
-	queue, consumed, err := getLVString[uint8](args, offset)
+	queue, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Failed to get queue in basic get method")
+		logger.Debug("Failed to get queue in basic get method")
 		return false, false
 	}
 	m.method = "basic.get"
 	params, err := getBitParamsAt(args, offset)
 	if err {
-		logp.Debug("amqp", "Failed to get params in basic get method")
+		logger.Debug("Failed to get params in basic get method")
 		return false, false
 	}
 	m.isRequest = true
@@ -849,24 +849,24 @@ func basicGetMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicGetOkMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicGetOkMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	params, err := getBitParamsAt(args, 8)
 	if err {
-		logp.Debug("amqp", "Failed to get params in basic get-ok")
+		logger.Debug("Failed to get params in basic get-ok")
 		return false, false
 
 	}
 	offset := uint32(9)
-	exchange, consumed, err := getLVString[uint8](args, offset)
+	exchange, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Failed to get queue in basic get-ok")
+		logger.Debug("Failed to get queue in basic get-ok")
 		return false, false
 	}
-	routingKey, consumed, err := getLVString[uint8](args, offset)
+	routingKey, consumed, err := getLVString[uint8](args, offset, logger)
 	offset += consumed
 	if err {
-		logp.Debug("amqp", "Failed to get routing key in basic get-ok")
+		logger.Debug("Failed to get routing key in basic get-ok")
 		return false, false
 	}
 	m.method = "basic.get-ok"
@@ -890,20 +890,20 @@ func basicGetOkMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, false
 }
 
-func basicGetEmptyMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicGetEmptyMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	m.method = "basic.get-empty"
 	return true, true
 }
 
-func basicAckMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicAckMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	deliveryTag, err := getIntegerAt[uint64](args, 0)
 	if err {
-		logp.Debug("amqp", "Failed to get delivery-tag in basic ack")
+		logger.Debug("Failed to get delivery-tag in basic ack")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, 8)
 	if err {
-		logp.Debug("amqp", "Failed to get params in basic ack")
+		logger.Debug("Failed to get params in basic ack")
 		return false, false
 
 	}
@@ -917,15 +917,15 @@ func basicAckMethod(m *amqpMessage, args []byte) (bool, bool) {
 }
 
 // this is a rabbitMQ specific method
-func basicNackMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicNackMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	deliveryTag, err := getIntegerAt[uint64](args, 0)
 	if err {
-		logp.Debug("amqp", "Failed to get delivery-tag in basic nack")
+		logger.Debug("Failed to get delivery-tag in basic nack")
 		return false, false
 	}
 	params, err := getBitParamsAt(args, 8)
 	if err {
-		logp.Debug("amqp", "Failed to get params in basic nack")
+		logger.Debug("Failed to get params in basic nack")
 		return false, false
 
 	}
@@ -939,10 +939,10 @@ func basicNackMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicRejectMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicRejectMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	params, err := getBitParamsAt(args, 8)
 	if err {
-		logp.Debug("amqp", "Failed to get params in basic reject")
+		logger.Debug("Failed to get params in basic reject")
 		return false, false
 	}
 	// Saving the len check since this is before params in the args so it's guaranteed to be in bounds
@@ -957,10 +957,10 @@ func basicRejectMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func basicRecoverMethod(m *amqpMessage, args []byte) (bool, bool) {
+func basicRecoverMethod(m *amqpMessage, args []byte, logger *logp.Logger) (bool, bool) {
 	params, err := getBitParamsAt(args, 0)
 	if err {
-		logp.Debug("amqp", "Failed to get params in basic recover")
+		logger.Debug("Failed to get params in basic recover")
 		return false, false
 	}
 	m.isRequest = true
@@ -971,26 +971,26 @@ func basicRecoverMethod(m *amqpMessage, args []byte) (bool, bool) {
 	return true, true
 }
 
-func txSelectMethod(m *amqpMessage, args []byte) (bool, bool) {
+func txSelectMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	m.isRequest = true
 	m.method = "tx.select"
 	return true, true
 }
 
-func txCommitMethod(m *amqpMessage, args []byte) (bool, bool) {
+func txCommitMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	m.isRequest = true
 	m.method = "tx.commit"
 	return true, true
 }
 
-func txRollbackMethod(m *amqpMessage, args []byte) (bool, bool) {
+func txRollbackMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	m.isRequest = true
 	m.method = "tx.rollback"
 	return true, true
 }
 
 // simple function used when server/client responds to a sync method with no new info
-func okMethod(m *amqpMessage, args []byte) (bool, bool) {
+func okMethod(m *amqpMessage, args []byte, _ *logp.Logger) (bool, bool) {
 	return true, true
 }
 
@@ -999,7 +999,7 @@ func okMethod(m *amqpMessage, args []byte) (bool, bool) {
 // length and string, or if the offset itself is out of bounds. if length == 0
 // the function sends back an empty string. bytesConsumed represents the number
 // of bytes of the returned string + 1 for the length itself,
-func getLVString[T uint8 | uint16 | uint32](data []byte, offset uint32) (short string, bytesConsumed uint32, err bool) {
+func getLVString[T uint8 | uint16 | uint32](data []byte, offset uint32, logger *logp.Logger) (short string, bytesConsumed uint32, err bool) {
 	var length T
 	if len(data) == 0 {
 		return "", 0, true
@@ -1033,7 +1033,7 @@ func getLVString[T uint8 | uint16 | uint32](data []byte, offset uint32) (short s
 
 	start64 := offset64 + lengthSize64
 	if strlen64 > dataLen64-start64 {
-		logp.Debug("amqp", "Not enough data for string")
+		logger.Debug("Not enough data for string")
 		return "", 0, true
 	}
 	if strlen > ^uint32(0)-lengthSize {

--- a/packetbeat/protos/amqp/amqp_parser.go
+++ b/packetbeat/protos/amqp/amqp_parser.go
@@ -30,18 +30,18 @@ func (amqp *amqpPlugin) amqpMessageParser(s *amqpStream) (ok bool, complete bool
 	for s.parseOffset < len(s.data) {
 
 		if len(s.data[s.parseOffset:]) < 8 {
-			logp.Debug("amqp", "AMQP message smaller than a frame, waiting for more data")
+			amqp.amqpLogger.Debug("AMQP message smaller than a frame, waiting for more data")
 			return true, false
 		}
 
 		yes, version := isProtocolHeader(s.data[s.parseOffset:])
 		if yes {
-			debugf("Client header detected, version %d.%d.%d",
+			amqp.debugf("Client header detected, version %d.%d.%d",
 				version[0], version[1], version[2])
 			s.parseOffset += 8
 		}
 
-		f, err := readFrameHeader(s.data[s.parseOffset:])
+		f, err := readFrameHeader(s.data[s.parseOffset:], amqp.amqpLogger)
 		if err {
 			// incorrect header
 			return false, false
@@ -58,9 +58,9 @@ func (amqp *amqpPlugin) amqpMessageParser(s *amqpStream) (ok bool, complete bool
 		case bodyType:
 			ok, complete = s.decodeBodyFrame(f.content)
 		case heartbeatType:
-			detailedf("Heartbeat frame received")
+			amqp.detailedf("Heartbeat frame received")
 		default:
-			logp.Debug("amqp", "Received unknown AMQP frame")
+			amqp.amqpLogger.Debug("Received unknown AMQP frame")
 			return false, false
 		}
 
@@ -84,19 +84,19 @@ func isProtocolHeader(data []byte) (isHeader bool, version string) {
 }
 
 // func to read a frame header and check if it is valid and complete
-func readFrameHeader(data []byte) (ret *amqpFrame, err bool) {
+func readFrameHeader(data []byte, logger *logp.Logger) (ret *amqpFrame, err bool) {
 	var frame amqpFrame
 	if len(data) < 8 {
-		logp.Debug("amqp", "Partial frame header, waiting for more data")
+		logger.Debug("Partial frame header, waiting for more data")
 		return nil, false
 	}
 	frame.size = binary.BigEndian.Uint32(data[3:7])
 	if len(data) < int(frame.size)+8 {
-		logp.Debug("amqp", "Frame shorter than declared size, waiting for more data")
+		logger.Debug("Frame shorter than declared size, waiting for more data")
 		return nil, false
 	}
 	if data[frame.size+7] != frameEndOctet {
-		logp.Debug("amqp", "Missing frame end octet in frame, discarding it")
+		logger.Debug("Missing frame end octet in frame, discarding it")
 		return nil, true
 	}
 	frame.Type = frameType(data[0])
@@ -120,7 +120,7 @@ The Method Payload, according to official doc :
 
 func (amqp *amqpPlugin) decodeMethodFrame(s *amqpStream, buf []byte) (bool, bool) {
 	if len(buf) < 4 {
-		logp.Debug("amqp", "Method frame too small, waiting for more data")
+		amqp.amqpLogger.Debug("Method frame too small, waiting for more data")
 		return true, false
 	}
 	class := codeClass(binary.BigEndian.Uint16(buf[0:2]))
@@ -129,15 +129,15 @@ func (amqp *amqpPlugin) decodeMethodFrame(s *amqpStream, buf []byte) (bool, bool
 	s.message.parseArguments = amqp.parseArguments
 	s.message.bodySize = uint64(len(buf[4:]))
 
-	debugf("Received frame of class %d and method %d", class, method)
+	amqp.debugf("Received frame of class %d and method %d", class, method)
 
 	fn, exists := amqp.methodMap[class][method]
 	if !exists {
-		logp.Debug("amqpdetailed", "Received unknown or not supported method")
+		amqp.amqpDetailedLogger.Debug("Received unknown or not supported method")
 		return false, false
 	}
 
-	return fn(s.message, arguments)
+	return fn(s.message, arguments, amqp.amqpLogger)
 }
 
 /*
@@ -151,11 +151,11 @@ Structure of a content header, according to official doc :
 
 func (amqp *amqpPlugin) decodeHeaderFrame(s *amqpStream, buf []byte) bool {
 	if len(buf) < 14 {
-		logp.Debug("amqp", "Header frame too small, waiting for mode data")
+		amqp.amqpLogger.Debug("Header frame too small, waiting for more data")
 		return true
 	}
 	s.message.bodySize = binary.BigEndian.Uint64(buf[4:12])
-	debugf("Received Header frame. A message of %d bytes is expected", s.message.bodySize)
+	amqp.debugf("Received Header frame. A message of %d bytes is expected", s.message.bodySize)
 
 	if amqp.parseHeaders {
 		err := getMessageProperties(s, buf[12:])
@@ -176,7 +176,7 @@ Structure of a body frame, according to official doc :
 func (s *amqpStream) decodeBodyFrame(buf []byte) (ok bool, complete bool) {
 	s.message.body = append(s.message.body, buf...)
 
-	debugf("A body frame of %d bytes long has been transmitted",
+	s.logger.Debugf("A body frame of %d bytes long has been transmitted",
 		len(buf))
 	// is the message complete ? If yes, let's publish it
 
@@ -193,7 +193,7 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	m := s.message
 
 	if len(data) < 2 {
-		logp.Debug("amqp", "Malformed packet: unexpected end of data")
+		s.logger.Debug("Malformed packet: unexpected end of data")
 		return true
 	}
 
@@ -212,17 +212,17 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 			break
 		}
 		if lastbit >= len(data) {
-			logp.Debug("amqp", "Malformed packet: unexpected end of data")
+			s.logger.Debug("Malformed packet: unexpected end of data")
 			return true
 		}
 	}
 
-	logp.Debug("amqp", "offset:%d, lastbit:%d", offset, lastbit)
+	s.logger.Debugf("offset:%d, lastbit:%d", offset, lastbit)
 
 	if hasProperty(prop1, contentTypeProp) {
-		contentType, consumed, err := getLVString[uint8](data, offset)
+		contentType, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get content type in header frame")
+			s.logger.Debug("Failed to get content type in header frame")
 			return true
 		}
 		m.fields["content-type"] = contentType
@@ -230,9 +230,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop1, contentEncodingProp) {
-		contentEncoding, consumed, err := getLVString[uint8](data, offset)
+		contentEncoding, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get content encoding in header frame")
+			s.logger.Debug("Failed to get content encoding in header frame")
 			return true
 		}
 		m.fields["content-encoding"] = contentEncoding
@@ -241,15 +241,15 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 
 	if hasProperty(prop1, headersProp) {
 		if int(offset) >= len(data) {
-			logp.Debug("amqp", "Malformed packet: unexpected end of data")
+			s.logger.Debug("Malformed packet: unexpected end of data")
 			return true
 		}
 		headers := mapstr.M{}
-		next, err, exists := getTable(headers, data, offset)
+		next, err, exists := getTable(headers, data, offset, s.logger)
 		if !err && exists {
 			m.fields["headers"] = headers
 		} else if err {
-			logp.Debug("amqp", "Failed to get headers")
+			s.logger.Debug("Failed to get headers")
 			return true
 		}
 		offset = next
@@ -257,7 +257,7 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 
 	if hasProperty(prop1, deliveryModeProp) {
 		if int(offset) >= len(data) {
-			logp.Debug("amqp", "Malformed packet: unexpected end of data")
+			s.logger.Debug("Malformed packet: unexpected end of data")
 			return true
 		}
 		switch data[offset] {
@@ -271,7 +271,7 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 
 	if hasProperty(prop1, priorityProp) {
 		if int(offset) >= len(data) {
-			logp.Debug("amqp", "Malformed packet: unexpected end of data")
+			s.logger.Debug("Malformed packet: unexpected end of data")
 			return true
 		}
 		m.fields["priority"] = data[offset]
@@ -279,9 +279,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop1, correlationIDProp) {
-		correlationID, consumed, err := getLVString[uint8](data, offset)
+		correlationID, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get correlation-id in header frame")
+			s.logger.Debug("Failed to get correlation-id in header frame")
 			return true
 		}
 		m.fields["correlation-id"] = correlationID
@@ -289,9 +289,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop1, replyToProp) {
-		replyTo, consumed, err := getLVString[uint8](data, offset)
+		replyTo, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get reply-to in header frame")
+			s.logger.Debug("Failed to get reply-to in header frame")
 			return true
 		}
 		m.fields["reply-to"] = replyTo
@@ -299,9 +299,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop1, expirationProp) {
-		expiration, consumed, err := getLVString[uint8](data, offset)
+		expiration, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get expiration in header frame")
+			s.logger.Debug("Failed to get expiration in header frame")
 			return true
 		}
 		m.fields["expiration"] = expiration
@@ -309,9 +309,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop2, messageIDProp) {
-		messageID, consumed, err := getLVString[uint8](data, offset)
+		messageID, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get message id in header frame")
+			s.logger.Debug("Failed to get message id in header frame")
 			return true
 		}
 		m.fields["message-id"] = messageID
@@ -321,7 +321,7 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	if hasProperty(prop2, timestampProp) {
 		timeInt, err := getIntegerAt[int64](data, offset)
 		if err {
-			logp.Debug("amqp", "Malformed packet: unexpected end of data")
+			s.logger.Debug("Malformed packet: unexpected end of data")
 			return true
 		}
 		t := time.Unix(timeInt, 0)
@@ -330,9 +330,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop2, typeProp) {
-		msgType, consumed, err := getLVString[uint8](data, offset)
+		msgType, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get message type in header frame")
+			s.logger.Debug("Failed to get message type in header frame")
 			return true
 		}
 		m.fields["type"] = msgType
@@ -340,9 +340,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop2, userIDProp) {
-		userID, consumed, err := getLVString[uint8](data, offset)
+		userID, consumed, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get user id in header frame")
+			s.logger.Debug("Failed to get user id in header frame")
 			return true
 		}
 		m.fields["user-id"] = userID
@@ -350,9 +350,9 @@ func getMessageProperties(s *amqpStream, data []byte) bool {
 	}
 
 	if hasProperty(prop2, appIDProp) {
-		appID, _, err := getLVString[uint8](data, offset)
+		appID, _, err := getLVString[uint8](data, offset, s.logger)
 		if err {
-			logp.Debug("amqp", "Failed to get app-id in header frame")
+			s.logger.Debug("Failed to get app-id in header frame")
 			return true
 		}
 		m.fields["app-id"] = appID
@@ -364,7 +364,7 @@ func (amqp *amqpPlugin) handleAmqp(m *amqpMessage, tcptuple *common.TCPTuple, di
 	if amqp.mustHideCloseMethod(m) {
 		return
 	}
-	debugf("A message is ready to be handled")
+	amqp.debugf("A message is ready to be handled")
 	m.tcpTuple = *tcptuple
 	m.direction = dir
 	m.cmdlineTuple = amqp.watcher.FindProcessesTupleTCP(tcptuple.IPPort())

--- a/packetbeat/protos/amqp/amqp_parser.go
+++ b/packetbeat/protos/amqp/amqp_parser.go
@@ -27,6 +27,9 @@ import (
 )
 
 func (amqp *amqpPlugin) amqpMessageParser(s *amqpStream) (ok bool, complete bool) {
+	if s.logger == nil {
+		s.logger = amqp.amqpLogger
+	}
 	for s.parseOffset < len(s.data) {
 
 		if len(s.data[s.parseOffset:]) < 8 {
@@ -133,7 +136,7 @@ func (amqp *amqpPlugin) decodeMethodFrame(s *amqpStream, buf []byte) (bool, bool
 
 	fn, exists := amqp.methodMap[class][method]
 	if !exists {
-		amqp.amqpDetailedLogger.Debug("Received unknown or not supported method")
+		amqp.detailedf("Received unknown or not supported method")
 		return false, false
 	}
 

--- a/packetbeat/protos/amqp/amqp_structs.go
+++ b/packetbeat/protos/amqp/amqp_structs.go
@@ -21,10 +21,11 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-type amqpMethod func(*amqpMessage, []byte) (bool, bool)
+type amqpMethod func(*amqpMessage, []byte, *logp.Logger) (bool, bool)
 
 const (
 	transactionsHashSize = 1 << 16
@@ -218,6 +219,7 @@ type amqpStream struct {
 	data        []byte
 	parseOffset int
 	message     *amqpMessage
+	logger      *logp.Logger
 }
 
 // contains the result of parsing

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -48,11 +48,12 @@ func (e *eventStore) publish(event beat.Event) {
 }
 
 func amqpModForTests() (*eventStore, *amqpPlugin, error) {
-	var amqp amqpPlugin
 	results := &eventStore{}
-	config := defaultConfig
-	err := amqp.init(results.publish, &procs.ProcessesWatcher{}, &config)
-	return results, &amqp, err
+	plugin, err := New(true, results.publish, &procs.ProcessesWatcher{}, nil, logp.L())
+	if err != nil {
+		return nil, nil, err
+	}
+	return results, plugin.(*amqpPlugin), nil
 }
 
 func testTCPTuple() *common.TCPTuple {

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	"github.com/elastic/beats/v7/packetbeat/procs"
@@ -1248,7 +1249,7 @@ func TestAmqp_BasicReturnMethod_ParsesOffsets(t *testing.T) {
 		0x02, 'r', 'k', // routing-key
 	}
 
-	ok, complete := basicReturnMethod(m, args)
+	ok, complete := basicReturnMethod(m, args, logptest.NewTestingLogger(t, ""))
 	assert.True(t, ok)
 	assert.False(t, complete)
 	assert.Equal(t, "basic.return", m.method)
@@ -1268,7 +1269,7 @@ func TestAmqp_BasicGetOkMethod_ParsesOffsets(t *testing.T) {
 		0x00, 0x00, 0x00, 0x05, // message-count = 5
 	}
 
-	ok, complete := basicGetOkMethod(m, args)
+	ok, complete := basicGetOkMethod(m, args, logptest.NewTestingLogger(t, ""))
 	assert.True(t, ok)
 	assert.False(t, complete)
 	assert.Equal(t, "basic.get-ok", m.method)
@@ -1285,7 +1286,7 @@ func TestAmqp_GetTable_EmptyTableAtEndOfData(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // table length = 0
 	}
 
-	next, err, exists := getTable(fields, data, 1)
+	next, err, exists := getTable(fields, data, 1, logptest.NewTestingLogger(t, ""))
 	assert.False(t, err)
 	assert.False(t, exists)
 	assert.Equal(t, uint32(5), next)
@@ -1298,7 +1299,7 @@ func TestAmqp_OverflowValidation_GetLVStringUint32OffsetWrap(t *testing.T) {
 	data := []byte{0, 0, 0, 1, 'x'}
 	var err bool
 	assert.NotPanics(t, func() {
-		_, _, err = getLVString[uint32](data, math.MaxUint32-1)
+		_, _, err = getLVString[uint32](data, math.MaxUint32-1, logptest.NewTestingLogger(t, ""))
 	})
 	assert.True(t, err)
 }
@@ -1313,7 +1314,7 @@ func TestAmqp_OverflowValidation_GetTableOffsetWrap(t *testing.T) {
 		exists bool
 	)
 	assert.NotPanics(t, func() {
-		next, err, exists = getTable(fields, data, math.MaxUint32-1)
+		next, err, exists = getTable(fields, data, math.MaxUint32-1, logptest.NewTestingLogger(t, ""))
 	})
 	assert.True(t, err)
 	assert.False(t, exists)
@@ -1330,7 +1331,7 @@ func TestAmqp_OverflowValidation_GetArrayOffsetWrap(t *testing.T) {
 		exists bool
 	)
 	assert.NotPanics(t, func() {
-		next, err, exists = getArray(fields, data, math.MaxUint32-1)
+		next, err, exists = getArray(fields, data, math.MaxUint32-1, logptest.NewTestingLogger(t, ""))
 	})
 	assert.True(t, err)
 	assert.False(t, exists)

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -187,7 +187,7 @@ func (cassandra *cassandra) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int,
 	private protos.ProtocolData,
 ) (protos.ProtocolData, bool) {
-	conn := getConnection(private)
+	conn := getConnection(private, cassandra.logger)
 	if conn != nil {
 		cassandra.onDropConnection(conn)
 	}
@@ -201,7 +201,7 @@ func (cassandra *cassandra) onDropConnection(conn *connection) {
 }
 
 func (cassandra *cassandra) ensureConnection(private protos.ProtocolData) *connection {
-	conn := getConnection(private)
+	conn := getConnection(private, cassandra.logger)
 	if conn == nil {
 		conn = &connection{}
 		conn.trans.init(&cassandra.transConfig, cassandra.watcher, cassandra.pub.onTransaction, cassandra.logger)
@@ -209,18 +209,18 @@ func (cassandra *cassandra) ensureConnection(private protos.ProtocolData) *conne
 	return conn
 }
 
-func getConnection(private protos.ProtocolData) *connection {
+func getConnection(private protos.ProtocolData, logger *logp.Logger) *connection {
 	if private == nil {
 		return nil
 	}
 
 	priv, ok := private.(*connection)
 	if !ok {
-		logp.Warn("cassandra connection type error")
+		logger.Warn("cassandra connection type error")
 		return nil
 	}
 	if priv == nil {
-		logp.Warn("Unexpected: cassandra connection data not set")
+		logger.Warn("Unexpected: cassandra connection data not set")
 		return nil
 	}
 	return priv

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -82,6 +82,7 @@ func New(
 	return p, nil
 }
 
+//go:inline
 func (cassandra *cassandra) debugf(format string, args ...interface{}) {
 	if cassandra.isDebug {
 		cassandra.logger.Debugf(format, args...)

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -38,6 +38,8 @@ type cassandra struct {
 	transConfig  transactionConfig
 	watcher      *procs.ProcessesWatcher
 	pub          transPub
+	logger       *logp.Logger
+	isDebug      bool
 }
 
 // Application Layer tcp stream data to be stored on tcp connection context.
@@ -50,8 +52,6 @@ type connection struct {
 type stream struct {
 	parser parser
 }
-
-var debugf = logp.MakeDebug("cassandra")
 
 func init() {
 	protos.Register("cassandra", New)
@@ -66,6 +66,9 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &cassandra{}
+	p.logger = logger
+	p.isDebug = p.logger.IsDebug()
+
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -77,6 +80,12 @@ func New(
 		return nil, err
 	}
 	return p, nil
+}
+
+func (cassandra *cassandra) debugf(format string, args ...interface{}) {
+	if cassandra.isDebug {
+		cassandra.logger.Debugf(format, args...)
+	}
 }
 
 func (cassandra *cassandra) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *cassandraConfig) error {
@@ -112,7 +121,7 @@ func (cassandra *cassandra) setFromConfig(config *cassandraConfig) error {
 			maps[op] = true
 		}
 		parser.ignoredOps = maps
-		debugf("parsed config IgnoredOPs: %v ", parser.ignoredOps)
+		cassandra.debugf("parsed config IgnoredOPs: %v ", parser.ignoredOps)
 	}
 
 	// set transaction correlator configuration
@@ -153,12 +162,12 @@ func (cassandra *cassandra) Parse(
 		st = &stream{}
 		st.parser.init(&cassandra.parserConfig, func(msg *message) error {
 			return conn.trans.onMessage(tcptuple.IPPort(), dir, msg)
-		})
+		}, cassandra.logger)
 		conn.streams[dir] = st
 	}
 
 	if err := st.parser.feed(pkt.Ts, pkt.Payload); err != nil {
-		debugf("%v, dropping TCP stream for error in direction %v.", err, dir)
+		cassandra.debugf("%v, dropping TCP stream for error in direction %v.", err, dir)
 		cassandra.onDropConnection(conn)
 		return nil
 	}
@@ -195,7 +204,7 @@ func (cassandra *cassandra) ensureConnection(private protos.ProtocolData) *conne
 	conn := getConnection(private)
 	if conn == nil {
 		conn = &connection{}
-		conn.trans.init(&cassandra.transConfig, cassandra.watcher, cassandra.pub.onTransaction)
+		conn.trans.init(&cassandra.transConfig, cassandra.watcher, cassandra.pub.onTransaction, cassandra.logger)
 	}
 	return conn
 }

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -29,7 +29,6 @@ import (
 
 var (
 	ErrFrameTooBig = errors.New("frame length is bigger than the maximum allowed")
-	debugf         = logp.MakeDebug("cassandra")
 )
 
 type frameHeader struct {
@@ -76,11 +75,14 @@ type Framer struct {
 	r *streambuf.Buffer
 
 	decoder Decoder
+
+	logger *logp.Logger
 }
 
-func NewFramer(r *streambuf.Buffer, compressor Compressor) *Framer {
+func NewFramer(r *streambuf.Buffer, compressor Compressor, logger *logp.Logger) *Framer {
 	f := framerPool.Get().(*Framer)
 	f.compres = compressor
+	f.logger = logger
 	f.r = r
 
 	return f
@@ -159,7 +161,7 @@ func (f *Framer) ReadHeader() (head *frameHeader, err error) {
 	headSize := f.r.BufferConsumed()
 	head.HeadLength = headSize
 
-	debugf("header: %v", head)
+	f.logger.Debugf("header: %v", head)
 
 	f.Header = head
 	return head, nil
@@ -195,7 +197,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	// the frame body. The rest of the body will then be the usual body
 	// corresponding to the response opcode.
 	if f.Header.Flags&flagTracing == flagTracing && (f.Header.Op&opQuery == opQuery || f.Header.Op&opExecute == opExecute || f.Header.Op&opPrepare == opPrepare) {
-		debugf("tracing enabled")
+		f.logger.Debugf("tracing enabled")
 
 		// seems no UUID to read, protocol incorrect?
 		// uid := decoder.ReadUUID()
@@ -203,7 +205,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	}
 
 	if f.Header.Flags&flagWarning == flagWarning {
-		debugf("hit warning flags")
+		f.logger.Debugf("hit warning flags")
 
 		warnings := decoder.ReadStringList()
 		// dealing with warnings
@@ -211,7 +213,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	}
 
 	if f.Header.Flags&flagCustomPayload == flagCustomPayload {
-		debugf("hit custom payload flags")
+		f.logger.Debugf("hit custom payload flags")
 
 		f.Header.CustomPayload = decoder.ReadBytesMap()
 	}
@@ -234,7 +236,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 		decoder.Data = &dec
 		f.decoder = decoder
 
-		debugf("hit compress flags")
+		f.logger.Debugf("hit compress flags")
 	}
 
 	// assumes that the frame body has been read into rbuf
@@ -266,7 +268,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 
 	default:
 		// ignore
-		debugf("unknow ops, not processed, %v", f.Header)
+		f.logger.Debugf("unknow ops, not processed, %v", f.Header)
 
 	}
 

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -154,7 +154,7 @@ func (f *Framer) ReadHeader() (head *frameHeader, err error) {
 		return nil, fmt.Errorf("frame body length can not be less than 0: %d", head.BodyLength)
 	} else if head.BodyLength > maxFrameSize {
 		// need to free up the connection to be used again
-		logp.Err("head length is too large")
+		f.logger.Errorf("head length is too large")
 		return nil, ErrFrameTooBig
 	}
 
@@ -221,7 +221,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	if f.Header.Flags&flagCompress == flagCompress {
 		// decompress data and switch to use bytearray decoder
 		if f.compres == nil {
-			logp.Err("hit compress flag, but compressor was not set")
+			f.logger.Errorf("hit compress flag, but compressor was not set")
 			panic(errors.New("hit compress flag, but compressor was not set"))
 		}
 
@@ -358,7 +358,7 @@ func (f *Framer) parseErrorFrame() (data map[string]interface{}) {
 		errProtocol, errServer, errSyntax, errTruncate, errUnauthorized:
 		// ignored
 	default:
-		logp.Err("unknown error code: 0x%x", code)
+		f.logger.Errorf("unknown error code: 0x%x", code)
 	}
 
 	if len(detail) > 0 {
@@ -458,7 +458,7 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 
 	uuid, err := UUIDFromBytes((f.decoder).ReadShortBytes())
 	if err != nil {
-		logp.Err("Error in parsing UUID")
+		f.logger.Errorf("Error in parsing UUID")
 	}
 
 	result["prepared_id"] = uuid.String()
@@ -506,7 +506,7 @@ func (f *Framer) parseResultSchemaChange() (data map[string]interface{}) {
 			data["args"] = decoder.ReadStringList()
 
 		default:
-			logp.Warn("unknown SCHEMA_CHANGE target: %q change: %q", target, change)
+			f.logger.Warnf("unknown SCHEMA_CHANGE target: %q change: %q", target, change)
 		}
 	}
 	return data
@@ -553,7 +553,7 @@ func (f *Framer) parseEventFrame() (data map[string]interface{}) {
 		// this should work for all versions
 		data["schema_change"] = f.parseResultSchemaChange()
 	default:
-		logp.Err("unknown event type: %q", eventType)
+		f.logger.Errorf("unknown event type: %q", eventType)
 	}
 
 	return data

--- a/packetbeat/protos/cassandra/internal/gocql/marshal.go
+++ b/packetbeat/protos/cassandra/internal/gocql/marshal.go
@@ -351,11 +351,13 @@ const (
 
 type protoVersion byte
 
-func (p protoVersion) IsRequest() bool {
+func (p protoVersion) IsRequest(logger *logp.Logger) bool {
 	v := p.version()
 
 	if v < protoVersion1 || v > protoVersion4 {
-		logp.Err("unsupported request version: %x", v)
+		if logger != nil {
+			logger.Errorf("unsupported request version: %x", v)
+		}
 	}
 
 	if v == protoVersion4 {
@@ -369,11 +371,13 @@ func (p protoVersion) IsRequest() bool {
 	return p == 0x00
 }
 
-func (p protoVersion) IsResponse() bool {
+func (p protoVersion) IsResponse(logger *logp.Logger) bool {
 	v := p.version()
 
 	if v < protoVersion1 || v > protoVersion4 {
-		logp.Err("unsupported response version: %x", v)
+		if logger != nil {
+			logger.Errorf("unsupported response version: %x", v)
+		}
 	}
 
 	if v == protoVersion4 {
@@ -393,7 +397,7 @@ func (p protoVersion) version() byte {
 
 func (p protoVersion) String() string {
 	dir := "REQ"
-	if p.IsResponse() {
+	if p.IsResponse(nil) {
 		dir = "RESP"
 	}
 

--- a/packetbeat/protos/cassandra/parser.go
+++ b/packetbeat/protos/cassandra/parser.go
@@ -230,7 +230,7 @@ func (p *parser) parse() (*message, error) {
 	if p.CheckFrameOpsIgnored() {
 		// as we already ignore the content, we now mark the result is ignored
 		p.message.ignored = true
-		p.debugf("Ops: %s was marked to be ignored, ignoring, request:%v", p.framer.Header.Op.String(), p.framer.Header.Version.IsRequest())
+		p.debugf("Ops: %s was marked to be ignored, ignoring, request:%v", p.framer.Header.Op.String(), p.framer.Header.Version.IsRequest(p.logger))
 	}
 
 	msg := p.message
@@ -248,7 +248,7 @@ func (p *parser) parse() (*message, error) {
 	dir := applayer.NetOriginalDirection
 
 	isRequest := true
-	if p.framer.Header.Version.IsResponse() {
+	if p.framer.Header.Version.IsResponse(p.logger) {
 		dir = applayer.NetReverseDirection
 		isRequest = false
 	}

--- a/packetbeat/protos/cassandra/parser.go
+++ b/packetbeat/protos/cassandra/parser.go
@@ -70,7 +70,6 @@ type message struct {
 // Error code if stream exceeds max allowed size on append.
 var (
 	errStreamTooLarge = errors.New("Stream data too large")
-	isDebug           = false
 )
 
 func (p *parser) init(
@@ -162,9 +161,7 @@ func (p *parser) parserBody() (bool, error) {
 
 	// check if the ops already ignored
 	if p.message.ignored {
-		if isDebug {
-			p.debugf("message marked to be ignored, let's do this")
-		}
+		p.debugf("message marked to be ignored, let's do this")
 		p.buf.Collect(bdyLen)
 	} else {
 		// start to parse body
@@ -183,7 +180,7 @@ func (p *parser) parserBody() (bool, error) {
 		if unParsedSize > 0 {
 			if !p.buf.Avail(unParsedSize) {
 				err := errors.New("should be enough bytes for cleanup,but not enough")
-				logp.Err("Finishing frame failed with: %v", err)
+				p.logger.Errorf("Finishing frame failed with: %v", err)
 				return false, err
 			}
 
@@ -195,7 +192,7 @@ func (p *parser) parserBody() (bool, error) {
 
 	finalCollectedFrameLength := p.buf.BufferConsumed()
 	if finalCollectedFrameLength-headLen != bdyLen {
-		logp.Err("body_length:%d, head_length:%d, all_consumed:%d",
+		p.logger.Errorf("body_length:%d, head_length:%d, all_consumed:%d",
 			bdyLen, headLen, finalCollectedFrameLength)
 		return false, errors.New("data messed while parse frame body")
 	}
@@ -223,7 +220,7 @@ func (p *parser) parse() (*message, error) {
 
 		_, err := p.framer.ReadHeader()
 		if err != nil {
-			logp.Err("%v", err)
+			p.logger.Errorf("%v", err)
 			p.framer = nil
 			return nil, err
 		}

--- a/packetbeat/protos/cassandra/parser.go
+++ b/packetbeat/protos/cassandra/parser.go
@@ -34,6 +34,8 @@ type parser struct {
 	framer    *gocql.Framer
 	message   *message
 	onMessage func(m *message) error
+	logger    *logp.Logger
+	isDebug   bool
 }
 
 type parserConfig struct {
@@ -74,14 +76,22 @@ var (
 func (p *parser) init(
 	cfg *parserConfig,
 	onMessage func(*message) error,
+	logger *logp.Logger,
 ) {
 	*p = parser{
 		buf:       streambuf.Buffer{},
 		config:    cfg,
 		onMessage: onMessage,
+		logger:    logger, // the incoming logger is the cassandra logger
+		isDebug:   logger.IsDebug(),
 	}
 
-	isDebug = logp.IsDebug("cassandra")
+}
+
+func (p *parser) debugf(format string, args ...interface{}) {
+	if p.isDebug {
+		p.logger.Debugf(format, args...)
+	}
 }
 
 func (p *parser) append(data []byte) error {
@@ -144,18 +154,16 @@ func (p *parser) parserBody() (bool, error) {
 	}
 
 	// let's wait for enough buf
-	debugf("bodyLength: %d", bdyLen)
+	p.debugf("bodyLength: %d", bdyLen)
 	if !p.buf.Avail(bdyLen) {
-		if isDebug {
-			debugf("buf not enough for body, waiting for more, return")
-		}
+		p.debugf("buf not enough for body, waiting for more, return")
 		return false, nil
 	}
 
 	// check if the ops already ignored
 	if p.message.ignored {
 		if isDebug {
-			debugf("message marked to be ignored, let's do this")
+			p.debugf("message marked to be ignored, let's do this")
 		}
 		p.buf.Collect(bdyLen)
 	} else {
@@ -198,19 +206,18 @@ func (p *parser) parserBody() (bool, error) {
 func (p *parser) parse() (*message, error) {
 	// if p.frame is nil then create a new framer, or continue to process the last message
 	if p.framer == nil {
-		if isDebug {
-			debugf("start new framer")
+		if p.isDebug {
+			p.debugf("start new framer")
 		}
-		p.framer = gocql.NewFramer(&p.buf, p.config.compressor)
+		p.framer = gocql.NewFramer(&p.buf, p.config.compressor, p.logger)
 	}
 
 	// check if the frame header were parsed or not
 	if p.framer.Header == nil {
-		if isDebug {
-			debugf("start to parse header")
-		}
+		p.debugf("start to parse header")
+
 		if !p.buf.Avail(9) {
-			debugf("not enough head bytes, ignore")
+			p.debugf("not enough head bytes, ignore")
 			return nil, nil
 		}
 
@@ -226,9 +233,7 @@ func (p *parser) parse() (*message, error) {
 	if p.CheckFrameOpsIgnored() {
 		// as we already ignore the content, we now mark the result is ignored
 		p.message.ignored = true
-		if isDebug {
-			debugf("Ops: %s was marked to be ignored, ignoring, request:%v", p.framer.Header.Op.String(), p.framer.Header.Version.IsRequest())
-		}
+		p.debugf("Ops: %s was marked to be ignored, ignoring, request:%v", p.framer.Header.Op.String(), p.framer.Header.Version.IsRequest())
 	}
 
 	msg := p.message

--- a/packetbeat/protos/cassandra/trans.go
+++ b/packetbeat/protos/cassandra/trans.go
@@ -35,6 +35,8 @@ type transactions struct {
 	onTransaction transactionHandler
 
 	watcher *procs.ProcessesWatcher
+
+	logger *logp.Logger
 }
 
 type transactionConfig struct {
@@ -48,10 +50,11 @@ type messageList struct {
 	head, tail *message
 }
 
-func (trans *transactions) init(c *transactionConfig, watcher *procs.ProcessesWatcher, cb transactionHandler) {
+func (trans *transactions) init(c *transactionConfig, watcher *procs.ProcessesWatcher, cb transactionHandler, logger *logp.Logger) {
 	trans.config = c
 	trans.watcher = watcher
 	trans.onTransaction = cb
+	trans.logger = logger
 }
 
 func (trans *transactions) onMessage(
@@ -66,12 +69,12 @@ func (trans *transactions) onMessage(
 
 	if msg.IsRequest {
 		if isDebug {
-			debugf("Received request with tuple: %s", tuple)
+			trans.logger.Debugf("Received request with tuple: %s", tuple)
 		}
 		err = trans.onRequest(tuple, dir, msg)
 	} else {
 		if isDebug {
-			debugf("Received response with tuple: %s", tuple)
+			trans.logger.Debugf("Received response with tuple: %s", tuple)
 		}
 		err = trans.onResponse(tuple, dir, msg)
 	}
@@ -157,7 +160,7 @@ func (trans *transactions) correlate() error {
 
 			if resp.header["op"] == "EVENT" {
 				if isDebug {
-					logp.Debug("cassandra", "server pushed message,%v", resp.header)
+					trans.logger.Debugf("server pushed message,%v", resp.header)
 				}
 
 				responses.pop()

--- a/packetbeat/protos/cassandra/trans.go
+++ b/packetbeat/protos/cassandra/trans.go
@@ -68,15 +68,11 @@ func (trans *transactions) onMessage(
 	msg.CmdlineTuple = trans.watcher.FindProcessesTupleTCP(&msg.Tuple)
 
 	if msg.IsRequest {
-		if isDebug {
-			trans.logger.Debugf("Received request with tuple: %s", tuple)
-		}
-		err = trans.onRequest(tuple, dir, msg)
+		trans.logger.Debugf("Received request with tuple: %s", tuple)
+		err = trans.onRequest(msg)
 	} else {
-		if isDebug {
-			trans.logger.Debugf("Received response with tuple: %s", tuple)
-		}
-		err = trans.onResponse(tuple, dir, msg)
+		trans.logger.Debugf("Received response with tuple: %s", tuple)
+		err = trans.onResponse(msg)
 	}
 
 	return err
@@ -85,8 +81,6 @@ func (trans *transactions) onMessage(
 // onRequest handles request messages, merging with incomplete requests
 // and adding non-merged requests into the correlation list.
 func (trans *transactions) onRequest(
-	tuple *common.IPPortTuple,
-	dir uint8,
 	msg *message,
 ) error {
 	prev := trans.requests.last()
@@ -110,8 +104,6 @@ func (trans *transactions) onRequest(
 // onRequest handles response messages, merging with incomplete requests
 // and adding non-merged responses into the correlation list.
 func (trans *transactions) onResponse(
-	tuple *common.IPPortTuple,
-	dir uint8,
 	msg *message,
 ) error {
 	prev := trans.responses.last()
@@ -159,9 +151,7 @@ func (trans *transactions) correlate() error {
 			}
 
 			if resp.header["op"] == "EVENT" {
-				if isDebug {
-					trans.logger.Debugf("server pushed message,%v", resp.header)
-				}
+				trans.logger.Debugf("server pushed message,%v", resp.header)
 
 				responses.pop()
 
@@ -172,7 +162,7 @@ func (trans *transactions) correlate() error {
 				return nil
 			}
 
-			logp.Warn("Response from unknown transaction. Ignoring. %v", resp.header)
+			trans.logger.Warnf("Response from unknown transaction. Ignoring. %v", resp.header)
 			responses.pop()
 		}
 		return nil

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -100,11 +100,6 @@ type httpPlugin struct {
 	logger, httpLogger, httpDetailedLogger *logp.Logger
 }
 
-var (
-	isDebug    = false
-	isDetailed = false
-)
-
 func init() {
 	protos.Register("http", New)
 }
@@ -271,7 +266,7 @@ func (http *httpPlugin) Parse(
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	conn := ensureHTTPConnection(private)
+	conn := ensureHTTPConnection(private, http.logger)
 	conn = http.doParse(conn, pkt, tcptuple, dir)
 	if conn == nil {
 		return nil
@@ -279,26 +274,26 @@ func (http *httpPlugin) Parse(
 	return conn
 }
 
-func ensureHTTPConnection(private protos.ProtocolData) *httpConnectionData {
-	conn := getHTTPConnection(private)
+func ensureHTTPConnection(private protos.ProtocolData, logger *logp.Logger) *httpConnectionData {
+	conn := getHTTPConnection(private, logger)
 	if conn == nil {
 		conn = &httpConnectionData{}
 	}
 	return conn
 }
 
-func getHTTPConnection(private protos.ProtocolData) *httpConnectionData {
+func getHTTPConnection(private protos.ProtocolData, logger *logp.Logger) *httpConnectionData {
 	if private == nil {
 		return nil
 	}
 
 	priv, ok := private.(*httpConnectionData)
 	if !ok {
-		logp.Warn("http connection data type error")
+		logger.Warn("http connection data type error")
 		return nil
 	}
 	if priv == nil {
-		logp.Warn("Unexpected: http connection data not set")
+		logger.Warn("Unexpected: http connection data not set")
 		return nil
 	}
 
@@ -378,7 +373,7 @@ func (http *httpPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
 	http.debugf("Received FIN")
-	conn := getHTTPConnection(private)
+	conn := getHTTPConnection(private, http.logger)
 	if conn == nil {
 		return private
 	}
@@ -405,7 +400,7 @@ func (http *httpPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 func (http *httpPlugin) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool,
 ) {
-	conn := getHTTPConnection(private)
+	conn := getHTTPConnection(private, http.logger)
 	if conn == nil {
 		return private, false
 	}
@@ -548,7 +543,7 @@ func (http *httpPlugin) newTransaction(requ, resp *message) beat.Event {
 		http.decodeBody(requ)
 		path, params, err := http.extractParameters(requ)
 		if err != nil {
-			logp.Warn("Fail to parse HTTP parameters: %v", err)
+			http.logger.Warnf("Fail to parse HTTP parameters: %v", err)
 		}
 
 		pbf.Source.Bytes = int64(requ.size)
@@ -872,7 +867,7 @@ func (http *httpPlugin) isSecretParameter(key string) bool {
 }
 
 func (http *httpPlugin) Expired(tuple *common.TCPTuple, private protos.ProtocolData) {
-	conn := getHTTPConnection(private)
+	conn := getHTTPConnection(private, http.logger)
 	if conn == nil {
 		return
 	}

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -335,7 +335,7 @@ func (http *httpPlugin) doParse(
 			st.message = &message{ts: pkt.Ts}
 		}
 
-		parser := newParser(&http.parserConfig, http.logger)
+		parser := newParser(&http.parserConfig, http.httpLogger, http.httpDetailedLogger)
 		ok, complete := parser.parse(st, extraMsgSize)
 		extraMsgSize = 0
 		if !ok {

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -98,6 +98,7 @@ type httpPlugin struct {
 	results                                protos.Reporter
 	watcher                                *procs.ProcessesWatcher
 	logger, httpLogger, httpDetailedLogger *logp.Logger
+	isDebug, isDetail                      bool
 }
 
 func init() {
@@ -115,6 +116,7 @@ func New(
 	p.logger = logger
 	p.httpLogger = logger.Named("http")
 	p.httpDetailedLogger = logger.Named("httpdetailed")
+	p.isDebug, p.isDetail = p.httpLogger.IsDebug(), p.httpDetailedLogger.IsDebug()
 
 	config := defaultConfig
 	if !testMode {
@@ -131,14 +133,14 @@ func New(
 
 //go:inline
 func (p *httpPlugin) debugf(format string, args ...interface{}) {
-	if p.httpLogger.IsDebug() {
+	if p.isDebug {
 		p.httpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
 func (p *httpPlugin) detailedf(format string, args ...interface{}) {
-	if p.httpDetailedLogger.IsDebug() {
+	if p.isDetail {
 		p.httpDetailedLogger.Debugf(format, args...)
 	}
 }

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -40,11 +40,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
-var (
-	debugf    = logp.MakeDebug("http")
-	detailedf = logp.MakeDebug("httpdetailed")
-)
-
 type parserState uint8
 
 const (
@@ -100,8 +95,9 @@ type httpPlugin struct {
 
 	transactionTimeout time.Duration
 
-	results protos.Reporter
-	watcher *procs.ProcessesWatcher
+	results                                protos.Reporter
+	watcher                                *procs.ProcessesWatcher
+	logger, httpLogger, httpDetailedLogger *logp.Logger
 }
 
 var (
@@ -121,6 +117,10 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &httpPlugin{}
+	p.logger = logger
+	p.httpLogger = logger.Named("http")
+	p.httpDetailedLogger = logger.Named("httpdetailed")
+
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -134,12 +134,24 @@ func New(
 	return p, nil
 }
 
+//go:inline
+func (p *httpPlugin) debugf(format string, args ...interface{}) {
+	if p.httpLogger.IsDebug() {
+		p.httpLogger.Debugf(format, args...)
+	}
+}
+
+//go:inline
+func (p *httpPlugin) detailedf(format string, args ...interface{}) {
+	if p.httpDetailedLogger.IsDebug() {
+		p.httpDetailedLogger.Debugf(format, args...)
+	}
+}
+
 // Init initializes the HTTP protocol analyser.
 func (http *httpPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *httpConfig) error {
 	http.setFromConfig(config)
 
-	isDebug = logp.IsDebug("http")
-	isDetailed = logp.IsDebug("httpdetailed")
 	http.results = results
 	http.watcher = watcher
 	return nil
@@ -199,9 +211,7 @@ func (http *httpPlugin) messageGap(s *stream, nbytes int) (ok bool, complete boo
 		// we know we cannot recover from these
 		return false, false
 	case stateBody:
-		if isDebug {
-			debugf("gap in body: %d", nbytes)
-		}
+		http.debugf("gap in body: %d", nbytes)
 
 		if m.isRequest {
 			if !m.packetLossReq {
@@ -302,9 +312,7 @@ func (http *httpPlugin) doParse(
 	tcptuple *common.TCPTuple,
 	dir uint8,
 ) *httpConnectionData {
-	if isDetailed {
-		detailedf("Payload received: [%s]", pkt.Payload)
-	}
+	http.detailedf("Payload received: [%s]", pkt.Payload)
 
 	extraMsgSize := 0 // size of a "seen" packet for which we don't store the actual bytes
 
@@ -320,9 +328,7 @@ func (http *httpPlugin) doParse(
 			totalLength += len(msg.body)
 		}
 		if totalLength > http.maxMessageSize {
-			if isDebug {
-				debugf("Stream data too large, ignoring message")
-			}
+			http.debugf("Stream data too large, ignoring message")
 			extraMsgSize = len(pkt.Payload)
 		} else {
 			st.data = append(st.data, pkt.Payload...)
@@ -334,7 +340,7 @@ func (http *httpPlugin) doParse(
 			st.message = &message{ts: pkt.Ts}
 		}
 
-		parser := newParser(&http.parserConfig)
+		parser := newParser(&http.parserConfig, http.logger)
 		ok, complete := parser.parse(st, extraMsgSize)
 		extraMsgSize = 0
 		if !ok {
@@ -371,7 +377,7 @@ func newStream(pkt *protos.Packet, tcptuple *common.TCPTuple) *stream {
 func (http *httpPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	debugf("Received FIN")
+	http.debugf("Received FIN")
 	conn := getHTTPConnection(private)
 	if conn == nil {
 		return private
@@ -411,9 +417,7 @@ func (http *httpPlugin) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	}
 
 	ok, complete := http.messageGap(stream, nbytes)
-	if isDetailed {
-		detailedf("messageGap returned ok=%v complete=%v", ok, complete)
-	}
+	http.detailedf("messageGap returned ok=%v complete=%v", ok, complete)
 	if !ok {
 		// on errors, drop stream
 		conn.streams[dir] = nil
@@ -446,14 +450,10 @@ func (http *httpPlugin) handleHTTP(
 	http.hideHeaders(m)
 
 	if m.isRequest {
-		if isDebug {
-			debugf("Received request with tuple: %s", m.tcpTuple)
-		}
+		http.debugf("Received request with tuple: %s", m.tcpTuple)
 		conn.requests.append(m)
 	} else {
-		if isDebug {
-			debugf("Received response with tuple: %s", m.tcpTuple)
-		}
+		http.debugf("Received response with tuple: %s", m.tcpTuple)
 		conn.responses.append(m)
 		http.correlate(conn)
 	}
@@ -463,10 +463,10 @@ func (http *httpPlugin) flushResponses(conn *httpConnectionData) {
 	for !conn.responses.empty() {
 		unmatchedResponses.Add(1)
 		resp := conn.responses.pop()
-		debugf("Response from unknown transaction: %s. Reporting error.", resp.tcpTuple)
+		http.debugf("Response from unknown transaction: %s. Reporting error.", resp.tcpTuple)
 
 		if resp.statusCode == 100 {
-			debugf("Drop first 100-continue response")
+			http.debugf("Drop first 100-continue response")
 			return
 		}
 
@@ -479,7 +479,7 @@ func (http *httpPlugin) flushRequests(conn *httpConnectionData) {
 	for !conn.requests.empty() {
 		unmatchedRequests.Add(1)
 		requ := conn.requests.pop()
-		debugf("Request from unknown transaction %s. Reporting error.", requ.tcpTuple)
+		http.debugf("Request from unknown transaction %s. Reporting error.", requ.tcpTuple)
 		event := http.newTransaction(requ, nil)
 		http.publishTransaction(event)
 	}
@@ -498,9 +498,7 @@ func (http *httpPlugin) correlate(conn *httpConnectionData) {
 		resp := conn.responses.pop()
 		event := http.newTransaction(requ, resp)
 
-		if isDebug {
-			debugf("HTTP transaction completed")
-		}
+		http.debugf("HTTP transaction completed")
 		http.publishTransaction(event)
 	}
 }
@@ -686,7 +684,7 @@ func (http *httpPlugin) decodeBody(m *message) {
 	if m.saveBody && len(m.body) > 0 {
 		if http.mustDecodeBody && len(m.encodings) > 0 {
 			var err error
-			m.body, err = decodeBody(m.body, m.encodings, http.maxMessageSize)
+			m.body, err = decodeBody(m.body, m.encodings, http.maxMessageSize, http.httpLogger)
 			if err != nil {
 				// Body can contain partial data
 				m.notes = append(m.notes, err.Error())
@@ -695,9 +693,9 @@ func (http *httpPlugin) decodeBody(m *message) {
 	}
 }
 
-func decodeBody(body []byte, encodings []string, maxSize int) (result []byte, err error) {
-	if isDebug {
-		debugf("decoding body with encodings=%v", encodings)
+func decodeBody(body []byte, encodings []string, maxSize int, logger *logp.Logger) (result []byte, err error) {
+	if logger.IsDebug() {
+		logger.Debugf("decoding body with encodings=%v", encodings)
 	}
 	for idx := len(encodings) - 1; idx >= 0; idx-- {
 		format := encodings[idx]
@@ -785,10 +783,8 @@ func (http *httpPlugin) hideHeaders(m *message) {
 	authHeaderEndX := limit
 
 	for authHeaderStartX < limit {
-		if isDebug {
-			debugf("looking for authorization from %d to %d",
-				authHeaderStartX, authHeaderEndX)
-		}
+		http.debugf("looking for authorization from %d to %d",
+			authHeaderStartX, authHeaderEndX)
 
 		startOfHeader := bytes.Index(msg[authHeaderStartX:], authText)
 		if startOfHeader >= 0 {
@@ -802,9 +798,7 @@ func (http *httpPlugin) hideHeaders(m *message) {
 					authHeaderEndX = limit
 				}
 
-				if isDebug {
-					debugf("Redact authorization from %d to %d", authHeaderStartX, authHeaderEndX)
-				}
+				http.debugf("Redact authorization from %d to %d", authHeaderStartX, authHeaderEndX)
 
 				for i := authHeaderStartX + len(authText); i < authHeaderEndX; i++ {
 					msg[i] = byte('*')
@@ -864,9 +858,7 @@ func (http *httpPlugin) extractParameters(m *message) (path string, params strin
 	}
 
 	params = paramsMap.Encode()
-	if isDetailed {
-		detailedf("Form parameters: %s", params)
-	}
+	http.detailedf("Form parameters: %s", params)
 	return
 }
 
@@ -884,16 +876,12 @@ func (http *httpPlugin) Expired(tuple *common.TCPTuple, private protos.ProtocolD
 	if conn == nil {
 		return
 	}
-	if isDebug {
-		debugf("expired connection %s", tuple)
-	}
+	http.debugf("expired connection %s", tuple)
 	// terminate streams
 	for dir, s := range conn.streams {
 		// Do not send incomplete or empty messages
 		if s != nil && s.message != nil && s.message.headersReceived() {
-			if isDebug {
-				debugf("got message %+v", s.message)
-			}
+			http.debugf("got message %+v", s.message)
 			http.handleHTTP(conn, s.message, tuple, uint8(dir))
 			s.PrepareForNewMessage()
 		}

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -95,8 +95,9 @@ func (v version) String() string {
 }
 
 type parser struct {
-	config *parserConfig
-	logger *logp.Logger
+	config             *parserConfig
+	httpLogger         *logp.Logger
+	httpDetailedLogger *logp.Logger
 }
 
 type parserConfig struct {
@@ -127,21 +128,25 @@ var (
 	nameUserAgent        = []byte("user-agent")
 )
 
-func newParser(config *parserConfig, logger *logp.Logger) *parser {
-	return &parser{config: config, logger: logger}
+func newParser(config *parserConfig, httpLogger, httpDetailedLogger *logp.Logger) *parser {
+	return &parser{
+		config:             config,
+		httpLogger:         httpLogger,
+		httpDetailedLogger: httpDetailedLogger,
+	}
 }
 
 //go:inline
 func (parser *parser) debugf(format string, args ...interface{}) {
-	if parser.logger.Named("http").IsDebug() {
-		parser.logger.Named("http").Debugf(format, args...)
+	if parser.httpLogger.IsDebug() {
+		parser.httpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
 func (parser *parser) detailedf(format string, args ...interface{}) {
-	if parser.logger.Named("httpdetailed").IsDebug() {
-		parser.logger.Named("httpdetailed").Debugf(format, args...)
+	if parser.httpDetailedLogger.IsDebug() {
+		parser.httpDetailedLogger.Debugf(format, args...)
 	}
 }
 
@@ -204,9 +209,9 @@ func (p *parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) 
 		// RESPONSE
 		m.isRequest = false
 		version = fline[5:8]
-		m.statusCode, m.statusPhrase, err = parseResponseStatus(fline[9:], p.logger)
+		m.statusCode, m.statusPhrase, err = parseResponseStatus(fline[9:], p.httpLogger)
 		if err != nil {
-			p.logger.Warn("Failed to understand HTTP response status: %s", fline[9:])
+			p.httpLogger.Warn("Failed to understand HTTP response status: %s", fline[9:])
 			return false, false, false
 		}
 
@@ -500,7 +505,7 @@ func (p *parser) eatBody(s *stream, m *message, size int) (ok, complete bool) {
 		// HTTP/1.0 no content length. Add until the end of the connection
 		p.debugf("http conn close, received %d", size)
 		if size < 0 {
-			p.logger.Warn("invalid body size in packet")
+			p.httpLogger.Warn("invalid body size in packet")
 			return false, true
 		}
 		m.size += uint64(size)
@@ -512,7 +517,7 @@ func (p *parser) eatBody(s *stream, m *message, size int) (ok, complete bool) {
 		s.bodyReceived += wanted
 		bodySize := len(m.rawHeaders) + m.contentLength
 		if bodySize < 0 {
-			p.logger.Warn("invalid body size in packet")
+			p.httpLogger.Warn("invalid body size in packet")
 			return false, true
 		}
 		m.size = uint64(bodySize)
@@ -534,7 +539,7 @@ func (p *parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complet
 	line := string(s.data[:i])
 	chunkLength, err := strconv.ParseInt(line, 16, 32)
 	if err != nil {
-		p.logger.Warn("Failed to understand chunked body start line")
+		p.httpLogger.Warn("Failed to understand chunked body start line")
 		return false, false, false
 	}
 	m.chunkedLength = int(chunkLength)
@@ -542,7 +547,7 @@ func (p *parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complet
 	s.data = s.data[i+2:] //+ \r\n
 	newSize := i + 2
 	if newSize < 0 {
-		p.logger.Warn("Invalid body size while parsing message")
+		p.httpLogger.Warn("Invalid body size while parsing message")
 		return false, false, false
 	}
 	m.size += uint64(newSize)
@@ -554,7 +559,7 @@ func (p *parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complet
 		}
 		m.size += 2
 		if s.data[0] != '\r' || s.data[1] != '\n' {
-			p.logger.Warn("expected CRLF sequence at end of message")
+			p.httpLogger.Warn("expected CRLF sequence at end of message")
 			return false, false, false
 		}
 		s.data = s.data[2:]
@@ -575,7 +580,7 @@ func (p *parser) parseBodyChunked(s *stream, m *message) (cont, ok, complete boo
 		}
 		newSize := wanted + 2
 		if newSize < 0 {
-			p.logger.Warn("invalid body size in http body")
+			p.httpLogger.Warn("invalid body size in http body")
 			return false, false, false
 		}
 		m.size += uint64(newSize)
@@ -607,7 +612,7 @@ func (p *parser) parseBodyChunkedWaitFinalCRLF(s *stream, m *message) (ok, compl
 
 	m.size += 2
 	if s.data[0] != '\r' || s.data[1] != '\n' {
-		p.logger.Warn("Expected CRLF sequence at end of message")
+		p.httpLogger.Warn("Expected CRLF sequence at end of message")
 		return false, false
 	}
 

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -618,16 +618,12 @@ func (p *parser) parseBodyChunkedWaitFinalCRLF(s *stream, m *message) (ok, compl
 func (p *parser) shouldIncludeInBody(contenttype []byte, capturedContentTypes []string) bool {
 	for _, include := range capturedContentTypes {
 		if bytes.Contains(contenttype, []byte(include)) {
-			if isDebug {
-				p.debugf("Should Include Body = true Content-Type %s include_body %s",
-					contenttype, include)
-			}
+			p.debugf("Should Include Body = true Content-Type %s include_body %s",
+				contenttype, include)
 			return true
 		}
 	}
-	if isDebug {
-		p.debugf("Should Include Body = false Content-Type %s", contenttype)
-	}
+	p.debugf("Should Include Body = false Content-Type %s", contenttype)
 	return false
 }
 

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -96,6 +96,7 @@ func (v version) String() string {
 
 type parser struct {
 	config *parserConfig
+	logger *logp.Logger
 }
 
 type parserConfig struct {
@@ -126,8 +127,22 @@ var (
 	nameUserAgent        = []byte("user-agent")
 )
 
-func newParser(config *parserConfig) *parser {
-	return &parser{config: config}
+func newParser(config *parserConfig, logger *logp.Logger) *parser {
+	return &parser{config: config, logger: logger}
+}
+
+//go:inline
+func (parser *parser) debugf(format string, args ...interface{}) {
+	if parser.logger.Named("http").IsDebug() {
+		parser.logger.Named("http").Debugf(format, args...)
+	}
+}
+
+//go:inline
+func (parser *parser) detailedf(format string, args ...interface{}) {
+	if parser.logger.Named("httpdetailed").IsDebug() {
+		parser.logger.Named("httpdetailed").Debugf(format, args...)
+	}
 }
 
 func (parser *parser) parse(s *stream, extraMsgSize int) (bool, bool) {
@@ -170,7 +185,7 @@ func (parser *parser) parse(s *stream, extraMsgSize int) (bool, bool) {
 	return true, false
 }
 
-func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
+func (p *parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 	i := bytes.Index(s.data[s.parseOffset:], []byte("\r\n"))
 	if i == -1 {
 		return false, true, false
@@ -182,24 +197,20 @@ func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 	var err error
 	fline := s.data[s.parseOffset:i]
 	if len(fline) < 9 {
-		if isDebug {
-			debugf("First line too small")
-		}
+		p.debugf("First line too small")
 		return false, false, false
 	}
 	if bytes.Equal(fline[0:5], constHTTPVersion) {
 		// RESPONSE
 		m.isRequest = false
 		version = fline[5:8]
-		m.statusCode, m.statusPhrase, err = parseResponseStatus(fline[9:])
+		m.statusCode, m.statusPhrase, err = parseResponseStatus(fline[9:], p.logger)
 		if err != nil {
-			logp.Warn("Failed to understand HTTP response status: %s", fline[9:])
+			p.logger.Warn("Failed to understand HTTP response status: %s", fline[9:])
 			return false, false, false
 		}
 
-		if isDebug {
-			debugf("HTTP status_code=%d, status_phrase=%s", m.statusCode, m.statusPhrase)
-		}
+		p.debugf("HTTP status_code=%d, status_phrase=%s", m.statusCode, m.statusPhrase)
 	} else {
 		// REQUEST
 		afterMethodIdx := bytes.IndexFunc(fline, unicode.IsSpace)
@@ -207,9 +218,7 @@ func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 
 		// Make sure we have the VERB + URI + HTTP_VERSION
 		if afterMethodIdx == -1 || afterRequestURIIdx == -1 || afterMethodIdx == afterRequestURIIdx {
-			if isDebug {
-				debugf("Couldn't understand HTTP request: %s", fline)
-			}
+			p.debugf("Couldn't understand HTTP request: %s", fline)
 			return false, false, false
 		}
 
@@ -221,24 +230,18 @@ func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 			m.isRequest = true
 			version = fline[versionIdx:]
 		} else {
-			if isDebug {
-				debugf("Couldn't understand HTTP version: %s", fline)
-			}
+			p.debugf("Couldn't understand HTTP version: %s", fline)
 			return false, false, false
 		}
 	}
 
 	m.version.major, m.version.minor, err = parseVersion(version)
 	if err != nil {
-		if isDebug {
-			debugf("Failed to understand HTTP version: %v", version)
-		}
+		p.debugf("Failed to understand HTTP version: %v", version)
 		m.version.major = 1
 		m.version.minor = 0
 	}
-	if isDebug {
-		debugf("HTTP version %d.%d", m.version.major, m.version.minor)
-	}
+	p.debugf("HTTP version %d.%d", m.version.major, m.version.minor)
 
 	// ok so far
 	s.parseOffset = i + 2
@@ -248,9 +251,9 @@ func (*parser) parseHTTPLine(s *stream, m *message) (cont, ok, complete bool) {
 	return true, true, true
 }
 
-func parseResponseStatus(s []byte) (uint16, []byte, error) {
-	if isDebug {
-		debugf("parseResponseStatus: %s", s)
+func parseResponseStatus(s []byte, logger *logp.Logger) (uint16, []byte, error) {
+	if logger.IsDebug() {
+		logger.Debug("parseResponseStatus: %s", s)
 	}
 
 	var phrase []byte
@@ -289,7 +292,7 @@ func (parser *parser) parseHeaders(s *stream, m *message) (cont, ok, complete bo
 		// EOH
 		offset := s.parseOffset + 2
 		if offset < 0 {
-			debugf("invalid byte offset for headers: %v", offset)
+			parser.debugf("invalid byte offset for headers: %v", offset)
 			return false, false, true
 		}
 		m.size = uint64(offset)
@@ -300,9 +303,7 @@ func (parser *parser) parseHeaders(s *stream, m *message) (cont, ok, complete bo
 		if !m.isRequest && ((100 <= m.statusCode && m.statusCode < 200) || m.statusCode == 204 || m.statusCode == 304) {
 			// response with a 1xx, 204 , or 304 status  code is always terminated
 			// by the first empty line after the  header fields
-			if isDebug {
-				debugf("Terminate response, status code %d", m.statusCode)
-			}
+			parser.debugf("Terminate response, status code %d", m.statusCode)
 			return false, true, true
 		}
 
@@ -316,24 +317,18 @@ func (parser *parser) parseHeaders(s *stream, m *message) (cont, ok, complete bo
 		if m.isChunked {
 			// support for HTTP/1.1 Chunked transfer
 			// Transfer-Encoding overrides the Content-Length
-			if isDebug {
-				debugf("Read chunked body")
-			}
+			parser.debugf("Read chunked body")
 			s.parseState = stateBodyChunkedStart
 			return true, true, true
 		}
 
 		if m.contentLength == 0 && (m.isRequest || m.hasContentLength) {
-			if isDebug {
-				debugf("Empty content length, ignore body")
-			}
+			parser.debugf("Empty content length, ignore body")
 			// Ignore body for request that contains a message body but not a Content-Length
 			return false, true, true
 		}
 
-		if isDebug {
-			debugf("Read body")
-		}
+		parser.debugf("Read body")
 		s.parseState = stateBody
 	} else {
 		ok, hfcomplete, offset := parser.parseHeader(m, s.data[s.parseOffset:])
@@ -361,10 +356,8 @@ func (parser *parser) parseHeader(m *message, data []byte) (bool, bool, int) {
 	config := parser.config
 
 	// enabled if required. Allocs for parameters slow down parser big times
-	if isDetailed {
-		detailedf("Data: %s", data)
-		detailedf("Header: %s", data[:i])
-	}
+	parser.detailedf("Data: %s", data)
+	parser.detailedf("Header: %s", data[:i])
 
 	// skip folding line
 	for p := i + 1; p < len(data); {
@@ -380,9 +373,7 @@ func (parser *parser) parseHeader(m *message, data []byte) (bool, bool, int) {
 			var headerNameBuf [140]byte
 			headerName := toLower(headerNameBuf[:], data[:i])
 			headerVal := trim(data[i+1 : p])
-			if isDebug {
-				debugf("Header: '%s' Value: '%s'\n", data[:i], headerVal)
-			}
+			parser.debugf("Header: '%s' Value: '%s'\n", data[:i], headerVal)
 
 			// Headers we need for parsing. Make sure we always
 			// capture their value
@@ -458,7 +449,7 @@ func parseCommaSeparatedList(s common.NetString) (list []string) {
 	return list
 }
 
-func (*parser) parseBody(s *stream, m *message) (ok, complete bool) {
+func (p *parser) parseBody(s *stream, m *message) (ok, complete bool) {
 	nbytes := len(s.data)
 	if !m.hasContentLength && (bytes.Equal(m.connection, constClose) ||
 		(isVersion(m.version, 1, 0) && !bytes.Equal(m.connection, constKeepAlive))) {
@@ -468,9 +459,7 @@ func (*parser) parseBody(s *stream, m *message) (ok, complete bool) {
 		m.contentLength += nbytes
 
 		// HTTP/1.0 no content length. Add until the end of the connection
-		if isDebug {
-			debugf("http conn close, received %d", len(s.data))
-		}
+		p.debugf("http conn close, received %d", len(s.data))
 		if m.saveBody {
 			m.body = append(m.body, s.data...)
 		}
@@ -479,7 +468,7 @@ func (*parser) parseBody(s *stream, m *message) (ok, complete bool) {
 	} else if nbytes >= m.contentLength-s.bodyReceived {
 		wanted := m.contentLength - s.bodyReceived
 		if wanted < 0 {
-			debugf("http body length wrong. Ignoring")
+			p.debugf("http body length wrong. Ignoring")
 			return false, true
 		}
 		if m.saveBody {
@@ -496,28 +485,22 @@ func (*parser) parseBody(s *stream, m *message) (ok, complete bool) {
 		s.data = nil
 		s.bodyReceived += nbytes
 		m.size += uint64(nbytes)
-		if isDebug {
-			debugf("bodyReceived: %d", s.bodyReceived)
-		}
+		p.debugf("bodyReceived: %d", s.bodyReceived)
 		return true, false
 	}
 }
 
 // eatBody acts as if size bytes were received, without having access to
 // those bytes.
-func (*parser) eatBody(s *stream, m *message, size int) (ok, complete bool) {
-	if isDebug {
-		debugf("eatBody body")
-	}
+func (p *parser) eatBody(s *stream, m *message, size int) (ok, complete bool) {
+	p.debugf("eatBody body")
 	if !m.hasContentLength && (bytes.Equal(m.connection, constClose) ||
 		(isVersion(m.version, 1, 0) && !bytes.Equal(m.connection, constKeepAlive))) {
 
 		// HTTP/1.0 no content length. Add until the end of the connection
-		if isDebug {
-			debugf("http conn close, received %d", size)
-		}
+		p.debugf("http conn close, received %d", size)
 		if size < 0 {
-			logp.Warn("invalid body size in packet")
+			p.logger.Warn("invalid body size in packet")
 			return false, true
 		}
 		m.size += uint64(size)
@@ -529,7 +512,7 @@ func (*parser) eatBody(s *stream, m *message, size int) (ok, complete bool) {
 		s.bodyReceived += wanted
 		bodySize := len(m.rawHeaders) + m.contentLength
 		if bodySize < 0 {
-			logp.Warn("invalid body size in packet")
+			p.logger.Warn("invalid body size in packet")
 			return false, true
 		}
 		m.size = uint64(bodySize)
@@ -537,14 +520,12 @@ func (*parser) eatBody(s *stream, m *message, size int) (ok, complete bool) {
 	} else {
 		s.bodyReceived += size
 		m.size += uint64(size)
-		if isDebug {
-			debugf("bodyReceived: %d", s.bodyReceived)
-		}
+		p.debugf("bodyReceived: %d", s.bodyReceived)
 		return true, false
 	}
 }
 
-func (*parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complete bool) {
+func (p *parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complete bool) {
 	// read hexa length
 	i := bytes.Index(s.data, constCRLF)
 	if i == -1 {
@@ -553,7 +534,7 @@ func (*parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complete 
 	line := string(s.data[:i])
 	chunkLength, err := strconv.ParseInt(line, 16, 32)
 	if err != nil {
-		logp.Warn("Failed to understand chunked body start line")
+		p.logger.Warn("Failed to understand chunked body start line")
 		return false, false, false
 	}
 	m.chunkedLength = int(chunkLength)
@@ -561,7 +542,7 @@ func (*parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complete 
 	s.data = s.data[i+2:] //+ \r\n
 	newSize := i + 2
 	if newSize < 0 {
-		logp.Warn("Invalid body size while parsing message")
+		p.logger.Warn("Invalid body size while parsing message")
 		return false, false, false
 	}
 	m.size += uint64(newSize)
@@ -573,7 +554,7 @@ func (*parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complete 
 		}
 		m.size += 2
 		if s.data[0] != '\r' || s.data[1] != '\n' {
-			logp.Warn("expected CRLF sequence at end of message")
+			p.logger.Warn("expected CRLF sequence at end of message")
 			return false, false, false
 		}
 		s.data = s.data[2:]
@@ -585,7 +566,7 @@ func (*parser) parseBodyChunkedStart(s *stream, m *message) (cont, ok, complete 
 	return true, true, false
 }
 
-func (*parser) parseBodyChunked(s *stream, m *message) (cont, ok, complete bool) {
+func (p *parser) parseBodyChunked(s *stream, m *message) (cont, ok, complete bool) {
 	wanted := m.chunkedLength - s.bodyReceived
 	if len(s.data) >= wanted+2 /*\r\n*/ {
 		// Received more data than expected
@@ -594,7 +575,7 @@ func (*parser) parseBodyChunked(s *stream, m *message) (cont, ok, complete bool)
 		}
 		newSize := wanted + 2
 		if newSize < 0 {
-			logp.Warn("invalid body size in http body")
+			p.logger.Warn("invalid body size in http body")
 			return false, false, false
 		}
 		m.size += uint64(newSize)
@@ -619,14 +600,14 @@ func (*parser) parseBodyChunked(s *stream, m *message) (cont, ok, complete bool)
 	return false, true, false
 }
 
-func (*parser) parseBodyChunkedWaitFinalCRLF(s *stream, m *message) (ok, complete bool) {
+func (p *parser) parseBodyChunkedWaitFinalCRLF(s *stream, m *message) (ok, complete bool) {
 	if len(s.data) < 2 {
 		return true, false
 	}
 
 	m.size += 2
 	if s.data[0] != '\r' || s.data[1] != '\n' {
-		logp.Warn("Expected CRLF sequence at end of message")
+		p.logger.Warn("Expected CRLF sequence at end of message")
 		return false, false
 	}
 
@@ -634,18 +615,18 @@ func (*parser) parseBodyChunkedWaitFinalCRLF(s *stream, m *message) (ok, complet
 	return true, true
 }
 
-func (parser *parser) shouldIncludeInBody(contenttype []byte, capturedContentTypes []string) bool {
+func (p *parser) shouldIncludeInBody(contenttype []byte, capturedContentTypes []string) bool {
 	for _, include := range capturedContentTypes {
 		if bytes.Contains(contenttype, []byte(include)) {
 			if isDebug {
-				debugf("Should Include Body = true Content-Type %s include_body %s",
+				p.debugf("Should Include Body = true Content-Type %s include_body %s",
 					contenttype, include)
 			}
 			return true
 		}
 	}
 	if isDebug {
-		debugf("Should Include Body = false Content-Type %s", contenttype)
+		p.debugf("Should Include Body = false Content-Type %s", contenttype)
 	}
 	return false
 }

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -49,6 +49,10 @@ type testParser struct {
 
 var testParserConfig = parserConfig{}
 
+func newParserForTest(config *parserConfig, logger *logp.Logger) *parser {
+	return newParser(config, logger.Named("http"), logger.Named("httpdetailed"))
+}
+
 type eventStore struct {
 	events []beat.Event
 }
@@ -77,7 +81,7 @@ func (tp *testParser) parse() (*message, bool, bool) {
 		tp.payloads = tp.payloads[1:]
 	}
 
-	parser := newParser(&tp.http.parserConfig, logp.NewNopLogger())
+	parser := newParserForTest(&tp.http.parserConfig, logp.NewNopLogger())
 	ok, complete := parser.parse(st, 0)
 	return st.message, ok, complete
 }
@@ -101,7 +105,7 @@ func testParse(http *httpPlugin, data string) (*message, bool, bool) {
 }
 
 func testParseStream(http *httpPlugin, st *stream, extraLen int) (bool, bool) {
-	parser := newParser(&http.parserConfig, logp.NewNopLogger())
+	parser := newParserForTest(&http.parserConfig, logp.NewNopLogger())
 	return parser.parse(st, extraLen)
 }
 
@@ -632,7 +636,7 @@ func TestEatBodyChunked(t *testing.T) {
 		chunkedLength: 5,
 		contentLength: 0,
 	}
-	parser := newParser(&testParserConfig, logptest.NewTestingLogger(t, ""))
+	parser := newParserForTest(&testParserConfig, logptest.NewTestingLogger(t, ""))
 
 	cont, ok, complete := parser.parseBodyChunkedStart(st, msg)
 	if cont != false || ok != true || complete != false {
@@ -703,7 +707,7 @@ func TestEatBodyChunkedWaitCRLF(t *testing.T) {
 		chunkedLength: 5,
 		contentLength: 0,
 	}
-	parser := newParser(&testParserConfig, logptest.NewTestingLogger(t, ""))
+	parser := newParserForTest(&testParserConfig, logptest.NewTestingLogger(t, ""))
 
 	cont, ok, complete := parser.parseBodyChunkedStart(st, msg)
 	if cont != true || ok != true || complete != false {
@@ -1933,7 +1937,7 @@ func TestExtractHostHeader(t *testing.T) {
 
 func benchmarkHTTPMessage(b *testing.B, data []byte) {
 	http := httpModForTests(nil)
-	parser := newParser(&http.parserConfig, logp.NewNopLogger())
+	parser := newParserForTest(&http.parserConfig, logp.NewNopLogger())
 
 	for i := 0; i < b.N; i++ {
 		stream := &stream{data: data, message: new(message)}
@@ -1992,7 +1996,7 @@ func BenchmarkHTTPSplitResponse(b *testing.B) {
 		"\r\n")
 
 	http := httpModForTests(nil)
-	parser := newParser(&http.parserConfig, logp.NewNopLogger())
+	parser := newParserForTest(&http.parserConfig, logp.NewNopLogger())
 
 	for i := 0; i < b.N; i++ {
 		stream := &stream{data: data1, message: new(message)}

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/beats/v7/packetbeat/publish"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -76,7 +77,7 @@ func (tp *testParser) parse() (*message, bool, bool) {
 		tp.payloads = tp.payloads[1:]
 	}
 
-	parser := newParser(&tp.http.parserConfig)
+	parser := newParser(&tp.http.parserConfig, logp.NewNopLogger())
 	ok, complete := parser.parse(st, 0)
 	return st.message, ok, complete
 }
@@ -100,7 +101,7 @@ func testParse(http *httpPlugin, data string) (*message, bool, bool) {
 }
 
 func testParseStream(http *httpPlugin, st *stream, extraLen int) (bool, bool) {
-	parser := newParser(&http.parserConfig)
+	parser := newParser(&http.parserConfig, logp.NewNopLogger())
 	return parser.parse(st, extraLen)
 }
 
@@ -615,7 +616,6 @@ func TestHttpParser_PhraseContainsSpaces(t *testing.T) {
 }
 
 func TestEatBodyChunked(t *testing.T) {
-	logp.TestingSetup(logp.WithSelectors("http", "httpdetailed"))
 
 	msgs := [][]byte{
 		[]byte("03\r"),
@@ -632,7 +632,7 @@ func TestEatBodyChunked(t *testing.T) {
 		chunkedLength: 5,
 		contentLength: 0,
 	}
-	parser := newParser(&testParserConfig)
+	parser := newParser(&testParserConfig, logptest.NewTestingLogger(t, ""))
 
 	cont, ok, complete := parser.parseBodyChunkedStart(st, msg)
 	if cont != false || ok != true || complete != false {
@@ -703,7 +703,7 @@ func TestEatBodyChunkedWaitCRLF(t *testing.T) {
 		chunkedLength: 5,
 		contentLength: 0,
 	}
-	parser := newParser(&testParserConfig)
+	parser := newParser(&testParserConfig, logptest.NewTestingLogger(t, ""))
 
 	cont, ok, complete := parser.parseBodyChunkedStart(st, msg)
 	if cont != true || ok != true || complete != false {
@@ -1933,7 +1933,7 @@ func TestExtractHostHeader(t *testing.T) {
 
 func benchmarkHTTPMessage(b *testing.B, data []byte) {
 	http := httpModForTests(nil)
-	parser := newParser(&http.parserConfig)
+	parser := newParser(&http.parserConfig, logp.NewNopLogger())
 
 	for i := 0; i < b.N; i++ {
 		stream := &stream{data: data, message: new(message)}
@@ -1992,7 +1992,7 @@ func BenchmarkHTTPSplitResponse(b *testing.B) {
 		"\r\n")
 
 	http := httpModForTests(nil)
-	parser := newParser(&http.parserConfig)
+	parser := newParser(&http.parserConfig, logp.NewNopLogger())
 
 	for i := 0; i < b.N; i++ {
 		stream := &stream{data: data1, message: new(message)}

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -72,7 +72,7 @@ var (
 
 func New(testMode bool, results protos.Reporter, watcher *procs.ProcessesWatcher, cfg *conf.C, logger *logp.Logger) (*icmpPlugin, error) {
 	p := &icmpPlugin{}
-	p.logger = logger
+	p.logger = logger.Named("icmp")
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -94,10 +94,10 @@ func (icmp *icmpPlugin) init(results protos.Reporter, watcher *procs.ProcessesWa
 		icmp.logger.Errorf("Error getting local IP addresses: %+v", err)
 		localIPs = nil
 	}
-	icmp.logger.Named("icmp").Debugf("Local IP addresses: %v", localIPs)
+	icmp.logger.Debugf("Local IP addresses: %v", localIPs)
 
 	removalListener := func(k common.Key, v common.Value) {
-		tuple, ok := k.(hashableIcmpTuple)
+		_, ok := k.(hashableIcmpTuple)
 		if !ok {
 			return
 		}
@@ -105,7 +105,7 @@ func (icmp *icmpPlugin) init(results protos.Reporter, watcher *procs.ProcessesWa
 		if !ok {
 			return
 		}
-		icmp.expireTransaction(tuple, trans)
+		icmp.expireTransaction(trans)
 	}
 
 	icmp.transactions = common.NewCacheWithRemovalListener(
@@ -249,9 +249,9 @@ func (icmp *icmpPlugin) deleteTransaction(k hashableIcmpTuple) *icmpTransaction 
 	return nil
 }
 
-func (icmp *icmpPlugin) expireTransaction(tuple hashableIcmpTuple, trans *icmpTransaction) {
+func (icmp *icmpPlugin) expireTransaction(trans *icmpTransaction) {
 	trans.notes = append(trans.notes, orphanedRequestMsg)
-	logp.Debug("icmp", orphanedRequestMsg+" %s", &trans.tuple)
+	icmp.logger.Debugf(orphanedRequestMsg+" %s", &trans.tuple)
 	unmatchedRequests.Add(1)
 	icmp.publishTransaction(trans)
 }
@@ -261,7 +261,7 @@ func (icmp *icmpPlugin) publishTransaction(trans *icmpTransaction) {
 		return
 	}
 
-	icmp.logger.Named("icmp").Debugf("Publishing transaction. %s", &trans.tuple)
+	icmp.logger.Debugf("Publishing transaction. %s", &trans.tuple)
 
 	evt, pbf := pb.NewBeatEvent(trans.ts)
 	pbf.Source = &ecs.Source{IP: trans.tuple.srcIP.String()}

--- a/packetbeat/protos/memcache/binary.go
+++ b/packetbeat/protos/memcache/binary.go
@@ -237,7 +237,7 @@ func defBinaryCounterCommand(opcodes []memcacheOpcode, code commandCode) {
 }
 
 func parseBinaryCommand(parser *parser, buf *streambuf.Buffer) parseResult {
-	debug("on binary message")
+	parser.debugf("on binary message")
 
 	if !buf.Avail(memcacheHeaderSize) {
 		return parser.needMore()
@@ -262,20 +262,20 @@ func parseBinaryCommand(parser *parser, buf *streambuf.Buffer) parseResult {
 		return parser.failing(err)
 	}
 
-	debug("magic: %v", magic)
-	debug("opcode: %v", opcode)
-	debug("extra len: %v", extraLen)
-	debug("key len: %v", keyLen)
+	parser.debugf("magic: %v", magic)
+	parser.debugf("opcode: %v", opcode)
+	parser.debugf("extra len: %v", extraLen)
+	parser.debugf("key len: %v", keyLen)
 
 	totalHeaderLen := memcacheHeaderSize + int(extraLen) + int(keyLen)
-	debug("total header len: %v", totalHeaderLen)
+	parser.debugf("total header len: %v", totalHeaderLen)
 	if !buf.Avail(totalHeaderLen) {
 		return parser.needMore()
 	}
 
 	command := memcacheBinaryCommandTable[memcacheOpcode(opcode)]
 	if command == nil {
-		debug("unknown command")
+		parser.debugf("unknown command")
 		command = binaryUnknownCommand
 	}
 
@@ -384,7 +384,7 @@ func parseDataBinary(parser *parser, buf *streambuf.Buffer) parseResult {
 		return parser.failing(err)
 	}
 
-	debug("found data message")
+	parser.debugf("found data message")
 	if msg.bytesLost > 0 {
 		msg.countValues++
 	} else {

--- a/packetbeat/protos/memcache/commands.go
+++ b/packetbeat/protos/memcache/commands.go
@@ -46,7 +46,7 @@ func argOptional(arg argDef) argDef {
 			return nil
 		}
 		if err != nil {
-			debug("optional err: %s", err)
+			parser.debugf("optional err: %s", err)
 		}
 		return err
 	}

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -49,6 +49,7 @@ type memcache struct {
 
 	handler memcacheHandler
 	logger  *logp.Logger
+	isDebug bool
 }
 
 type memcacheHandler interface {
@@ -141,6 +142,7 @@ func New(
 ) (protos.Plugin, error) {
 	p := &memcache{}
 	p.logger = logger.Named("memcache")
+	p.isDebug = p.logger.IsDebug()
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -155,7 +157,7 @@ func New(
 }
 
 func (mc *memcache) debugf(format string, args ...interface{}) {
-	if mc.logger.IsDebug() {
+	if mc.isDebug {
 		mc.logger.Debugf(format, args...)
 	}
 }

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -122,8 +122,6 @@ type memcacheStat struct {
 	Value memcacheString `json:"value"`
 }
 
-var debug = logp.MakeDebug("memcache")
-
 var (
 	unmatchedRequests      = monitoring.NewInt(nil, "memcache.unmatched_requests")
 	unmatchedResponses     = monitoring.NewInt(nil, "memcache.unmatched_responses")
@@ -154,6 +152,12 @@ func New(
 		return nil, err
 	}
 	return p, nil
+}
+
+func (mc *memcache) debugf(format string, args ...interface{}) {
+	if mc.logger.IsDebug() {
+		mc.logger.Debugf(format, args...)
+	}
 }
 
 // Called to initialize the Plugin
@@ -396,7 +400,7 @@ func (t *transaction) Init(msg *message) {
 func (t *transaction) Event(event *beat.Event) error {
 	t.logger.Debugf("count event notes: %v", len(t.Notes))
 	if err := t.Transaction.Event(event); err != nil {
-		logp.Warn("error filling generic transaction fields: %v", err)
+		t.logger.Warnf("error filling generic transaction fields: %v", err)
 		return err
 	}
 
@@ -411,7 +415,7 @@ func (t *transaction) Event(event *beat.Event) error {
 	if t.request != nil {
 		_, err := t.request.SubEvent("request", mc)
 		if err != nil {
-			logp.Warn("error filling transaction request: %v", err)
+			t.logger.Warnf("error filling transaction request: %v", err)
 			return err
 		}
 		event.Fields["event.action"] = "memcache." + strings.ToLower(t.request.command.typ.String())
@@ -419,7 +423,7 @@ func (t *transaction) Event(event *beat.Event) error {
 	if t.response != nil {
 		_, err := t.response.SubEvent("response", mc)
 		if err != nil {
-			logp.Warn("error filling transaction response: %v", err)
+			t.logger.Warnf("error filling transaction response: %v", err)
 			return err
 		}
 		normalized := normalizeEventOutcome(memcacheStatusCode(t.response.status).String())

--- a/packetbeat/protos/memcache/parse.go
+++ b/packetbeat/protos/memcache/parse.go
@@ -37,6 +37,7 @@ type parser struct {
 	message *message
 	config  *parserConfig
 	logger  *logp.Logger
+	isDebug bool
 }
 
 type parserState uint8
@@ -70,13 +71,14 @@ func init() {
 func newParser(config *parserConfig, logger *logp.Logger) *parser {
 	var p parser
 	p.logger = logger
+	p.isDebug = p.logger.IsDebug()
 	p.init(config)
 	return &p
 }
 
 //go:inline
 func (p *parser) debugf(format string, args ...interface{}) {
-	if p.logger.IsDebug() {
+	if p.isDebug {
 		p.logger.Debugf(format, args...)
 	}
 }

--- a/packetbeat/protos/memcache/parse.go
+++ b/packetbeat/protos/memcache/parse.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/streambuf"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 type parserConfig struct {
@@ -35,6 +36,7 @@ type parser struct {
 	state   parserState
 	message *message
 	config  *parserConfig
+	logger  *logp.Logger
 }
 
 type parserState uint8
@@ -65,10 +67,18 @@ func init() {
 	parseCommand = doParseCommand
 }
 
-func newParser(config *parserConfig) *parser {
+func newParser(config *parserConfig, logger *logp.Logger) *parser {
 	var p parser
+	p.logger = logger
 	p.init(config)
 	return &p
+}
+
+//go:inline
+func (p *parser) debugf(format string, args ...interface{}) {
+	if p.logger.IsDebug() {
+		p.logger.Debugf(format, args...)
+	}
 }
 
 func (p *parser) init(config *parserConfig) {
@@ -78,7 +88,7 @@ func (p *parser) init(config *parserConfig) {
 }
 
 func (p *parser) reset() {
-	debug("parser(%p) reset", p)
+	p.debugf("parser(%p) reset", p)
 	p.init(p.config)
 }
 
@@ -123,7 +133,7 @@ func (p *parser) yield(nbytes int) parseResult {
 	msg := p.message
 	msg.Size = uint64(nbytes - int(msg.bytesLost))
 	p.message = nil
-	debug("yield(%p) memcache message type %v", p, msg.command.code)
+	p.debugf("yield(%p) memcache message type %v", p, msg.command.code)
 	return parseResult{nil, msg}
 }
 

--- a/packetbeat/protos/memcache/parse_test.go
+++ b/packetbeat/protos/memcache/parse_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/streambuf"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -74,7 +75,7 @@ var defaultTestParserConfig = parserConfig{
 func newTestParser(tst *testing.T, state parserState) *testParser {
 	t := &testParser{
 		testing: tst,
-		parser:  newParser(&defaultTestParserConfig),
+		parser:  newParser(&defaultTestParserConfig, logptest.NewTestingLogger(tst, "")),
 		buf:     streambuf.New(nil),
 	}
 	return t

--- a/packetbeat/protos/memcache/plugin_tcp.go
+++ b/packetbeat/protos/memcache/plugin_tcp.go
@@ -366,7 +366,7 @@ func (mc *memcache) GapInStream(
 		parser.state == parseStateIncompleteData
 	if inData {
 		if msg == nil {
-			logp.NewLogger("memcache").DPanic("parser message is nil on data load")
+			mc.logger.DPanic("parser message is nil on data load")
 			return private, true
 		}
 

--- a/packetbeat/protos/memcache/plugin_tcp.go
+++ b/packetbeat/protos/memcache/plugin_tcp.go
@@ -47,6 +47,7 @@ type tcpConnectionData struct {
 type stream struct {
 	applayer.Stream
 	parser parser
+	logger *logp.Logger
 }
 
 type connection struct {
@@ -60,18 +61,18 @@ type messageList struct {
 	tail *message
 }
 
-func ensureMemcacheConnection(private protos.ProtocolData) *tcpConnectionData {
+func ensureMemcacheConnection(private protos.ProtocolData, logger *logp.Logger) *tcpConnectionData {
 	if private == nil {
 		return &tcpConnectionData{}
 	}
 
 	priv, ok := private.(*tcpConnectionData)
 	if !ok {
-		logp.Warn("memcache connection data type error, create new one")
+		logger.Warn("memcache connection data type error, create new one")
 		return &tcpConnectionData{}
 	}
 	if priv == nil {
-		logp.Warn("Unexpected: memcache TCP connection data not set, create new one")
+		logger.Warn("Unexpected: memcache TCP connection data not set, create new one")
 		return &tcpConnectionData{}
 	}
 	return priv
@@ -97,7 +98,7 @@ func (mc *memcache) Parse(
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	tcpConn := ensureMemcacheConnection(private)
+	tcpConn := ensureMemcacheConnection(private, mc.logger)
 	mc.logger.Debugf("memcache connection %p", tcpConn)
 	tcpConn = mc.memcacheParseTCP(tcpConn, pkt, tcptuple, dir)
 	if tcpConn == nil {
@@ -108,8 +109,10 @@ func (mc *memcache) Parse(
 }
 
 func (mc *memcache) newStream() *stream {
-	s := &stream{}
-	s.parser.init(&mc.config)
+	s := &stream{
+		logger: mc.logger,
+		parser: *newParser(&mc.config, mc.logger),
+	}
 	s.Stream.Init(tcp.TCPMaxDataInStream)
 	return s
 }
@@ -166,7 +169,7 @@ func (mc *memcache) memcacheParseTCP(
 		tuple := tcptuple.IPPort()
 		err = mc.onTCPMessage(conn, tuple, dir, msg)
 		if err != nil {
-			logp.Warn("error processing memcache message: %s", err)
+			mc.logger.Warnf("error processing memcache message: %s", err)
 		}
 	}
 
@@ -267,7 +270,7 @@ func (mc *memcache) correlateTCP(conn *connection) error {
 			requ = conn.requests.pop()
 			if requ.isBinary != resp.isBinary {
 				err := errMixOfBinaryAndText
-				logp.Warn("%v", err)
+				mc.logger.Warnf("%v", err)
 				return err
 			}
 
@@ -286,7 +289,7 @@ func (mc *memcache) correlateTCP(conn *connection) error {
 			// received a response
 			if requ.isBinary && !requ.isQuiet {
 				note := noteNonQuietResponseOnly
-				logp.Warn("%s", note)
+				mc.logger.Warnf("%s", note)
 				requ.AddNotes(note)
 				unmatchedRequests.Add(1)
 			}
@@ -295,7 +298,7 @@ func (mc *memcache) correlateTCP(conn *connection) error {
 			mc.logger.Debugf("send single request=%p", requ)
 			err := mc.onTCPTrans(requ, nil)
 			if err != nil {
-				logp.Warn("error processing memcache transaction: %s", err)
+				mc.logger.Warnf("error processing memcache transaction: %s", err)
 			}
 			requ = nil
 		}
@@ -312,7 +315,7 @@ func (mc *memcache) correlateTCP(conn *connection) error {
 		mc.logger.Debugf("merge request=%p and response=%p", requ, resp)
 		err := mc.onTCPTrans(requ, resp)
 		if err != nil {
-			logp.Warn("error processing memcache transaction: %s", err)
+			mc.logger.Warnf("error processing memcache transaction: %s", err)
 		}
 		// continue processing more transactions (reporting error only)
 	}
@@ -420,7 +423,7 @@ func (mc *memcache) pushAllTCPTrans(conn *connection) {
 		mc.logger.Debugf("push incomplete request=%p", msg)
 		err := mc.onTCPTrans(msg, nil)
 		if err != nil {
-			logp.Warn("failed to publish unfinished transaction with %v", err)
+			mc.logger.Warnf("failed to publish unfinished transaction with %v", err)
 		}
 		// continue processing more transactions (reporting error only)
 	}
@@ -433,7 +436,7 @@ func (private *tcpConnectionData) drop(dir uint8) {
 
 func (stream *stream) reset() {
 	parser := &stream.parser
-	debug("consumed %v bytes", stream.Buf.BufferConsumed())
+	stream.logger.Debugf("consumed %v bytes", stream.Buf.BufferConsumed())
 	stream.Stream.Reset()
 	parser.reset()
 }
@@ -466,7 +469,6 @@ func (ml *messageList) pop() *message {
 	if ml.head == nil {
 		ml.tail = nil
 	}
-	debug("new head=%p", ml.head)
 	return msg
 }
 

--- a/packetbeat/protos/memcache/plugin_udp.go
+++ b/packetbeat/protos/memcache/plugin_udp.go
@@ -88,21 +88,21 @@ func (mc *memcache) ParseUDP(pkt *protos.Packet) {
 	buffer := streambuf.NewFixed(pkt.Payload)
 	header, err := parseUDPHeader(buffer)
 	if err != nil {
-		debug("parsing memcache udp header failed")
+		mc.debugf("parsing memcache udp header failed")
 		return
 	}
 
-	debug("new udp datagram requestId=%v, seqNumber=%v, numDatagrams=%v",
+	mc.debugf("new udp datagram requestId=%v, seqNumber=%v, numDatagrams=%v",
 		header.requestID, header.seqNumber, header.numDatagrams)
 
 	// find connection object based on ips and ports (forward->reverse connection)
 	connection, dir := mc.getUDPConnection(&pkt.Tuple)
-	debug("udp connection: %p", connection)
+	mc.debugf("udp connection: %p", connection)
 
 	// get udp transaction combining forward/reverse direction 'streams'
 	// for current requestId
 	trans := connection.udpTransactionForID(header.requestID)
-	debug("udp transaction (id=%v): %p", header.requestID, trans)
+	mc.debugf("udp transaction (id=%v): %p", header.requestID, trans)
 
 	// Clean old transaction. We do the cleaning after potentially adding a new
 	// transaction to the connection object, so connection object will not be
@@ -117,12 +117,12 @@ func (mc *memcache) ParseUDP(pkt *protos.Packet) {
 	// get UDP transaction stream combining datagram packets in transaction
 	udpMsg := trans.udpMessageForDir(&header, dir)
 	if udpMsg == nil {
-		debug("dropping memcache(UDP) transaction with invalid fragment metadata")
+		mc.debugf("dropping memcache(UDP) transaction with invalid fragment metadata")
 		connection.killTransaction(trans)
 		return
 	}
 	if udpMsg.numDatagrams != header.numDatagrams {
-		debug("number of datagram mismatches in stream")
+		mc.debugf("number of datagram mismatches in stream")
 		connection.killTransaction(trans)
 		return
 	}
@@ -132,9 +132,9 @@ func (mc *memcache) ParseUDP(pkt *protos.Packet) {
 	done := false
 	if payload != nil {
 		// parse memcached message
-		msg, err := parseUDP(&mc.config, pkt.Ts, payload)
+		msg, err := parseUDP(&mc.config, pkt.Ts, payload, mc.logger)
 		if err != nil {
-			debug("failed to parse memcached(UDP) message: %s", err)
+			mc.debugf("failed to parse memcached(UDP) message: %s", err)
 			connection.killTransaction(trans)
 			return
 		}
@@ -142,16 +142,16 @@ func (mc *memcache) ParseUDP(pkt *protos.Packet) {
 		// apply memcached to transaction
 		done, err = mc.onUDPMessage(trans, &pkt.Tuple, dir, msg)
 		if err != nil {
-			debug("error processing memcache message: %s", err)
+			mc.debugf("error processing memcache message: %s", err)
 			connection.killTransaction(trans)
 			done = true
 		}
 	}
 	if !done {
 		trans.timer = time.AfterFunc(mc.udpConfig.transTimeout, func() {
-			debug("transaction timeout -> forward")
+			mc.debugf("transaction timeout -> forward")
 			if err := mc.onUDPTrans(trans); err != nil {
-				debug("error processing timeout memcache transaction: %s", err)
+				mc.debugf("error processing timeout memcache transaction: %s", err)
 			}
 			mc.udpExpTrans.push(trans)
 		})
@@ -181,7 +181,7 @@ func (mc *memcache) onUDPMessage(
 	dir applayer.NetDirection,
 	msg *message,
 ) (bool, error) {
-	debug("received memcached(udp) message")
+	mc.debugf("received memcached(udp) message")
 
 	if msg.IsRequest {
 		msg.Direction = applayer.NetOriginalDirection
@@ -215,7 +215,7 @@ func (mc *memcache) onUDPMessage(
 }
 
 func (mc *memcache) onUDPTrans(udp *udpTransaction) error {
-	debug("received memcache(udp) transaction")
+	mc.debugf("received memcache(udp) transaction")
 	trans := newTransaction(udp.request, udp.response, mc.logger)
 	return mc.finishTransaction(trans)
 }
@@ -234,7 +234,7 @@ func (c *udpConnection) udpTransactionForID(requestID uint16) *udpTransaction {
 	if trans != nil && trans.timer != nil {
 		stopped := trans.timer.Stop()
 		if !stopped {
-			logp.Warn("timer stopped while processing transaction -> create new transaction")
+			c.memcache.logger.Warnf("timer stopped while processing transaction -> create new transaction")
 			trans = nil
 		}
 	}
@@ -368,8 +368,9 @@ func parseUDP(
 	config *parserConfig,
 	ts time.Time,
 	buf *streambuf.Buffer,
+	logger *logp.Logger,
 ) (*message, error) {
-	parser := newParser(config)
+	parser := newParser(config, logger)
 	msg, err := parser.parse(buf, ts)
 	if err != nil && msg == nil {
 		err = errUDPIncompleteMessage

--- a/packetbeat/protos/memcache/text.go
+++ b/packetbeat/protos/memcache/text.go
@@ -120,6 +120,7 @@ var (
 
 var argNoReply = argDef{
 	parse: func(parser *parser, hdr, buf *streambuf.Buffer) error {
+		parser.debugf("parse noreply")
 		b, err := parseNoReplyArg(buf)
 		parser.message.noreply = b
 		return err
@@ -383,10 +384,10 @@ func makeSubMessageParser(commands []textCommandType) parserStateFn {
 			return parser.failing(err)
 		}
 
-		debug("handle subcommand: %s", sub)
+		parser.debugf("handle subcommand: %s", sub)
 		cmd := findTextCommandType(commands, sub)
 		if cmd == nil {
-			debug("unknown sub-command: %s", sub)
+			parser.debugf("unknown sub-command: %s", sub)
 			if parser.config.parseUnknown {
 				cmd = &unknownCommand
 			} else {
@@ -450,7 +451,7 @@ func doParseTextCommand(parser *parser, buf *streambuf.Buffer) parseResult {
 		return parser.failing(err)
 	}
 
-	debug("parse command: '%s' '%s'", command, args)
+	parser.debugf("parse command: '%s' '%s'", command, args)
 
 	msg.IsRequest = 'a' <= command[0] && command[0] <= 'z'
 	var cmd *textCommandType
@@ -466,7 +467,7 @@ func doParseTextCommand(parser *parser, buf *streambuf.Buffer) parseResult {
 		}
 	}
 	if cmd == nil {
-		debug("unknown command: %s", msg.command)
+		parser.debugf("unknown command: %v", msg.command)
 		if parser.config.parseUnknown {
 			cmd = &unknownCommand
 		} else {
@@ -495,16 +496,16 @@ func parseCounterResponse(parser *parser, buf *streambuf.Buffer) parseResult {
 	msg.value, _ = tmp.UintASCII(false)
 	if tmp.Failed() {
 		err := tmp.Err()
-		debug("counter response invalid: %v", err)
+		parser.debugf("counter response invalid: %v", err)
 		return parser.failing(err)
 	}
-	debug("parsed counter response: %v", msg.value)
+	parser.debugf("parsed counter response: %v", msg.value)
 	return parser.yieldNoData(buf)
 }
 
 func parseData(parser *parser, buf *streambuf.Buffer) parseResult {
 	msg := parser.message
-	debug("parse message data (%v)", msg.bytes)
+	parser.debugf("parse message data (%v)", msg.bytes)
 	data, err := buf.CollectWithSuffix(
 		int(msg.bytes-msg.bytesLost),
 		[]byte("\r\n"),
@@ -516,7 +517,7 @@ func parseData(parser *parser, buf *streambuf.Buffer) parseResult {
 		return parser.failing(err)
 	}
 
-	debug("found message data")
+	parser.debugf("found message data")
 	if msg.bytesLost > 0 {
 		msg.countValues++
 	} else {
@@ -543,7 +544,7 @@ func parseStatLine(parser *parser, hdr, buf *streambuf.Buffer) error {
 func parseTextArgs(parser *parser, args []argDef) (err error) {
 	buf := streambuf.NewFixed(parser.message.rawArgs)
 	for _, arg := range args {
-		debug("args rest: %s", buf.Bytes())
+		parser.debugf("args rest: %s", buf.Bytes())
 		err = arg.parse(parser, nil, buf)
 		if err != nil {
 			break
@@ -582,8 +583,6 @@ func parseKeyArg(buf *streambuf.Buffer) ([]memcacheString, error) {
 }
 
 func parseNoReplyArg(buf *streambuf.Buffer) (bool, error) {
-	debug("parse noreply")
-
 	err := parseNextArg(buf)
 	if err != nil {
 		return false, textArgError(err)

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -36,8 +36,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-var debugf = logp.MakeDebug("mongodb")
-
 type mongodbPlugin struct {
 	// config
 	ports        []int
@@ -52,6 +50,7 @@ type mongodbPlugin struct {
 
 	results protos.Reporter
 	watcher *procs.ProcessesWatcher
+	logger  *logp.Logger
 }
 
 type transactionKey struct {
@@ -73,6 +72,7 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &mongodbPlugin{}
+	p.logger = logger.Named("mongodb")
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -86,8 +86,15 @@ func New(
 	return p, nil
 }
 
+//go:inline
+func (mongodb *mongodbPlugin) debugf(format string, v ...interface{}) {
+	if mongodb.logger.IsDebug() {
+		mongodb.logger.Debugf(format, v...)
+	}
+}
+
 func (mongodb *mongodbPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *mongodbConfig) error {
-	debugf("Init a MongoDB protocol parser")
+	mongodb.debugf("Init a MongoDB protocol parser")
 	mongodb.setFromConfig(config)
 
 	mongodb.requests = common.NewCache(
@@ -132,9 +139,9 @@ func (mongodb *mongodbPlugin) Parse(
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	debugf("Parse method triggered")
+	mongodb.debugf("Parse method triggered")
 
-	conn := ensureMongodbConnection(private)
+	conn := ensureMongodbConnection(private, mongodb.logger)
 	conn = mongodb.doParse(conn, pkt, tcptuple, dir)
 	if conn == nil {
 		return nil
@@ -142,18 +149,20 @@ func (mongodb *mongodbPlugin) Parse(
 	return conn
 }
 
-func ensureMongodbConnection(private protos.ProtocolData) *mongodbConnectionData {
+func ensureMongodbConnection(private protos.ProtocolData, logger *logp.Logger) *mongodbConnectionData {
 	if private == nil {
 		return &mongodbConnectionData{}
 	}
 
 	priv, ok := private.(*mongodbConnectionData)
 	if !ok {
-		logp.Warn("mongodb connection data type error, create new one")
+		logger.Warn("mongodb connection data type error, create new one")
 		return &mongodbConnectionData{}
 	}
 	if priv == nil {
-		debugf("Unexpected: mongodb connection data not set, create new one")
+		if logger.IsDebug() {
+			logger.Debug("Unexpected: mongodb connection data not set, create new one")
+		}
 		return &mongodbConnectionData{}
 	}
 
@@ -170,12 +179,12 @@ func (mongodb *mongodbPlugin) doParse(
 	if st == nil {
 		st = newStream(pkt, tcptuple)
 		conn.streams[dir] = st
-		debugf("new stream: %p (dir=%v, len=%v)", st, dir, len(pkt.Payload))
+		mongodb.debugf("new stream: %p (dir=%v, len=%v)", st, dir, len(pkt.Payload))
 	} else {
 		// concatenate bytes
 		st.data = append(st.data, pkt.Payload...)
 		if len(st.data) > tcp.TCPMaxDataInStream {
-			debugf("Stream data too large, dropping TCP stream")
+			mongodb.debugf("Stream data too large, dropping TCP stream")
 			conn.streams[dir] = nil
 			return conn
 		}
@@ -186,23 +195,23 @@ func (mongodb *mongodbPlugin) doParse(
 			st.message = &mongodbMessage{ts: pkt.Ts}
 		}
 
-		ok, complete := mongodbMessageParser(st)
+		ok, complete := mongodbMessageParser(st, mongodb.logger)
 		if !ok {
 			// drop this tcp stream. Will retry parsing with the next
 			// segment in it
 			conn.streams[dir] = nil
-			debugf("Ignore Mongodb message. Drop tcp stream. Try parsing with the next segment")
+			mongodb.debugf("Ignore Mongodb message. Drop tcp stream. Try parsing with the next segment")
 			return conn
 		}
 
 		if !complete {
 			// wait for more data
-			debugf("MongoDB wait for more data before parsing message")
+			mongodb.debugf("MongoDB wait for more data before parsing message")
 			break
 		}
 
 		// all ok, go to next level and reset stream for new message
-		debugf("MongoDB message complete")
+		mongodb.debugf("MongoDB message complete")
 		mongodb.handleMongodb(conn, st.message, tcptuple, dir)
 		st.PrepareForNewMessage()
 	}
@@ -230,10 +239,10 @@ func (mongodb *mongodbPlugin) handleMongodb(
 	m.cmdlineTuple = mongodb.watcher.FindProcessesTupleTCP(tcptuple.IPPort())
 
 	if m.isResponse {
-		debugf("MongoDB response message")
+		mongodb.debugf("MongoDB response message")
 		mongodb.onResponse(conn, m)
 	} else {
-		debugf("MongoDB request message")
+		mongodb.debugf("MongoDB request message")
 		mongodb.onRequest(conn, m)
 	}
 }
@@ -252,7 +261,7 @@ func (mongodb *mongodbPlugin) onRequest(conn *mongodbConnectionData, msg *mongod
 	if v := mongodb.responses.Delete(key); v != nil {
 		resp, ok := v.(*mongodbMessage)
 		if !ok {
-			debugf("Unexpected type in responses cache for key %+v", key)
+			mongodb.debugf("Unexpected type in responses cache for key %+v", key)
 			return
 		}
 		mongodb.onTransComplete(msg, resp)
@@ -262,7 +271,7 @@ func (mongodb *mongodbPlugin) onRequest(conn *mongodbConnectionData, msg *mongod
 	// insert into cache for correlation
 	old := mongodb.requests.Put(key, msg)
 	if old != nil {
-		debugf("Two requests without a Response. Dropping old request")
+		mongodb.debugf("Two requests without a Response. Dropping old request")
 		unmatchedRequests.Add(1)
 	}
 }
@@ -275,7 +284,7 @@ func (mongodb *mongodbPlugin) onResponse(conn *mongodbConnectionData, msg *mongo
 	if v := mongodb.requests.Delete(key); v != nil {
 		requ, ok := v.(*mongodbMessage)
 		if !ok {
-			debugf("Unexpected type in requests cache for key %+v", key)
+			mongodb.debugf("Unexpected type in requests cache for key %+v", key)
 			return
 		}
 		mongodb.onTransComplete(requ, msg)
@@ -288,7 +297,7 @@ func (mongodb *mongodbPlugin) onResponse(conn *mongodbConnectionData, msg *mongo
 
 func (mongodb *mongodbPlugin) onTransComplete(requ, resp *mongodbMessage) {
 	trans := newTransaction(requ, resp)
-	debugf("Mongodb transaction completed: %s", trans.mongodb)
+	mongodb.debugf("Mongodb transaction completed: %s", trans.mongodb)
 	mongodb.publishTransaction(trans)
 }
 
@@ -358,7 +367,7 @@ func copyMapWithoutKey(d map[string]interface{}, keys ...string) map[string]inte
 	return res
 }
 
-func reconstructQuery(t *transaction, full bool) (query string) {
+func reconstructQuery(t *transaction, full bool, logger *logp.Logger) (query string) {
 	query = t.resource + "." + t.method + "("
 	var doc interface{}
 
@@ -389,7 +398,7 @@ func reconstructQuery(t *transaction, full bool) (query string) {
 
 	queryString, err := doc2str(doc)
 	if err != nil {
-		debugf("Error marshaling query document: %v", err)
+		logger.Debugf("Error marshaling query document: %v", err)
 	} else {
 		query += queryString
 	}
@@ -409,7 +418,7 @@ func reconstructQuery(t *transaction, full bool) (query string) {
 
 func (mongodb *mongodbPlugin) publishTransaction(t *transaction) {
 	if mongodb.results == nil {
-		debugf("Try to publish transaction with null results")
+		mongodb.debugf("Try to publish transaction with null results")
 		return
 	}
 
@@ -437,10 +446,10 @@ func (mongodb *mongodbPlugin) publishTransaction(t *transaction) {
 	fields["mongodb"] = t.event
 	fields["method"] = t.method
 	fields["resource"] = t.resource
-	fields["query"] = reconstructQuery(t, false)
+	fields["query"] = reconstructQuery(t, false, mongodb.logger)
 
 	if mongodb.sendRequest {
-		fields["request"] = reconstructQuery(t, true)
+		fields["request"] = reconstructQuery(t, true, mongodb.logger)
 	}
 	if mongodb.sendResponse {
 		if len(t.documents) > 0 {
@@ -453,7 +462,7 @@ func (mongodb *mongodbPlugin) publishTransaction(t *transaction) {
 				}
 				str, err := doc2str(doc)
 				if err != nil {
-					logp.Warn("Failed to JSON marshal document from Mongo: %v (error: %v)", doc, err)
+					mongodb.logger.Warnf("Failed to JSON marshal document from Mongo: %v (error: %v)", doc, err)
 				} else {
 					if mongodb.maxDocLength > 0 && len(str) > mongodb.maxDocLength {
 						str = str[:mongodb.maxDocLength] + " ..."

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -51,6 +51,7 @@ type mongodbPlugin struct {
 	results protos.Reporter
 	watcher *procs.ProcessesWatcher
 	logger  *logp.Logger
+	isDebug bool
 }
 
 type transactionKey struct {
@@ -73,6 +74,7 @@ func New(
 ) (protos.Plugin, error) {
 	p := &mongodbPlugin{}
 	p.logger = logger.Named("mongodb")
+	p.isDebug = p.logger.IsDebug()
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -88,7 +90,7 @@ func New(
 
 //go:inline
 func (mongodb *mongodbPlugin) debugf(format string, v ...interface{}) {
-	if mongodb.logger.IsDebug() {
+	if mongodb.isDebug {
 		mongodb.logger.Debugf(format, v...)
 	}
 }

--- a/packetbeat/protos/mongodb/mongodb_parser.go
+++ b/packetbeat/protos/mongodb/mongodb_parser.go
@@ -38,7 +38,7 @@ var (
 // Header consists of: messageLength (4) + requestID (4) + responseTo (4) + opCode (4) = 16 bytes.
 const mongoHeaderSize = 16
 
-func mongodbMessageParser(s *stream) (bool, bool) {
+func mongodbMessageParser(s *stream, logger *logp.Logger) (bool, bool) {
 	d := newDecoder(s.data)
 
 	length, err := d.readInt32()
@@ -48,7 +48,7 @@ func mongodbMessageParser(s *stream) (bool, bool) {
 	}
 
 	if length < mongoHeaderSize {
-		debugf("Invalid MongoDB message length: %d", length)
+		logger.Debugf("Invalid MongoDB message length: %d", length)
 		return false, false
 	}
 
@@ -74,7 +74,7 @@ func mongodbMessageParser(s *stream) (bool, bool) {
 		mutex.Lock()
 		defer mutex.Unlock()
 		if _, reported := unknownOpcodes[opCode]; !reported {
-			logp.Err("Unknown operation code: %d (%v)", opCode, opCode)
+			logger.Errorf("Unknown operation code: %d (%v)", opCode, opCode)
 			unknownOpcodes[opCode] = struct{}{}
 		}
 		return false, false
@@ -82,7 +82,7 @@ func mongodbMessageParser(s *stream) (bool, bool) {
 
 	s.message.opCode = opCode
 	s.message.isResponse = false // default is that the message is a request. If not opReplyParse will set this to true
-	debugf("opCode = %d (%v)", s.message.opCode, s.message.opCode)
+	logger.Debugf("opCode = %d (%v)", s.message.opCode, s.message.opCode)
 
 	// then split depending on operation type
 	s.message.event = mapstr.M{}
@@ -90,24 +90,24 @@ func mongodbMessageParser(s *stream) (bool, bool) {
 	switch s.message.opCode {
 	case opReply:
 		s.message.isResponse = true
-		return opReplyParse(d, s.message)
+		return opReplyParse(d, s.message, logger)
 	case opMsgLegacy:
 		s.message.method = "msg"
-		return opMsgLegacyParse(d, s.message)
+		return opMsgLegacyParse(d, s.message, logger)
 	case opUpdate:
 		s.message.method = "update"
-		return opUpdateParse(d, s.message)
+		return opUpdateParse(d, s.message, logger)
 	case opInsert:
 		s.message.method = "insert"
-		return opInsertParse(d, s.message)
+		return opInsertParse(d, s.message, logger)
 	case opQuery:
-		return opQueryParse(d, s.message)
+		return opQueryParse(d, s.message, logger)
 	case opGetMore:
 		s.message.method = "getMore"
-		return opGetMoreParse(d, s.message)
+		return opGetMoreParse(d, s.message, logger)
 	case opDelete:
 		s.message.method = "delete"
-		return opDeleteParse(d, s.message)
+		return opDeleteParse(d, s.message, logger)
 	case opKillCursor:
 		s.message.method = "killCursors"
 		return opKillCursorsParse(d, s.message)
@@ -118,58 +118,58 @@ func mongodbMessageParser(s *stream) (bool, bool) {
 		if s.message.responseTo > 0 {
 			s.message.isResponse = true
 		}
-		return opMsgParse(d, s.message)
+		return opMsgParse(d, s.message, logger)
 	}
 
 	return false, false
 }
 
 // see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-reply
-func opReplyParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opReplyParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	_, err := d.readInt32() // ignore flags for now
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_REPLY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_REPLY message: %s", err)
 		return false, false
 	}
 	m.event["cursorId"], err = d.readInt64()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_REPLY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_REPLY message: %s", err)
 		return false, false
 	}
 	m.event["startingFrom"], err = d.readInt32()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_REPLY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_REPLY message: %s", err)
 		return false, false
 	}
 
 	numberReturned, err := d.readInt32()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_REPLY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_REPLY message: %s", err)
 		return false, false
 	}
 
 	if numberReturned < 0 {
-		debugf("OP_REPLY has invalid negative numberReturned: %d", numberReturned)
+		logger.Debugf("OP_REPLY has invalid negative numberReturned: %d", numberReturned)
 		return false, false
 	}
 	remainingBytes := len(d.in) - d.i
 	maxPossibleDocs := remainingBytes / minBSONDocSize
 	if int(numberReturned) > maxPossibleDocs {
-		debugf("OP_REPLY numberReturned (%d) exceeds maximum possible documents (%d) in remaining %d bytes",
+		logger.Debugf("OP_REPLY numberReturned (%d) exceeds maximum possible documents (%d) in remaining %d bytes",
 			numberReturned, maxPossibleDocs, remainingBytes)
 		return false, false
 	}
 
 	m.event["numberReturned"] = numberReturned
 
-	debugf("Prepare to read %d document from reply", m.event["numberReturned"])
+	logger.Debugf("Prepare to read %d document from reply", m.event["numberReturned"])
 
 	documents := make([]interface{}, numberReturned)
 	for i := int32(0); i < numberReturned; i++ {
 		var document bson.M
-		document, err = d.readDocument()
+		document, err = d.readDocument(logger)
 		if err != nil {
-			logp.Err("An error occurred while parsing OP_REPLY message: %s", err)
+			logger.Errorf("An error occurred while parsing OP_REPLY message: %s", err)
 			return false, false
 		}
 
@@ -178,7 +178,7 @@ func opReplyParse(d *decoder, m *mongodbMessage) (bool, bool) {
 			if mongoError, present := document["$err"]; present {
 				m.error, err = doc2str(mongoError)
 				if err != nil {
-					logp.Err("An error occurred while parsing OP_REPLY message: %s", err)
+					logger.Errorf("An error occurred while parsing OP_REPLY message: %s", err)
 					return false, false
 				}
 			}
@@ -186,7 +186,7 @@ func opReplyParse(d *decoder, m *mongodbMessage) (bool, bool) {
 			if writeErrors, present := document["writeErrors"]; present {
 				m.error, err = doc2str(writeErrors)
 				if err != nil {
-					logp.Err("An error occurred while parsing OP_REPLY message: %s", err)
+					logger.Errorf("An error occurred while parsing OP_REPLY message: %s", err)
 					return false, false
 				}
 			}
@@ -199,50 +199,50 @@ func opReplyParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opMsgLegacyParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opMsgLegacyParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	var err error
 	m.event["message"], err = d.readCStr()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_MSG message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 		return false, false
 	}
 	return true, true
 }
 
-func opUpdateParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opUpdateParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	_, err := d.readInt32() // always ZERO, a slot reserved in the protocol for future use
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_UPDATE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_UPDATE message: %s", err)
 		return false, false
 	}
 	m.event["fullCollectionName"], err = d.readCStr()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_UPDATE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_UPDATE message: %s", err)
 		return false, false
 	}
 	_, err = d.readInt32() // ignore flags for now
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_UPDATE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_UPDATE message: %s", err)
 		return false, false
 	}
-	m.event["selector"], err = d.readDocumentStr()
+	m.event["selector"], err = d.readDocumentStr(logger)
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_UPDATE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_UPDATE message: %s", err)
 		return false, false
 	}
-	m.event["update"], err = d.readDocumentStr()
+	m.event["update"], err = d.readDocumentStr(logger)
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_UPDATE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_UPDATE message: %s", err)
 		return false, false
 	}
 
 	return true, true
 }
 
-func opInsertParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opInsertParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	_, err := d.readInt32() // ignore flags for now
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_INSERT message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_INSERT message: %s", err)
 		return false, false
 	}
 	m.event["fullCollectionName"], err = d.readCStr()
@@ -252,7 +252,7 @@ func opInsertParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	// Find an old client to generate a pcap with legacy protocol ?
 
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_INSERT message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_INSERT message: %s", err)
 		return false, false
 	}
 
@@ -281,39 +281,39 @@ func isDatabaseCommand(key string, val interface{}) bool {
 	return false
 }
 
-func opQueryParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opQueryParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	_, err := d.readInt32() // ignore flags for now
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_QUERY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_QUERY message: %s", err)
 		return false, false
 	}
 	fullCollectionName, err := d.readCStr()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_QUERY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_QUERY message: %s", err)
 		return false, false
 	}
 	m.event["fullCollectionName"] = fullCollectionName
 
 	m.event["numberToSkip"], err = d.readInt32()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_QUERY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_QUERY message: %s", err)
 		return false, false
 	}
 	m.event["numberToReturn"], err = d.readInt32()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_QUERY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_QUERY message: %s", err)
 		return false, false
 	}
 
-	query, err := d.readDocument()
+	query, err := d.readDocument(logger)
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_QUERY message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_QUERY message: %s", err)
 		return false, false
 	}
 	if d.i < len(d.in) {
-		m.event["returnFieldsSelector"], err = d.readDocumentStr()
+		m.event["returnFieldsSelector"], err = d.readDocumentStr(logger)
 		if err != nil {
-			logp.Err("An error occurred while parsing OP_QUERY returnFieldsSelector: %s", err)
+			logger.Errorf("An error occurred while parsing OP_QUERY returnFieldsSelector: %s", err)
 			return false, false
 		}
 	}
@@ -323,9 +323,9 @@ func opQueryParse(d *decoder, m *mongodbMessage) (bool, bool) {
 		m.method = "otherCommand"
 		m.resource = fullCollectionName
 		for key, val := range query {
-			debugf("key=%v val=%s", key, val)
+			logger.Debugf("key=%v val=%s", key, val)
 			if isDatabaseCommand(key, val) {
-				debugf("is db command")
+				logger.Debugf("is db command")
 				col, ok := val.(string)
 				if ok {
 					// replace $cmd with the actual collection name
@@ -345,49 +345,49 @@ func opQueryParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opGetMoreParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opGetMoreParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	_, err := d.readInt32() // always ZERO, a slot reserved in the protocol for future use
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_GET_MORE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_GET_MORE message: %s", err)
 		return false, false
 	}
 	m.event["fullCollectionName"], err = d.readCStr()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_GET_MORE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_GET_MORE message: %s", err)
 		return false, false
 	}
 	m.event["numberToReturn"], err = d.readInt32()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_GET_MORE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_GET_MORE message: %s", err)
 		return false, false
 	}
 	m.event["cursorId"], err = d.readInt64()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_GET_MORE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_GET_MORE message: %s", err)
 		return false, false
 	}
 	return true, true
 }
 
-func opDeleteParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opDeleteParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	_, err := d.readInt32() // always ZERO, a slot reserved in the protocol for future use
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_DELETE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_DELETE message: %s", err)
 		return false, false
 	}
 	m.event["fullCollectionName"], err = d.readCStr()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_DELETE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_DELETE message: %s", err)
 		return false, false
 	}
 	_, err = d.readInt32() // ignore flags for now
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_DELETE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_DELETE message: %s", err)
 		return false, false
 	}
-	m.event["selector"], err = d.readDocumentStr()
+	m.event["selector"], err = d.readDocumentStr(logger)
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_DELETE message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_DELETE message: %s", err)
 		return false, false
 	}
 
@@ -399,11 +399,11 @@ func opKillCursorsParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	return true, true
 }
 
-func opMsgParse(d *decoder, m *mongodbMessage) (bool, bool) {
+func opMsgParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool) {
 	// ignore flagbits
 	flagBits, err := d.readInt32()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_MSG message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 		return false, false
 	}
 
@@ -412,15 +412,15 @@ func opMsgParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	// read sections
 	kind, err := d.readByte()
 	if err != nil {
-		logp.Err("An error occurred while parsing OP_MSG message: %s", err)
+		logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 		return false, false
 	}
 
 	switch msgKind(kind) {
 	case msgKindBody:
-		document, err := d.readDocument()
+		document, err := d.readDocument(logger)
 		if err != nil {
-			logp.Err("An error occurred while parsing OP_MSG message: %s", err)
+			logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 			return false, false
 		}
 		m.documents = []interface{}{document}
@@ -429,31 +429,31 @@ func opMsgParse(d *decoder, m *mongodbMessage) (bool, bool) {
 		start := d.i
 		size, err := d.readInt32()
 		if err != nil {
-			logp.Err("An error occurred while parsing OP_MSG message: %s", err)
+			logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 			return false, false
 		}
 
 		if size < 0 {
-			debugf("OP_MSG has invalid negative document sequence size: %d", size)
+			logger.Errorf("OP_MSG has invalid negative document sequence size: %d", size)
 			return false, false
 		}
 		end := start + int(size)
 		if end < start || end > len(d.in) {
-			debugf("OP_MSG document sequence size %d exceeds buffer bounds", size)
+			logger.Errorf("OP_MSG document sequence size %d exceeds buffer bounds", size)
 			return false, false
 		}
 
 		cstring, err := d.readCStr()
 		if err != nil {
-			logp.Err("An error occurred while parsing OP_MSG message: %s", err)
+			logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 			return false, false
 		}
 		m.event["message"] = cstring
 		var documents []interface{}
 		for d.i < start+int(size) {
-			document, err := d.readDocument()
+			document, err := d.readDocument(logger)
 			if err != nil {
-				logp.Err("An error occurred while parsing OP_MSG message: %s", err)
+				logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 				return false, false
 			}
 			documents = append(documents, document)
@@ -462,7 +462,7 @@ func opMsgParse(d *decoder, m *mongodbMessage) (bool, bool) {
 	case msgKindInternal:
 		// Ignore the internal purposes section
 	default:
-		logp.Err("Unknown message kind: %v", kind)
+		logger.Errorf("Unknown message kind: %v", kind)
 		return false, false
 	}
 
@@ -544,14 +544,16 @@ func (d *decoder) readInt64() (int64, error) {
 // A BSON document has at least: length (4 bytes) + null terminator (1 byte) = 5 bytes.
 const minBSONDocSize = 5
 
-func (d *decoder) readDocument() (bson.M, error) {
+func (d *decoder) readDocument(logger *logp.Logger) (bson.M, error) {
 	start := d.i
 	documentLength, err := d.readInt32()
 	if err != nil {
+		logger.Errorf("An error occurred while parsing BSON document: %s", err)
 		return nil, err
 	}
 
 	if documentLength < minBSONDocSize {
+		logger.Errorf("Invalid BSON document length: %d", documentLength)
 		return nil, errors.New("invalid BSON document length")
 	}
 
@@ -562,11 +564,11 @@ func (d *decoder) readDocument() (bson.M, error) {
 
 	documentMap := bson.M{}
 
-	debugf("Parse %d bytes document from remaining %d bytes", documentLength, len(d.in)-start)
+	logger.Debugf("Parse %d bytes document from remaining %d bytes", documentLength, len(d.in)-start)
 	err = bson.Unmarshal(d.in[start:end], documentMap)
 
 	if err != nil {
-		debugf("Unmarshall error %v", err)
+		logger.Debugf("Unmarshall error %v", err)
 		return nil, err
 	}
 
@@ -579,8 +581,8 @@ func doc2str(documentMap interface{}) (string, error) {
 	return string(document), err
 }
 
-func (d *decoder) readDocumentStr() (string, error) {
-	documentMap, err := d.readDocument()
+func (d *decoder) readDocumentStr(logger *logp.Logger) (string, error) {
+	documentMap, err := d.readDocument(logger)
 	if err != nil {
 		return "", err
 	}

--- a/packetbeat/protos/mongodb/mongodb_parser_test.go
+++ b/packetbeat/protos/mongodb/mongodb_parser_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestMongodbParser_messageNotEvenStarted(t *testing.T) {
@@ -34,7 +36,7 @@ func TestMongodbParser_messageNotEvenStarted(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	if !ok {
 		t.Errorf("Parsing returned error")
@@ -50,7 +52,7 @@ func TestMongodbParser_messageNotFinished(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	if !ok {
 		t.Errorf("Parsing returned error")
@@ -70,7 +72,7 @@ func TestMongodbParser_simpleRequest(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	if !ok {
 		t.Errorf("Parsing returned error")
@@ -98,7 +100,7 @@ func TestMongodbParser_OpMsg(t *testing.T) {
 
 		st := &stream{data: data, message: new(mongodbMessage)}
 
-		ok, complete := mongodbMessageParser(st)
+		ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 		if !ok {
 			t.Errorf("Parsing returned error")
@@ -122,7 +124,7 @@ func TestMongodbParser_unknownOpCode(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	if ok {
 		t.Errorf("Parsing should have returned an error")
@@ -195,7 +197,7 @@ func TestMongodbParser_negativeMessageLength(t *testing.T) {
 		}
 	}()
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	// Should reject the message (ok=false) without completing
 	assert.False(t, ok, "Parser should reject negative message length")
@@ -213,7 +215,7 @@ func TestMongodbParser_messageLengthTooSmall(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	assert.False(t, ok, "Parser should reject message length smaller than header")
 	assert.False(t, complete, "Message should not be complete")
@@ -246,7 +248,7 @@ func TestMongodbParser_negativeBSONLength(t *testing.T) {
 		}
 	}()
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	assert.False(t, ok, "Parser should reject negative BSON document length")
 	assert.False(t, complete, "Message should not be complete")
@@ -271,7 +273,7 @@ func TestMongodbParser_zeroBSONLength(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	assert.False(t, ok, "Parser should reject zero BSON document length")
 	assert.False(t, complete, "Message should not be complete")
@@ -301,7 +303,7 @@ func TestMongodbParser_negativeNumberReturned(t *testing.T) {
 		}
 	}()
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	assert.False(t, ok, "Parser should reject negative numberReturned")
 	assert.False(t, complete, "Message should not be complete")
@@ -333,7 +335,7 @@ func TestMongodbParser_hugeNumberReturned(t *testing.T) {
 		}
 	}()
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	// Should reject because numberReturned exceeds what could fit in remaining bytes
 	assert.False(t, ok, "Parser should reject numberReturned exceeding buffer capacity")
@@ -364,7 +366,7 @@ func TestMongodbParser_negativeOpMsgSequenceSize(t *testing.T) {
 		}
 	}()
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	assert.False(t, ok, "Parser should reject negative OP_MSG document sequence size")
 	assert.False(t, complete, "Message should not be complete")
@@ -388,7 +390,7 @@ func TestMongodbParser_opMsgSequenceSizeExceedsBuffer(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	assert.False(t, ok, "Parser should reject OP_MSG sequence size exceeding buffer")
 	assert.False(t, complete, "Message should not be complete")
@@ -414,7 +416,7 @@ func TestMongodbParser_validOpReply(t *testing.T) {
 
 	st := &stream{data: data, message: new(mongodbMessage)}
 
-	ok, complete := mongodbMessageParser(st)
+	ok, complete := mongodbMessageParser(st, logptest.NewTestingLogger(t, ""))
 
 	assert.True(t, ok, "Parser should accept valid OP_REPLY")
 	assert.True(t, complete, "Message should be complete")

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -45,11 +45,14 @@ func (e *eventStore) publish(event beat.Event) {
 
 // Helper function returning a Mongodb module that can be used
 // in tests. It publishes the transactions in the results channel.
-func mongodbModForTests() (*eventStore, *mongodbPlugin) {
+func mongodbModForTests(t *testing.T) (*eventStore, *mongodbPlugin) {
 	var mongodb mongodbPlugin
+	logger := logp.NewNopLogger()
+	mongodb.logger = logger.Named("mongodb")
 	results := &eventStore{}
 	config := defaultConfig
 	mongodb.init(results.publish, &procs.ProcessesWatcher{}, &config)
+	mongodb.logger = logptest.NewTestingLogger(t, "mongodb")
 	return results, &mongodb
 }
 
@@ -81,9 +84,8 @@ func expectTransaction(t *testing.T, e *eventStore) mapstr.M {
 
 // Test simple request / response.
 func TestSimpleFindLimit1(t *testing.T) {
-	logp.TestingSetup(logp.WithSelectors("mongodb", "mongodbdetailed"))
 
-	results, mongodb := mongodbModForTests()
+	results, mongodb := mongodbModForTests(t)
 
 	// request and response from tests/pcaps/mongo_one_row.pcap
 	reqData, err := hex.DecodeString(
@@ -148,9 +150,8 @@ func TestSimpleFindLimit1(t *testing.T) {
 // Test simple request / response, where the response is split in
 // 3 messages
 func TestSimpleFindLimit1_split(t *testing.T) {
-	logp.TestingSetup(logp.WithSelectors("mongodb", "mongodbdetailed"))
 
-	results, mongodb := mongodbModForTests()
+	results, mongodb := mongodbModForTests(t)
 	mongodb.sendRequest = true
 	mongodb.sendResponse = true
 
@@ -282,7 +283,6 @@ func TestReconstructQuery(t *testing.T) {
 
 // max_docs option should be respected
 func TestMaxDocs(t *testing.T) {
-	logp.TestingSetup(logp.WithSelectors("mongodb", "mongodbdetailed"))
 
 	// more docs than configured
 	trans := transaction{
@@ -291,7 +291,7 @@ func TestMaxDocs(t *testing.T) {
 		},
 	}
 
-	results, mongodb := mongodbModForTests()
+	results, mongodb := mongodbModForTests(t)
 	mongodb.sendResponse = true
 	mongodb.maxDocs = 3
 
@@ -336,7 +336,6 @@ func TestMaxDocs(t *testing.T) {
 }
 
 func TestMaxDocSize(t *testing.T) {
-	logp.TestingSetup(logp.WithSelectors("mongodb", "mongodbdetailed"))
 
 	// more docs than configured
 	trans := transaction{
@@ -347,7 +346,7 @@ func TestMaxDocSize(t *testing.T) {
 		},
 	}
 
-	results, mongodb := mongodbModForTests()
+	results, mongodb := mongodbModForTests(t)
 	mongodb.sendResponse = true
 	mongodb.maxDocLength = 5
 
@@ -372,9 +371,8 @@ func TestOpCodeNames(t *testing.T) {
 
 // Test for a (recovered) panic parsing document length in request/response messages
 func TestDocumentLengthBoundsChecked(t *testing.T) {
-	logp.TestingSetup(logp.WithSelectors("mongodb", "mongodbdetailed"))
 
-	_, mongodb := mongodbModForTests()
+	_, mongodb := mongodbModForTests(t)
 
 	// request and response from tests/pcaps/mongo_one_row.pcap
 	reqData, err := hex.DecodeString(

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -275,7 +276,7 @@ func TestReconstructQuery(t *testing.T) {
 
 	for _, test := range tests {
 		assert.Equal(t, test.Output,
-			reconstructQuery(&test.Input, test.Full))
+			reconstructQuery(&test.Input, test.Full, logptest.NewTestingLogger(t, "")))
 	}
 }
 

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -116,7 +116,8 @@ type mysqlStream struct {
 	parseState  parseState
 	isClient    bool
 
-	message *mysqlMessage
+	message                             *mysqlMessage
+	logger, mysqlLogger, mysqlDetLogger *logp.Logger
 }
 
 type parseState int
@@ -163,6 +164,8 @@ type mysqlPlugin struct {
 	// function pointer for mocking
 	handleMysql func(mysql *mysqlPlugin, m *mysqlMessage, tcp *common.TCPTuple,
 		dir uint8, raw_msg []byte)
+
+	logger, mysqlLogger, mysqlDetLogger *logp.Logger
 }
 
 func init() {
@@ -177,6 +180,9 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &mysqlPlugin{}
+	p.logger = logger
+	p.mysqlLogger = logger.Named("mysql")
+	p.mysqlDetLogger = logger.Named("mysql.detail")
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -285,7 +291,7 @@ func isRequest(typ uint8) bool {
 }
 
 func mysqlMessageParser(s *mysqlStream) (bool, bool) {
-	logp.Debug("mysqldetailed", "MySQL parser called. parseState = %s", s.parseState)
+	s.mysqlDetLogger.Debugf("MySQL parser called. parseState = %s", s.parseState)
 
 	m := s.message
 	for s.parseOffset < len(s.data) {
@@ -301,7 +307,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 			m.seq = hdr[3]
 			m.typ = hdr[4]
 
-			logp.Debug("mysqldetailed", "MySQL Header: Packet length %d, Seq %d, Type=%d isClient=%v", m.packetLength, m.seq, m.typ, s.isClient)
+			s.mysqlLogger.Debugf("MySQL Header: Packet length %d, Seq %d, Type=%d isClient=%v", m.packetLength, m.seq, m.typ, s.isClient)
 
 			if s.isClient {
 				// starts Command Phase
@@ -321,17 +327,17 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 				m.isRequest = false
 
 				if hdr[4] == 0x00 || hdr[4] == 0xfe {
-					logp.Debug("mysqldetailed", "Received OK response")
+					s.mysqlDetLogger.Debug("Received OK response")
 					m.start = s.parseOffset
 					s.parseState = mysqlStateEatMessage
 					m.isOK = true
 				} else if hdr[4] == 0xff {
-					logp.Debug("mysqldetailed", "Received ERR response")
+					s.mysqlDetLogger.Debug("Received ERR response")
 					m.start = s.parseOffset
 					s.parseState = mysqlStateEatMessage
 					m.isError = true
 				} else if m.packetLength == 1 {
-					logp.Debug("mysqldetailed", "Query response. Number of fields %d", hdr[4])
+					s.mysqlDetLogger.Debugf("Query response. Number of fields %d", hdr[4])
 					m.numberOfFields = int(hdr[4])
 					m.start = s.parseOffset
 					s.parseOffset += 5
@@ -356,7 +362,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 				// get the statement id
 				if m.typ == mysqlCmdStmtExecute || m.typ == mysqlCmdStmtClose {
 					if len(s.data[m.start+5:]) < 4 {
-						logp.Warn("MySQL statementID data too short. Ignoring")
+						s.logger.Warn("MySQL statementID data too short. Ignoring")
 						return false, false
 					}
 					m.statementID = int(binary.LittleEndian.Uint32(s.data[m.start+5:]))
@@ -374,7 +380,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 					return true, false
 				}
 				if err != nil {
-					logp.Debug("mysql", "Error on read_linteger: %s", err)
+					s.mysqlLogger.Debugf("Error on read_linteger: %s", err)
 					return false, false
 				}
 				m.affectedRows = affectedRows
@@ -385,7 +391,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 					return true, false
 				}
 				if err != nil {
-					logp.Debug("mysql", "Error on read_linteger: %s", err)
+					s.mysqlLogger.Debugf("Error on read_linteger: %s", err)
 					return false, false
 				}
 				m.insertID = insertID
@@ -396,7 +402,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 				// string[5] sql state
 				// string<EOF> error message
 				if (m.start + 13) >= len(s.data) {
-					logp.Warn("MySql Error code is the wrong size. Ignoring.")
+					s.logger.Warn("MySql Error code is the wrong size. Ignoring.")
 					return false, false
 				}
 				m.errorCode = binary.LittleEndian.Uint16(s.data[m.start+5 : m.start+7])
@@ -405,11 +411,11 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 			}
 			msgSize := m.end - m.start
 			if msgSize < 0 {
-				logp.Warn("MySQL message size invalid. Ignoring.")
+				s.logger.Warn("MySQL message size invalid. Ignoring.")
 				return false, false
 			}
 			m.size = uint64(msgSize)
-			logp.Debug("mysqldetailed", "Message complete. remaining=%d",
+			s.mysqlDetLogger.Debugf("Message complete. remaining=%d",
 				len(s.data[s.parseOffset:]))
 
 			// PREPARE_OK packet for Prepared Statement
@@ -443,7 +449,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 					return false, false
 				}
 				if s.data[s.parseOffset] == 0xfe {
-					logp.Debug("mysqldetailed", "Received EOF packet")
+					s.mysqlDetLogger.Debug("Received EOF packet")
 					// EOF marker
 					s.parseOffset += int(m.packetLength)
 
@@ -454,7 +460,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 						return true, false
 					}
 					if err != nil {
-						logp.Debug("mysql", "Error on read_lstring: %s", err)
+						s.mysqlLogger.Debugf("Error on read_lstring: %s", err)
 						return false, false
 					}
 					db /*schema */, off, complete, err := readLstring(s.data, off)
@@ -462,7 +468,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 						return true, false
 					}
 					if err != nil {
-						logp.Debug("mysql", "Error on read_lstring: %s", err)
+						s.mysqlLogger.Debugf("Error on read_lstring: %s", err)
 						return false, false
 					}
 					table /* table */, _ /*off*/, complete, err := readLstring(s.data, off)
@@ -470,7 +476,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 						return true, false
 					}
 					if err != nil {
-						logp.Debug("mysql", "Error on read_lstring: %s", err)
+						s.mysqlLogger.Debugf("Error on read_lstring: %s", err)
 						return false, false
 					}
 
@@ -481,7 +487,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 					} else if !strings.Contains(m.tables, dbTable) {
 						m.tables = m.tables + ", " + dbTable
 					}
-					logp.Debug("mysqldetailed", "db=%s, table=%s", db, table)
+					s.mysqlDetLogger.Debugf("db=%s, table=%s", db, table)
 					s.parseOffset += int(m.packetLength)
 					// go to next field
 				}
@@ -499,7 +505,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 			m.packetLength = leUint24(hdr[:3])
 			m.seq = hdr[3]
 
-			logp.Debug("mysqldetailed", "Rows: packet length %d, packet number %d", m.packetLength, m.seq)
+			s.mysqlDetLogger.Debugf("Rows: packet length %d, packet number %d", m.packetLength, m.seq)
 
 			if len(s.data[s.parseOffset:]) < int(m.packetLength)+4 {
 				// wait for more
@@ -508,12 +514,12 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 
 			s.parseOffset += 4 // header
 			if len(s.data) <= s.parseOffset {
-				logp.Warn("MySQL packet has no data after header. Ignoring.")
+				s.logger.Warn("MySQL packet has no data after header. Ignoring.")
 				return false, false
 			}
 
 			if s.data[s.parseOffset] == 0xfe {
-				logp.Debug("mysqldetailed", "Received EOF packet")
+				s.mysqlDetLogger.Debugf("Received EOF packet")
 				// EOF marker
 				s.parseOffset += int(m.packetLength)
 
@@ -528,7 +534,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 				}
 				bodySize := m.end - m.start
 				if bodySize < 0 {
-					logp.Warn("MySQL message body size invalid. Ignoring.")
+					s.logger.Warn("MySQL message body size invalid. Ignoring.")
 					return false, false
 				}
 				m.size = uint64(bodySize)
@@ -613,12 +619,13 @@ func (mysql *mysqlPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 			data:     pkt.Payload,
 			message:  &mysqlMessage{ts: pkt.Ts},
 			isClient: mysql.isServerPort(dstPort),
+			logger:   mysql.logger,
 		}
 	} else {
 		// concatenate bytes
 		priv.data[dir].data = append(priv.data[dir].data, pkt.Payload...)
 		if len(priv.data[dir].data) > tcp.TCPMaxDataInStream {
-			logp.Debug("mysql", "Stream data too large, dropping TCP stream")
+			mysql.mysqlLogger.Debug("Stream data too large, dropping TCP stream")
 			priv.data[dir] = nil
 			return priv
 		}
@@ -631,12 +638,12 @@ func (mysql *mysqlPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 		}
 
 		ok, complete := mysqlMessageParser(priv.data[dir])
-		logp.Debug("mysqldetailed", "mysqlMessageParser returned ok=%v complete=%v", ok, complete)
+		mysql.mysqlDetLogger.Debugf("mysqlMessageParser returned ok=%v complete=%v", ok, complete)
 		if !ok {
 			// drop this tcp stream. Will retry parsing with the next
 			// segment in it
 			priv.data[dir] = nil
-			logp.Debug("mysql", "Ignore MySQL message. Drop tcp stream. Try parsing with the next segment")
+			mysql.mysqlLogger.Debug("Ignore MySQL message. Drop tcp stream. Try parsing with the next segment")
 			return priv
 		}
 
@@ -705,7 +712,7 @@ func (mysql *mysqlPlugin) receivedMysqlRequest(msg *mysqlMessage) {
 	trans := mysql.getTransaction(tuple.Hashable())
 	if trans != nil {
 		if trans.mysql != nil {
-			logp.Debug("mysql", "Two requests without a Response. Dropping old request: %s", trans.mysql)
+			mysql.logger.Debugf("Two requests without a Response. Dropping old request: %s", trans.mysql)
 			unmatchedRequests.Add(1)
 		}
 	} else {
@@ -784,13 +791,13 @@ func (mysql *mysqlPlugin) receivedMysqlRequest(msg *mysqlMessage) {
 func (mysql *mysqlPlugin) receivedMysqlResponse(msg *mysqlMessage) {
 	trans := mysql.getTransaction(msg.tcpTuple.Hashable())
 	if trans == nil {
-		logp.Debug("mysql", "Response from unknown transaction. Ignoring.")
+		mysql.logger.Debug("Response from unknown transaction. Ignoring.")
 		unmatchedResponses.Add(1)
 		return
 	}
 	// check if the request was received
 	if trans.mysql == nil {
-		logp.Debug("mysql", "Response from unknown transaction. Ignoring.")
+		mysql.logger.Debug("Response from unknown transaction. Ignoring.")
 		unmatchedResponses.Add(1)
 		return
 
@@ -841,13 +848,13 @@ func (mysql *mysqlPlugin) receivedMysqlResponse(msg *mysqlMessage) {
 	mysql.publishTransaction(trans)
 	mysql.transactions.Delete(trans.tuple.Hashable())
 
-	logp.Debug("mysql", "Mysql transaction completed: %s %s %s", trans.query, trans.params, trans.mysql)
+	mysql.mysqlLogger.Debugf("Mysql transaction completed: %s %s %s", trans.query, trans.params, trans.mysql)
 }
 
 func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysqlStmtData) []string {
 	dataLen := len(data)
 	if dataLen < 14 {
-		logp.Debug("mysql", "Data too small")
+		mysql.mysqlLogger.Debug("Data too small")
 		return nil
 	}
 	var paramType, paramUnsigned uint8
@@ -873,7 +880,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 	}
 	// stmt bound
 	if dataLen <= offset {
-		logp.Debug("mysql", "Data too small")
+		mysql.mysqlLogger.Debug("Data too small")
 		return nil
 	}
 	stmtBound := data[offset]
@@ -882,7 +889,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 	if stmtBound == 1 {
 		paramOffset += nparam * 2
 		if dataLen <= paramOffset {
-			logp.Debug("mysql", "Data too small to contain parameters")
+			mysql.mysqlLogger.Debug("Data too small to contain parameters")
 			return nil
 		}
 		// First call or rebound (1)
@@ -890,11 +897,11 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 			paramType = data[offset]
 			offset++
 			nparamType = append(nparamType, paramType)
-			logp.Debug("mysqldetailed", "type = %d", paramType)
+			mysql.mysqlLogger.Named("mysqldetailed").Debugf("type = %d", paramType)
 			paramUnsigned = data[offset]
 			offset++
 			if paramUnsigned != 0 {
-				logp.Debug("mysql", "Illegal param unsigned")
+				mysql.mysqlLogger.Debug("Illegal param unsigned")
 				return nil
 			}
 		}
@@ -922,7 +929,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 		// FIELD_TYPE_SHORT
 		case 0x02:
 			if dataLen < paramOffset+2 {
-				logp.Debug("mysql", "Data too small")
+				mysql.mysqlLogger.Debug("Data too small")
 				return nil
 			}
 			valueString := strconv.Itoa(int(binary.LittleEndian.Uint16(data[paramOffset:])))
@@ -931,7 +938,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 		// FIELD_TYPE_LONG
 		case 0x03:
 			if dataLen < paramOffset+4 {
-				logp.Debug("mysql", "Data too small")
+				mysql.mysqlLogger.Debug("Data too small")
 				return nil
 			}
 			valueString := strconv.Itoa(int(binary.LittleEndian.Uint32(data[paramOffset:])))
@@ -951,7 +958,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 		//  FIELD_TYPE_LONGLONG
 		case 0x08:
 			if dataLen < paramOffset+8 {
-				logp.Debug("mysql", "Data too small")
+				mysql.mysqlLogger.Debug("Data too small")
 				return nil
 			}
 			valueInt := binary.LittleEndian.Uint64(data[paramOffset : paramOffset+8])
@@ -965,7 +972,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 			var year, month, day, hour, minute, second string
 			paramLen := int(data[paramOffset])
 			if dataLen < paramOffset+paramLen+1 {
-				logp.Debug("mysql", "Data too small")
+				mysql.mysqlLogger.Debug("Data too small")
 				return nil
 			}
 			paramOffset++
@@ -993,7 +1000,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 		case 0x0b:
 			paramLen := int(data[paramOffset])
 			if dataLen < paramOffset+paramLen+1 {
-				logp.Debug("mysql", "Data too small")
+				mysql.mysqlLogger.Debug("Data too small")
 				return nil
 			}
 			paramOffset++
@@ -1009,7 +1016,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 			case 0xfc: /* 252 - 64k chars */
 				paramLen16 := int(binary.LittleEndian.Uint16(data[paramOffset : paramOffset+2]))
 				if dataLen < paramOffset+paramLen16+2 {
-					logp.Debug("mysql", "Data too small")
+					mysql.mysqlLogger.Debug("Data too small")
 					return nil
 				}
 				paramOffset += 2
@@ -1018,7 +1025,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 			case 0xfd: /* 64k - 16M chars */
 				paramLen24 := int(leUint24(data[paramOffset : paramOffset+3]))
 				if dataLen < paramOffset+paramLen24+3 {
-					logp.Debug("mysql", "Data too small")
+					mysql.mysqlLogger.Debug("Data too small")
 					return nil
 				}
 				paramOffset += 3
@@ -1026,14 +1033,14 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 				paramOffset += paramLen24
 			default: /* < 252 chars     */
 				if dataLen < paramOffset+paramLen {
-					logp.Debug("mysql", "Data too small")
+					mysql.mysqlLogger.Debug("Data too small")
 					return nil
 				}
 				paramString = append(paramString, string(data[paramOffset:paramOffset+paramLen]))
 				paramOffset += paramLen
 			}
 		default:
-			logp.Debug("mysql", "Unknown param type")
+			mysql.mysqlLogger.Debug("Unknown param type")
 			return nil
 		}
 
@@ -1067,7 +1074,7 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 	default:
 		offset := 5
 
-		logp.Debug("mysql", "Data len: %d", len(data))
+		mysql.mysqlLogger.Debugf("Data len: %d", len(data))
 
 		// Read fields
 		for {
@@ -1090,32 +1097,32 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 
 			_ /* catalog */, off, complete, err := readLstring(data, offset+4)
 			if err != nil || !complete {
-				logp.Debug("mysql", "Reading field: %v %v", err, complete)
+				mysql.mysqlLogger.Debugf("Reading field: %v %v", err, complete)
 				return fields, rows
 			}
 			_ /*database*/, off, complete, err = readLstring(data, off)
 			if err != nil || !complete {
-				logp.Debug("mysql", "Reading field: %v %v", err, complete)
+				mysql.mysqlLogger.Debugf("Reading field: %v %v", err, complete)
 				return fields, rows
 			}
 			_ /*table*/, off, complete, err = readLstring(data, off)
 			if err != nil || !complete {
-				logp.Debug("mysql", "Reading field: %v %v", err, complete)
+				mysql.mysqlLogger.Debugf("Reading field: %v %v", err, complete)
 				return fields, rows
 			}
 			_ /*org table*/, off, complete, err = readLstring(data, off)
 			if err != nil || !complete {
-				logp.Debug("mysql", "Reading field: %v %v", err, complete)
+				mysql.logger.Debug("Reading field: %v %v", err, complete)
 				return fields, rows
 			}
 			name, off, complete, err := readLstring(data, off)
 			if err != nil || !complete {
-				logp.Debug("mysql", "Reading field: %v %v", err, complete)
+				mysql.mysqlLogger.Debugf("Reading field: %v %v", err, complete)
 				return fields, rows
 			}
 			_ /* org name */, _ /*off*/, complete, err = readLstring(data, off)
 			if err != nil || !complete {
-				logp.Debug("mysql", "Reading field: %v %v", err, complete)
+				mysql.mysqlLogger.Debugf("Reading field: %v %v", err, complete)
 				return fields, rows
 			}
 
@@ -1165,7 +1172,7 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 					var complete bool
 					text, off, complete, err = readLstring(data, off)
 					if err != nil || !complete {
-						logp.Debug("mysql", "Error parsing rows: %+v %t", err, complete)
+						mysql.mysqlLogger.Debugf("Error parsing rows: %+v %t", err, complete)
 						// nevertheless, return what we have so far
 						return fields, rows
 					}
@@ -1180,7 +1187,7 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 				}
 			}
 
-			logp.Debug("mysqldetailed", "Append row: %v", row)
+			mysql.mysqlDetLogger.Debugf("Append row: %v", row)
 
 			rows = append(rows, row)
 			if len(rows) >= mysql.maxStoreRows {
@@ -1198,7 +1205,7 @@ func (mysql *mysqlPlugin) publishTransaction(t *mysqlTransaction) {
 		return
 	}
 
-	logp.Debug("mysql", "mysql.results exists")
+	mysql.mysqlLogger.Debug("mysql.results exists")
 
 	evt, pbf := pb.NewBeatEvent(t.ts)
 	pbf.SetSource(&t.src)

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -299,7 +299,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 		case mysqlStateStart:
 			m.start = s.parseOffset
 			if len(s.data[s.parseOffset:]) < 5 {
-				logp.Warn("MySQL Message too short. Ignore it.")
+				s.logger.Warnf("MySQL Message too short. Ignore it.")
 				return false, false
 			}
 			hdr := s.data[s.parseOffset : s.parseOffset+5]
@@ -368,7 +368,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 					m.statementID = int(binary.LittleEndian.Uint32(s.data[m.start+5:]))
 				} else {
 					if m.start+5 > m.end || m.end > len(s.data) {
-						logp.Warn("MySQL query data too short. Ignoring.")
+						s.logger.Warnf("MySQL query data too short. Ignoring.")
 						return false, false
 					}
 					m.query = string(s.data[m.start+5 : m.end])
@@ -445,7 +445,7 @@ func mysqlMessageParser(s *mysqlStream) (bool, bool) {
 			if len(s.data[s.parseOffset:]) >= int(m.packetLength)+4 {
 				s.parseOffset += 4 // header
 				if len(s.data) <= s.parseOffset {
-					logp.Warn("MySQL packet has no data after header. Ignoring.")
+					s.logger.Warnf("MySQL packet has no data after header. Ignoring.")
 					return false, false
 				}
 				if s.data[s.parseOffset] == 0xfe {
@@ -1051,16 +1051,16 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string) {
 	length, err := readLength(data, 0)
 	if err != nil {
-		logp.Warn("Invalid response: %v", err)
+		mysql.logger.Warn("Invalid response: %v", err)
 		return []string{}, [][]string{}
 	}
 	if length < 1 {
-		logp.Warn("Warning: Skipping empty Response")
+		mysql.logger.Warn("Warning: Skipping empty Response")
 		return []string{}, [][]string{}
 	}
 
 	if len(data) < 5 {
-		logp.Warn("Invalid response: data less than 5 bytes")
+		mysql.logger.Warn("Invalid response: data less than 5 bytes")
 		return []string{}, [][]string{}
 	}
 
@@ -1080,12 +1080,12 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 		for {
 			length, err = readLength(data, offset)
 			if err != nil {
-				logp.Warn("Invalid response: %v", err)
+				mysql.logger.Warn("Invalid response: %v", err)
 				return []string{}, [][]string{}
 			}
 
 			if len(data[offset:]) < 5 {
-				logp.Warn("Invalid response.")
+				mysql.logger.Warn("Invalid response.")
 				return []string{}, [][]string{}
 			}
 
@@ -1130,7 +1130,7 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 
 			offset += length + 4
 			if len(data) < offset {
-				logp.Warn("Invalid response.")
+				mysql.logger.Warn("Invalid response.")
 				return []string{}, [][]string{}
 			}
 		}
@@ -1141,7 +1141,7 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 			var rowLen int
 
 			if len(data[offset:]) < 5 {
-				logp.Warn("Invalid response.")
+				mysql.logger.Warn("Invalid response.")
 				break
 			}
 
@@ -1153,7 +1153,7 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 
 			length, err = readLength(data, offset)
 			if err != nil {
-				logp.Warn("Invalid response: %v", err)
+				mysql.logger.Warn("Invalid response: %v", err)
 				break
 			}
 			off := offset + 4 // skip length + packet number

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -1053,7 +1053,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string) {
 	length, err := readLength(data, 0)
 	if err != nil {
-		mysql.logger.Warn("Invalid response: %v", err)
+		mysql.logger.Warnf("Invalid response: %v", err)
 		return []string{}, [][]string{}
 	}
 	if length < 1 {
@@ -1114,7 +1114,7 @@ func (mysql *mysqlPlugin) parseMysqlResponse(data []byte) ([]string, [][]string)
 			}
 			_ /*org table*/, off, complete, err = readLstring(data, off)
 			if err != nil || !complete {
-				mysql.logger.Debug("Reading field: %v %v", err, complete)
+				mysql.logger.Debugf("Reading field: %v %v", err, complete)
 				return fields, rows
 			}
 			name, off, complete, err := readLstring(data, off)

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -616,10 +616,12 @@ func (mysql *mysqlPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 			dstPort = tcptuple.SrcPort
 		}
 		priv.data[dir] = &mysqlStream{
-			data:     pkt.Payload,
-			message:  &mysqlMessage{ts: pkt.Ts},
-			isClient: mysql.isServerPort(dstPort),
-			logger:   mysql.logger,
+			data:           pkt.Payload,
+			message:        &mysqlMessage{ts: pkt.Ts},
+			isClient:       mysql.isServerPort(dstPort),
+			logger:         mysql.logger,
+			mysqlLogger:    mysql.mysqlLogger,
+			mysqlDetLogger: mysql.mysqlDetLogger,
 		}
 	} else {
 		// concatenate bytes

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -56,10 +56,26 @@ func mysqlModForTests(store *eventStore) *mysqlPlugin {
 	}
 
 	var mysql mysqlPlugin
+	logger := logp.NewNopLogger()
+	mysql.logger = logger
+	mysql.mysqlLogger = logger.Named("mysql")
+	mysql.mysqlDetLogger = logger.Named("mysql.detail")
 	config := defaultConfig
 	config.Ports = []int{serverPort}
 	mysql.init(callback, &procs.ProcessesWatcher{}, &config)
 	return &mysql
+}
+
+func newTestMySQLStream(data []byte, isClient bool) *mysqlStream {
+	logger := logp.NewNopLogger()
+	return &mysqlStream{
+		data:           data,
+		message:        new(mysqlMessage),
+		isClient:       isClient,
+		logger:         logger,
+		mysqlLogger:    logger.Named("mysql"),
+		mysqlDetLogger: logger.Named("mysql.detail"),
+	}
 }
 
 func Test_parseStateNames(t *testing.T) {
@@ -85,7 +101,7 @@ func TestMySQLParser_simpleRequest(t *testing.T) {
 		t.Errorf("Failed to decode hex string")
 	}
 
-	stream := &mysqlStream{data: message, message: new(mysqlMessage), isClient: true}
+	stream := newTestMySQLStream(message, true)
 
 	ok, complete := mysqlMessageParser(stream)
 
@@ -116,7 +132,7 @@ func TestMySQLParser_OKResponse(t *testing.T) {
 		t.Errorf("Failed to decode hex string")
 	}
 
-	stream := &mysqlStream{data: message, message: new(mysqlMessage)}
+	stream := newTestMySQLStream(message, false)
 
 	ok, complete := mysqlMessageParser(stream)
 
@@ -152,7 +168,7 @@ func TestMySQLParser_errorResponse(t *testing.T) {
 		t.Errorf("Failed to decode hex string")
 	}
 
-	stream := &mysqlStream{data: message, message: new(mysqlMessage)}
+	stream := newTestMySQLStream(message, false)
 
 	ok, complete := mysqlMessageParser(stream)
 
@@ -197,7 +213,7 @@ func TestMySQLParser_dataResponse(t *testing.T) {
 		t.Errorf("Failed to decode hex string")
 	}
 
-	stream := &mysqlStream{data: message, message: new(mysqlMessage)}
+	stream := newTestMySQLStream(message, false)
 
 	ok, complete := mysqlMessageParser(stream)
 
@@ -250,7 +266,7 @@ func TestMySQLParser_simpleUpdateResponse(t *testing.T) {
 		t.Errorf("Failed to decode hex string")
 	}
 
-	stream := &mysqlStream{data: message, message: new(mysqlMessage)}
+	stream := newTestMySQLStream(message, false)
 
 	ok, complete := mysqlMessageParser(stream)
 
@@ -286,7 +302,7 @@ func TestMySQLParser_simpleUpdateResponseSplit(t *testing.T) {
 		t.Errorf("Failed to decode hex string")
 	}
 
-	stream := &mysqlStream{data: message, message: new(mysqlMessage)}
+	stream := newTestMySQLStream(message, false)
 
 	ok, complete := mysqlMessageParser(stream)
 
@@ -571,7 +587,7 @@ func Test_gap_in_eat_message(t *testing.T) {
 			"66726f6d20746573")
 	assert.NoError(t, err)
 
-	stream := &mysqlStream{data: reqData, message: new(mysqlMessage), isClient: true}
+	stream := newTestMySQLStream(reqData, true)
 	ok, complete := mysqlMessageParser(stream)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, false, complete)

--- a/packetbeat/protos/nfs/malformed.go
+++ b/packetbeat/protos/nfs/malformed.go
@@ -19,9 +19,9 @@ package nfs
 
 import "github.com/elastic/elastic-agent-libs/logp"
 
-func dropMalformed(context string, err error) bool {
+func dropMalformed(context string, err error, logger *logp.Logger) bool {
 	if err != nil {
-		logp.Warn("nfs: dropping malformed %s: %v", context, err)
+		logger.Warnf("nfs: dropping malformed %s: %v", context, err)
 		return true
 	}
 	return false

--- a/packetbeat/protos/nfs/request_handler.go
+++ b/packetbeat/protos/nfs/request_handler.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
@@ -54,11 +53,11 @@ func (r *rpc) handleExpiredPacket(nfs *nfs) {
 
 // called when we process a RPC call
 func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TCPTuple, dir uint8) {
-	if _, err := xdr.getUInt(); dropMalformed("rpc call version", err) {
+	if _, err := xdr.getUInt(); dropMalformed("rpc call version", err, r.logger) {
 		return
 	}
 	rpcProg, err := xdr.getUInt()
-	if dropMalformed("rpc call program", err) {
+	if dropMalformed("rpc call program", err, r.logger) {
 		return
 	}
 	if rpcProg != nfsProgramNumber {
@@ -92,11 +91,11 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 	pbf.Network.Transport = "tcp"
 
 	nfsVers, err := xdr.getUInt()
-	if dropMalformed("rpc call nfs version", err) {
+	if dropMalformed("rpc call nfs version", err, r.logger) {
 		return
 	}
 	nfsProc, err := xdr.getUInt()
-	if dropMalformed("rpc call nfs procedure", err) {
+	if dropMalformed("rpc call nfs procedure", err, r.logger) {
 		return
 	}
 
@@ -117,11 +116,11 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 	fields := evt.Fields
 
 	authFlavor, err := xdr.getUInt()
-	if dropMalformed("rpc auth flavor", err) {
+	if dropMalformed("rpc auth flavor", err, r.logger) {
 		return
 	}
 	authOpaque, err := xdr.getDynamicOpaque()
-	if dropMalformed("rpc auth opaque", err) {
+	if dropMalformed("rpc auth opaque", err, r.logger) {
 		return
 	}
 	switch authFlavor {
@@ -132,12 +131,12 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 		cred := mapstr.M{}
 		credXdr := makeXDR(authOpaque)
 		stamp, err := credXdr.getUInt()
-		if dropMalformed("rpc unix cred stamp", err) {
+		if dropMalformed("rpc unix cred stamp", err, r.logger) {
 			return
 		}
 		cred["stamp"] = stamp
 		machine, err := credXdr.getString()
-		if dropMalformed("rpc unix cred machinename", err) {
+		if dropMalformed("rpc unix cred machinename", err, r.logger) {
 			return
 		}
 		if machine == "" {
@@ -149,21 +148,21 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 		fields["host.hostname"] = machine
 
 		uid, err := credXdr.getUInt()
-		if dropMalformed("rpc unix cred uid", err) {
+		if dropMalformed("rpc unix cred uid", err, r.logger) {
 			return
 		}
 		cred["uid"] = uid
 		fields["user.id"] = uid
 
 		gid, err := credXdr.getUInt()
-		if dropMalformed("rpc unix cred gid", err) {
+		if dropMalformed("rpc unix cred gid", err, r.logger) {
 			return
 		}
 		cred["gid"] = gid
 		fields["group.id"] = gid
 
 		gids, err := credXdr.getUIntVector()
-		if dropMalformed("rpc unix cred gids", err) {
+		if dropMalformed("rpc unix cred gids", err, r.logger) {
 			return
 		}
 		cred["gids"] = gids
@@ -175,10 +174,10 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 	}
 
 	// eat auth verifier
-	if _, err := xdr.getUInt(); dropMalformed("rpc verifier flavor", err) {
+	if _, err := xdr.getUInt(); dropMalformed("rpc verifier flavor", err, r.logger) {
 		return
 	}
-	if _, err := xdr.getDynamicOpaque(); dropMalformed("rpc verifier body", err) {
+	if _, err := xdr.getDynamicOpaque(); dropMalformed("rpc verifier body", err, r.logger) {
 		return
 	}
 
@@ -192,7 +191,7 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 		event: evt,
 	}
 	info, err := nfs.getRequestInfo(xdr)
-	if dropMalformed("nfs request info", err) {
+	if dropMalformed("nfs request info", err, r.logger) {
 		return
 	}
 	fields["nfs"] = info
@@ -211,7 +210,7 @@ func (r *rpc) handleCall(xid string, xdr *xdr, ts time.Time, tcptuple *common.TC
 // called when we process a RPC reply
 func (r *rpc) handleReply(xid string, xdr *xdr, ts time.Time, tcptuple *common.TCPTuple, dir uint8) {
 	replyStatus, err := xdr.getUInt()
-	if dropMalformed("rpc reply status", err) {
+	if dropMalformed("rpc reply status", err, r.logger) {
 		return
 	}
 	// we are interested only in accepted rpc reply
@@ -220,10 +219,10 @@ func (r *rpc) handleReply(xid string, xdr *xdr, ts time.Time, tcptuple *common.T
 	}
 
 	// eat auth verifier
-	if _, err := xdr.getUInt(); dropMalformed("rpc reply verifier flavor", err) {
+	if _, err := xdr.getUInt(); dropMalformed("rpc reply verifier flavor", err, r.logger) {
 		return
 	}
-	if _, err := xdr.getDynamicOpaque(); dropMalformed("rpc reply verifier body", err) {
+	if _, err := xdr.getDynamicOpaque(); dropMalformed("rpc reply verifier body", err, r.logger) {
 		return
 	}
 
@@ -242,7 +241,7 @@ func (r *rpc) handleReply(xid string, xdr *xdr, ts time.Time, tcptuple *common.T
 	if v != nil {
 		nfs, ok := v.(*nfs)
 		if !ok {
-			logp.Warn("nfs: failed to assert nfs interface")
+			r.logger.Warnf("nfs: failed to assert nfs interface")
 			return
 
 		}
@@ -252,17 +251,17 @@ func (r *rpc) handleReply(xid string, xdr *xdr, ts time.Time, tcptuple *common.T
 		fields := nfs.event.Fields
 		rpcInfo, ok := fields["rpc"].(mapstr.M)
 		if !ok {
-			logp.Warn("nfs: failed to assert map[string]")
+			r.logger.Warnf("nfs: failed to assert map[string]")
 			return
 
 		}
 		statusVal, err := xdr.getUInt()
-		if dropMalformed("rpc accept status", err) {
+		if dropMalformed("rpc accept status", err, r.logger) {
 			return
 		}
 		status := int(statusVal)
 		if status < 0 || status >= len(acceptStatus) {
-			logp.Warn("nfs: rpc accept status %d out of range", status)
+			r.logger.Warnf("nfs: rpc accept status %d out of range", status)
 			return
 		}
 		rpcInfo["status"] = acceptStatus[status]
@@ -271,12 +270,12 @@ func (r *rpc) handleReply(xid string, xdr *xdr, ts time.Time, tcptuple *common.T
 		if status == 0 {
 			nfsInfo, ok := fields["nfs"].(mapstr.M)
 			if !ok {
-				logp.Warn("nfs: failed to assert map[string]")
+				r.logger.Warnf("nfs: failed to assert map[string]")
 				return
 
 			}
 			nfsStatus, err := nfs.getNFSReplyStatus(xdr)
-			if dropMalformed("nfs reply status", err) {
+			if dropMalformed("nfs reply status", err, r.logger) {
 				return
 			}
 			nfsInfo["status"] = nfsStatus

--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -103,7 +103,7 @@ func (r *rpc) init(results protos.Reporter, config *rpcConfig) error {
 		func(k common.Key, v common.Value) {
 			nfs, ok := v.(*nfs)
 			if !ok {
-				r.logger.Error("Expired value is not a MapStr (%T).", v)
+				r.logger.Errorf("Expired value is not a MapStr (%T).", v)
 				return
 			}
 			r.handleExpiredPacket(nfs)

--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -35,8 +35,6 @@ import (
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
 )
 
-var debugf = logp.MakeDebug("rpc")
-
 const (
 	rpcLastFrag = 0x80000000
 	rpcSizeMask = 0x7fffffff
@@ -61,6 +59,7 @@ type rpc struct {
 	ports              []int
 	callsSeen          *common.Cache
 	transactionTimeout time.Duration
+	logger             *logp.Logger
 
 	results protos.Reporter // Channel where results are pushed.
 }
@@ -77,16 +76,17 @@ func New(
 	log *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &rpc{}
+	p.logger = log.Named("rpc")
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
-			logp.Warn("failed to read config")
+			p.logger.Warnf("failed to read config")
 			return nil, err
 		}
 	}
 
 	if err := p.init(results, &config); err != nil {
-		logp.Warn("failed to init")
+		p.logger.Warnf("failed to init")
 		return nil, err
 	}
 	return p, nil
@@ -103,7 +103,7 @@ func (r *rpc) init(results protos.Reporter, config *rpcConfig) error {
 		func(k common.Key, v common.Value) {
 			nfs, ok := v.(*nfs)
 			if !ok {
-				logp.Err("Expired value is not a MapStr (%T).", v)
+				r.logger.Error("Expired value is not a MapStr (%T).", v)
 				return
 			}
 			r.handleExpiredPacket(nfs)
@@ -134,7 +134,7 @@ func (r *rpc) Parse(
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	conn := ensureRPCConnection(private)
+	conn := ensureRPCConnection(private, r.logger)
 
 	conn = r.handleRPCFragment(conn, pkt, tcptuple, dir)
 	if conn == nil {
@@ -167,26 +167,26 @@ func (r *rpc) ConnectionTimeout() time.Duration {
 	return r.transactionTimeout
 }
 
-func ensureRPCConnection(private protos.ProtocolData) *rpcConnectionData {
-	conn := getRPCConnection(private)
+func ensureRPCConnection(private protos.ProtocolData, logger *logp.Logger) *rpcConnectionData {
+	conn := getRPCConnection(private, logger)
 	if conn == nil {
 		conn = &rpcConnectionData{}
 	}
 	return conn
 }
 
-func getRPCConnection(private protos.ProtocolData) *rpcConnectionData {
+func getRPCConnection(private protos.ProtocolData, logger *logp.Logger) *rpcConnectionData {
 	if private == nil {
 		return nil
 	}
 
 	priv, ok := private.(*rpcConnectionData)
 	if !ok {
-		logp.Warn("rpc connection data type error")
+		logger.Warn("rpc connection data type error")
 		return nil
 	}
 	if priv == nil {
-		logp.Warn("Unexpected: rpc connection data not set")
+		logger.Warn("Unexpected: rpc connection data not set")
 		return nil
 	}
 
@@ -208,7 +208,7 @@ func (r *rpc) handleRPCFragment(
 		// concatenate bytes
 		st.rawData = append(st.rawData, pkt.Payload...)
 		if len(st.rawData) > tcp.TCPMaxDataInStream {
-			debugf("Stream data too large, dropping TCP stream")
+			r.logger.Debug("Stream data too large, dropping TCP stream")
 			conn.streams[dir] = nil
 			return conn
 		}
@@ -217,7 +217,9 @@ func (r *rpc) handleRPCFragment(
 	for len(st.rawData) > 0 {
 
 		if len(st.rawData) < 4 {
-			debugf("Waiting for more data")
+			if r.logger.IsDebug() {
+				r.logger.Debug("Waiting for more data")
+			}
 			break
 		}
 
@@ -226,12 +228,14 @@ func (r *rpc) handleRPCFragment(
 		islast := (marker & rpcLastFrag) != 0
 
 		if len(st.rawData)-4 < size {
-			debugf("Waiting for more data")
+			if r.logger.IsDebug() {
+				r.logger.Debug("Waiting for more data")
+			}
 			break
 		}
 
 		if !islast {
-			logp.Warn("multifragment rpc message")
+			r.logger.Warn("multifragment rpc message")
 			break
 		}
 
@@ -248,18 +252,18 @@ func (r *rpc) handleRPCFragment(
 func (r *rpc) handleRPCPacket(xdr *xdr, ts time.Time, tcptuple *common.TCPTuple, dir uint8) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			logp.Warn("nfs: recovered from panic while parsing RPC/NFS: %v", rec)
+			r.logger.Warnf("nfs: recovered from panic while parsing RPC/NFS: %v", rec)
 		}
 	}()
 
 	xidVal, err := xdr.getUInt()
-	if dropMalformed("rpc packet xid", err) {
+	if dropMalformed("rpc packet xid", err, r.logger) {
 		return
 	}
 	xid := fmt.Sprintf("%.8x", xidVal)
 
 	msgType, err := xdr.getUInt()
-	if dropMalformed("rpc packet msgType", err) {
+	if dropMalformed("rpc packet msgType", err, r.logger) {
 		return
 	}
 
@@ -269,7 +273,7 @@ func (r *rpc) handleRPCPacket(xdr *xdr, ts time.Time, tcptuple *common.TCPTuple,
 	case rpcReply:
 		r.handleReply(xid, xdr, ts, tcptuple, dir)
 	default:
-		logp.Warn("Bad RPC message")
+		r.logger.Warn("Bad RPC message")
 	}
 }
 

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -33,8 +33,6 @@ import (
 	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/beats/v7/packetbeat/protos/tcp"
-
-	"go.uber.org/zap"
 )
 
 type pgsqlPlugin struct {
@@ -145,6 +143,10 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &pgsqlPlugin{}
+	p.log = logger
+	p.debug = logger.Named("pgsql")
+	p.detail = logger.Named("pgsqldetailed")
+
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -160,11 +162,6 @@ func New(
 
 func (pgsql *pgsqlPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *pgsqlConfig) error {
 	pgsql.setFromConfig(config)
-
-	pgsql.log = logp.NewLogger("pgsql")
-	pgsql.debug = logp.NewLogger("pgsql", zap.AddCallerSkip(1))
-	pgsql.detail = logp.NewLogger("pgsqldetailed", zap.AddCallerSkip(1))
-	pgsql.isDebug, pgsql.isDetail = logp.IsDebug("pgsql"), logp.IsDebug("pgsqldetailed")
 
 	pgsql.transactions = common.NewCache(
 		pgsql.transactionTimeout,
@@ -202,14 +199,14 @@ func (pgsql *pgsqlPlugin) getTransaction(k common.HashableTCPTuple) []*pgsqlTran
 
 //go:inline
 func (pgsql *pgsqlPlugin) debugf(format string, v ...interface{}) {
-	if pgsql.isDebug {
+	if pgsql.debug.IsDebug() {
 		pgsql.debug.Debugf(format, v...)
 	}
 }
 
 //go:inline
 func (pgsql *pgsqlPlugin) detailf(format string, v ...interface{}) {
-	if pgsql.isDetail {
+	if pgsql.detail.IsDebug() {
 		pgsql.detail.Debugf(format, v...)
 	}
 }

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -37,6 +37,7 @@ import (
 
 type pgsqlPlugin struct {
 	log, debug, detail *logp.Logger
+	isDebug, isDetail  bool
 
 	// config
 	ports        []int
@@ -146,6 +147,9 @@ func New(
 	p.debug = logger.Named("pgsql")
 	p.detail = logger.Named("pgsqldetailed")
 
+	p.isDebug = p.debug.IsDebug()
+	p.isDetail = p.detail.IsDebug()
+
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -198,14 +202,14 @@ func (pgsql *pgsqlPlugin) getTransaction(k common.HashableTCPTuple) []*pgsqlTran
 
 //go:inline
 func (pgsql *pgsqlPlugin) debugf(format string, v ...interface{}) {
-	if pgsql.debug.IsDebug() {
+	if pgsql.isDebug {
 		pgsql.debug.Debugf(format, v...)
 	}
 }
 
 //go:inline
 func (pgsql *pgsqlPlugin) detailf(format string, v ...interface{}) {
-	if pgsql.detail.IsDebug() {
+	if pgsql.isDetail {
 		pgsql.detail.Debugf(format, v...)
 	}
 }

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -37,7 +37,6 @@ import (
 
 type pgsqlPlugin struct {
 	log, debug, detail *logp.Logger
-	isDebug, isDetail  bool
 
 	// config
 	ports        []int

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -53,6 +53,10 @@ func pgsqlModForTests(store *eventStore) *pgsqlPlugin {
 	}
 
 	var pgsql pgsqlPlugin
+	logger := logp.NewNopLogger()
+	pgsql.log = logger
+	pgsql.debug = logger.Named("pgsql")
+	pgsql.detail = logger.Named("pgsqldetailed")
 	config := defaultConfig
 	pgsql.init(callback, &procs.ProcessesWatcher{}, &config)
 	return &pgsql

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -19,6 +19,7 @@ package redis
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"time"
 
@@ -39,6 +40,7 @@ type stream struct {
 	applayer.Stream
 	parser   parser
 	tcptuple *common.TCPTuple
+	logger   *logp.Logger
 }
 
 type redisConnectionData struct {
@@ -58,12 +60,8 @@ type redisPlugin struct {
 
 	watcher *procs.ProcessesWatcher
 	results protos.Reporter
+	logger  *logp.Logger
 }
-
-var (
-	debugf  = logp.MakeDebug("redis")
-	isDebug = false
-)
 
 var (
 	unmatchedResponses = monitoring.NewInt(nil, "redis.unmatched_responses")
@@ -82,6 +80,8 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &redisPlugin{}
+	p.logger = logger.Named("redis")
+
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -95,12 +95,18 @@ func New(
 	return p, nil
 }
 
+//go:inline
+func (redis *redisPlugin) debugf(format string, args ...interface{}) {
+	if redis.logger.IsDebug() {
+		redis.logger.Debug(fmt.Sprintf(format, args...))
+	}
+}
+
 func (redis *redisPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *redisConfig) error {
 	redis.setFromConfig(config)
 
 	redis.results = results
 	redis.watcher = watcher
-	isDebug = logp.IsDebug("redis")
 
 	return nil
 }
@@ -174,22 +180,16 @@ func (redis *redisPlugin) doParse(
 ) *redisConnectionData {
 	st := conn.streams[dir]
 	if st == nil {
-		st = newStream(pkt.Ts, tcptuple)
+		st = newStream(pkt.Ts, tcptuple, redis.logger)
 		conn.streams[dir] = st
-		if isDebug {
-			debugf("new stream: %p (dir=%v, len=%v)", st, dir, len(pkt.Payload))
-		}
+		redis.debugf("new stream: %p (dir=%v, len=%v)", st, dir, len(pkt.Payload))
 	}
 
 	if err := st.Append(pkt.Payload); err != nil {
-		if isDebug {
-			debugf("%v, dropping TCP stream: ", err)
-		}
+		redis.debugf("%v, dropping TCP stream: ", err)
 		return nil
 	}
-	if isDebug {
-		debugf("stream add data: %p (dir=%v, len=%v)", st, dir, len(pkt.Payload))
-	}
+	redis.debugf("stream add data: %p (dir=%v, len=%v)", st, dir, len(pkt.Payload))
 
 	for st.Buf.Len() > 0 {
 		if st.parser.message == nil {
@@ -201,9 +201,7 @@ func (redis *redisPlugin) doParse(
 			// drop this tcp stream. Will retry parsing with the next
 			// segment in it
 			conn.streams[dir] = nil
-			if isDebug {
-				debugf("Ignore Redis message. Drop tcp stream. Try parsing with the next segment")
-			}
+			redis.debugf("Ignore Redis message. Drop tcp stream. Try parsing with the next segment")
 			return conn
 		}
 
@@ -213,12 +211,10 @@ func (redis *redisPlugin) doParse(
 		}
 
 		msg := st.parser.message
-		if isDebug {
-			if msg.isRequest {
-				debugf("REDIS (%p) request message: %s", conn, msg.message)
-			} else {
-				debugf("REDIS (%p) response message: %s", conn, msg.message)
-			}
+		if msg.isRequest {
+			redis.debugf("REDIS (%p) request message: %s", conn, msg.message)
+		} else {
+			redis.debugf("REDIS (%p) response message: %s", conn, msg.message)
 		}
 
 		// all ok, go to next level and reset stream for new message
@@ -229,11 +225,14 @@ func (redis *redisPlugin) doParse(
 	return conn
 }
 
-func newStream(ts time.Time, tcptuple *common.TCPTuple) *stream {
+func newStream(ts time.Time, tcptuple *common.TCPTuple, logger *logp.Logger) *stream {
 	s := &stream{
 		tcptuple: tcptuple,
+		logger:   logger,
 	}
 	s.parser.message = newMessage(ts)
+	s.parser.logger = logger
+
 	s.Stream.Init(tcp.TCPMaxDataInStream)
 	return s
 }
@@ -269,7 +268,7 @@ func (redis *redisPlugin) correlate(conn *redisConnectionData) {
 	// drop responses with missing requests
 	if conn.requests.IsEmpty() {
 		for !conn.responses.IsEmpty() {
-			debugf("Response from unknown transaction. Ignoring")
+			redis.debugf("Response from unknown transaction. Ignoring")
 			unmatchedResponses.Add(1)
 			conn.responses.Pop()
 		}

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -61,6 +61,7 @@ type redisPlugin struct {
 	watcher *procs.ProcessesWatcher
 	results protos.Reporter
 	logger  *logp.Logger
+	isDebug bool
 }
 
 var (
@@ -81,6 +82,7 @@ func New(
 ) (protos.Plugin, error) {
 	p := &redisPlugin{}
 	p.logger = logger.Named("redis")
+	p.isDebug = p.logger.IsDebug()
 
 	config := defaultConfig
 	if !testMode {
@@ -97,7 +99,7 @@ func New(
 
 //go:inline
 func (redis *redisPlugin) debugf(format string, args ...interface{}) {
-	if redis.logger.IsDebug() {
+	if redis.isDebug {
 		redis.logger.Debug(fmt.Sprintf(format, args...))
 	}
 }

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -161,11 +161,11 @@ func (redis *redisPlugin) ensureRedisConnection(private protos.ProtocolData) *re
 
 	priv, ok := private.(*redisConnectionData)
 	if !ok {
-		logp.Warn("redis connection data type error, create new one")
+		redis.logger.Warn("redis connection data type error, create new one")
 		return redis.newConnectionData()
 	}
 	if priv == nil {
-		logp.Warn("Unexpected: redis connection data not set, create new one")
+		redis.logger.Warn("Unexpected: redis connection data not set, create new one")
 		return redis.newConnectionData()
 	}
 
@@ -280,7 +280,7 @@ func (redis *redisPlugin) correlate(conn *redisConnectionData) {
 		requ, okReq := conn.requests.Pop().(*redisMessage)
 		resp, okResp := conn.responses.Pop().(*redisMessage)
 		if !okReq || !okResp {
-			logp.Err("invalid type found in message queue")
+			redis.logger.Error("invalid type found in message queue")
 			continue
 		}
 		if redis.results != nil {

--- a/packetbeat/protos/redis/redis_parse.go
+++ b/packetbeat/protos/redis/redis_parse.go
@@ -31,6 +31,8 @@ type parser struct {
 	parseOffset int
 	// bytesReceived int
 	message *redisMessage
+
+	logger *logp.Logger
 }
 
 type redisMessage struct {
@@ -302,9 +304,7 @@ func (p *parser) dispatch(depth int, buf *streambuf.Buffer) (common.NetString, b
 		iserror = true
 		value, ok, complete = p.parseSimpleString(buf)
 	default:
-		if isDebug {
-			debugf("Unexpected message starting with %s", buf.Bytes()[0])
-		}
+		p.logger.Debugf("Unexpected message starting with %s", buf.Bytes()[0])
 		return empty, false, false, false
 	}
 
@@ -363,14 +363,10 @@ func (p *parser) parseString(buf *streambuf.Buffer) (common.NetString, bool, boo
 func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (common.NetString, bool, bool, bool) {
 	line, err := buf.UntilCRLF()
 	if err != nil {
-		if isDebug {
-			debugf("End of line not found, waiting for more data")
-		}
+		p.logger.Debugf("End of line not found, waiting for more data")
 		return empty, false, false, false
 	}
-	if isDebug {
-		debugf("line %s: %d", line, buf.BufferConsumed())
-	}
+	p.logger.Debugf("line %s: %d", line, buf.BufferConsumed())
 
 	if len(line) == 3 && line[1] == '-' && line[2] == '1' {
 		return nilStr, false, true, true
@@ -414,9 +410,7 @@ func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (common.NetString,
 
 		value, iserror, ok, complete := p.dispatch(depth+1, buf)
 		if !ok || !complete {
-			if isDebug {
-				debugf("Array incomplete")
-			}
+			p.logger.Debug("Array incomplete")
 			return empty, iserror, ok, complete
 		}
 

--- a/packetbeat/protos/redis/redis_parse.go
+++ b/packetbeat/protos/redis/redis_parse.go
@@ -304,7 +304,7 @@ func (p *parser) dispatch(depth int, buf *streambuf.Buffer) (common.NetString, b
 		iserror = true
 		value, ok, complete = p.parseSimpleString(buf)
 	default:
-		p.logger.Debugf("Unexpected message starting with %s", buf.Bytes()[0])
+		p.logger.Debugf("Unexpected message starting with %d", buf.Bytes()[0])
 		return empty, false, false, false
 	}
 
@@ -318,7 +318,7 @@ func (p *parser) parseInt(buf *streambuf.Buffer) (common.NetString, bool, bool) 
 	value, ok, complete := p.parseSimpleString(buf)
 	if ok && complete {
 		if _, err := parseInt(value); err != nil {
-			logp.Err("Failed to read integer reply: %s", err)
+			p.logger.Errorf("Failed to read integer reply: %s", err)
 		}
 	}
 	return value, ok, complete
@@ -345,7 +345,7 @@ func (p *parser) parseString(buf *streambuf.Buffer) (common.NetString, bool, boo
 
 	length, err := parseInt(line[1:])
 	if err != nil {
-		logp.Err("Failed to read bulk message: %s", err)
+		p.logger.Errorf("Failed to read bulk message: %s", err)
 		return empty, false, false
 	}
 
@@ -378,7 +378,7 @@ func (p *parser) parseArray(depth int, buf *streambuf.Buffer) (common.NetString,
 
 	count, err := parseInt(line[1:])
 	if err != nil {
-		logp.Err("Failed to read number of bulk messages: %s", err)
+		p.logger.Errorf("Failed to read number of bulk messages: %s", err)
 		return empty, false, false, false
 	}
 	if count < 0 {

--- a/packetbeat/protos/redis/redis_test.go
+++ b/packetbeat/protos/redis/redis_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func newTestStream(content []byte) *stream {

--- a/packetbeat/protos/redis/redis_test.go
+++ b/packetbeat/protos/redis/redis_test.go
@@ -23,11 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/stretchr/testify/assert"
 )
 
 func newTestStream(content []byte) *stream {
-	st := newStream(time.Now(), nil)
+	st := newStream(time.Now(), nil, logp.NewNopLogger())
 	st.Append(content)
 	return st
 }

--- a/packetbeat/protos/sip/parser.go
+++ b/packetbeat/protos/sip/parser.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/streambuf"
 	"github.com/elastic/beats/v7/packetbeat/protos"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // sip Message
@@ -93,7 +94,9 @@ type parsingInfo struct {
 	state        parserState
 	bodyReceived int
 
-	message *message
+	message           *message
+	sipLogger         *logp.Logger
+	sipDetailedLogger *logp.Logger
 }
 
 func (pi *parsingInfo) prepareForNewMessage() {
@@ -103,10 +106,26 @@ func (pi *parsingInfo) prepareForNewMessage() {
 	pi.message = nil
 }
 
-func newParsingInfo(pkt *protos.Packet, tuple common.BaseTuple) *parsingInfo {
+//go:inline
+func (pi *parsingInfo) debugf(format string, args ...interface{}) {
+	if pi.sipLogger.IsDebug() {
+		pi.sipLogger.Debugf(format, args...)
+	}
+}
+
+//go:inline
+func (pi *parsingInfo) detailedf(format string, args ...interface{}) {
+	if pi.sipDetailedLogger.IsDebug() {
+		pi.sipDetailedLogger.Debugf(format, args...)
+	}
+}
+
+func newParsingInfo(pkt *protos.Packet, tuple common.BaseTuple, sipLogger, sipDetailedLogger *logp.Logger) *parsingInfo {
 	return &parsingInfo{
-		pkt:  pkt,
-		data: pkt.Payload,
+		pkt:               pkt,
+		data:              pkt.Payload,
+		sipLogger:         sipLogger,
+		sipDetailedLogger: sipDetailedLogger,
 	}
 }
 
@@ -164,9 +183,7 @@ func parseSIPLine(pi *parsingInfo, m *message) (ok, cont, complete bool) {
 	const minStatusLineLength = len("SIP/2.0 XXX OK")
 	fline := pi.data[pi.parseOffset:i]
 	if len(fline) < minStatusLineLength {
-		if isDebug {
-			debugf("First line too small")
-		}
+		pi.debugf("First line too small")
 		return false, false, false
 	}
 
@@ -176,17 +193,13 @@ func parseSIPLine(pi *parsingInfo, m *message) (ok, cont, complete bool) {
 		// RESPONSE
 		m.isRequest = false
 		version = fline[4:7]
-		m.statusCode, m.statusPhrase, err = parseResponseStatus(fline[8:])
+		m.statusCode, m.statusPhrase, err = parseResponseStatus(fline[8:], pi.sipLogger)
 		if err != nil {
-			if isDebug {
-				debugf("Failed to understand SIP response status: %s", fline[8:])
-			}
+			pi.debugf("Failed to understand SIP response status: %s", fline[8:])
 			return false, false, false
 		}
 
-		if isDebug {
-			debugf("SIP status_code=%d, status_phrase=%s", m.statusCode, m.statusPhrase)
-		}
+		pi.debugf("SIP status_code=%d, status_phrase=%s", m.statusCode, m.statusPhrase)
 	} else {
 		// REQUEST
 		afterMethodIdx := bytes.IndexFunc(fline, unicode.IsSpace)
@@ -194,9 +207,7 @@ func parseSIPLine(pi *parsingInfo, m *message) (ok, cont, complete bool) {
 
 		// Make sure we have the VERB + URI + SIP_VERSION
 		if afterMethodIdx == -1 || afterRequestURIIdx == -1 || afterMethodIdx == afterRequestURIIdx {
-			if isDebug {
-				debugf("Couldn't understand SIP request: %s", fline)
-			}
+			pi.debugf("Couldn't understand SIP request: %s", fline)
 			return false, false, false
 		}
 
@@ -208,23 +219,17 @@ func parseSIPLine(pi *parsingInfo, m *message) (ok, cont, complete bool) {
 			m.isRequest = true
 			version = fline[versionIdx:]
 		} else {
-			if isDebug {
-				debugf("Couldn't understand SIP version: %s", fline)
-			}
+			pi.debugf("Couldn't understand SIP version: %s", fline)
 			return false, false, false
 		}
 	}
 
 	m.version.major, m.version.minor, err = parseVersion(version)
 	if err != nil {
-		if isDebug {
-			debugf(err.Error(), version)
-		}
+		pi.debugf(err.Error(), version)
 		return false, false, false
 	}
-	if isDebug {
-		debugf("SIP version %d.%d", m.version.major, m.version.minor)
-	}
+	pi.debugf("SIP version %d.%d", m.version.major, m.version.minor)
 
 	// ok so far
 	pi.parseOffset = i + 2
@@ -234,9 +239,9 @@ func parseSIPLine(pi *parsingInfo, m *message) (ok, cont, complete bool) {
 	return true, true, true
 }
 
-func parseResponseStatus(s []byte) (uint16, []byte, error) {
-	if isDebug {
-		debugf("parseResponseStatus: %s", s)
+func parseResponseStatus(s []byte, logger *logp.Logger) (uint16, []byte, error) {
+	if logger.IsDebug() {
+		logger.Debugf("parseResponseStatus: %s", s)
 	}
 
 	var phrase []byte
@@ -293,15 +298,11 @@ func parseHeaders(pi *parsingInfo, m *message) (ok, cont, complete bool) {
 	pi.parseOffset = 0
 
 	if m.contentLength == 0 && (m.isRequest || m.hasContentLength) {
-		if isDebug {
-			debugf("Empty content length, ignore body")
-		}
+		pi.debugf("Empty content length, ignore body")
 		return true, false, true
 	}
 
-	if isDebug {
-		debugf("Read body")
-	}
+	pi.debugf("Read body")
 
 	pi.state = stateBody
 
@@ -322,10 +323,8 @@ func parseHeader(pi *parsingInfo, m *message) (ok, complete bool, offset int) {
 	}
 
 	// enabled if required. Allocs for parameters slow down parser big times
-	if isDetailed {
-		detailedf("Data: %s", data)
-		detailedf("Header: %s", data[:i])
-	}
+	pi.detailedf("Data: %s", data)
+	pi.detailedf("Header: %s", data[:i])
 
 	// skip folding line
 	for p := i + 1; p < len(data); {
@@ -343,9 +342,7 @@ func parseHeader(pi *parsingInfo, m *message) (ok, complete bool, offset int) {
 
 		headerName := getExpandedHeaderName(bytes.ToLower(data[:i]))
 		headerVal := bytes.TrimSpace(data[i+1 : p])
-		if isDebug {
-			debugf("Header: '%s' Value: '%s'\n", data[:i], headerVal)
-		}
+		pi.debugf("Header: '%s' Value: '%s'\n", data[:i], headerVal)
 
 		// Headers we need for parsing. Make sure we always
 		// capture their value
@@ -415,9 +412,7 @@ func parseBody(pi *parsingInfo, m *message) (ok, complete bool) {
 	pi.data = nil
 	pi.bodyReceived += numBytes
 	m.size += uint64(numBytes)
-	if isDebug {
-		debugf("bodyReceived: %d", pi.bodyReceived)
-	}
+	pi.debugf("bodyReceived: %d", pi.bodyReceived)
 	return true, false
 }
 

--- a/packetbeat/protos/sip/parser.go
+++ b/packetbeat/protos/sip/parser.go
@@ -94,9 +94,9 @@ type parsingInfo struct {
 	state        parserState
 	bodyReceived int
 
-	message           *message
-	sipLogger         *logp.Logger
-	sipDetailedLogger *logp.Logger
+	message                      *message
+	sipLogger, sipDetailedLogger *logp.Logger
+	isDebug, isDetailedDebug     bool
 }
 
 func (pi *parsingInfo) prepareForNewMessage() {
@@ -108,14 +108,14 @@ func (pi *parsingInfo) prepareForNewMessage() {
 
 //go:inline
 func (pi *parsingInfo) debugf(format string, args ...interface{}) {
-	if pi.sipLogger.IsDebug() {
+	if pi.isDebug {
 		pi.sipLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
 func (pi *parsingInfo) detailedf(format string, args ...interface{}) {
-	if pi.sipDetailedLogger.IsDebug() {
+	if pi.isDetailedDebug {
 		pi.sipDetailedLogger.Debugf(format, args...)
 	}
 }
@@ -126,6 +126,8 @@ func newParsingInfo(pkt *protos.Packet, tuple common.BaseTuple, sipLogger, sipDe
 		data:              pkt.Payload,
 		sipLogger:         sipLogger,
 		sipDetailedLogger: sipDetailedLogger,
+		isDebug:           sipLogger.IsDebug(),
+		isDetailedDebug:   sipDetailedLogger.IsDebug(),
 	}
 }
 

--- a/packetbeat/protos/sip/plugin.go
+++ b/packetbeat/protos/sip/plugin.go
@@ -35,11 +35,6 @@ import (
 )
 
 var (
-	debugf     = logp.MakeDebug("sip")
-	detailedf  = logp.MakeDebug("sipdetailed")
-	isDebug    = false
-	isDetailed = false
-
 	_ protos.UDPPlugin                = &plugin{}
 	_ protos.ExpirationAwareTCPPlugin = &plugin{}
 )
@@ -54,9 +49,10 @@ type connectionData struct {
 
 // SIP application level protocol analyser UDP and TCP plugin.
 type plugin struct {
-	cfg     *config
-	results protos.Reporter
-	watcher *procs.ProcessesWatcher
+	cfg                                  *config
+	results                              protos.Reporter
+	watcher                              *procs.ProcessesWatcher
+	logger, sipLogger, sipDetailedLogger *logp.Logger
 }
 
 func New(
@@ -67,9 +63,6 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	logger.Warn(cfgwarn.Beta("packetbeat SIP protocol is used"))
-
-	isDebug = logger.Named("sip").IsDebug()
-	isDetailed = logger.Named("sipdetailed").IsDebug()
 
 	config := defaultConfig
 	if !testMode {
@@ -82,11 +75,28 @@ func New(
 	switch tp {
 	case "tcp", "udp":
 		p := &plugin{}
+		p.logger = logger
+		p.sipLogger = logger.Named("sip")
+		p.sipDetailedLogger = logger.Named("sipdetailed")
 		p.init(results, watcher, &config)
 		return p, nil
 	}
 
 	return nil, fmt.Errorf("unsupported transport_protocol: %s", tp)
+}
+
+//go:inline
+func (p *plugin) debugf(format string, args ...interface{}) {
+	if p.sipLogger.IsDebug() {
+		p.sipLogger.Debugf(format, args...)
+	}
+}
+
+//go:inline
+func (p *plugin) detailedf(format string, args ...interface{}) {
+	if p.sipDetailedLogger.IsDebug() {
+		p.sipDetailedLogger.Debugf(format, args...)
+	}
 }
 
 // Init initializes the HTTP protocol analyser.
@@ -101,7 +111,7 @@ func (p *plugin) GetPorts() []int {
 }
 
 func (p *plugin) ParseUDP(pkt *protos.Packet) {
-	pi := newParsingInfo(pkt, pkt.Tuple.BaseTuple)
+	pi := newParsingInfo(pkt, pkt.Tuple.BaseTuple, p.sipLogger, p.sipDetailedLogger)
 	if _, err := p.doParse(pi); err != nil {
 		logp.Error(err)
 	}
@@ -117,7 +127,7 @@ func (p *plugin) Parse(
 	conn := ensureConnection(private)
 	st := conn.streams[dir]
 	if st == nil {
-		st = newParsingInfo(pkt, tcptuple.BaseTuple)
+		st = newParsingInfo(pkt, tcptuple.BaseTuple, p.sipLogger, p.sipDetailedLogger)
 		conn.streams[dir] = st
 	} else {
 		st.data = append(st.data, pkt.Payload...)
@@ -170,7 +180,7 @@ func (p *plugin) ReceivedFin(
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	debugf("Received FIN")
+	p.debugf("Received FIN")
 	conn := getConnection(private)
 	if conn == nil {
 		return private
@@ -217,9 +227,7 @@ func (p *plugin) GapInStream(
 	}
 
 	ok, complete := p.messageGap(st, nbytes)
-	if isDetailed {
-		detailedf("messageGap returned ok=%v complete=%v", ok, complete)
-	}
+	p.detailedf("messageGap returned ok=%v complete=%v", ok, complete)
 	if !ok {
 		// on errors, drop stream
 		conn.streams[dir] = nil
@@ -250,9 +258,7 @@ func (p *plugin) messageGap(pi *parsingInfo, nbytes int) (ok bool, complete bool
 		// we know we cannot recover from these
 		return false, false
 	case stateBody:
-		if isDebug {
-			debugf("gap in body: %d", nbytes)
-		}
+		p.debugf("gap in body: %d", nbytes)
 		if len(pi.data)+nbytes >= m.contentLength-pi.bodyReceived {
 			// we're done, but the last portion of the data is gone
 			return true, true
@@ -275,16 +281,12 @@ func (p *plugin) Expired(tuple *common.TCPTuple, private protos.ProtocolData) {
 	if conn == nil {
 		return
 	}
-	if isDebug {
-		debugf("expired connection %s", tuple)
-	}
+	p.debugf("expired connection %s", tuple)
 	// terminate streams
 	for _, st := range conn.streams {
 		// Do not send incomplete or empty messages
 		if st != nil && st.message != nil && st.message.headerOffset > 0 {
-			if isDebug {
-				debugf("got message %+v", st.message)
-			}
+			p.debugf("got message %+v", st.message)
 			// Current message is complete, we need to publish from here
 			evt, err := p.buildEvent(p.cfg, st)
 			if err != nil {
@@ -300,9 +302,7 @@ func (p *plugin) Expired(tuple *common.TCPTuple, private protos.ProtocolData) {
 }
 
 func (p *plugin) doParse(pi *parsingInfo) (bool, error) {
-	if isDetailed {
-		detailedf("Payload received: [%s]", pi.pkt.Payload)
-	}
+	p.detailedf("Payload received: [%s]", pi.pkt.Payload)
 
 	for len(pi.data) > 0 {
 		if pi.message == nil {
@@ -357,10 +357,10 @@ func (p *plugin) buildEvent(cfg *config, pi *parsingInfo) (*beat.Event, error) {
 		populateResponseFields(m, &sipFields)
 	}
 
-	populateHeadersFields(cfg, m, evt, pbf, &sipFields)
+	populateHeadersFields(cfg, m, evt, pbf, &sipFields, p.sipLogger, p.sipDetailedLogger)
 
 	if cfg.ParseBody {
-		populateBodyFields(m, pbf, &sipFields)
+		populateBodyFields(m, pbf, &sipFields, p.sipLogger, p.sipDetailedLogger)
 	}
 
 	pbf.Network.IANANumber = "17"
@@ -413,7 +413,13 @@ func populateResponseFields(m *message, fields *ProtocolFields) {
 	fields.Version = m.version.String()
 }
 
-func populateHeadersFields(cfg *config, m *message, evt beat.Event, pbf *pb.Fields, fields *ProtocolFields) {
+func populateHeadersFields(
+	cfg *config,
+	m *message,
+	evt beat.Event,
+	pbf *pb.Fields,
+	fields *ProtocolFields,
+	sipLogger, sipDetailedLogger *logp.Logger) {
 	fields.Allow = m.allow
 	fields.CallID = m.callID
 	fields.ContentLength = m.contentLength
@@ -454,7 +460,7 @@ func populateHeadersFields(cfg *config, m *message, evt beat.Event, pbf *pb.Fiel
 	populateContactFields(m, pbf, fields)
 
 	if cfg.ParseAuthorization {
-		populateAuthFields(m, evt, pbf, fields)
+		populateAuthFields(m, evt, pbf, fields, sipLogger, sipDetailedLogger)
 	}
 }
 
@@ -556,24 +562,24 @@ func populateEventFields(cfg *config, pi *parsingInfo, pbf *pb.Fields, fields Pr
 	pbf.Event.Reason = string(fields.Status)
 }
 
-func populateAuthFields(m *message, evt beat.Event, pbf *pb.Fields, fields *ProtocolFields) {
+func populateAuthFields(m *message, evt beat.Event, pbf *pb.Fields, fields *ProtocolFields, sipLogger, sipDetailedLogger *logp.Logger) {
 	auths, found := m.headers["authorization"]
 	if !found || len(auths) == 0 {
-		if isDetailed {
-			detailedf("sip packet without authorization header")
+		if sipDetailedLogger.IsDebug() {
+			sipDetailedLogger.Debug("sip packet without authorization header")
 		}
 		return
 	}
 
-	if isDetailed {
-		detailedf("sip packet with authorization header")
+	if sipDetailedLogger.IsDebug() {
+		sipDetailedLogger.Debug("sip packet with authorization header")
 	}
 
 	auth := bytes.TrimSpace(auths[0])
 	pos := bytes.IndexByte(auth, ' ')
 	if pos == -1 {
-		if isDebug {
-			debugf("malformed authorization header: missing scheme")
+		if sipLogger.IsDebug() {
+			sipLogger.Debug("malformed authorization header: missing scheme")
 		}
 		return
 	}
@@ -608,21 +614,21 @@ func populateAuthFields(m *message, evt beat.Event, pbf *pb.Fields, fields *Prot
 
 var constSDPContentType = []byte("application/sdp")
 
-func populateBodyFields(msg *message, pbf *pb.Fields, fields *ProtocolFields) {
+func populateBodyFields(msg *message, pbf *pb.Fields, fields *ProtocolFields, sipLogger, sipDetailedLogger *logp.Logger) {
 	if !msg.hasContentLength {
 		return
 	}
 
 	if !bytes.Equal(msg.contentType, constSDPContentType) {
-		if isDebug {
-			debugf("body content-type: %s is not supported", msg.contentType)
+		if sipLogger.IsDebug() {
+			sipLogger.Debug("body content-type: %s is not supported", msg.contentType)
 		}
 		return
 	}
 
 	if _, found := msg.headers["content-encoding"]; found {
-		if isDebug {
-			debugf("body decoding is not supported yet if content-encoding is present")
+		if sipDetailedLogger.IsDebug() {
+			sipDetailedLogger.Debug("body decoding is not supported yet if content-encoding is present")
 		}
 		return
 	}
@@ -666,8 +672,8 @@ func populateBodyFields(msg *message, pbf *pb.Fields, fields *ProtocolFields) {
 			}()
 			parts := bytes.SplitN(kv[1][pos:], []byte(" "), nParts)
 			if len(parts) != nParts {
-				if isDebug {
-					debugf("malformed owner SDP line")
+				if sipLogger.IsDebug() {
+					sipLogger.Debug("malformed owner SDP line")
 				}
 				continue
 			}

--- a/packetbeat/protos/sip/plugin.go
+++ b/packetbeat/protos/sip/plugin.go
@@ -53,6 +53,7 @@ type plugin struct {
 	results                              protos.Reporter
 	watcher                              *procs.ProcessesWatcher
 	logger, sipLogger, sipDetailedLogger *logp.Logger
+	isDebug, isDetailed                  bool
 }
 
 func New(
@@ -78,6 +79,7 @@ func New(
 		p.logger = logger
 		p.sipLogger = logger.Named("sip")
 		p.sipDetailedLogger = logger.Named("sipdetailed")
+		p.isDebug, p.isDetailed = p.sipLogger.IsDebug(), p.sipDetailedLogger.IsDebug()
 		p.init(results, watcher, &config)
 		return p, nil
 	}
@@ -87,14 +89,14 @@ func New(
 
 //go:inline
 func (p *plugin) debugf(format string, args ...interface{}) {
-	if p.sipLogger.IsDebug() {
+	if p.isDebug {
 		p.sipLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
 func (p *plugin) detailedf(format string, args ...interface{}) {
-	if p.sipDetailedLogger.IsDebug() {
+	if p.isDetailed {
 		p.sipDetailedLogger.Debugf(format, args...)
 	}
 }
@@ -621,7 +623,7 @@ func populateBodyFields(msg *message, pbf *pb.Fields, fields *ProtocolFields, si
 
 	if !bytes.Equal(msg.contentType, constSDPContentType) {
 		if sipLogger.IsDebug() {
-			sipLogger.Debug("body content-type: %s is not supported", msg.contentType)
+			sipLogger.Debugf("body content-type: %s is not supported", msg.contentType)
 		}
 		return
 	}

--- a/packetbeat/protos/sip/plugin.go
+++ b/packetbeat/protos/sip/plugin.go
@@ -113,7 +113,7 @@ func (p *plugin) GetPorts() []int {
 func (p *plugin) ParseUDP(pkt *protos.Packet) {
 	pi := newParsingInfo(pkt, pkt.Tuple.BaseTuple, p.sipLogger, p.sipDetailedLogger)
 	if _, err := p.doParse(pi); err != nil {
-		logp.Error(err)
+		p.logger.Error(err)
 	}
 }
 
@@ -124,7 +124,7 @@ func (p *plugin) Parse(
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	conn := ensureConnection(private)
+	conn := ensureConnection(private, p.logger)
 	st := conn.streams[dir]
 	if st == nil {
 		st = newParsingInfo(pkt, tcptuple.BaseTuple, p.sipLogger, p.sipDetailedLogger)
@@ -136,7 +136,7 @@ func (p *plugin) Parse(
 
 	ok, err := p.doParse(st)
 	if err != nil {
-		logp.Error(err)
+		p.logger.Error(err)
 	}
 
 	if !ok {
@@ -148,26 +148,26 @@ func (p *plugin) Parse(
 	return private
 }
 
-func ensureConnection(private protos.ProtocolData) *connectionData {
-	conn := getConnection(private)
+func ensureConnection(private protos.ProtocolData, logger *logp.Logger) *connectionData {
+	conn := getConnection(private, logger)
 	if conn == nil {
 		conn = &connectionData{}
 	}
 	return conn
 }
 
-func getConnection(private protos.ProtocolData) *connectionData {
+func getConnection(private protos.ProtocolData, logger *logp.Logger) *connectionData {
 	if private == nil {
 		return nil
 	}
 
 	priv, ok := private.(*connectionData)
 	if !ok {
-		logp.Warn("connection data type error")
+		logger.Warn("connection data type error")
 		return nil
 	}
 	if priv == nil {
-		logp.Warn("Unexpected: connection data not set")
+		logger.Warn("Unexpected: connection data not set")
 		return nil
 	}
 
@@ -181,7 +181,7 @@ func (p *plugin) ReceivedFin(
 	private protos.ProtocolData,
 ) protos.ProtocolData {
 	p.debugf("Received FIN")
-	conn := getConnection(private)
+	conn := getConnection(private, p.logger)
 	if conn == nil {
 		return private
 	}
@@ -215,7 +215,7 @@ func (p *plugin) GapInStream(
 	private protos.ProtocolData,
 ) (priv protos.ProtocolData, drop bool,
 ) {
-	conn := getConnection(private)
+	conn := getConnection(private, p.logger)
 	if conn == nil {
 		return private, false
 	}
@@ -277,7 +277,7 @@ func (p *plugin) ConnectionTimeout() time.Duration {
 }
 
 func (p *plugin) Expired(tuple *common.TCPTuple, private protos.ProtocolData) {
-	conn := getConnection(private)
+	conn := getConnection(private, p.logger)
 	if conn == nil {
 		return
 	}

--- a/packetbeat/protos/sip/plugin_test.go
+++ b/packetbeat/protos/sip/plugin_test.go
@@ -126,7 +126,7 @@ func TestMalformedBodyFiends(t *testing.T) {
 	for _, test := range cases {
 		bpf := &pb.Fields{}
 		fields := &ProtocolFields{}
-		populateBodyFields(test.msg, bpf, fields)
+		populateBodyFields(test.msg, bpf, fields, logptest.NewTestingLogger(t, ""), logptest.NewTestingLogger(t, ""))
 	}
 }
 

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -86,7 +86,7 @@ func NewTCP(p protos.Protocols, id, device string, idx int, logger *logp.Logger)
 
 func (tcp *TCP) debugf(format string, args ...interface{}) {
 	if tcp.logger.IsDebug() {
-		tcp.logger.Debug(fmt.Sprintf(format, args...))
+		tcp.logger.Debugf(format, args...)
 	}
 }
 

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -57,11 +57,11 @@ type TCP struct {
 	expiredConns expirationQueue
 
 	metrics *inputMetrics
+	logger  *logp.Logger
 }
 
 // Creates and returns a new Tcp.
-func NewTCP(p protos.Protocols, id, device string, idx int) (*TCP, error) {
-	isDebug = logp.IsDebug("tcp")
+func NewTCP(p protos.Protocols, id, device string, idx int, logger *logp.Logger) (*TCP, error) {
 
 	portMap, err := buildPortsMap(p.GetAllTCP())
 	if err != nil {
@@ -71,7 +71,8 @@ func NewTCP(p protos.Protocols, id, device string, idx int) (*TCP, error) {
 	tcp := &TCP{
 		protocols: p,
 		portMap:   portMap,
-		metrics:   newInputMetrics(fmt.Sprintf("%s_%d", id, idx), device, portMap),
+		metrics:   newInputMetrics(fmt.Sprintf("%s_%d", id, idx), device, portMap, logger),
+		logger:    logger.Named("tcp"),
 	}
 	tcp.streams = common.NewCacheWithRemovalListener(
 		protos.DefaultTransactionExpiration,
@@ -79,11 +80,14 @@ func NewTCP(p protos.Protocols, id, device string, idx int) (*TCP, error) {
 		tcp.removalListener)
 
 	tcp.streams.StartJanitor(protos.DefaultTransactionExpiration)
-	if isDebug {
-		logp.Debug("tcp", "Port map: %v", portMap)
-	}
-
+	tcp.debugf("Port map: %v", portMap)
 	return tcp, nil
+}
+
+func (tcp *TCP) debugf(format string, args ...interface{}) {
+	if tcp.logger.IsDebug() {
+		tcp.logger.Debug(fmt.Sprintf(format, args...))
+	}
 }
 
 func (tcp *TCP) removalListener(_ common.Key, value common.Value) {
@@ -115,9 +119,7 @@ func (tcp *TCP) Process(id *flows.FlowID, tcphdr *layers.TCP, pkt *protos.Packet
 		id.AddConnectionID(uint64(conn.id))
 	}
 
-	if isDebug {
-		logp.Debug("tcp", "tcp flow id: %p", id)
-	}
+	tcp.debugf("tcp flow id: %p", id)
 
 	if len(pkt.Payload) == 0 && !tcphdr.FIN {
 		// return early if packet is not interesting. Still need to find/create
@@ -133,20 +135,17 @@ func (tcp *TCP) Process(id *flows.FlowID, tcphdr *layers.TCP, pkt *protos.Packet
 	}
 	tcpSeq := tcpStartSeq + uint32(payloadLen)
 	lastSeq := conn.lastSeq[stream.dir]
-	if isDebug {
-		logp.Debug("tcp", "pkt.start_seq=%v pkt.last_seq=%v stream.last_seq=%v (len=%d)",
-			tcpStartSeq, tcpSeq, lastSeq, len(pkt.Payload))
-	}
+	tcp.debugf("pkt.start_seq=%v pkt.last_seq=%v stream.last_seq=%v (len=%d)",
+		tcpStartSeq, tcpSeq, lastSeq, len(pkt.Payload))
 
 	if len(pkt.Payload) != 0 {
 		tcp.metrics.log(pkt)
 	}
 	if len(pkt.Payload) > 0 && lastSeq != 0 {
 		if tcpSeqBeforeEq(tcpSeq, lastSeq) {
-			if isDebug {
-				logp.Debug("tcp", "Ignoring retransmitted segment. pkt.seq=%v len=%v stream.seq=%v",
-					tcphdr.Seq, len(pkt.Payload), lastSeq)
-			}
+			tcp.debugf("Ignoring retransmitted segment. pkt.seq=%v len=%v stream.seq=%v",
+				tcphdr.Seq, len(pkt.Payload), lastSeq)
+
 			return
 		}
 
@@ -157,12 +156,12 @@ func (tcp *TCP) Process(id *flows.FlowID, tcphdr *layers.TCP, pkt *protos.Packet
 			}
 
 			gap := int(tcpStartSeq - lastSeq)
-			logp.Debug("tcp", "Gap in tcp stream. last_seq: %d, seq: %d, gap: %d", lastSeq, tcpStartSeq, gap)
+			tcp.debugf("Gap in tcp stream. last_seq: %d, seq: %d, gap: %d", lastSeq, tcpStartSeq, gap)
 			drop := stream.gapInStream(gap)
 			if drop {
-				if isDebug {
-					logp.Debug("tcp", "Dropping connection state because of gap")
-				}
+
+				tcp.debugf("Dropping connection state because of gap")
+
 				tcp.metrics.logDrop()
 
 				// drop application layer connection state and
@@ -175,10 +174,8 @@ func (tcp *TCP) Process(id *flows.FlowID, tcphdr *layers.TCP, pkt *protos.Packet
 			// lastSeq > tcpStartSeq => overlapping TCP segment detected. shrink packet
 			delta := lastSeq - tcpStartSeq
 
-			if isDebug {
-				logp.Debug("tcp", "Overlapping tcp segment. last_seq %d, seq: %d, delta: %d",
-					lastSeq, tcpStartSeq, delta)
-			}
+			tcp.debugf("Overlapping tcp segment. last_seq %d, seq: %d, delta: %d",
+				lastSeq, tcpStartSeq, delta)
 
 			pkt.Payload = pkt.Payload[delta:]
 			tcphdr.Seq += delta
@@ -192,11 +189,11 @@ func (tcp *TCP) Process(id *flows.FlowID, tcphdr *layers.TCP, pkt *protos.Packet
 
 func (tcp *TCP) getStream(pkt *protos.Packet) (stream TCPStream, created bool) {
 	if conn := tcp.findStream(pkt.Tuple.Hashable()); conn != nil {
-		return TCPStream{conn: conn, dir: TCPDirectionOriginal}, false
+		return TCPStream{conn: conn, dir: TCPDirectionOriginal, logger: tcp.logger}, false
 	}
 
 	if conn := tcp.findStream(pkt.Tuple.RevHashable()); conn != nil {
-		return TCPStream{conn: conn, dir: TCPDirectionReverse}, false
+		return TCPStream{conn: conn, dir: TCPDirectionReverse, logger: tcp.logger}, false
 	}
 
 	protocol := tcp.decideProtocol(&pkt.Tuple)
@@ -211,9 +208,9 @@ func (tcp *TCP) getStream(pkt *protos.Packet) (stream TCPStream, created bool) {
 		timeout = mod.ConnectionTimeout()
 	}
 
-	if isDebug {
+	if tcp.logger.IsDebug() {
 		t := pkt.Tuple
-		logp.Debug("tcp", "Connection src[%s:%d] dst[%s:%d] doesn't exist, creating new",
+		tcp.debugf("Connection src[%s:%d] dst[%s:%d] doesn't exist, creating new",
 			t.SrcIP.String(), t.SrcPort,
 			t.DstIP.String(), t.DstPort)
 	}
@@ -226,7 +223,7 @@ func (tcp *TCP) getStream(pkt *protos.Packet) (stream TCPStream, created bool) {
 	}
 	conn.tcptuple = common.TCPTupleFromIPPort(conn.tuple, conn.id)
 	tcp.streams.PutWithTimeout(pkt.Tuple.Hashable(), conn, timeout)
-	return TCPStream{conn: conn, dir: TCPDirectionOriginal}, true
+	return TCPStream{conn: conn, dir: TCPDirectionOriginal, logger: tcp.logger}, true
 }
 
 func tcpSeqCompare(seq1, seq2 uint32) seqCompare {
@@ -307,17 +304,18 @@ func (conn *TCPConnection) String() string {
 }
 
 type TCPStream struct {
-	conn *TCPConnection
-	dir  uint8
+	conn   *TCPConnection
+	dir    uint8
+	logger *logp.Logger
 }
 
 func (stream *TCPStream) addPacket(pkt *protos.Packet, tcphdr *layers.TCP) {
 	conn := stream.conn
 	mod := conn.tcp.protocols.GetTCP(conn.protocol)
 	if mod == nil {
-		if isDebug {
+		if stream.logger.IsDebug() {
 			protocol := conn.protocol
-			logp.Debug("tcp", "Ignoring protocol for which we have no module loaded: %s",
+			stream.logger.Debugf("Ignoring protocol for which we have no module loaded: %s",
 				protocol)
 		}
 		return
@@ -426,7 +424,7 @@ type inputMetrics struct {
 
 // newInputMetrics returns an input metric for the TCP processor. If id or
 // device is empty a nil inputMetric is returned.
-func newInputMetrics(id, device string, ports map[uint16]protos.Protocol) *inputMetrics {
+func newInputMetrics(id, device string, ports map[uint16]protos.Protocol, logger *logp.Logger) *inputMetrics {
 	if id == "" || device == "" {
 		// An empty id signals to not record metrics,
 		// while an empty device means we are reading
@@ -457,9 +455,9 @@ func newInputMetrics(id, device string, ports map[uint16]protos.Protocol) *input
 	}
 
 	//TODO: use local logger here
-	_ = adapter.NewGoMetrics(reg, "arrival_period", logp.NewLogger(""), adapter.Accept).
+	_ = adapter.NewGoMetrics(reg, "arrival_period", logger, adapter.Accept).
 		Register("histogram", metrics.NewHistogram(out.arrivalPeriod))
-	_ = adapter.NewGoMetrics(reg, "processing_time", logp.NewLogger(""), adapter.Accept).
+	_ = adapter.NewGoMetrics(reg, "processing_time", logger, adapter.Accept).
 		Register("histogram", metrics.NewHistogram(out.processingTime))
 
 	out.device.Set(device)

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -130,7 +130,7 @@ func (tcp *TCP) Process(id *flows.FlowID, tcphdr *layers.TCP, pkt *protos.Packet
 	tcpStartSeq := tcphdr.Seq
 	payloadLen := uint64(len(pkt.Payload))
 	if payloadLen > uint64(^uint32(0)) {
-		logp.Warn("TCP payload length (%d) overflows uint32; dropping packet", len(pkt.Payload))
+		tcp.logger.Warnf("TCP payload length (%d) overflows uint32; dropping packet", len(pkt.Payload))
 		return
 	}
 	tcpSeq := tcpStartSeq + uint32(payloadLen)
@@ -245,8 +245,6 @@ const (
 	seqEq seqCompare = 0
 	seqGT seqCompare = 1
 )
-
-var isDebug = false
 
 func (tcp *TCP) getID() uint32 {
 	tcp.id++

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -58,6 +58,7 @@ type TCP struct {
 
 	metrics *inputMetrics
 	logger  *logp.Logger
+	isDebug bool
 }
 
 // Creates and returns a new Tcp.
@@ -73,6 +74,7 @@ func NewTCP(p protos.Protocols, id, device string, idx int, logger *logp.Logger)
 		portMap:   portMap,
 		metrics:   newInputMetrics(fmt.Sprintf("%s_%d", id, idx), device, portMap, logger),
 		logger:    logger.Named("tcp"),
+		isDebug:   logger.IsDebug(),
 	}
 	tcp.streams = common.NewCacheWithRemovalListener(
 		protos.DefaultTransactionExpiration,
@@ -84,8 +86,9 @@ func NewTCP(p protos.Protocols, id, device string, idx int, logger *logp.Logger)
 	return tcp, nil
 }
 
+//go:inline
 func (tcp *TCP) debugf(format string, args ...interface{}) {
-	if tcp.logger.IsDebug() {
+	if tcp.isDebug {
 		tcp.logger.Debugf(format, args...)
 	}
 }

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -306,7 +307,7 @@ func TestTCSeqPayload(t *testing.T) {
 						parse: makeCollectPayload(&state, true),
 					},
 				},
-			}, "test", "test", 0)
+			}, "test", "test", 0, logptest.NewTestingLogger(t, ""))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -344,7 +345,7 @@ func BenchmarkParallelProcess(b *testing.B) {
 	p := protocols{}
 	p.tcp = make(map[protos.Protocol]protos.TCPPlugin)
 	p.tcp[1] = &TestProtocol{Ports: []int{ServerPort}}
-	tcp, _ := NewTCP(p, "", "", 0)
+	tcp, _ := NewTCP(p, "", "", 0, logptest.NewTestingLogger(b, ""))
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -296,7 +296,7 @@ func (thrift *thriftPlugin) readConfig(config *thriftConfig) error {
 	}
 
 	if len(config.IdlFiles) > 0 {
-		thrift.idl, err = newThriftIdl(config.IdlFiles)
+		thrift.idl, err = newThriftIdl(config.IdlFiles, thrift.logger)
 		if err != nil {
 			return err
 		}
@@ -819,7 +819,7 @@ func (thrift *thriftPlugin) messageParser(s *thriftStream) (bool, bool) {
 					}
 				} else {
 					if len(m.fields) > 1 {
-						logp.Warn("Thrift RPC response with more than field. Ignoring all but first")
+						thrift.logger.Warn("Thrift RPC response with more than field. Ignoring all but first")
 					}
 					if len(m.fields) > 0 {
 						field := m.fields[0]

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -892,7 +892,7 @@ func (thrift *thriftPlugin) messageComplete(tcptuple *common.TCPTuple, dir uint8
 	flush := false
 
 	if stream.message.isRequest {
-		thrift.logger.Debug("Thrift request message: %s", stream.message.method)
+		thrift.logger.Debugf("Thrift request message: %s", stream.message.method)
 		if !thrift.captureReply {
 			// enable the stream in the other direction to get the reply
 			streamRev := priv.data[1-dir]

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -57,10 +57,11 @@ type thriftPlugin struct {
 	transactions       *common.Cache
 	transactionTimeout time.Duration
 
-	publishQueue chan *thriftTransaction
-	results      protos.Reporter
-	watcher      *procs.ProcessesWatcher
-	idl          *thriftIdl
+	publishQueue                 chan *thriftTransaction
+	results                      protos.Reporter
+	watcher                      *procs.ProcessesWatcher
+	idl                          *thriftIdl
+	logger, thriftDetailedLogger *logp.Logger
 }
 
 type thriftMessage struct {
@@ -163,8 +164,7 @@ const (
 
 // Thrift protocol types
 const (
-	thriftTBinary  = 1
-	thriftTCompact = 2
+	thriftTBinary = 1
 )
 
 // Thrift transport types
@@ -190,6 +190,9 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &thriftPlugin{}
+	p.logger = logger.Named("thrift")
+	p.thriftDetailedLogger = logger.Named("thriftdetailed")
+
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -325,14 +328,14 @@ func (thrift *thriftPlugin) readMessageBegin(s *thriftStream) (bool, bool) {
 	if int32(sz) < 0 { //nolint: gosec // cast value is not used outside of this
 		m.version = sz & thriftVersionMask
 		if m.version != thriftVersion1 {
-			logp.Debug("thrift", "Unexpected version: %d", m.version)
+			thrift.logger.Debugf("Unexpected version: %d", m.version)
 		}
 
-		logp.Debug("thriftdetailed", "version = %d", m.version)
+		thrift.thriftDetailedLogger.Debugf("version = %d", m.version)
 
 		offset = s.parseOffset + 4
 
-		logp.Debug("thriftdetailed", "offset = %d", offset)
+		thrift.thriftDetailedLogger.Debugf("offset = %d", offset)
 
 		m.Type = sz & ThriftTypeMask
 		m.method, ok, complete, off = thrift.readString(s.data[offset:])
@@ -340,16 +343,16 @@ func (thrift *thriftPlugin) readMessageBegin(s *thriftStream) (bool, bool) {
 			return false, false // not ok, not complete
 		}
 		if !complete {
-			logp.Debug("thriftdetailed", "Method name not complete")
+			thrift.thriftDetailedLogger.Debugf("Method name not complete")
 			return true, false // ok, not complete
 		}
 		offset += off
 
-		logp.Debug("thriftdetailed", "method = %s", m.method)
-		logp.Debug("thriftdetailed", "offset = %d", offset)
+		thrift.thriftDetailedLogger.Debugf("method = %s", m.method)
+		thrift.thriftDetailedLogger.Debugf("offset = %d", offset)
 
 		if len(s.data[offset:]) < 4 {
-			logp.Debug("thriftdetailed", "Less then 4 bytes remaining")
+			thrift.thriftDetailedLogger.Debugf("Less then 4 bytes remaining")
 			return true, false // ok, not complete
 		}
 		m.seqID = common.BytesNtohl(s.data[offset : offset+4])
@@ -363,13 +366,13 @@ func (thrift *thriftPlugin) readMessageBegin(s *thriftStream) (bool, bool) {
 			return false, false // not ok, not complete
 		}
 		if !complete {
-			logp.Debug("thriftdetailed", "Method name not complete")
+			thrift.thriftDetailedLogger.Debugf("Method name not complete")
 			return true, false // ok, not complete
 		}
 		offset += off
 
-		logp.Debug("thriftdetailed", "method = %s", m.method)
-		logp.Debug("thriftdetailed", "offset = %d", offset)
+		thrift.thriftDetailedLogger.Debugf("method = %s", m.method)
+		thrift.thriftDetailedLogger.Debugf("offset = %d", offset)
 
 		if len(s.data[offset:]) < 5 {
 			return true, false // ok, not complete
@@ -510,13 +513,13 @@ func (thrift *thriftPlugin) readListOrSet(data []byte) (value string, ok bool, c
 
 	funcReader, typeFound := thrift.funcReadersByType(typ)
 	if !typeFound {
-		logp.Debug("thrift", "Field type %d not known", typ)
+		thrift.logger.Debugf("Field type %d not known", typ)
 		return "", false, false, 0
 	}
 
 	sz := int(common.BytesNtohl(data[1:5]))
 	if sz < 0 {
-		logp.Debug("thrift", "List/Set too big: %d", sz)
+		thrift.logger.Debugf("List/Set too big: %d", sz)
 		return "", false, false, 0
 	}
 
@@ -568,19 +571,19 @@ func (thrift *thriftPlugin) readMap(data []byte) (value string, ok bool, complet
 
 	funcReaderKey, typeFound := thrift.funcReadersByType(typeKey)
 	if !typeFound {
-		logp.Debug("thrift", "Field type %d not known", typeKey)
+		thrift.logger.Debugf("Field type %d not known", typeKey)
 		return "", false, false, 0
 	}
 
 	funcReaderValue, typeFound := thrift.funcReadersByType(typeValue)
 	if !typeFound {
-		logp.Debug("thrift", "Field type %d not known", typeValue)
+		thrift.logger.Debugf("Field type %d not known", typeValue)
 		return "", false, false, 0
 	}
 
 	sz := int(common.BytesNtohl(data[2:6]))
 	if sz < 0 {
-		logp.Debug("thrift", "Map too big: %d", sz)
+		thrift.logger.Debugf("Map too big: %d", sz)
 		return "", false, false, 0
 	}
 
@@ -628,7 +631,7 @@ func (thrift *thriftPlugin) readStruct(data []byte) (value string, ok bool, comp
 		var field thriftField
 
 		if i >= thrift.dropAfterNStructFields {
-			logp.Debug("thrift", "Too many fields in struct. Dropping as error")
+			thrift.logger.Debugf("Too many fields in struct. Dropping as error")
 			return "", false, false, 0
 		}
 
@@ -651,7 +654,7 @@ func (thrift *thriftPlugin) readStruct(data []byte) (value string, ok bool, comp
 
 		funcReader, typeFound := thrift.funcReadersByType(field.Type)
 		if !typeFound {
-			logp.Debug("thrift", "Field type %d not known", field.Type)
+			thrift.logger.Debugf("Field type %d not known", field.Type)
 			return "", false, false, 0
 		}
 
@@ -739,7 +742,7 @@ func (thrift *thriftPlugin) readField(s *thriftStream) (ok bool, complete bool, 
 
 	funcReader, typeFound := thrift.funcReadersByType(field.Type)
 	if !typeFound {
-		logp.Debug("thrift", "Field type %d not known", field.Type)
+		thrift.logger.Debugf("Field type %d not known", field.Type)
 		return false, false, nil
 	}
 
@@ -761,7 +764,7 @@ func (thrift *thriftPlugin) messageParser(s *thriftStream) (bool, bool) {
 	var ok, complete bool
 	m := s.message
 
-	logp.Debug("thriftdetailed", "messageParser called parseState=%v offset=%v",
+	thrift.thriftDetailedLogger.Debugf("messageParser called parseState=%v offset=%v",
 		s.parseState, s.parseOffset)
 
 	for s.parseOffset < len(s.data) {
@@ -778,7 +781,7 @@ func (thrift *thriftPlugin) messageParser(s *thriftStream) (bool, bool) {
 			}
 
 			ok, complete = thrift.readMessageBegin(s)
-			logp.Debug("thriftdetailed", "readMessageBegin returned: %v %v", ok, complete)
+			thrift.thriftDetailedLogger.Debugf("readMessageBegin returned: %v %v", ok, complete)
 			if !ok {
 				return false, false
 			}
@@ -788,7 +791,7 @@ func (thrift *thriftPlugin) messageParser(s *thriftStream) (bool, bool) {
 
 			if !m.isRequest && !thrift.captureReply {
 				// don't actually read the result
-				logp.Debug("thrift", "Don't capture reply")
+				thrift.logger.Debug("Don't capture reply")
 				m.returnValue = ""
 				m.exceptions = ""
 				return true, true
@@ -796,7 +799,7 @@ func (thrift *thriftPlugin) messageParser(s *thriftStream) (bool, bool) {
 			s.parseState = thriftFieldState
 		case thriftFieldState:
 			ok, complete, field := thrift.readField(s)
-			logp.Debug("thriftdetailed", "readField returned: %v %v", ok, complete)
+			thrift.thriftDetailedLogger.Debugf("readField returned: %v %v", ok, complete)
 			if !ok {
 				return false, false
 			}
@@ -889,7 +892,7 @@ func (thrift *thriftPlugin) messageComplete(tcptuple *common.TCPTuple, dir uint8
 	flush := false
 
 	if stream.message.isRequest {
-		logp.Debug("thrift", "Thrift request message: %s", stream.message.method)
+		thrift.logger.Debug("Thrift request message: %s", stream.message.method)
 		if !thrift.captureReply {
 			// enable the stream in the other direction to get the reply
 			streamRev := priv.data[1-dir]
@@ -898,7 +901,7 @@ func (thrift *thriftPlugin) messageComplete(tcptuple *common.TCPTuple, dir uint8
 			}
 		}
 	} else {
-		logp.Debug("thrift", "Thrift response message: %s", stream.message.method)
+		thrift.logger.Debug("Thrift response message: %s", stream.message.method)
 		if !thrift.captureReply {
 			// disable stream in this direction
 			stream.skipInput = true
@@ -960,7 +963,7 @@ func (thrift *thriftPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 		// concatenate bytes
 		stream.data = append(stream.data, pkt.Payload...)
 		if len(stream.data) > tcp.TCPMaxDataInStream {
-			logp.Debug("thrift", "Stream data too large, dropping TCP stream")
+			thrift.logger.Debug("Stream data too large, dropping TCP stream")
 			priv.data[dir] = nil
 			return priv
 		}
@@ -972,13 +975,13 @@ func (thrift *thriftPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 		}
 
 		ok, complete := thrift.messageParser(priv.data[dir])
-		logp.Debug("thriftdetailed", "messageParser returned %v %v", ok, complete)
+		thrift.thriftDetailedLogger.Debugf("messageParser returned %v %v", ok, complete)
 
 		if !ok {
 			// drop this tcp stream. Will retry parsing with the next
 			// segment in it
 			priv.data[dir] = nil
-			logp.Debug("thrift", "Ignore Thrift message. Drop tcp stream. Try parsing with the next segment")
+			thrift.logger.Debug("Ignore Thrift message. Drop tcp stream. Try parsing with the next segment")
 			return priv
 		}
 
@@ -990,7 +993,7 @@ func (thrift *thriftPlugin) Parse(pkt *protos.Packet, tcptuple *common.TCPTuple,
 		}
 	}
 
-	logp.Debug("thriftdetailed", "Out")
+	thrift.thriftDetailedLogger.Debugf("Out")
 
 	return priv
 }
@@ -1008,7 +1011,7 @@ func (thrift *thriftPlugin) receivedRequest(msg *thriftMessage) {
 
 	trans := thrift.getTransaction(tuple.Hashable())
 	if trans != nil {
-		logp.Debug("thrift", "Two requests without reply, assuming the old one is oneway")
+		thrift.logger.Debug("Two requests without reply, assuming the old one is oneway")
 		unmatchedRequests.Add(1)
 		thrift.publishQueue <- trans
 	}
@@ -1034,13 +1037,13 @@ func (thrift *thriftPlugin) receivedReply(msg *thriftMessage) {
 
 	trans := thrift.getTransaction(tuple.Hashable())
 	if trans == nil {
-		logp.Debug("thrift", "Response from unknown transaction. Ignoring: %v", tuple)
+		thrift.logger.Debug("Response from unknown transaction. Ignoring: %v", tuple)
 		unmatchedResponses.Add(1)
 		return
 	}
 
 	if trans.request.method != msg.method {
-		logp.Debug("thrift", "Response from another request received '%s' '%s'"+
+		thrift.logger.Debug("Response from another request received '%s' '%s'"+
 			". Ignoring.", trans.request.method, msg.method)
 		unmatchedResponses.Add(1)
 		return
@@ -1052,7 +1055,7 @@ func (thrift *thriftPlugin) receivedReply(msg *thriftMessage) {
 	thrift.publishQueue <- trans
 	thrift.transactions.Delete(tuple.Hashable())
 
-	logp.Debug("thrift", "Transaction queued")
+	thrift.logger.Debug("Transaction queued")
 }
 
 func (thrift *thriftPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
@@ -1061,7 +1064,7 @@ func (thrift *thriftPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	trans := thrift.getTransaction(tcptuple.Hashable())
 	if trans != nil {
 		if trans.request != nil && trans.reply == nil {
-			logp.Debug("thrift", "FIN and had only one transaction. Assuming one way")
+			thrift.logger.Debug("FIN and had only one transaction. Assuming one way")
 			thrift.publishQueue <- trans
 			thrift.transactions.Delete(trans.tuple.Hashable())
 		}
@@ -1073,7 +1076,7 @@ func (thrift *thriftPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 func (thrift *thriftPlugin) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool,
 ) {
-	logp.Debug("thriftdetailed", "GapInStream called")
+	thrift.thriftDetailedLogger.Debugf("GapInStream called")
 
 	if private == nil {
 		return private, false
@@ -1172,6 +1175,6 @@ func (thrift *thriftPlugin) publishTransactions() {
 			thrift.results(evt)
 		}
 
-		logp.Debug("thrift", "Published event")
+		thrift.logger.Debug("Published event")
 	}
 }

--- a/packetbeat/protos/thrift/thrift_idl.go
+++ b/packetbeat/protos/thrift/thrift_idl.go
@@ -60,14 +60,14 @@ func fieldsToArrayByID(fields []*parser.Field) []*string {
 	return output
 }
 
-func buildMethodsMap(thriftFiles map[string]parser.Thrift) map[string]*thriftIdlMethod {
+func buildMethodsMap(thriftFiles map[string]parser.Thrift, logger *logp.Logger) map[string]*thriftIdlMethod {
 	output := make(map[string]*thriftIdlMethod)
 
 	for _, thrift := range thriftFiles {
 		for _, service := range thrift.Services {
 			for _, method := range service.Methods {
 				if _, exists := output[method.Name]; exists {
-					logp.Warn("Thrift IDL: Method %s is defined in more services: %s and %s",
+					logger.Warnf("Thrift IDL: Method %s is defined in more services: %s and %s",
 						method.Name, output[method.Name].service.Name, service.Name)
 				}
 				output[method.Name] = &thriftIdlMethod{
@@ -106,7 +106,7 @@ func (thriftidl *thriftIdl) findMethod(name string) *thriftIdlMethod {
 	return thriftidl.methodsByName[name]
 }
 
-func newThriftIdl(idlFiles []string) (*thriftIdl, error) {
+func newThriftIdl(idlFiles []string, logger *logp.Logger) (*thriftIdl, error) {
 	if len(idlFiles) == 0 {
 		return nil, nil
 	}
@@ -116,6 +116,6 @@ func newThriftIdl(idlFiles []string) (*thriftIdl, error) {
 	}
 
 	return &thriftIdl{
-		methodsByName: buildMethodsMap(thriftFiles),
+		methodsByName: buildMethodsMap(thriftFiles, logger),
 	}, nil
 }

--- a/packetbeat/protos/thrift/thrift_idl_test.go
+++ b/packetbeat/protos/thrift/thrift_idl_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func thriftIdlForTesting(t *testing.T, content string) *thriftIdl {
@@ -32,7 +33,7 @@ func thriftIdlForTesting(t *testing.T, content string) *thriftIdl {
 	f.WriteString(content)
 	f.Close()
 
-	idl, err := newThriftIdl([]string{f.Name()})
+	idl, err := newThriftIdl([]string{f.Name()}, logptest.NewTestingLogger(t, ""))
 	if err != nil {
 		t.Fatal("Parsing failed:", err)
 	}

--- a/packetbeat/protos/thrift/thrift_test.go
+++ b/packetbeat/protos/thrift/thrift_test.go
@@ -30,10 +30,15 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/packetbeat/procs"
 	"github.com/elastic/beats/v7/packetbeat/protos"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func thriftForTests() *thriftPlugin {
-	t := &thriftPlugin{}
+	logger := logp.NewNopLogger()
+	t := &thriftPlugin{
+		logger:               logger.Named("thrift"),
+		thriftDetailedLogger: logger.Named("thriftdetailed"),
+	}
 	config := defaultConfig
 	t.init(true, nil, &procs.ProcessesWatcher{}, &config)
 	return t
@@ -81,6 +86,9 @@ func TestThrift_readMessageBegin(t *testing.T) {
 	var m *thriftMessage
 
 	var thrift thriftPlugin
+	logger := logp.NewNopLogger()
+	thrift.logger = logger.Named("thrift")
+	thrift.thriftDetailedLogger = logger.Named("thriftdetailed")
 	thrift.InitDefaults()
 
 	data, _ = hex.DecodeString("800100010000000470696e670000000000")
@@ -161,6 +169,9 @@ func TestThrift_thriftReadField(t *testing.T) {
 	var _old int
 
 	var thrift thriftPlugin
+	logger := logp.NewNopLogger()
+	thrift.logger = logger.Named("thrift")
+	thrift.thriftDetailedLogger = logger.Named("thriftdetailed")
 	thrift.InitDefaults()
 
 	data, _ = hex.DecodeString("08000100000001")
@@ -437,6 +448,9 @@ func TestThrift_thriftMessageParser(t *testing.T) {
 	var m *thriftMessage
 
 	var thrift thriftPlugin
+	logger := logp.NewNopLogger()
+	thrift.logger = logger.Named("thrift")
+	thrift.thriftDetailedLogger = logger.Named("thriftdetailed")
 	thrift.InitDefaults()
 
 	data, _ = hex.DecodeString("800100010000000470696e670000000000")

--- a/packetbeat/protos/tls/alerts.go
+++ b/packetbeat/protos/tls/alerts.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -110,7 +109,7 @@ func (parser *parser) parseAlert(buf *bufferView) error {
 		return errRead
 	}
 	if severity < 1 || severity > 2 {
-		logp.Warn("invalid severity in alert: %v", severity)
+		parser.logger.Warnf("invalid severity in alert: %v", severity)
 	}
 	alert := alert{alertSeverity(severity), alertCode(code)}
 	parser.debugf("Got alert %v", alert)

--- a/packetbeat/protos/tls/alerts.go
+++ b/packetbeat/protos/tls/alerts.go
@@ -99,9 +99,9 @@ func (alert alert) toMap(source string) mapstr.M {
 
 func (parser *parser) parseAlert(buf *bufferView) error {
 	if buf.length() != 2 {
-		if isDebug {
-			debugf("ignoring encrypted alert")
-		}
+
+		parser.debugf("ignoring encrypted alert")
+
 		return nil
 	}
 
@@ -113,9 +113,7 @@ func (parser *parser) parseAlert(buf *bufferView) error {
 		logp.Warn("invalid severity in alert: %v", severity)
 	}
 	alert := alert{alertSeverity(severity), alertCode(code)}
-	if isDebug {
-		debugf("Got alert %v", alert)
-	}
+	parser.debugf("Got alert %v", alert)
 	parser.alerts = append(parser.alerts, alert)
 	return nil
 }

--- a/packetbeat/protos/tls/alerts_test.go
+++ b/packetbeat/protos/tls/alerts_test.go
@@ -27,11 +27,12 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common/streambuf"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
-func getParser() *parser {
+func getParser(t *testing.T) *parser {
 	logp.TestingSetup(logp.WithSelectors("tls", "tlsdetailed"))
-	return &parser{}
+	return &parser{logger: logptest.NewTestingLogger(t, "")}
 }
 
 func mkBuf(t *testing.T, s string, length int) *bufferView {
@@ -41,7 +42,7 @@ func mkBuf(t *testing.T, s string, length int) *bufferView {
 }
 
 func TestParse(t *testing.T) {
-	parser := getParser()
+	parser := getParser(t)
 	err := parser.parseAlert(mkBuf(t, "0102", 2))
 	assert.NoError(t, err)
 	assert.Len(t, parser.alerts, 1)
@@ -50,7 +51,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestShortBuffer(t *testing.T) {
-	parser := getParser()
+	parser := getParser(t)
 	err := parser.parseAlert(mkBuf(t, "", 2))
 	assert.Error(t, err)
 	assert.Empty(t, parser.alerts)
@@ -61,7 +62,7 @@ func TestShortBuffer(t *testing.T) {
 }
 
 func TestEncrypted(t *testing.T) {
-	parser := getParser()
+	parser := getParser(t)
 	err := parser.parseAlert(mkBuf(t, "010200000000", 6))
 	assert.NoError(t, err)
 	assert.Empty(t, parser.alerts)

--- a/packetbeat/protos/tls/extensions.go
+++ b/packetbeat/protos/tls/extensions.go
@@ -36,7 +36,7 @@ type Extensions struct {
 }
 
 type (
-	extensionParser func(reader bufferView) interface{}
+	extensionParser func(reader bufferView, logger *logp.Logger) interface{}
 	extension       struct {
 		label   string
 		parser  extensionParser
@@ -73,7 +73,7 @@ var extensionMap = map[uint16]extension{
 }
 
 // ParseExtensions returns an Extensions object parsed from the supplied buffer
-func ParseExtensions(buffer bufferView) Extensions {
+func ParseExtensions(buffer bufferView, logger *logp.Logger) Extensions {
 	var extensionsLength uint16
 	if !buffer.read16Net(0, &extensionsLength) || extensionsLength == 0 {
 		// No extensions
@@ -90,7 +90,7 @@ func ParseExtensions(buffer bufferView) Extensions {
 	for base := 2; base < limit; {
 		var code, length uint16
 		if !buffer.read16Net(base, &code) || !buffer.read16Net(base+2, &length) {
-			logp.Warn("failed parsing extensions")
+			logger.Warn("failed parsing extensions")
 			return Extensions{}
 		}
 
@@ -103,7 +103,7 @@ func ParseExtensions(buffer bufferView) Extensions {
 		}
 
 		result.InOrder = append(result.InOrder, ExtensionID(code))
-		label, parsed, saveRaw := parseExtension(code, extBuffer)
+		label, parsed, saveRaw := parseExtension(code, extBuffer, logger)
 		if parsed != nil {
 			result.Parsed[label] = parsed
 		} else {
@@ -119,15 +119,15 @@ func ParseExtensions(buffer bufferView) Extensions {
 	return result
 }
 
-func parseExtension(code uint16, buffer bufferView) (string, interface{}, bool) {
+func parseExtension(code uint16, buffer bufferView, logger *logp.Logger) (string, interface{}, bool) {
 	if ext, ok := extensionMap[code]; ok {
-		parsed := ext.parser(buffer)
+		parsed := ext.parser(buffer, logger)
 		return ext.label, parsed, ext.saveRaw
 	}
 	return strconv.Itoa(int(code)), nil, false
 }
 
-func parseSni(buffer bufferView) interface{} {
+func parseSni(buffer bufferView, logger *logp.Logger) interface{} {
 	var listLength uint16
 	if !buffer.read16Net(0, &listLength) {
 		return nil
@@ -139,7 +139,7 @@ func parseSni(buffer bufferView) interface{} {
 		var host string
 		if !buffer.read8(pos, &nameType) || !buffer.read16Net(pos+1, &nameLen) ||
 			limit < pos+3+int(nameLen) || !buffer.readString(pos+3, int(nameLen), &host) {
-			logp.Warn("SNI hostname list truncated")
+			logger.Warn("SNI hostname list truncated")
 			break
 		}
 		if nameType == 0 {
@@ -150,7 +150,7 @@ func parseSni(buffer bufferView) interface{} {
 	return hosts
 }
 
-func parseMaxFragmentLen(buffer bufferView) interface{} {
+func parseMaxFragmentLen(buffer bufferView, _ *logp.Logger) interface{} {
 	var val uint8
 	if buffer.length() == 1 && buffer.read8(0, &val) {
 		if val > 0 && val < 5 {
@@ -161,11 +161,11 @@ func parseMaxFragmentLen(buffer bufferView) interface{} {
 	return nil
 }
 
-func ignoreContent(_ bufferView) interface{} {
+func ignoreContent(_ bufferView, _ *logp.Logger) interface{} {
 	return nil
 }
 
-func parseStatusReq(buffer bufferView) interface{} {
+func parseStatusReq(buffer bufferView, _ *logp.Logger) interface{} {
 	if buffer.length() == 0 {
 		// Initial server response.
 		return mapstr.M{"response": true}
@@ -185,14 +185,14 @@ func parseStatusReq(buffer bufferView) interface{} {
 	return mapstr.M{"type": typ, "responder_id_list_length": list, "request_extensions": exts}
 }
 
-func expectEmpty(buffer bufferView) interface{} {
+func expectEmpty(buffer bufferView, _ *logp.Logger) interface{} {
 	if buffer.length() != 0 {
 		return fmt.Sprintf("(expected empty: found %d bytes)", buffer.length())
 	}
 	return ""
 }
 
-func parseCertType(buffer bufferView) interface{} {
+func parseCertType(buffer bufferView, _ *logp.Logger) interface{} {
 	var value uint8
 	var types []string
 	pos, limit := 0, buffer.length()
@@ -220,7 +220,7 @@ func parseCertType(buffer bufferView) interface{} {
 	return types
 }
 
-func parseSupportedGroups(buffer bufferView) interface{} {
+func parseSupportedGroups(buffer bufferView, _ *logp.Logger) interface{} {
 	var value uint16
 	if !buffer.read16Net(0, &value) || int(value)+2 != buffer.length() {
 		return nil
@@ -234,7 +234,7 @@ func parseSupportedGroups(buffer bufferView) interface{} {
 	return groups
 }
 
-func parseEcPoints(buffer bufferView) interface{} {
+func parseEcPoints(buffer bufferView, _ *logp.Logger) interface{} {
 	var value, length uint8
 	if !buffer.read8(0, &length) || int(length)+1 != buffer.length() {
 		return nil
@@ -246,7 +246,7 @@ func parseEcPoints(buffer bufferView) interface{} {
 	return formats
 }
 
-func parseSrp(buffer bufferView) interface{} {
+func parseSrp(buffer bufferView, _ *logp.Logger) interface{} {
 	var length uint8
 	if !buffer.read8(0, &length) || int(length)+1 > buffer.length() {
 		return nil
@@ -258,7 +258,7 @@ func parseSrp(buffer bufferView) interface{} {
 	return user
 }
 
-func parseSignatureSchemes(buffer bufferView) interface{} {
+func parseSignatureSchemes(buffer bufferView, _ *logp.Logger) interface{} {
 	var value uint16
 	if !buffer.read16Net(0, &value) || int(value)+2 != buffer.length() {
 		return nil
@@ -270,14 +270,14 @@ func parseSignatureSchemes(buffer bufferView) interface{} {
 	return groups
 }
 
-func parseTicket(buffer bufferView) interface{} {
+func parseTicket(buffer bufferView, _ *logp.Logger) interface{} {
 	if buffer.length() > 0 {
 		return fmt.Sprintf("(%d bytes)", buffer.length())
 	}
 	return ""
 }
 
-func parseALPN(buffer bufferView) interface{} {
+func parseALPN(buffer bufferView, _ *logp.Logger) interface{} {
 	var length uint16
 	if !buffer.read16Net(0, &length) || int(length)+2 != buffer.length() {
 		return nil
@@ -295,7 +295,7 @@ func parseALPN(buffer bufferView) interface{} {
 	return protos
 }
 
-func parseSupportedVersions(buffer bufferView) interface{} {
+func parseSupportedVersions(buffer bufferView, _ *logp.Logger) interface{} {
 	// Parsing the supported_versions extensions requires knowing whether the
 	// extension is included in a client_hello or server_hello, but a workaround
 	// can be done by looking at the extension length.

--- a/packetbeat/protos/tls/extensions_test.go
+++ b/packetbeat/protos/tls/extensions_test.go
@@ -23,9 +23,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestSni(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
+
 	// Single element
 
 	buf := mkBuf(t, "000d"+ // 13 bytes
@@ -33,7 +37,7 @@ func TestSni(t *testing.T) {
 		"000a"+ // 10 byte string
 		"656c61737469632e636f", // elastic.co
 		15)
-	r := parseSni(*buf)
+	r := parseSni(*buf, logger)
 	assert.NotNil(t, r)
 	assert.Equal(t, []string{"elastic.co"}, r.([]string))
 
@@ -50,7 +54,7 @@ func TestSni(t *testing.T) {
 		"0009"+ // 9 byte string
 		"6c6f63616c686f7374", // localhost
 		41)
-	r = parseSni(*buf)
+	r = parseSni(*buf, logger)
 	assert.NotNil(t, r)
 	assert.Equal(t, []string{"elastic.co", "example.net", "localhost"}, r.([]string))
 
@@ -67,7 +71,7 @@ func TestSni(t *testing.T) {
 		"0009"+ // 9 byte string
 		"6c6f63616c686f7374", // localhost
 		41)
-	r = parseSni(*buf)
+	r = parseSni(*buf, logger)
 	assert.NotNil(t, r)
 	assert.Equal(t, []string{"elastic.co", "localhost"}, r.([]string))
 
@@ -84,7 +88,7 @@ func TestSni(t *testing.T) {
 		"0009"+ // 9 byte string
 		"6c6f63616c686f7374", // localhost
 		41)
-	r = parseSni(*buf)
+	r = parseSni(*buf, logger)
 	assert.NotNil(t, r)
 	assert.Equal(t, []string{"elastic.co", "example.net", "localhost"}, r.([]string))
 
@@ -101,7 +105,7 @@ func TestSni(t *testing.T) {
 		"0009"+ // 9 byte string
 		"6c6f63616c686f7374", // localhost
 		41)
-	r = parseSni(*buf)
+	r = parseSni(*buf, logger)
 	assert.NotNil(t, r)
 	assert.Equal(t, []string{"elastic.co", "example.net"}, r.([]string))
 
@@ -118,45 +122,49 @@ func TestSni(t *testing.T) {
 		"0009"+ // 9 byte string
 		"6c6f63616c686f7374", // localhost
 		41)
-	r = parseSni(*buf)
+	r = parseSni(*buf, logger)
 	assert.NotNil(t, r)
 	assert.Equal(t, []string{"elastic.co", "example.net"}, r.([]string))
 }
 
 func TestParseMaxFragmentLength(t *testing.T) {
-	r := parseMaxFragmentLen(*mkBuf(t, "01", 1))
+	logger := logptest.NewTestingLogger(t, "")
+	r := parseMaxFragmentLen(*mkBuf(t, "01", 1), logger)
 	assert.Equal(t, "2^9", r.(string))
-	r = parseMaxFragmentLen(*mkBuf(t, "04", 1))
+	r = parseMaxFragmentLen(*mkBuf(t, "04", 1), logger)
 	assert.Equal(t, "2^12", r.(string))
-	r = parseMaxFragmentLen(*mkBuf(t, "00", 1))
+	r = parseMaxFragmentLen(*mkBuf(t, "00", 1), logger)
 	assert.Equal(t, "(unknown:0)", r.(string))
-	r = parseMaxFragmentLen(*mkBuf(t, "FF", 1))
+	r = parseMaxFragmentLen(*mkBuf(t, "FF", 1), logger)
 	assert.Equal(t, "(unknown:255)", r.(string))
-	r = parseMaxFragmentLen(*mkBuf(t, "FF", 2))
+	r = parseMaxFragmentLen(*mkBuf(t, "FF", 2), logger)
 	assert.Nil(t, r)
 }
 
 func TestParseCertType(t *testing.T) {
-	r := parseCertType(*mkBuf(t, "00", 1))
+	logger := logptest.NewTestingLogger(t, "")
+	r := parseCertType(*mkBuf(t, "00", 1), logger)
 	assert.Equal(t, []string{"X.509"}, r.([]string))
-	r = parseCertType(*mkBuf(t, "01", 1))
+	r = parseCertType(*mkBuf(t, "01", 1), logger)
 	assert.Equal(t, []string{"OpenPGP"}, r.([]string))
-	r = parseCertType(*mkBuf(t, "02", 1))
+	r = parseCertType(*mkBuf(t, "02", 1), logger)
 	assert.Equal(t, []string{"RawPubKey"}, r.([]string))
-	r = parseCertType(*mkBuf(t, "3c", 1))
+	r = parseCertType(*mkBuf(t, "3c", 1), logger)
 	assert.Equal(t, []string{"(unknown:60)"}, r.([]string))
-	r = parseCertType(*mkBuf(t, "03020100", 4))
+	r = parseCertType(*mkBuf(t, "03020100", 4), logger)
 	assert.Equal(t, []string{"RawPubKey", "OpenPGP", "X.509"}, r.([]string))
 }
 
 func TestParseSrp(t *testing.T) {
-	r := parseSrp(*mkBuf(t, "04726f6f74", 5))
+	logger := logptest.NewTestingLogger(t, "")
+	r := parseSrp(*mkBuf(t, "04726f6f74", 5), logger)
 	assert.Equal(t, "root", r.(string))
-	r = parseSrp(*mkBuf(t, "FF726f6f74", 5))
+	r = parseSrp(*mkBuf(t, "FF726f6f74", 5), logger)
 	assert.Nil(t, r)
 }
 
 func TestParseSupportedVersions(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
 	for _, testCase := range []struct {
 		title    string
 		data     string
@@ -205,7 +213,7 @@ func TestParseSupportedVersions(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.title, func(t *testing.T) {
-			r := parseSupportedVersions(*mkBuf(t, testCase.data, len(testCase.data)/2))
+			r := parseSupportedVersions(*mkBuf(t, testCase.data, len(testCase.data)/2), logger)
 			if testCase.expected == nil {
 				assert.Nil(t, r, testCase.data)
 				return

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -431,12 +431,12 @@ func parseCommonHello(buffer bufferView, dest *helloMessage) (int, bool) {
 	}
 
 	if dest.version.major != 3 {
-		dest.logger.Warn("Not a TLS hello (reported version %d.%d)",
+		dest.logger.Warnf("Not a TLS hello (reported version %d.%d)",
 			dest.version.major, dest.version.minor)
 		return 0, false
 	}
 	if sessionIDLength > 32 {
-		dest.logger.Warn("Not a TLS hello (session id length %d out of bounds)", sessionIDLength)
+		dest.logger.Warnf("Not a TLS hello (session id length %d out of bounds)", sessionIDLength)
 		return 0, false
 	}
 

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -106,6 +106,7 @@ type parser struct {
 
 	// If a key-exchange message has been sent. Used to detect session resumption
 	keyExchanged bool
+	tlsLogger    *logp.Logger
 }
 
 // https://www.rfc-editor.org/rfc/rfc6960#section-4.2.1
@@ -247,6 +248,12 @@ func (hello *helloMessage) supportedCiphers() []string {
 	return ciphers
 }
 
+func (parser *parser) debugf(format string, args ...interface{}) {
+	if parser.tlsLogger != nil && parser.tlsLogger.IsDebug() {
+		parser.tlsLogger.Debugf(format, args...)
+	}
+}
+
 func (parser *parser) parse(buf *streambuf.Buffer) parserResult {
 	for buf.Avail(recordHeaderSize) {
 
@@ -266,17 +273,13 @@ func (parser *parser) parse(buf *streambuf.Buffer) parserResult {
 
 		switch header.recordType {
 		case recordTypeChangeCipherSpec: // single message of size 1 (byte 1)
-			if isDebug {
-				debugf("handshake completed")
-			}
+			parser.debugf("handshake completed")
 			// discard remaining data for this stream (encrypted)
 			_ = buf.Advance(buf.Len())
 			return resultEncrypted
 
 		case recordTypeHandshake:
-			if isDebug {
-				debugf("got handshake record of size %d", header.length)
-			}
+			parser.debugf("got handshake record of size %d", header.length)
 			if err = parser.bufferHandshake(buf, int(header.length)); err != nil {
 				logp.Warn("Error parsing handshake message: %v", err)
 				return resultFailed
@@ -290,14 +293,10 @@ func (parser *parser) parse(buf *streambuf.Buffer) parserResult {
 
 		case recordTypeApplicationData:
 			// TODO: Request / Response analytics
-			if isDebug {
-				debugf("ignoring application data length %d", header.length)
-			}
+			parser.debugf("ignoring application data length %d", header.length)
 
 		default:
-			if isDebug {
-				debugf("ignoring record type %d length %d", header.recordType, header.length)
-			}
+			parser.debugf("ignoring record type %d length %d", header.recordType, header.length)
 		}
 
 		_ = buf.Advance(limit)
@@ -369,9 +368,7 @@ func (parser *parser) setDirection(dir direction) {
 }
 
 func (parser *parser) parseHandshake(handshakeType handshakeType, buffer bufferView) bool {
-	if isDebug {
-		debugf("got handshake message %v [%d]", handshakeType, buffer.length())
-	}
+	parser.debugf("got handshake message %v [%d]", handshakeType, buffer.length())
 	switch handshakeType {
 	case helloRequest:
 		parser.setDirection(dirServer)

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -106,7 +106,7 @@ type parser struct {
 
 	// If a key-exchange message has been sent. Used to detect session resumption
 	keyExchanged bool
-	tlsLogger    *logp.Logger
+	logger       *logp.Logger
 }
 
 // https://www.rfc-editor.org/rfc/rfc6960#section-4.2.1
@@ -161,6 +161,7 @@ type helloMessage struct {
 		compression compressionMethod
 	}
 	extensions Extensions
+	logger     *logp.Logger
 }
 
 func readRecordHeader(buf *streambuf.Buffer) (*recordHeader, error) {
@@ -249,8 +250,8 @@ func (hello *helloMessage) supportedCiphers() []string {
 }
 
 func (parser *parser) debugf(format string, args ...interface{}) {
-	if parser.tlsLogger != nil && parser.tlsLogger.IsDebug() {
-		parser.tlsLogger.Debugf(format, args...)
+	if parser.logger != nil && parser.logger.IsDebug() {
+		parser.logger.Debugf(format, args...)
 	}
 }
 
@@ -260,7 +261,7 @@ func (parser *parser) parse(buf *streambuf.Buffer) parserResult {
 		header, err := readRecordHeader(buf)
 		if err != nil || !header.isValid() {
 			if err != nil {
-				logp.Warn("internal buffer error: %v", err)
+				parser.logger.Warnf("internal buffer error: %v", err)
 			}
 			return resultFailed
 		}
@@ -281,13 +282,13 @@ func (parser *parser) parse(buf *streambuf.Buffer) parserResult {
 		case recordTypeHandshake:
 			parser.debugf("got handshake record of size %d", header.length)
 			if err = parser.bufferHandshake(buf, int(header.length)); err != nil {
-				logp.Warn("Error parsing handshake message: %v", err)
+				parser.logger.Warnf("Error parsing handshake message: %v", err)
 				return resultFailed
 			}
 
 		case recordTypeAlert:
 			if err = parser.parseAlert(newBufferView(buf, recordHeaderSize, int(header.length))); err != nil {
-				logp.Warn("Error parsing alert message: %v", err)
+				parser.logger.Warnf("Error parsing alert message: %v", err)
 				return resultFailed
 			}
 
@@ -312,7 +313,7 @@ func (parser *parser) bufferHandshake(buf *streambuf.Buffer, length int) (err er
 	// TODO: parse in-place if message in received buffer is complete
 	err = parser.handshakeBuf.Append(buf.Bytes()[recordHeaderSize : recordHeaderSize+length])
 	if err != nil {
-		logp.Warn("failed appending to buffer: %v", err)
+		parser.logger.Warnf("failed appending to buffer: %v", err)
 		// Discard buffer
 		parser.handshakeBuf.Init(nil, false)
 		return err
@@ -334,7 +335,7 @@ func (parser *parser) bufferHandshake(buf *streambuf.Buffer, length int) (err er
 		// type
 		header, err := readHandshakeHeader(&parser.handshakeBuf)
 		if err != nil {
-			logp.Warn("read failed: %v", err)
+			parser.logger.Warnf("read failed: %v", err)
 			parser.handshakeBuf.Init(nil, false)
 			return err
 		}
@@ -362,7 +363,7 @@ func (parser *parser) bufferHandshake(buf *streambuf.Buffer, length int) (err er
 
 func (parser *parser) setDirection(dir direction) {
 	if parser.direction != dir && parser.direction != dirUnknown {
-		logp.Warn("client/server identification mismatch")
+		parser.logger.Warn("client/server identification mismatch")
 	}
 	parser.direction = dir
 }
@@ -372,18 +373,18 @@ func (parser *parser) parseHandshake(handshakeType handshakeType, buffer bufferV
 	switch handshakeType {
 	case helloRequest:
 		parser.setDirection(dirServer)
-		return parseHelloRequest(buffer)
+		return parseHelloRequest(buffer, parser.logger)
 
 	case clientHello:
 		parser.setDirection(dirClient)
-		if parser.hello = parseClientHello(buffer); parser.hello == nil {
+		if parser.hello = parseClientHello(buffer, parser.logger); parser.hello == nil {
 			return false
 		}
 		return true
 
 	case serverHello:
 		parser.setDirection(dirServer)
-		if parser.hello = parseServerHello(buffer); parser.hello == nil {
+		if parser.hello = parseServerHello(buffer, parser.logger); parser.hello == nil {
 			return false
 		}
 		return true
@@ -410,9 +411,9 @@ func (parser *parser) parseHandshake(handshakeType handshakeType, buffer bufferV
 	return true
 }
 
-func parseHelloRequest(buffer bufferView) bool {
+func parseHelloRequest(buffer bufferView, logger *logp.Logger) bool {
 	if buffer.length() != 0 {
-		logp.Warn("non-empty hello request")
+		logger.Warn("non-empty hello request")
 	}
 	return true
 }
@@ -425,23 +426,23 @@ func parseCommonHello(buffer bufferView, dest *helloMessage) (int, bool) {
 		!buffer.read32Net(2, &dest.timestamp) ||
 		// ignore 28 random bytes
 		!buffer.read8(6+randomDataLength, &sessionIDLength) {
-		logp.Warn("failed reading hello message")
+		dest.logger.Warn("failed reading hello message")
 		return 0, false
 	}
 
 	if dest.version.major != 3 {
-		logp.Warn("Not a TLS hello (reported version %d.%d)",
+		dest.logger.Warn("Not a TLS hello (reported version %d.%d)",
 			dest.version.major, dest.version.minor)
 		return 0, false
 	}
 	if sessionIDLength > 32 {
-		logp.Warn("Not a TLS hello (session id length %d out of bounds)", sessionIDLength)
+		dest.logger.Warn("Not a TLS hello (session id length %d out of bounds)", sessionIDLength)
 		return 0, false
 	}
 
 	bytes := buffer.readBytes(7+randomDataLength, int(sessionIDLength))
 	if len(bytes) != int(sessionIDLength) {
-		logp.Warn("Not a TLS hello (failed reading session ID)")
+		dest.logger.Warn("Not a TLS hello (failed reading session ID)")
 		return 0, false
 	}
 	dest.sessionID = hex.EncodeToString(bytes)
@@ -451,19 +452,20 @@ func parseCommonHello(buffer bufferView, dest *helloMessage) (int, bool) {
 }
 
 func (hello *helloMessage) parseExtensions(buffer bufferView) {
-	hello.extensions = ParseExtensions(buffer)
+	hello.extensions = ParseExtensions(buffer, hello.logger)
 	if ticket, err := hello.extensions.Parsed.GetValue("session_ticket"); err == nil {
 		if value, ok := ticket.(string); ok {
 			hello.ticket.present = true
 			hello.ticket.value = value
 		} else {
-			logp.Err("tls ticket data type error")
+			hello.logger.Error("tls ticket data type error")
 		}
 	}
 }
 
-func parseClientHello(buffer bufferView) *helloMessage {
+func parseClientHello(buffer bufferView, logger *logp.Logger) *helloMessage {
 	var result helloMessage
+	result.logger = logger
 	pos, ok := parseCommonHello(buffer, &result)
 	if !ok {
 		return nil
@@ -471,14 +473,14 @@ func parseClientHello(buffer bufferView) *helloMessage {
 
 	var cipherSuitesLength uint16
 	if !buffer.read16Net(pos, &cipherSuitesLength) {
-		logp.Warn("failed parsing client hello cipher suite length")
+		logger.Warn("failed parsing client hello cipher suite length")
 		return nil
 	}
 
 	for base := pos + 2; base < pos+2+int(cipherSuitesLength); base += 2 {
 		var cipher uint16
 		if !buffer.read16Net(base, &cipher) {
-			logp.Warn("failed parsing client hello cipher suite")
+			logger.Warn("failed parsing client hello cipher suite")
 			return nil
 		}
 		if !isGreaseValue(cipher) {
@@ -489,14 +491,14 @@ func parseClientHello(buffer bufferView) *helloMessage {
 	pos += 2 + int(cipherSuitesLength)
 	var compMethodsLength uint8
 	if !buffer.read8(pos, &compMethodsLength) {
-		logp.Warn("failed parsing client hello compression methods length")
+		logger.Warn("failed parsing client hello compression methods length")
 		return nil
 	}
 	limit := pos + 1 + int(compMethodsLength)
 	for base := pos + 1; base < limit; base++ {
 		var method uint8
 		if !buffer.read8(base, &method) {
-			logp.Warn("failed parsing client hello compression methods")
+			logger.Warn("failed parsing client hello compression methods")
 			return nil
 		}
 		result.supported.compression = append(result.supported.compression, compressionMethod(method))
@@ -506,8 +508,9 @@ func parseClientHello(buffer bufferView) *helloMessage {
 	return &result
 }
 
-func parseServerHello(buffer bufferView) *helloMessage {
+func parseServerHello(buffer bufferView, logger *logp.Logger) *helloMessage {
 	var result helloMessage
+	result.logger = logger
 	pos, ok := parseCommonHello(buffer, &result)
 	if !ok {
 		return nil

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -170,7 +170,7 @@ func TestParseHandshakeHeader(t *testing.T) {
 
 func TestParserParse(t *testing.T) {
 
-	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
+	parser := &parser{logger: logptest.NewTestingLogger(t, "")}
 	// An incomplete record header is ok but not complete
 	assert.Equal(t, resultMore, parser.parse(sBuf(t, "14")))
 
@@ -193,7 +193,7 @@ func TestParserParse(t *testing.T) {
 
 func TestParserHello(t *testing.T) {
 
-	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
+	parser := &parser{logger: logptest.NewTestingLogger(t, "")}
 	// An incomplete handshake header is ok and complete
 	assert.Equal(t, resultOK, parser.parse(sBuf(t, "160301000502000002FF")))
 	assert.Equal(t, 5, parser.handshakeBuf.Len())
@@ -272,7 +272,7 @@ func TestParserHello(t *testing.T) {
 }
 
 func TestCertificates(t *testing.T) {
-	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
+	parser := &parser{logger: logptest.NewTestingLogger(t, "")}
 
 	// A certificates message with two certificates
 	assert.Equal(t, resultOK, parser.parse(sBuf(t, certsMsg)))
@@ -353,7 +353,7 @@ func TestCertificates(t *testing.T) {
 }
 
 func TestRandom(t *testing.T) {
-	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
+	parser := &parser{logger: logptest.NewTestingLogger(t, "")}
 
 	for i, test := range []struct {
 		msg  string
@@ -491,7 +491,7 @@ func TestRandom(t *testing.T) {
 }
 
 func TestBadCertMessage(t *testing.T) {
-	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
+	parser := &parser{logger: logptest.NewTestingLogger(t, "")}
 
 	msgs := []string{
 		// empty message

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common/streambuf"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -127,7 +128,6 @@ func mapGet(t *testing.T, m mapstr.M, key string) interface{} {
 
 func TestParseRecordHeader(t *testing.T) {
 	if testing.Verbose() {
-		isDebug = true
 		logp.TestingSetup(logp.WithSelectors("tls", "tlsdetailed"))
 	}
 
@@ -153,10 +153,6 @@ func TestParseRecordHeader(t *testing.T) {
 }
 
 func TestParseHandshakeHeader(t *testing.T) {
-	if testing.Verbose() {
-		isDebug = true
-		logp.TestingSetup(logp.WithSelectors("tls", "tlsdetailed"))
-	}
 
 	_, err := readHandshakeHeader(sBuf(t, ""))
 	assert.Error(t, err)
@@ -173,12 +169,8 @@ func TestParseHandshakeHeader(t *testing.T) {
 }
 
 func TestParserParse(t *testing.T) {
-	if testing.Verbose() {
-		isDebug = true
-		logp.TestingSetup(logp.WithSelectors("tls", "tlsdetailed"))
-	}
 
-	parser := &parser{}
+	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
 	// An incomplete record header is ok but not complete
 	assert.Equal(t, resultMore, parser.parse(sBuf(t, "14")))
 
@@ -200,12 +192,8 @@ func TestParserParse(t *testing.T) {
 }
 
 func TestParserHello(t *testing.T) {
-	if testing.Verbose() {
-		isDebug = true
-		logp.TestingSetup(logp.WithSelectors("tls", "tlsdetailed"))
-	}
 
-	parser := &parser{}
+	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
 	// An incomplete handshake header is ok and complete
 	assert.Equal(t, resultOK, parser.parse(sBuf(t, "160301000502000002FF")))
 	assert.Equal(t, 5, parser.handshakeBuf.Len())
@@ -284,7 +272,7 @@ func TestParserHello(t *testing.T) {
 }
 
 func TestCertificates(t *testing.T) {
-	parser := &parser{}
+	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
 
 	// A certificates message with two certificates
 	assert.Equal(t, resultOK, parser.parse(sBuf(t, certsMsg)))
@@ -365,7 +353,7 @@ func TestCertificates(t *testing.T) {
 }
 
 func TestRandom(t *testing.T) {
-	parser := &parser{}
+	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
 
 	for i, test := range []struct {
 		msg  string
@@ -503,7 +491,7 @@ func TestRandom(t *testing.T) {
 }
 
 func TestBadCertMessage(t *testing.T) {
-	parser := &parser{}
+	parser := &parser{tlsLogger: logptest.NewTestingLogger(t, "")}
 
 	msgs := []string{
 		// empty message

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -187,7 +187,7 @@ func (plugin *tlsPlugin) doParse(
 	if st == nil {
 		st = newStream(tcptuple)
 		st.cmdlineTuple = plugin.watcher.FindProcessesTupleTCP(tcptuple.IPPort())
-		st.parser.tlsLogger = plugin.tlsLogger
+		st.parser.logger = plugin.tlsLogger
 		conn.streams[dir] = st
 	}
 
@@ -281,7 +281,7 @@ func (plugin *tlsPlugin) createEvent(conn *tlsConnectionData) beat.Event {
 	}
 	detailed := mapstr.M{}
 
-	emptyHello := &helloMessage{}
+	emptyHello := &helloMessage{logger: plugin.tlsLogger}
 	var clientHello, serverHello *helloMessage
 	if client.parser.hello != nil {
 		clientHello = client.parser.hello

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -62,11 +62,10 @@ type tlsPlugin struct {
 	transactionTimeout     time.Duration
 	results                protos.Reporter
 	watcher                *procs.ProcessesWatcher
+	logger, tlsLogger      *logp.Logger
 }
 
 var (
-	debugf  = logp.MakeDebug("tls")
-	isDebug = false
 
 	// ensure that tlsPlugin fulfills the TCPPlugin interface
 	_ protos.TCPPlugin = &tlsPlugin{}
@@ -85,6 +84,8 @@ func New(
 	logger *logp.Logger,
 ) (protos.Plugin, error) {
 	p := &tlsPlugin{}
+	p.logger = logger
+	p.tlsLogger = logger.Named("tls")
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -98,6 +99,12 @@ func New(
 	return p, nil
 }
 
+func (plugin *tlsPlugin) debugf(format string, args ...interface{}) {
+	if plugin.tlsLogger.IsDebug() {
+		plugin.tlsLogger.Debugf(format, args...)
+	}
+}
+
 func (plugin *tlsPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *tlsConfig) error {
 	if err := plugin.setFromConfig(config); err != nil {
 		return err
@@ -105,7 +112,6 @@ func (plugin *tlsPlugin) init(results protos.Reporter, watcher *procs.ProcessesW
 
 	plugin.results = results
 	plugin.watcher = watcher
-	isDebug = logp.IsDebug("tls")
 
 	return nil
 }
@@ -140,7 +146,7 @@ func (plugin *tlsPlugin) Parse(
 	dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	conn := ensureTLSConnection(private)
+	conn := ensureTLSConnection(private, plugin.logger)
 	if private == nil {
 		conn.startTime = pkt.Ts
 	}
@@ -151,14 +157,14 @@ func (plugin *tlsPlugin) Parse(
 	return conn
 }
 
-func ensureTLSConnection(private protos.ProtocolData) *tlsConnectionData {
+func ensureTLSConnection(private protos.ProtocolData, logger *logp.Logger) *tlsConnectionData {
 	if private == nil {
 		return &tlsConnectionData{}
 	}
 
 	priv, ok := private.(*tlsConnectionData)
 	if !ok {
-		logp.Warn("tls connection data type error, creating a new one")
+		logger.Warn("tls connection data type error, creating a new one")
 		return &tlsConnectionData{}
 	}
 
@@ -181,13 +187,12 @@ func (plugin *tlsPlugin) doParse(
 	if st == nil {
 		st = newStream(tcptuple)
 		st.cmdlineTuple = plugin.watcher.FindProcessesTupleTCP(tcptuple.IPPort())
+		st.parser.tlsLogger = plugin.tlsLogger
 		conn.streams[dir] = st
 	}
 
 	if err := st.Append(pkt.Payload); err != nil {
-		if isDebug {
-			debugf("%v, dropping TCP stream", err)
-		}
+		plugin.debugf("%v, dropping TCP stream", err)
 		return nil
 	}
 
@@ -204,9 +209,7 @@ func (plugin *tlsPlugin) doParse(
 			// drop this tcp stream. Will retry parsing with the next
 			// segment in it
 			conn.streams[dir] = nil
-			if isDebug {
-				debugf("non-TLS message: TCP stream dropped. Try parsing with the next segment")
-			}
+			plugin.debugf("non-TLS message: TCP stream dropped. Try parsing with the next segment")
 
 		case resultEncrypted:
 			conn.handshakeCompleted |= 1 << dir
@@ -231,7 +234,7 @@ func newStream(tcptuple *common.TCPTuple) *stream {
 func (plugin *tlsPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	private protos.ProtocolData,
 ) protos.ProtocolData {
-	if conn := ensureTLSConnection(private); conn != nil {
+	if conn := ensureTLSConnection(private, plugin.logger); conn != nil {
 		plugin.sendEvent(conn)
 	}
 	return private
@@ -239,7 +242,7 @@ func (plugin *tlsPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 
 func (plugin *tlsPlugin) GapInStream(tcptuple *common.TCPTuple, dir uint8,
 	nbytes int, private protos.ProtocolData) (priv protos.ProtocolData, drop bool) {
-	if conn := ensureTLSConnection(private); conn != nil {
+	if conn := ensureTLSConnection(private, plugin.logger); conn != nil {
 		plugin.sendEvent(conn)
 	}
 	return private, true

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -63,6 +63,7 @@ type tlsPlugin struct {
 	results                protos.Reporter
 	watcher                *procs.ProcessesWatcher
 	logger, tlsLogger      *logp.Logger
+	isDebug                bool
 }
 
 var (
@@ -86,6 +87,7 @@ func New(
 	p := &tlsPlugin{}
 	p.logger = logger
 	p.tlsLogger = logger.Named("tls")
+	p.isDebug = p.tlsLogger.IsDebug()
 	config := defaultConfig
 	if !testMode {
 		if err := cfg.Unpack(&config); err != nil {
@@ -99,8 +101,9 @@ func New(
 	return p, nil
 }
 
+//go:inline
 func (plugin *tlsPlugin) debugf(format string, args ...interface{}) {
-	if plugin.tlsLogger.IsDebug() {
+	if plugin.isDebug {
 		plugin.tlsLogger.Debugf(format, args...)
 	}
 }

--- a/packetbeat/protos/udp/udp.go
+++ b/packetbeat/protos/udp/udp.go
@@ -45,10 +45,11 @@ type UDP struct {
 	portMap   map[uint16]protos.Protocol
 
 	metrics *inputMetrics
+	logger  *logp.Logger
 }
 
 // NewUDP creates and returns a new UDP.
-func NewUDP(p protos.Protocols, id, device string, idx int) (*UDP, error) {
+func NewUDP(p protos.Protocols, id, device string, idx int, logger *logp.Logger) (*UDP, error) {
 	portMap, err := buildPortsMap(p.GetAllUDP())
 	if err != nil {
 		return nil, err
@@ -57,9 +58,10 @@ func NewUDP(p protos.Protocols, id, device string, idx int) (*UDP, error) {
 	udp := &UDP{
 		protocols: p,
 		portMap:   portMap,
-		metrics:   newInputMetrics(fmt.Sprintf("%s_%d", id, idx), device, portMap),
+		metrics:   newInputMetrics(fmt.Sprintf("%s_%d", id, idx), device, portMap, logger),
+		logger:    logger.Named("udp"),
 	}
-	logp.Debug("udp", "Port map: %v", portMap)
+	logger.Debugf("Port map: %v", portMap)
 
 	return udp, nil
 }
@@ -94,18 +96,18 @@ func buildPortsMap(plugins map[protos.Protocol]protos.UDPPlugin) (map[uint16]pro
 func (udp *UDP) Process(id *flows.FlowID, pkt *protos.Packet) {
 	protocol := udp.decideProtocol(&pkt.Tuple)
 	if protocol == protos.UnknownProtocol {
-		logp.Debug("udp", "unknown protocol")
+		udp.logger.Debug("unknown protocol")
 		return
 	}
 
 	plugin := udp.protocols.GetUDP(protocol)
 	if plugin == nil {
-		logp.Debug("udp", "Ignoring protocol for which we have no module loaded: %s", protocol)
+		udp.logger.Debugf("Ignoring protocol for which we have no module loaded: %s", protocol)
 		return
 	}
 
 	if len(pkt.Payload) > 0 {
-		logp.Debug("udp", "Parsing packet from %v of length %d.",
+		udp.logger.Debugf("Parsing packet from %v of length %d.",
 			pkt.Tuple.String(), len(pkt.Payload))
 		plugin.ParseUDP(pkt)
 		udp.metrics.log(pkt)
@@ -151,7 +153,7 @@ type inputMetrics struct {
 
 // newInputMetrics returns an input metric for the UDP processor. If id or
 // device is empty a nil inputMetric is returned.
-func newInputMetrics(id, device string, ports map[uint16]protos.Protocol) *inputMetrics {
+func newInputMetrics(id, device string, ports map[uint16]protos.Protocol, logger *logp.Logger) *inputMetrics {
 	if id == "" || device == "" {
 		// An empty id signals to not record metrics,
 		// while an empty device means we are reading
@@ -169,10 +171,9 @@ func newInputMetrics(id, device string, ports map[uint16]protos.Protocol) *input
 		processingTime: metrics.NewUniformSample(1024),
 	}
 
-	// TODO: https://github.com/elastic/ingest-dev/issues/6000
-	_ = adapter.NewGoMetrics(reg, "arrival_period", logp.NewLogger(""), adapter.Accept).
+	_ = adapter.NewGoMetrics(reg, "arrival_period", logger, adapter.Accept).
 		Register("histogram", metrics.NewHistogram(out.arrivalPeriod))
-	_ = adapter.NewGoMetrics(reg, "processing_time", logp.NewLogger(""), adapter.Accept).
+	_ = adapter.NewGoMetrics(reg, "processing_time", logger, adapter.Accept).
 		Register("histogram", metrics.NewHistogram(out.processingTime))
 
 	out.device.Set(device)

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 
 	// import plugins for testing
 	_ "github.com/elastic/beats/v7/packetbeat/protos/http"
@@ -110,7 +111,7 @@ func testSetup(t *testing.T) *TestStruct {
 	plugin := &TestProtocol{Ports: []int{PORT}}
 	protocols.udp[PROTO] = plugin
 
-	udp, err := NewUDP(protocols, "test", "test", 0)
+	udp, err := NewUDP(protocols, "test", "test", 0, logptest.NewTestingLogger(t, ""))
 	if err != nil {
 		t.Error("Error creating UDP handler: ", err)
 	}

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -156,7 +156,7 @@ func (p *TransactionPublisher) worker(ch chan beat.Event, client beat.Client) {
 
 func (p *transProcessor) Run(event *beat.Event) (*beat.Event, error) {
 	if err := validateEvent(event); err != nil {
-		p.logger.Warn("Dropping invalid event: %v", err)
+		p.logger.Warnf("Dropping invalid event: %v", err)
 		return nil, nil
 	}
 

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -167,7 +167,7 @@ func (p *transProcessor) Run(event *beat.Event) (*beat.Event, error) {
 
 	if fields != nil {
 		if p.ignoreOutgoing && fields.Network.Direction == pb.Egress {
-			p.logger.Debug("Ignore outbound transaction on: %s -> %s",
+			p.logger.Debugf("Ignore outbound transaction on: %s -> %s",
 				fields.Source.IP, fields.Destination.IP)
 			return nil, nil
 		}

--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -44,9 +44,8 @@ type transProcessor struct {
 	localIPs         []net.IP // TODO: Periodically update this list.
 	internalNetworks []string
 	name             string
+	logger           *logp.Logger
 }
-
-var debugf = logp.MakeDebug("publish")
 
 func NewTransactionPublisher(
 	name string,
@@ -54,6 +53,7 @@ func NewTransactionPublisher(
 	ignoreOutgoing bool,
 	canDrop bool,
 	internalNetworks []string,
+	logger *logp.Logger,
 ) (*TransactionPublisher, error) {
 	addrs, err := common.LocalIPAddrs()
 	if err != nil {
@@ -75,6 +75,7 @@ func NewTransactionPublisher(
 			internalNetworks: internalNetworks,
 			name:             name,
 			ignoreOutgoing:   ignoreOutgoing,
+			logger:           logger.Named("publish"),
 		},
 	}
 	return p, nil
@@ -155,7 +156,7 @@ func (p *TransactionPublisher) worker(ch chan beat.Event, client beat.Client) {
 
 func (p *transProcessor) Run(event *beat.Event) (*beat.Event, error) {
 	if err := validateEvent(event); err != nil {
-		logp.Warn("Dropping invalid event: %v", err)
+		p.logger.Warn("Dropping invalid event: %v", err)
 		return nil, nil
 	}
 
@@ -166,7 +167,7 @@ func (p *transProcessor) Run(event *beat.Event) (*beat.Event, error) {
 
 	if fields != nil {
 		if p.ignoreOutgoing && fields.Network.Direction == pb.Egress {
-			debugf("Ignore outbound transaction on: %s -> %s",
+			p.logger.Debug("Ignore outbound transaction on: %s -> %s",
 				fields.Source.IP, fields.Destination.IP)
 			return nil, nil
 		}

--- a/packetbeat/publish/publish_test.go
+++ b/packetbeat/publish/publish_test.go
@@ -142,6 +142,7 @@ func TestFilterEvent(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "").Named("publish")
 	srcIP, dstIP := "192.145.2.4", "192.145.2.5"
 
 	event := func() *beat.Event {
@@ -167,6 +168,7 @@ func TestPublish(t *testing.T) {
 		processor := transProcessor{
 			localIPs: []net.IP{net.ParseIP(dstIP)},
 			name:     "test",
+			logger:   logger,
 		}
 
 		res, _ := processor.Run(event())
@@ -182,6 +184,7 @@ func TestPublish(t *testing.T) {
 		processor := transProcessor{
 			localIPs: []net.IP{net.ParseIP(srcIP)},
 			name:     "test",
+			logger:   logger,
 		}
 
 		res, _ := processor.Run(event())
@@ -197,6 +200,7 @@ func TestPublish(t *testing.T) {
 		processor := transProcessor{
 			localIPs: []net.IP{net.ParseIP(srcIP), net.ParseIP(dstIP)},
 			name:     "test",
+			logger:   logger,
 		}
 
 		res, _ := processor.Run(event())
@@ -212,6 +216,7 @@ func TestPublish(t *testing.T) {
 		processor := transProcessor{
 			localIPs: []net.IP{net.ParseIP(dstIP + "1")},
 			name:     "test",
+			logger:   logger,
 		}
 
 		res, _ := processor.Run(event())
@@ -228,6 +233,7 @@ func TestPublish(t *testing.T) {
 			localIPs:       []net.IP{net.ParseIP(srcIP)},
 			ignoreOutgoing: true,
 			name:           "test",
+			logger:         logger,
 		}
 
 		res, err := processor.Run(event())

--- a/packetbeat/publish/publish_test.go
+++ b/packetbeat/publish/publish_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/ecs"
 	"github.com/elastic/beats/v7/packetbeat/pb"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -66,7 +67,7 @@ func (p *mockPipeline) Disconnect(ctx context.Context) error {
 func TestStopWaitsForWorkers(t *testing.T) {
 	client := &mockClient{}
 	pipeline := &mockPipeline{client: client}
-	pub, err := NewTransactionPublisher("test", pipeline, false, false, nil)
+	pub, err := NewTransactionPublisher("test", pipeline, false, false, nil, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	cfg, err := conf.NewConfigFrom(mapstr.M{})

--- a/packetbeat/sniffer/decoders.go
+++ b/packetbeat/sniffer/decoders.go
@@ -74,12 +74,12 @@ func DecodersFor(
 			icmp6 = p
 		}
 
-		tcp, err := tcp.NewTCP(protocols, id, device, idx)
+		tcp, err := tcp.NewTCP(protocols, id, device, idx, logger)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		udp, err := udp.NewUDP(protocols, id, device, idx)
+		udp, err := udp.NewUDP(protocols, id, device, idx, logger)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/packetbeat/sniffer/device.go
+++ b/packetbeat/sniffer/device.go
@@ -83,7 +83,7 @@ func formatDeviceNames(devices []pcap.Interface, withDescription, withIP bool) [
 	return names
 }
 
-func resolveDeviceName(name string) (string, error) {
+func resolveDeviceName(name string, logger *logp.Logger) (string, error) {
 	if name == "" {
 		if runtime.GOOS == "linux" {
 			return "any", nil
@@ -148,7 +148,7 @@ func resolveDeviceName(name string) (string, error) {
 		return "", fmt.Errorf("invalid device index %d: %w", index, err)
 	}
 
-	logp.L().Named("sniffer").Info("Resolved device index %d to device: %s", index, name)
+	logger.Infof("Resolved device index %d to device: %s", index, name)
 	return name, nil
 }
 

--- a/packetbeat/sniffer/file.go
+++ b/packetbeat/sniffer/file.go
@@ -41,12 +41,12 @@ type fileHandler struct {
 	log *logp.Logger
 }
 
-func newFileHandler(file string, topSpeed bool, maxLoopCount int) (*fileHandler, error) {
+func newFileHandler(file string, topSpeed bool, maxLoopCount int, logger *logp.Logger) (*fileHandler, error) {
 	h := &fileHandler{
 		file:         file,
 		topSpeed:     topSpeed,
 		maxLoopCount: maxLoopCount,
-		log:          logp.NewLogger("sniffer"),
+		log:          logger,
 	}
 	if err := h.open(); err != nil {
 		return nil, err

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -500,7 +500,7 @@ func (s *sniffer) sniffHandle(ctx context.Context, handle snifferHandle, dec *de
 
 func (s *sniffer) open(device string) (snifferHandle, error) {
 	if s.config.File != "" {
-		return newFileHandler(s.config.File, s.config.TopSpeed, s.config.Loop)
+		return newFileHandler(s.config.File, s.config.TopSpeed, s.config.Loop, s.log)
 	}
 
 	switch s.config.Type {

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -145,7 +145,7 @@ func New(
 			iface.Device = ""
 		} else {
 			// try to resolve device name (ignore error if testMode is enabled)
-			if name, err := resolveDeviceName(iface.Device); err != nil {
+			if name, err := resolveDeviceName(iface.Device, s.log); err != nil {
 				if !testMode {
 					return nil, err
 				}
@@ -292,7 +292,7 @@ func (s *sniffer) pollDefaultRoute(ctx context.Context, device chan<- string, re
 // if it has a change from the old default route interface. If device resolution
 // fails, the default route interface is left unchanged.
 func (s *sniffer) poll(old string, device chan<- string) (current string) {
-	current, err := resolveDeviceName(s.config.Device)
+	current, err := resolveDeviceName(s.config.Device, s.log)
 	if err != nil {
 		s.log.Warnf("sniffer failed to poll default route device: %v", err)
 		return old


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
This PR removes global loggers from packetbeat. This is required so that we can multiple instances of packetbeat receiver from inside elastic-agent

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact
None

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Partially fixes https://github.com/elastic/beats/issues/51429
- Also partially fixes https://github.com/elastic/ingest-dev/issues/6000

