### PR TITLE
filestream: fix duplicate harvesters on growing fingerprint migration

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -58,10 +58,11 @@ type Harvester interface {
 	Run(inputv2.Context, Source, Cursor, Publisher, *Metrics) error
 }
 
-// reader is the handle for one running harvester's registration in a readerGroup.
+// reader is the handle for one harvester's registration in a readerGroup.
 type reader struct {
-	group  *readerGroup
-	srcID  string // current registration key, guarded by group.mu
+	group *readerGroup
+	// srcID is the current registration key, guarded by group.mu.
+	srcID  string
 	cancel context.CancelFunc
 }
 
@@ -72,12 +73,45 @@ func (rd *reader) currentID() string {
 	return rd.srcID
 }
 
-// remove cancels the reader's context and deletes its registration from the group.
+// currentResource atomically returns the reader's registration key and the store resource for it.
+func (rd *reader) currentResource(store *store) (string, *resource) {
+	rd.group.mu.Lock()
+	defer rd.group.mu.Unlock()
+
+	return rd.srcID, store.Get(rd.srcID)
+}
+
+// register upgrades a reservation into a running registration and returns the harvester's context.
+// It registers under the reader's current ID, which may differ from the reserved one.
+func (rd *reader) register(cancelation inputv2.Canceler) (context.Context, error) {
+	rd.group.mu.Lock()
+	defer rd.group.mu.Unlock()
+
+	if rd.group.table[rd.srcID] != rd {
+		return nil, fmt.Errorf("reservation for %s was removed before the harvester started", rd.srcID)
+	}
+	if rd.cancel != nil {
+		return nil, ErrHarvesterAlreadyRunning
+	}
+
+	ctx, cancel := context.WithCancel(ctxtool.FromCanceller(cancelation))
+	rd.cancel = cancel
+	return ctx, nil
+}
+
+// remove cancels the reader's context and deletes its registration from the group. A removed reader
+// cannot register anymore.
 func (rd *reader) remove() {
 	rd.group.mu.Lock()
 	defer rd.group.mu.Unlock()
 
-	rd.cancel()
+	rd.unsafeRemove()
+}
+
+func (rd *reader) unsafeRemove() {
+	if rd.cancel != nil {
+		rd.cancel()
+	}
 	if rd.group.table[rd.srcID] == rd {
 		delete(rd.group.table, rd.srcID)
 	}
@@ -85,8 +119,7 @@ func (rd *reader) remove() {
 
 type readerGroup struct {
 	mu sync.Mutex
-	// table maps each source ID to its reader handle; a nil value is a
-	// reservation made by reserve before the harvester registers itself.
+	// table maps each source ID to its non-nil reader handle
 	table map[string]*reader
 }
 
@@ -96,70 +129,54 @@ func newReaderGroup() *readerGroup {
 	}
 }
 
-// newContext creates a new context and registers a reader for the given id within the reader group.
-// The returned reader carries the cancel function for the context; calling it is optional and does
-// not remove the registration.
-// An error is returned if a reader is already registered for the id.
-//
-// The context will be automatically cancelled once the ID is removed from the group.
-func (r *readerGroup) newContext(id string, cancelation inputv2.Canceler) (context.Context, *reader, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if existing := r.table[id]; existing != nil {
-		return nil, nil, ErrHarvesterAlreadyRunning
-	}
-
-	ctx, cancel := context.WithCancel(ctxtool.FromCanceller(cancelation))
-
-	rd := &reader{group: r, srcID: id, cancel: cancel}
-	r.table[id] = rd
-	return ctx, rd, nil
-}
-
 func (r *readerGroup) remove(id string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if rd := r.table[id]; rd != nil {
-		rd.cancel()
+		rd.unsafeRemove()
 	}
-
-	delete(r.table, id)
 }
 
-// migrate moves a running harvester's registration from oldID to newID, keeping the same reader.
-func (r *readerGroup) migrate(oldID, newID string) bool {
+// migrate atomically applies updateStore and re-keys any harvester registration from oldID to
+// newID, keeping the same reader handle.
+func (r *readerGroup) migrate(oldID, newID string, updateStore func() error) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	rd := r.table[oldID]
-	if rd == nil {
-		// Nothing running under oldID (absent or only reserved).
-		return false
-	}
-
 	if _, exists := r.table[newID]; exists {
 		// Target occupied — don't clobber an existing registration.
-		return false
+		return fmt.Errorf("a harvester is already registered for %q", newID)
+	}
+
+	if err := updateStore(); err != nil {
+		return err
+	}
+
+	rd := r.table[oldID]
+	if rd == nil {
+		// No harvester for oldID; only the store needed re-keying.
+		return nil
 	}
 
 	delete(r.table, oldID)
 	rd.srcID = newID
 	r.table[newID] = rd
-	return true
+	return nil
 }
 
-func (r *readerGroup) reserve(id string) bool {
+// reserve creates a reservation for the id, to be upgraded via reader.register once the harvester
+// goroutine runs. It returns nil if the id is already taken.
+func (r *readerGroup) reserve(id string) *reader {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	_, ok := r.table[id]
-	if ok {
-		return false
+	if _, exists := r.table[id]; exists {
+		return nil
 	}
-	r.table[id] = nil
-	return true
+	rd := &reader{group: r, srcID: id}
+	r.table[id] = rd
+	return rd
 }
 
 // HarvesterGroup is responsible for running the
@@ -178,7 +195,7 @@ type HarvesterGroup interface {
 	// SetObserver sets the observer to get notified when a harvester closes
 	SetObserver(c chan HarvesterStatus)
 	// Migrate moves a running harvester's bookkeeping registration in-place
-	Migrate(oldID string, next Source)
+	Migrate(oldID string, next Source, updateStore func(newID string) error) error
 }
 
 type defaultHarvesterGroup struct {
@@ -266,29 +283,28 @@ func startHarvester(
 	inputID string,
 ) func(context.Context) error {
 	srcID := hg.identifier.ID(src)
-	if !restart && !hg.readers.reserve(srcID) {
-		// A harvester is already running for this source, no need to start another.
-		// This check must happen here, before task.Group.Go spawns a goroutine.
-		// When harvester_limit is set, the spawned goroutine blocks on a semaphore
-		// until a slot is available. Without this early check, repeated file events
-		// would spawn goroutines that wait on the semaphore only to discover (after
-		// acquiring it) that a harvester is already running, causing a goroutine leak.
-		ctx.Logger.Debugf("Harvester already running for %s", srcID)
-		return nil
+	// rd is this harvester's registration handle; all key-dependent steps go through it rather than
+	// srcID because a migration can re-key the registration at any time.
+	var rd *reader
+	if !restart {
+		rd = hg.readers.reserve(srcID)
+		if rd == nil {
+			// A harvester is already running for this source, no need to start another. This check
+			// must happen here, before task.Group.Go spawns a goroutine. When harvester_limit is
+			// set, the spawned goroutine blocks on a semaphore until a slot is available. Without
+			// this early check, repeated file events would spawn goroutines that wait on the
+			// semaphore only to discover (after acquiring it) that a harvester is already running.
+			ctx.Logger.Debugf("Harvester already running for %s", srcID)
+			return nil
+		}
 	}
 
 	return func(canceler context.Context) (err error) {
-		// rd is this harvester's registration handle; cleanup goes through it
-		// rather than srcID because a migration can re-key the registration.
-		var rd *reader
 		defer func() {
 			if v := recover(); v != nil {
 				err = fmt.Errorf("harvester panic for source %q: %+v\n%s", srcID, v, debug.Stack())
 				if rd != nil {
 					rd.remove()
-				} else {
-					// Not registered yet, only the reserve() placeholder exists.
-					hg.readers.remove(srcID)
 				}
 			}
 
@@ -305,27 +321,22 @@ func startHarvester(
 		ctx.Logger = ctx.Logger.With("source_file", srcID)
 
 		if restart {
-			// stop previous harvester
+			// Stop the previous harvester and take its place.
 			hg.readers.remove(srcID)
-		}
-
-		var harvesterCtx context.Context
-		harvesterCtx, rd, err = hg.readers.newContext(srcID, canceler)
-		if err != nil {
-			// The only possible returned error is ErrHarvesterAlreadyRunning, which is a normal
-			// behaviour of the Filestream input, it's not really an error, it's just a situation.
-			// If the harvester is already running we don't need to start a new one.
-			// At the moment of writing even the returned error is ignored. So the
-			// only real effect of this branch is to not start a second harvester.
-			//
-			// Currently the only places this error is checked is on task.Group and the
-			// only thing it does is to log the error. So to avoid unnecessary errors,
-			// we just return nil.
-			if errors.Is(err, ErrHarvesterAlreadyRunning) {
-				ctx.Logger.Debug("Harvester already running")
+			rd = hg.readers.reserve(srcID)
+			if rd == nil {
+				// Another Start raced in; leave the source to it.
+				ctx.Logger.Debugf("Harvester already running for %s", srcID)
 				return nil
 			}
-			return fmt.Errorf("error while adding new reader to the bookkeeper %w", err)
+		}
+
+		harvesterCtx, err := rd.register(canceler)
+		if err != nil {
+			// A normal situation, not really an error: the source was stopped before this goroutine
+			// got to run.
+			ctx.Logger.Debugf("Harvester not started: %v", err)
+			return nil
 		}
 
 		defer func() {
@@ -339,8 +350,8 @@ func startHarvester(
 		ctx.Cancelation = harvesterCtx
 		defer rd.cancel()
 
-		resource, err := lock(ctx, hg.store, srcID)
-		if err != nil {
+		id, resource := rd.currentResource(hg.store)
+		if err := lockResource(ctx, resource, id); err != nil {
 			rd.remove()
 			return fmt.Errorf("error while locking resource: %w", err)
 		}
@@ -450,21 +461,17 @@ func (hg *defaultHarvesterGroup) Continue(ctx inputv2.Context, previous, next So
 	}
 }
 
-// Stop stops the running Harvester for a given Source.
+// Stop stops the running (or pending) Harvester for a given Source. It is synchronous so that a
+// Stop can never outrun a later Start.
 func (hg *defaultHarvesterGroup) Stop(s Source) {
-	_ = hg.tg.Go(func(_ context.Context) error {
-		hg.readers.remove(hg.identifier.ID(s))
-		return nil
-	})
+	hg.readers.remove(hg.identifier.ID(s))
 }
 
-// Migrate moves a running harvester's bookkeeping registration from oldID to next's identity
-// WITHOUT stopping it. It is used after an in-place registry key migration so that a subsequent
-// Start(next) finds the harvester already registered and no-ops, instead of spawning a duplicate
-// that would block forever on the shared resource lock. It does nothing if no harvester runs under
-// oldID or next's key is already taken.
-func (hg *defaultHarvesterGroup) Migrate(oldID string, next Source) {
-	hg.readers.migrate(oldID, hg.identifier.ID(next))
+// Migrate re-keys the registry entry and any harvester registration from oldID to next's identity
+// without stopping the harvester.
+func (hg *defaultHarvesterGroup) Migrate(oldID string, next Source, updateStore func(newID string) error) error {
+	newID := hg.identifier.ID(next)
+	return hg.readers.migrate(oldID, newID, func() error { return updateStore(newID) })
 }
 
 // StopHarvesters stops all running Harvesters.
@@ -476,7 +483,14 @@ func (hg *defaultHarvesterGroup) StopHarvesters() error {
 // the cursor state and unlock the key.
 func lock(ctx inputv2.Context, store *store, key string) (*resource, error) {
 	resource := store.Get(key)
+	if err := lockResource(ctx, resource, key); err != nil {
+		return nil, err
+	}
+	return resource, nil
+}
 
+// lockResource locks an already retained resource for exclusive access.
+func lockResource(ctx inputv2.Context, resource *resource, key string) error {
 	if !resource.lock.TryLock() {
 		ctx.Logger.Infof("Resource '%s' currently in use, waiting...", key)
 		err := resource.lock.LockContext(ctx.Cancelation)
@@ -484,7 +498,7 @@ func lock(ctx inputv2.Context, store *store, key string) (*resource, error) {
 		if err != nil {
 			ctx.Logger.Infof("Input for resource '%s' has been stopped while waiting", key)
 			resource.Release()
-			return nil, err
+			return err
 		}
 	}
 
@@ -492,7 +506,7 @@ func lock(ctx inputv2.Context, store *store, key string) (*resource, error) {
 	resource.lockedVersion = resource.version
 	resource.stateMutex.Unlock()
 
-	return resource, nil
+	return nil
 }
 
 func releaseResource(resource *resource) {

--- a/filebeat/input/filestream/internal/input-logfile/harvester_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester_test.go
@@ -60,7 +60,8 @@ func requireEventuallyWithT(t *testing.T, condition func(c *assert.CollectT), ms
 	require.EventuallyWithT(t, condition, eventuallyTimeout, eventuallyInterval, msgAndArgs...)
 }
 
-// hasID is only used in tests to check if a source is registered in the reader group.
+// hasID is only used in tests to check if a source has an entry (reserved or
+// registered) in the reader group.
 func (r *readerGroup) hasID(id string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -68,19 +69,44 @@ func (r *readerGroup) hasID(id string) bool {
 	return r.table[id] != nil
 }
 
+// isRegistered is only used in tests to check if a running harvester (not just
+// a reservation) is registered for the id.
+func (r *readerGroup) isRegistered(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rd := r.table[id]
+	return rd != nil && rd.cancel != nil
+}
+
+// noopStoreUpdate stands in for the registry UpdateKey callback in tests that
+// only exercise the reader bookkeeping.
+func noopStoreUpdate() error { return nil }
+
+// mustRegister reserves and registers a reader for the id.
+func mustRegister(t *testing.T, rg *readerGroup, id string) (*reader, context.Context) {
+	t.Helper()
+	rd := rg.reserve(id)
+	require.NotNil(t, rd, "reserve(%q) should succeed", id)
+	ctx, err := rd.register(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+	return rd, ctx
+}
+
+// awaitCursor receives the cursor a mock harvester sends when it starts.
+func awaitCursor(t *testing.T, ch <-chan Cursor) Cursor {
+	t.Helper()
+	select {
+	case cursor := <-ch:
+		return cursor
+	case <-time.After(eventuallyTimeout):
+		t.Fatal("harvester did not start")
+		return Cursor{}
+	}
+}
+
 func TestReaderGroup(t *testing.T) {
-	requireGroupSuccess := func(t *testing.T, ctx context.Context, rd *reader, err error) {
-		require.NotNil(t, ctx)
-		require.NotNil(t, rd)
-		require.NoError(t, err)
-	}
-
-	requireGroupError := func(t *testing.T, ctx context.Context, rd *reader, err error) {
-		require.Nil(t, ctx)
-		require.Nil(t, rd)
-		require.Error(t, err)
-	}
-
 	t.Run("assert new group is empty", func(t *testing.T) {
 		rg := newReaderGroup()
 		require.Empty(t, rg.table)
@@ -93,44 +119,45 @@ func TestReaderGroup(t *testing.T) {
 		require.Empty(t, rg.table)
 	})
 
-	t.Run("assert inserting existing key returns error", func(t *testing.T) {
+	t.Run("assert register upgrades a reservation", func(t *testing.T) {
 		rg := newReaderGroup()
-		ctx, rd, err := rg.newContext("test-id", t.Context())
-		requireGroupSuccess(t, ctx, rd, err)
-		require.Len(t, rg.table, 1)
 
-		newCtx, newRd, err := rg.newContext("test-id", t.Context())
-		requireGroupError(t, newCtx, newRd, err)
+		rd := rg.reserve("test-id")
+		require.NotNil(t, rd, "first reserve should succeed")
+		require.Nil(t, rg.reserve("test-id"), "reserve on a taken id must fail")
+
+		ctx, err := rd.register(t.Context())
+		require.NotNil(t, ctx)
+		require.NoError(t, err)
+
+		// A second register must fail since the harvester is now registered.
+		newCtx, err := rd.register(t.Context())
+		require.Nil(t, newCtx)
+		require.ErrorIs(t, err, ErrHarvesterAlreadyRunning)
+
+		require.Nil(t, rg.reserve("test-id"), "reserve on a registered id must fail")
 	})
 
-	t.Run("assert reserve allows newContext to upgrade the reservation", func(t *testing.T) {
+	t.Run("assert remove on a reserved entry allows re-reserve and fails its register", func(t *testing.T) {
 		rg := newReaderGroup()
 
-		assert.True(t, rg.reserve("test-id"), "first reserve should succeed")
-
-		ctx, rd, err := rg.newContext("test-id", t.Context())
-		requireGroupSuccess(t, ctx, rd, err)
-
-		// A second newContext should fail since a real harvester is now registered.
-		newCtx, newRd, err := rg.newContext("test-id", t.Context())
-		requireGroupError(t, newCtx, newRd, err)
-	})
-
-	t.Run("assert remove on a reserved entry and allows re-reserve", func(t *testing.T) {
-		rg := newReaderGroup()
-
-		assert.True(t, rg.reserve("test-id"), "first reserve should succeed")
-		assert.False(t, rg.reserve("test-id"), "second reserve for same id should fail")
+		rd := rg.reserve("test-id")
+		require.NotNil(t, rd, "first reserve should succeed")
+		assert.Nil(t, rg.reserve("test-id"), "second reserve for same id should fail")
 		rg.remove("test-id")
 		assert.Empty(t, rg.table)
 
-		assert.True(t, rg.reserve("test-id"), "reserve should succeed after remove")
+		// The removed reservation must not be able to register anymore, e.g.
+		// when the source was stopped before the harvester goroutine ran.
+		ctx, err := rd.register(t.Context())
+		assert.Nil(t, ctx)
+		assert.ErrorContains(t, err, "reservation for test-id was removed before the harvester started")
+		assert.NotNil(t, rg.reserve("test-id"), "reserve should succeed after remove")
 	})
 
 	t.Run("assert new key is added, can be removed and its context is cancelled", func(t *testing.T) {
 		rg := newReaderGroup()
-		ctx, rd, err := rg.newContext("test-id", t.Context())
-		requireGroupSuccess(t, ctx, rd, err)
+		_, ctx := mustRegister(t, rg, "test-id")
 		require.Len(t, rg.table, 1)
 
 		require.NoError(t, ctx.Err())
@@ -139,23 +166,20 @@ func TestReaderGroup(t *testing.T) {
 		require.Empty(t, rg.table)
 		require.ErrorIs(t, ctx.Err(), context.Canceled)
 
-		newCtx, newRd, err := rg.newContext("test-id", t.Context())
-		requireGroupSuccess(t, newCtx, newRd, err)
+		_, newCtx := mustRegister(t, rg, "test-id")
 		require.Len(t, rg.table, 1)
 		require.NoError(t, newCtx.Err())
 	})
 
 	t.Run("migrate moves a running registration to a new id", func(t *testing.T) {
 		rg := newReaderGroup()
-		require.True(t, rg.reserve("old-id"), "reserve should succeed")
-		ctx, rd, err := rg.newContext("old-id", t.Context())
-		requireGroupSuccess(t, ctx, rd, err)
+		rd, ctx := mustRegister(t, rg, "old-id")
 		require.Equal(t, "old-id", rd.currentID())
 
-		require.True(t, rg.migrate("old-id", "new-id"), "migrate should succeed")
+		require.NoError(t, rg.migrate("old-id", "new-id", noopStoreUpdate), "migrate should succeed")
 		assert.True(t, rg.hasID("new-id"), "registration should be under the new id")
 		assert.False(t, rg.hasID("old-id"), "old id should be gone")
-		assert.False(t, rg.reserve("new-id"), "reserve on the migrated id must fail")
+		assert.Nil(t, rg.reserve("new-id"), "reserve on the migrated id must fail")
 		assert.Equal(t, "new-id", rd.currentID(), "the reader handle must track the new id")
 		require.NoError(t, ctx.Err(), "migration must not cancel the running context")
 
@@ -165,23 +189,72 @@ func TestReaderGroup(t *testing.T) {
 		require.ErrorIs(t, ctx.Err(), context.Canceled, "reader.remove must cancel the context")
 	})
 
-	t.Run("migrate is a no-op when it cannot move the registration", func(t *testing.T) {
+	t.Run("migrate moves a reservation and register follows the new id", func(t *testing.T) {
+		// A reservation exists from Start until the harvester goroutine gets to
+		// run, which can take arbitrarily long (scheduling, harvester_limit). A
+		// migration in that window must re-key the reservation so that
+		// 1) a subsequent Start(new-id) does not spawn a duplicate harvester, and
+		// 2) the pending harvester registers under the new id, not the stale one.
 		rg := newReaderGroup()
-		ctx, rd, err := rg.newContext("running", t.Context())
-		requireGroupSuccess(t, ctx, rd, err)
-		ctx, rd, err = rg.newContext("other", t.Context())
-		requireGroupSuccess(t, ctx, rd, err)
-		require.True(t, rg.reserve("reserved-only"), "reserve should succeed")
+		rd := rg.reserve("old-id")
+		require.NotNil(t, rd, "reserve should succeed")
 
-		assert.False(t, rg.migrate("absent", "dest"), "absent old id must not migrate")
-		assert.False(t, rg.migrate("reserved-only", "dest"), "reserved-only old id must not migrate")
-		assert.False(t, rg.migrate("running", "other"), "occupied new id must not be clobbered")
-		assert.False(t, rg.migrate("running", "running"), "equal ids must not migrate")
+		require.NoError(t, rg.migrate("old-id", "new-id", noopStoreUpdate),
+			"a reservation must migrate like a running registration")
+		assert.Nil(t, rg.reserve("new-id"), "reserve on the migrated id must fail")
+		assert.False(t, rg.hasID("old-id"), "old id should be gone")
+		require.Equal(t, "new-id", rd.currentID())
+
+		ctx, err := rd.register(t.Context())
+		require.NotNil(t, ctx)
+		require.NoError(t, err)
+		assert.True(t, rg.isRegistered("new-id"), "register must land on the migrated id")
+		assert.False(t, rg.hasID("old-id"), "nothing must resurrect the old id")
+	})
+
+	t.Run("migrate without a reader still applies the store update", func(t *testing.T) {
+		rg := newReaderGroup()
+
+		called := false
+		require.NoError(t, rg.migrate("absent", "dest", func() error {
+			called = true
+			return nil
+		}))
+		assert.True(t, called, "the store update must run even with no harvester")
+		assert.False(t, rg.hasID("dest"), "no registration must be invented")
+	})
+
+	t.Run("migrate refuses an occupied target without touching the store", func(t *testing.T) {
+		rg := newReaderGroup()
+		mustRegister(t, rg, "running")
+		mustRegister(t, rg, "other")
+		require.NotNil(t, rg.reserve("reserved"), "reserve should succeed")
+
+		failStoreUpdate := func() error {
+			t.Error("the store update must not run when the target is occupied")
+			return nil
+		}
+		assert.Error(t, rg.migrate("running", "other", failStoreUpdate), "occupied new id must not be clobbered")
+		assert.Error(t, rg.migrate("running", "reserved", failStoreUpdate), "reserved new id must not be clobbered")
+		assert.Error(t, rg.migrate("running", "running", failStoreUpdate), "equal ids must not migrate")
 
 		// None of the failed migrations changed the table.
 		assert.True(t, rg.hasID("running"))
 		assert.True(t, rg.hasID("other"))
-		assert.False(t, rg.hasID("dest"))
+		assert.True(t, rg.hasID("reserved"))
+	})
+
+	t.Run("migrate keeps the registration when the store update fails", func(t *testing.T) {
+		rg := newReaderGroup()
+		rd, _ := mustRegister(t, rg, "running")
+
+		storeErr := fmt.Errorf("store update failed")
+		err := rg.migrate("running", "dest", func() error { return storeErr })
+		require.ErrorIs(t, err, storeErr)
+
+		assert.True(t, rg.hasID("running"), "failed migration must keep the old registration")
+		assert.False(t, rg.hasID("dest"), "failed migration must not create the new registration")
+		assert.Equal(t, "running", rd.currentID())
 	})
 }
 
@@ -574,7 +647,7 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 			"harvester should be running and registered under the old key")
 
 		// Simulate the growing-fingerprint bookkeeper migration old->new.
-		hg.Migrate(id1, source2)
+		require.NoError(t, hg.Migrate(id1, source2, func(string) error { return nil }))
 		require.True(t, hg.readers.hasID(id2), "registration should move to the new key")
 		assert.False(t, hg.readers.hasID(id1), "old key should be gone")
 
@@ -591,6 +664,190 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 		requireEventually(t,
 			func() bool { return !hg.readers.hasID(id2) },
 			"source should be removed from bookkeeper after stop on the new key")
+
+		require.NoError(t, hg.StopHarvesters())
+		require.Equal(t, 1, mockHarvester.getRunCount())
+	})
+
+	t.Run("assert Migrate re-keys a pending (reserved) harvester so Start(new) does not spawn a duplicate", func(t *testing.T) {
+		// Regression test for the growing-fingerprint duplication bug: a
+		// harvester that Start has reserved but whose goroutine has not
+		// registered yet must be re-keyed by Migrate like a running one.
+		// Before the fix, Migrate ignored reservations, so the follow-up
+		// Start(new) spawned a second harvester reading the same file from
+		// offset 0 under a second registry key.
+		release := make(chan struct{})
+		cursorCh := make(chan Cursor, 1)
+		mockHarvester := &mockHarvester{onRun: func(c input.Context, s Source, cur Cursor, _ Publisher) error {
+			if s.Name() == "/path/to/blocker" {
+				<-release
+				return nil
+			}
+			cursorCh <- cur
+			<-c.Cancelation.Done()
+			return nil
+		}}
+		// harvester_limit=1: the blocker harvester occupies the only slot, so
+		// the growing file's harvester deterministically stays in the
+		// reserved-but-not-registered state while waiting on the task group
+		// semaphore — the window the migration races with in production.
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 1)
+
+		goroutinesChecker := resources.NewGoroutinesChecker()
+		defer goroutinesChecker.WaitUntilOriginalCount()
+
+		blocker := &testSource{name: "/path/to/blocker"}
+		growing := &testSource{name: "/path/to/growing/short"}
+		grown := &testSource{name: "/path/to/growing/full"}
+		growingID := hg.identifier.ID(growing)
+		grownID := hg.identifier.ID(grown)
+
+		ctx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
+		hg.Start(ctx, blocker)
+		requireEventually(t,
+			func() bool { return mockHarvester.getRunCount() == 1 },
+			"blocker harvester should be running")
+
+		// The growing file is discovered: Start reserves its id, but the
+		// goroutine cannot register while the blocker holds the only slot.
+		hg.Start(ctx, growing)
+		require.True(t, hg.readers.hasID(growingID), "growing id should be reserved")
+		require.False(t, hg.readers.isRegistered(growingID), "growing harvester must not have registered yet")
+
+		// The file crosses the fingerprint threshold: the prospector migrates
+		// the registry key and bookkeeping, then starts the new identity.
+		srcStore := newSourceStore(hg.store, hg.identifier, nil)
+		liveResource := hg.store.Get(growingID)
+		defer liveResource.Release()
+		require.NoError(t, hg.Migrate(growingID, grown, func(newID string) error {
+			require.Equal(t, grownID, newID, "Migrate must derive the id a follow-up Start reserves")
+			return srcStore.UpdateKey(growingID, newID, nil)
+		}))
+		hg.Start(ctx, grown)
+
+		// Free the slot: the pending harvester must register under the
+		// migrated id, and no second harvester must appear for it.
+		close(release)
+		requireEventually(t,
+			func() bool { return hg.readers.isRegistered(grownID) },
+			"pending harvester should register under the migrated id")
+		assert.False(t, hg.readers.hasID(growingID), "stale id must not be resurrected")
+
+		// The pending harvester must run on the migrated (live) resource, not
+		// on a fresh offset-0 resource under the stale key.
+		cursor := awaitCursor(t, cursorCh)
+		assert.Same(t, liveResource, cursor.resource,
+			"the pending harvester must run on the migrated resource")
+
+		require.Never(t,
+			func() bool { return mockHarvester.getRunCount() > 2 },
+			200*time.Millisecond, eventuallyInterval,
+			"the migrated file must be served by exactly one harvester")
+
+		require.NoError(t, hg.StopHarvesters())
+		require.Equal(t, 2, mockHarvester.getRunCount())
+	})
+
+	t.Run("assert a harvester migrated between registering and locking uses the live resource", func(t *testing.T) {
+		// Regression test for the narrower window of the growing-fingerprint
+		// duplication bug: the migration lands after the harvester registered
+		// but before it locked its resource. The harvester must end up on the
+		// migrated (live) resource instead of resurrecting a fresh offset-0
+		// resource under the stale key and re-reading the whole file.
+		cursorCh := make(chan Cursor, 1)
+		mockHarvester := &mockHarvester{onRun: func(c input.Context, _ Source, cur Cursor, _ Publisher) error {
+			cursorCh <- cur
+			<-c.Cancelation.Done()
+			return nil
+		}}
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 0)
+		inputCtx := input.Context{Logger: logptest.NewTestingLogger(t, ""), Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
+
+		goroutinesChecker := resources.NewGoroutinesChecker()
+		defer goroutinesChecker.WaitUntilOriginalCount()
+
+		oldSrc := &testSource{name: "/path/to/growing/old"}
+		newSrc := &testSource{name: "/path/to/growing/new"}
+		oldID := hg.identifier.ID(oldSrc)
+		newID := hg.identifier.ID(newSrc)
+		srcStore := newSourceStore(hg.store, hg.identifier, nil)
+
+		// Pre-lock the resource so the starting harvester blocks in lock()
+		// after registering.
+		liveResource, err := lock(inputCtx, hg.store, oldID)
+		require.NoError(t, err)
+
+		hg.Start(inputCtx, oldSrc)
+		requireEventually(t,
+			func() bool { return hg.readers.isRegistered(oldID) },
+			"harvester should be registered while waiting for the resource")
+
+		// The migration lands in the registered-but-not-locked window: the
+		// registry entry and the registration are re-keyed atomically.
+		require.NoError(t, hg.Migrate(oldID, newSrc, func(id string) error {
+			return srcStore.UpdateKey(oldID, id, nil)
+		}))
+		require.True(t, hg.readers.isRegistered(newID), "registration should move to the new key")
+
+		releaseResource(liveResource)
+
+		cursor := awaitCursor(t, cursorCh)
+		assert.Same(t, liveResource, cursor.resource,
+			"the harvester must run on the migrated resource, not a fresh one under the stale key")
+
+		assert.False(t, srcStore.KeyExists(oldID), "no resource must be resurrected under the stale key")
+
+		require.NoError(t, hg.StopHarvesters())
+		require.Equal(t, 1, mockHarvester.getRunCount())
+	})
+
+	t.Run("assert Stop on a reserved harvester prevents it from starting", func(t *testing.T) {
+		release := make(chan struct{})
+		mockHarvester := &mockHarvester{onRun: func(c input.Context, s Source, _ Cursor, _ Publisher) error {
+			if s.Name() == "/path/to/blocker" {
+				<-release
+				return nil
+			}
+			<-c.Cancelation.Done()
+			return nil
+		}}
+		// harvester_limit=1 keeps the second harvester in the reserved state.
+		hg := testDefaultHarvesterGroup(t, mockHarvester, 1)
+
+		goroutinesChecker := resources.NewGoroutinesChecker()
+		defer goroutinesChecker.WaitUntilOriginalCount()
+
+		blocker := &testSource{name: "/path/to/blocker"}
+		pending := &testSource{name: "/path/to/pending"}
+		pendingID := hg.identifier.ID(pending)
+
+		testLogger := logptest.NewFileLogger(
+			t,
+			filepath.Join("..", "..", "..", "..", "build", "integration-tests"),
+		)
+		ctx := input.Context{Logger: testLogger.Logger, Cancelation: t.Context()}.WithStatusReporter(mockStatusReporter{})
+		hg.Start(ctx, blocker)
+		requireEventually(t,
+			func() bool { return mockHarvester.getRunCount() == 1 },
+			"blocker harvester should be running")
+
+		hg.Start(ctx, pending)
+		require.True(t, hg.readers.hasID(pendingID), "pending id should be reserved")
+
+		// Stop is synchronous, so it takes effect even though the pending
+		// harvester's goroutine is still queued on the harvester_limit slot.
+		hg.Stop(pending)
+		require.False(t, hg.readers.hasID(pendingID), "Stop must remove the reservation")
+		close(release)
+
+		// The pending goroutine acquires the freed slot and must give up: wait
+		// for the rejection to prove the register path actually ran.
+		testLogger.WaitLogsContains(t,
+			"Harvester not started",
+			eventuallyTimeout,
+			"the pending goroutine should reject its removed reservation")
+		assert.Equal(t, 1, mockHarvester.getRunCount(), "no harvester must start for the stopped source")
+		assert.False(t, hg.readers.hasID(pendingID), "the stopped source must not be registered")
 
 		require.NoError(t, hg.StopHarvesters())
 		require.Equal(t, 1, mockHarvester.getRunCount())

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -299,7 +299,7 @@ func (s *sourceStore) UpdateKey(oldKey, newKey string, meta any) error {
 		res.key = oldKeyValue
 		res.cursorMeta = oldMeta
 		res.stored = oldStored
-		s.store.ephemeralStore.table[oldKey] = res
+		s.store.ephemeralStore.table[oldKeyValue] = res
 		delete(s.store.ephemeralStore.table, newKey)
 		return fmt.Errorf(
 			"UpdateKey: failed to persist new key %q; keeping old key %q to avoid state loss",

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -18,6 +18,7 @@
 package input_logfile
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -34,6 +35,9 @@ import (
 	"github.com/elastic/go-concert"
 	"github.com/elastic/go-concert/unison"
 )
+
+// ErrKeyGone indicates the registry key does not exist (anymore)
+var ErrKeyGone = errors.New("registry key does not exist")
 
 // sourceStore is a store which can access resources using the Source
 // from an input.
@@ -256,11 +260,11 @@ func (s *sourceStore) UpdateKey(oldKey, newKey string, meta any) error {
 
 	res := s.store.ephemeralStore.table[oldKey]
 	if res == nil {
-		return fmt.Errorf("old key %s not found", oldKey)
+		return fmt.Errorf("old key %s: %w", oldKey, ErrKeyGone)
 	}
 
 	if res.isDeleted() {
-		return fmt.Errorf("old key %s is deleted", oldKey)
+		return fmt.Errorf("old key %s is deleted: %w", oldKey, ErrKeyGone)
 	}
 
 	// Check if new key already exists
@@ -272,9 +276,14 @@ func (s *sourceStore) UpdateKey(oldKey, newKey string, meta any) error {
 	defer res.stateMutex.Unlock()
 
 	oldKeyValue := res.key
+	oldMeta := res.cursorMeta
+	oldStored := res.stored
 	res.key = newKey
 	res.cursorMeta = meta
 	res.stored = false
+	// The entry belongs to a live, just-scanned file; refresh Updated so the migrated entry is not
+	// immediately eligible for clean_inactive gc.
+	res.internalState.Updated = time.Now()
 
 	// Update the table: remove old entry, add new entry with same resource.
 	s.store.ephemeralStore.table[newKey] = res
@@ -286,10 +295,12 @@ func (s *sourceStore) UpdateKey(oldKey, newKey string, meta any) error {
 	// res.stored=true only on a successful write.
 	s.store.writeState(res)
 	if !res.stored {
-		// The write under newKey failed (already logged by writeState). Do NOT
-		// remove the old key: it is still the only durable record of this entry.
-		// The in-memory resource now lives under newKey and will be re-persisted
-		// on the next cursor checkpoint, so we do not lose state in memory either.
+		// The write under newKey failed. Roll back so memory and disk agree on oldKey again.
+		res.key = oldKeyValue
+		res.cursorMeta = oldMeta
+		res.stored = oldStored
+		s.store.ephemeralStore.table[oldKey] = res
+		delete(s.store.ephemeralStore.table, newKey)
 		return fmt.Errorf(
 			"UpdateKey: failed to persist new key %q; keeping old key %q to avoid state loss",
 			newKey, oldKeyValue)

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -470,6 +470,10 @@ func (p *fileProspector) onFSEvent(
 			if found {
 				if err := p.migrateGrowingFingerprint(updater, group, oldKey, src, event); err != nil {
 					log.Errorf("failed to migrate growing fingerprint on rename: %v", err)
+					// Running onRename now would create state under the new key and block the
+					// migration retry forever; migrateGrowingFingerprint kept the index entry
+					// pointing at the renamed path so a later scan retries.
+					return
 				}
 			}
 		}
@@ -606,11 +610,9 @@ func (t *ignoreInactiveType) Unpack(v string) error {
 	return nil
 }
 
-// handleGrowingFingerprintLookup handles the lookup logic for growing-mode
-// fingerprint events. Two transitions are reconciled here: continued growth
-// below threshold (raw header extending) and the one-time threshold crossing
-// where the identity becomes a SHA-256 (the descriptor still carries the raw
-// header in Fingerprint.Raw to bridge the transition).
+// handleGrowingFingerprintLookup reconciles growing-mode fingerprint events: continued growth
+// below threshold and the one-time crossing where the identity becomes a SHA-256.
+// If a needed migration fails, the OLD source is returned so the file keeps its old identity.
 func (p *fileProspector) handleGrowingFingerprintLookup(
 	log *logp.Logger,
 	event loginp.FSEvent,
@@ -631,15 +633,29 @@ func (p *fileProspector) handleGrowingFingerprintLookup(
 		return src
 	}
 
-	// Found a prefix match - migrate to new key. The old harvester keeps
-	// running under the new key and the caller's group.Start(src) no-ops;
-	// see HarvesterGroup.Migrate.
+	// Found a prefix match. Migrate to new key.
 	if err := p.migrateGrowingFingerprint(updater, group, oldKey, src, event); err != nil {
 		log.Errorf("failed to migrate growing fingerprint: %v", err)
-		// Continue anyway - might create duplicate, but better than losing data
+		// Processing the event under the new identity would create a second state and reader.
+		// Stay on the old identity so data keeps flowing until a later scan retries the migration.
+		return sourceForKey(src, oldKey)
 	}
 
 	return src
+}
+
+// sourceForKey re-targets src at an existing registry key's identity, or returns src unchanged.
+func sourceForKey(src loginp.Source, key string) loginp.Source {
+	rk, ok := parseRegistryKey(key)
+	if !ok {
+		return src
+	}
+	fs, ok := src.(fileSource)
+	if !ok {
+		return src
+	}
+	fs.fileID = rk.identity()
+	return fs
 }
 
 // buildShortFingerprintSet scans the store once and populates shortFingerprints
@@ -735,9 +751,9 @@ func (p *fileProspector) findGrowingFingerprintMatch(
 	return "", false
 }
 
-// migrateGrowingFingerprint migrates a registry entry from an old key to a new key when a file's
-// fingerprint has grown, and keeps the dependent state in sync: the short-fingerprint index and the
-// running harvester's bookkeeper registration.
+// migrateGrowingFingerprint migrates a registry entry from an old key to newSrc's identity when a
+// file's fingerprint has grown, keeping the short-fingerprint index in sync on both outcomes.
+// It returns nil when the old key is already gone; the file proceeds under its current identity.
 func (p *fileProspector) migrateGrowingFingerprint(
 	updater loginp.StateMetadataUpdater,
 	group loginp.HarvesterGroup,
@@ -757,23 +773,24 @@ func (p *fileProspector) migrateGrowingFingerprint(
 		FingerprintLen: event.Descriptor.Fingerprint.GrowingByteLen(),
 	}
 
-	// Keep the old key's plugin/input prefix and swap in the new identity.
-	// keyForIdentity is robust to input IDs that merely contain "fingerprint"
-	// as a substring (e.g. "my-fingerprint-input").
-	rk, ok := parseRegistryKey(oldKey)
-	if !ok {
-		return fmt.Errorf("invalid old key format: %s", oldKey)
-	}
-	newKey := rk.keyForIdentity(newSrc.Name())
-
-	err := updater.UpdateKey(oldKey, newKey, newMeta)
+	var newKey string
+	err := group.Migrate(oldKey, newSrc, func(newID string) error {
+		newKey = newID
+		return updater.UpdateKey(oldKey, newID, newMeta)
+	})
 	if err != nil {
-		return fmt.Errorf("failed to migrate growing fingerprint from %s to %s: %w", oldKey, newKey, err)
+		if errors.Is(err, loginp.ErrKeyGone) {
+			// The old key no longer exists: the matched index entry is stale. Drop it.
+			p.shortFingerprints.Remove(oldKey)
+			return nil
+		}
+		// Keep the entry indexed for a later retry, at the event's current path.
+		p.shortFingerprints.UpdateSource(oldKey, event.NewPath)
+		return fmt.Errorf("failed to migrate growing fingerprint from %s to %s: %w", oldKey, newSrc.Name(), err)
 	}
 
 	p.shortFingerprints.Remove(oldKey)
 	p.indexGrowingFingerprint(newKey, event.Descriptor, event.NewPath)
-	group.Migrate(oldKey, newSrc)
 
 	return nil
 }

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -703,8 +703,17 @@ func (t *testHarvesterGroup) Stop(s loginp.Source) {
 	t.events = append(t.events, harvesterStop(s.Name()))
 }
 
-func (t *testHarvesterGroup) Migrate(oldID string, next loginp.Source) {
-	t.events = append(t.events, harvesterMigrate(oldID+" -> "+next.Name()))
+func (t *testHarvesterGroup) Migrate(oldID string, next loginp.Source, updateStore func(string) error) error {
+	rk, ok := parseRegistryKey(oldID)
+	if !ok {
+		return fmt.Errorf("invalid old key: %s", oldID)
+	}
+	newID := rk.keyForIdentity(next.Name())
+	if err := updateStore(newID); err != nil {
+		return err
+	}
+	t.events = append(t.events, harvesterMigrate(oldID+" -> "+newID))
+	return nil
 }
 
 func (t *testHarvesterGroup) StopHarvesters() error {
@@ -790,6 +799,7 @@ type mockMetadataUpdater struct {
 	IterateOnPrefixCalled atomic.Int64
 	KeyExistsCalled       atomic.Int64
 	UpdateKeyCalled       int
+	UpdateKeyErr          error
 }
 
 func newMockMetadataUpdater() *mockMetadataUpdater {
@@ -897,8 +907,11 @@ func (mu *mockMetadataUpdater) UpdateKey(oldKey, newKey string, meta any) error 
 	mu.mu.Lock()
 	defer mu.mu.Unlock()
 	mu.UpdateKeyCalled++
+	if mu.UpdateKeyErr != nil {
+		return mu.UpdateKeyErr
+	}
 	if _, ok := mu.table[oldKey]; !ok {
-		return fmt.Errorf("old key %s not found", oldKey)
+		return fmt.Errorf("old key %s: %w", oldKey, loginp.ErrKeyGone)
 	}
 	mu.table[newKey] = meta
 	delete(mu.table, oldKey)
@@ -1640,12 +1653,12 @@ func TestHandleGrowingFingerprintLookup_KeyExistsFastPath(t *testing.T) {
 		assert.Positive(t, store.IterateOnPrefixCalled.Load(), "slow path must scan the registry")
 		assert.Positive(t, store.UpdateKeyCalled, "slow path must migrate the matched entry")
 		assert.False(t, store.has(oldKey), "old key must be removed after migration")
-		assert.Contains(t, hg.events, harvesterMigrate(oldKey+" -> "+src.Name()),
-			"migration must re-key the running harvester's registration")
 		// migrateGrowingFingerprint keeps the old key's plugin/input prefix and
 		// swaps in the new identity (src.Name()), which is the SHA-256-derived
 		// key, not the literal raw value used for event.SrcID.
 		newKey := "filestream::my-input::" + src.Name()
+		assert.Contains(t, hg.events, harvesterMigrate(oldKey+" -> "+newKey),
+			"migration must re-key the running harvester's registration")
 		assert.NotEqual(t, oldKey, newKey)
 		assert.True(t, store.has(newKey), "migrated entry must exist under the new key")
 	})
@@ -1723,7 +1736,7 @@ func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 		assert.Equal(t, rawEntry(newFingerprint, path), p.shortFingerprints.entries[newKey])
 
 		// The running harvester's registration is re-keyed along with the entry.
-		assert.Contains(t, hg.events, harvesterMigrate(oldKey+" -> "+src.Name()),
+		assert.Contains(t, hg.events, harvesterMigrate(oldKey+" -> "+newKey),
 			"migration must re-key the running harvester's registration")
 	})
 
@@ -1776,8 +1789,69 @@ func TestOnFSEvent_GrowingFingerprintMigration(t *testing.T) {
 		assert.Empty(t, p.shortFingerprints.entries, "short fingerprint set is empty after transition")
 
 		// The running harvester's registration is re-keyed along with the entry.
-		assert.Contains(t, hg.events, harvesterMigrate(oldKey+" -> "+src.Name()),
+		assert.Contains(t, hg.events, harvesterMigrate(oldKey+" -> "+newKey),
 			"migration must re-key the running harvester's registration")
+	})
+
+	// runGrowthEvent drives one below-threshold OpWrite growth event for the
+	// indexed oldKey against the given store.
+	runGrowthEvent := func(t *testing.T, store *mockMetadataUpdater) (p *fileProspector, hg *testHarvesterGroup, src loginp.Source, newKey string) {
+		t.Helper()
+		desc := loginp.FileDescriptor{
+			Fingerprint: loginp.FingerprintID{Raw: oldFingerprint + "ccdd"},
+		}
+		newKey = "filestream::" + inputID + "::fingerprint::" + desc.Fingerprint.Key()
+		p = &fileProspector{
+			logger:             log,
+			identifier:         identifier,
+			shortFingerprints:  newShortFingerprintSet(),
+			growingFingerprint: true,
+		}
+		p.shortFingerprints.AddRaw(oldKey, oldFingerprint, path)
+		event := loginp.FSEvent{
+			Op:         loginp.OpWrite,
+			OldPath:    path,
+			NewPath:    path,
+			SrcID:      newKey,
+			Descriptor: desc,
+		}
+		src = identifier.GetSource(event)
+		hg = newTestHarvesterGroup()
+		p.onFSEvent(log, input.Context{}, event, src, store, hg, time.Time{})
+		return p, hg, src, newKey
+	}
+
+	t.Run("failed migration: the event proceeds under the old identity", func(t *testing.T) {
+		// If the registry migration fails, the entry is still under the old
+		// key; starting a harvester under the new key would produce a second
+		// state and reader for the file. Data must keep flowing under the old
+		// identity until a later scan retries the migration.
+		store := newMockMetadataUpdater()
+		store.setRaw(oldKey, growingMeta(path, oldFingerprint))
+		store.UpdateKeyErr = fmt.Errorf("registry write failed")
+
+		p, hg, _, newKey := runGrowthEvent(t, store)
+
+		assert.True(t, store.has(oldKey), "old key must remain after a failed migration")
+		assert.False(t, store.has(newKey), "no state must be created under the new key")
+		assert.NotContains(t, hg.events, harvesterMigrate(oldKey+" -> "+newKey),
+			"no migration must be recorded")
+		assert.Contains(t, hg.events, harvesterStart("fingerprint::"+oldFingerprint),
+			"the harvester must be started under the old identity")
+		assert.Contains(t, p.shortFingerprints.entries, oldKey,
+			"the old entry must stay indexed so the next scan retries the migration")
+	})
+
+	t.Run("stale index entry: pruned and the file starts under its current identity", func(t *testing.T) {
+		// The index still knows oldKey but the registry entry is gone (e.g.
+		// removed by the cleaner): the stale entry must be dropped and the
+		// file ingested as new. The empty store makes UpdateKey fail with
+		// ErrKeyGone.
+		p, hg, src, _ := runGrowthEvent(t, newMockMetadataUpdater())
+
+		assert.NotContains(t, p.shortFingerprints.entries, oldKey, "the stale entry must be pruned")
+		assert.Contains(t, hg.events, harvesterStart(src.Name()),
+			"the file must be started under its current identity")
 	})
 }
 


### PR DESCRIPTION
## Proposed commit message

```
With file_identity.fingerprint.growing enabled, the registry key
migration that follows a file's fingerprint growth raced with
asynchronously starting harvesters. Start reserves the source id
synchronously, but the harvester goroutine only registers and locks its
resource when it gets to run. A migration landing in that window ignored
the reserved-but-unregistered harvester, so the follow-up Start of the
new key spawned a second harvester for the same file, while the pending
one registered under the stale key, locked a fresh offset-0 resource,
and re-read the whole file. Every line was ingested once per extra
harvester (2x-3x observed) and the migrated-away keys were resurrected
in the registry with cursor data.

The reader bookkeeping now stores a handle from reservation on and the
whole identity chain moves atomically:

- reserve() returns a *reader handle; the goroutine upgrades it via
  register(), which follows any re-keying that happened in the meantime
  and fails if the reservation was removed, so a Stop that arrives
  before the harvester starts now sticks.
- HarvesterGroup.Migrate re-keys the registry entry (UpdateKey) and any
  registration in one critical section, and derives the new key from the
  Source so it always matches what a follow-up Start reserves.
- Harvesters read their (key, resource) pair atomically; because
  UpdateKey re-keys resources in place, the pair stays live across
  migrations and a stale key can no longer mint a fresh resource.
- UpdateKey rolls back its in-memory swap when persisting fails, so a
  failed migration leaves a consistent old-keyed world; the prospector
  keeps the file flowing under its old identity and retries on a later
  scan, pruning index entries whose registry key is gone (ErrKeyGone).
- Stop is synchronous so a queued Stop can never cancel a newer Start's
  reservation, and stopping is no longer delayed behind the
  harvester_limit semaphore.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ (skip-changelog: the growing fingerprint feature is unreleased)

## Disruptive User Impact

None.

## How to test this PR locally

Unit and integration tests:

```bash
go test -race ./filebeat/input/filestream/...
go test -tags integration ./filebeat/input/filestream/...
```

Reproduce with `harvester_limit` which keeps starting harvesters queued on the task group semaphore.

```yaml
filebeat.inputs:
  - type: filestream
    id: repro-growing
    paths: ["/tmp/gfp/logs/*.log"]
    prospector.scanner.check_interval: 100ms
    prospector.scanner.fingerprint.enabled: true
    prospector.scanner.fingerprint.offset: 0
    prospector.scanner.fingerprint.length: 1024
    file_identity.fingerprint.growing: true
    harvester_limit: 10
    close.on_state_change.inactive: 500ms
output.file:
  path: /tmp/gfp/out
  filename: events
```

Create ~30 files with ~600 bytes (below the 1024-byte fingerprint threshold), start filebeat, then append lines in two waves so each file first grows below the threshold and then crosses it. Group the output docs by `(log.file.path, log.offset)`: before this fix files that were queued behind the limit get every line 2-3 times (and `filebeat.harvester.started` exceeds the file count); after it every pair appears exactly once.
