### PR TITLE
AGENTS.md: Add warning regarding stresstest script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ cd filebeat  # or any beat directory
 go test -v -race -run TestName ./path/to/package/...
 
 # Stress test to find flaky tests (runs a test repeatedly with x/tools/cmd/stress)
-script/stresstest.sh [--tags integration] [--race] ./path/to/package ^TestName$ -p 32
+# It runs FOREVER (stress -timeout is per-run, not total); bound it with an outer `timeout`.
+timeout 5m script/stresstest.sh [--tags integration] [--race] ./path/to/package ^TestName$ -p 32 [-failfast]
 ```
 
 ### Integration Tests


### PR DESCRIPTION
My agents keep encountering this issue, running the script without a timeout, getting stuck indefinitely.