### PR TITLE
winlogbeat: fix winlog crash and event loss on shutdown

### DIFF
--- a/changelog/fragments/1783321186-fix-winlog-shutdown-render-crash.yaml
+++ b/changelog/fragments/1783321186-fix-winlog-shutdown-render-crash.yaml
@@ -1,0 +1,30 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix winlog input crash and event loss during shutdown
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  The winlog input could crash with a native access violation (0xc0000005)
+  during shutdown when the event log was closed while a Read was still
+  rendering an event. The event log was closed asynchronously from a
+  context-cancellation callback on a different goroutine than the read loop,
+  so closing freed the native Windows Event Log handles (subscription, render
+  contexts and publisher metadata) while in-flight EvtRender/EvtFormatMessage
+  calls were still using them. The crash restarted the component and dropped
+  in-flight events. The event log is now closed on the same goroutine as the
+  read loop, after it has stopped, eliminating the race.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat

--- a/winlogbeat/eventlog/runner.go
+++ b/winlogbeat/eventlog/runner.go
@@ -30,7 +30,6 @@ import (
 	"github.com/elastic/beats/v7/winlogbeat/checkpoint"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
-	"github.com/elastic/go-concert/ctxtool"
 	"github.com/elastic/go-concert/timed"
 )
 
@@ -59,16 +58,25 @@ func Run(
 	defer runtime.UnlockOSThread()
 
 	reporter.UpdateStatus(status.Starting, fmt.Sprintf("Starting to read from %s", api.Channel()))
-	// setup closing the API if either the run function is signaled asynchronously
-	// to shut down or when returning after io.EOF
-	cancelCtx, cancelFn := ctxtool.WithFunc(
-		ctx,
-		func() {
-			if err := api.Close(); err != nil {
-				log.Errorw("error while closing Windows Event Log access", "error", err)
-			}
-		})
+
+	cancelCtx, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
+
+	// Close the event log on this same goroutine once the read loop has
+	// returned, rather than asynchronously from a context-cancellation
+	// callback. Closing frees native Windows Event Log handles (subscription,
+	// render contexts and publisher metadata). If that happens on another
+	// goroutine while a Read is rendering an event, the in-flight
+	// EvtRender/EvtFormatMessage calls operate on freed handles and the
+	// process crashes with an access violation (0xc0000005) during shutdown.
+	// Reads are non-blocking (EvtNext uses a zero timeout) and the loop below
+	// exits promptly when cancelCtx is cancelled, so closing here keeps
+	// shutdown responsive without racing an active render.
+	defer func() {
+		if err := api.Close(); err != nil {
+			log.Errorw("error while closing Windows Event Log access", "error", err)
+		}
+	}()
 
 	openChannelNotFoundErrDetected := false
 	logChannelNotFoundOpenRetry := func(err error) {

--- a/winlogbeat/eventlog/runner_test.go
+++ b/winlogbeat/eventlog/runner_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -167,6 +168,112 @@ func (l *replayingGapEventLog) IsFile() bool {
 func (l *replayingGapEventLog) IgnoreMissingChannel() bool {
 	return false
 }
+
+// TestRunClosesEventLogWithoutRacingRead verifies that when the runner's
+// context is cancelled while a Read is in progress, the event log is not
+// closed until that Read has returned. Closing the event log frees native
+// Windows Event Log handles; doing so concurrently with an in-flight
+// Read/render previously caused an access violation crash during shutdown.
+func TestRunClosesEventLogWithoutRacingRead(t *testing.T) {
+	api := &concurrencyProbeEventLog{readStarted: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(
+			noOpStatusReporter{},
+			ctx,
+			monitoring.NewRegistry(),
+			api,
+			checkpoint.EventLogState{Name: "System"},
+			noOpPublisher{},
+			logp.NewLogger("eventlog_runner_test"),
+		)
+	}()
+
+	// Cancel only once a Read is actively in progress so that a close racing
+	// the read would be observable.
+	<-api.readStarted
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+
+	require.False(t, api.observedOverlap(), "Close must not run while a Read is in progress")
+	require.True(t, api.wasClosed(), "event log must be closed when the runner returns")
+}
+
+// concurrencyProbeEventLog records whether Read and Close ever overlap.
+type concurrencyProbeEventLog struct {
+	mu          sync.Mutex
+	reading     bool
+	overlap     bool
+	closed      bool
+	readStarted chan struct{}
+	signalOnce  sync.Once
+}
+
+func (l *concurrencyProbeEventLog) Open(_ checkpoint.EventLogState, _ *monitoring.Registry) error {
+	return nil
+}
+
+func (l *concurrencyProbeEventLog) Checkpoint() checkpoint.EventLogState {
+	return checkpoint.EventLogState{Name: "System"}
+}
+
+func (l *concurrencyProbeEventLog) Read() ([]Record, error) {
+	l.mu.Lock()
+	if l.closed {
+		l.overlap = true
+	}
+	l.reading = true
+	l.mu.Unlock()
+
+	l.signalOnce.Do(func() { close(l.readStarted) })
+
+	// Keep the read in progress long enough to expose a racing close.
+	time.Sleep(50 * time.Millisecond)
+
+	l.mu.Lock()
+	l.reading = false
+	l.mu.Unlock()
+	return nil, nil
+}
+
+func (l *concurrencyProbeEventLog) Reset() error { return nil }
+
+func (l *concurrencyProbeEventLog) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.reading {
+		l.overlap = true
+	}
+	l.closed = true
+	return nil
+}
+
+func (l *concurrencyProbeEventLog) observedOverlap() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.overlap
+}
+
+func (l *concurrencyProbeEventLog) wasClosed() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.closed
+}
+
+func (l *concurrencyProbeEventLog) Name() string               { return "System" }
+func (l *concurrencyProbeEventLog) Channel() string            { return "System" }
+func (l *concurrencyProbeEventLog) IsFile() bool               { return false }
+func (l *concurrencyProbeEventLog) IgnoreMissingChannel() bool { return false }
 
 type noOpPublisher struct{}
 


### PR DESCRIPTION
## Proposed commit message

The `winlog` input could crash with a native access violation (`0xc0000005`) during shutdown when the event log was closed while a `Read` was still rendering an event.

- **WHAT**: close the event log on the same goroutine as the read loop (after it returns) instead of asynchronously from a context-cancellation callback (`ctxtool.WithFunc`).
- **WHY**: closing frees native Windows Event Log handles (subscription, render contexts and publisher metadata). Doing so on a different goroutine while a `Read` was in-flight let the native `EvtRender`/`EvtFormatMessage` calls operate on freed handles, crashing the `winlog` component and dropping all in-flight events. The crash was surfaced by the shutdown-ordering change in #50677, which keeps inputs running slightly longer during shutdown, widening the race window. `Read` is non-blocking (`EvtNext` uses a zero timeout) and the loop exits promptly on cancellation, so closing after the loop keeps shutdown responsive without racing an active render.

The crash observed in the field (German locale, Windows Server 2019), right after `Closing event log reader handles.`:

```
Exception 0xc0000005 0x0 0x264ee66980a 0x7ff8525a80b4
signal arrived during external code execution
runtime.cgocall(...)
  _EvtFormatMessage -> FormatEventString -> RenderEvent -> XMLRenderer.Render
  -> winEventLog.processHandle -> winEventLog.Read
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. This fixes a shutdown-time crash and the associated event loss. Behavior during normal operation is unchanged.

## How to test this PR locally

```bash
go test ./winlogbeat/eventlog/ -run TestRunClosesEventLogWithoutRacingRead -race -count=1 -v
```

The new test cancels the runner's context while a `Read` is in progress and asserts that `Close` (which frees the native handles) never runs concurrently with an in-flight `Read`.

## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/7273
- Relates #50677

## Logs

The added test is a regression guard: it fails against the pre-fix runner (async close) and passes with the fix.

```
### WITHOUT FIX ###
=== RUN   TestRunClosesEventLogWithoutRacingRead
    runner_test.go:208:
        	Error Trace:	winlogbeat/eventlog/runner_test.go:208
        	Error:      	Should be false
        	Test:       	TestRunClosesEventLogWithoutRacingRead
        	Messages:   	Close must not run while a Read is in progress
--- FAIL: TestRunClosesEventLogWithoutRacingRead (0.05s)
FAIL	github.com/elastic/beats/v7/winlogbeat/eventlog	0.056s
(go test exit: 1)

### WITH FIX (with -race) ###
=== RUN   TestRunClosesEventLogWithoutRacingRead
--- PASS: TestRunClosesEventLogWithoutRacingRead (0.05s)
ok  	github.com/elastic/beats/v7/winlogbeat/eventlog	1.066s
(go test exit: 0)
```