### PR TITLE
Fix nolint directives referencing old linters

### DIFF
--- a/filebeat/input/journald/pkg/journalctl/chroot_test.go
+++ b/filebeat/input/journald/pkg/journalctl/chroot_test.go
@@ -167,7 +167,7 @@ func TestInDockerNewFactory(t *testing.T) {
 	// without the need of any messages in the journal
 	jctl, err := factory(jctlCtx, logger.Logger, "--version")
 	require.NoError(t, err, "failed to create journalctl with chroot")
-	defer jctl.Kill() //nolint: deadcode,errcheck // It's a test, there is nothing to do
+	defer jctl.Kill() //nolint:errcheck // It's a test, there is nothing to do
 
 	data, err := jctl.Next(jctlCtx)
 	require.NoError(t, err, "failed to read from journalctl")

--- a/libbeat/publisher/queue/memqueue/config.go
+++ b/libbeat/publisher/queue/memqueue/config.go
@@ -59,7 +59,7 @@ func SettingsForUserConfig(cfg *c.C) (Settings, error) {
 			return Settings{}, fmt.Errorf("couldn't unpack memory queue config: %w", err)
 		}
 	}
-	//nolint:gosimple // Actually want this conversion to be explicit since the types aren't definitionally equal.
+	//nolint:staticcheck // Actually want this conversion to be explicit since the types aren't definitionally equal.
 	return Settings{
 		Events:        config.Events,
 		MaxGetRequest: config.MaxGetRequest,

--- a/x-pack/filebeat/input/azureblobstorage/mock/data.go
+++ b/x-pack/filebeat/input/azureblobstorage/mock/data.go
@@ -234,5 +234,5 @@ var Beatscontainer_2_blob_data3_json = `{
     ]
 }`
 
-//nolint:stylecheck // intentionally indented like this
+//nolint:staticcheck // intentionally indented like this
 var NotFoundErr = errors.New("--------------------------------------------------------------------------------\nRESPONSE 404: 404 Not Found\nERROR CODE UNAVAILABLE\n--------------------------------------------------------------------------------\nresource not found\n--------------------------------------------------------------------------------\n")

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:deadcode,unused // This code will be used later.
 package cel
 
 import (
@@ -2766,15 +2765,6 @@ func newChainTestServer(serve func(http.Handler) *httptest.Server) func(*testing
 	}
 }
 
-func newV2Context() (v2.Context, func()) {
-	ctx, cancel := context.WithCancel(context.Background())
-	return v2.Context{
-		Logger:      logp.NewLogger("httpjson_test"),
-		ID:          "test_id",
-		Cancelation: ctx,
-	}, cancel
-}
-
 //nolint:errcheck // No point checking errors in test server.
 func defaultHandler(expectedMethod, expectedBody string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -3034,26 +3024,6 @@ func paginationHandler() http.HandlerFunc {
 			w.Write([]byte(`{"@timestamp":"2002-10-02T15:00:02Z","items":[{"foo":"c"}]}`))
 		case 3:
 			w.Write([]byte(`{"@timestamp":"2002-10-02T15:00:03Z","items":[{"foo":"d"}]}`))
-		}
-		count++
-	}
-}
-
-//nolint:errcheck // No point checking errors in test server.
-func paginationArrayHandler() http.HandlerFunc {
-	var count int
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("content-type", "application/json")
-		switch count {
-		case 0:
-			w.Write([]byte(`[{"nextPageToken":"bar","foo":"bar"},{"foo":"bar"}]`))
-		case 1:
-			if r.URL.Query().Get("page") != "bar" {
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(`{"error":"wrong page token value"}`))
-				return
-			}
-			w.Write([]byte(`[{"foo":"bar"}]`))
 		}
 		count++
 	}

--- a/x-pack/filebeat/input/gcs/mock/data.go
+++ b/x-pack/filebeat/input/gcs/mock/data.go
@@ -288,7 +288,5 @@ var Gcs_test_latest_object_data3_json = `{
 }`
 
 // These 2 variables are intentionally indented like this to match the output of certain tests
-//
-//nolint:stylecheck // required for edge case test scenario
 var Gcs_test_latest_object_ata_json_parsed = `[{"brand":"Apple","category":"smartphones","description":"An apple mobile which is nothing like apple","discountPercentage":12.96,"id":1,"images":["https://dummyjson.com/image/i/products/1/1.jpg","https://dummyjson.com/image/i/products/1/2.jpg","https://dummyjson.com/image/i/products/1/3.jpg","https://dummyjson.com/image/i/products/1/4.jpg","https://dummyjson.com/image/i/products/1/thumbnail.jpg"],"price":549,"rating":4.69,"stock":94,"thumbnail":"https://dummyjson.com/image/i/products/1/thumbnail.jpg","title":"iPhone 9"}]`
 var Gcs_test_latest_object_data3_json_parsed = `[{"brand":"Samsung","category":"smartphones","description":"Samsung's new variant which goes beyond Galaxy to the Universe","discountPercentage":15.46,"id":3,"images":["https://dummyjson.com/image/i/products/3/1.jpg"],"price":1249,"rating":4.09,"stock":36,"thumbnail":"https://dummyjson.com/image/i/products/3/thumbnail.jpg","title":"Samsung Universe 9"}]`

--- a/x-pack/filebeat/input/gcs/mock/data_files.go
+++ b/x-pack/filebeat/input/gcs/mock/data_files.go
@@ -385,8 +385,6 @@ var objectFileList = map[string]string{
 }
 
 // These variables are intentionally indented like this to match the output of certain tests
-//
-//nolint:stylecheck // required for edge case test scenario
 var BeatsFilesBucket_multiline_json = []string{
 	"{\n    \"@timestamp\": \"2021-05-25T17:25:42.806Z\",\n    \"log.level\": \"error\",\n    \"message\": \"error making request\"\n}",
 	"{\n    \"@timestamp\": \"2021-05-25T17:25:51.391Z\",\n    \"log.level\": \"info\",\n    \"message\": \"available space 44.3gb\"\n}",


### PR DESCRIPTION
## Proposed commit message

```
Fix nolint directives referencing old linters

Fixes a warning:

    WARN [runner/nolint_filter] Found unknown linters in //nolint directives: deadcode, gosimple, stylecheck

This updates the stale directives across the repo:

- `deadcode` -> `unused`
- `gosimple` -> `staticcheck`
- `stylecheck` -> `staticcheck`

In `x-pack/filebeat/input/cel/input_test.go` the file-level
`//nolint:deadcode,unused // This code will be used later.` directive
only masked two helpers, `newV2Context` and `paginationArrayHandler`,
copied from the httpjson input test scaffolding when the CEL input was
created (#31233) and never used since.
Both functions and the directive are removed, the helpers can be
re-introduced if ever needed.
```

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- ~~[ ] I have added an entry in `./changelog/fragments`~~ (test/lint-only change, `skip-changelog`)
