### PR TITLE
fix(heartbeat): preserve dotted keys in browser monitor params

### DIFF
--- a/changelog/fragments/1783521312-preserve-dotted-keys-heartbeat-browser-monitors.yaml
+++ b/changelog/fragments/1783521312-preserve-dotted-keys-heartbeat-browser-monitors.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Preserve dotted keys in browser monitor params
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: heartbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/51685

--- a/x-pack/heartbeat/cmd/root.go
+++ b/x-pack/heartbeat/cmd/root.go
@@ -15,7 +15,9 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	ucfg "github.com/elastic/go-ucfg"
 
 	_ "github.com/elastic/beats/v7/heartbeat/include"
 	_ "github.com/elastic/beats/v7/x-pack/libbeat/include"
@@ -28,9 +30,23 @@ var RootCmd *cmd.BeatsRootCmd
 // heartbeatCfg is a callback registered via SetTransform that returns a Elastic Agent client.Unit
 // configuration generated from a raw Elastic Agent config
 func heartbeatCfg(rawIn *proto.UnitExpectedConfig, agentInfo *client.AgentInfo) ([]*reload.ConfigWithMeta, error) {
-	configList, err := management.CreateReloadConfigFromInputs(TransformRawIn(rawIn))
+	rawInputs := TransformRawIn(rawIn)
+
+	// Browser "params" keys may contain literal dots (e.g. "subdomain.example.com"),
+	// so extract them before the dot-expanding parse and restore them after.
+	// See https://github.com/elastic/beats/issues/51685
+	browserParams, err := extractBrowserParams(rawInputs)
+	if err != nil {
+		return nil, err
+	}
+
+	configList, err := management.CreateReloadConfigFromInputs(rawInputs)
 	if err != nil {
 		return nil, fmt.Errorf("error creating reloader config: %w", err)
+	}
+
+	if err := restoreBrowserParams(configList, browserParams); err != nil {
+		return nil, err
 	}
 
 	processors := agentInfoRule(agentInfo)
@@ -46,6 +62,49 @@ func heartbeatCfg(rawIn *proto.UnitExpectedConfig, agentInfo *client.AgentInfo) 
 	}
 
 	return unnestedList, nil
+}
+
+// streamRef locates a stream within the raw input list.
+type streamRef struct{ input, stream int }
+
+// extractBrowserParams removes "params" from every browser stream in rawInputs
+// and pre-parses them with PathSep("") so dotted keys are kept literal.
+// Note: it mutates rawInputs.
+func extractBrowserParams(rawInputs []map[string]interface{}) (map[streamRef]*conf.C, error) {
+	extracted := map[streamRef]*conf.C{}
+	for i, input := range rawInputs {
+		streams, _ := input["streams"].([]interface{})
+		for j, s := range streams {
+			stream, ok := s.(map[string]interface{})
+			if kind, _ := stream["type"].(string); !ok || kind != "browser" {
+				continue
+			}
+			if params, ok := stream["params"].(map[string]interface{}); ok {
+				parsed, err := ucfg.NewFrom(params, ucfg.PathSep(""))
+				if err != nil {
+					return nil, fmt.Errorf("error parsing browser params for stream %d: %w", j, err)
+				}
+				extracted[streamRef{i, j}] = (*conf.C)(parsed)
+				delete(stream, "params")
+			}
+		}
+	}
+	return extracted, nil
+}
+
+// restoreBrowserParams puts the extracted browser params back into the parsed
+// configs, preserving their literal dotted keys.
+func restoreBrowserParams(configList []*reload.ConfigWithMeta, params map[streamRef]*conf.C) error {
+	for ref, p := range params {
+		streamCfg, err := configList[ref.input].Config.Child("streams", ref.stream)
+		if err != nil {
+			return fmt.Errorf("error restoring browser params for stream %d: %w", ref.stream, err)
+		}
+		if err := streamCfg.SetChild("params", -1, p); err != nil {
+			return fmt.Errorf("error restoring browser params for stream %d: %w", ref.stream, err)
+		}
+	}
+	return nil
 }
 
 // TransformRawIn removes unwanted fields to keep consistent hashing on reload()

--- a/x-pack/heartbeat/cmd/root_test.go
+++ b/x-pack/heartbeat/cmd/root_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/libbeat/common/reload"
@@ -94,6 +95,98 @@ func readOut(filename string) (cfg []map[string]interface{}, err error) {
 		return nil, err
 	}
 	return cfg, err
+}
+
+// TestHeartbeatCfg_BrowserParamsDottedKeys verifies that dotted keys in browser
+// "params" are kept literal, while dotted keys elsewhere in the monitor config
+// still expand into nested structure (see https://github.com/elastic/beats/issues/51685).
+func TestHeartbeatCfg_BrowserParamsDottedKeys(t *testing.T) {
+	tests := []struct {
+		name         string
+		streamFields map[string]interface{}
+		assert       func(t *testing.T, monitor map[string]interface{})
+	}{
+		{
+			name: "dotted param keys are preserved literally",
+			streamFields: map[string]interface{}{
+				"params": map[string]interface{}{
+					"subdomain":             "value1",
+					"subdomain.example.com": "value2",
+				},
+			},
+			assert: func(t *testing.T, monitor map[string]interface{}) {
+				params, ok := monitor["params"].(map[string]interface{})
+				require.True(t, ok, "expected browser params map in monitor config")
+				assert.Equal(t, "value1", params["subdomain"], "expected non-dotted param key to be preserved")
+				assert.Equal(t, "value2", params["subdomain.example.com"], "expected dotted param key to be preserved literally")
+			},
+		},
+		{
+			name: "dotted keys outside params still expand",
+			streamFields: map[string]interface{}{
+				// A dotted key that is NOT a param must still expand to nested structure.
+				"a.b.c": "nested",
+				"params": map[string]interface{}{
+					"subdomain.example.com": "literal",
+				},
+			},
+			assert: func(t *testing.T, monitor map[string]interface{}) {
+				// The non-param dotted key expands into nested maps.
+				a, ok := monitor["a"].(map[string]interface{})
+				require.True(t, ok, "expected dotted key 'a.b.c' to expand into nested maps")
+				b, ok := a["b"].(map[string]interface{})
+				require.True(t, ok, "expected 'a.b' to be a nested map")
+				assert.Equal(t, "nested", b["c"], "expected 'a.b.c' to expand")
+
+				// The param dotted key stays literal.
+				params, ok := monitor["params"].(map[string]interface{})
+				require.True(t, ok, "expected browser params map in monitor config")
+				assert.Equal(t, "literal", params["subdomain.example.com"], "expected param dotted key to stay literal")
+				assert.NotContains(t, params, "subdomain", "param dotted key must not expand")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runBrowserCfg(t, tc.streamFields)
+			tc.assert(t, got[0])
+		})
+	}
+}
+
+// runBrowserCfg loads the browser test fixture, merges the given fields into its
+// first (browser) stream, runs it through heartbeatCfg, and returns the
+// resulting monitor configs as maps.
+func runBrowserCfg(t *testing.T, streamFields map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+
+	var rawIn proto.UnitExpectedConfig
+	err := readRawIn("testdata/simple-browser.in.json", &rawIn)
+	require.NoError(t, err, "failed to read browser test fixture")
+
+	sourceMap := rawIn.GetSource().AsMap()
+	streams, ok := sourceMap["streams"].([]interface{})
+	require.True(t, ok, "expected streams to be a slice")
+	require.NotEmpty(t, streams, "expected at least one stream")
+
+	browserStream, ok := streams[0].(map[string]interface{})
+	require.True(t, ok, "expected browser stream to be an object")
+	for k, v := range streamFields {
+		browserStream[k] = v
+	}
+
+	rawIn.Source, err = structpb.NewStruct(sourceMap)
+	require.NoError(t, err, "failed to rebuild proto source")
+
+	cfg, err := heartbeatCfg(&rawIn, &client.AgentInfo{ID: "abc7d0a8-ce04-4663-95da-ff6d537c268f", Version: "8.13.1"})
+	require.NoError(t, err, "heartbeatCfg returned an error")
+
+	got, err := cfgToArrMap(cfg)
+	require.NoError(t, err, "failed to convert configs to maps")
+	require.NotEmpty(t, got, "expected at least one monitor config")
+
+	return got
 }
 
 func cfgToArrMap(cfg []*reload.ConfigWithMeta) ([]map[string]interface{}, error) {


### PR DESCRIPTION
Browser monitor params keys that contain literal dots were passed
through the Heartbeat dot-expanding configuration parser, which
incorrectly converted the params into a nested config path.

Extract each browser stream's parameter before the parse in order to
keep them literal.

Closes #51685

Assisted-By: pi

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
Browser monitor `params` keys that contain literal dots were passed
through the Heartbeat dot-expanding configuration parser, which
incorrectly converted the params into a nested config path.

Extract each browser stream's parameter before the parse in order to
keep them literal.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
go test -v -race -tags synthetics ./x-pack/heartbeat/cmd/...

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #51685

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
