### PR TITLE
filestream: persist growing fingerprint as hash+length

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -320,39 +320,45 @@ func (w *fileWatcher) watch(
 	//   3. Unmatched-leftover emission — anything still in w.prev becomes
 	//      OpDelete, anything still in newFilesByName becomes OpCreate.
 
-	// Exact-FileID rename match: For growing mode, also accumulate the
-	// short-fingerprint index from prev entries that did NOT get an exact
-	// match — they are the candidates for the next (prefix-match) pass.
-	var shortFingerprints *shortFingerprintSet
-	if w.growingFingerprint {
-		shortFingerprints = newShortFingerprintSet()
-	}
-
+	// Exact-FileID rename match.
 	for remainingPath, remainingDesc := range w.prev {
 		newDesc, renamed := newFilesByID[remainingDesc.FileID()]
+		if !renamed {
+			continue
+		}
 
-		switch {
-		// Exact-FileID rename match
-		case renamed:
-			srcID := w.getFileIdentity(remainingDesc)
-			select {
-			case <-ctx.Done():
-				return
-			case w.events <- renamedEvent(
-				remainingPath, newDesc.Filename, *newDesc, srcID):
-				renamedCount++
+		srcID := w.getFileIdentity(remainingDesc)
+		select {
+		case <-ctx.Done():
+			return
+		case w.events <- renamedEvent(
+			remainingPath, newDesc.Filename, *newDesc, srcID):
+			renamedCount++
+		}
+
+		delete(newFilesByName, newDesc.Filename)
+		delete(newFilesByID, remainingDesc.FileID())
+		delete(w.prev, remainingPath)
+	}
+
+	// Prefix-match candidates are the still-growing prev entries left after
+	// the exact-match pass (GrowingRaw is empty for completed entries, which
+	// match by their SHA-256 identity instead). The index is only built when
+	// this scan has a new file that could justify a match — a delete-only
+	// scan pays no hashing.
+	var shortFingerprints *shortFingerprintSet
+	if w.growingFingerprint {
+		for _, newDesc := range newFilesByName {
+			if newDesc.Fingerprint.Complete() {
+				shortFingerprints = newShortFingerprintSet()
+				break
 			}
-
-			delete(newFilesByName, newDesc.Filename)
-			delete(newFilesByID, remainingDesc.FileID())
-			delete(w.prev, remainingPath)
-
-		// If it isn't an exact match, make it a candidate for prefix-match.
-		// GrowingRaw keeps only still-growing predecessors in the
-		// index; completed entries match by their SHA-256 identity instead.
-		case w.growingFingerprint:
+		}
+	}
+	if shortFingerprints != nil {
+		for remainingPath, remainingDesc := range w.prev {
 			if raw := remainingDesc.Fingerprint.GrowingRaw(); raw != "" {
-				shortFingerprints.Add(remainingPath, raw, remainingPath)
+				shortFingerprints.AddRaw(remainingPath, raw, remainingPath)
 			}
 		}
 	}

--- a/filebeat/input/filestream/identifier_test.go
+++ b/filebeat/input/filestream/identifier_test.go
@@ -229,17 +229,48 @@ func TestFingerprintIDKey(t *testing.T) {
 	})
 }
 
-// TestGrowingRawFingerprint verifies the growing-phase helpers: raw material
-// (and its persisted byte length) is exposed only while the file is still
-// growing; a completed descriptor exposes neither.
-func TestGrowingRawFingerprint(t *testing.T) {
-	raw := "41414141"
-	assert.Equal(t, raw, (loginp.FingerprintID{Raw: raw}).GrowingRaw(),
-		"a growing descriptor must expose its raw fingerprint for prefix matching")
-	assert.Equal(t, int64(4), (loginp.FingerprintID{Raw: raw}).GrowingByteLen(),
-		"a growing descriptor must expose the material's byte length for persistence")
-	assert.Empty(t, (loginp.FingerprintID{Raw: raw, Sum: raw}).GrowingRaw(),
-		"a completed descriptor must not expose raw material")
-	assert.Zero(t, (loginp.FingerprintID{Raw: raw, Sum: raw}).GrowingByteLen(),
-		"a completed descriptor must persist a zero length (keeps the entry byte-identical to static)")
+// TestGrowingFingerprintHelpers verifies the growing-phase helpers
+func TestGrowingFingerprintHelpers(t *testing.T) {
+	const raw = "41414141"
+
+	testCases := []struct {
+		name        string
+		fp          loginp.FingerprintID
+		wantRaw     string
+		wantByteLen int64
+	}{
+		{
+			name:        "growing descriptor exposes raw material and its byte length",
+			fp:          loginp.FingerprintID{Raw: raw},
+			wantRaw:     raw,
+			wantByteLen: 4,
+		},
+		{
+			name:        "completed descriptor (raw and sum) exposes neither",
+			fp:          loginp.FingerprintID{Raw: raw, Sum: raw},
+			wantRaw:     "",
+			wantByteLen: 0,
+		},
+		{
+			name:        "completed descriptor (sum only) exposes neither",
+			fp:          loginp.FingerprintID{Sum: raw},
+			wantRaw:     "",
+			wantByteLen: 0,
+		},
+		{
+			name:        "empty descriptor exposes neither",
+			fp:          loginp.FingerprintID{},
+			wantRaw:     "",
+			wantByteLen: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantRaw, tc.fp.GrowingRaw(),
+				"GrowingRaw must expose raw material only while the file is still growing")
+			assert.Equal(t, tc.wantByteLen, tc.fp.GrowingByteLen(),
+				"GrowingByteLen must report the growing material's byte length, or 0 once complete")
+		})
+	}
 }

--- a/filebeat/input/filestream/identifier_test.go
+++ b/filebeat/input/filestream/identifier_test.go
@@ -229,12 +229,17 @@ func TestFingerprintIDKey(t *testing.T) {
 	})
 }
 
-// TestGrowingRawFingerprint verifies the value-side helper: the raw fingerprint
-// is persisted (in fileMeta.Fingerprint) only while the file is still growing.
+// TestGrowingRawFingerprint verifies the growing-phase helpers: raw material
+// (and its persisted byte length) is exposed only while the file is still
+// growing; a completed descriptor exposes neither.
 func TestGrowingRawFingerprint(t *testing.T) {
 	raw := "41414141"
 	assert.Equal(t, raw, (loginp.FingerprintID{Raw: raw}).GrowingRaw(),
-		"a growing descriptor must persist its raw fingerprint for prefix matching")
+		"a growing descriptor must expose its raw fingerprint for prefix matching")
+	assert.Equal(t, int64(4), (loginp.FingerprintID{Raw: raw}).GrowingByteLen(),
+		"a growing descriptor must expose the material's byte length for persistence")
 	assert.Empty(t, (loginp.FingerprintID{Raw: raw, Sum: raw}).GrowingRaw(),
-		"a completed descriptor must not persist a raw fingerprint (keeps the entry byte-identical to static)")
+		"a completed descriptor must not expose raw material")
+	assert.Zero(t, (loginp.FingerprintID{Raw: raw, Sum: raw}).GrowingByteLen(),
+		"a completed descriptor must persist a zero length (keeps the entry byte-identical to static)")
 }

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -880,7 +880,7 @@ func (inp *filestream) handleReadError(
 		// an explicit Close — the input is not shutting down and we must
 		// close normally.
 		if inp.readUntilEOF.Enabled && ctx.Cancelation.Err() != nil {
-			return nil, true
+			return nil, true //nolint:nilerr // intentional
 		}
 
 		log.Debugf("Reader was closed. Closing. Path='%s'", path)

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -57,17 +57,7 @@ type state struct {
 type fileMeta struct {
 	Source         string `json:"source" struct:"source"`
 	IdentifierName string `json:"identifier_name" struct:"identifier_name"`
-	// FingerprintLen is the number of content bytes (from the configured
-	// offset) the still-growing fingerprint covers. The registry key already
-	// is the hash of the raw material (bounded key), and hash-based prefix
-	// matching needs only that hash plus this length, so the raw header bytes
-	// themselves are never persisted.
-	//
-	// A non-zero FingerprintLen is the single source of truth for "this entry
-	// is still growing": final SHA-256 entries (and legacy/static entries
-	// written before this feature) leave it zero, so with omitempty they
-	// serialize to exactly the same {source, identifier_name} shape as before.
-	FingerprintLen int64 `json:"fingerprint_len,omitempty" struct:"fingerprint_len,omitempty"`
+	FingerprintLen int64  `json:"fingerprint_len,omitempty" struct:"fingerprint_len,omitempty"`
 }
 
 // filestream is the input for reading from files which

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -57,18 +57,17 @@ type state struct {
 type fileMeta struct {
 	Source         string `json:"source" struct:"source"`
 	IdentifierName string `json:"identifier_name" struct:"identifier_name"`
-	// Fingerprint holds the raw (hex-encoded) growing fingerprint while the file
-	// is still below the threshold (offset+length). With the bounded-key
-	// optimization the registry key is a fixed-size hash of this value, so the
-	// raw fingerprint—which prefix matching needs—must be persisted in the value
-	// instead of the key.
+	// FingerprintLen is the number of content bytes (from the configured
+	// offset) the still-growing fingerprint covers. The registry key already
+	// is the hash of the raw material (bounded key), and hash-based prefix
+	// matching needs only that hash plus this length, so the raw header bytes
+	// themselves are never persisted.
 	//
-	// A non-empty Fingerprint is the single source of truth for "this entry is
-	// still growing": final SHA-256 entries (and legacy/static entries written
-	// before this feature) leave it empty, so they serialize to exactly the same
-	// {source, identifier_name} shape as before and need no migration. omitempty
-	// guarantees that byte-identical form on disk.
-	Fingerprint string `json:"fingerprint,omitempty" struct:"fingerprint,omitempty"`
+	// A non-zero FingerprintLen is the single source of truth for "this entry
+	// is still growing": final SHA-256 entries (and legacy/static entries
+	// written before this feature) leave it zero, so with omitempty they
+	// serialize to exactly the same {source, identifier_name} shape as before.
+	FingerprintLen int64 `json:"fingerprint_len,omitempty" struct:"fingerprint_len,omitempty"`
 }
 
 // filestream is the input for reading from files which

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -92,7 +92,7 @@ func NewRawFingerprintHasher() *RawFingerprintHasher {
 
 // Feed appends raw fingerprint material to the stream.
 func (r *RawFingerprintHasher) Feed(material []byte) {
-	r.h.Write(material) //nolint:errcheck // sha256 Write cannot fail
+	r.h.Write(material)
 }
 
 // Reset restores the hasher for a new stream, so callers can reuse one allocation across lookups.

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -78,11 +78,8 @@ type FingerprintID struct {
 // which is exactly when the final SHA-256 Sum is set.
 func (f FingerprintID) Complete() bool { return f.Sum != "" }
 
-// RawFingerprintHasher incrementally computes the growing-key hash,
-// hex(sha256(raw)): Key snapshots the hash of everything fed so far without
-// disturbing the stream, so prefix hashes at several lengths cost one pass.
-// It is the single definition of the formula; HashRawFingerprint is its
-// one-shot form.
+// RawFingerprintHasher incrementally computes the growing-key hash, hex(sha256(raw)): Key snapshots
+// the hash of everything fed so far, so prefix hashes at several lengths cost one pass.
 type RawFingerprintHasher struct {
 	h      hash.Hash
 	sumBuf [sha256.Size]byte
@@ -95,28 +92,22 @@ func NewRawFingerprintHasher() *RawFingerprintHasher {
 
 // Feed appends raw fingerprint material to the stream.
 func (r *RawFingerprintHasher) Feed(material []byte) {
-	//nolint:errcheck // sha256 Write cannot fail
-	r.h.Write(material)
+	r.h.Write(material) //nolint:errcheck // sha256 Write cannot fail
 }
 
-// Reset restores the hasher for a new stream, so callers can reuse one
-// allocation across lookups.
+// Reset restores the hasher for a new stream, so callers can reuse one allocation across lookups.
 func (r *RawFingerprintHasher) Reset() {
 	r.h.Reset()
 }
 
-// Key returns the hash of everything fed so far. The returned slice is reused
-// by the next call: index a map with string(Key()) or copy it, don't retain it.
+// Key returns the hash of everything fed so far. The next call reuses the returned slice.
 func (r *RawFingerprintHasher) Key() []byte {
 	hex.Encode(r.hexBuf[:], r.h.Sum(r.sumBuf[:0]))
 	return r.hexBuf[:]
 }
 
-// HashRawFingerprint returns hex(sha256(raw)), the identity hash of growing
-// fingerprint material: the registry-key tail Key() produces for still-growing
-// entries, and the value the prefix-match index compares against. It is the
-// one-shot form of RawFingerprintHasher, kept allocation-light (stack Sum256)
-// because Key() calls it per event on the watch loop.
+// HashRawFingerprint returns hex(sha256(raw)), the identity hash of growing fingerprint material.
+// It is the one-shot form of RawFingerprintHasher.
 func HashRawFingerprint(raw string) string {
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
@@ -152,9 +143,8 @@ func (f FingerprintID) GrowingRaw() string {
 	return f.Raw
 }
 
-// GrowingByteLen returns the number of content bytes covered by the growing
-// fingerprint (half its hex length), or 0 once the fingerprint is complete.
-// It is what fileMeta persists instead of the raw material itself.
+// GrowingByteLen returns the number of content bytes covered by the growing fingerprint, or 0 once
+// the fingerprint is complete.
 func (f FingerprintID) GrowingByteLen() int64 {
 	return int64(len(f.GrowingRaw()) / 2)
 }

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -20,6 +20,7 @@ package input_logfile
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"hash"
 	"strings"
 	"time"
 
@@ -77,6 +78,44 @@ type FingerprintID struct {
 // which is exactly when the final SHA-256 Sum is set.
 func (f FingerprintID) Complete() bool { return f.Sum != "" }
 
+// RawFingerprintHasher incrementally computes the growing-key hash,
+// hex(sha256(raw)): Key snapshots the hash of everything fed so far without
+// disturbing the stream, so prefix hashes at several lengths cost one pass.
+// It is the single definition of the formula; HashRawFingerprint is its
+// one-shot form.
+type RawFingerprintHasher struct {
+	h      hash.Hash
+	sumBuf [sha256.Size]byte
+	hexBuf [2 * sha256.Size]byte
+}
+
+func NewRawFingerprintHasher() *RawFingerprintHasher {
+	return &RawFingerprintHasher{h: sha256.New()}
+}
+
+// Feed appends raw fingerprint material to the stream.
+func (r *RawFingerprintHasher) Feed(material []byte) {
+	//nolint:errcheck // sha256 Write cannot fail
+	r.h.Write(material)
+}
+
+// Key returns the hash of everything fed so far. The returned slice is reused
+// by the next call: index a map with string(Key()) or copy it, don't retain it.
+func (r *RawFingerprintHasher) Key() []byte {
+	hex.Encode(r.hexBuf[:], r.h.Sum(r.sumBuf[:0]))
+	return r.hexBuf[:]
+}
+
+// HashRawFingerprint returns hex(sha256(raw)), the identity hash of growing
+// fingerprint material: the registry-key tail Key() produces for still-growing
+// entries, and the value the prefix-match index compares against. It is the
+// one-shot form of RawFingerprintHasher, kept allocation-light (stack Sum256)
+// because Key() calls it per event on the watch loop.
+func HashRawFingerprint(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
 // Key returns the registry/identity key for this fingerprint:
 // - The complete Sum when it's available.
 // - A SHA-256 hash of Raw when it's incomplete.
@@ -86,8 +125,7 @@ func (f FingerprintID) Key() string {
 	case f.Complete():
 		return f.Sum
 	case f.Raw != "":
-		sum := sha256.Sum256([]byte(f.Raw))
-		return hex.EncodeToString(sum[:])
+		return HashRawFingerprint(f.Raw)
 	default:
 		return ""
 	}
@@ -106,6 +144,13 @@ func (f FingerprintID) GrowingRaw() string {
 		return ""
 	}
 	return f.Raw
+}
+
+// GrowingByteLen returns the number of content bytes covered by the growing
+// fingerprint (half its hex length), or 0 once the fingerprint is complete.
+// It is what fileMeta persists instead of the raw material itself.
+func (f FingerprintID) GrowingByteLen() int64 {
+	return int64(len(f.GrowingRaw()) / 2)
 }
 
 // FileDescriptor represents full information about a file.

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -146,7 +146,7 @@ func (f FingerprintID) GrowingRaw() string {
 // GrowingByteLen returns the number of content bytes covered by the growing fingerprint, or 0 once
 // the fingerprint is complete.
 func (f FingerprintID) GrowingByteLen() int64 {
-	return int64(len(f.GrowingRaw()) / 2)
+	return int64(hex.DecodedLen(len(f.GrowingRaw())))
 }
 
 // FileDescriptor represents full information about a file.

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -99,6 +99,12 @@ func (r *RawFingerprintHasher) Feed(material []byte) {
 	r.h.Write(material)
 }
 
+// Reset restores the hasher for a new stream, so callers can reuse one
+// allocation across lookups.
+func (r *RawFingerprintHasher) Reset() {
+	r.h.Reset()
+}
+
 // Key returns the hash of everything fed so far. The returned slice is reused
 // by the next call: index a map with string(Key()) or copy it, don't retain it.
 func (r *RawFingerprintHasher) Key() []byte {

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -18,10 +18,10 @@
 package filestream
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/elastic/beats/v7/filebeat/input/file"
@@ -167,10 +167,10 @@ func (p *fileProspector) takeOverFn(
 
 	newKey := newID(p.identifier.GetSource(loginp.FSEvent{NewPath: fm.Source, Descriptor: fd}))
 	fm.IdentifierName = p.identifier.Name()
-	// Carry the raw growing fingerprint of the current descriptor into the migrated meta.
-	// GrowingRaw returns "" for completed descriptors, so the field is omitted on disk, matching a
+	// Carry the growing fingerprint length of the current descriptor into the migrated meta.
+	// GrowingByteLen returns 0 for completed descriptors, so the field is omitted on disk, matching a
 	// static fingerprint entry.
-	fm.Fingerprint = fd.Fingerprint.GrowingRaw()
+	fm.FingerprintLen = fd.Fingerprint.GrowingByteLen()
 	p.logger.Infof("Taking over state: '%s' -> '%s'", v.Key, newKey)
 	return newKey, fm
 }
@@ -408,7 +408,7 @@ func (p *fileProspector) onFSEvent(
 			err := updater.UpdateMetadata(src, fileMeta{
 				Source:         event.NewPath,
 				IdentifierName: p.identifier.Name(),
-				Fingerprint:    event.Descriptor.Fingerprint.GrowingRaw(),
+				FingerprintLen: event.Descriptor.Fingerprint.GrowingByteLen(),
 			})
 			if err != nil {
 				log.Errorf("Failed to set cursor meta data of entry %s: %v", src.Name(), err)
@@ -531,7 +531,8 @@ func (p *fileProspector) onRename(log *logp.Logger, ctx input.Context, fe loginp
 
 		hg.Start(ctx, src)
 	} else {
-		// The path changed; update the persisted metadata but preserve the raw growing Fingerprint.
+		// The path changed; update the persisted metadata but preserve the
+		// growing FingerprintLen.
 		var meta fileMeta
 		err := s.FindCursorMeta(src, &meta)
 		if err != nil {
@@ -558,20 +559,22 @@ func (p *fileProspector) onRename(log *logp.Logger, ctx input.Context, fe loginp
 	}
 }
 
-// isStrictPrefix reports whether prefix is a non-empty string strictly
-// shorter than target, and target begins with prefix.
-func isStrictPrefix(target, prefix string) bool {
-	return prefix != "" && len(prefix) < len(target) && strings.HasPrefix(target, prefix)
-}
-
 // indexGrowingFingerprint adds an entry to the prefix-matching index, but only
 // while the file is still growing. Completed (final SHA-256) entries match by
 // their exact identity and must not participate in prefix matching, so they are
 // skipped.
 func (p *fileProspector) indexGrowingFingerprint(key string, d loginp.FileDescriptor, source string) {
-	if raw := d.Fingerprint.GrowingRaw(); raw != "" {
-		p.shortFingerprints.Add(key, raw, source)
+	raw := d.Fingerprint.GrowingRaw()
+	if raw == "" {
+		return
 	}
+	// The registry key's identity tail already is the hash of raw
+	// (FingerprintID.Key), so don't recompute the SHA-256.
+	if rk, ok := parseRegistryKey(key); ok && rk.isFingerprint() {
+		p.shortFingerprints.Add(key, rk.fingerprintHash(), len(raw), source)
+		return
+	}
+	p.shortFingerprints.AddRaw(key, raw, source)
 }
 
 func (p *fileProspector) stopHarvesterGroup(log *logp.Logger, hg loginp.HarvesterGroup) {
@@ -642,10 +645,10 @@ func (p *fileProspector) handleGrowingFingerprintLookup(
 }
 
 // buildShortFingerprintSet scans the store once and populates shortFingerprints
-// with the still-growing entries: those whose persisted fileMeta.Fingerprint is
-// a non-empty raw-hex value (still below the configured threshold). Completed
-// (final SHA-256) and legacy/static entries leave Fingerprint empty and are
-// skipped, since they match by exact identity rather than prefix.
+// with the still-growing entries: those whose persisted fileMeta.FingerprintLen
+// is non-zero (still below the configured threshold). Completed (final SHA-256)
+// and legacy/static entries leave FingerprintLen zero and are skipped, since
+// they match by exact identity rather than prefix.
 func (p *fileProspector) buildShortFingerprintSet(updater loginp.StateMetadataUpdater) {
 	p.shortFingerprints = newShortFingerprintSet()
 
@@ -657,27 +660,18 @@ func (p *fileProspector) buildShortFingerprintSet(updater loginp.StateMetadataUp
 			return
 		}
 
-		// Convert with typeconv: when entries are freshly written in this
-		// process the cursorMeta is a fileMeta value, but when loaded from
-		// the persistent registry on startup it is a map[string]interface{}
-		// produced by JSON decoding into interface{}. typeconv.Convert
-		// handles both cases.
+		// Convert with typeconv: cursorMeta is a fileMeta value when freshly
+		// written in this process, a map[string]interface{} when loaded from
+		// the persistent registry on startup; typeconv.Convert handles both.
 		var fm fileMeta
 		if err := typeconv.Convert(&fm, meta); err != nil {
 			p.logger.Debugf("buildShortFingerprintSet: skipping %s: cannot convert meta to fileMeta: %v",
 				key, err)
 			return
 		}
-		// The registry key holds only a fixed-size hash of the fingerprint
-		// (bounded-key optimization), so the raw fingerprint needed for prefix
-		// matching is read from the persisted value, not parsed from the key.
-		// A non-empty Fingerprint is exactly the set of still-growing entries;
-		// final SHA-256 and legacy/static entries leave it empty and are not
-		// eligible for prefix matching.
-		if fm.Fingerprint == "" {
-			return
-		}
-		p.shortFingerprints.Add(key, fm.Fingerprint, fm.Source)
+		// The key carries the hash, the value the length — exactly what
+		// hash-based prefix matching needs. Add() drops non-growing entries.
+		p.shortFingerprints.Add(key, rk.fingerprintHash(), hex.EncodedLen(int(fm.FingerprintLen)), fm.Source)
 	})
 }
 
@@ -755,16 +749,16 @@ func (p *fileProspector) migrateGrowingFingerprint(
 	newSrc loginp.Source,
 	event loginp.FSEvent,
 ) error {
-	// Carry the raw growing fingerprint into the migrated meta.
-	// On growth below threshold it is the (longer) raw-hex, keeping the entry
+	// Carry the growing fingerprint length into the migrated meta.
+	// On growth below threshold it is the (larger) length, keeping the entry
 	// marked as growing. On a threshold-crossing migration the descriptor is
-	// final SHA-256, so GrowingRaw returns "" and the field is
+	// final SHA-256, so GrowingByteLen returns 0 and the field is
 	// omitted on disk — making the migrated entry byte-identical to a static
 	// fingerprint entry.
 	newMeta := fileMeta{
 		Source:         event.NewPath,
 		IdentifierName: fingerprintName,
-		Fingerprint:    event.Descriptor.Fingerprint.GrowingRaw(),
+		FingerprintLen: event.Descriptor.Fingerprint.GrowingByteLen(),
 	}
 
 	// Keep the old key's plugin/input prefix and swap in the new identity.

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -168,8 +168,6 @@ func (p *fileProspector) takeOverFn(
 	newKey := newID(p.identifier.GetSource(loginp.FSEvent{NewPath: fm.Source, Descriptor: fd}))
 	fm.IdentifierName = p.identifier.Name()
 	// Carry the growing fingerprint length of the current descriptor into the migrated meta.
-	// GrowingByteLen returns 0 for completed descriptors, so the field is omitted on disk, matching a
-	// static fingerprint entry.
 	fm.FingerprintLen = fd.Fingerprint.GrowingByteLen()
 	p.logger.Infof("Taking over state: '%s' -> '%s'", v.Key, newKey)
 	return newKey, fm
@@ -660,9 +658,7 @@ func (p *fileProspector) buildShortFingerprintSet(updater loginp.StateMetadataUp
 			return
 		}
 
-		// Convert with typeconv: cursorMeta is a fileMeta value when freshly
-		// written in this process, a map[string]interface{} when loaded from
-		// the persistent registry on startup; typeconv.Convert handles both.
+		// typeconv.Convert handles both fileMeta and map[string]any
 		var fm fileMeta
 		if err := typeconv.Convert(&fm, meta); err != nil {
 			p.logger.Debugf("buildShortFingerprintSet: skipping %s: cannot convert meta to fileMeta: %v",

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -1331,7 +1331,7 @@ func TestFileProspector_takeOverFn(t *testing.T) {
 			},
 			shouldTakeOver: true,
 		},
-		"successful takeover - native to growing fingerprint preserves raw fingerprint": {
+		"successful takeover - native to growing fingerprint preserves growing length": {
 			identifier: mustIdentifier(t, fingerprintName),
 			takeOverState: loginp.TakeOverState{
 				Source:         "/path/to/file",
@@ -1348,11 +1348,11 @@ func TestFileProspector_takeOverFn(t *testing.T) {
 				source := fingerprintIdent.GetSource(loginp.FSEvent{NewPath: "/path/to/file", Descriptor: growingFD})
 				return "filestream::new-id::" + source.Name()
 			}(),
-			// The below-threshold raw fingerprint must survive takeover
+			// The below-threshold growing fingerprint length must survive takeover
 			expectedMeta: fileMeta{
 				Source:         "/path/to/file",
 				IdentifierName: fingerprintName,
-				Fingerprint:    growingFD.Fingerprint.GrowingRaw(),
+				FingerprintLen: growingFD.Fingerprint.GrowingByteLen(),
 			},
 			shouldTakeOver: true,
 		},
@@ -1399,8 +1399,25 @@ func mustIdentifier(t *testing.T, name string) fileIdentifier {
 	return identifier
 }
 
+// growingMeta is the persisted form of a still-growing entry: only the
+// material's byte length; the hash lives in the registry key.
+func growingMeta(source, raw string) fileMeta {
+	return fileMeta{
+		Source:         source,
+		IdentifierName: fingerprintName,
+		FingerprintLen: int64(len(raw) / 2),
+	}
+}
+
 func TestFindGrowingFingerprintMatch(t *testing.T) {
 	const currentPath = "/var/log/app.log"
+
+	// fpKey returns the registry key the scanner/identifier would produce for
+	// still-growing raw material: the bounded key tail is the SHA-256 of the
+	// raw, which is also the hash prefix matching compares against.
+	fpKey := func(raw string) string {
+		return "filestream::my-input::fingerprint::" + loginp.HashRawFingerprint(raw)
+	}
 
 	testCases := map[string]struct {
 		storeEntries       map[string]any
@@ -1417,33 +1434,21 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 		},
 		"valid prefix match": {
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::aabb": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabb",
-				},
+				fpKey("aabb"): growingMeta(currentPath, "aabb"),
 			},
 			currentFingerprint: "aabbccdd",
 			currentPath:        currentPath,
-			expectedKey:        "filestream::my-input::fingerprint::aabb",
+			expectedKey:        fpKey("aabb"),
 			expectedFound:      true,
 		},
 		"prefix match among entries for different paths": {
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::aa": fileMeta{
-					Source:         "/other/file.log",
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aa",
-				},
-				"filestream::my-input::fingerprint::aabb": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabb",
-				},
+				fpKey("aa"):   growingMeta("/other/file.log", "aa"),
+				fpKey("aabb"): growingMeta(currentPath, "aabb"),
 			},
 			currentFingerprint: "aabbccddee",
 			currentPath:        currentPath,
-			expectedKey:        "filestream::my-input::fingerprint::aabb",
+			expectedKey:        fpKey("aabb"),
 			expectedFound:      true,
 		},
 		"skips non-fingerprint identity": {
@@ -1459,11 +1464,7 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 		},
 		"skips key with too many separators": {
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::aabb::extra": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabb",
-				},
+				"filestream::my-input::fingerprint::aabb::extra": growingMeta(currentPath, "aabb"),
 			},
 			currentFingerprint: "aabbccdd",
 			currentPath:        currentPath,
@@ -1471,25 +1472,20 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 		},
 		"skips key with too few separators": {
 			storeEntries: map[string]any{
-				"filestream::malformed": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabb",
-				},
+				"filestream::malformed": growingMeta(currentPath, "aabb"),
 			},
 			currentFingerprint: "aabbccdd",
 			currentPath:        currentPath,
 			expectedFound:      false,
 		},
-		"skips empty stored fingerprint": {
+		"skips zero stored fingerprint length": {
 			// With the bounded-key optimization a growing entry is identified by
-			// a non-empty fileMeta.Fingerprint (the raw hex), not by the key tail.
-			// An entry with an empty Fingerprint is treated as final and skipped.
+			// a non-zero fileMeta.FingerprintLen, not by the key tail. An entry
+			// with a zero FingerprintLen is treated as final and skipped.
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::aabb": fileMeta{
+				fpKey("aabb"): fileMeta{
 					Source:         currentPath,
 					IdentifierName: fingerprintName,
-					Fingerprint:    "",
 				},
 			},
 			currentFingerprint: "aabbccdd",
@@ -1498,11 +1494,7 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 		},
 		"skips stored fingerprint longer than current": {
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::aabbccddee": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabbccddee",
-				},
+				fpKey("aabbccddee"): growingMeta(currentPath, "aabbccddee"),
 			},
 			currentFingerprint: "aabb",
 			currentPath:        currentPath,
@@ -1510,11 +1502,7 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 		},
 		"skips stored fingerprint equal length to current": {
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::aabb": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabb",
-				},
+				fpKey("aabb"): growingMeta(currentPath, "aabb"),
 			},
 			currentFingerprint: "aabb",
 			currentPath:        currentPath,
@@ -1522,11 +1510,7 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 		},
 		"skips non-prefix fingerprint": {
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::xxxx": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "xxxx",
-				},
+				fpKey("xxxx"): growingMeta(currentPath, "xxxx"),
 			},
 			currentFingerprint: "aabbccdd",
 			currentPath:        currentPath,
@@ -1539,11 +1523,7 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 			// sources are rejected to avoid confusing two distinct files with a
 			// shared content prefix for renames of one another.
 			storeEntries: map[string]any{
-				"filestream::my-input::fingerprint::aabb": fileMeta{
-					Source:         "/other/file.log",
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabb",
-				},
+				fpKey("aabb"): growingMeta("/other/file.log", "aabb"),
 			},
 			currentFingerprint: "aabbccdd",
 			currentPath:        currentPath,
@@ -1551,15 +1531,11 @@ func TestFindGrowingFingerprintMatch(t *testing.T) {
 		},
 		"single colon in input ID is not a separator": {
 			storeEntries: map[string]any{
-				"filestream::my:input::fingerprint::aabb": fileMeta{
-					Source:         currentPath,
-					IdentifierName: fingerprintName,
-					Fingerprint:    "aabb",
-				},
+				"filestream::my:input::fingerprint::" + loginp.HashRawFingerprint("aabb"): growingMeta(currentPath, "aabb"),
 			},
 			currentFingerprint: "aabbccdd",
 			currentPath:        currentPath,
-			expectedKey:        "filestream::my:input::fingerprint::aabb",
+			expectedKey:        "filestream::my:input::fingerprint::" + loginp.HashRawFingerprint("aabb"),
 			expectedFound:      true,
 		},
 	}
@@ -1640,17 +1616,15 @@ func TestHandleGrowingFingerprintLookup_KeyExistsFastPath(t *testing.T) {
 	})
 
 	t.Run("slow path: key does not exist falls through to scan", func(t *testing.T) {
-		const oldKey = "filestream::my-input::fingerprint::aabb"
+		// The old key's tail is the bounded hash of the raw material — the
+		// value hash-based prefix matching compares against.
+		oldKey := "filestream::my-input::fingerprint::" + loginp.HashRawFingerprint("aabb")
 		store := newMockMetadataUpdater()
 		// Only a prefix match exists, not the exact key. The stored entry must
-		// carry a real growing-phase raw fingerprint ("aabb") that is a strict
-		// prefix of the event's raw fingerprint ("aabbccdd") so that
+		// carry the growing-phase length (2 bytes of material, hex "aabb",
+		// a strict prefix of the event's raw fingerprint "aabbccdd") so that
 		// buildShortFingerprintSet indexes it and the prefix match succeeds.
-		store.table[oldKey] = fileMeta{
-			Source:         currentPath,
-			IdentifierName: fingerprintName,
-			Fingerprint:    "aabb",
-		}
+		store.table[oldKey] = growingMeta(currentPath, "aabb")
 
 		p := &fileProspector{
 			logger:     logptest.NewTestingLogger(t, ""),
@@ -1683,13 +1657,13 @@ func TestHandleGrowingFingerprintLookup_KeyExistsFastPath(t *testing.T) {
 //
 //   - below-threshold growth: the descriptor still carries a raw-hex Raw
 //     (Complete=false). The registry key migrates from the shorter raw-hex to
-//     the longer raw-hex; the resulting state still carries the raw fingerprint
-//     so the new entry remains in the short-fingerprint index for further
-//     matching.
+//     the longer raw-hex; the resulting state still carries the growing
+//     fingerprint length so the new entry remains in the short-fingerprint
+//     index for further matching.
 //   - at-threshold transition: the descriptor is Complete (Sum holds the
 //     SHA-256) and still carries the raw header in Raw for one scan. The
-//     registry key migrates to the SHA-256 key; the resulting state has an
-//     empty raw fingerprint (omitted from the serialized form) and is dropped
+//     registry key migrates to the SHA-256 key; the resulting state has a
+//     zero growing length (omitted from the serialized form) and is dropped
 //     from the short-fingerprint index.
 func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 	path := "/var/log/app.log"
@@ -1712,18 +1686,14 @@ func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 		newKey := "filestream::" + inputID + "::fingerprint::" + desc.Fingerprint.Key()
 
 		store := newMockMetadataUpdater()
-		store.table[oldKey] = fileMeta{
-			Source:         path,
-			IdentifierName: fingerprintName,
-			Fingerprint:    oldFingerprint,
-		}
+		store.table[oldKey] = growingMeta(path, oldFingerprint)
 		p := &fileProspector{
 			logger:             log,
 			identifier:         identifier,
 			shortFingerprints:  newShortFingerprintSet(),
 			growingFingerprint: true,
 		}
-		p.shortFingerprints.Add(oldKey, oldFingerprint, path)
+		p.shortFingerprints.AddRaw(oldKey, oldFingerprint, path)
 
 		event := loginp.FSEvent{
 			Op:         loginp.OpWrite,
@@ -1741,16 +1711,16 @@ func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 		assert.True(t, store.has(newKey), "new key should have been added by migration")
 		assert.Len(t, store.table, 1, "registry should have exactly one entry")
 
-		// The migrated entry is still growing: it persists the raw fingerprint
-		// (the bounded-key marker for "still growing").
+		// The migrated entry is still growing: it persists the growing
+		// fingerprint length (the marker for "still growing").
 		gotMeta := store.table[newKey].(fileMeta)
-		assert.Equal(t, newFingerprint, gotMeta.Fingerprint,
-			"migrated entry should persist the raw growing fingerprint while below threshold")
+		assert.Equal(t, int64(len(newFingerprint)/2), gotMeta.FingerprintLen,
+			"migrated entry should persist the growing fingerprint length while below threshold")
 
 		// Short fingerprint set tracks the new key, drops the old.
 		assert.NotContains(t, p.shortFingerprints.entries, oldKey, "old entry removed from short fingerprint set")
 		assert.Contains(t, p.shortFingerprints.entries, newKey, "new entry added to short fingerprint set")
-		assert.Equal(t, newFingerprint, p.shortFingerprints.entries[newKey].Fingerprint)
+		assert.Equal(t, rawEntry(newFingerprint, path), p.shortFingerprints.entries[newKey])
 
 		// The running harvester's registration is re-keyed along with the entry.
 		assert.Contains(t, hg.events, harvesterMigrate(oldKey+" -> "+src.Name()),
@@ -1763,18 +1733,14 @@ func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 		newKey := "filestream::" + inputID + "::fingerprint::" + sha256Fingerprint
 
 		store := newMockMetadataUpdater()
-		store.table[oldKey] = fileMeta{
-			Source:         path,
-			IdentifierName: fingerprintName,
-			Fingerprint:    oldFingerprint,
-		}
+		store.table[oldKey] = growingMeta(path, oldFingerprint)
 		p := &fileProspector{
 			logger:             log,
 			identifier:         identifier,
 			shortFingerprints:  newShortFingerprintSet(),
 			growingFingerprint: true,
 		}
-		p.shortFingerprints.Add(oldKey, oldFingerprint, path)
+		p.shortFingerprints.AddRaw(oldKey, oldFingerprint, path)
 
 		event := loginp.FSEvent{
 			Op:      loginp.OpWrite,
@@ -1797,11 +1763,11 @@ func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 		assert.True(t, store.has(newKey), "new key (SHA-256) should exist after migration")
 		assert.Len(t, store.table, 1, "registry should have exactly one entry")
 
-		// The migrated entry is final at threshold: the raw fingerprint is
+		// The migrated entry is final at threshold: the growing length is
 		// cleared (omitted on disk → byte-identical to a static entry).
 		gotMeta := store.table[newKey].(fileMeta)
-		assert.Empty(t, gotMeta.Fingerprint,
-			"migrated entry should clear the raw fingerprint at threshold")
+		assert.Zero(t, gotMeta.FingerprintLen,
+			"migrated entry should clear the growing fingerprint length at threshold")
 
 		// Short fingerprint set drops the old (migrated away) and does NOT add
 		// the new entry (it's final SHA-256, not growing anymore).
@@ -1816,26 +1782,24 @@ func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 }
 
 func TestBuildShortFingerprintSet(t *testing.T) {
+	growingKey := "filestream::input::fingerprint::" + loginp.HashRawFingerprint("aabb")
+
 	store := newMockMetadataUpdater()
-	// Growing fingerprint entry (non-empty raw Fingerprint) — should be included
-	store.table["filestream::input::fingerprint::aabb"] = fileMeta{
-		Source:         "/a.log",
-		IdentifierName: fingerprintName,
-		Fingerprint:    "aabb",
-	}
-	// Final SHA-256 entry (empty Fingerprint) — should be excluded
+	// Growing fingerprint entry (non-zero FingerprintLen) — should be included
+	store.table[growingKey] = growingMeta("/a.log", "aabb")
+	// Final SHA-256 entry (zero FingerprintLen) — should be excluded
 	store.table["filestream::input::fingerprint::"+strings.Repeat("ab", 32)] = fileMeta{
 		Source:         "/b.log",
 		IdentifierName: fingerprintName,
 	}
-	// Legacy entry from a registry written before the feature existed
-	// (no Fingerprint field present → empty on read → treated as final),
+	// Entry from a registry written before the feature existed
+	// (no FingerprintLen field present → zero on read → treated as final),
 	// should be excluded
 	store.table["filestream::input::fingerprint::ccddeeff"] = fileMeta{
 		Source:         "/legacy.log",
 		IdentifierName: fingerprintName,
 	}
-	// Empty raw fingerprint — treated as final, should be excluded
+	// Zero growing length — treated as final, should be excluded
 	store.table["filestream::input::fingerprint::"] = fileMeta{
 		Source:         "/c.log",
 		IdentifierName: fingerprintName,
@@ -1846,21 +1810,20 @@ func TestBuildShortFingerprintSet(t *testing.T) {
 		IdentifierName: nativeName,
 	}
 	// Malformed key (too few separators) — should be excluded even though it
-	// carries a raw fingerprint.
+	// carries a growing length.
 	store.table["filestream::malformed"] = fileMeta{
 		Source:         "/e.log",
 		IdentifierName: fingerprintName,
-		Fingerprint:    "aabb",
+		FingerprintLen: 2,
 	}
 
 	p := &fileProspector{logger: logptest.NewTestingLogger(t, "")}
 	p.buildShortFingerprintSet(store)
 
 	require.Len(t, p.shortFingerprints.entries, 1)
-	got, ok := p.shortFingerprints.entries["filestream::input::fingerprint::aabb"]
+	got, ok := p.shortFingerprints.entries[growingKey]
 	require.True(t, ok, "expected the growing entry to be in the set")
-	assert.Equal(t, "aabb", got.Fingerprint, "fingerprint mismatch")
-	assert.Equal(t, "/a.log", got.Source, "source mismatch")
+	assert.Equal(t, rawEntry("aabb", "/a.log"), got, "growing entry mismatch")
 }
 
 func TestShortFingerprintEntries_EventMaintenance(t *testing.T) {
@@ -1886,7 +1849,10 @@ func TestShortFingerprintEntries_EventMaintenance(t *testing.T) {
 			identifier:        identifier,
 			shortFingerprints: newShortFingerprintSet(),
 		}
-		event := makeEvent(loginp.OpCreate, "/a.log", "filestream::input::fingerprint::aabb", "aabb")
+		// The SrcID's identity tail is the hash of the raw material, exactly
+		// as the identifier produces it (indexing relies on that).
+		srcID := "filestream::input::fingerprint::" + loginp.HashRawFingerprint("aabb")
+		event := makeEvent(loginp.OpCreate, "/a.log", srcID, "aabb")
 		src := identifier.GetSource(event)
 		store := newMockMetadataUpdater()
 		hg := newTestHarvesterGroup()
@@ -1894,10 +1860,9 @@ func TestShortFingerprintEntries_EventMaintenance(t *testing.T) {
 		p.onFSEvent(logptest.NewTestingLogger(t, ""), input.Context{}, event, src, store, hg, time.Time{})
 
 		require.Len(t, p.shortFingerprints.entries, 1)
-		entry, ok := p.shortFingerprints.entries["filestream::input::fingerprint::aabb"]
+		entry, ok := p.shortFingerprints.entries[srcID]
 		require.True(t, ok)
-		assert.Equal(t, "aabb", entry.Fingerprint)
-		assert.Equal(t, "/a.log", entry.Source)
+		assert.Equal(t, rawEntry("aabb", "/a.log"), entry)
 	})
 
 	t.Run("OpCreate with non-growing entry does NOT add entry", func(t *testing.T) {
@@ -1923,12 +1888,11 @@ func TestShortFingerprintEntries_EventMaintenance(t *testing.T) {
 	t.Run("OpDelete removes entry", func(t *testing.T) {
 		srcID := "filestream::input::fingerprint::aabb"
 		p := &fileProspector{
-			logger:     logptest.NewTestingLogger(t, ""),
-			identifier: identifier,
-			shortFingerprints: &shortFingerprintSet{entries: map[string]shortFingerprintEntry{
-				srcID: {Fingerprint: "aabb", Source: "/a.log"},
-			}},
+			logger:            logptest.NewTestingLogger(t, ""),
+			identifier:        identifier,
+			shortFingerprints: newShortFingerprintSet(),
 		}
+		p.shortFingerprints.AddRaw(srcID, "aabb", "/a.log")
 		event := makeEvent(loginp.OpDelete, "/a.log", srcID, "aabb")
 		event.OldPath = "/a.log"
 		event.NewPath = ""
@@ -1944,12 +1908,11 @@ func TestShortFingerprintEntries_EventMaintenance(t *testing.T) {
 	t.Run("OpRename updates source path", func(t *testing.T) {
 		srcID := "filestream::input::fingerprint::aabb"
 		p := &fileProspector{
-			logger:     logptest.NewTestingLogger(t, ""),
-			identifier: identifier,
-			shortFingerprints: &shortFingerprintSet{entries: map[string]shortFingerprintEntry{
-				srcID: {Fingerprint: "aabb", Source: "/a.log"},
-			}},
+			logger:            logptest.NewTestingLogger(t, ""),
+			identifier:        identifier,
+			shortFingerprints: newShortFingerprintSet(),
 		}
+		p.shortFingerprints.AddRaw(srcID, "aabb", "/a.log")
 		event := loginp.FSEvent{
 			Op:      loginp.OpRename,
 			OldPath: "/a.log",
@@ -1969,7 +1932,42 @@ func TestShortFingerprintEntries_EventMaintenance(t *testing.T) {
 		require.Len(t, p.shortFingerprints.entries, 1)
 		entry := p.shortFingerprints.entries[srcID]
 		assert.Equal(t, "/a.log.1", entry.Source)
-		assert.Equal(t, "aabb", entry.Fingerprint)
+		assert.Equal(t, loginp.HashRawFingerprint("aabb"), entry.Hash)
+	})
+
+	t.Run("OpRename preserves growing marker", func(t *testing.T) {
+		// A rename round-trips the persisted meta (FindCursorMeta →
+		// UpdateMetadata); the growing marker must survive, or the entry
+		// would stop prefix-matching after a restart.
+		srcID := "filestream::input::fingerprint::" + loginp.HashRawFingerprint("aabb")
+		p := &fileProspector{
+			logger:            logptest.NewTestingLogger(t, ""),
+			identifier:        identifier,
+			shortFingerprints: newShortFingerprintSet(),
+		}
+		p.shortFingerprints.AddRaw(srcID, "aabb", "/a.log")
+		event := loginp.FSEvent{
+			Op:      loginp.OpRename,
+			OldPath: "/a.log",
+			NewPath: "/a.log.1",
+			SrcID:   srcID,
+			Descriptor: loginp.FileDescriptor{
+				Fingerprint: loginp.FingerprintID{Raw: "aabb"},
+				Info:        file.ExtendFileInfo(&testFileInfo{"/a.log.1", 100, time.Now(), nil}),
+			},
+		}
+		src := identifier.GetSource(event)
+		store := newMockMetadataUpdater()
+		store.table[src.Name()] = growingMeta("/a.log", "aabb")
+		hg := newTestHarvesterGroup()
+
+		p.onFSEvent(logptest.NewTestingLogger(t, ""), input.Context{}, event, src, store, hg, time.Time{})
+
+		got, ok := store.table[src.Name()].(fileMeta)
+		require.True(t, ok, "rename must rewrite the meta as fileMeta")
+		assert.Equal(t, "/a.log.1", got.Source)
+		assert.Equal(t, int64(2), got.FingerprintLen,
+			"the growing marker must survive the rename round-trip")
 	})
 
 	t.Run("OpTruncate removes stale entry by path", func(t *testing.T) {
@@ -1977,12 +1975,11 @@ func TestShortFingerprintEntries_EventMaintenance(t *testing.T) {
 		// After truncation, the SrcID is based on the NEW (truncated) fingerprint
 		truncatedSrcID := "filestream::input::fingerprint::xx"
 		p := &fileProspector{
-			logger:     logptest.NewTestingLogger(t, ""),
-			identifier: identifier,
-			shortFingerprints: &shortFingerprintSet{entries: map[string]shortFingerprintEntry{
-				oldSrcID: {Fingerprint: "aabb", Source: "/a.log"},
-			}},
+			logger:            logptest.NewTestingLogger(t, ""),
+			identifier:        identifier,
+			shortFingerprints: newShortFingerprintSet(),
 		}
+		p.shortFingerprints.AddRaw(oldSrcID, "aabb", "/a.log")
 		event := makeEvent(loginp.OpTruncate, "/a.log", truncatedSrcID, "xx")
 		src := identifier.GetSource(event)
 		store := newMockMetadataUpdater()
@@ -2009,15 +2006,14 @@ func TestShortFingerprintEntries_MigrationMaintenance(t *testing.T) {
 			loginp.FingerprintID{Raw: newFingerprint}.Key()
 
 		store := newMockMetadataUpdater()
-		store.table[oldKey] = fileMeta{Source: path, IdentifierName: fingerprintName, Fingerprint: oldFingerprint}
+		store.table[oldKey] = growingMeta(path, oldFingerprint)
 
 		p := &fileProspector{
-			logger:     logptest.NewTestingLogger(t, ""),
-			identifier: identifier,
-			shortFingerprints: &shortFingerprintSet{entries: map[string]shortFingerprintEntry{
-				oldKey: {Fingerprint: oldFingerprint, Source: path},
-			}},
+			logger:            logptest.NewTestingLogger(t, ""),
+			identifier:        identifier,
+			shortFingerprints: newShortFingerprintSet(),
 		}
+		p.shortFingerprints.AddRaw(oldKey, oldFingerprint, path)
 
 		event := loginp.FSEvent{
 			NewPath: path,
@@ -2035,7 +2031,7 @@ func TestShortFingerprintEntries_MigrationMaintenance(t *testing.T) {
 			"old entry should be removed")
 		require.Contains(t, p.shortFingerprints.entries, newSrcID,
 			"new entry should be added")
-		assert.Equal(t, newFingerprint, p.shortFingerprints.entries[newSrcID].Fingerprint)
+		assert.Equal(t, loginp.HashRawFingerprint(newFingerprint), p.shortFingerprints.entries[newSrcID].Hash)
 		assert.Equal(t, path, p.shortFingerprints.entries[newSrcID].Source)
 	})
 
@@ -2052,15 +2048,14 @@ func TestShortFingerprintEntries_MigrationMaintenance(t *testing.T) {
 		newSrcID := "filestream::input::fingerprint::" + newFingerprint
 
 		store := newMockMetadataUpdater()
-		store.table[oldKey] = fileMeta{Source: path, IdentifierName: fingerprintName, Fingerprint: oldFingerprint}
+		store.table[oldKey] = growingMeta(path, oldFingerprint)
 
 		p := &fileProspector{
-			logger:     logptest.NewTestingLogger(t, ""),
-			identifier: identifier,
-			shortFingerprints: &shortFingerprintSet{entries: map[string]shortFingerprintEntry{
-				oldKey: {Fingerprint: oldFingerprint, Source: path},
-			}},
+			logger:            logptest.NewTestingLogger(t, ""),
+			identifier:        identifier,
+			shortFingerprints: newShortFingerprintSet(),
 		}
+		p.shortFingerprints.AddRaw(oldKey, oldFingerprint, path)
 
 		event := loginp.FSEvent{
 			NewPath: path,
@@ -2093,20 +2088,14 @@ func TestShortFingerprintEntries_MigrationMaintenance(t *testing.T) {
 			loginp.FingerprintID{Raw: newFingerprint}.Key()
 
 		store := newMockMetadataUpdater()
-		store.table[oldKey] = fileMeta{
-			Source:         path,
-			IdentifierName: fingerprintName,
-			Fingerprint:    oldFingerprint,
-		}
+		store.table[oldKey] = growingMeta(path, oldFingerprint)
 
 		p := &fileProspector{
-			logger:     logptest.NewTestingLogger(t, ""),
-			identifier: identifier,
-			shortFingerprints: &shortFingerprintSet{
-				entries: map[string]shortFingerprintEntry{
-					oldKey: {Fingerprint: oldFingerprint, Source: path},
-				}},
+			logger:            logptest.NewTestingLogger(t, ""),
+			identifier:        identifier,
+			shortFingerprints: newShortFingerprintSet(),
 		}
+		p.shortFingerprints.AddRaw(oldKey, oldFingerprint, path)
 
 		event := loginp.FSEvent{
 			NewPath: path,
@@ -2156,8 +2145,8 @@ func TestShortFingerprintEntries_FullLifecycle(t *testing.T) {
 	store := newMockMetadataUpdater()
 	hg := newTestHarvesterGroup()
 
-	// An entry is "still growing" while its raw Fingerprint is non-empty; the
-	// final SHA-256 transition clears it.
+	// An entry is "still growing" while its persisted FingerprintLen is
+	// non-zero; the final SHA-256 transition clears it.
 	//   file A: raw-hex "aa" -> raw-hex "aabb" -> SHA-256 (final)
 	//   file B: raw-hex "bb" -> SHA-256 (final)
 	//   file C: raw-hex "cc" -> deleted
@@ -2180,13 +2169,13 @@ func TestShortFingerprintEntries_FullLifecycle(t *testing.T) {
 			},
 		}
 		src := identifier.GetSource(event)
-		store.table[makeKey(fingerprint, true)] = fileMeta{Source: path, IdentifierName: fingerprintName, Fingerprint: fingerprint}
+		store.table[makeKey(fingerprint, true)] = growingMeta(path, fingerprint)
 		p.onFSEvent(log, input.Context{}, event, src, store, hg, time.Time{})
 	}
 	assert.Equal(t, map[string]shortFingerprintEntry{
-		makeKey("aa", true): {Fingerprint: "aa", Source: "/a.log"},
-		makeKey("bb", true): {Fingerprint: "bb", Source: "/b.log"},
-		makeKey("cc", true): {Fingerprint: "cc", Source: "/c.log"},
+		makeKey("aa", true): rawEntry("aa", "/a.log"),
+		makeKey("bb", true): rawEntry("bb", "/b.log"),
+		makeKey("cc", true): rawEntry("cc", "/c.log"),
 	}, p.shortFingerprints.entries, "cycle 1: all 3 growing entries present")
 
 	// --- Cycle 2: file A still growing: "aa" -> "aabb" ---
@@ -2202,9 +2191,9 @@ func TestShortFingerprintEntries_FullLifecycle(t *testing.T) {
 	src := identifier.GetSource(event)
 	p.onFSEvent(log, input.Context{}, event, src, store, hg, time.Time{})
 	assert.Equal(t, map[string]shortFingerprintEntry{
-		makeKey("aabb", true): {Fingerprint: "aabb", Source: "/a.log"},
-		makeKey("bb", true):   {Fingerprint: "bb", Source: "/b.log"}, // unchanged
-		makeKey("cc", true):   {Fingerprint: "cc", Source: "/c.log"}, // unchanged
+		makeKey("aabb", true): rawEntry("aabb", "/a.log"),
+		makeKey("bb", true):   rawEntry("bb", "/b.log"), // unchanged
+		makeKey("cc", true):   rawEntry("cc", "/c.log"), // unchanged
 	}, p.shortFingerprints.entries, "cycle 2: file A migrated aa->aabb, B and C unchanged")
 
 	// --- Cycle 3: file A reaches threshold: raw-hex "aabb" -> SHA-256 ---
@@ -2224,8 +2213,8 @@ func TestShortFingerprintEntries_FullLifecycle(t *testing.T) {
 	src = identifier.GetSource(event)
 	p.onFSEvent(logptest.NewTestingLogger(t, ""), input.Context{}, event, src, store, hg, time.Time{})
 	assert.Equal(t, map[string]shortFingerprintEntry{
-		makeKey("bb", true): {Fingerprint: "bb", Source: "/b.log"},
-		makeKey("cc", true): {Fingerprint: "cc", Source: "/c.log"},
+		makeKey("bb", true): rawEntry("bb", "/b.log"),
+		makeKey("cc", true): rawEntry("cc", "/c.log"),
 	}, p.shortFingerprints.entries, "cycle 3: file A transitioned to SHA-256, removed from set")
 
 	// --- Cycle 4: file B reaches threshold: raw-hex "bb" -> SHA-256 ---
@@ -2245,7 +2234,7 @@ func TestShortFingerprintEntries_FullLifecycle(t *testing.T) {
 	src = identifier.GetSource(event)
 	p.onFSEvent(log, input.Context{}, event, src, store, hg, time.Time{})
 	assert.Equal(t, map[string]shortFingerprintEntry{
-		makeKey("cc", true): {Fingerprint: "cc", Source: "/c.log"},
+		makeKey("cc", true): rawEntry("cc", "/c.log"),
 	}, p.shortFingerprints.entries, "cycle 4: file B transitioned to SHA-256, only C remains")
 
 	// --- Cycle 5: file C deleted ---

--- a/filebeat/input/filestream/registry_key.go
+++ b/filebeat/input/filestream/registry_key.go
@@ -84,6 +84,13 @@ func (k registryKey) isFingerprint() bool {
 	return k.identityName == fingerprintName
 }
 
+// fingerprintHash returns the identity tail of a fingerprint key: the bounded
+// hash FingerprintID.Key() produced (the final SHA-256, or the hash of the
+// growing raw material). Only meaningful when isFingerprint().
+func (k registryKey) fingerprintHash() string {
+	return k.identityValue
+}
+
 // keyForIdentity returns a full registry key that keeps this key's plugin and
 // input prefix but swaps in a new "<identityName>::<identityValue>" identity
 // (typically Source.Name()). It is used when a file's fingerprint grows and its

--- a/filebeat/input/filestream/short_fingerprint_index.go
+++ b/filebeat/input/filestream/short_fingerprint_index.go
@@ -23,27 +23,14 @@ import (
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 )
 
-// shortFingerprintSet manages a set of entries whose fingerprint is still
-// in the growing phase (below the configured threshold). Used by both the
-// filewatcher (for rename+grow detection) and the prospector (for key
-// migration on growth and threshold transition).
-//
-// It never holds raw fingerprint material: an entry is only the identity hash
-// (FingerprintID.Key(), which the registry key carries) plus the raw
-// material's hex length; "stored raw is a strict prefix of target" is decided
-// as "the hashes agree at the stored length". This is what lets the registry
-// persist only (hash, length) for growing entries.
+// shortFingerprintSet manages a set of entries whose fingerprint is still in the growing phase.
 type shortFingerprintSet struct {
 	entries map[string]shortFingerprintEntry // key → entry
-	// byLen indexes entry keys by (hex length, hash) so a lookup is one hash
-	// snapshot + one map access per distinct stored length, independent of the
-	// number of entries. The innermost set handles distinct keys sharing the
-	// same material (e.g. two identical-content files in the watcher's
-	// path-keyed set).
+	// byLen indexes entry keys by (hex length, hash) so a lookup is one hash snapshot and one map
+	// access per distinct stored length, independent of the number of entries.
 	byLen map[int]map[string]map[string]struct{} // hex length → hash → keys
 
-	// Scratch state reused across FindPrefixMatchFunc calls to keep lookups
-	// allocation-free.
+	// Scratch state reused across FindPrefixMatchFunc calls to keep lookups allocation-free.
 	hasher  *loginp.RawFingerprintHasher
 	target  []byte
 	lengths []int

--- a/filebeat/input/filestream/short_fingerprint_index.go
+++ b/filebeat/input/filestream/short_fingerprint_index.go
@@ -17,35 +17,105 @@
 
 package filestream
 
+import (
+	"slices"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+)
+
 // shortFingerprintSet manages a set of entries whose fingerprint is still
-// in the growing phase (raw-hex, below the configured threshold). Used by both
-// the filewatcher (for rename+grow detection) and the prospector (for key
+// in the growing phase (below the configured threshold). Used by both the
+// filewatcher (for rename+grow detection) and the prospector (for key
 // migration on growth and threshold transition).
+//
+// It never holds raw fingerprint material: an entry is only the identity hash
+// (FingerprintID.Key(), which the registry key carries) plus the raw
+// material's hex length; "stored raw is a strict prefix of target" is decided
+// as "the hashes agree at the stored length". This is what lets the registry
+// persist only (hash, length) for growing entries.
 type shortFingerprintSet struct {
 	entries map[string]shortFingerprintEntry // key → entry
+	// byLen indexes entry keys by (hex length, hash) so a lookup is one hash
+	// snapshot + one map access per distinct stored length, independent of the
+	// number of entries. The innermost set handles distinct keys sharing the
+	// same material (e.g. two identical-content files in the watcher's
+	// path-keyed set).
+	byLen map[int]map[string]map[string]struct{} // hex length → hash → keys
 }
 
 // shortFingerprintEntry represents a tracked short fingerprint.
 type shortFingerprintEntry struct {
-	Fingerprint string
-	Source      string // file path
+	Hash   string // hex(sha256(raw)) — FingerprintID.Key() of the raw material
+	HexLen int    // len(raw): hex characters, i.e. 2× the content bytes
+	Source string // file path
 }
 
 func newShortFingerprintSet() *shortFingerprintSet {
 	return &shortFingerprintSet{
 		entries: make(map[string]shortFingerprintEntry),
+		byLen:   make(map[int]map[string]map[string]struct{}),
 	}
 }
 
-// Add adds an entry. Callers must only add entries that are currently in the
-// growing phase; the index does not enforce this. Entries with an empty
-// fingerprint are ignored. Safe to call on a nil receiver.
-func (s *shortFingerprintSet) Add(key, fingerprint, source string) {
-	if s == nil || fingerprint == "" {
+// Add adds an entry from its already-derived (hash, hex length) form, e.g.
+// loaded from the registry where the key carries the hash and the value the
+// length. Callers must only add entries that are currently in the growing
+// phase; the set does not enforce this. Entries with an empty hash or a
+// non-positive length are ignored. Safe to call on a nil receiver.
+func (s *shortFingerprintSet) Add(key, hash string, hexLen int, source string) {
+	if s == nil || hash == "" || hexLen <= 0 {
 		return
 	}
 
-	s.entries[key] = shortFingerprintEntry{Fingerprint: fingerprint, Source: source}
+	if old, ok := s.entries[key]; ok {
+		s.deleteIndexSlot(old.HexLen, old.Hash, key)
+	}
+	s.entries[key] = shortFingerprintEntry{Hash: hash, HexLen: hexLen, Source: source}
+
+	hashes := s.byLen[hexLen]
+	if hashes == nil {
+		hashes = make(map[string]map[string]struct{})
+		s.byLen[hexLen] = hashes
+	}
+	keys := hashes[hash]
+	if keys == nil {
+		keys = make(map[string]struct{})
+		hashes[hash] = keys
+	}
+	keys[key] = struct{}{}
+}
+
+// AddRaw adds an entry from in-memory raw (hex) fingerprint material, deriving
+// the (hash, hex length) form. The raw material itself is not retained.
+// Entries with an empty fingerprint are ignored. Safe to call on a nil
+// receiver.
+func (s *shortFingerprintSet) AddRaw(key, raw, source string) {
+	if s == nil || raw == "" {
+		return
+	}
+	s.Add(key, loginp.HashRawFingerprint(raw), len(raw), source)
+}
+
+// deleteIndexSlot removes key from the (hexLen, hash) bucket, pruning emptied
+// maps: a long-lived set would otherwise accumulate dead lengths (every
+// growth migration retires one) and pay a hash snapshot per dead length on
+// every lookup.
+func (s *shortFingerprintSet) deleteIndexSlot(hexLen int, hash, key string) {
+	hashes := s.byLen[hexLen]
+	if hashes == nil {
+		return
+	}
+	keys := hashes[hash]
+	if keys == nil {
+		return
+	}
+	delete(keys, key)
+	if len(keys) == 0 {
+		delete(hashes, hash)
+	}
+	if len(hashes) == 0 {
+		delete(s.byLen, hexLen)
+	}
 }
 
 // Remove removes an entry by key. Safe to call on a nil receiver.
@@ -53,7 +123,10 @@ func (s *shortFingerprintSet) Remove(key string) {
 	if s == nil {
 		return
 	}
-	delete(s.entries, key)
+	if e, ok := s.entries[key]; ok {
+		s.deleteIndexSlot(e.HexLen, e.Hash, key)
+		delete(s.entries, key)
+	}
 }
 
 // RemoveBySource removes every entry whose source matches.
@@ -68,6 +141,7 @@ func (s *shortFingerprintSet) RemoveBySource(source string) {
 	}
 	for key, entry := range s.entries {
 		if entry.Source == source {
+			s.deleteIndexSlot(entry.HexLen, entry.Hash, key)
 			delete(s.entries, key)
 		}
 	}
@@ -106,20 +180,46 @@ func (s *shortFingerprintSet) FindPrefixMatch(targetFingerprint, matchSource str
 // rename-eligible candidate instead of testing only the single longest prefix
 // match (which could discard a genuine rename in favor of a still-present
 // distinct file that merely shares a longer header).
-// Returns the key and entry on match. Safe to call on a nil receiver.
+//
+// targetFingerprint is streamed through a single hasher; at every stored
+// length below len(targetFingerprint) the hash is snapshotted and looked up in
+// that length's bucket, so the cost is one pass over the target plus a map
+// access per distinct stored length — no raw fingerprint material is needed or
+// kept. Returns the key and entry on match. Safe to call on a nil receiver.
 func (s *shortFingerprintSet) FindPrefixMatchFunc(targetFingerprint string, keep func(shortFingerprintEntry) bool) (key string, entry shortFingerprintEntry, found bool) {
-	if s == nil || targetFingerprint == "" {
+	if s == nil || targetFingerprint == "" || len(s.entries) == 0 {
 		return "", shortFingerprintEntry{}, false
 	}
-	for k, e := range s.entries {
-		if !isStrictPrefix(targetFingerprint, e.Fingerprint) {
-			continue
+
+	// Only lengths strictly below the target's can hold strict prefixes.
+	lengths := make([]int, 0, len(s.byLen))
+	for l := range s.byLen {
+		if l < len(targetFingerprint) {
+			lengths = append(lengths, l)
 		}
-		if keep != nil && !keep(e) {
-			continue
-		}
-		if !found || len(e.Fingerprint) > len(entry.Fingerprint) {
-			key, entry, found = k, e, true
+	}
+	if len(lengths) == 0 {
+		return "", shortFingerprintEntry{}, false
+	}
+	slices.Sort(lengths)
+
+	// Ascending walk so the hash is fed incrementally; a hit at a longer
+	// length overwrites earlier ones, implementing longest-match-wins.
+	// Indexing the bucket with string(Key()) lets the compiler elide the
+	// lookup-key allocation.
+	hasher := loginp.NewRawFingerprintHasher()
+	target := []byte(targetFingerprint)
+	fed := 0
+	for _, l := range lengths {
+		hasher.Feed(target[fed:l])
+		fed = l
+		candidates := s.byLen[l][string(hasher.Key())]
+		for candidate := range candidates {
+			e := s.entries[candidate]
+			if keep == nil || keep(e) {
+				key, entry, found = candidate, e, true
+				break
+			}
 		}
 	}
 	return key, entry, found

--- a/filebeat/input/filestream/short_fingerprint_index.go
+++ b/filebeat/input/filestream/short_fingerprint_index.go
@@ -41,6 +41,12 @@ type shortFingerprintSet struct {
 	// same material (e.g. two identical-content files in the watcher's
 	// path-keyed set).
 	byLen map[int]map[string]map[string]struct{} // hex length → hash → keys
+
+	// Scratch state reused across FindPrefixMatchFunc calls to keep lookups
+	// allocation-free.
+	hasher  *loginp.RawFingerprintHasher
+	target  []byte
+	lengths []int
 }
 
 // shortFingerprintEntry represents a tracked short fingerprint.
@@ -54,6 +60,7 @@ func newShortFingerprintSet() *shortFingerprintSet {
 	return &shortFingerprintSet{
 		entries: make(map[string]shortFingerprintEntry),
 		byLen:   make(map[int]map[string]map[string]struct{}),
+		hasher:  loginp.NewRawFingerprintHasher(),
 	}
 }
 
@@ -192,28 +199,28 @@ func (s *shortFingerprintSet) FindPrefixMatchFunc(targetFingerprint string, keep
 	}
 
 	// Only lengths strictly below the target's can hold strict prefixes.
-	lengths := make([]int, 0, len(s.byLen))
+	s.lengths = s.lengths[:0]
 	for l := range s.byLen {
 		if l < len(targetFingerprint) {
-			lengths = append(lengths, l)
+			s.lengths = append(s.lengths, l)
 		}
 	}
-	if len(lengths) == 0 {
+	if len(s.lengths) == 0 {
 		return "", shortFingerprintEntry{}, false
 	}
-	slices.Sort(lengths)
+	slices.Sort(s.lengths)
 
 	// Ascending walk so the hash is fed incrementally; a hit at a longer
 	// length overwrites earlier ones, implementing longest-match-wins.
 	// Indexing the bucket with string(Key()) lets the compiler elide the
 	// lookup-key allocation.
-	hasher := loginp.NewRawFingerprintHasher()
-	target := []byte(targetFingerprint)
+	s.hasher.Reset()
+	s.target = append(s.target[:0], targetFingerprint...)
 	fed := 0
-	for _, l := range lengths {
-		hasher.Feed(target[fed:l])
+	for _, l := range s.lengths {
+		s.hasher.Feed(s.target[fed:l])
 		fed = l
-		candidates := s.byLen[l][string(hasher.Key())]
+		candidates := s.byLen[l][string(s.hasher.Key())]
 		for candidate := range candidates {
 			e := s.entries[candidate]
 			if keep == nil || keep(e) {

--- a/filebeat/input/filestream/short_fingerprint_index.go
+++ b/filebeat/input/filestream/short_fingerprint_index.go
@@ -79,10 +79,9 @@ func (s *shortFingerprintSet) Add(key, hash string, hexLen int, source string) {
 	keys[key] = struct{}{}
 }
 
-// AddRaw adds an entry from in-memory raw (hex) fingerprint material, deriving
-// the (hash, hex length) form. The raw material itself is not retained.
-// Entries with an empty fingerprint are ignored. Safe to call on a nil
-// receiver.
+// AddRaw adds an entry from in-memory raw fingerprint material, deriving the (hash, hex length)
+// form. The raw material itself is not retained. Entries with an empty fingerprint are ignored.
+// Safe to call on a nil receiver.
 func (s *shortFingerprintSet) AddRaw(key, raw, source string) {
 	if s == nil || raw == "" {
 		return
@@ -197,10 +196,8 @@ func (s *shortFingerprintSet) FindPrefixMatchFunc(targetFingerprint string, keep
 	}
 	slices.Sort(s.lengths)
 
-	// Ascending walk so the hash is fed incrementally; a hit at a longer
-	// length overwrites earlier ones, implementing longest-match-wins.
-	// Indexing the bucket with string(Key()) lets the compiler elide the
-	// lookup-key allocation.
+	// Ascending walk so the hash is fed incrementally; a hit at a longer length overwrites earlier
+	// ones, implementing longest-match-wins.
 	s.hasher.Reset()
 	s.target = append(s.target[:0], targetFingerprint...)
 	fed := 0

--- a/filebeat/input/filestream/short_fingerprint_index_test.go
+++ b/filebeat/input/filestream/short_fingerprint_index_test.go
@@ -22,56 +22,80 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 )
+
+// rawEntry is the expected in-memory form of raw material added via AddRaw.
+func rawEntry(raw, source string) shortFingerprintEntry {
+	return shortFingerprintEntry{
+		Hash:   loginp.HashRawFingerprint(raw),
+		HexLen: len(raw),
+		Source: source,
+	}
+}
 
 func TestShortFingerprintIndex_Add(t *testing.T) {
 	set := newShortFingerprintSet()
 
 	t.Run("adds entry with non-empty fingerprint", func(t *testing.T) {
 		key := "key1"
-		want := shortFingerprintEntry{
-			Fingerprint: "aabb",
-			Source:      "/a.log",
-		}
-		set.Add(key, want.Fingerprint, want.Source)
+		want := rawEntry("aabb", "/a.log")
+		set.AddRaw(key, "aabb", "/a.log")
 		assert.Equal(t, 1, set.Len(), "non-empty fingerprint should be added")
 		assert.Equal(t, want, set.entries[key], "ShortFingerprintSet entry did not match")
 	})
 
 	t.Run("adds entry regardless of fingerprint length", func(t *testing.T) {
 		key := "key2"
-		want := shortFingerprintEntry{
-			// A full-length (64-char) fingerprint, so this subtest actually
-			// exercises length-independent insertion rather than re-using the
-			// 4-char value above.
-			Fingerprint: "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
-			Source:      "/a.log",
-		}
-		set.Add(key, want.Fingerprint, want.Source)
+		// A full-length (64-char) fingerprint, so this subtest actually
+		// exercises length-independent insertion rather than re-using the
+		// 4-char value above.
+		raw := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+		want := rawEntry(raw, "/a.log")
+		set.AddRaw(key, raw, "/a.log")
 		assert.Equal(t, 2, set.Len(), "long fingerprint should be added")
 		assert.Equal(t, want, set.entries[key], "ShortFingerprintSet entry did not match")
 	})
 
 	t.Run("rejects empty fingerprint", func(t *testing.T) {
 		key := "key3"
-		want := shortFingerprintEntry{
-			Fingerprint: "",
-			Source:      "/a.log",
-		}
-		set.Add("key3", want.Fingerprint, want.Source)
+		set.AddRaw(key, "", "/a.log")
 		assert.Equal(t, 2, set.Len(), "length should not change")
 		assert.Empty(t, set.entries[key], "empty fingerprint should not be added")
+	})
+
+	t.Run("rejects empty hash or non-positive length", func(t *testing.T) {
+		set.Add("key4", "", 4, "/a.log")
+		set.Add("key5", loginp.HashRawFingerprint("aabb"), 0, "/a.log")
+		set.Add("key6", loginp.HashRawFingerprint("aabb"), -2, "/a.log")
+		assert.Equal(t, 2, set.Len(), "invalid entries should not be added")
+	})
+
+	t.Run("re-adding a key replaces its index slot", func(t *testing.T) {
+		set := newShortFingerprintSet()
+		set.AddRaw("key", "aabb", "/a.log")
+		set.AddRaw("key", "aabbcc", "/a.log")
+		assert.Equal(t, 1, set.Len())
+
+		// Only the new material matches; the stale (shorter) slot is gone.
+		_, _, found := set.FindPrefixMatch("aabbccdd", "")
+		require.True(t, found, "new material should match")
+		gotKey, _, found := set.FindPrefixMatch("aabbdd", "")
+		assert.False(t, found, "stale material must not match, got key %q", gotKey)
 	})
 }
 
 func TestShortFingerprintIndex_Remove(t *testing.T) {
 	idx := newShortFingerprintSet()
-	idx.Add("key1", "aabb", "/a.log")
-	idx.Add("key2", "ccdd", "/b.log")
+	idx.AddRaw("key1", "aabb", "/a.log")
+	idx.AddRaw("key2", "ccdd", "/b.log")
 	require.Equal(t, 2, idx.Len())
 
 	idx.Remove("key1")
 	assert.Equal(t, 1, idx.Len())
+	_, _, found := idx.FindPrefixMatch("aabbcc", "")
+	assert.False(t, found, "removed entry must not match anymore")
 
 	idx.Remove("nonexistent") // no-op
 	assert.Equal(t, 1, idx.Len())
@@ -79,8 +103,8 @@ func TestShortFingerprintIndex_Remove(t *testing.T) {
 
 func TestShortFingerprintIndex_RemoveBySource(t *testing.T) {
 	idx := newShortFingerprintSet()
-	idx.Add("key1", "aabb", "/a.log")
-	idx.Add("key2", "ccdd", "/b.log")
+	idx.AddRaw("key1", "aabb", "/a.log")
+	idx.AddRaw("key2", "ccdd", "/b.log")
 
 	idx.RemoveBySource("/a.log")
 	assert.Equal(t, 1, idx.Len())
@@ -88,11 +112,13 @@ func TestShortFingerprintIndex_RemoveBySource(t *testing.T) {
 	_, entry, found := idx.FindPrefixMatch("ccddee", "")
 	require.True(t, found, "key2 should still be present")
 	assert.Equal(t, "/b.log", entry.Source)
+	_, _, found = idx.FindPrefixMatch("aabbcc", "")
+	assert.False(t, found, "removed source must not match anymore")
 }
 
 func TestShortFingerprintIndex_UpdateSource(t *testing.T) {
 	idx := newShortFingerprintSet()
-	idx.Add("key1", "aabb", "/a.log")
+	idx.AddRaw("key1", "aabb", "/a.log")
 
 	idx.UpdateSource("key1", "/a.log.1")
 	assert.Equal(t, "/a.log.1", idx.entries["key1"].Source)
@@ -103,15 +129,14 @@ func TestShortFingerprintIndex_UpdateSource(t *testing.T) {
 
 func TestShortFingerprintIndex_FindPrefixMatch(t *testing.T) {
 	idx := newShortFingerprintSet()
-	idx.Add("key1", "aabb", "/a.log")
-	idx.Add("key2", "ccdd", "/b.log")
+	idx.AddRaw("key1", "aabb", "/a.log")
+	idx.AddRaw("key2", "ccdd", "/b.log")
 
 	t.Run("finds prefix match without source check", func(t *testing.T) {
 		key, entry, found := idx.FindPrefixMatch("aabbccdd", "")
 		require.True(t, found, "should find prefix match")
 		assert.Equal(t, "key1", key)
-		assert.Equal(t, "aabb", entry.Fingerprint)
-		assert.Equal(t, "/a.log", entry.Source)
+		assert.Equal(t, rawEntry("aabb", "/a.log"), entry)
 	})
 
 	t.Run("finds prefix match with source check", func(t *testing.T) {
@@ -145,14 +170,70 @@ func TestShortFingerprintIndex_FindPrefixMatch(t *testing.T) {
 		assert.False(t, found, "stored 'aabb' is not shorter than target 'aabb'")
 	})
 
+	t.Run("same length different content is not a match", func(t *testing.T) {
+		_, _, found := idx.FindPrefixMatch("aacc", "")
+		assert.False(t, found, "stored 'aabb' does not hash-match target prefix 'aacc'")
+	})
+
 	t.Run("without source filter returns longest prefix match", func(t *testing.T) {
 		idx := newShortFingerprintSet()
-		idx.Add("short", "aa", "/x.log")
-		idx.Add("long", "aabb", "/y.log")
+		idx.AddRaw("short", "aa", "/x.log")
+		idx.AddRaw("long", "aabb", "/y.log")
 
 		key, entry, found := idx.FindPrefixMatch("aabbccdd", "")
 		require.True(t, found, "should find prefix match")
 		assert.Equal(t, "long", key, "should pick the longest prefix match")
-		assert.Equal(t, "aabb", entry.Fingerprint)
+		assert.Equal(t, rawEntry("aabb", "/y.log"), entry)
 	})
+
+	t.Run("filtered-out longer match falls back to shorter match", func(t *testing.T) {
+		idx := newShortFingerprintSet()
+		idx.AddRaw("short", "aa", "/x.log")
+		idx.AddRaw("long", "aabb", "/y.log")
+
+		key, _, found := idx.FindPrefixMatch("aabbccdd", "/x.log")
+		require.True(t, found, "shorter entry matching the source filter should be found")
+		assert.Equal(t, "short", key)
+	})
+
+	t.Run("distinct keys sharing identical material both stay findable", func(t *testing.T) {
+		// The watcher's set is path-keyed, so two identical-content files
+		// produce two keys with the same (length, hash). Removing one must not
+		// orphan the other.
+		idx := newShortFingerprintSet()
+		idx.AddRaw("/x.log", "aabb", "/x.log")
+		idx.AddRaw("/y.log", "aabb", "/y.log")
+		require.Equal(t, 2, idx.Len())
+
+		idx.Remove("/x.log")
+		key, entry, found := idx.FindPrefixMatch("aabbccdd", "")
+		require.True(t, found, "the remaining twin must still match")
+		assert.Equal(t, "/y.log", key)
+		assert.Equal(t, "/y.log", entry.Source)
+	})
+}
+
+// TestShortFingerprintIndex_HashFormulaMatchesRegistryKey pins the invariant
+// the whole scheme rests on: hashing a target's prefix during FindPrefixMatch
+// produces exactly the value FingerprintID.Key() produced when that prefix was
+// the full raw material — which is also the registry key's identity tail that
+// buildShortFingerprintSet feeds to Add. If the streaming implementation ever
+// diverges from HashRawFingerprint, restart migration silently breaks; this
+// test makes that loud.
+func TestShortFingerprintIndex_HashFormulaMatchesRegistryKey(t *testing.T) {
+	target := "00112233445566778899aabbccddeeff"
+	for hexLen := 2; hexLen < len(target); hexLen += 2 {
+		prefix := target[:hexLen]
+
+		idx := newShortFingerprintSet()
+		// Simulate the registry-load path: the hash comes from the key that
+		// FingerprintID.Key() produced for the prefix, the length from the
+		// persisted fileMeta.FingerprintLen.
+		keyHash := loginp.FingerprintID{Raw: prefix}.Key()
+		idx.Add("key", keyHash, hexLen, "/a.log")
+
+		got, _, found := idx.FindPrefixMatch(target, "")
+		require.True(t, found, "prefix of hex length %d must match", hexLen)
+		assert.Equal(t, "key", got)
+	}
 }

--- a/filebeat/tests/integration/filestream_fingerprint_test.go
+++ b/filebeat/tests/integration/filestream_fingerprint_test.go
@@ -319,9 +319,9 @@ func TestFilestreamGrowingFingerprint(t *testing.T) {
 	filebeat.Stop()
 
 	// Registry shape: the plain files crossed the threshold and are now keyed by
-	// a final SHA-256 entry (no meta.fingerprint); the gzipped files stayed
+	// a final SHA-256 entry (no meta.fingerprint_len); the gzipped files stayed
 	// below the threshold (fingerprint is computed on decompressed content) and
-	// remain growing (raw-hex) entries.
+	// remain growing entries.
 	assertSingleSHA256RegistryEntry(t, tempDir, file1)
 	assertSingleSHA256RegistryEntry(t, tempDir, file2)
 	assertSingleSHA256RegistryEntry(t, tempDir, file3)
@@ -946,8 +946,8 @@ func TestFilestreamEnhancedFingerprint_NoDuplicationOnUpgrade(t *testing.T) {
 	filebeat.Stop()
 
 	// Registry state: largeFile keyed by the same SHA-256 from the static
-	// phase (no extra entries on upgrade); smallFile keyed by raw-hex with a
-	// non-empty meta.fingerprint (still growing, below threshold).
+	// phase (no extra entries on upgrade); smallFile keyed by the bounded hash
+	// with a non-zero meta.fingerprint_len (still growing, below threshold).
 	assertSingleSHA256RegistryEntry(t, tempDir, largeFile)
 	assertGrowingRegistryEntry(t, tempDir, smallFile)
 }
@@ -1611,7 +1611,7 @@ func TestFilestreamEnhancedFingerprint_RenameBelowThresholdAcrossRestartKeepRemo
 //
 // Two files exist from the start:
 //   - smallGz: decompressed ~250 bytes → below threshold → growing tracking
-//     (raw-hex registry key with a non-empty meta.fingerprint).
+//     (bounded-hash registry key with a non-zero meta.fingerprint_len).
 //   - largeGz: decompressed ~1500 bytes → above threshold → SHA-256 tracking.
 //
 // Both must be ingested completely under growing mode.
@@ -1748,9 +1748,9 @@ type fingerprintRegistryEntry struct {
 	removed     bool   // true if the latest op for this key was "remove"
 	// growing is true while the entry is in the growing phase. With the
 	// bounded-key optimization the key part is always a 64-char hash (so its
-	// length no longer distinguishes growing from final); the raw-hex
-	// fingerprint lives in the value (Meta.Fingerprint) and a non-empty value
-	// is the marker of a still-growing entry.
+	// length no longer distinguishes growing from final); the growing
+	// fingerprint's byte length lives in the value (Meta.FingerprintLen) and
+	// a non-zero value is the marker of a still-growing entry.
 	growing bool
 }
 
@@ -1783,7 +1783,7 @@ func readFingerprintRegistry(t *testing.T, tempDir string) map[string]fingerprin
 			fingerprint: fp,
 			source:      source,
 			removed:     e.Op == "remove",
-			growing:     e.Fingerprint != "",
+			growing:     e.FingerprintLen > 0,
 		}
 	}
 	return state
@@ -1834,8 +1834,8 @@ func assertFingerprintMigratedToSHA256(t *testing.T, homeDir, filePath string) {
 			continue
 		}
 		// With the bounded-key optimization the growing key is also 64 chars,
-		// so we classify by the value-side marker (Meta.Fingerprint), not key
-		// length.
+		// so we classify by the value-side marker (Meta.FingerprintLen), not
+		// key length.
 		if e.growing {
 			activeGrowing = append(activeGrowing, e.key)
 		} else {
@@ -1881,7 +1881,7 @@ func assertSingleSHA256RegistryEntry(t *testing.T, tempDir, filePath string) {
 
 // assertGrowingRegistryEntry asserts that the file has exactly one active
 // fingerprint entry still in the growing phase. Growing is identified by a
-// non-empty Meta.Fingerprint (see fingerprintRegistryEntry.growing), not by
+// non-zero Meta.FingerprintLen (see fingerprintRegistryEntry.growing), not by
 // key length: with the bounded-key optimization a growing key is also 64
 // chars. Used to verify that a small file below the configured threshold is
 // tracked under growing mode (and would migrate to SHA-256 if it ever grew

--- a/filebeat/tests/integration/filestream_truncation_test.go
+++ b/filebeat/tests/integration/filestream_truncation_test.go
@@ -180,9 +180,9 @@ type registryEntry struct {
 	TTL      time.Duration
 	Op       string
 	Removed  bool
-	// Fingerprint is the value-side raw-hex growing fingerprint (meta.fingerprint);
-	// non-empty only for still-growing entries.
-	Fingerprint string
+	// FingerprintLen is the value-side growing fingerprint byte length
+	// (meta.fingerprint_len); non-zero only for still-growing entries.
+	FingerprintLen int64
 }
 
 func readFilestreamRegistryLog(t *testing.T, path string) ([]registryEntry, map[string]string) {
@@ -212,14 +212,14 @@ func readFilestreamRegistryLog(t *testing.T, path string) ([]registryEntry, map[
 		}
 		// Filestream entry
 		et := registryEntry{
-			Key:         e.Key,
-			Offset:      e.Value.Cursor.Offset,
-			EOF:         e.Value.Cursor.EOF,
-			TTL:         e.Value.TTL,
-			Filename:    e.Value.Meta.Source,
-			Removed:     lastOperation == "remove",
-			Op:          lastOperation,
-			Fingerprint: e.Value.Meta.Fingerprint,
+			Key:            e.Key,
+			Offset:         e.Value.Cursor.Offset,
+			EOF:            e.Value.Cursor.EOF,
+			TTL:            e.Value.TTL,
+			Filename:       e.Value.Meta.Source,
+			Removed:        lastOperation == "remove",
+			Op:             lastOperation,
+			FingerprintLen: e.Value.Meta.FingerprintLen,
 		}
 
 		// Handle the log input entries, they have a different format.
@@ -254,11 +254,12 @@ type entry struct {
 		} `json:"cursor"`
 		Meta struct {
 			Source string `json:"source"`
-			// Fingerprint is the raw-hex growing fingerprint, persisted in the
-			// entry value only while the file is below threshold (bounded-key
-			// optimization). Empty for final SHA-256 / static entries, so a
-			// non-empty value is the marker of a still-growing entry.
-			Fingerprint string `json:"fingerprint"`
+			// FingerprintLen is the growing fingerprint's byte length,
+			// persisted in the entry value only while the file is below
+			// threshold (the hash is the registry key). Zero for final
+			// SHA-256 / static entries, so a non-zero value is the marker of
+			// a still-growing entry.
+			FingerprintLen int64 `json:"fingerprint_len"`
 		} `json:"meta"`
 
 		// Log input fields


### PR DESCRIPTION
[Single-page overview PDF](https://github.com/user-attachments/files/29748001/growing-fingerprint-hash-only-registry.pdf)

## Proposed commit message

```
filestream: persist hash+length instead of raw growing fingerprint

Growing (below-threshold) registry entries stored the raw hex-encoded
header bytes in the value (fileMeta.Fingerprint, up to ~2 KiB) so prefix
matching could re-link entries after a restart. The registry key is
already hex(sha256(raw)) (bounded key), so the value only needs the
material's byte length: "stored raw is a strict prefix of the target" is
equivalent to "the hashes agree at the stored length".

- fileMeta.Fingerprint (raw hex) -> fileMeta.FingerprintLen (bytes).
- shortFingerprintSet becomes a length-bucketed hash index; a lookup
  streams the target through one SHA-256 and snapshots the digest at
  each stored length (allocation-free).
- loginp.RawFingerprintHasher is the single owner of the hash formula,
  shared by FingerprintID.Key() and the index.
- The watcher builds its per-scan prefix index lazily (delete-only scans
  pay no hashing) and the prospector reuses the hash embedded in the
  registry key instead of recomputing it.

Growing entries shrink from ~2 KiB to ~20 B, cutting registry/WAL churn
for the many-small-files workload the feature targets, the in-memory
index drops ~20x, and raw header content (possible PII) never rests on
disk. The format break only affects the unreleased growing fingerprint:
static fingerprint entries and pre-growing registries are unaffected,
and entries written in the old in-tree growing format are re-keyed as
new files.

Benchstat:
goos: linux
goarch: amd64
pkg: github.com/elastic/beats/v7/filebeat/input/filestream
cpu: Intel(R) Core(TM) Ultra 7 265U
                                  │     main     │                 pr                  │
                                  │    sec/op    │    sec/op     vs base               │
Filestream/1000_files/growing-14    31.04m ± ∞ ¹   26.13m ± ∞ ¹  -15.83% (p=0.032 n=5)
Filestream/10000_files/growing-14   816.7m ± ∞ ¹   288.3m ± ∞ ¹  -64.70% (p=0.008 n=5)
geomean                             159.2m         86.79m        -45.49%
¹ need >= 6 samples for confidence interval at level 0.95

                                  │     main      │                 pr                  │
                                  │     B/op      │     B/op       vs base              │
Filestream/1000_files/growing-14    24.11Mi ± ∞ ¹   24.48Mi ± ∞ ¹  +1.54% (p=0.008 n=5)
Filestream/10000_files/growing-14   239.8Mi ± ∞ ¹   243.4Mi ± ∞ ¹  +1.51% (p=0.008 n=5)
geomean                             76.03Mi         77.19Mi        +1.52%
¹ need >= 6 samples for confidence interval at level 0.95

                                  │     main     │                 pr                 │
                                  │  allocs/op   │  allocs/op    vs base              │
Filestream/1000_files/growing-14    203.0k ± ∞ ¹   205.2k ± ∞ ¹  +1.10% (p=0.008 n=5)
Filestream/10000_files/growing-14   2.038M ± ∞ ¹   2.057M ± ∞ ¹  +0.94% (p=0.008 n=5)
geomean                             643.1k         649.7k        +1.02%
¹ need >= 6 samples for confidence interval at level 0.95

Pre-release follow-up to #50566 (Enhanced Fingerprint).
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments`~~ — no changelog: the growing fingerprint feature (#50566) is unreleased, so this pre-release refactor has no user-visible effect.

## Disruptive User Impact

None. This only changes the on-disk shape of still-growing fingerprint registry entries, a format introduced by #50566 the day before and not present in any release. No configuration changes.

## How to test this PR locally

Runs the actual binary against a real config so you can watch the new on-disk shape and the restart behavior directly in the registry.

```bash
cd filebeat && go build -o /tmp/gfp/filebeat .
mkdir -p /tmp/gfp/home /tmp/gfp/logs
cat > /tmp/gfp/filebeat.yml <<'YAML'
filebeat.inputs:
  - type: filestream
    id: growing-fp-demo
    enabled: true
    paths:
      - /tmp/gfp/logs/*.log
    prospector.scanner:
      check_interval: 1s
      # Fingerprint SIZE (offset+length) is the threshold. 64 is the minimum
      # (sha256.BlockSize). NOTE: these live under prospector.scanner.fingerprint,
      # NOT file_identity.fingerprint (which only accepts `growing`).
      fingerprint:
        offset: 0
        length: 64
    file_identity.fingerprint:
      growing: true

queue.mem:
  flush.timeout: 0s
path.home: /tmp/gfp/home
output.file:
  path: ${path.home}
  filename: "events"
  rotate_on_startup: false
logging:
  level: debug
YAML

printf 'alpha\nbravo\n' > /tmp/gfp/logs/app.log   # 12 bytes, below the 64-byte threshold
cd /tmp/gfp && ./filebeat -e --strict.perms=false -c filebeat.yml
```

Inspect the registry and emitted events from another shell:

```bash
cat /tmp/gfp/home/data/registry/filebeat/log.json
grep -o '"message":"[^"]*"' /tmp/gfp/home/events-*.ndjson
```

What to verify:

1. **Below threshold, the raw bytes are never persisted.** The small file is ingested immediately (events `alpha`, `bravo`) and its registry value carries only the length: `"meta":{...,"fingerprint_len":12}` — there is no raw `fingerprint` field. The key tail equals `sha256(hex(first 12 bytes))`:

   ```bash
   python3 -c "import hashlib;d=open('/tmp/gfp/logs/app.log','rb').read()[:64];print(hashlib.sha256(d.hex().encode()).hexdigest())"
   ```

2. **Crossing the threshold rekeys to the static SHA-256 key, with no re-ingest.** Grow the file past 64 bytes:

   ```bash
   printf 'charlie\ndelta\necho\nfoxtrot\ngolf\nhotel\nindia\njuliet\nkilo\nlima\nmike\n' >> /tmp/gfp/logs/app.log
   ```

   The entry rekeys to `sha256(first 64 bytes)` — byte-identical to what the static fingerprint produces — its growing marker becomes zero (`fingerprint_len:0`), the old key gets a `remove` op, and the cursor offset is preserved (no line is re-read; only the new lines are emitted).

3. **Restart resume via the registry-load path.** Stop filebeat, append a few bytes while it is down, then restart. On startup the growing index is rebuilt from only the persisted `(key-hash, fingerprint_len)`; the grown file prefix-matches the stored entry, the key migrates to `sha256(hex(new prefix))`, the old key is removed, the harvester resumes at the saved offset, and only the newly appended lines appear in `/tmp/gfp/home/events-*.ndjson` (the earlier lines are not re-ingested).

## Related issues

- Relates #50566
