### PR TITLE
Disable periodic metrics logging for beats receivers by default

### DIFF
--- a/changelog/fragments/1783077556-disable-metric-log-snapshots-by-default-in-receivers.yaml
+++ b/changelog/fragments/1783077556-disable-metric-log-snapshots-by-default-in-receivers.yaml
@@ -1,0 +1,8 @@
+# REQUIRED
+kind: enhancement
+
+# REQUIRED
+summary: Disable periodic metrics logging (`logging.metrics`) by default when a beat runs as an OTel Collector receiver.
+
+# REQUIRED
+component: beats

--- a/x-pack/auditbeat/abreceiver/receiver_test.go
+++ b/x-pack/auditbeat/abreceiver/receiver_test.go
@@ -87,8 +87,8 @@ func TestNewReceiver(t *testing.T) {
 				return getFromSocket(t, &lastError, monitorSocket, "stats")
 			}, "failed to connect to monitoring socket stats endpoint, last error was: %s", &lastError)
 			assert.Condition(c, func() bool {
-				metricsStarted := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s")
-				return assert.NotEmpty(t, metricsStarted.All(), "metrics logging not started")
+				metricsSkipped := zapLogs.FilterMessageSnippet("Skipping metrics logging")
+				return assert.NotEmpty(t, metricsSkipped.All(), "metric reporter did not initialize")
 			}, "failed to check metrics logging")
 		},
 	})
@@ -185,10 +185,10 @@ func TestMultipleReceivers(t *testing.T) {
 			r2StartLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "auditbeatreceiver/r2"))
 			assert.Equal(c, 1, r2StartLogs.Len(), "r2 should have a single start log")
 
-			r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "auditbeatreceiver/r1"))
-			assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single start metrics logging every 30s")
-			r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "auditbeatreceiver/r2"))
-			assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single start metrics logging every 30s")
+			r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "auditbeatreceiver/r1"))
+			assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single skipping metrics logging entry")
+			r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "auditbeatreceiver/r2"))
+			assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single skipping metrics logging entry")
 
 			var lastError strings.Builder
 			assert.Conditionf(c, func() bool {

--- a/x-pack/filebeat/fbreceiver/receiver_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_test.go
@@ -105,8 +105,8 @@ func TestNewReceiver(t *testing.T) {
 				return assert.NotContains(c, logs["r1"][0].Flatten(), "host.architecture")
 			}, "failed to check processors loaded")
 			assert.Condition(c, func() bool {
-				metricsStarted := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s")
-				return assert.NotEmpty(t, metricsStarted.All(), "metrics logging not started")
+				metricsSkipped := zapLogs.FilterMessageSnippet("Skipping metrics logging")
+				return assert.NotEmpty(t, metricsSkipped.All(), "metric reporter did not initialize")
 			}, "failed to check metrics logging")
 		},
 	})
@@ -287,8 +287,8 @@ func TestMultipleReceivers(t *testing.T) {
 				startLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "filebeatreceiver/"+helper.name))
 				assert.Equalf(c, 1, startLogs.Len(), "%v should have a single start log", helper)
 
-				startMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "filebeatreceiver/"+helper.name))
-				assert.Equalf(c, 1, startMetricsLogs.Len(), "%v should have a single start metrircs logging every 30s", helper)
+				startMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "filebeatreceiver/"+helper.name))
+				assert.Equalf(c, 1, startMetricsLogs.Len(), "%v should have a single skipping metrics logging entry", helper)
 
 				metaPath := filepath.Join(helper.home, "/data/meta.json")
 				assert.FileExistsf(c, metaPath, "%s of %v should exist", metaPath, helper)

--- a/x-pack/heartbeat/hbreceiver/receiver_leak_test.go
+++ b/x-pack/heartbeat/hbreceiver/receiver_leak_test.go
@@ -84,7 +84,7 @@ func startAndStopReceiver(t *testing.T, factory receiver.Factory, consumer consu
 	require.NoError(t, rec.Start(t.Context(), componenttest.NewNopHost()))
 	if !assert.Eventually(t,
 		func() bool {
-			return observedLogs.FilterMessageSnippet("Starting metrics logging every 30s").Len() >= 1
+			return observedLogs.FilterMessageSnippet("Skipping metrics logging").Len() >= 1
 		},
 		60*time.Second,
 		1*time.Second,

--- a/x-pack/heartbeat/hbreceiver/receiver_test.go
+++ b/x-pack/heartbeat/hbreceiver/receiver_test.go
@@ -99,8 +99,8 @@ func TestNewReceiver(t *testing.T) {
 			return getFromSocket(t, &lastError, monitorSocket, "stats")
 		}, "failed to connect to monitoring socket stats endpoint, last error was: %s", &lastError)
 
-		metricsStarted := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s")
-		assert.NotEmpty(c, metricsStarted.All(), "metrics logging not started")
+		metricsSkipped := zapLogs.FilterMessageSnippet("Skipping metrics logging")
+		assert.NotEmpty(c, metricsSkipped.All(), "metric reporter did not initialize")
 	}, 2*time.Minute, 1*time.Second,
 		"timeout waiting for heartbeat receiver to start")
 
@@ -208,10 +208,10 @@ func TestMultipleReceivers(t *testing.T) {
 		r2StartLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "heartbeatreceiver/r2"))
 		assert.Equal(c, 1, r2StartLogs.Len(), "r2 should have a single start log")
 
-		r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "heartbeatreceiver/r1"))
-		assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single start metrics logging every 30s")
-		r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "heartbeatreceiver/r2"))
-		assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single start metrics logging every 30s")
+		r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "heartbeatreceiver/r1"))
+		assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single skipping metrics logging entry")
+		r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "heartbeatreceiver/r2"))
+		assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single skipping metrics logging entry")
 
 		var lastError strings.Builder
 		assert.Conditionf(c, func() bool {

--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -156,6 +156,12 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 	}
 
 	b.RawConfig = cfg
+
+	// Periodic metrics snapshots are expensive to collect and mostly
+	// redundant under a receiver, where metrics are already exported
+	// through the otel telemetry provider. Default them off.
+	b.Config.MetricLogging = config.MustNewConfigFrom(map[string]any{"period": 0})
+
 	err = cfg.Unpack(&b.Config)
 	if err != nil {
 		return nil, fmt.Errorf("error unpacking config data: %w", err)

--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -120,7 +120,7 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 		if err := instance.InitPaths(cfg); err != nil {
 			return nil, fmt.Errorf("error initializing paths: %w", err)
 		}
-		b.Info.Paths = paths.Paths
+		b.Info.Paths = paths.Paths //nolint:forbidigo // to be fixed
 	}
 
 	// We have to initialize the keystore before any unpack or merging the cloud

--- a/x-pack/libbeat/cmd/instance/beat_test.go
+++ b/x-pack/libbeat/cmd/instance/beat_test.go
@@ -7,6 +7,7 @@ package instance
 import (
 	"maps"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,5 +81,68 @@ type: "log"`)
 type: "log"`)
 		require.NoError(t, err)
 		assert.False(t, log.AllowDeprecatedUse(cfg))
+	})
+}
+
+func TestNewBeatForReceiverMetricLoggingDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseCfg := map[string]any{
+		"filebeat": map[string]any{
+			"inputs": []map[string]any{
+				{
+					"type":    "benchmark",
+					"enabled": true,
+					"message": "test",
+					"count":   10,
+				},
+			},
+		},
+		"path.home": tmpDir,
+	}
+
+	t.Run("defaults to disabled metric logging when unset", func(t *testing.T) {
+		beat, err := NewBeatForReceiver(cmd.FilebeatSettings("filebeat"), baseCfg, consumertest.NewNop(), "testcomponent", zapcore.NewNopCore())
+		require.NoError(t, err)
+		require.NotNil(t, beat.Config.MetricLogging)
+
+		var metricCfg struct {
+			Period time.Duration `config:"period"`
+		}
+		require.NoError(t, beat.Config.MetricLogging.Unpack(&metricCfg))
+		assert.Equal(t, time.Duration(0), metricCfg.Period)
+	})
+
+	t.Run("honors an explicitly configured period", func(t *testing.T) {
+		tmpCfg := map[string]any{}
+		maps.Copy(tmpCfg, baseCfg)
+		tmpCfg["logging.metrics.period"] = "15s"
+
+		beat, err := NewBeatForReceiver(cmd.FilebeatSettings("filebeat"), tmpCfg, consumertest.NewNop(), "testcomponent", zapcore.NewNopCore())
+		require.NoError(t, err)
+		require.NotNil(t, beat.Config.MetricLogging)
+
+		var metricCfg struct {
+			Period time.Duration `config:"period"`
+		}
+		require.NoError(t, beat.Config.MetricLogging.Unpack(&metricCfg))
+		assert.Equal(t, 15*time.Second, metricCfg.Period)
+	})
+
+	t.Run("keeps the default period when an unrelated metric logging field is set", func(t *testing.T) {
+		tmpCfg := map[string]any{}
+		maps.Copy(tmpCfg, baseCfg)
+		tmpCfg["logging.metrics.enabled"] = true
+
+		beat, err := NewBeatForReceiver(cmd.FilebeatSettings("filebeat"), tmpCfg, consumertest.NewNop(), "testcomponent", zapcore.NewNopCore())
+		require.NoError(t, err)
+		require.NotNil(t, beat.Config.MetricLogging)
+
+		var metricCfg struct {
+			Enabled bool          `config:"enabled"`
+			Period  time.Duration `config:"period"`
+		}
+		require.NoError(t, beat.Config.MetricLogging.Unpack(&metricCfg))
+		assert.True(t, metricCfg.Enabled)
+		assert.Equal(t, time.Duration(0), metricCfg.Period)
 	})
 }

--- a/x-pack/metricbeat/mbreceiver/receiver_test.go
+++ b/x-pack/metricbeat/mbreceiver/receiver_test.go
@@ -104,8 +104,8 @@ func TestNewReceiver(t *testing.T) {
 				return assert.NotContains(c, logs["r1"][0].Flatten(), "host.architecture")
 			}, "failed to check processors loaded")
 			assert.Condition(c, func() bool {
-				metricsStarted := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s")
-				return assert.NotEmpty(t, metricsStarted.All(), "metrics logging not started")
+				metricsSkipped := zapLogs.FilterMessageSnippet("Skipping metrics logging")
+				return assert.NotEmpty(t, metricsSkipped.All(), "metric reporter did not initialize")
 			}, "failed to check metrics logging")
 		},
 	})
@@ -214,10 +214,10 @@ func TestMultipleReceivers(t *testing.T) {
 			r2StartLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "metricbeatreceiver/r2"))
 			assert.Equal(c, 1, r2StartLogs.Len(), "r2 should have a single start log")
 
-			r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "metricbeatreceiver/r1"))
-			assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single start metrircs logging every 30s")
-			r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "metricbeatreceiver/r1"))
-			assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single start metrircs logging every 30s")
+			r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "metricbeatreceiver/r1"))
+			assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single skipping metrics logging entry")
+			r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "metricbeatreceiver/r1"))
+			assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single skipping metrics logging entry")
 
 			var lastError strings.Builder
 			assert.Conditionf(c, func() bool {

--- a/x-pack/osquerybeat/osqreceiver/receiver_leak_test.go
+++ b/x-pack/osquerybeat/osqreceiver/receiver_leak_test.go
@@ -78,12 +78,12 @@ func startAndStopReceiver(t *testing.T, factory receiver.Factory, consumer consu
 	rec, err := factory.CreateLogs(t.Context(), receiverSettings, config, consumer)
 	require.NoError(t, err)
 	require.NoError(t, rec.Start(t.Context(), componenttest.NewNopHost()))
-	// Wait for the osquerybeat receiver to start running. The "Starting metrics
+	// Wait for the osquerybeat receiver to start running. The "Skipping metrics
 	// logging" message is emitted by the metric reporter inside BeatReceiver.Start,
 	// after the reporter is created, ensuring it is safe to call Shutdown.
 	if !assert.Eventually(t,
 		func() bool {
-			return observedLogs.FilterMessageSnippet("Starting metrics logging").Len() >= 1
+			return observedLogs.FilterMessageSnippet("Skipping metrics logging").Len() >= 1
 		},
 		60*time.Second,
 		1*time.Second,

--- a/x-pack/otel/oteltestcol/collector_test.go
+++ b/x-pack/otel/oteltestcol/collector_test.go
@@ -87,8 +87,8 @@ service:
 
 	require.Eventually(t, func() bool {
 		return col.ObservedLogs().
-			FilterMessageSnippet("Starting metrics logging every 30s").Len() > 0
-	}, 30*time.Second, 100*time.Millisecond, "Expected auditbeat receiver to start and log metrics")
+			FilterMessageSnippet("Skipping metrics logging").Len() > 0
+	}, 30*time.Second, 100*time.Millisecond, "Expected auditbeat receiver to start and initialize the metric reporter")
 }
 
 func TestHeartbeatReceiver(t *testing.T) {
@@ -126,8 +126,8 @@ service:
 
 	require.Eventually(t, func() bool {
 		return col.ObservedLogs().
-			FilterMessageSnippet("Starting metrics logging every 30s").Len() > 0
-	}, 30*time.Second, 100*time.Millisecond, "Expected heartbeat receiver to start and log metrics")
+			FilterMessageSnippet("Skipping metrics logging").Len() > 0
+	}, 30*time.Second, 100*time.Millisecond, "Expected heartbeat receiver to start and initialize the metric reporter")
 }
 
 // TestOsquerybeatReceiverRegistered verifies that the osquerybeat receiver
@@ -213,6 +213,6 @@ service:
 
 	require.Eventually(t, func() bool {
 		return col.ObservedLogs().
-			FilterMessageSnippet("Starting metrics logging every 30s").Len() > 0
-	}, 30*time.Second, 100*time.Millisecond, "Expected packetbeat receiver to start and log metrics")
+			FilterMessageSnippet("Skipping metrics logging").Len() > 0
+	}, 30*time.Second, 100*time.Millisecond, "Expected packetbeat receiver to start and initialize the metric reporter")
 }

--- a/x-pack/packetbeat/pbreceiver/receiver_leak_test.go
+++ b/x-pack/packetbeat/pbreceiver/receiver_leak_test.go
@@ -72,7 +72,7 @@ func startAndStopReceiver(t *testing.T, factory receiver.Factory, consumer consu
 	require.NoError(t, rec.Start(t.Context(), componenttest.NewNopHost()))
 	if !assert.Eventually(t,
 		func() bool {
-			return observedLogs.FilterMessageSnippet("Starting metrics logging every 30s").Len() >= 1
+			return observedLogs.FilterMessageSnippet("Skipping metrics logging").Len() >= 1
 		},
 		60*time.Second,
 		1*time.Second,

--- a/x-pack/packetbeat/pbreceiver/receiver_test.go
+++ b/x-pack/packetbeat/pbreceiver/receiver_test.go
@@ -105,9 +105,9 @@ func TestNewReceiver(t *testing.T) {
 			return getFromSocket(t, &lastError, monitorSocket, "stats")
 		}, "failed to connect to monitoring socket stats endpoint, last error was: %s", &lastError)
 
-		// Verify metrics logging started.
-		metricsStarted := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s")
-		assert.NotEmpty(c, metricsStarted.All(), "metrics logging not started")
+		// Verify the metric reporter initialized.
+		metricsSkipped := zapLogs.FilterMessageSnippet("Skipping metrics logging")
+		assert.NotEmpty(c, metricsSkipped.All(), "metric reporter did not initialize")
 
 		// Verify that packetbeat decoded and forwarded at least one event from the pcap.
 		assert.Positive(c, sink.LogRecordCount(), "expected at least one log record from pcap replay")
@@ -228,10 +228,10 @@ func TestMultipleReceivers(t *testing.T) {
 		r2StartLogs := zapLogs.FilterMessageSnippet("Beat ID").FilterField(zap.String("otelcol.component.id", "packetbeatreceiver/r2"))
 		assert.Equal(c, 1, r2StartLogs.Len(), "r2 should have a single start log")
 
-		r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "packetbeatreceiver/r1"))
-		assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single start metrics logging every 30s")
-		r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Starting metrics logging every 30s").FilterField(zap.String("otelcol.component.id", "packetbeatreceiver/r2"))
-		assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single start metrics logging every 30s")
+		r1StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "packetbeatreceiver/r1"))
+		assert.Equalf(c, 1, r1StartMetricsLogs.Len(), "r1 should have a single skipping metrics logging entry")
+		r2StartMetricsLogs := zapLogs.FilterMessageSnippet("Skipping metrics logging").FilterField(zap.String("otelcol.component.id", "packetbeatreceiver/r2"))
+		assert.Equalf(c, 1, r2StartMetricsLogs.Len(), "r2 should have a single skipping metrics logging entry")
 
 		// Verify monitoring sockets.
 		var lastError strings.Builder


### PR DESCRIPTION
## Proposed commit message

Disable periodic metrics logging for beats receivers by default.

Beats receivers emit metrics via the otel collector telemetry provider, including the Prometheus endpoint enabled by default. The snapshots are both noisy and surprisingly expensive to produce in some environments. Disable them by default.

This is done by setting a default before config unmarshalling in the shared beat instance constructor. The rest of the PR consists of updates to unit tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

Build the test distribution, run a filebeat receiver, and notice the lack of snapshot logs.

## Related issues

- Relates https://github.com/elastic/beats/issues/51459
