### PR TITLE
add_kubernetes_metadata: fix startup data race

### DIFF
--- a/changelog/fragments/1783324408-fix-add-kubernetes-metadata-async-init-race.yaml
+++ b/changelog/fragments/1783324408-fix-add-kubernetes-metadata-async-init-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix a startup data race in the add_kubernetes_metadata processor
+component: libbeat

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -153,7 +153,8 @@ func New(cfg *config.C, log *logp.Logger) (beat.Processor, error) {
 			return nil, fmt.Errorf("add_kubernetes_metadata: %w", err)
 		}
 	} else {
-		// Complete the processor's initialization asynchronously
+		// complete processor's initialisation asynchronously to re-try on failing k8s client initialisations in case
+		// the k8s node is not yet ready.
 		processor.wg.Go(func() {
 			_ = processor.init(ctx, config, cfg)
 		})

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -47,20 +48,23 @@ const (
 	selector = "kubernetes"
 )
 
+// initializedState holds the fields that init populates and that Run or Close read after startup.
+type initializedState struct {
+	watcher     kubernetes.Watcher
+	nsWatcher   kubernetes.Watcher
+	nodeWatcher kubernetes.Watcher
+	rsWatcher   kubernetes.Watcher
+	jobWatcher  kubernetes.Watcher
+	matchers    *Matchers
+}
+
 type kubernetesAnnotator struct {
-	log                 *logp.Logger
-	watcher             kubernetes.Watcher
-	nsWatcher           kubernetes.Watcher
-	nodeWatcher         kubernetes.Watcher
-	rsWatcher           kubernetes.Watcher
-	jobWatcher          kubernetes.Watcher
-	indexers            *Indexers
-	matchers            *Matchers
-	cache               *cache
-	kubernetesAvailable bool
-	initOnce            sync.Once
-	wg                  sync.WaitGroup
-	cancelCtx           context.CancelFunc
+	log       *logp.Logger
+	state     atomic.Pointer[initializedState]
+	cache     *cache
+	initOnce  sync.Once
+	wg        sync.WaitGroup
+	cancelCtx context.CancelFunc
 }
 
 func init() {
@@ -144,18 +148,15 @@ func New(cfg *config.C, log *logp.Logger) (beat.Processor, error) {
 
 	if config.WaitMetadata {
 		err := processor.init(ctx, config, cfg)
-		if !processor.kubernetesAvailable {
+		if processor.state.Load() == nil {
 			cancelCtx()
 			return nil, fmt.Errorf("add_kubernetes_metadata: %w", err)
 		}
 	} else {
-		// complete processor's initialisation asynchronously to re-try on failing k8s client initialisations in case
-		// the k8s node is not yet ready.
-		processor.wg.Add(1)
-		go func() {
-			defer processor.wg.Done()
+		// Complete the processor's initialization asynchronously
+		processor.wg.Go(func() {
 			_ = processor.init(ctx, config, cfg)
-		}()
+		})
 	}
 
 	return processor, nil
@@ -186,15 +187,6 @@ func (k *kubernetesAnnotator) init(ctx context.Context, config kubeAnnotatorConf
 	k.initOnce.Do(func() {
 		var replicaSetWatcher, jobWatcher, namespaceWatcher, nodeWatcher kubernetes.Watcher
 
-		// We initialise the use_kubeadm variable based on modules KubeAdm base configuration
-		err := config.AddResourceMetadata.Namespace.SetBool("use_kubeadm", -1, config.KubeAdm)
-		if err != nil {
-			k.log.Errorf("couldn't set kubeadm variable for namespace due to error %+v", err)
-		}
-		err = config.AddResourceMetadata.Node.SetBool("use_kubeadm", -1, config.KubeAdm)
-		if err != nil {
-			k.log.Errorf("couldn't set kubeadm variable for node due to error %+v", err)
-		}
 		client, err := kubernetes.GetKubernetesClient(config.KubeConfig, config.KubeClientOptions)
 		if err != nil {
 			if kubernetes.IsInCluster(config.KubeConfig) {
@@ -216,13 +208,11 @@ func (k *kubernetesAnnotator) init(ctx context.Context, config kubeAnnotatorConf
 		matchers := NewMatchers(config.Matchers, k.log)
 
 		if matchers.Empty() {
-			commonMsg := "Could not initialize kubernetes plugin with zero matcher plugins"
-			k.log.Debug(commonMsg)
-			k8sError = errors.New(commonMsg)
+			k.log.Debug("Could not initialize kubernetes plugin with zero matcher plugins")
+			k8sError = errors.New("could not initialize kubernetes plugin with zero matcher plugins")
 			return
 		}
 
-		k.matchers = matchers
 		nd := &kubernetes.DiscoverKubernetesNodeParams{
 			ConfigHost:  config.Node,
 			Client:      client,
@@ -250,7 +240,11 @@ func (k *kubernetesAnnotator) init(ctx context.Context, config kubeAnnotatorConf
 			return
 		}
 
-		metaConf := config.AddResourceMetadata
+		// Copy add_resource_metadata and its sub-configs before propagating use_kubeadm, so init
+		// never mutates the caller-owned config.
+		metaConf := *config.AddResourceMetadata
+		metaConf.Node = configWithKubeadm(k.log, metaConf.Node, config.KubeAdm)
+		metaConf.Namespace = configWithKubeadm(k.log, metaConf.Namespace, config.KubeAdm)
 
 		if metaConf.Node.Enabled() {
 			nodeWatcher, k8sError = kubernetes.NewNamedWatcher("add_kubernetes_metadata_node", client, &kubernetes.Node{}, kubernetes.WatchOptions{
@@ -300,7 +294,6 @@ func (k *kubernetesAnnotator) init(ctx context.Context, config kubeAnnotatorConf
 			if k8sError != nil {
 				k.log.Errorf("Error creating watcher for %T due to error %+v", &kubernetes.ReplicaSet{}, k8sError)
 			}
-			k.rsWatcher = replicaSetWatcher
 		}
 		if metaConf.CronJob {
 			jobWatcher, k8sError = kubernetes.NewNamedWatcher("resource_metadata_enricher_job", client, &kubernetes.Job{}, kubernetes.WatchOptions{
@@ -311,55 +304,60 @@ func (k *kubernetesAnnotator) init(ctx context.Context, config kubeAnnotatorConf
 			if k8sError != nil {
 				k.log.Errorf("Error creating watcher for %T due to error %+v", &kubernetes.Job{}, k8sError)
 			}
-			k.jobWatcher = jobWatcher
 		}
 
 		// TODO: refactor the above section to a common function to be used by NeWPodEventer too
-		metaGen := metadata.GetPodMetaGen(cfg, watcher, nodeWatcher, namespaceWatcher, replicaSetWatcher, jobWatcher, metaConf)
+		metaGen := metadata.GetPodMetaGen(cfg, watcher, nodeWatcher, namespaceWatcher, replicaSetWatcher, jobWatcher, &metaConf)
 
-		k.indexers = NewIndexers(config.Indexers, metaGen)
-		k.watcher = watcher
-		k.kubernetesAvailable = true
-		k.nodeWatcher = nodeWatcher
-		k.nsWatcher = namespaceWatcher
+		indexers := NewIndexers(config.Indexers, metaGen)
 
 		watcher.AddEventHandler(kubernetes.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				pod, _ := obj.(*kubernetes.Pod)
-				k.addPod(pod)
+				k.addPod(indexers, pod)
 			},
 			UpdateFunc: func(obj interface{}) {
 				pod, _ := obj.(*kubernetes.Pod)
-				k.updatePod(pod)
+				k.updatePod(indexers, pod)
 			},
 			DeleteFunc: func(obj interface{}) {
 				pod, _ := obj.(*kubernetes.Pod)
-				k.removePod(pod)
+				k.removePod(indexers, pod)
 			},
+		})
+
+		// Publish the fully constructed state atomically before starting the watchers
+		k.state.Store(&initializedState{
+			watcher:     watcher,
+			nsWatcher:   namespaceWatcher,
+			nodeWatcher: nodeWatcher,
+			rsWatcher:   replicaSetWatcher,
+			jobWatcher:  jobWatcher,
+			matchers:    matchers,
 		})
 
 		// NOTE: order is important here since pod meta will include node meta and hence node.Store() should
 		// be populated before trying to generate metadata for Pods.
-		if k.nodeWatcher != nil {
-			if err := k.nodeWatcher.Start(); err != nil {
+		if nodeWatcher != nil {
+			if err := nodeWatcher.Start(); err != nil {
 				k.log.Debugf("Couldn't start node watcher: %v", err)
 				return
 			}
 		}
-		if k.nsWatcher != nil {
-			if err := k.nsWatcher.Start(); err != nil {
+		if namespaceWatcher != nil {
+			if err := namespaceWatcher.Start(); err != nil {
 				k.log.Debugf("Couldn't start namespace watcher: %v", err)
 				return
 			}
 		}
-		if k.rsWatcher != nil {
-			if err := k.rsWatcher.Start(); err != nil {
+		if replicaSetWatcher != nil {
+			if err := replicaSetWatcher.Start(); err != nil {
 				k.log.Debugf("Couldn't start replicaSet watcher: %v", err)
 				return
 			}
 		}
-		if k.jobWatcher != nil {
-			if err := k.jobWatcher.Start(); err != nil {
+		if jobWatcher != nil {
+			if err := jobWatcher.Start(); err != nil {
 				k.log.Debugf("Couldn't start job watcher: %v", err)
 				return
 			}
@@ -381,11 +379,14 @@ func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 		return event, nil
 	}
 
-	if !k.kubernetesAvailable {
+	// A nil state means init has not published yet (still running or kubernetes unavailable); the
+	// load pairs with the Store in init for a race-free read.
+	state := k.state.Load()
+	if state == nil {
 		return event, nil
 	}
 
-	index := k.matchers.MetadataIndex(event.Fields)
+	index := state.matchers.MetadataIndex(event.Fields)
 	if index == "" {
 		k.log.Debug("No container match string, not adding kubernetes data")
 		return event, nil
@@ -430,22 +431,25 @@ func (k *kubernetesAnnotator) Close() error {
 	if k.cancelCtx != nil {
 		k.cancelCtx()
 	}
+	// Wait for any in-flight init goroutine to finish before tearing down.
 	k.wg.Wait()
 
-	if k.watcher != nil {
-		k.watcher.Stop()
-	}
-	if k.nodeWatcher != nil {
-		k.nodeWatcher.Stop()
-	}
-	if k.nsWatcher != nil {
-		k.nsWatcher.Stop()
-	}
-	if k.rsWatcher != nil {
-		k.rsWatcher.Stop()
-	}
-	if k.jobWatcher != nil {
-		k.jobWatcher.Stop()
+	if state := k.state.Load(); state != nil {
+		if state.watcher != nil {
+			state.watcher.Stop()
+		}
+		if state.nodeWatcher != nil {
+			state.nodeWatcher.Stop()
+		}
+		if state.nsWatcher != nil {
+			state.nsWatcher.Stop()
+		}
+		if state.rsWatcher != nil {
+			state.rsWatcher.Stop()
+		}
+		if state.jobWatcher != nil {
+			state.jobWatcher.Stop()
+		}
 	}
 	if k.cache != nil {
 		k.cache.stop()
@@ -454,26 +458,26 @@ func (k *kubernetesAnnotator) Close() error {
 	return nil
 }
 
-func (k *kubernetesAnnotator) addPod(pod *kubernetes.Pod) {
-	metadata := k.indexers.GetMetadata(pod)
+func (k *kubernetesAnnotator) addPod(indexers *Indexers, pod *kubernetes.Pod) {
+	metadata := indexers.GetMetadata(pod)
 	for _, m := range metadata {
 		k.cache.set(m.Index, m.Data)
 	}
 }
 
-func (k *kubernetesAnnotator) updatePod(pod *kubernetes.Pod) {
-	k.removePod(pod)
+func (k *kubernetesAnnotator) updatePod(indexers *Indexers, pod *kubernetes.Pod) {
+	k.removePod(indexers, pod)
 
 	// Add it again only if it is not being deleted
 	if pod.GetObjectMeta().GetDeletionTimestamp() != nil {
 		return
 	}
 
-	k.addPod(pod)
+	k.addPod(indexers, pod)
 }
 
-func (k *kubernetesAnnotator) removePod(pod *kubernetes.Pod) {
-	indexes := k.indexers.GetIndexes(pod)
+func (k *kubernetesAnnotator) removePod(indexers *Indexers, pod *kubernetes.Pod) {
+	indexes := indexers.GetIndexes(pod)
 	for _, idx := range indexes {
 		k.cache.delete(idx)
 	}
@@ -481,4 +485,21 @@ func (k *kubernetesAnnotator) removePod(pod *kubernetes.Pod) {
 
 func (*kubernetesAnnotator) String() string {
 	return "add_kubernetes_metadata"
+}
+
+// configWithKubeadm returns sets use_kubeadm to the given value, without mutating cfg.
+func configWithKubeadm(log *logp.Logger, cfg *config.C, kubeAdm bool) *config.C {
+	if cfg == nil {
+		return nil
+	}
+	clone, err := config.MergeConfigs(cfg)
+	if err != nil {
+		// Copying a valid config does not fail in practice; keep the original untouched
+		log.Errorf("couldn't copy add_resource_metadata config to set use_kubeadm: %+v", err)
+		return cfg
+	}
+	if err := clone.SetBool("use_kubeadm", -1, kubeAdm); err != nil {
+		log.Errorf("couldn't set use_kubeadm variable due to error %+v", err)
+	}
+	return clone
 }

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_concurrent_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_concurrent_test.go
@@ -69,6 +69,46 @@ func containerEvent(containerID string) *beat.Event {
 	}
 }
 
+func TestAnnotatorRun_ConcurrentInitPublishAndRun(t *testing.T) {
+	const readers = 100
+	const containerID = "init-publish-cid"
+
+	cfg := config.MustNewConfigFrom(map[string]any{
+		"lookup_fields": []string{"container.id"},
+	})
+	matcher, err := NewFieldMatcher(*cfg, logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+
+	processor := &kubernetesAnnotator{
+		log:   logptest.NewTestingLogger(t, selector),
+		cache: newCache(10 * time.Second),
+	}
+	processor.cache.set(containerID, metaMap(containerID))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Publish the state exactly once, concurrently with the readers below.
+	wg.Go(func() {
+		<-start
+		setReady(processor, &Matchers{matchers: []Matcher{matcher}})
+	})
+
+	// Readers call the real Run while init is still publishing. Each must get either the
+	// un-enriched event (state not yet visible) or the fully enriched one.
+	for range readers {
+		wg.Go(func() {
+			<-start
+			out, runErr := processor.Run(containerEvent(containerID))
+			assert.NoError(t, runErr)
+			assert.NotNil(t, out)
+		})
+	}
+
+	close(start)
+	wg.Wait()
+}
+
 func TestAnnotatorRun_ConcurrentRace(t *testing.T) {
 	const goroutines = 100
 	const containerID = "race-cid"
@@ -135,11 +175,10 @@ func TestAnnotatorRun_EachEventAnnotatedIndependently(t *testing.T) {
 	require.NoError(t, err)
 
 	processor := &kubernetesAnnotator{
-		log:                 logptest.NewTestingLogger(t, selector),
-		cache:               newCache(10 * time.Second),
-		matchers:            &Matchers{matchers: []Matcher{matcher}},
-		kubernetesAvailable: true,
+		log:   logptest.NewTestingLogger(t, selector),
+		cache: newCache(10 * time.Second),
 	}
+	setReady(processor, &Matchers{matchers: []Matcher{matcher}})
 
 	for i := 0; i < goroutines; i++ {
 		cid := fmt.Sprintf("cid-%d", i)
@@ -293,11 +332,10 @@ func TestAnnotatorRun_SharedWrapper_EventIndependenceUnderConcurrency(t *testing
 
 	cache := newCache(10 * time.Second)
 	annotator := &kubernetesAnnotator{
-		log:                 logptest.NewTestingLogger(t, selector),
-		cache:               cache,
-		matchers:            &Matchers{matchers: []Matcher{matcher}},
-		kubernetesAvailable: true,
+		log:   logptest.NewTestingLogger(t, selector),
+		cache: cache,
 	}
+	setReady(annotator, &Matchers{matchers: []Matcher{matcher}})
 
 	// each goroutine has its own container ID in the cache.
 	for i := range goroutines {

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
@@ -53,11 +53,8 @@ func TestAnnotatorSkipped(t *testing.T) {
 	processor := kubernetesAnnotator{
 		log:   logptest.NewTestingLogger(t, selector),
 		cache: newCache(10 * time.Second),
-		matchers: &Matchers{
-			matchers: []Matcher{matcher},
-		},
-		kubernetesAvailable: true,
 	}
+	setReady(&processor, &Matchers{matchers: []Matcher{matcher}})
 
 	processor.cache.set("foo",
 		mapstr.M{
@@ -102,20 +99,9 @@ func TestAnnotatorSkipped(t *testing.T) {
 
 // Test metadata are not included in the event
 func TestAnnotatorWithNoKubernetesAvailable(t *testing.T) {
-	cfg := config.MustNewConfigFrom(map[string]interface{}{
-		"lookup_fields": []string{"kubernetes.pod.name"},
-	})
-	matcher, err := NewFieldMatcher(*cfg, logptest.NewTestingLogger(t, ""))
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	// state is left nil, i.e. init never published (kubernetes unavailable).
 	processor := kubernetesAnnotator{
 		cache: newCache(10 * time.Second),
-		matchers: &Matchers{
-			matchers: []Matcher{matcher},
-		},
-		kubernetesAvailable: false,
 	}
 
 	intialEventMap := mapstr.M{
@@ -253,13 +239,17 @@ func newAnnotatorForTest(t testing.TB, cacheKey string, meta mapstr.M) *kubernet
 	processor := &kubernetesAnnotator{
 		log:   logptest.NewTestingLogger(t, selector),
 		cache: newCache(10 * time.Second),
-		matchers: &Matchers{
-			matchers: []Matcher{matcher},
-		},
-		kubernetesAvailable: true,
 	}
+	setReady(processor, &Matchers{matchers: []Matcher{matcher}})
 	processor.cache.set(cacheKey, meta)
 	return processor
+}
+
+// setReady publishes a minimal initializedState so the processor treats
+// kubernetes as available, mirroring what init does on success. Tests that
+// don't drive real watchers only need matchers populated.
+func setReady(k *kubernetesAnnotator, matchers *Matchers) {
+	k.state.Store(&initializedState{matchers: matchers})
 }
 
 // baseEvent returns an event that will match cacheKey via container.id.
@@ -410,11 +400,8 @@ func TestAnnotatorRunNoContainerSubMap(t *testing.T) {
 	processor := &kubernetesAnnotator{
 		log:   logptest.NewTestingLogger(t, selector),
 		cache: newCache(10 * time.Second),
-		matchers: &Matchers{
-			matchers: []Matcher{matcher},
-		},
-		kubernetesAvailable: true,
 	}
+	setReady(processor, &Matchers{matchers: []Matcher{matcher}})
 	processor.cache.set("mypod", meta)
 
 	event, err := processor.Run(&beat.Event{
@@ -561,11 +548,8 @@ func BenchmarkKubernetesAnnotatorRun(b *testing.B) {
 	processor := &kubernetesAnnotator{
 		log:   logptest.NewTestingLogger(b, selector),
 		cache: newCache(10 * time.Second),
-		matchers: &Matchers{
-			matchers: []Matcher{matcher},
-		},
-		kubernetesAvailable: true,
 	}
+	setReady(processor, &Matchers{matchers: []Matcher{matcher}})
 
 	const cacheKey = "abc123container"
 
@@ -623,7 +607,7 @@ func BenchmarkKubernetesAnnotatorRun(b *testing.B) {
 // isKubernetesAvailableWithTimeout loops until timeout or context cancel.
 func unavailableK8sClient() k8sclient.Interface {
 	client := k8sfake.NewSimpleClientset()
-	client.Fake.PrependReactor("get", "version", func(k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("get", "version", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("kubernetes unavailable")
 	})
 	return client


### PR DESCRIPTION
## Proposed commit message

```
add_kubernetes_metadata: fix startup data race

When add_kubernetes_metadata is configured without wait_for_metadata,
init runs in a background goroutine and published its results (the pod,
node, namespace, replicaset and job watchers, the indexers and matchers,
and the kubernetesAvailable flag) by writing struct fields directly. The
Run and Close methods read those same fields without any synchronization,
so under the race detector this is a data race and readers could observe
a partially constructed processor.

Bundle everything init produces into a single immutable initializedState
value and publish it through an atomic.Pointer before the watchers are
started. Run and Close now load that pointer once: a nil value means init
has not finished (or kubernetes is unavailable) and replaces the old
kubernetesAvailable flag, while a non-nil value is a fully constructed,
read-only view. The pod event callbacks receive the indexers as an
argument instead of reading a shared field.

While fixing the race, stop mutating the caller-owned
add_resource_metadata config in place when propagating use_kubeadm. For
shared processor instances that config has already been hashed for
deduplication before the async init runs, so an in-place change would be
a side effect on state owned by the caller; use_kubeadm is now applied to
a copy.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

```bash
timeout 5m script/stresstest.sh --race ./libbeat/processors/add_kubernetes_metadata '^TestAnnotatorRun_ConcurrentInitPublishAndRun$' -p 32 -failfast
```

## Related issues

- Relates #50507
