### PR TITLE
[x-pack/filebeat/input/azureblobstorage] -  Harden blob listing against transient failures and implement configurable retries

### DIFF
--- a/changelog/fragments/1783054266-azureblobstorage-configurable-retries.yaml
+++ b/changelog/fragments/1783054266-azureblobstorage-configurable-retries.yaml
@@ -1,0 +1,37 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add a configurable retry policy to the Azure Blob Storage input.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  The `azure-blob-storage` input now exposes a `retry` configuration block
+  (`max_retries`, `initial_retry_delay` and `max_retry_delay`) that tunes the
+  Azure SDK retry policy. Because the policy lives in the client request
+  pipeline, it now covers blob listing (pagination) in addition to downloads;
+  previously a transient error such as an HTTP 503 `ServerBusy` during listing
+  could exhaust the small, non-configurable default retries and stop the input.
+  The settings apply per storage account. Defaults are unchanged when the block
+  is omitted.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "filebeat"
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# pr: https://github.com/elastic/beats/pull/0000
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/44629

--- a/changelog/fragments/1783054266-azureblobstorage-configurable-retries.yaml
+++ b/changelog/fragments/1783054266-azureblobstorage-configurable-retries.yaml
@@ -23,7 +23,11 @@ description: >
   previously a transient error such as an HTTP 503 `ServerBusy` during listing
   could exhaust the small, non-configurable default retries and stop the input.
   The settings apply per storage account. Defaults are unchanged when the block
-  is omitted.
+  is omitted. Additionally, when polling is enabled, a transient blob-listing
+  failure that outlives the retries (503, 429 or a network timeout) is now
+  non-fatal: the input is marked degraded and retries on the next poll interval
+  instead of exiting, so longer outages are ridden out. Permanent failures such
+  as a missing container still stop the input.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: "filebeat"

--- a/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
+++ b/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
@@ -137,7 +137,7 @@ $$$supported-attributes$$$
 14. [timestamp_epoch](#attrib-timestamp_epoch)
 15. [path_prefix](#attrib-path_prefix) {applies_to}`stack: ga 9.1.4+`
 16. [custom_properties](#attrib-custom-properties) {applies_to}`stack: ga 9.1.0+`
-17. [retry](#attrib-retry) {applies_to}`stack: ga 8.19.9` {applies_to}`stack: ga 9.3.8` {applies_to}`stack: ga 9.4.4` {applies_to}`stack: ga 9.5.0`
+17. [retry](#attrib-retry) {applies_to}`stack: ga 9.3+`
 
 ## `account_name` [attrib-account-name]
 
@@ -373,19 +373,21 @@ The example configuration above will fetch blobs present in specified container 
 
 ## `retry` [attrib-retry]
 
-{applies_to}`stack: ga 8.19.9` {applies_to}`stack: ga 9.3.8` {applies_to}`stack: ga 9.4.4` {applies_to}`stack: ga 9.5.0`
+```{applies_to}
+stack: ga 9.3+
+```
 
-This attribute controls how transient Azure Storage failures are retried. Azure occasionally returns throttling responses such as `HTTP 429` or `HTTP 503` (`ServerBusy`), and brief network problems can also interrupt requests. The retry settings feed the Azure SDK's retry policy, which sits in the client request pipeline, so they apply to **every** request the input makes — both listing blobs (pagination) and downloading them.
+This attribute controls how transient Azure Storage failures are retried. Azure occasionally returns throttling responses such as `HTTP 429` or `HTTP 503` (`ServerBusy`), and brief network problems can also interrupt requests. The retry settings feed the Azure SDK's retry policy, which sits in the client request pipeline, so they apply to **every** request the input makes — both for listing blobs (pagination) and for downloading them.
 
 The `retry` attribute contains the following sub-attributes:
 
-1. `max_retries`: The number of times a failed request is retried after the first attempt. A negative value disables retries. Defaults to `3`.
-2. `initial_retry_delay`: The base delay used for the exponential backoff between attempts. Each subsequent retry waits longer, up to `max_retry_delay`. Defaults to `800ms`.
-3. `max_retry_delay`: The upper bound on the backoff, so that during a long outage the input keeps retrying at a steady interval instead of drifting towards ever larger waits. Defaults to `60s`.
+- `max_retries`: The number of times a failed request is retried after the first attempt. A negative value disables retries. Defaults to `3`.
+- `initial_retry_delay`: The base delay used for the exponential backoff between attempts. Each subsequent retry waits longer, up to `max_retry_delay`. Defaults to `800ms`.
+- `max_retry_delay`: The upper bound on the backoff, so that during a long outage the input keeps retrying at a steady interval instead of drifting towards ever larger waits. Defaults to `60s`.
 
-Every sub-attribute is optional. Omitting the `retry` attribute (or any of its sub-attributes) keeps the Azure SDK defaults, so existing configurations continue to behave as before. The settings are applied per storage account and therefore affect all configured containers.
+Every sub-attribute is optional. Omitting the `retry` attribute (or any of its sub-attributes) keeps the Azure SDK defaults, so existing configurations continue to behave as before. The settings are applied per storage account and, therefore, affect all configured containers.
 
-When polling is enabled, a transient blob-listing failure that outlives these retries (for example an HTTP 503 `ServerBusy`, an HTTP 429, or a network timeout) no longer stops the input. Instead the input is marked `degraded` and the listing is retried on the next [`poll_interval`](#attrib-poll_interval). This allows the input to ride out longer outages rather than exiting. Permanent failures, such as a missing container or an authentication error, still stop the input.
+When polling is enabled, a transient blob-listing failure that outlives these retries (for example, an HTTP 503 `ServerBusy`, an HTTP 429, or a network timeout) no longer stops the input. Instead, the input is marked `degraded` and the listing is retried on the next [`poll_interval`](#attrib-poll_interval). This allows the input to ride out longer outages rather than exiting. Permanent failures, such as a missing container or an authentication error, still stop the input.
 
 ### Example configuration
 
@@ -404,7 +406,7 @@ filebeat.inputs:
   - name: container_1
 ```
 
-The example above lets the input ride out longer bursts of Azure throttling: it retries a failed request up to `20` times, starting with a `1s` delay and backing off exponentially up to a `30s` ceiling between attempts.
+This example lets the input ride out longer bursts of Azure throttling: it retries a failed request up to `20` times, starting with a `1s` delay and backing off exponentially up to a `30s` ceiling between attempts.
 
 ## Custom properties [attrib-custom-properties]
 ```{applies_to}

--- a/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
+++ b/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
@@ -137,6 +137,7 @@ $$$supported-attributes$$$
 14. [timestamp_epoch](#attrib-timestamp_epoch)
 15. [path_prefix](#attrib-path_prefix) {applies_to}`stack: ga 9.1.4+`
 16. [custom_properties](#attrib-custom-properties) {applies_to}`stack: ga 9.1.0+`
+17. [retry](#attrib-retry)
 
 ## `account_name` [attrib-account-name]
 
@@ -369,6 +370,37 @@ filebeat.inputs:
 ```
 
 The example configuration above will fetch blobs present in specified container from the virtual `cloudTrail` directory. This operation occurs via the SDK in the blob-storage server so the impact on memory is negligible.
+
+## `retry` [attrib-retry]
+
+This attribute controls how transient Azure Storage failures are retried. Azure occasionally returns throttling responses such as `HTTP 429` or `HTTP 503` (`ServerBusy`), and brief network problems can also interrupt requests. The retry settings feed the Azure SDK's retry policy, which sits in the client request pipeline, so they apply to **every** request the input makes — both listing blobs (pagination) and downloading them.
+
+The `retry` attribute contains the following sub-attributes:
+
+1. `max_retries`: The number of times a failed request is retried after the first attempt. A negative value disables retries. Defaults to `3`.
+2. `initial_retry_delay`: The base delay used for the exponential backoff between attempts. Each subsequent retry waits longer, up to `max_retry_delay`. Defaults to `800ms`.
+3. `max_retry_delay`: The upper bound on the backoff, so that during a long outage the input keeps retrying at a steady interval instead of drifting towards ever larger waits. Defaults to `60s`.
+
+Every sub-attribute is optional. Omitting the `retry` attribute (or any of its sub-attributes) keeps the Azure SDK defaults, so existing configurations continue to behave as before. The settings are applied per storage account and therefore affect all configured containers.
+
+### Example configuration
+
+```yaml
+filebeat.inputs:
+- type: azure-blob-storage
+  id: my-azureblobstorage-id
+  enabled: true
+  account_name: some_account
+  auth.shared_credentials.account_key: some_key
+  retry:
+    max_retries: 20
+    initial_retry_delay: 1s
+    max_retry_delay: 30s
+  containers:
+  - name: container_1
+```
+
+The example above lets the input ride out longer bursts of Azure throttling: it retries a failed request up to `20` times, starting with a `1s` delay and backing off exponentially up to a `30s` ceiling between attempts.
 
 ## Custom properties [attrib-custom-properties]
 ```{applies_to}

--- a/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
+++ b/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
@@ -137,7 +137,7 @@ $$$supported-attributes$$$
 14. [timestamp_epoch](#attrib-timestamp_epoch)
 15. [path_prefix](#attrib-path_prefix) {applies_to}`stack: ga 9.1.4+`
 16. [custom_properties](#attrib-custom-properties) {applies_to}`stack: ga 9.1.0+`
-17. [retry](#attrib-retry)
+17. [retry](#attrib-retry) {applies_to}`stack: ga 8.19.9` {applies_to}`stack: ga 9.3.8` {applies_to}`stack: ga 9.4.4` {applies_to}`stack: ga 9.5.0`
 
 ## `account_name` [attrib-account-name]
 
@@ -372,6 +372,8 @@ filebeat.inputs:
 The example configuration above will fetch blobs present in specified container from the virtual `cloudTrail` directory. This operation occurs via the SDK in the blob-storage server so the impact on memory is negligible.
 
 ## `retry` [attrib-retry]
+
+{applies_to}`stack: ga 8.19.9` {applies_to}`stack: ga 9.3.8` {applies_to}`stack: ga 9.4.4` {applies_to}`stack: ga 9.5.0`
 
 This attribute controls how transient Azure Storage failures are retried. Azure occasionally returns throttling responses such as `HTTP 429` or `HTTP 503` (`ServerBusy`), and brief network problems can also interrupt requests. The retry settings feed the Azure SDK's retry policy, which sits in the client request pipeline, so they apply to **every** request the input makes — both listing blobs (pagination) and downloading them.
 

--- a/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
+++ b/docs/reference/filebeat/filebeat-input-azure-blob-storage.md
@@ -383,6 +383,8 @@ The `retry` attribute contains the following sub-attributes:
 
 Every sub-attribute is optional. Omitting the `retry` attribute (or any of its sub-attributes) keeps the Azure SDK defaults, so existing configurations continue to behave as before. The settings are applied per storage account and therefore affect all configured containers.
 
+When polling is enabled, a transient blob-listing failure that outlives these retries (for example an HTTP 503 `ServerBusy`, an HTTP 429, or a network timeout) no longer stops the input. Instead the input is marked `degraded` and the listing is retried on the next [`poll_interval`](#attrib-poll_interval). This allows the input to ride out longer outages rather than exiting. Permanent failures, such as a missing container or an authentication error, still stop the input.
+
 ### Example configuration
 
 ```yaml

--- a/x-pack/filebeat/input/azureblobstorage/auth_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/auth_test.go
@@ -6,6 +6,7 @@ package azureblobstorage
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 	beattest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/azureblobstorage/mock"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -238,6 +240,105 @@ wait:
 	assert.NoError(t, g.Wait(), "input run should complete without error")
 	assert.GreaterOrEqual(t, transport.attempts(), 3,
 		"the list-blobs request should have been retried past the transient 503s")
+}
+
+// recordingStatusReporter captures the statuses reported by the input so tests
+// can assert on the transitions.
+type recordingStatusReporter struct {
+	mu       sync.Mutex
+	statuses []status.Status
+}
+
+func (r *recordingStatusReporter) UpdateStatus(s status.Status, _ string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.statuses = append(r.statuses, s)
+}
+
+func (r *recordingStatusReporter) has(target status.Status) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, s := range r.statuses {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+// Test_ListBlobsNonFatalWhilePolling verifies that a sustained listing failure
+// (throttling that outlives the SDK's per-request retries) is non-fatal when
+// polling: the input is marked Degraded and keeps running so it can recover on
+// a later poll. Without polling there is no next cycle, so the failure surfaces
+// and the input stops.
+func Test_ListBlobsNonFatalWhilePolling(t *testing.T) {
+	logp.TestingSetup()
+
+	// A server that always answers with 503 ServerBusy, simulating a sustained
+	// Azure Storage outage.
+	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `<?xml version="1.0" encoding="utf-8"?><Error><Code>ServerBusy</Code><Message>The server is busy.</Message></Error>`)
+	}))
+	t.Cleanup(serv.Close)
+
+	baseConfig := map[string]interface{}{
+		"account_name":                        "beatsblobnew",
+		"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+		"max_workers":                         1,
+		"containers": []map[string]interface{}{
+			{"name": beatsContainer},
+		},
+		// Keep the retry backoff tiny so the failing list call returns quickly.
+		"retry": map[string]interface{}{
+			"max_retries":         1,
+			"initial_retry_delay": "1ms",
+			"max_retry_delay":     "5ms",
+		},
+	}
+
+	newSched := func(t *testing.T, poll bool, statusRec status.StatusReporter) *scheduler {
+		t.Helper()
+		cfg := conf.MustNewConfigFrom(baseConfig)
+		c := defaultConfig()
+		require.NoError(t, cfg.Unpack(&c), "config should unpack")
+
+		log := logp.NewNopLogger()
+		serviceClient, credential, err := fetchServiceClientAndCreds(c, c.Retry, serv.URL+"/", log)
+		require.NoError(t, err, "service client should be created")
+		containerClient, err := fetchContainerClient(serviceClient, beatsContainer, log)
+		require.NoError(t, err, "container client should be created")
+
+		src := &Source{
+			AccountName:   c.AccountName,
+			ContainerName: beatsContainer,
+			MaxWorkers:    1,
+			Poll:          poll,
+			PollInterval:  time.Millisecond,
+			Retry:         c.Retry,
+		}
+		return newScheduler(&publisher{}, containerClient, credential, src, &c, newState(), serv.URL+"/", statusRec, nil, log)
+	}
+
+	t.Run("polling keeps the input alive and Degraded", func(t *testing.T) {
+		rec := &recordingStatusReporter{}
+		sched := newSched(t, true, rec)
+
+		err := sched.scheduleOnce(context.Background())
+		assert.NoError(t, err, "a listing failure while polling must be non-fatal so the input keeps running")
+		assert.True(t, rec.has(status.Degraded), "the input should be marked Degraded after a listing failure")
+		assert.False(t, rec.has(status.Failed), "a polling listing failure must not mark the input Failed")
+	})
+
+	t.Run("without polling the failure is fatal", func(t *testing.T) {
+		rec := &recordingStatusReporter{}
+		sched := newSched(t, false, rec)
+
+		err := sched.scheduleOnce(context.Background())
+		assert.Error(t, err, "without polling there is no recovery, so the listing failure must surface")
+		assert.True(t, rec.has(status.Failed), "a one-shot listing failure should mark the input Failed")
+	})
 }
 
 func Test_OAuth2(t *testing.T) {

--- a/x-pack/filebeat/input/azureblobstorage/auth_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/auth_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/azureblobstorage/mock"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 // customTransporter implements the Transporter interface with a custom Do & RoundTrip method
@@ -150,7 +152,7 @@ func serverBusyResponse(req *http.Request) *http.Response {
 // blob listing no longer kills the input: with retries configured, the pager
 // recovers and every expected blob is still ingested.
 func Test_ListBlobsRetriesOnTransientError(t *testing.T) {
-	logp.TestingSetup()
+	logger := logptest.NewTestingLogger(t, "")
 
 	serv := httptest.NewServer(mock.AzureStorageServer())
 	t.Cleanup(serv.Close)
@@ -197,7 +199,7 @@ func Test_ListBlobsRetriesOnTransientError(t *testing.T) {
 		Transport:                       transport,
 	}
 
-	input := newStatelessInput(c, serv.URL+"/", logp.NewNopLogger())
+	input := newStatelessInput(c, serv.URL+"/", logger)
 	assert.NoError(t, input.Test(v2.TestContext{}), "input.Test should succeed")
 
 	chanClient := beattest.NewChanClient(len(expected))
@@ -266,14 +268,22 @@ func (r *recordingStatusReporter) has(target status.Status) bool {
 	return false
 }
 
+// last returns the most recently reported status, if any.
+func (r *recordingStatusReporter) last() (status.Status, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.statuses) == 0 {
+		return 0, false
+	}
+	return r.statuses[len(r.statuses)-1], true
+}
+
 // Test_ListBlobsNonFatalWhilePolling verifies that a sustained listing failure
 // (throttling that outlives the SDK's per-request retries) is non-fatal when
 // polling: the input is marked Degraded and keeps running so it can recover on
 // a later poll. Without polling there is no next cycle, so the failure surfaces
 // and the input stops.
 func Test_ListBlobsNonFatalWhilePolling(t *testing.T) {
-	logp.TestingSetup()
-
 	// A server that always answers with 503 ServerBusy, simulating a sustained
 	// Azure Storage outage.
 	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -304,7 +314,7 @@ func Test_ListBlobsNonFatalWhilePolling(t *testing.T) {
 		c := defaultConfig()
 		require.NoError(t, cfg.Unpack(&c), "config should unpack")
 
-		log := logp.NewNopLogger()
+		log := logptest.NewTestingLogger(t, "")
 		serviceClient, credential, err := fetchServiceClientAndCreds(c, c.Retry, serv.URL+"/", log)
 		require.NoError(t, err, "service client should be created")
 		containerClient, err := fetchContainerClient(serviceClient, beatsContainer, log)
@@ -341,6 +351,84 @@ func Test_ListBlobsNonFatalWhilePolling(t *testing.T) {
 	})
 }
 
+// Test_ListBlobsRecoversToRunningOnEmptyPoll covers the Degraded -> Running
+// recovery path for the edge case where a poll recovers but schedules no jobs
+// (no new blobs, or everything filtered out or already past the checkpoint).
+// A transient listing failure first marks the input Degraded; once listing
+// succeeds the input must report Running again even though the successful poll
+// publishes no events (so nothing else would clear the Degraded state).
+func Test_ListBlobsRecoversToRunningOnEmptyPoll(t *testing.T) {
+	// healthy flips from false (503 ServerBusy) to true (a valid but empty
+	// listing) between the two polls, simulating an outage that clears.
+	var healthy atomic.Bool
+	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		if !healthy.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, `<?xml version="1.0" encoding="utf-8"?><Error><Code>ServerBusy</Code><Message>The server is busy.</Message></Error>`)
+			return
+		}
+		// A valid but empty blob listing: the poll succeeds yet schedules no jobs.
+		_, _ = io.WriteString(w, `<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="https://127.0.0.1/" ContainerName="`+beatsContainer+`">
+	<Blobs></Blobs>
+	<NextMarker />
+</EnumerationResults>`)
+	}))
+	t.Cleanup(serv.Close)
+
+	baseConfig := map[string]interface{}{
+		"account_name":                        "beatsblobnew",
+		"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+		"max_workers":                         1,
+		"poll":                                true,
+		"containers": []map[string]interface{}{
+			{"name": beatsContainer},
+		},
+		// Keep the retry backoff tiny so the failing list call returns quickly.
+		"retry": map[string]interface{}{
+			"max_retries":         1,
+			"initial_retry_delay": "1ms",
+			"max_retry_delay":     "5ms",
+		},
+	}
+
+	cfg := conf.MustNewConfigFrom(baseConfig)
+	c := defaultConfig()
+	require.NoError(t, cfg.Unpack(&c), "config should unpack")
+
+	log := logptest.NewTestingLogger(t, "")
+	serviceClient, credential, err := fetchServiceClientAndCreds(c, c.Retry, serv.URL+"/", log)
+	require.NoError(t, err, "service client should be created")
+	containerClient, err := fetchContainerClient(serviceClient, beatsContainer, log)
+	require.NoError(t, err, "container client should be created")
+
+	src := &Source{
+		AccountName:   c.AccountName,
+		ContainerName: beatsContainer,
+		MaxWorkers:    1,
+		Poll:          true,
+		PollInterval:  time.Millisecond,
+		Retry:         c.Retry,
+	}
+	rec := &recordingStatusReporter{}
+	sched := newScheduler(&publisher{}, containerClient, credential, src, &c, newState(), serv.URL+"/", rec, nil, log)
+
+	// First poll: the outage is ongoing, so the transient listing failure is
+	// non-fatal and marks the input Degraded.
+	require.NoError(t, sched.scheduleOnce(context.Background()), "a transient listing failure while polling must be non-fatal")
+	require.True(t, rec.has(status.Degraded), "the input should be Degraded after a transient listing failure")
+
+	// Second poll: listing succeeds but returns no blobs. The input must still
+	// report Running so a recovery that schedules no jobs is not left Degraded.
+	healthy.Store(true)
+	require.NoError(t, sched.scheduleOnce(context.Background()), "a successful empty poll must not error")
+
+	got, ok := rec.last()
+	require.True(t, ok, "at least one status should have been reported")
+	assert.Equal(t, status.Running, got, "an empty but successful poll should return the input to Running")
+}
+
 func Test_OAuth2(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -375,7 +463,6 @@ func Test_OAuth2(t *testing.T) {
 		},
 	}
 
-	logp.TestingSetup()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			serv := httptest.NewServer(tt.mockHandler())

--- a/x-pack/filebeat/input/azureblobstorage/auth_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/auth_test.go
@@ -12,11 +12,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"regexp"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
@@ -89,6 +92,152 @@ func createJSONResponse(data interface{}, statusCode int) (*http.Response, error
 
 	resp.Header.Set("Content-Type", "application/json")
 	return resp, nil
+}
+
+// flakyTransporter wraps customTransporter and answers the first failListBlobs
+// "list blobs" requests with a synthetic Azure "503 ServerBusy" before letting
+// requests through. It reproduces the transient throttling from sdh-beats#7324
+// so we can assert that blob listing (pagination) is now retried.
+type flakyTransporter struct {
+	inner         *customTransporter
+	failListBlobs int
+
+	mu           sync.Mutex
+	listAttempts int
+}
+
+func (t *flakyTransporter) Do(req *http.Request) (*http.Response, error) {
+	// The list-blobs call is the pagination request (GET on the container with
+	// comp=list); blob downloads use a different path and are left untouched.
+	if req.URL.Query().Get("comp") == "list" {
+		t.mu.Lock()
+		shouldFail := t.listAttempts < t.failListBlobs
+		if shouldFail {
+			t.listAttempts++
+		}
+		t.mu.Unlock()
+		if shouldFail {
+			return serverBusyResponse(req), nil
+		}
+	}
+	return t.inner.Do(req)
+}
+
+// attempts reports how many list-blobs requests have been observed so far,
+// under the same lock used to record them.
+func (t *flakyTransporter) attempts() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.listAttempts
+}
+
+func serverBusyResponse(req *http.Request) *http.Response {
+	const body = `<?xml version="1.0" encoding="utf-8"?><Error><Code>ServerBusy</Code><Message>The server is busy.</Message></Error>`
+	h := make(http.Header)
+	h.Set("Content-Type", "application/xml")
+	return &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     "503 The server is busy.",
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     h,
+		Request:    req,
+	}
+}
+
+// Test_ListBlobsRetriesOnTransientError verifies that a transient 503 during
+// blob listing no longer kills the input: with retries configured, the pager
+// recovers and every expected blob is still ingested.
+func Test_ListBlobsRetriesOnTransientError(t *testing.T) {
+	logp.TestingSetup()
+
+	serv := httptest.NewServer(mock.AzureStorageServer())
+	t.Cleanup(serv.Close)
+
+	// Fail the first three list attempts, then succeed. With max_retries: 10 the
+	// pager has enough attempts left to get through the throttling.
+	transport := &flakyTransporter{
+		inner:         &customTransporter{rt: http.DefaultTransport, servURL: serv.URL},
+		failListBlobs: 3,
+	}
+
+	baseConfig := map[string]interface{}{
+		"account_name": "beatsblobnew",
+		"auth.oauth2": map[string]interface{}{
+			"client_id":     "12345678-90ab-cdef-1234-567890abcdef",
+			"client_secret": "abcdefg1234567890!@#$%^&*()-_=+",
+			"tenant_id":     "87654321-abcd-ef90-1234-fedcba098765",
+		},
+		"max_workers": 2,
+		"poll":        false,
+		"containers": []map[string]interface{}{
+			{"name": beatsContainer},
+		},
+		// Keep the backoff tiny so the test stays fast.
+		"retry": map[string]interface{}{
+			"max_retries":         10,
+			"initial_retry_delay": "1ms",
+			"max_retry_delay":     "5ms",
+		},
+	}
+	expected := map[string]bool{
+		mock.Beatscontainer_blob_ata_json:      true,
+		mock.Beatscontainer_blob_data3_json:    true,
+		mock.Beatscontainer_blob_docs_ata_json: true,
+	}
+
+	cfg := conf.MustNewConfigFrom(baseConfig)
+	c := config{}
+	require.NoError(t, cfg.Unpack(&c))
+
+	// inject the flaky transport; the retry policy is wired from c.Retry.
+	c.Auth.OAuth2.clientOptions = azcore.ClientOptions{
+		InsecureAllowCredentialWithHTTP: true,
+		Transport:                       transport,
+	}
+
+	input := newStatelessInput(c, serv.URL+"/", logp.NewNopLogger())
+	assert.NoError(t, input.Test(v2.TestContext{}), "input.Test should succeed")
+
+	chanClient := beattest.NewChanClient(len(expected))
+	t.Cleanup(func() { _ = chanClient.Close() })
+
+	ctx, cancel := newV2Context(t)
+	t.Cleanup(cancel)
+	ctx.ID += "-retry"
+
+	var g errgroup.Group
+	g.Go(func() error {
+		return input.Run(ctx, chanClient)
+	})
+
+	timeout := time.NewTimer(10 * time.Second)
+	t.Cleanup(func() { timeout.Stop() })
+
+	var receivedCount int
+wait:
+	for {
+		select {
+		case <-timeout.C:
+			t.Errorf("timed out waiting for %d events after transient list failures", len(expected))
+			cancel()
+			break wait
+		case got := <-chanClient.Channel:
+			val, err := got.Fields.GetValue("message")
+			assert.NoError(t, err, "published event should carry a message field")
+			assert.True(t, expected[val.(string)], "received unexpected message: %v", val)
+			receivedCount++
+			if receivedCount == len(expected) {
+				cancel()
+				break wait
+			}
+		}
+	}
+
+	// Wait for the input to finish so the transport goroutines are done before
+	// we inspect the attempt counter.
+	assert.NoError(t, g.Wait(), "input run should complete without error")
+	assert.GreaterOrEqual(t, transport.attempts(), 3,
+		"the list-blobs request should have been retried past the transient 503s")
 }
 
 func Test_OAuth2(t *testing.T) {

--- a/x-pack/filebeat/input/azureblobstorage/client.go
+++ b/x-pack/filebeat/input/azureblobstorage/client.go
@@ -40,7 +40,7 @@ func fetchServiceClientAndCreds(cfg config, retryCfg retryConfig, url string, lo
 // defaultConfig, so a zero value here only occurs when explicitly configured.
 func azureRetryOptions(rc retryConfig) policy.RetryOptions {
 	return policy.RetryOptions{
-		MaxRetries:    int32(rc.MaxRetries),
+		MaxRetries:    rc.MaxRetries,
 		RetryDelay:    rc.InitialRetryDelay,
 		MaxRetryDelay: rc.MaxRetryDelay,
 	}

--- a/x-pack/filebeat/input/azureblobstorage/client.go
+++ b/x-pack/filebeat/input/azureblobstorage/client.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -17,20 +19,34 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func fetchServiceClientAndCreds(cfg config, url string, log *logp.Logger) (*service.Client, *serviceCredentials, error) {
+func fetchServiceClientAndCreds(cfg config, retryCfg retryConfig, url string, log *logp.Logger) (*service.Client, *serviceCredentials, error) {
+	retry := azureRetryOptions(retryCfg)
 	switch {
 	case cfg.Auth.SharedCredentials != nil:
-		return fetchServiceClientWithSharedKeyCreds(url, cfg.AccountName, cfg.Auth.SharedCredentials, log)
+		return fetchServiceClientWithSharedKeyCreds(url, cfg.AccountName, cfg.Auth.SharedCredentials, retry, log)
 	case cfg.Auth.ConnectionString != nil:
-		return fetchServiceClientWithConnectionString(cfg.Auth.ConnectionString, log)
+		return fetchServiceClientWithConnectionString(cfg.Auth.ConnectionString, retry, log)
 	case cfg.Auth.OAuth2 != nil:
-		return fetchServiceClientWithOAuth2(url, cfg.Auth.OAuth2)
+		return fetchServiceClientWithOAuth2(url, cfg.Auth.OAuth2, retry)
 	}
 
 	return nil, nil, fmt.Errorf("no valid auth specified")
 }
 
-func fetchServiceClientWithSharedKeyCreds(url string, accountName string, cfg *sharedKeyConfig, log *logp.Logger) (*service.Client, *serviceCredentials, error) {
+// azureRetryOptions translates the input's retry configuration into the Azure
+// SDK's pipeline retry policy. The policy lives in the client pipeline, so these
+// settings apply to every request the client makes — listing blobs (pagination)
+// as well as downloading them. The values are seeded with the SDK defaults in
+// defaultConfig, so a zero value here only occurs when explicitly configured.
+func azureRetryOptions(rc retryConfig) policy.RetryOptions {
+	return policy.RetryOptions{
+		MaxRetries:    int32(rc.MaxRetries),
+		RetryDelay:    rc.InitialRetryDelay,
+		MaxRetryDelay: rc.MaxRetryDelay,
+	}
+}
+
+func fetchServiceClientWithSharedKeyCreds(url string, accountName string, cfg *sharedKeyConfig, retry policy.RetryOptions, log *logp.Logger) (*service.Client, *serviceCredentials, error) {
 	// Creates a default request pipeline using your storage account name and account key.
 	credential, err := azblob.NewSharedKeyCredential(accountName, cfg.AccountKey)
 	if err != nil {
@@ -38,7 +54,9 @@ func fetchServiceClientWithSharedKeyCreds(url string, accountName string, cfg *s
 		return nil, nil, err
 	}
 
-	client, err := service.NewClientWithSharedKeyCredential(url, credential, nil)
+	client, err := service.NewClientWithSharedKeyCredential(url, credential, &service.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Retry: retry},
+	})
 	if err != nil {
 		log.Errorf("Invalid credentials with error: %v", err)
 		return nil, nil, err
@@ -46,9 +64,11 @@ func fetchServiceClientWithSharedKeyCreds(url string, accountName string, cfg *s
 	return client, &serviceCredentials{sharedKeyCreds: credential, cType: sharedKeyType}, nil
 }
 
-func fetchServiceClientWithConnectionString(connectionString *connectionStringConfig, log *logp.Logger) (*service.Client, *serviceCredentials, error) {
+func fetchServiceClientWithConnectionString(connectionString *connectionStringConfig, retry policy.RetryOptions, log *logp.Logger) (*service.Client, *serviceCredentials, error) {
 	// Creates a default request pipeline using your connection string.
-	serviceClient, err := service.NewClientFromConnectionString(connectionString.URI, nil)
+	serviceClient, err := service.NewClientFromConnectionString(connectionString.URI, &service.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Retry: retry},
+	})
 	if err != nil {
 		log.Errorf("Invalid credentials with error: %v", err)
 		return nil, nil, err
@@ -57,16 +77,21 @@ func fetchServiceClientWithConnectionString(connectionString *connectionStringCo
 	return serviceClient, &serviceCredentials{connectionStrCreds: connectionString.URI, cType: connectionStringType}, nil
 }
 
-func fetchServiceClientWithOAuth2(url string, cfg *OAuth2Config) (*service.Client, *serviceCredentials, error) {
+func fetchServiceClientWithOAuth2(url string, cfg *OAuth2Config, retry policy.RetryOptions) (*service.Client, *serviceCredentials, error) {
+	// Start from the (test-injected) client options and layer the retry policy on
+	// top, so retries apply without discarding a custom transport used in tests.
+	clientOpts := cfg.clientOptions
+	clientOpts.Retry = retry
+
 	creds, err := azidentity.NewClientSecretCredential(cfg.TenantID, cfg.ClientID, cfg.ClientSecret, &azidentity.ClientSecretCredentialOptions{
-		ClientOptions: cfg.clientOptions,
+		ClientOptions: clientOpts,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create client secret credential with oauth2 config: %w", err)
 	}
 
 	client, err := azblob.NewClient(url, creds, &azblob.ClientOptions{
-		ClientOptions: cfg.clientOptions,
+		ClientOptions: clientOpts,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create azblob service client: %w", err)
@@ -76,25 +101,28 @@ func fetchServiceClientWithOAuth2(url string, cfg *OAuth2Config) (*service.Clien
 }
 
 // fetchBlobClient, generic function that returns a BlobClient based on the credential type
-func fetchBlobClient(url string, credential *blobCredentials, cfg config, log *logp.Logger) (*blob.Client, error) {
+func fetchBlobClient(url string, credential *blobCredentials, cfg config, retryCfg retryConfig, log *logp.Logger) (*blob.Client, error) {
 	if credential == nil {
 		return nil, fmt.Errorf("no valid blob credentials found")
 	}
 
+	retry := azureRetryOptions(retryCfg)
 	switch credential.serviceCreds.cType {
 	case sharedKeyType:
-		return fetchBlobClientWithSharedKey(url, credential.serviceCreds.sharedKeyCreds, log)
+		return fetchBlobClientWithSharedKey(url, credential.serviceCreds.sharedKeyCreds, retry, log)
 	case connectionStringType:
-		return fetchBlobClientWithConnectionString(credential.serviceCreds.connectionStrCreds, credential.containerName, credential.blobName, log)
+		return fetchBlobClientWithConnectionString(credential.serviceCreds.connectionStrCreds, credential.containerName, credential.blobName, retry, log)
 	case oauth2Type:
-		return fetchBlobClientWithOAuth2(url, credential.serviceCreds.oauth2Creds, cfg.Auth.OAuth2)
+		return fetchBlobClientWithOAuth2(url, credential.serviceCreds.oauth2Creds, cfg.Auth.OAuth2, retry)
 	default:
 		return nil, fmt.Errorf("no valid service credential 'type' found: %s", credential.serviceCreds.cType)
 	}
 }
 
-func fetchBlobClientWithSharedKey(url string, credential *azblob.SharedKeyCredential, log *logp.Logger) (*blob.Client, error) {
-	blobClient, err := blob.NewClientWithSharedKeyCredential(url, credential, nil)
+func fetchBlobClientWithSharedKey(url string, credential *azblob.SharedKeyCredential, retry policy.RetryOptions, log *logp.Logger) (*blob.Client, error) {
+	blobClient, err := blob.NewClientWithSharedKeyCredential(url, credential, &blob.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Retry: retry},
+	})
 	if err != nil {
 		log.Errorf("Error fetching blob client for url: %s, error: %v", url, err)
 		return nil, err
@@ -103,8 +131,10 @@ func fetchBlobClientWithSharedKey(url string, credential *azblob.SharedKeyCreden
 	return blobClient, nil
 }
 
-func fetchBlobClientWithConnectionString(connectionString string, containerName string, blobName string, log *logp.Logger) (*blob.Client, error) {
-	blobClient, err := blob.NewClientFromConnectionString(connectionString, containerName, blobName, nil)
+func fetchBlobClientWithConnectionString(connectionString string, containerName string, blobName string, retry policy.RetryOptions, log *logp.Logger) (*blob.Client, error) {
+	blobClient, err := blob.NewClientFromConnectionString(connectionString, containerName, blobName, &blob.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Retry: retry},
+	})
 	if err != nil {
 		log.Errorf("Error fetching blob client for connectionString: %s, error: %v", stripKey(connectionString), err)
 		return nil, err
@@ -129,9 +159,13 @@ func stripKey(s string) string {
 	return uri
 }
 
-func fetchBlobClientWithOAuth2(url string, credential *azidentity.ClientSecretCredential, oauth2Cfg *OAuth2Config) (*blob.Client, error) {
+func fetchBlobClientWithOAuth2(url string, credential *azidentity.ClientSecretCredential, oauth2Cfg *OAuth2Config, retry policy.RetryOptions) (*blob.Client, error) {
+	// Preserve any test-injected transport while applying the configured retries.
+	clientOpts := oauth2Cfg.clientOptions
+	clientOpts.Retry = retry
+
 	blobClient, err := blob.NewClient(url, credential, &blob.ClientOptions{
-		ClientOptions: oauth2Cfg.clientOptions,
+		ClientOptions: clientOpts,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch blob client for %s: %w", url, err)

--- a/x-pack/filebeat/input/azureblobstorage/config.go
+++ b/x-pack/filebeat/input/azureblobstorage/config.go
@@ -6,6 +6,7 @@ package azureblobstorage
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,6 +15,17 @@ import (
 	"github.com/elastic/beats/v7/libbeat/reader/parser"
 	"github.com/elastic/beats/v7/x-pack/libbeat/reader/decoder"
 	conf "github.com/elastic/elastic-agent-libs/config"
+)
+
+// Default retry settings. These mirror the Azure SDK's own pipeline retry
+// policy defaults, so leaving the retry block (or any field within it) unset
+// behaves exactly as it did before these options existed. They are seeded in
+// defaultConfig rather than relying on the SDK's implicit zero-value fallback,
+// which keeps the effective policy visible and testable.
+const (
+	defaultMaxRetries        = 3
+	defaultInitialRetryDelay = 800 * time.Millisecond
+	defaultMaxRetryDelay     = 60 * time.Second
 )
 
 // defaultReaderConfig is a default readerConfig state that is used to evaluate
@@ -65,6 +77,10 @@ type config struct {
 	ExpandEventListFromField string `config:"expand_event_list_from_field"`
 	// PathPrefix is the prefix for blob paths, useful for filtering blobs in a specific directory structure.
 	PathPrefix string `config:"path_prefix"`
+	// Retry tunes how transient Azure Storage failures are retried. It applies
+	// to the whole account (all containers), since the SDK client is created per
+	// container from these shared values.
+	Retry retryConfig `config:"retry"`
 }
 
 // container contains the config for each specific blob storage container in the root account.
@@ -121,6 +137,30 @@ type readerConfig struct {
 	OverrideEncoding bool `config:"override_encoding"`
 }
 
+// retryConfig tunes how the input copes with transient Azure Storage failures,
+// such as HTTP 429/503 throttling ("ServerBusy") or brief network drops. These
+// values feed the Azure SDK's pipeline retry policy, which every request passes
+// through, so they cover both blob listing (pagination) and blob downloads.
+//
+// The defaults (seeded in defaultConfig) mirror the Azure SDK's own retry
+// policy, so omitting the retry block behaves exactly as before these options
+// existed.
+type retryConfig struct {
+	// MaxRetries is how many times a failed request is retried after the first
+	// attempt. Defaults to 3. A negative value disables retrying of failed
+	// requests. (Note that the SDK's blob-download stream reader always retries
+	// a mid-stream read failure at least a few times regardless of this value.)
+	MaxRetries int `config:"max_retries"`
+	// InitialRetryDelay is the starting delay for the exponential backoff
+	// between attempts. Each subsequent retry waits longer, capped by
+	// MaxRetryDelay. Defaults to 800ms.
+	InitialRetryDelay time.Duration `config:"initial_retry_delay"`
+	// MaxRetryDelay caps the backoff so that, during a long outage, the input
+	// keeps retrying at a steady interval instead of drifting towards ever
+	// larger waits. Defaults to 60s.
+	MaxRetryDelay time.Duration `config:"max_retry_delay"`
+}
+
 // authConfig defines the various authentication methods for connecting to Azure Storage.
 // Only one authentication method should be configured.
 type authConfig struct {
@@ -159,12 +199,28 @@ type OAuth2Config struct {
 func defaultConfig() config {
 	return config{
 		AccountName: "some_account",
+		Retry: retryConfig{
+			MaxRetries:        defaultMaxRetries,
+			InitialRetryDelay: defaultInitialRetryDelay,
+			MaxRetryDelay:     defaultMaxRetryDelay,
+		},
 	}
 }
 
 func (c config) Validate() error {
 	if c.Auth.OAuth2 != nil && (c.Auth.OAuth2.ClientID == "" || c.Auth.OAuth2.ClientSecret == "" || c.Auth.OAuth2.TenantID == "") {
 		return errors.New("client_id, client_secret and tenant_id are required for OAuth2 auth")
+	}
+	if c.Retry.InitialRetryDelay < 0 {
+		return fmt.Errorf("retry.initial_retry_delay must not be negative, got %s", c.Retry.InitialRetryDelay)
+	}
+	if c.Retry.MaxRetryDelay < 0 {
+		return fmt.Errorf("retry.max_retry_delay must not be negative, got %s", c.Retry.MaxRetryDelay)
+	}
+	// A ceiling below the starting delay is almost certainly a mistake, and would
+	// silently clamp every backoff to MaxRetryDelay.
+	if c.Retry.MaxRetryDelay > 0 && c.Retry.InitialRetryDelay > c.Retry.MaxRetryDelay {
+		return fmt.Errorf("retry.max_retry_delay (%s) must not be smaller than retry.initial_retry_delay (%s)", c.Retry.MaxRetryDelay, c.Retry.InitialRetryDelay)
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/azureblobstorage/config.go
+++ b/x-pack/filebeat/input/azureblobstorage/config.go
@@ -150,7 +150,7 @@ type retryConfig struct {
 	// attempt. Defaults to 3. A negative value disables retrying of failed
 	// requests. (Note that the SDK's blob-download stream reader always retries
 	// a mid-stream read failure at least a few times regardless of this value.)
-	MaxRetries int `config:"max_retries"`
+	MaxRetries int32 `config:"max_retries"`
 	// InitialRetryDelay is the starting delay for the exponential backoff
 	// between attempts. Each subsequent retry waits longer, capped by
 	// MaxRetryDelay. Defaults to 800ms.

--- a/x-pack/filebeat/input/azureblobstorage/config_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/config_test.go
@@ -7,8 +7,10 @@ package azureblobstorage
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -57,6 +59,56 @@ var configTests = []struct {
 			},
 		},
 	},
+	{
+		name: "valid_retry_config",
+		config: map[string]interface{}{
+			"account_name":                        "beatsblobnew",
+			"auth.shared_credentials.account_key": "someKey",
+			"containers": []map[string]interface{}{
+				{
+					"name": beatsContainer,
+				},
+			},
+			"retry": map[string]interface{}{
+				"max_retries":         20,
+				"initial_retry_delay": "1s",
+				"max_retry_delay":     "30s",
+			},
+		},
+	},
+	{
+		name: "negative_initial_retry_delay",
+		config: map[string]interface{}{
+			"account_name":                        "beatsblobnew",
+			"auth.shared_credentials.account_key": "someKey",
+			"containers": []map[string]interface{}{
+				{
+					"name": beatsContainer,
+				},
+			},
+			"retry": map[string]interface{}{
+				"initial_retry_delay": "-1s",
+			},
+		},
+		wantErr: fmt.Errorf("retry.initial_retry_delay must not be negative, got -1s accessing config"),
+	},
+	{
+		name: "max_retry_delay_below_initial",
+		config: map[string]interface{}{
+			"account_name":                        "beatsblobnew",
+			"auth.shared_credentials.account_key": "someKey",
+			"containers": []map[string]interface{}{
+				{
+					"name": beatsContainer,
+				},
+			},
+			"retry": map[string]interface{}{
+				"initial_retry_delay": "30s",
+				"max_retry_delay":     "5s",
+			},
+		},
+		wantErr: fmt.Errorf("retry.max_retry_delay (5s) must not be smaller than retry.initial_retry_delay (30s) accessing config"),
+	},
 }
 
 func TestConfig(t *testing.T) {
@@ -77,4 +129,76 @@ func TestConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRetryConfig checks that the retry block unpacks into the config and maps
+// onto the Azure SDK retry options, and that any option left unset keeps the
+// SDK-matching default seeded by defaultConfig (including for a partial block).
+func TestRetryConfig(t *testing.T) {
+	logp.TestingSetup()
+
+	t.Run("explicit", func(t *testing.T) {
+		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+			"account_name":                        "beatsblobnew",
+			"auth.shared_credentials.account_key": "someKey",
+			"containers": []map[string]interface{}{
+				{"name": beatsContainer},
+			},
+			"retry": map[string]interface{}{
+				"max_retries":         20,
+				"initial_retry_delay": "1s",
+				"max_retry_delay":     "30s",
+			},
+		})
+		c := defaultConfig()
+		require.NoError(t, cfg.Unpack(&c), "unpacking a valid retry config should succeed")
+
+		assert.Equal(t, 20, c.Retry.MaxRetries, "max_retries should unpack")
+		assert.Equal(t, time.Second, c.Retry.InitialRetryDelay, "initial_retry_delay should unpack")
+		assert.Equal(t, 30*time.Second, c.Retry.MaxRetryDelay, "max_retry_delay should unpack")
+
+		got := azureRetryOptions(c.Retry)
+		assert.Equal(t, int32(20), got.MaxRetries, "MaxRetries should map through")
+		assert.Equal(t, time.Second, got.RetryDelay, "RetryDelay should map through")
+		assert.Equal(t, 30*time.Second, got.MaxRetryDelay, "MaxRetryDelay should map through")
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+			"account_name":                        "beatsblobnew",
+			"auth.shared_credentials.account_key": "someKey",
+			"containers": []map[string]interface{}{
+				{"name": beatsContainer},
+			},
+		})
+		c := defaultConfig()
+		require.NoError(t, cfg.Unpack(&c), "unpacking a config without a retry block should succeed")
+
+		// Omitting the retry block keeps the seeded SDK-matching defaults, so
+		// behaviour is identical to not configuring retries at all.
+		assert.Equal(t, defaultMaxRetries, c.Retry.MaxRetries, "an unset max_retries must keep the default")
+		assert.Equal(t, defaultInitialRetryDelay, c.Retry.InitialRetryDelay, "an unset initial_retry_delay must keep the default")
+		assert.Equal(t, defaultMaxRetryDelay, c.Retry.MaxRetryDelay, "an unset max_retry_delay must keep the default")
+	})
+
+	t.Run("partial", func(t *testing.T) {
+		// A partial retry block overrides only the provided field and keeps the
+		// seeded defaults for the rest.
+		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+			"account_name":                        "beatsblobnew",
+			"auth.shared_credentials.account_key": "someKey",
+			"containers": []map[string]interface{}{
+				{"name": beatsContainer},
+			},
+			"retry": map[string]interface{}{
+				"max_retries": 7,
+			},
+		})
+		c := defaultConfig()
+		require.NoError(t, cfg.Unpack(&c), "unpacking a partial retry config should succeed")
+
+		assert.Equal(t, 7, c.Retry.MaxRetries, "an explicit max_retries must be preserved")
+		assert.Equal(t, defaultInitialRetryDelay, c.Retry.InitialRetryDelay, "an omitted initial_retry_delay must keep the default")
+		assert.Equal(t, defaultMaxRetryDelay, c.Retry.MaxRetryDelay, "an omitted max_retry_delay must keep the default")
+	})
 }

--- a/x-pack/filebeat/input/azureblobstorage/config_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/config_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 var configTests = []struct {
@@ -112,7 +111,6 @@ var configTests = []struct {
 }
 
 func TestConfig(t *testing.T) {
-	logp.TestingSetup()
 	for _, test := range configTests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := conf.MustNewConfigFrom(test.config)
@@ -135,8 +133,6 @@ func TestConfig(t *testing.T) {
 // onto the Azure SDK retry options, and that any option left unset keeps the
 // SDK-matching default seeded by defaultConfig (including for a partial block).
 func TestRetryConfig(t *testing.T) {
-	logp.TestingSetup()
-
 	t.Run("explicit", func(t *testing.T) {
 		cfg := conf.MustNewConfigFrom(map[string]interface{}{
 			"account_name":                        "beatsblobnew",
@@ -153,7 +149,7 @@ func TestRetryConfig(t *testing.T) {
 		c := defaultConfig()
 		require.NoError(t, cfg.Unpack(&c), "unpacking a valid retry config should succeed")
 
-		assert.Equal(t, 20, c.Retry.MaxRetries, "max_retries should unpack")
+		assert.Equal(t, int32(20), c.Retry.MaxRetries, "max_retries should unpack")
 		assert.Equal(t, time.Second, c.Retry.InitialRetryDelay, "initial_retry_delay should unpack")
 		assert.Equal(t, 30*time.Second, c.Retry.MaxRetryDelay, "max_retry_delay should unpack")
 
@@ -176,7 +172,7 @@ func TestRetryConfig(t *testing.T) {
 
 		// Omitting the retry block keeps the seeded SDK-matching defaults, so
 		// behaviour is identical to not configuring retries at all.
-		assert.Equal(t, defaultMaxRetries, c.Retry.MaxRetries, "an unset max_retries must keep the default")
+		assert.Equal(t, int32(defaultMaxRetries), c.Retry.MaxRetries, "an unset max_retries must keep the default")
 		assert.Equal(t, defaultInitialRetryDelay, c.Retry.InitialRetryDelay, "an unset initial_retry_delay must keep the default")
 		assert.Equal(t, defaultMaxRetryDelay, c.Retry.MaxRetryDelay, "an unset max_retry_delay must keep the default")
 	})
@@ -197,7 +193,7 @@ func TestRetryConfig(t *testing.T) {
 		c := defaultConfig()
 		require.NoError(t, cfg.Unpack(&c), "unpacking a partial retry config should succeed")
 
-		assert.Equal(t, 7, c.Retry.MaxRetries, "an explicit max_retries must be preserved")
+		assert.Equal(t, int32(7), c.Retry.MaxRetries, "an explicit max_retries must be preserved")
 		assert.Equal(t, defaultInitialRetryDelay, c.Retry.InitialRetryDelay, "an omitted initial_retry_delay must keep the default")
 		assert.Equal(t, defaultMaxRetryDelay, c.Retry.MaxRetryDelay, "an omitted max_retry_delay must keep the default")
 	})

--- a/x-pack/filebeat/input/azureblobstorage/decoding_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/decoding_test.go
@@ -112,7 +112,7 @@ func TestDecoding(t *testing.T) {
 					LastModified: &time.Time{},
 				},
 			}
-			j := newJob(&blob.Client{}, item, "https://foo.blob.core.windows.net/", newState(), &Source{}, p, noopReporter{}, nil, log)
+			j := newJob(&blob.Client{}, item, "https://foo.blob.core.windows.net/", newState(), &Source{}, 0, p, noopReporter{}, nil, log)
 			j.src.ReaderConfig.Decoding = tc.config
 			err = j.decode(context.Background(), f, "test")
 			if err != nil {

--- a/x-pack/filebeat/input/azureblobstorage/decoding_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/decoding_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/x-pack/libbeat/reader/decoder"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 // all test files are read from the "testdata" directory
@@ -35,8 +35,7 @@ type noopReporter struct{}
 func (n noopReporter) UpdateStatus(status status.Status, msg string) {}
 
 func TestDecoding(t *testing.T) {
-	logp.TestingSetup()
-	log := logp.L()
+	log := logptest.NewTestingLogger(t, "")
 
 	testCases := []struct {
 		name          string

--- a/x-pack/filebeat/input/azureblobstorage/input.go
+++ b/x-pack/filebeat/input/azureblobstorage/input.go
@@ -84,6 +84,7 @@ func configure(cfg *conf.C, logger *logp.Logger) ([]cursor.Source, cursor.Input,
 			FileSelectors:            container.FileSelectors,
 			ReaderConfig:             container.ReaderConfig,
 			PathPrefix:               container.PathPrefix,
+			Retry:                    config.Retry,
 		})
 	}
 
@@ -212,7 +213,7 @@ func (input *azurebsInput) run(inputCtx v2.Context, src cursor.Source, st *state
 		cancel()
 	}()
 
-	serviceClient, credential, err := fetchServiceClientAndCreds(input.config, input.serviceURL, log)
+	serviceClient, credential, err := fetchServiceClientAndCreds(input.config, currentSource.Retry, input.serviceURL, log)
 	if err != nil {
 		metrics.errorsTotal.Inc()
 		inputCtx.UpdateStatus(status.Failed, "failed to get service client: "+err.Error())

--- a/x-pack/filebeat/input/azureblobstorage/input_stateless_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/input_stateless_test.go
@@ -63,6 +63,7 @@ func (in *statelessInput) Run(inputCtx v2.Context, publisher stateless.Publisher
 			FileSelectors:            container.FileSelectors,
 			ReaderConfig:             container.ReaderConfig,
 			PathPrefix:               container.PathPrefix,
+			Retry:                    in.config.Retry,
 		}
 
 		st := newState()
@@ -79,7 +80,7 @@ func (in *statelessInput) Run(inputCtx v2.Context, publisher stateless.Publisher
 			cancel()
 		}()
 
-		serviceClient, credential, err := fetchServiceClientAndCreds(in.config, in.serviceURL, log)
+		serviceClient, credential, err := fetchServiceClientAndCreds(in.config, currentSource.Retry, in.serviceURL, log)
 		if err != nil {
 			return err
 		}

--- a/x-pack/filebeat/input/azureblobstorage/input_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/input_test.go
@@ -834,6 +834,7 @@ func TestConcurrency(t *testing.T) {
 					MaxWorkers:    *container.MaxWorkers,
 					Poll:          *container.Poll,
 					PollInterval:  *container.PollInterval,
+					Retry:         input.config.Retry,
 				}
 			}
 			v2Ctx, cancel := newV2Context(t)

--- a/x-pack/filebeat/input/azureblobstorage/job.go
+++ b/x-pack/filebeat/input/azureblobstorage/job.go
@@ -40,6 +40,9 @@ type job struct {
 	blob *azcontainer.BlobItem
 	// azure blob url for the resource
 	blobURL string
+	// downloadRetries bounds how many times a mid-stream read failure is retried
+	// while downloading a blob. A value below 1 lets the SDK apply its default (3).
+	downloadRetries int32
 	// object hash, used in setting event id
 	hash string
 	// flag to denote if object is gzip compressed or not
@@ -62,7 +65,7 @@ type job struct {
 
 // newJob, returns an instance of a job, which is a unit of work that can be assigned to a go routine
 func newJob(client *blob.Client, blob *azcontainer.BlobItem, blobURL string,
-	state *state, src *Source, publisher cursor.Publisher, stat status.StatusReporter, metrics *inputMetrics, log *logp.Logger,
+	state *state, src *Source, downloadRetries int32, publisher cursor.Publisher, stat status.StatusReporter, metrics *inputMetrics, log *logp.Logger,
 ) *job {
 	if metrics == nil {
 		// metrics are optional, initialize a stub if not provided
@@ -70,16 +73,17 @@ func newJob(client *blob.Client, blob *azcontainer.BlobItem, blobURL string,
 	}
 
 	return &job{
-		client:    client,
-		blob:      blob,
-		blobURL:   blobURL,
-		hash:      azureObjectHash(src, blob),
-		state:     state,
-		src:       src,
-		publisher: publisher,
-		log:       log,
-		status:    stat,
-		metrics:   metrics,
+		client:          client,
+		blob:            blob,
+		blobURL:         blobURL,
+		downloadRetries: downloadRetries,
+		hash:            azureObjectHash(src, blob),
+		state:           state,
+		src:             src,
+		publisher:       publisher,
+		log:             log,
+		status:          stat,
+		metrics:         metrics,
 	}
 }
 
@@ -160,9 +164,11 @@ func (j *job) processAndPublishData(ctx context.Context, id string) error {
 		j.status.UpdateStatus(status.Degraded, "failed to create a download stream: "+err.Error())
 		return fmt.Errorf("failed to download data from blob with error: %w", err)
 	}
-	const maxRetries = 3
+	// The retry policy on the client pipeline already retries the download
+	// request itself; this retry reader additionally recovers from failures that
+	// occur mid-stream, while the body is being read.
 	reader := get.NewRetryReader(ctx, &azblob.RetryReaderOptions{
-		MaxRetries: maxRetries,
+		MaxRetries: j.downloadRetries,
 	})
 	defer func() {
 		err = reader.Close()

--- a/x-pack/filebeat/input/azureblobstorage/scheduler.go
+++ b/x-pack/filebeat/input/azureblobstorage/scheduler.go
@@ -200,7 +200,7 @@ func (s *scheduler) scheduleOnce(ctx context.Context) error {
 				return err
 			}
 
-			job := newJob(blobClient, v, blobURL, s.state, s.src, int32(s.src.Retry.MaxRetries), s.publisher, s.status, s.metrics, s.log)
+			job := newJob(blobClient, v, blobURL, s.state, s.src, s.src.Retry.MaxRetries, s.publisher, s.status, s.metrics, s.log)
 			jobs = append(jobs, job)
 		}
 
@@ -244,6 +244,16 @@ func (s *scheduler) scheduleOnce(ctx context.Context) error {
 		if len(jobs) != 0 {
 			s.log.Debugf("scheduler: first job in current batch: %s\nscheduler: last job in current batch: %s", jobs[0].name(), jobs[len(jobs)-1].name())
 		}
+	}
+
+	// A successful listing pass is itself a recovery signal. When jobs are
+	// scheduled they report Running as they publish events, but a poll that
+	// lists cleanly yet schedules no jobs (no new blobs, or everything filtered
+	// out or already past the checkpoint) would otherwise leave the input stuck
+	// in a Degraded state set by an earlier transient listing failure. Report
+	// Running here so the input recovers even on an empty poll.
+	if s.src.Poll && numJobs == 0 {
+		s.status.UpdateStatus(status.Running, "")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/azureblobstorage/scheduler.go
+++ b/x-pack/filebeat/input/azureblobstorage/scheduler.go
@@ -6,11 +6,15 @@ package azureblobstorage
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"slices"
 	"sort"
 	"sync"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	azcontainer "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
@@ -21,6 +25,37 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/go-concert/timed"
 )
+
+// transientListStatusCodes are the HTTP status codes treated as transient when
+// listing blobs. They mirror the Azure SDK's own retryable set, so an error
+// carrying one of these means the SDK already exhausted its per-request retries
+// on a throttling or availability blip that is likely to clear on its own.
+var transientListStatusCodes = map[int]bool{
+	http.StatusRequestTimeout:      true, // 408
+	http.StatusTooManyRequests:     true, // 429
+	http.StatusInternalServerError: true, // 500
+	http.StatusBadGateway:          true, // 502
+	http.StatusServiceUnavailable:  true, // 503
+	http.StatusGatewayTimeout:      true, // 504
+}
+
+// isTransientListError reports whether a blob-listing failure is transient and
+// therefore safe to ride out by retrying on the next poll, as opposed to a
+// permanent failure (e.g. a missing container or an auth error) that will not
+// resolve on its own and should stop the input.
+func isTransientListError(err error) bool {
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		return transientListStatusCodes[respErr.StatusCode]
+	}
+	// A network timeout (the request could not reach the service in time) is
+	// also transient.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
 
 // limiter, is used to limit the number of goroutines from blowing up the stack
 type limiter struct {
@@ -113,7 +148,25 @@ func (s *scheduler) scheduleOnce(ctx context.Context) error {
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		if err != nil {
+			// A cancelled context means the input is shutting down; propagate it
+			// so the scheduler loop exits cleanly without counting it as an error.
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			s.metrics.errorsTotal.Inc()
+			// When polling, a *transient* listing failure must not kill the
+			// input. This covers throttling (HTTP 503 ServerBusy, 429) or a brief
+			// network timeout that outlived the SDK's own per-request retries.
+			// Mark the input Degraded and let schedule() retry on the next poll
+			// interval so a longer outage is ridden out instead of permanently
+			// stopping the input. Permanent failures (e.g. a missing container or
+			// an auth error) will not resolve on their own, so they still stop
+			// the input.
+			if s.src.Poll && isTransientListError(err) {
+				s.log.Warnw("transient failure while listing blobs; will retry on the next poll interval", "error", err)
+				s.status.UpdateStatus(status.Degraded, "transient failure listing blobs (will retry on next poll): "+err.Error())
+				return nil
+			}
 			s.status.UpdateStatus(status.Failed, "failed to fetch next page during pagination: "+err.Error())
 			return err
 		}

--- a/x-pack/filebeat/input/azureblobstorage/scheduler.go
+++ b/x-pack/filebeat/input/azureblobstorage/scheduler.go
@@ -139,7 +139,7 @@ func (s *scheduler) scheduleOnce(ctx context.Context) error {
 				containerName: s.src.ContainerName,
 			}
 
-			blobClient, err := fetchBlobClient(blobURL, blobCreds, *s.cfg, s.log)
+			blobClient, err := fetchBlobClient(blobURL, blobCreds, *s.cfg, s.src.Retry, s.log)
 			if err != nil {
 				s.metrics.errorsTotal.Inc()
 				s.log.Errorf("Job creation failed for container %s with error %v", s.src.ContainerName, err)
@@ -147,7 +147,7 @@ func (s *scheduler) scheduleOnce(ctx context.Context) error {
 				return err
 			}
 
-			job := newJob(blobClient, v, blobURL, s.state, s.src, s.publisher, s.status, s.metrics, s.log)
+			job := newJob(blobClient, v, blobURL, s.state, s.src, int32(s.src.Retry.MaxRetries), s.publisher, s.status, s.metrics, s.log)
 			jobs = append(jobs, job)
 		}
 

--- a/x-pack/filebeat/input/azureblobstorage/types.go
+++ b/x-pack/filebeat/input/azureblobstorage/types.go
@@ -25,6 +25,7 @@ type Source struct {
 	ReaderConfig             readerConfig
 	ExpandEventListFromField string
 	PathPrefix               string
+	Retry                    retryConfig
 }
 
 func (s *Source) Name() string {


### PR DESCRIPTION
## Type of change
- Bug
- Enhancement

## Proposed commit message
```
x-pack/filebeat/input/azureblobstorage: harden blob listing against transient failures

Transient Azure Storage failures (HTTP 503 ServerBusy, HTTP 429
throttling, or brief network timeouts) during blob listing (pagination)
could exhaust the small, non-configurable default retries and fatally
stop the input with no recovery, leaving long ingestion gaps.

This change:

- Exposes a retry configuration block (max_retries, initial_retry_delay,
  max_retry_delay) wired into the Azure SDK pipeline retry policy. Because
  the policy lives in the client request pipeline, it covers blob listing
  as well as downloads, and the download stream reader's retry count is
  also driven by max_retries. Defaults mirror the SDK's own policy (3
  retries, 800ms base delay, 60s ceiling), so configs that omit the block
  behave exactly as before.
- Makes a transient listing failure non-fatal while polling: the input is
  marked Degraded and the listing is retried on the next poll interval, so
  it rides out longer outages and recovers on its own. No blobs are
  skipped, because each poll re-lists from scratch and the checkpoint only
  advances for processed blobs. Permanent failures (a missing container or
  an authentication error) still stop the input, and one-shot (non-polling)
  runs are unchanged.
- Reports Running again after a successful listing pass that schedules no
  jobs, so a poll that recovers but has no new work (no new blobs, or
  everything filtered out or already past the checkpoint) no longer leaves
  the input stuck in Degraded.
- Migrates the package tests to localized logptest loggers (dropping the
  deprecated logp.TestingSetup) and documents the stack versions the retry
  attribute is available in.

Fixes #44629
Assisted-By: Cursor (Claude Opus 4.8)
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/beats/issues/44629

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
