### PR TITLE
synchronize filebeat run and shutdown functions

### DIFF
--- a/changelog/fragments/1783461968-filebeat-sync-run-and-shutdown-functions.yaml
+++ b/changelog/fragments/1783461968-filebeat-sync-run-and-shutdown-functions.yaml
@@ -36,7 +36,7 @@ component: filebeat
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-# pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/beats/pull/51800
 
 # AUTOMATED
 # OPTIONAL to manually add other issue URLs

--- a/changelog/fragments/1783461968-filebeat-sync-run-and-shutdown-functions.yaml
+++ b/changelog/fragments/1783461968-filebeat-sync-run-and-shutdown-functions.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Synchronize Filebeat Run and Shutdown functions. 
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
@@ -83,6 +84,7 @@ type Filebeat struct {
 	pipeline                 beat.PipelineConnector
 	logger                   *logp.Logger
 	otelStatusFactoryWrapper func(cfgfile.RunnerFactory) cfgfile.RunnerFactory
+	running                  atomic.Bool
 }
 
 type PluginFactory func(beat.Info, statestore.States) []v2.Plugin
@@ -530,6 +532,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	// Add done channel to wait for shutdown signal
 	waitFinished.AddChan(fb.done)
+	fb.running.Store(true)
 	waitFinished.Wait()
 
 	// Stop reloadable lists, autodiscover -> Stop crawler -> stop inputs -> stop harvesters.
@@ -589,6 +592,16 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 // Stop is called on exit to stop the crawling, spooling and registration processes.
 func (fb *Filebeat) Stop() {
 	fb.logger.Info("Stopping filebeat")
+
+	if !fb.running.Load() {
+		fb.logger.Info("Waiting for init to finish before stopping")
+		// Wait for Run to reach waitFinished.Wait() before closing done, so that
+		// Stop is never delivered before the beater is ready to handle it. Poll
+		// for up to 5 seconds; if Run hasn't started by then, proceed anyway.
+		for i := 0; i < 50 && !fb.running.Load(); i++ {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
 
 	// Stop Filebeat
 	fb.stopOnce.Do(func() { close(fb.done) })

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -83,7 +83,7 @@ type Filebeat struct {
 	pipeline                 beat.PipelineConnector
 	logger                   *logp.Logger
 	otelStatusFactoryWrapper func(cfgfile.RunnerFactory) cfgfile.RunnerFactory
-	runningCh                chan struct{}
+	runReady                 *closeOnce
 }
 
 type PluginFactory func(beat.Info, statestore.States) []v2.Plugin
@@ -175,7 +175,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 
 	fb := &Filebeat{
 		done:           make(chan struct{}),
-		runningCh:      make(chan struct{}),
+		runReady:       &closeOnce{},
 		config:         &config,
 		moduleRegistry: moduleRegistry,
 		pluginFactory:  plugins,
@@ -272,6 +272,9 @@ func (fb *Filebeat) loadModulesPipelines(b *beat.Beat) error {
 func (fb *Filebeat) Run(b *beat.Beat) error {
 	var err error
 	config := fb.config
+	// Close runReady so that Shutdown doesn't have to wait no
+	// matter how we exit from Run.
+	defer fb.runReady.Close()
 
 	if b.Manager != nil {
 		b.Manager.RegisterDiagnosticHook("input_metrics", "Metrics from active inputs.",
@@ -532,7 +535,8 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	// Add done channel to wait for shutdown signal
 	waitFinished.AddChan(fb.done)
-	close(fb.runningCh)
+	// Safe for Shutdown to be called
+	fb.runReady.Close()
 	waitFinished.Wait()
 
 	// Stop reloadable lists, autodiscover -> Stop crawler -> stop inputs -> stop harvesters.
@@ -596,7 +600,7 @@ func (fb *Filebeat) Stop() {
 	// Wait for Run to reach waitFinished.Wait() before closing done, so that
 	// Stop is never delivered before the beater is ready to handle it.
 	select {
-	case <-fb.runningCh:
+	case <-fb.runReady.ch:
 	case <-time.After(5 * time.Second):
 		fb.logger.Warn("Timed out waiting for Run to reach ready state; stopping anyway")
 	}
@@ -615,4 +619,15 @@ func newPipelineLoaderFactory(ctx context.Context, esConfig *conf.C, info beat.I
 		return esClient, nil
 	}
 	return pipelineLoaderFactory
+}
+
+type closeOnce struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+func (coc *closeOnce) Close() {
+	coc.once.Do(func() {
+		close(coc.ch)
+	})
 }

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -175,7 +175,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 
 	fb := &Filebeat{
 		done:           make(chan struct{}),
-		runReady:       &closeOnce{},
+		runReady:       &closeOnce{ch: make(chan struct{})},
 		config:         &config,
 		moduleRegistry: moduleRegistry,
 		pluginFactory:  plugins,

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -595,17 +595,24 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 // Stop is called on exit to stop the crawling, spooling and registration processes.
 func (fb *Filebeat) Stop() {
+	fb.StopWithContext(context.Background())
+}
+
+// StopWithContext is like Stop but respects ctx when waiting for Run to reach
+// its ready state, so the caller's deadline is not consumed by the wait.
+func (fb *Filebeat) StopWithContext(ctx context.Context) {
 	fb.logger.Info("Stopping filebeat")
 
 	// Wait for Run to reach waitFinished.Wait() before closing done, so that
 	// Stop is never delivered before the beater is ready to handle it.
 	select {
 	case <-fb.runReady.ch:
+	case <-ctx.Done():
+		fb.logger.Warn("Context cancelled waiting for Run to reach ready state; stopping anyway")
 	case <-time.After(5 * time.Second):
 		fb.logger.Warn("Timed out waiting for Run to reach ready state; stopping anyway")
 	}
 
-	// Stop Filebeat
 	fb.stopOnce.Do(func() { close(fb.done) })
 }
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
@@ -84,7 +83,7 @@ type Filebeat struct {
 	pipeline                 beat.PipelineConnector
 	logger                   *logp.Logger
 	otelStatusFactoryWrapper func(cfgfile.RunnerFactory) cfgfile.RunnerFactory
-	running                  atomic.Bool
+	runningCh                chan struct{}
 }
 
 type PluginFactory func(beat.Info, statestore.States) []v2.Plugin
@@ -176,6 +175,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 
 	fb := &Filebeat{
 		done:           make(chan struct{}),
+		runningCh:      make(chan struct{}),
 		config:         &config,
 		moduleRegistry: moduleRegistry,
 		pluginFactory:  plugins,
@@ -532,7 +532,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	// Add done channel to wait for shutdown signal
 	waitFinished.AddChan(fb.done)
-	fb.running.Store(true)
+	close(fb.runningCh)
 	waitFinished.Wait()
 
 	// Stop reloadable lists, autodiscover -> Stop crawler -> stop inputs -> stop harvesters.
@@ -593,14 +593,12 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 func (fb *Filebeat) Stop() {
 	fb.logger.Info("Stopping filebeat")
 
-	if !fb.running.Load() {
-		fb.logger.Info("Waiting for init to finish before stopping")
-		// Wait for Run to reach waitFinished.Wait() before closing done, so that
-		// Stop is never delivered before the beater is ready to handle it. Poll
-		// for up to 5 seconds; if Run hasn't started by then, proceed anyway.
-		for i := 0; i < 50 && !fb.running.Load(); i++ {
-			time.Sleep(100 * time.Millisecond)
-		}
+	// Wait for Run to reach waitFinished.Wait() before closing done, so that
+	// Stop is never delivered before the beater is ready to handle it.
+	select {
+	case <-fb.runningCh:
+	case <-time.After(5 * time.Second):
+		fb.logger.Warn("Timed out waiting for Run to reach ready state; stopping anyway")
 	}
 
 	// Stop Filebeat

--- a/filebeat/beater/stop_test.go
+++ b/filebeat/beater/stop_test.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// TestStopWaitsForRunReady proves that Stop does not close the done channel
+// until Run has set fb.running to true (i.e., reached waitFinished.Wait).
+// This guards against a race where the OTel collector calls Shutdown before
+// the beat's Run goroutine has initialised its shutdown-signal machinery.
+func TestStopWaitsForRunReady(t *testing.T) {
+	fb := &Filebeat{
+		done:   make(chan struct{}),
+		logger: logp.NewNopLogger(),
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		fb.Stop()
+	}()
+
+	// Give Stop a moment to enter its polling loop.
+	time.Sleep(150 * time.Millisecond)
+
+	// done must still be open: Stop is waiting for running to become true.
+	select {
+	case <-fb.done:
+		t.Fatal("Stop closed done before Run set running to true")
+	default:
+	}
+
+	// Simulate Run() reaching the waitFinished.Wait() call.
+	fb.running.Store(true)
+
+	// Stop should close done within the next polling interval (≤100 ms).
+	select {
+	case <-fb.done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stop did not close done after running was set to true")
+	}
+
+	<-stopDone
+}

--- a/filebeat/beater/stop_test.go
+++ b/filebeat/beater/stop_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 // TestStopWaitsForRunReady proves that Stop does not close the done channel
-// until Run has closed runningCh (i.e., reached waitFinished.Wait).
+// until Run has closed runReady (i.e., reached waitFinished.Wait).
 // This guards against a race where the OTel collector calls Shutdown before
 // the beat's Run goroutine has initialised its shutdown-signal machinery.
 func TestStopWaitsForRunReady(t *testing.T) {
 	fb := &Filebeat{
-		done:      make(chan struct{}),
-		runningCh: make(chan struct{}),
-		logger:    logp.NewNopLogger(),
+		done:     make(chan struct{}),
+		runReady: &closeOnce{ch: make(chan struct{})},
+		logger:   logp.NewNopLogger(),
 	}
 
 	stopDone := make(chan struct{})
@@ -41,20 +41,20 @@ func TestStopWaitsForRunReady(t *testing.T) {
 		fb.Stop()
 	}()
 
-	// done must still be open: Stop is waiting for runningCh to be closed.
+	// done must still be open: Stop is waiting for runReady to be closed.
 	select {
 	case <-fb.done:
-		t.Fatal("Stop closed done before Run closed runningCh")
+		t.Fatal("Stop closed done before Run closed runReady")
 	default:
 	}
 
 	// Simulate Run() reaching the waitFinished.Wait() call.
-	close(fb.runningCh)
+	fb.runReady.Close()
 
 	select {
 	case <-fb.done:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Stop did not close done after runningCh was closed")
+		t.Fatal("Stop did not close done after runReady was closed")
 	}
 
 	<-stopDone

--- a/filebeat/beater/stop_test.go
+++ b/filebeat/beater/stop_test.go
@@ -25,13 +25,14 @@ import (
 )
 
 // TestStopWaitsForRunReady proves that Stop does not close the done channel
-// until Run has set fb.running to true (i.e., reached waitFinished.Wait).
+// until Run has closed runningCh (i.e., reached waitFinished.Wait).
 // This guards against a race where the OTel collector calls Shutdown before
 // the beat's Run goroutine has initialised its shutdown-signal machinery.
 func TestStopWaitsForRunReady(t *testing.T) {
 	fb := &Filebeat{
-		done:   make(chan struct{}),
-		logger: logp.NewNopLogger(),
+		done:      make(chan struct{}),
+		runningCh: make(chan struct{}),
+		logger:    logp.NewNopLogger(),
 	}
 
 	stopDone := make(chan struct{})
@@ -40,24 +41,20 @@ func TestStopWaitsForRunReady(t *testing.T) {
 		fb.Stop()
 	}()
 
-	// Give Stop a moment to enter its polling loop.
-	time.Sleep(150 * time.Millisecond)
-
-	// done must still be open: Stop is waiting for running to become true.
+	// done must still be open: Stop is waiting for runningCh to be closed.
 	select {
 	case <-fb.done:
-		t.Fatal("Stop closed done before Run set running to true")
+		t.Fatal("Stop closed done before Run closed runningCh")
 	default:
 	}
 
 	// Simulate Run() reaching the waitFinished.Wait() call.
-	fb.running.Store(true)
+	close(fb.runningCh)
 
-	// Stop should close done within the next polling interval (≤100 ms).
 	select {
 	case <-fb.done:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Stop did not close done after running was set to true")
+		t.Fatal("Stop did not close done after runningCh was closed")
 	}
 
 	<-stopDone

--- a/x-pack/libbeat/cmd/instance/receiver.go
+++ b/x-pack/libbeat/cmd/instance/receiver.go
@@ -30,6 +30,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+// contextStopper is an optional extension of beat.Beater for beaters that can
+// respect a context deadline while waiting to reach their ready state. If a
+// beater implements this, Shutdown uses it so the OTel context deadline is not
+// consumed by the ready-state wait before Disconnect is called.
+type contextStopper interface {
+	StopWithContext(ctx context.Context)
+}
+
 // BaseReceiver holds common configurations for beatreceivers.
 type BeatReceiver struct {
 	beat                *instance.Beat
@@ -196,7 +204,13 @@ func (br *BeatReceiver) Shutdown(ctx context.Context) error {
 	// The Beater owns shutdown sequencing: stop it first so it can close its
 	// inputs and finalize acknowledgments before the pipeline is disconnected.
 	// See https://github.com/elastic/beats/issues/49794.
-	br.beater.Stop()
+	// Pass ctx so beaters that implement contextStopper don't exhaust the OTel
+	// shutdown deadline during their ready-state wait.
+	if cs, ok := br.beater.(contextStopper); ok {
+		cs.StopWithContext(ctx)
+	} else {
+		br.beater.Stop()
+	}
 
 	// Trigger the stop callback. Some beaters (e.g. metricbeat) call
 	// Manager.Stop() in their Run() method, but others (e.g. packetbeat in

--- a/x-pack/libbeat/cmd/instance/receiver.go
+++ b/x-pack/libbeat/cmd/instance/receiver.go
@@ -46,6 +46,7 @@ type BeatReceiver struct {
 	Logger              *logp.Logger
 	bridge              *oteltelemetry.RegistryBridge
 	releaseSystemBridge func()
+	runDone             chan error // receives the error from beater.Run; closed when Run returns
 }
 
 // NewBeatReceiver creates a BeatReceiver.  This will also create the beater and start the monitoring server if configured
@@ -181,12 +182,14 @@ func (br *BeatReceiver) Start(host component.Host) error {
 		br.reporter = rep
 	}
 
-	if err := br.beater.Run(&br.beat.Beat); err != nil {
-		// set beatreceiver status
-		groupReporter.UpdateStatus(status.Failed, err.Error())
-		return fmt.Errorf("beat receiver run error: %w", err)
-	}
-
+	br.runDone = make(chan error, 1)
+	go func() {
+		err := br.beater.Run(&br.beat.Beat)
+		if err != nil {
+			groupReporter.UpdateStatus(status.Failed, err.Error())
+		}
+		br.runDone <- err
+	}()
 	return nil
 }
 
@@ -217,6 +220,15 @@ func (br *BeatReceiver) Shutdown(ctx context.Context) error {
 	// static mode) do not. The OtelManager.stopOnce ensures the callback runs
 	// exactly once regardless.
 	br.beat.Manager.Stop()
+
+	// Wait for beater.Run to return before disconnecting the pipeline, so the
+	// beater owns its full shutdown drain and the pipeline is not torn down
+	// while inputs are still active. Bounded by ctx so a hung beater does not
+	// block Shutdown indefinitely.
+	select {
+	case <-br.runDone:
+	case <-ctx.Done():
+	}
 
 	// Now disconnect the publisher pipeline (this waits for outstanding events
 	// to be acknowledged, bounded by the caller's context deadline or the


### PR DESCRIPTION
## Proposed commit message

Fix a race condition between Filebeat.Run and Filebeat.Stop where Stop could close the done channel before Run had reached the point of waiting on it. This was observable when Filebeat is embedded in the OTel collector, which may call Shutdown before the beater's Run goroutine has finished initializing its shutdown-signal machinery.

What changed

- Added an atomic.Bool running flag on Filebeat.
- Run sets running = true immediately before entering waitFinished.Wait(), signaling that the done channel is now wired up and safe to close.
- Stop polls running for up to 5 seconds (50 × 100ms) before proceeding to close(fb.done). If Run has not started within that window, Stop proceeds anyway to avoid hanging the shutdown path indefinitely.
- New unit test TestStopWaitsForRunReady in filebeat/beater/stop_test.go verifies that Stop blocks until running is set, then completes promptly.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

For Filebeat receiver this could slow down restarts, but will prevent
race conditions.

## How to test this PR locally

```shell
go test ./filebeat/beater/...
```


## Related issues

- Relates #51791

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
