### PR TITLE
x-pack/filebeat/input/streaming: fix CrowdStrike retry cap and soften transient handling

### DIFF
--- a/changelog/fragments/1783081692-fix-crowdstrike-streaming-retry-cap.yaml
+++ b/changelog/fragments/1783081692-fix-crowdstrike-streaming-retry-cap.yaml
@@ -1,0 +1,37 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix CrowdStrike streaming input retry cap so max_attempts and infinite_retries are honoured.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Fix the CrowdStrike streaming input retry loop so a configured max_attempts
+  greater than 10 and infinite_retries are no longer silently capped at the
+  unconfigured default of 10. The empty-body case from the discover endpoint is
+  now reported as a distinct transient error, and the input no longer reports
+  DEGRADED on the first transient failure.
+
+# Affected component; a word indicating the component this changeset affects.
+component: filebeat
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -248,6 +248,10 @@ func (s *falconHoseStream) FollowStream(ctx context.Context) error {
 	var err error
 	attempt := 0
 	const maxAttemptsUnconfigured = 10
+	// Number of consecutive failures tolerated before reporting DEGRADED,
+	// so a single transient blip (e.g. an empty discover response) does not
+	// churn the unit health status.
+	const degradeAfterAttempts = 3
 	for {
 		state, err = s.followSession(ctx, cli, state)
 		if err != nil {
@@ -262,8 +266,14 @@ func (s *falconHoseStream) FollowStream(ctx context.Context) error {
 
 			attempt++
 
-			if s.cfg.Retry != nil && !s.cfg.Retry.InfiniteRetries && attempt >= s.cfg.Retry.MaxAttempts {
-				return fmt.Errorf("max retry attempts (%d) exceeded: %w", s.cfg.Retry.MaxAttempts, err)
+			// The unconfigured cap must only apply when no retry policy is
+			// set. Keeping it as an else-if on the configured branch caused
+			// infinite_retries and max_attempts > 10 to be silently capped
+			// at 10.
+			if s.cfg.Retry != nil {
+				if !s.cfg.Retry.InfiniteRetries && attempt >= s.cfg.Retry.MaxAttempts {
+					return fmt.Errorf("max retry attempts (%d) exceeded: %w", s.cfg.Retry.MaxAttempts, err)
+				}
 			} else if attempt >= maxAttemptsUnconfigured {
 				return fmt.Errorf("max retry attempts (%d unconfigured) exceeded: %w", maxAttemptsUnconfigured, err)
 			}
@@ -280,7 +290,9 @@ func (s *falconHoseStream) FollowStream(ctx context.Context) error {
 				waitTime = rle.wait
 			}
 
-			s.status.UpdateStatus(status.Degraded, err.Error())
+			if attempt >= degradeAfterAttempts {
+				s.status.UpdateStatus(status.Degraded, err.Error())
+			}
 			s.log.Warnw("session warning", "error", err, "attempt", attempt, "wait", waitTime.String())
 
 			select {
@@ -310,9 +322,10 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	}
 	resp, err := cli.Do(req)
 	if err != nil {
-		err = fmt.Errorf("failed GET to discover stream: %w", err)
-		s.status.UpdateStatus(status.Degraded, err.Error())
-		return state, err
+		// Status transitions are owned by the FollowStream retry loop so
+		// that a single transient failure does not immediately report
+		// DEGRADED; just return the error here.
+		return state, fmt.Errorf("failed GET to discover stream: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -354,6 +367,13 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	}
 	err = dec.Decode(&body)
 	if err != nil {
+		// A 200 response with an empty body yields io.EOF from Decode. This
+		// is a transient upstream condition (the discover endpoint
+		// occasionally returns no content), distinct from a malformed body,
+		// so surface it clearly rather than as a generic decode failure.
+		if errors.Is(err, io.EOF) {
+			return state, errors.New("discover stream returned an empty body")
+		}
 		return state, fmt.Errorf("failed to decode discover body: %w", err)
 	}
 	s.log.Debugw("stream discover metadata", logp.Namespace(s.ns), "meta", mapstr.M(body.Meta))

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	cursor "github.com/elastic/beats/v7/filebeat/input/v2/input-cursor"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
@@ -295,6 +297,164 @@ func TestCrowdstrikeOAuthHTTPClientRespectsConfiguredTimeout(t *testing.T) {
 	if elapsed > tokenDelay {
 		t.Fatalf("expected FollowStream to fail before server delay %v, but it took %v: %v", tokenDelay, elapsed, err)
 	}
+}
+
+func TestFollowStreamRetryCapHonorsMaxAttempts(t *testing.T) {
+	logp.TestingSetup()
+
+	discoverURL, tokenURL, hits := startEmptyDiscover(t)
+	const maxAttempts = 15 // Deliberately > the unconfigured cap of 10.
+	cfg := emptyDiscoverConfig(t, discoverURL, tokenURL, &retry{MaxAttempts: maxAttempts, WaitMin: time.Millisecond, WaitMax: time.Millisecond})
+	s := newEmptyDiscoverFollower(t, cfg, nil)
+
+	err := s.FollowStream(context.Background())
+	if err == nil {
+		t.Fatal("FollowStream() error = nil; want max-attempts error")
+	}
+	// Regression: a configured MaxAttempts greater than 10 must be honoured,
+	// not silently capped at the unconfigured default of 10.
+	want := fmt.Sprintf("max retry attempts (%d) exceeded", maxAttempts)
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("FollowStream() error = %v; want substring %q", err, want)
+	}
+	if got := hits.Load(); got != int64(maxAttempts) {
+		t.Errorf("discover attempts = %d; want %d", got, maxAttempts)
+	}
+}
+
+func TestFollowStreamInfiniteRetriesDoesNotCap(t *testing.T) {
+	logp.TestingSetup()
+
+	discoverURL, tokenURL, hits := startEmptyDiscover(t)
+	// MaxAttempts is intentionally tiny: InfiniteRetries must override it and
+	// the unconfigured cap of 10 entirely.
+	cfg := emptyDiscoverConfig(t, discoverURL, tokenURL, &retry{InfiniteRetries: true, MaxAttempts: 1, WaitMin: time.Millisecond, WaitMax: time.Millisecond})
+	s := newEmptyDiscoverFollower(t, cfg, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.FollowStream(ctx) }()
+
+	// Wait until well past the unconfigured cap to prove the input keeps
+	// retrying, then cancel.
+	deadline := time.After(10 * time.Second)
+	for hits.Load() <= 12 {
+		select {
+		case <-deadline:
+			t.Fatalf("discover attempts = %d before timeout; want > 12", hits.Load())
+		case err := <-done:
+			t.Fatalf("FollowStream returned early after %d attempts: %v", hits.Load(), err)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("FollowStream() error = %v; want nil after context cancel", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for FollowStream to return after cancel")
+	}
+}
+
+func TestFollowStreamDefersDegraded(t *testing.T) {
+	logp.TestingSetup()
+
+	discoverURL, tokenURL, _ := startEmptyDiscover(t)
+	// With MaxAttempts=5 and the degrade threshold of 3, the input reports
+	// DEGRADED only on attempts 3 and 4, then terminates on attempt 5 without
+	// reporting DEGRADED on the earlier transient failures.
+	cfg := emptyDiscoverConfig(t, discoverURL, tokenURL, &retry{MaxAttempts: 5, WaitMin: time.Millisecond, WaitMax: time.Millisecond})
+	rec := &degradedRecorder{}
+	s := newEmptyDiscoverFollower(t, cfg, rec)
+
+	if err := s.FollowStream(context.Background()); err == nil {
+		t.Fatal("FollowStream() error = nil; want max-attempts error")
+	}
+	if got := rec.count(); got != 2 {
+		t.Errorf("DEGRADED reports = %d; want 2 (attempts 3 and 4 only)", got)
+	}
+}
+
+// startEmptyDiscover starts a token endpoint and a discover endpoint that
+// returns 200 with an empty body (the transient EOF condition observed from
+// CrowdStrike), returning the discover URL, token URL, and a counter of
+// discover requests.
+func startEmptyDiscover(t *testing.T) (discoverURL, tokenURL string, hits *atomic.Int64) {
+	t.Helper()
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"token","token_type":"bearer","expires_in":3600}`)
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	hits = new(atomic.Int64)
+	discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+	}))
+	t.Cleanup(discoverSrv.Close)
+	return discoverSrv.URL, tokenSrv.URL, hits
+}
+
+func emptyDiscoverConfig(t *testing.T, discoverURL, tokenURL string, r *retry) config {
+	t.Helper()
+	u, err := url.Parse(discoverURL)
+	if err != nil {
+		t.Fatalf("failed to parse discover URL: %v", err)
+	}
+	return config{
+		Type: "crowdstrike",
+		URL:  &urlConfig{u},
+		Auth: authConfig{
+			OAuth2: oAuth2Config{
+				ClientID:     "id",
+				ClientSecret: "secret",
+				TokenURL:     tokenURL,
+			},
+		},
+		CrowdstrikeAppID: "test",
+		Retry:            r,
+		Program: `
+			state.response.decode_json().as(body,{
+				"events": [body],
+			})`,
+	}
+}
+
+func newEmptyDiscoverFollower(t *testing.T, cfg config, stat status.StatusReporter) StreamFollower {
+	t.Helper()
+	log := logp.NewNopLogger()
+	env := v2.Context{ID: "crowdstrike_test", MetricsRegistry: monitoring.NewRegistry()}
+	s, err := NewFalconHoseFollower(context.Background(), env, cfg, nil, &testPublisher{log}, stat, log, time.Now)
+	if err != nil {
+		t.Fatalf("failed to construct follower: %v", err)
+	}
+	return s
+}
+
+// degradedRecorder counts the number of times DEGRADED is reported.
+type degradedRecorder struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (r *degradedRecorder) UpdateStatus(s status.Status, _ string) {
+	if s != status.Degraded {
+		return
+	}
+	r.mu.Lock()
+	r.n++
+	r.mu.Unlock()
+}
+
+func (r *degradedRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.n
 }
 
 func TestFollowStreamCancelsRefreshOnReconnect(t *testing.T) {

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -300,12 +299,12 @@ func TestCrowdstrikeOAuthHTTPClientRespectsConfiguredTimeout(t *testing.T) {
 }
 
 func TestFollowStreamRetryCapHonorsMaxAttempts(t *testing.T) {
-	logp.TestingSetup()
+	log := logptest.NewTestingLogger(t, t.Name())
 
 	discoverURL, tokenURL, hits := startEmptyDiscover(t)
 	const maxAttempts = 15 // Deliberately > the unconfigured cap of 10.
 	cfg := emptyDiscoverConfig(t, discoverURL, tokenURL, &retry{MaxAttempts: maxAttempts, WaitMin: time.Millisecond, WaitMax: time.Millisecond})
-	s := newEmptyDiscoverFollower(t, cfg, nil)
+	s := newEmptyDiscoverFollower(t, cfg, nil, log)
 
 	err := s.FollowStream(context.Background())
 	if err == nil {
@@ -323,13 +322,13 @@ func TestFollowStreamRetryCapHonorsMaxAttempts(t *testing.T) {
 }
 
 func TestFollowStreamInfiniteRetriesDoesNotCap(t *testing.T) {
-	logp.TestingSetup()
+	log := logptest.NewTestingLogger(t, t.Name())
 
 	discoverURL, tokenURL, hits := startEmptyDiscover(t)
 	// MaxAttempts is intentionally tiny: InfiniteRetries must override it and
 	// the unconfigured cap of 10 entirely.
 	cfg := emptyDiscoverConfig(t, discoverURL, tokenURL, &retry{InfiniteRetries: true, MaxAttempts: 1, WaitMin: time.Millisecond, WaitMax: time.Millisecond})
-	s := newEmptyDiscoverFollower(t, cfg, nil)
+	s := newEmptyDiscoverFollower(t, cfg, nil, log)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -361,7 +360,7 @@ func TestFollowStreamInfiniteRetriesDoesNotCap(t *testing.T) {
 }
 
 func TestFollowStreamDefersDegraded(t *testing.T) {
-	logp.TestingSetup()
+	log := logptest.NewTestingLogger(t, t.Name())
 
 	discoverURL, tokenURL, _ := startEmptyDiscover(t)
 	// With MaxAttempts=5 and the degrade threshold of 3, the input reports
@@ -369,7 +368,7 @@ func TestFollowStreamDefersDegraded(t *testing.T) {
 	// reporting DEGRADED on the earlier transient failures.
 	cfg := emptyDiscoverConfig(t, discoverURL, tokenURL, &retry{MaxAttempts: 5, WaitMin: time.Millisecond, WaitMax: time.Millisecond})
 	rec := &degradedRecorder{}
-	s := newEmptyDiscoverFollower(t, cfg, rec)
+	s := newEmptyDiscoverFollower(t, cfg, rec, log)
 
 	if err := s.FollowStream(context.Background()); err == nil {
 		t.Fatal("FollowStream() error = nil; want max-attempts error")
@@ -425,9 +424,8 @@ func emptyDiscoverConfig(t *testing.T, discoverURL, tokenURL string, r *retry) c
 	}
 }
 
-func newEmptyDiscoverFollower(t *testing.T, cfg config, stat status.StatusReporter) StreamFollower {
+func newEmptyDiscoverFollower(t *testing.T, cfg config, stat status.StatusReporter, log *logp.Logger) StreamFollower {
 	t.Helper()
-	log := logp.NewNopLogger()
 	env := v2.Context{ID: "crowdstrike_test", MetricsRegistry: monitoring.NewRegistry()}
 	s, err := NewFalconHoseFollower(context.Background(), env, cfg, nil, &testPublisher{log}, stat, log, time.Now)
 	if err != nil {
@@ -438,23 +436,17 @@ func newEmptyDiscoverFollower(t *testing.T, cfg config, stat status.StatusReport
 
 // degradedRecorder counts the number of times DEGRADED is reported.
 type degradedRecorder struct {
-	mu sync.Mutex
-	n  int
+	n atomic.Int64
 }
 
 func (r *degradedRecorder) UpdateStatus(s status.Status, _ string) {
-	if s != status.Degraded {
-		return
+	if s == status.Degraded {
+		r.n.Add(1)
 	}
-	r.mu.Lock()
-	r.n++
-	r.mu.Unlock()
 }
 
-func (r *degradedRecorder) count() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.n
+func (r *degradedRecorder) count() int64 {
+	return r.n.Load()
 }
 
 func TestFollowStreamCancelsRefreshOnReconnect(t *testing.T) {

--- a/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	cursor "github.com/elastic/beats/v7/filebeat/input/v2/input-cursor"
@@ -65,8 +66,6 @@ func TestFollowSession_FirehoseHTTPError(t *testing.T) {
 }
 
 func TestFollowSession_EmptyDiscoverBody(t *testing.T) {
-	logp.TestingSetup()
-
 	discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// A 200 OK with an empty body, as observed from the CrowdStrike
 		// discover endpoint; Decode returns io.EOF.
@@ -176,7 +175,7 @@ func newTestStream(t *testing.T, discoverURL string, firehoseClient *http.Client
 
 func newTestStreamWithPublisher(t *testing.T, discoverURL string, firehoseClient *http.Client, pub cursor.Publisher) *falconHoseStream {
 	t.Helper()
-	log := logp.L()
+	log := logptest.NewTestingLogger(t, t.Name())
 	reg := monitoring.NewRegistry()
 	m := newInputMetrics(reg, log)
 

--- a/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
@@ -64,6 +64,29 @@ func TestFollowSession_FirehoseHTTPError(t *testing.T) {
 	}
 }
 
+func TestFollowSession_EmptyDiscoverBody(t *testing.T) {
+	logp.TestingSetup()
+
+	discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A 200 OK with an empty body, as observed from the CrowdStrike
+		// discover endpoint; Decode returns io.EOF.
+		w.Header().Set("Content-Type", "application/json")
+	}))
+	defer discoverSrv.Close()
+
+	s := newTestStream(t, discoverSrv.URL, discoverSrv.Client())
+	state, err := s.followSession(context.Background(), discoverSrv.Client(), map[string]any{})
+	if err == nil {
+		t.Fatal("expected error from followSession, got nil")
+	}
+	if want := "discover stream returned an empty body"; !strings.Contains(err.Error(), want) {
+		t.Errorf("followSession() error = %v; want substring %q", err, want)
+	}
+	if state == nil {
+		t.Error("expected non-nil state on non-hard error")
+	}
+}
+
 func TestFollowSession_NonObjectMessage(t *testing.T) {
 	logp.TestingSetup()
 


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: fix CrowdStrike retry cap and soften transient handling

The CrowdStrike FalconHose discover retry loop capped every run at 10
attempts: the unconfigured maximum was checked as an else-if on the
configured branch, so max_attempts greater than 10 and infinite_retries
were silently limited to 10, terminating the input and requiring a
restart during longer upstream outages. Apply the unconfigured cap only
when no retry policy is set so configured limits and infinite_retries
are honoured.

A 200 response with an empty discover body (io.EOF from Decode) is now
reported as a distinct transient error rather than a generic decode
failure, and DEGRADED is only reported after three consecutive failures
so a single transient blip no longer churns the unit health status. The
discover GET failure no longer updates status inside followSession; the
retry loop owns those transitions.

Add regression tests for the retry cap, infinite_retries, deferred
DEGRADED reporting, and the empty-body discover response.

Assisted-By: Cursor (Claude Opus 4.8)
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
