### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/azuread: bump entcollect for sign-in activity

### DIFF
--- a/changelog/fragments/1783306449-entcollect-signin-activity.yaml
+++ b/changelog/fragments/1783306449-entcollect-signin-activity.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add sign-in activity enrichment to the minimal-state EntraID entity analytics provider.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.4.1
 	github.com/cilium/ebpf v0.21.0
 	github.com/coder/websocket v1.8.14
-	github.com/elastic/entcollect v0.0.0-20260617022524-00a42d67f0df
+	github.com/elastic/entcollect v0.0.0-20260706024408-4a12ea00f54d
 	github.com/elastic/gokrb5/v8 v8.0.0-20251105095404-23cc45e6a102
 	github.com/jimlambrt/gldap v0.1.14
 	github.com/mattn/go-sqlite3 v1.14.32

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/elastic/elastic-agent-system-metrics v0.14.4 h1:XGGepNVOxhtfJmanQsgqC
 github.com/elastic/elastic-agent-system-metrics v0.14.4/go.mod h1:NyNMrdqMfznb/Zy8EmIAHlJpX6HuRlNW+bBL9UN7WQY=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
 github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/entcollect v0.0.0-20260617022524-00a42d67f0df h1:SVO1bpxnpZmVkgzqcLImLkVVWWfFZASPdTYrJ9hWZ6k=
-github.com/elastic/entcollect v0.0.0-20260617022524-00a42d67f0df/go.mod h1:ZcfSL3oNJg0mhiYrWNJnf/NeetQHr7HlkY4iWCjSGWo=
+github.com/elastic/entcollect v0.0.0-20260706024408-4a12ea00f54d h1:Xt7wszp8UIYLhuMIvl4oTA22QGrsjzfxcKVUn59o8QM=
+github.com/elastic/entcollect v0.0.0-20260706024408-4a12ea00f54d/go.mod h1:ZcfSL3oNJg0mhiYrWNJnf/NeetQHr7HlkY4iWCjSGWo=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQVCpGSRXmLqjEHpJKbR60rxh1nQZY4=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/fsnotify v1.6.1-0.20240920222514-49f82bdbc9e3 h1:UyNbxdkQiSfyipwsOCWAlO+ju3xXC61Z4prx/HBTtFk=

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/equivalence_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/equivalence_test.go
@@ -50,6 +50,8 @@ import (
 //   - Legacy puts MFA under azure_ad.mfa (fetcher.MFARegistrationDetails);
 //     entcollect puts MFA under user.risk.mfa (ecentraid.MFADetails).
 //     MFA user-ID coverage is compared; field values are not.
+//   - Sign-in activity uses the same field path (azure_ad.signInActivity)
+//     on both sides with compatible JSON tags, so values are compared.
 //   - event.kind: asset present only in minimal-state (set by adapter).
 //   - event.action format differs: legacy uses "user-discovered" etc.;
 //     minimal-state uses entcollect.ActionDiscovered.
@@ -60,7 +62,7 @@ import (
 //     Users migrating configs will see different ownership document shapes
 //     in production.
 func TestEquivalence_FullSync(t *testing.T) {
-	legacyUsers, legacyDevices, legacyUserGroups, legacyDeviceGroups, legacyMFAUserIDs := runLegacyFetch(t)
+	legacyUsers, legacyDevices, legacyUserGroups, legacyDeviceGroups, legacyMFAUserIDs, legacySignIn := runLegacyFetch(t)
 
 	srv := startEquivGraphServer(t)
 	minimalDocs := runMinimalFullSync(t, srv)
@@ -82,6 +84,7 @@ func TestEquivalence_FullSync(t *testing.T) {
 	compareGroups(t, "device", legacyDeviceGroups, minimalDevices, "device.group")
 
 	compareMFACoverage(t, legacyMFAUserIDs, minimalUsers)
+	compareSignInActivity(t, legacySignIn, minimalUsers)
 
 	// Sanity: verify we actually compared non-trivial data.
 	if len(legacyUsers) == 0 {
@@ -99,18 +102,23 @@ func TestEquivalence_FullSync(t *testing.T) {
 	if len(legacyMFAUserIDs) == 0 {
 		t.Error("sanity: no legacy MFA user IDs")
 	}
+	if len(legacySignIn) == 0 {
+		t.Error("sanity: no legacy sign-in activity data")
+	}
 }
 
 // runLegacyFetch runs the legacy doFetch path with the mock fetcher and
-// extracts entity payloads, group memberships, and MFA user-ID coverage.
+// extracts entity payloads, group memberships, MFA user-ID coverage,
+// and sign-in activity data.
 func runLegacyFetch(t *testing.T) (
 	users, devices []idPayload,
 	userGroups, deviceGroups map[string][]groupECS,
 	mfaUserIDs []string,
+	signInActivity map[string]json.RawMessage,
 ) {
 	t.Helper()
 	a := azure{
-		conf:    conf{Dataset: "all", EnrichWith: []string{"mfa"}},
+		conf:    conf{Dataset: "all", EnrichWith: []string{"mfa", "sign_in_activity"}},
 		logger:  logptest.NewTestingLogger(t, "test-legacy"),
 		auth:    mockauth.New(""),
 		fetcher: mockfetcher.New(),
@@ -127,6 +135,7 @@ func runLegacyFetch(t *testing.T) (
 	}
 
 	userGroups = make(map[string][]groupECS)
+	signInActivity = make(map[string]json.RawMessage)
 	for _, u := range ss.users {
 		b, err := json.Marshal(u.Fields)
 		if err != nil {
@@ -148,6 +157,13 @@ func runLegacyFetch(t *testing.T) (
 
 		if u.MFA != nil {
 			mfaUserIDs = append(mfaUserIDs, u.ID.String())
+		}
+		if u.SignInActivity != nil {
+			raw, err := json.Marshal(u.SignInActivity)
+			if err != nil {
+				t.Fatal(err)
+			}
+			signInActivity[u.ID.String()] = raw
 		}
 	}
 
@@ -172,7 +188,7 @@ func runLegacyFetch(t *testing.T) (
 		}
 	}
 
-	return users, devices, userGroups, deviceGroups, mfaUserIDs
+	return users, devices, userGroups, deviceGroups, mfaUserIDs, signInActivity
 }
 
 // runMinimalFullSync runs the entcollect FullSync path against the httptest
@@ -187,7 +203,7 @@ func runMinimalFullSync(t *testing.T, srv *httptest.Server) []entcollect.Documen
 	cfg.LoginEndpoint = srv.URL
 	cfg.APIEndpoint = srv.URL + "/v1.0"
 	cfg.Dataset = "all"
-	cfg.EnrichWith = []string{"mfa"}
+	cfg.EnrichWith = []string{"mfa", "sign_in_activity"}
 
 	p := ecentraid.NewWithClient(cfg, srv.Client())
 
@@ -290,6 +306,15 @@ func startEquivGraphServer(t *testing.T) *httptest.Server {
 		_ = json.NewEncoder(w).Encode(map[string]any{"value": mockMFAAsGraphJSON()})
 	})
 
+	// Sign-in activity.
+	mux.HandleFunc("GET /v1.0/users", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("$select") != "id,signInActivity" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": mockSignInActivityAsGraphJSON()})
+	})
+
 	srv := httptest.NewServer(mux)
 	srvURL = srv.URL
 	t.Cleanup(srv.Close)
@@ -364,6 +389,27 @@ func mockMFAAsGraphJSON() []map[string]any {
 			"methodsRegistered":     mfa.MethodsRegistered,
 			"userPreferredMethodForSecondaryAuthentication": mfa.UserPreferredMethodForSecondaryAuthentication,
 			"userType": mfa.UserType,
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// mockSignInActivityAsGraphJSON converts mock fetcher sign-in activity data
+// into Graph API response entries with nested signInActivity objects.
+func mockSignInActivityAsGraphJSON() []map[string]any {
+	var result []map[string]any
+	for userID, sia := range mockfetcher.SignInActivityResponse {
+		entry := map[string]any{
+			"id": userID.String(),
+			"signInActivity": map[string]any{
+				"lastSignInDateTime":                sia.LastSignInDateTime,
+				"lastSignInRequestId":               sia.LastSignInRequestId,
+				"lastNonInteractiveSignInDateTime":  sia.LastNonInteractiveSignInDateTime,
+				"lastNonInteractiveSignInRequestId": sia.LastNonInteractiveSignInRequestId,
+				"lastSuccessfulSignInDateTime":      sia.LastSuccessfulSignInDateTime,
+				"lastSuccessfulSignInRequestId":     sia.LastSuccessfulSignInRequestId,
+			},
 		}
 		result = append(result, entry)
 	}
@@ -492,6 +538,61 @@ func compareMFACoverage(t *testing.T, legacyMFAUserIDs []string, minimalUsers []
 	for i := range legacyMFAUserIDs {
 		if legacyMFAUserIDs[i] != minimalMFAUserIDs[i] {
 			t.Errorf("MFA user-ID[%d] mismatch: legacy=%q, minimal=%q", i, legacyMFAUserIDs[i], minimalMFAUserIDs[i])
+		}
+	}
+}
+
+// compareSignInActivity checks that the same set of user IDs received
+// sign-in activity enrichment and that the JSON-serialized values match.
+// Unlike MFA (which uses different field paths), both providers publish
+// sign-in activity at azure_ad.signInActivity with compatible JSON tags,
+// so values can be compared directly.
+func compareSignInActivity(t *testing.T, legacySignIn map[string]json.RawMessage, minimalUsers []entcollect.Document) {
+	t.Helper()
+
+	minimalSignIn := make(map[string]json.RawMessage)
+	for _, doc := range minimalUsers {
+		raw, ok := doc.Fields["azure_ad.signInActivity"]
+		if !ok {
+			continue
+		}
+		b, err := json.Marshal(raw)
+		if err != nil {
+			t.Fatalf("marshal minimal sign-in activity for %s: %v", doc.ID, err)
+		}
+		minimalSignIn[doc.ID] = b
+	}
+
+	if len(legacySignIn) != len(minimalSignIn) {
+		t.Errorf("sign-in activity user count mismatch: legacy=%d, minimal=%d", len(legacySignIn), len(minimalSignIn))
+	}
+
+	for id, legacyRaw := range legacySignIn {
+		minimalRaw, ok := minimalSignIn[id]
+		if !ok {
+			t.Errorf("sign-in activity for user %q: present in legacy, missing in minimal", id)
+			continue
+		}
+
+		var legacyMap, minimalMap map[string]any
+		if err := json.Unmarshal(legacyRaw, &legacyMap); err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(minimalRaw, &minimalMap); err != nil {
+			t.Fatal(err)
+		}
+
+		legacyNorm, _ := json.Marshal(legacyMap)
+		minimalNorm, _ := json.Marshal(minimalMap)
+		if string(legacyNorm) != string(minimalNorm) {
+			t.Errorf("sign-in activity for user %q value mismatch:\n  legacy:  %s\n  minimal: %s",
+				id, legacyNorm, minimalNorm)
+		}
+	}
+
+	for id := range minimalSignIn {
+		if _, ok := legacySignIn[id]; !ok {
+			t.Errorf("sign-in activity for user %q: present in minimal, missing in legacy", id)
 		}
 	}
 }


### PR DESCRIPTION
`<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics/provider/azuread: bump entcollect for sign-in activity

Bump entcollect to pick up sign-in activity enrichment support in the
EntraID provider. The minimal-state adapter already passes enrich_with
through, so no code changes are needed for runtime behaviour.

Add a sign-in activity case to the equivalence test. Unlike MFA (where
legacy and entcollect use different field paths), sign-in activity
publishes at azure_ad.signInActivity on both sides, so the test
compares values, not just user-ID coverage.

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #50774

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
