### PR TITLE
x-pack/osquerybeat: rename query profiling config and enable profiling by default

### DIFF
--- a/changelog/fragments/1783001090-osquerybeat-profiling-config.yaml
+++ b/changelog/fragments/1783001090-osquerybeat-profiling-config.yaml
@@ -1,0 +1,8 @@
+# REQUIRED
+kind: enhancement
+
+# REQUIRED
+summary: Rename osquerybeat query profiling settings to `profiling` and enable profiling by default
+
+# REQUIRED
+component: osquerybeat

--- a/x-pack/osquerybeat/_meta/config/beat.reference.yml.tmpl
+++ b/x-pack/osquerybeat/_meta/config/beat.reference.yml.tmpl
@@ -7,11 +7,17 @@ osquerybeat:
 #    - type: osquery
 #      osquery:
 #        elastic_options:
-#          query_profile_storage:
-#            # Enable local storage of live query profiles.
-#            #enabled: true
-#            # Maximum number of profiles kept (latest per query).
-#            #max_profiles: 64
+#          profiling:
+#            # Global default for collecting and publishing query profiles to the
+#            # osquery_manager.query_profile data stream for all queries (enabled by default).
+#            # Individual queries may override this with their own profiling flag. Requires the
+#            # query_profile input stream.
+#            #profiling_all: true
+#            storage:
+#              # Enable local storage of live query profiles (for diagnostics).
+#              #enabled: true
+#              # Maximum number of profiles kept (latest per query).
+#              #max_profiles: 64
 #          install:
 #            # Optional per-platform and per-architecture custom osquery artifacts.
 #            # If the current platform/arch is unset, bundled osquery is used.

--- a/x-pack/osquerybeat/beater/action_handler.go
+++ b/x-pack/osquerybeat/beater/action_handler.go
@@ -60,13 +60,30 @@ type namespaceProvider interface {
 	GetNamespace() string
 }
 
+// profileDefaultsProvider exposes the fleet-wide profiling default so live (ad-hoc)
+// queries can resolve it against their optional per-action override.
+type profileDefaultsProvider interface {
+	GlobalProfileEnabled() bool
+}
+
 type actionHandler struct {
-	log       *logp.Logger
-	inputType string
-	publisher actionQueryPublisher
-	queryExec queryExecutor
-	np        namespaceProvider
-	profiles  liveProfileRecorder
+	log             *logp.Logger
+	inputType       string
+	publisher       actionQueryPublisher
+	queryExec       queryExecutor
+	np              namespaceProvider
+	profiles        liveProfileRecorder
+	profileDefaults profileDefaultsProvider
+}
+
+// profileEnabled resolves whether this action should publish a profile, combining the
+// global default with the optional per-action override.
+func (a *actionHandler) profileEnabled(override *bool) bool {
+	var global bool
+	if a.profileDefaults != nil {
+		global = a.profileDefaults.GlobalProfileEnabled()
+	}
+	return config.ResolveProfiling(global, override)
 }
 
 func (a *actionHandler) Name() string {
@@ -128,7 +145,8 @@ func (a *actionHandler) executeQuery(ctx context.Context, index string, ac actio
 
 	var before runtimeSnapshot
 	beforeReady := false
-	shouldCollect := ac.Profile || a.profiles != nil
+	publishProfile := a.profileEnabled(ac.Profile)
+	shouldCollect := publishProfile || a.profiles != nil
 	if shouldCollect {
 		snapshot, err := collectRuntimeSnapshot(ctx, a.queryExec)
 		if err != nil {
@@ -153,12 +171,12 @@ func (a *actionHandler) executeQuery(ctx context.Context, index string, ac actio
 			if a.profiles != nil {
 				a.profiles.RecordLiveProfile(ac.Query, profile)
 			}
-			if ac.Profile {
+			if publishProfile {
 				a.publisher.PublishQueryProfile(config.QueryProfileDatastream(a.namespace()), "", ac.ID, responseID, profile, req["data"])
 			}
 		}
 	} else if shouldCollect && !beforeReady {
-		if ac.Profile {
+		if publishProfile {
 			a.log.Debug("profile requested but skipped: pre-query snapshot was not collected")
 		} else {
 			a.log.Debug("profile storage skipped: pre-query snapshot was not collected")

--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -81,6 +81,11 @@ type ConfigPlugin struct {
 	// Osquery configuration
 	osqueryConfig *config.OsqueryConfig
 
+	// globalProfileEnabled is the fleet-wide profiling default from
+	// elastic_options.profiling.profiling_all. Per-query overrides are resolved into
+	// QueryInfo.Profile at Set() time; this is used for live (ad-hoc) queries.
+	globalProfileEnabled bool
+
 	// onGenerateConfigApplied, if set, is invoked after osqueryd pulls generated config
 	// and pending query metadata is promoted (see GenerateConfig). Used so RRULE
 	// scheduling advances in lockstep with native osqueryd schedule application.
@@ -172,6 +177,14 @@ func (p *ConfigPlugin) LookupQueryProfile(name string) bool {
 	return false
 }
 
+// GlobalProfileEnabled returns the fleet-wide profiling default applied to queries
+// that do not set their own profile override (notably live ad-hoc queries).
+func (p *ConfigPlugin) GlobalProfileEnabled() bool {
+	p.mx.RLock()
+	defer p.mx.RUnlock()
+	return p.globalProfileEnabled
+}
+
 func (p *ConfigPlugin) GetNamespace() string {
 	p.mx.RLock()
 	defer p.mx.RUnlock()
@@ -246,6 +259,7 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) (err error) {
 	osqueryConfig := &config.OsqueryConfig{}
 	newQueryInfoMap := make(map[string]QueryInfo)
 	namespaces := make(map[string]string)
+	globalProfile := config.GetProfilingEnabled(inputs)
 
 	// Set the members if no errors
 	defer func() {
@@ -256,6 +270,7 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) (err error) {
 		p.newQueryInfoMap = newQueryInfoMap
 		p.namespaces = namespaces
 		p.queriesCount = queriesCount
+		p.globalProfileEnabled = globalProfile
 	}()
 
 	// Return if no inputs, all the members will be reset by deferred call above
@@ -291,7 +306,7 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) (err error) {
 			SpaceID:    qi.SpaceID,
 			Interval:   qi.Interval,
 			PackID:     packID,
-			Profile:    qi.Profile,
+			Profile:    config.ResolveProfiling(globalProfile, qi.Profiling),
 		}
 		namespaces[name] = ns
 		queriesCount++
@@ -358,7 +373,7 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) (err error) {
 				Platform:   stream.Platform,
 				Version:    stream.Version,
 				ECSMapping: stream.ECSMapping,
-				Profile:    stream.Profile,
+				Profiling:  stream.Profiling,
 			}
 
 			qi, err = registerQuery(getPackQueryName(input.Name, stream.ID), p.namespace, qi, input.Name)

--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -103,6 +103,9 @@ func NewConfigPlugin(log *logp.Logger) *ConfigPlugin {
 	p := &ConfigPlugin{
 		log:          log.With("ctx", "config"),
 		queryInfoMap: make(queryInfoMap),
+		// Profiling is enabled by default (see config.ProfilingAllOrDefault); keep the
+		// live/ad-hoc default consistent before the first successful Set() applies policy.
+		globalProfileEnabled: true,
 	}
 
 	return p

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -462,6 +462,13 @@ func TestSetScheduledQueryProfileFlag(t *testing.T) {
 	}
 }
 
+func TestNewConfigPluginProfilingEnabledByDefault(t *testing.T) {
+	cfgp := NewConfigPlugin(logp.NewLogger("config_test"))
+	if !cfgp.GlobalProfileEnabled() {
+		t.Fatal("expected global profiling to be enabled by default before the first Set()")
+	}
+}
+
 func TestSetQueryProfileGlobalDefaultAndOverride(t *testing.T) {
 	logger := logp.NewLogger("config_test")
 

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -428,6 +428,7 @@ func TestSetScheduledQueryProfileFlag(t *testing.T) {
 	logger := logp.NewLogger("config_test")
 	cfgp := NewConfigPlugin(logger)
 
+	profileOn := true
 	inputs := []config.InputConfig{
 		{
 			Name: "osquery-manager-1",
@@ -442,7 +443,7 @@ func TestSetScheduledQueryProfileFlag(t *testing.T) {
 						NativeSchedule: config.NativeSchedule{
 							Interval: 60,
 						},
-						Profile: true,
+						Profiling: &profileOn,
 					},
 				},
 			},
@@ -459,6 +460,95 @@ func TestSetScheduledQueryProfileFlag(t *testing.T) {
 	if !cfgp.LookupQueryProfile("scheduled_users") {
 		t.Fatal("expected scheduled query profile flag to be enabled")
 	}
+}
+
+func TestSetQueryProfileGlobalDefaultAndOverride(t *testing.T) {
+	logger := logp.NewLogger("config_test")
+
+	newInputs := func(globalProfileAll, defaultOverride, optedOut *bool) []config.InputConfig {
+		elastic := &config.ElasticOptions{Profiling: &config.ProfilingConfig{ProfilingAll: globalProfileAll}}
+		return []config.InputConfig{
+			{
+				Name: "osquery-manager-1",
+				Type: "osquery",
+				Osquery: &config.OsqueryConfig{
+					ElasticOptions: elastic,
+					Schedule: map[string]config.Query{
+						"inherits_global": {
+							Query:          "select 1",
+							NativeSchedule: config.NativeSchedule{Interval: 60},
+							Profiling:      defaultOverride,
+						},
+						"opts_out": {
+							Query:          "select 2",
+							NativeSchedule: config.NativeSchedule{Interval: 60},
+							Profiling:      optedOut,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	falseVal := false
+	trueVal := true
+
+	t.Run("global on, per-query inherits and override off", func(t *testing.T) {
+		cfgp := NewConfigPlugin(logger)
+		if err := cfgp.Set(newInputs(&trueVal, nil, &falseVal)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cfgp.GenerateConfig(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if !cfgp.GlobalProfileEnabled() {
+			t.Fatal("expected global profiling to be enabled")
+		}
+		if !cfgp.LookupQueryProfile("inherits_global") {
+			t.Fatal("expected query without override to inherit global profiling")
+		}
+		if cfgp.LookupQueryProfile("opts_out") {
+			t.Fatal("expected query with profile:false override to opt out of profiling")
+		}
+	})
+
+	t.Run("global off, per-query override on", func(t *testing.T) {
+		cfgp := NewConfigPlugin(logger)
+		if err := cfgp.Set(newInputs(&falseVal, &trueVal, nil)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cfgp.GenerateConfig(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if cfgp.GlobalProfileEnabled() {
+			t.Fatal("expected global profiling to be disabled")
+		}
+		if !cfgp.LookupQueryProfile("inherits_global") {
+			t.Fatal("expected query with profile:true override to enable profiling")
+		}
+		if cfgp.LookupQueryProfile("opts_out") {
+			t.Fatal("expected query without override to inherit disabled global profiling")
+		}
+	})
+
+	t.Run("global unset defaults on, per-query override off", func(t *testing.T) {
+		cfgp := NewConfigPlugin(logger)
+		if err := cfgp.Set(newInputs(nil, nil, &falseVal)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cfgp.GenerateConfig(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if !cfgp.GlobalProfileEnabled() {
+			t.Fatal("expected global profiling to default to enabled when unset")
+		}
+		if !cfgp.LookupQueryProfile("inherits_global") {
+			t.Fatal("expected query without override to inherit default-on global profiling")
+		}
+		if cfgp.LookupQueryProfile("opts_out") {
+			t.Fatal("expected query with profile:false override to opt out of profiling")
+		}
+	})
 }
 
 func TestSet_ScheduleMetadataIncludesSpaceID(t *testing.T) {

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -752,12 +752,13 @@ func (bt *osquerybeat) registerActionHandler(b *beat.Beat, cli *osqdcli.Client, 
 	}
 
 	ah := &actionHandler{
-		log:       bt.log,
-		inputType: osqueryInputType,
-		publisher: bt.pub,
-		queryExec: cli,
-		np:        configPlugin,
-		profiles:  bt.liveProfiles,
+		log:             bt.log,
+		inputType:       osqueryInputType,
+		publisher:       bt.pub,
+		queryExec:       cli,
+		np:              configPlugin,
+		profiles:        bt.liveProfiles,
+		profileDefaults: configPlugin,
 	}
 	rah.Attach(ah)
 	b.Manager.RegisterAction(rah)

--- a/x-pack/osquerybeat/internal/action/action.go
+++ b/x-pack/osquerybeat/internal/action/action.go
@@ -26,7 +26,9 @@ type Action struct {
 	// The optional action timeout
 	Timeout    time.Duration
 	ECSMapping ecs.Mapping
-	Profile    bool
+	// Profile is the optional per-action profiling override. When nil the global
+	// elastic_options.profiling.profiling_all default applies (see config.ResolveProfiling).
+	Profile *bool
 }
 
 func FromMap(m map[string]interface{}) (a Action, err error) {
@@ -47,7 +49,7 @@ func FromMap(m map[string]interface{}) (a Action, err error) {
 	var (
 		ecsm      ecs.Mapping
 		platforms []string
-		profile   bool
+		profile   *bool
 	)
 	if v, ok := m["data"]; ok {
 		var data map[string]interface{}
@@ -79,10 +81,11 @@ func FromMap(m map[string]interface{}) (a Action, err error) {
 			}
 		}
 		if profileRaw, ok := data["profile"]; ok {
-			profile, ok = profileRaw.(bool)
+			profileVal, ok := profileRaw.(bool)
 			if !ok {
 				return a, fmt.Errorf("invalid profile: %w", ErrActionRequest)
 			}
+			profile = &profileVal
 		}
 	}
 

--- a/x-pack/osquerybeat/internal/action/action_test.go
+++ b/x-pack/osquerybeat/internal/action/action_test.go
@@ -163,8 +163,8 @@ func TestActionFromMap(t *testing.T) {
 			}
 
 			if tc.Name == "valid profile flag" {
-				if !a.Profile {
-					t.Errorf("expected Profile to be true, got false")
+				if a.Profile == nil || !*a.Profile {
+					t.Errorf("expected Profile to be true, got %v", a.Profile)
 				}
 			}
 			if tc.Name == "valid platform" {

--- a/x-pack/osquerybeat/internal/config/config.go
+++ b/x-pack/osquerybeat/internal/config/config.go
@@ -44,11 +44,12 @@ type StreamConfig struct {
 	Platform   string                 `config:"platform"`    // restrict this query to a given platform, default is 'all' platforms; you may use commas to set multiple platforms
 	Version    string                 `config:"version"`     // only run on osquery versions greater than or equal-to this version string
 	ECSMapping map[string]interface{} `config:"ecs_mapping"` // ECS mapping definition where the key is the source field in osquery result and the value is the destination fields in ECS
-	// Profile enables per-query profiling for this stream. Published profiles for live-style
-	// paths reflect the osqueryd process while extension queries run (serialized on the beat
-	// client; native osqueryd schedules may still contribute load). Requires an input stream
-	// with dataset osquery_manager.query_profile to publish events.
-	Profile bool `config:"profile" json:"profile,omitempty"`
+	// Profiling is a per-query override for profiling on this stream. When nil the global
+	// elastic_options.profiling.profiling_all default applies (see ResolveProfiling). Published profiles
+	// for live-style paths reflect the osqueryd process while extension queries run (serialized
+	// on the beat client; native osqueryd schedules may still contribute load). Requires an
+	// input stream with dataset osquery_manager.query_profile to publish events.
+	Profiling *bool `config:"profiling" json:"profiling,omitempty"`
 }
 
 type DatastreamConfig struct {
@@ -316,13 +317,25 @@ func GetOsqueryInstallConfig(inputs []InputConfig) InstallConfig {
 	return *inputs[0].Osquery.ElasticOptions.Install
 }
 
-// GetQueryProfileStorageConfig returns live query profile storage settings from the first input if available.
+// GetProfilingEnabled returns the global query profiling default from the first input.
+// This is the fleet-wide on/off switch; individual queries may override it (see ResolveProfiling).
+// Profiling is enabled by default unless elastic_options.profiling.profiling_all is explicitly false.
+func GetProfilingEnabled(inputs []InputConfig) bool {
+	if len(inputs) == 0 || inputs[0].Osquery == nil || inputs[0].Osquery.ElasticOptions == nil || inputs[0].Osquery.ElasticOptions.Profiling == nil {
+		return ProfilingConfig{}.ProfilingAllOrDefault()
+	}
+	return inputs[0].Osquery.ElasticOptions.Profiling.ProfilingAllOrDefault()
+}
+
+// GetQueryProfileStorageConfig returns live query profile storage settings
+// (elastic_options.profiling.storage) from the first input if available.
 func GetQueryProfileStorageConfig(inputs []InputConfig) QueryProfileStorageConfig {
 	if len(inputs) == 0 {
 		return QueryProfileStorageConfig{}
 	}
-	if inputs[0].Osquery == nil || inputs[0].Osquery.ElasticOptions == nil || inputs[0].Osquery.ElasticOptions.QueryProfileStorage == nil {
+	o := inputs[0].Osquery
+	if o == nil || o.ElasticOptions == nil || o.ElasticOptions.Profiling == nil || o.ElasticOptions.Profiling.Storage == nil {
 		return QueryProfileStorageConfig{}
 	}
-	return *inputs[0].Osquery.ElasticOptions.QueryProfileStorage
+	return *o.ElasticOptions.Profiling.Storage
 }

--- a/x-pack/osquerybeat/internal/config/osquery.go
+++ b/x-pack/osquerybeat/internal/config/osquery.go
@@ -99,8 +99,37 @@ func (c *RRuleScheduleConfig) IsEnabled() bool {
 // ElasticOptions contains Beat-specific options that are not part of
 // osquery's native config schema.
 type ElasticOptions struct {
-	Install             *InstallConfig             `config:"install" json:"-"`
-	QueryProfileStorage *QueryProfileStorageConfig `config:"query_profile_storage" json:"-"`
+	Install *InstallConfig `config:"install" json:"-"`
+	// Profiling groups all query profiling settings (global publish default and local storage).
+	Profiling *ProfilingConfig `config:"profiling" json:"-"`
+}
+
+// ProfilingConfig groups all query profiling settings. When ProfilingAll is enabled (the default),
+// profiles are collected and published to the osquery_manager.query_profile data stream for all
+// queries that do not set their own profiling flag. It still requires the query_profile input stream
+// to be present for events to be published. Storage controls local retention of live profiles
+// for diagnostics, independent of publishing.
+type ProfilingConfig struct {
+	ProfilingAll *bool                      `config:"profiling_all" json:"-"`
+	Storage      *QueryProfileStorageConfig `config:"storage" json:"-"`
+}
+
+// ProfilingAllOrDefault returns the global profiling default, which is enabled unless
+// explicitly set to false.
+func (c ProfilingConfig) ProfilingAllOrDefault() bool {
+	if c.ProfilingAll == nil {
+		return true
+	}
+	return *c.ProfilingAll
+}
+
+// ResolveProfiling returns the effective profiling decision for a query: a per-query
+// override wins when set, otherwise the global default applies.
+func ResolveProfiling(globalDefault bool, override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	return globalDefault
 }
 
 // QueryProfileStorageConfig controls local storage of live query profiles.
@@ -163,11 +192,12 @@ type Query struct {
 	// This is the same as osquery behavior
 	Removed *bool `config:"removed,omitempty" json:"removed,omitempty"`
 
-	// Optional internal flag to emit per-query profiling for this scheduled query
+	// Optional per-query override to emit profiling for this scheduled query
 	// (native: osquery_schedule metrics; RRULE: process-level deltas like live queries).
+	// When nil the global elastic_options.profiling.profiling_all default applies (see ResolveProfiling).
 	// RRULE/live profiling uses the same serialized osquery client; native osqueryd schedules
 	// can still add process load outside that bracket. Not rendered into osqueryd configuration.
-	Profile bool `config:"profile" json:"-"`
+	Profiling *bool `config:"profiling" json:"-"`
 }
 
 type Pack struct {

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -7,11 +7,17 @@ osquerybeat:
 #    - type: osquery
 #      osquery:
 #        elastic_options:
-#          query_profile_storage:
-#            # Enable local storage of live query profiles.
-#            #enabled: true
-#            # Maximum number of profiles kept (latest per query).
-#            #max_profiles: 64
+#          profiling:
+#            # Global default for collecting and publishing query profiles to the
+#            # osquery_manager.query_profile data stream for all queries (enabled by default).
+#            # Individual queries may override this with their own profiling flag. Requires the
+#            # query_profile input stream.
+#            #profiling_all: true
+#            storage:
+#              # Enable local storage of live query profiles (for diagnostics).
+#              #enabled: true
+#              # Maximum number of profiles kept (latest per query).
+#              #max_profiles: 64
 #          install:
 #            # Optional per-platform and per-architecture custom osquery artifacts.
 #            # If the current platform/arch is unset, bundled osquery is used.


### PR DESCRIPTION
## Proposed commit message

Consolidate the osquerybeat query profiling settings under a single `elastic_options.profiling` block (`ProfilingConfig`):

- `profiling_all` is the fleet-wide default and `storage` keeps local retention of live profiles for diagnostics.
- Profiling is now **enabled by default**: `profiling_all` defaults to `true` when unset, and individual queries/actions may override it via their own `profiling` flag.
- Per-query and per-action overrides are tri-state (`*bool`) so an unset value inherits the global default while an explicit `false` opts out.

WHY: the previous naming (`profile` / `query_profile_storage`, boolean `enabled`) conflated the profiling activity with the produced profile artifacts and defaulted profiling off. Renaming to `profiling` and defaulting on makes the configuration clearer and profiling available out of the box, while still allowing per-query opt-out.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added an entry in `./changelog/fragments` using the changelog tool.

## Disruptive User Impact

The profiling configuration keys are renamed (`elastic_options.profiling`, `profiling_all`, per-query `profiling`) and profiling now defaults to on. This profiling feature has not yet shipped in a released version, so there is no migration required for existing deployments.

## How to test this PR locally

- `cd x-pack/osquerybeat && go test ./beater/ ./internal/config/ ./internal/action/`
- `mage update` and confirm `osquerybeat.reference.yml` shows the `profiling` block with `profiling_all: true`.

## Related issues

-