### PR TITLE
filestream: cap fingerprint length to limit memory use

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -42,8 +42,12 @@ import (
 const (
 	RecursiveGlobDepth           = 8
 	DefaultFingerprintSize int64 = 1024 // 1KB
-	scannerDebugKey              = "scanner"
-	watcherDebugKey              = "file_watcher"
+	// MinFingerprintSize is the smallest allowed fingerprint length (one SHA-256 block).
+	MinFingerprintSize int64 = sha256.BlockSize
+	// MaxFingerprintSize caps fingerprint length; larger values risk exhausting scanner memory.
+	MaxFingerprintSize int64 = 10 * 1024 * 1024 // 10MB
+	scannerDebugKey          = "scanner"
+	watcherDebugKey          = "file_watcher"
 )
 
 var (
@@ -600,9 +604,14 @@ func newFileScanner(logger *logp.Logger, paths []string, config fileScannerConfi
 	}
 
 	if s.cfg.Fingerprint.Enabled {
-		if s.cfg.Fingerprint.Length < sha256.BlockSize {
-			err := fmt.Errorf("fingerprint size %d bytes cannot be smaller than %d bytes", config.Fingerprint.Length, sha256.BlockSize)
+		if s.cfg.Fingerprint.Length < MinFingerprintSize {
+			err := fmt.Errorf("fingerprint size %d bytes cannot be smaller than %d bytes", config.Fingerprint.Length, MinFingerprintSize)
 			return nil, fmt.Errorf("error while reading configuration of fingerprint: %w", err)
+		}
+		if s.cfg.Fingerprint.Length > MaxFingerprintSize {
+			s.log.Warnf("fingerprint length %d bytes exceeds the maximum of %d bytes, capping to the maximum",
+				s.cfg.Fingerprint.Length, MaxFingerprintSize)
+			s.cfg.Fingerprint.Length = MaxFingerprintSize
 		}
 		s.log.Debugf("fingerprint mode enabled: offset %d, length %d, growing %t",
 			s.cfg.Fingerprint.Offset, s.cfg.Fingerprint.Length, s.cfg.Fingerprint.Growing)

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -1235,6 +1235,25 @@ scanner:
 		require.Contains(t, err.Error(), "fingerprint size 1 bytes cannot be smaller than 64 bytes")
 	})
 
+	t.Run("caps a fingerprint larger than the maximum and warns", func(t *testing.T) {
+		cfg := fileScannerConfig{
+			Fingerprint: fingerprintConfig{
+				Enabled: true,
+				Offset:  0,
+				Length:  MaxFingerprintSize + 1,
+			},
+		}
+		inMemoryLog, buff := logp.NewInMemoryLocal("", logp.JSONEncoderConfig())
+		s, err := newFileScanner(inMemoryLog, paths, cfg, CompressionNone)
+		require.NoError(t, err, "an oversized fingerprint length must be capped, not rejected")
+		assert.Equal(t, MaxFingerprintSize, s.cfg.Fingerprint.Length,
+			"the fingerprint length must be capped to the maximum")
+		assert.Len(t, s.readBuffer, int(MaxFingerprintSize),
+			"the read buffer must be allocated at the capped length, not the configured one")
+		assert.Contains(t, buff.String(), "exceeds the maximum",
+			"capping an oversized fingerprint length must log a warning")
+	})
+
 	t.Run("empty regular files are silently excluded", func(t *testing.T) {
 		dir := t.TempDir()
 		empty := filepath.Join(dir, "empty.log")


### PR DESCRIPTION
## Proposed commit message

```
filestream: cap fingerprint length to limit memory use

The filestream scanner allocates a read buffer of
prospector.scanner.fingerprint.length and reads that many bytes from the
start of every file on each scan. The value is user-configurable with
only a lower bound, so a mistyped or copy-pasted large length silently
turns into a huge allocation.

Cap the effective length at MaxFingerprintSize (10MB, well above any
realistic file-identity prefix; the default is 1KB). Oversized values are
clamped and a warning is logged rather than rejected, so existing
(but unlikely) configurations keep running.

Measured with the real binary under a 20GiB cgroup, growing mode, one
below-threshold and one above-threshold file:

  length=1GiB  before: ~7.6 GiB peak       after: ~92 MiB peak
  length=5GiB  before: OOM-killed at 20GiB  after: ~118 MiB peak

The unbounded allocation predates growing mode (static fingerprinting
also buffers length bytes), so the cap hardens both paths.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

Only configurations that set `prospector.scanner.fingerprint.length` above 10MB are affected, and such values are impractical (the default is 1KB). For those, the effective length is now clamped to 10MB, which changes the fingerprint (fewer bytes hashed) and can therefore change file identity, potentially causing affected files to be re-ingested once after upgrade. A warning naming the setting is logged so the change is discoverable. All other configurations are unchanged.

## How to test this PR locally

Unit test:

```bash
cd filebeat
go test -run 'TestFileScanner/caps_a_fingerprint_larger_than_the_maximum_and_warns' ./input/filestream/
```

End-to-end reproduction with the real binary, bounded by a 20GiB cgroup so a runaway allocation is OOM-killed inside the cgroup instead of hurting the host. Growing-fingerprint mode is the expensive path.

Config (`/var/tmp/fb/filebeat.yml`)

```yaml
filebeat.inputs:
  - type: filestream
    id: repro
    paths:
      - /var/tmp/fb/logs/*.log
    prospector.scanner.check_interval: 1s
    prospector.scanner.fingerprint.length: 5368709120   # 5 GiB
    file_identity.fingerprint:
      growing: true

# Bound harvester/queue memory so only the fingerprint allocation shows up.
queue.mem:
  events: 64
  flush.min_events: 1

# Non-connecting output: events queue and backpressure halts harvesting.
output.logstash:
  hosts: ["127.0.0.1:2"]
  ttl: 1s
  timeout: 1s

logging.level: info
```

Create a below-threshold and an above-threshold file, and run each inside a 20GiB cgroup:

```bash
mkdir -p /var/tmp/fb/logs
base64 /dev/urandom | head -c 67108864 > /var/tmp/fb/block          # 64MiB block, newline-terminated lines
head -c 102400 /var/tmp/fb/block > /var/tmp/fb/logs/below.log        # 100KiB, below threshold
for i in $(seq 1 82); do cat /var/tmp/fb/block; done > /var/tmp/fb/logs/above.log  # ~5.1GiB, above threshold

# Run inside a 20GiB cgroup and read peak memory (repeat with /tmp/fb-unpatched).
run() {
  systemctl --user reset-failed fbtest 2>/dev/null
  systemd-run --user --unit=fbtest -p MemoryMax=20G -p MemorySwapMax=0 --quiet \
    -- "$1" -e -c /var/tmp/fb/filebeat.yml --strict.perms=false --path.home=/var/tmp/fb/home
  sleep 15
  cg=$(systemctl --user show fbtest -p ControlGroup --value)
  echo "peak: $(( $(cat /sys/fs/cgroup${cg}/memory.peak) / 1048576 )) MiB  result: $(systemctl --user show fbtest -p Result --value)"
  awk '/oom_kill /{print "oom_kill:", $2}' /sys/fs/cgroup${cg}/memory.events 2>/dev/null
  systemctl --user stop fbtest 2>/dev/null; systemctl --user reset-failed fbtest 2>/dev/null
}
run /tmp/fb-unpatched   # main: OOM-killed at 20GiB
run /tmp/fb-patched     # this PR: capped, ~118 MiB, runs
```

Observed:

- Unpatched (`main`), `length=5GiB`: `peak: 20480 MiB  result: oom-kill  oom_kill: 1` — the process does not run.
- Patched (this PR), same config: `peak: ~118 MiB  result: success`, and the warning below is logged. Lowering `length` to `1073741824` (1GiB) shows unpatched ~7.6GiB vs patched ~92MiB.

## Related issues

- Relates #50116
