### PR TITLE
translate_ldap_attribute: fix String race during LDAP init

### DIFF
--- a/changelog/fragments/1783070300-fix-translate-ldap-attribute-string-race.yaml
+++ b/changelog/fragments/1783070300-fix-translate-ldap-attribute-string-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: fix data race in translate_ldap_attribute
+component: all

--- a/libbeat/processors/translate_ldap_attribute/translate_ldap_attribute.go
+++ b/libbeat/processors/translate_ldap_attribute/translate_ldap_attribute.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
@@ -54,6 +55,10 @@ type processor struct {
 	client *ldapClient
 	log    *logp.Logger
 
+	// description stores the processor's String output. It must remain lock-free because the logger
+	// evaluates this Stringer while client initialization is running.
+	description atomic.Value // stores string
+
 	clientMu          sync.Mutex
 	clientErr         error
 	nextClientAttempt time.Time
@@ -73,8 +78,14 @@ func New(cfg *conf.C, log *logp.Logger) (beat.Processor, error) {
 
 func newFromConfig(c config, logger *logp.Logger) (*processor, error) {
 	p := &processor{config: c}
+	p.storeDescription(c)
 	p.log = logger.Named(logName).With(logp.Stringer("processor", p))
 	return p, nil
+}
+
+func (p *processor) storeDescription(c config) {
+	p.description.Store(fmt.Sprintf("translate_ldap_attribute=[field=%s, ldap_address=%s, ldap_base_dn=%s, ldap_bind_user=%s, ldap_search_attribute=%s, ldap_mapped_attribute=%s]",
+		c.Field, c.LDAPAddress, c.LDAPBaseDN, c.LDAPBindUser, c.LDAPSearchAttribute, c.LDAPMappedAttribute))
 }
 
 // newClient creates a new LDAP client by discovering and connecting to available servers.
@@ -134,8 +145,8 @@ func newClient(c config, log *logp.Logger) (*ldapClient, error) {
 }
 
 func (p *processor) String() string {
-	return fmt.Sprintf("translate_ldap_attribute=[field=%s, ldap_address=%s, ldap_base_dn=%s, ldap_bind_user=%s, ldap_search_attribute=%s, ldap_mapped_attribute=%s]",
-		p.Field, p.LDAPAddress, p.LDAPBaseDN, p.LDAPBindUser, p.LDAPSearchAttribute, p.LDAPMappedAttribute)
+	description, _ := p.description.Load().(string)
+	return description
 }
 
 func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
@@ -283,6 +294,7 @@ func (p *processor) ensureClient() (*ldapClient, error) {
 	p.client = client
 	p.LDAPBaseDN = client.baseDN
 	p.LDAPAddress = client.address
+	p.storeDescription(p.config)
 	p.clientErr = nil
 	p.nextClientAttempt = time.Time{}
 	return client, nil

--- a/libbeat/processors/translate_ldap_attribute/translate_ldap_attribute_test.go
+++ b/libbeat/processors/translate_ldap_attribute/translate_ldap_attribute_test.go
@@ -1,0 +1,128 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !requirefips
+
+package translate_ldap_attribute
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+// newFakeLDAPServer starts a TCP listener that answers the initial LDAP bind
+// request on every connection with a canned success response. Together with a
+// configured base DN this is enough for newLDAPClient to succeed without a
+// real LDAP server.
+func newFakeLDAPServer(t *testing.T) net.Listener {
+	t.Helper()
+
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { l.Close() })
+
+	// BER-encoded LDAP BindResponse: messageID=1, resultCode=0 (success).
+	bindSuccess := []byte{0x30, 0x0c, 0x02, 0x01, 0x01, 0x61, 0x07, 0x0a, 0x01, 0x00, 0x04, 0x00, 0x04, 0x00}
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1024)
+				if _, err := c.Read(buf); err != nil {
+					return
+				}
+				if _, err := c.Write(bindSuccess); err != nil {
+					return
+				}
+				// Drain until the client closes the connection.
+				_, _ = io.Copy(io.Discard, c)
+			}(conn)
+		}
+	}()
+
+	return l
+}
+
+// TestConcurrentClientInitAndString exercises the race between String and the
+// lazy client initialization: ensureClient stores the discovered address and
+// base DN, while String reads the processor description. String is registered
+// on the processor logger via logp.Stringer, so it may be evaluated from any
+// goroutine while another initializes the client, because identically
+// configured processors are shared between inputs. Only meaningful under -race.
+func TestConcurrentClientInitAndString(t *testing.T) {
+	l := newFakeLDAPServer(t)
+
+	c := defaultConfig()
+	c.Field = "guid"
+	c.LDAPAddress = "ldap://" + l.Addr().String()
+	c.LDAPBaseDN = "dc=example,dc=com"
+	c.LDAPBindUser = "cn=admin,dc=example,dc=com"
+	c.LDAPBindPassword = "password"
+
+	p, err := newFromConfig(c, logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+	defer p.Close()
+
+	done := make(chan struct{})
+	var readers sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = p.String()
+				}
+			}
+		}()
+	}
+
+	var writers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for j := 0; j < 25; j++ {
+				_, _ = p.ensureClient()
+				if j%5 == 4 {
+					// Drop the client so the next ensureClient
+					// reinitializes it and writes the discovered values again.
+					_ = p.Close()
+				}
+			}
+		}()
+	}
+
+	writers.Wait()
+	close(done)
+	readers.Wait()
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

```text
translate_ldap_attribute: fix String race during LDAP init

The translate_ldap_attribute processor lazily initializes its LDAP client and
stores the selected LDAP address and base DN back on the processor config while
holding clientMu. String read those same fields without synchronization, and
String is reachable concurrently through logger fields and processor-group
error messages.

Store the processor description in an atomic value and make String read that
instead of reading the mutable config fields directly. Refresh the description
after successful LDAP discovery so logs can still show the discovered address
and base DN without making String take clientMu.

Add race-detector regression coverage with a fake LDAP listener that forces
client initialization and concurrent String evaluation.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

Run the stress test:

```bash
./script/stresstest.sh --race ./libbeat/processors/translate_ldap_attribute '^TestConcurrentClientInitAndString$' -p 16
```

## Logs

Without the fix, the focused race test reports the original race:

```text
WARNING: DATA RACE
Write at ... libbeat/processors/translate_ldap_attribute/translate_ldap_attribute.go:294
Previous read at ... libbeat/processors/translate_ldap_attribute/translate_ldap_attribute.go:147
WARNING: DATA RACE
Write at ... libbeat/processors/translate_ldap_attribute/translate_ldap_attribute.go:295
Previous read at ... libbeat/processors/translate_ldap_attribute/translate_ldap_attribute.go:147
--- FAIL: TestConcurrentClientInitAndString
```
