### PR TITLE
beatprocessor: close constructed processors on shutdown

### DIFF
--- a/changelog/fragments/1783323892-beatprocessor-close-on-shutdown.yaml
+++ b/changelog/fragments/1783323892-beatprocessor-close-on-shutdown.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Close Beat processors on beat OTel processor shutdown to avoid leaking resources on collector reloads.
+component: all

--- a/x-pack/otel/processor/beatprocessor/processor.go
+++ b/x-pack/otel/processor/beatprocessor/processor.go
@@ -105,8 +105,17 @@ func (p *beatProcessor) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
+// Shutdown closes every processor that was constructed for this component.
 func (p *beatProcessor) Shutdown(_ context.Context) error {
-	return nil
+	var errs []error
+	for _, proc := range p.processors {
+		if err := processors.Close(proc); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	// Drop the references so a repeated Shutdown does not double-close.
+	p.processors = nil
+	return errors.Join(errs...)
 }
 
 func (p *beatProcessor) ConsumeLogs(_ context.Context, logs plog.Logs) (plog.Logs, error) {

--- a/x-pack/otel/processor/beatprocessor/processor_test.go
+++ b/x-pack/otel/processor/beatprocessor/processor_test.go
@@ -6,9 +6,11 @@ package beatprocessor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/elastic/beats/v7/internal/otel/sharedcomponent"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	_ "github.com/elastic/beats/v7/libbeat/cmd/instance" // needed for registering processors
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
@@ -235,6 +238,70 @@ func TestCreateProcessor(t *testing.T) {
 	})
 }
 
+func TestShutdownClosesProcessors(t *testing.T) {
+	t.Run("closes every Closer exactly once and ignores non-Closers", func(t *testing.T) {
+		closer1 := &closerProcessor{}
+		closer2 := &closerProcessor{}
+		plain := mockProcessor{runFunc: func(e *beat.Event) (*beat.Event, error) { return e, nil }}
+
+		bp := &beatProcessor{
+			logger:     zap.NewNop(),
+			processors: []beat.Processor{closer1, plain, closer2},
+		}
+
+		require.NoError(t, bp.Shutdown(context.Background()))
+		assert.Equal(t, 1, closer1.closeCalls, "first Closer should be closed exactly once on Shutdown")
+		assert.Equal(t, 1, closer2.closeCalls, "second Closer should be closed exactly once on Shutdown")
+
+		// A second Shutdown must not close the processors again: for shared
+		// processors a double-close would over-decrement the refcount.
+		require.NoError(t, bp.Shutdown(context.Background()))
+		assert.Equal(t, 1, closer1.closeCalls, "Closer should not be closed again on a repeated Shutdown")
+		assert.Equal(t, 1, closer2.closeCalls, "Closer should not be closed again on a repeated Shutdown")
+	})
+
+	t.Run("joins close errors", func(t *testing.T) {
+		closer1 := &closerProcessor{err: errors.New("boom-1")}
+		closer2 := &closerProcessor{err: errors.New("boom-2")}
+		bp := &beatProcessor{
+			logger:     zap.NewNop(),
+			processors: []beat.Processor{closer1, closer2},
+		}
+
+		err := bp.Shutdown(context.Background())
+		require.Error(t, err, "Shutdown should surface errors returned by processor Close")
+		assert.ErrorContains(t, err, "boom-1")
+		assert.ErrorContains(t, err, "boom-2")
+	})
+}
+
+// TestLifecycleReloadClosesSharedProcessors reproduces a collector pipeline
+// reload: it builds the component through the shared-component map (as the
+// factory does), starts it, then shuts it down and asserts the constructed
+// processors were closed and the component was evicted so the next reload
+// rebuilds cleanly. Before the fix, Shutdown was a no-op, so the underlying
+// processors leaked their resources on every reload.
+func TestLifecycleReloadClosesSharedProcessors(t *testing.T) {
+	closer := &closerProcessor{}
+	sharedMap := sharedcomponent.NewMap[*Config, *beatProcessor]()
+	cfg := &Config{}
+
+	comp, err := sharedMap.LoadOrStore(cfg, func() (*beatProcessor, error) {
+		return &beatProcessor{
+			logger:     zap.NewNop(),
+			processors: []beat.Processor{closer},
+		}, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, sharedMap.Len(), "component should be registered after LoadOrStore")
+
+	require.NoError(t, comp.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, comp.Shutdown(context.Background()))
+
+	assert.Equal(t, 1, closer.closeCalls, "reload teardown should close the constructed processor")
+	assert.Equal(t, 0, sharedMap.Len(), "shared component should be evicted after Shutdown so the next reload rebuilds")
+}
+
 func testLogger() *logp.Logger {
 	return logp.NewNopLogger()
 }
@@ -249,4 +316,18 @@ func (m mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
 
 func (m mockProcessor) String() string {
 	return "mockProcessor"
+}
+
+// closerProcessor is a beat.Processor that also implements processors.Closer so
+// tests can observe that Shutdown closes the processors it holds.
+type closerProcessor struct {
+	closeCalls int
+	err        error
+}
+
+func (c *closerProcessor) Run(event *beat.Event) (*beat.Event, error) { return event, nil }
+func (c *closerProcessor) String() string                             { return "closerProcessor" }
+func (c *closerProcessor) Close() error {
+	c.closeCalls++
+	return c.err
 }


### PR DESCRIPTION
## Proposed commit message

```
beatprocessor: close constructed processors on shutdown

The beat OTel processor builds Beat processor instances from the libbeat
registry (processors.GetConstructor) for its pipeline, but its Shutdown
was a no-op, so those processors were never closed.

Shutdown now closes every processor it constructed (processors.Close
honors the Closer interface), joins any errors, and drops the references
so a repeated Shutdown does not double-close or over-decrement the shared
refcount.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

Unit tests (regression coverage):

```bash
cd x-pack
go test -count=1 -race ./otel/processor/beatprocessor/...
```

`TestShutdownClosesProcessors` and `TestLifecycleReloadClosesSharedProcessors` fail on `main` and pass with this change.

End-to-end reproduction through the real `elastic-agent otel` entry point. `add_docker_metadata` is used because, pointed at an unreachable docker socket with `wait_for_metadata_timeout: 0`, it keeps a background retry goroutine alive until `Close` is called, giving an observable per-reload leak.

Config (`otel.yaml`):

```yaml
extensions:
  pprof:
    endpoint: localhost:6060
receivers:
  nop: {}
processors:
  beat:
    processors:
      - add_docker_metadata:
          host: "unix:///nonexistent/docker.sock"
          wait_for_metadata_timeout: 0s
          wait_for_metadata_retry_period: 1s
exporters:
  debug:
    verbosity: basic
service:
  extensions: [pprof]
  pipelines:
    logs:
      receivers: [nop]
      processors: [beat]
      exporters: [debug]
  telemetry:
    logs:
      level: warn
    metrics:
      level: none
```

Run and reload (`elastic-agent otel` execs the collector in-place via `unix.Exec`, so SIGHUP to the PID reaches the collector's reload handler; `--supervised` is how the agent manager runs it):

```bash
/tmp/agentbin/elastic-agent otel --config file:otel.yaml --supervised &
PID=$!
# count the add_docker_metadata retry goroutines after each reload
count() { curl -s 'http://localhost:6060/debug/pprof/goroutine?debug=2' \
  | awk '/^goroutine [0-9]+ \[/{b=""} {b=b $0} /^$/{if (b ~ /add_docker_metadata.*retryConnectToDocker/) c++; b=""} END{print c+0}'; }
for i in 1 2 3 4 5; do kill -HUP $PID; sleep 2; echo "reload #$i: $(count)"; done
```

Observed `add_docker_metadata` retry goroutines (each run logged 5 `Config updated, restart service` reloads):

| reload | before (main) | after (this PR) |
|--------|---------------|-----------------|
| baseline | 1 | 1 |
| i=1 | 2 | 1 |
| i=2 | 3 | 1 |
| i=3 | 4 | 1 |
| i=4 | 5 | 1 |
| i=5 | 6 | 1 |

Before the fix the count grows by one per reload.
