### PR TITLE
processors: close when construction fails partway

### DIFF
--- a/changelog/fragments/1783070100-close-processors-on-construction-errors.yaml
+++ b/changelog/fragments/1783070100-close-processors-on-construction-errors.yaml
@@ -1,3 +1,3 @@
 kind: bug-fix
-summary: fix go routine leak when a processor fails to start
+summary: Fix goroutine leak when processor construction fails.
 component: all

--- a/changelog/fragments/1783070100-close-processors-on-construction-errors.yaml
+++ b/changelog/fragments/1783070100-close-processors-on-construction-errors.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: fix go routine leak when a processor fails to start
+component: all

--- a/libbeat/processors/conditionals.go
+++ b/libbeat/processors/conditionals.go
@@ -43,7 +43,16 @@ func NewConditional(
 			return nil, err
 		}
 
-		return addCondition(cfg, rule, log)
+		cond, err := addCondition(cfg, rule, log)
+		if err != nil {
+			// The processor was already constructed and may hold resources
+			// (or a reference to a shared instance): release it.
+			if closeErr := Close(rule); closeErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to close processor after condition error: %w", closeErr))
+			}
+			return nil, err
+		}
+		return cond, nil
 	}
 }
 
@@ -230,6 +239,13 @@ func NewIfElseThenProcessor(cfg *config.C, logger *logp.Logger) (beat.Processor,
 		return nil, err
 	}
 	if elseProcessors, err = newProcessors(c.Else); err != nil {
+		// The 'then' processors were already constructed and may hold
+		// resources (or references to shared instances): release them.
+		if ifProcessors != nil {
+			if closeErr := ifProcessors.Close(); closeErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to close 'then' processors after 'else' error: %w", closeErr))
+			}
+		}
 		return nil, err
 	}
 

--- a/libbeat/processors/conditionals_test.go
+++ b/libbeat/processors/conditionals_test.go
@@ -397,3 +397,33 @@ func requireImplements[T any](t *testing.T, v any) T {
 
 	return result
 }
+
+func TestConditionErrorClosesProcessor(t *testing.T) {
+	cons, p := newMockCloserConstructor()
+	wrapped := NewConditional(SafeWrap(cons))
+
+	cfg, err := conf.NewConfigFrom(map[string]any{"when": map[string]any{}})
+	require.NoError(t, err)
+
+	_, err = wrapped(cfg, logptest.NewTestingLogger(t, ""))
+	require.Error(t, err, "an empty condition must fail to build")
+	assert.Equal(t, 1, p.closeCount,
+		"the constructed processor must be closed when its condition fails to build")
+}
+
+func TestIfElseThenErrorClosesThenProcessors(t *testing.T) {
+	cons, p := newMockCloserConstructor()
+	RegisterPlugin("test-ifelse-close-on-error", cons)
+
+	cfg, err := conf.NewConfigFrom(map[string]any{
+		"if":   map[string]any{"equals": map[string]any{"a": "b"}},
+		"then": []any{map[string]any{"test-ifelse-close-on-error": map[string]any{}}},
+		"else": []any{map[string]any{"test-ifelse-does-not-exist": map[string]any{}}},
+	})
+	require.NoError(t, err)
+
+	_, err = NewIfElseThenProcessor(cfg, logptest.NewTestingLogger(t, ""))
+	require.Error(t, err, "building the 'else' list must fail")
+	assert.Equal(t, 1, p.closeCount,
+		"the 'then' processors must be closed when building the 'else' list fails")
+}

--- a/libbeat/processors/conditionals_test.go
+++ b/libbeat/processors/conditionals_test.go
@@ -427,3 +427,18 @@ func TestIfElseThenErrorClosesThenProcessors(t *testing.T) {
 	assert.Equal(t, 1, p.closeCount,
 		"the 'then' processors must be closed when building the 'else' list fails")
 }
+
+func TestNewErrorClosesAlreadyConstructedProcessors(t *testing.T) {
+	cons, p := newMockCloserConstructor()
+	RegisterPlugin("test-new-close-on-error", cons)
+
+	first, err := conf.NewConfigFrom(map[string]any{"test-new-close-on-error": map[string]any{}})
+	require.NoError(t, err)
+	second, err := conf.NewConfigFrom(map[string]any{"test-new-does-not-exist": map[string]any{}})
+	require.NoError(t, err)
+
+	_, err = New(PluginConfig{first, second}, logptest.NewTestingLogger(t, ""))
+	require.Error(t, err, "building the processor list must fail")
+	assert.Equal(t, 1, p.closeCount,
+		"the already-constructed processors must be closed when list construction fails partway")
+}

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -85,28 +85,37 @@ func New(config PluginConfig, logger *logp.Logger) (*Processors, error) {
 	}
 	procs := NewList(logger)
 
+	// abort closes the processors constructed so far, so a failed list does
+	// not leak their resources (or shared-instance references).
+	abort := func(err error) (*Processors, error) {
+		if closeErr := procs.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close partially constructed processor list: %w", closeErr))
+		}
+		return nil, err
+	}
+
 	for _, procConfig := range config {
 		// Handle if/then/else processor which has multiple top-level keys.
 		if procConfig.HasField("if") {
 			p, err := NewIfElseThenProcessor(procConfig, logger)
 			if err != nil {
-				return nil, fmt.Errorf("failed to make if/then/else processor: %w", err)
+				return abort(fmt.Errorf("failed to make if/then/else processor: %w", err))
 			}
 			procs.AddProcessor(p)
 			continue
 		}
 
 		if len(procConfig.GetFields()) != 1 {
-			return nil, fmt.Errorf("each processor must have exactly one "+
+			return abort(fmt.Errorf("each processor must have exactly one "+
 				"action, but found %d actions (%v)",
 				len(procConfig.GetFields()),
-				strings.Join(procConfig.GetFields(), ","))
+				strings.Join(procConfig.GetFields(), ",")))
 		}
 
 		actionName := procConfig.GetFields()[0]
 		actionCfg, err := procConfig.Child(actionName, -1)
 		if err != nil {
-			return nil, err
+			return abort(err)
 		}
 
 		gen, exists := registry.reg[actionName]
@@ -116,14 +125,14 @@ func New(config PluginConfig, logger *logp.Logger) (*Processors, error) {
 				validActions = append(validActions, k)
 
 			}
-			return nil, fmt.Errorf("the processor action %s does not exist. Valid actions: %v", actionName, strings.Join(validActions, ", "))
+			return abort(fmt.Errorf("the processor action %s does not exist. Valid actions: %v", actionName, strings.Join(validActions, ", ")))
 		}
 
 		common.PrintConfigDebugf(actionCfg, "Configure processor action '%v' with:", actionName)
 		constructor := gen.Plugin()
 		plugin, err := constructor(actionCfg, logger)
 		if err != nil {
-			return nil, err
+			return abort(err)
 		}
 
 		procs.AddProcessor(plugin)


### PR DESCRIPTION
## Proposed commit message

```
libbeat/processors: close processors when construction fails partway

Processor construction had three error paths that dropped
already-constructed processors without calling Close, leaking any
resources they held for the lifetime of the process:

- processors.New: while building a list, a processor that failed to
  construct caused the function to return without closing the
  processors built earlier in the same list.
- NewConditional: every registered processor is wrapped as
  NewConditional(SafeWrap(constructor)). The inner constructor runs
  first, then the `when` condition is parsed. A malformed condition
  returned an error but left the already-constructed processor open.
- NewIfElseThenProcessor: if the `else` branch failed to build, the
  already-built `then` processors were dropped without Close.

The fix closes the already-constructed processors on each of these error
paths.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. This only affects error paths during processor construction and does not change behavior for successfully built processors. The leaked resources are now released instead of being held for the process lifetime.

## How to test this PR locally

Run the package tests, including the two new tests that assert the constructed processor is closed on each error path:

```bash
cd libbeat
go test -race -run 'TestConditionErrorClosesProcessor|TestIfElseThenErrorClosesThenProcessors' ./processors/...
go test -race ./processors/...
```

### Reproduce the leak with a real Filebeat config

This needs no Docker. `add_docker_metadata` starts a background reconnect goroutine at construction that is stopped only by `Close()`; with `wait_for_metadata_timeout: 0` it retries forever. The empty `when` condition fails to build *after* that processor has already been constructed, so before this change the processor was dropped without `Close()` and its reconnect goroutine was orphaned for the lifetime of the process. The leak is an orphaned goroutine, so it is observed through the goroutine profile rather than through the config or the logs.

```bash
mkdir -p /tmp/fb-repro/data
for i in $(seq 1 60); do printf 'log line %04d filler filler filler filler filler filler filler\n' "$i"; done > /tmp/fb-repro/log.txt
```

`/tmp/fb-repro/filebeat.yml`:

```yaml
filebeat.inputs:
  - type: filestream
    id: leaking-input
    enabled: true
    paths:
      - /tmp/fb-repro/log.txt
    processors:
      - add_docker_metadata:
          host: "unix:///var/run/nonexistent-docker.sock"
          wait_for_metadata_timeout: 0
          when: {}

output.file:
  path: /tmp/fb-repro/out
  filename: filebeat-out

http.enabled: true
http.host: localhost
http.port: 5066
http.pprof.enabled: true
```

Run filebeat, then read the goroutine profile:

```bash
./filebeat -e -c /tmp/fb-repro/filebeat.yml \
  --path.home /tmp/fb-repro --path.data /tmp/fb-repro/data --strict.perms=false &
sleep 10
curl -s "http://localhost:5066/debug/pprof/goroutine?debug=1" | grep -c retryConnectToDocker
```

On `main` the `grep -c` prints `1`: the reconnect goroutine is orphaned and remains in the profile, with a parentless stack:

```
1 @ ...
#	...add_docker_metadata.(*addDockerMetadata).retryConnectToDocker	add_docker_metadata.go:227
#	...startDockerConnectionRetry.func3				add_docker_metadata.go:187
#	sync.(*WaitGroup).Go.func1					waitgroup.go:258
```

With this change the constructed processor is closed on the error path and the count is `0`.
