### PR TITLE
libbeat/processors/ratelimit: sort key fields once to avoid data race

### DIFF
--- a/changelog/fragments/1783323647-ratelimit-fields-data-race.yaml
+++ b/changelog/fragments/1783323647-ratelimit-fields-data-race.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix a data race in the rate_limit processor when configured with fields and run concurrently.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: libbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/libbeat/processors/ratelimit/rate_limit.go
+++ b/libbeat/processors/ratelimit/rate_limit.go
@@ -68,6 +68,8 @@ func new(cfg *c.C, log *logp.Logger) (beat.Processor, error) {
 		return nil, fmt.Errorf("could not set default configuration: %w", err)
 	}
 
+	sort.Strings(config.Fields)
+
 	algoConfig := algoConfig{
 		limit:  config.Limit,
 		config: *config.Algorithm.Config(),
@@ -127,7 +129,6 @@ func (p *rateLimit) makeKey(event *beat.Event) (uint64, error) {
 		return 0, nil
 	}
 
-	sort.Strings(p.config.Fields)
 	values := make([]string, len(p.config.Fields))
 	for _, field := range p.config.Fields {
 		value, err := event.GetValue(field)

--- a/libbeat/processors/ratelimit/rate_limit_test.go
+++ b/libbeat/processors/ratelimit/rate_limit_test.go
@@ -18,10 +18,12 @@
 package ratelimit
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -177,6 +179,44 @@ func TestRateLimit(t *testing.T) {
 			require.Equal(t, test.outEvents, out)
 		})
 	}
+}
+
+// TestRateLimitConcurrentRun exercises a single processor instance from
+// multiple goroutines. A beat-level (global) processor can be run
+// concurrently, so makeKey must not mutate the shared config. Run with -race
+// to catch the regression where makeKey sorted config.Fields in place on every
+// Run.
+func TestRateLimitConcurrentRun(t *testing.T) {
+	// Provide the fields unsorted so a per-Run sort would actually mutate the
+	// shared slice and trip the race detector.
+	p, err := new(conf.MustNewConfigFrom(mapstr.M{
+		"limit":  "1000000/s",
+		"fields": []string{"gamma", "alpha", "beta"},
+	}), logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+
+	const (
+		goroutines = 8
+		perRoutine = 200
+	)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Go(func() {
+			for i := range perRoutine {
+				event := beat.Event{
+					Fields: mapstr.M{
+						"alpha": g,
+						"beta":  i,
+						"gamma": g + i,
+					},
+				}
+				_, err := p.Run(&event)
+				assert.NoError(t, err)
+			}
+		})
+	}
+	wg.Wait()
 }
 
 func TestAllocs(t *testing.T) {


### PR DESCRIPTION
## Proposed commit message

```
libbeat/processors/ratelimit: sort key fields once to avoid data race

The rate_limit processor's makeKey called sort.Strings(p.config.Fields)
on every Run, mutating the shared config slice in place with no
synchronization. A single processor instance can process events
concurrently when used as a beat-level (global) processor, so concurrent
Run calls raced on the slice writes, and later reads raced with any
in-flight write.

Sort config.Fields once in the constructor instead. The field list is
fixed after construction, so the resulting key ordering is unchanged
while makeKey becomes a read-only operation on the shared slice.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

```bash
go test -race -run TestRateLimitConcurrentRun ./libbeat/processors/ratelimit/...
```

## Logs

Race detector output against main:

```
==================
WARNING: DATA RACE
Previous write at 0x00c000118390 by goroutine 21:
  slices.insertionSortOrdered[go.shape.string]()
  ...
  sort.Strings()
  github.com/elastic/beats/v7/libbeat/processors/ratelimit.(*rateLimit).makeKey()
      libbeat/processors/ratelimit/rate_limit.go:130
  github.com/elastic/beats/v7/libbeat/processors/ratelimit.(*rateLimit).Run()
      libbeat/processors/ratelimit/rate_limit.go:104
...
--- FAIL: TestRateLimitConcurrentRun (0.01s)
    testing.go:1712: race detected during execution of test
FAIL
```
