### PR TITLE
x-pack/filebeat/input/awss3: aggregate SQS health status reporting

### DIFF
--- a/changelog/fragments/1783548970-sqs-health-status-aggregation.yaml
+++ b/changelog/fragments/1783548970-sqs-health-status-aggregation.yaml
@@ -1,0 +1,11 @@
+kind: enhancement
+summary: Aggregate SQS mode health status to reduce false Degraded/Healthy transitions.
+description: |
+  Replace scattered per-event status reporting in the aws-s3 SQS input with a
+  centralized health aggregator. The input now stays Running while making forward
+  progress despite bounded retryable failures, reports Degraded only for sustained
+  conditions needing operator action (persistent receive failures, delete/finalize
+  errors, poison-pill messages), filters out context.Canceled from shutdown/reload,
+  and clears Degraded only when the specific causing condition resolves.
+component: filebeat
+issue: https://github.com/elastic/beats/issues/51692

--- a/x-pack/filebeat/input/awss3/health.go
+++ b/x-pack/filebeat/input/awss3/health.go
@@ -19,6 +19,10 @@ import (
 // failures required before the input reports Degraded for receive errors.
 const defaultRecvFailThreshold = 3
 
+// defaultProcFailThreshold is the number of consecutive S3 object processing
+// failures required before the input reports Degraded for processing errors.
+const defaultProcFailThreshold = 3
+
 // sqsHealth aggregates health signals from the SQS reader, S3 processors,
 // and message disposition callbacks into a single coherent status for Fleet.
 //
@@ -38,8 +42,13 @@ type sqsHealth struct {
 	consecutiveRecvFails int
 	recvFailThreshold    int
 
+	consecutiveProcFails int
+	procFailThreshold    int
+
 	currentStatus status.Status
 	currentMsg    string
+
+	closed bool
 }
 
 type condition string
@@ -47,6 +56,7 @@ type condition string
 const (
 	condReceive  condition = "receive"
 	condWorker   condition = "worker"
+	condProcess  condition = "process"
 	condDelete   condition = "delete"
 	condFinalize condition = "finalize"
 	condPoison   condition = "poison"
@@ -63,6 +73,7 @@ func newSQSHealth(reporter status.StatusReporter, log *logp.Logger) *sqsHealth {
 		log:               log,
 		conditions:        make(map[condition]healthCondition),
 		recvFailThreshold: defaultRecvFailThreshold,
+		procFailThreshold: defaultProcFailThreshold,
 	}
 }
 
@@ -77,11 +88,19 @@ func (h *sqsHealth) UpdateStatus(s status.Status, msg string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	if h.closed {
+		return
+	}
+
 	switch s {
 	case status.Starting, status.Configuring, status.Stopping, status.Stopped, status.Failed:
 		clear(h.conditions)
 		h.consecutiveRecvFails = 0
+		h.consecutiveProcFails = 0
 		h.publish(s, msg)
+		if s == status.Stopped || s == status.Failed {
+			h.closed = true
+		}
 	case status.Running:
 		h.consecutiveRecvFails = 0
 		delete(h.conditions, condReceive)
@@ -101,25 +120,37 @@ func (h *sqsHealth) UpdateStatus(s status.Status, msg string) {
 func (h *sqsHealth) SetWorkerError(err error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	h.conditions[condWorker] = healthCondition{
-		msg: fmt.Sprintf("worker setup failed: %s", err),
+		msg: fmt.Sprintf("The input could not start an SQS message processor: %s", err),
 		at:  time.Now(),
 	}
 	h.update()
 }
 
 // SetProcessingError records an S3 processing failure. Errors caused by
-// context cancellation (shutdown/reload) are suppressed.
+// context cancellation (shutdown) are suppressed. Individual failures do
+// not degrade, but sustained consecutive failures (above threshold)
+// indicate a persistent problem like missing S3 permissions.
 func (h *sqsHealth) SetProcessingError(err error) {
 	if isShutdownErr(err) {
 		return
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	// Processing errors are transient per the design; the message will
-	// retry via visibility timeout. We do not set a condition for individual
-	// processing failures; they are logged and counted in metrics.
-	// Only poison pills and delete/finalize failures set conditions.
+	if h.closed {
+		return
+	}
+	h.consecutiveProcFails++
+	if h.consecutiveProcFails >= h.procFailThreshold {
+		h.conditions[condProcess] = healthCondition{
+			msg: fmt.Sprintf("The input cannot process S3 objects (%d consecutive failures): %s", h.consecutiveProcFails, err),
+			at:  time.Now(),
+		}
+		h.update()
+	}
 }
 
 // SetDeleteFailed records a failure to delete an SQS message after
@@ -131,8 +162,11 @@ func (h *sqsHealth) SetDeleteFailed(err error) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	h.conditions[condDelete] = healthCondition{
-		msg: fmt.Sprintf("SQS delete failed (message may be reprocessed): %s", err),
+		msg: fmt.Sprintf("The input processed an SQS message but could not delete it from the queue. AWS may deliver the message again, which can result in duplicate events: %s", err),
 		at:  time.Now(),
 	}
 	h.update()
@@ -146,8 +180,11 @@ func (h *sqsHealth) SetFinalizeFailed(err error) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	h.conditions[condFinalize] = healthCondition{
-		msg: fmt.Sprintf("S3 finalization failed (manual cleanup required): %s", err),
+		msg: fmt.Sprintf("The input could not copy an S3 object to the backup bucket, or could not delete the source object after backup. Check the backup bucket configuration and permissions: %s", err),
 		at:  time.Now(),
 	}
 	h.update()
@@ -161,18 +198,27 @@ func (h *sqsHealth) RecordPoisonPill(err error) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	h.conditions[condPoison] = healthCondition{
-		msg: fmt.Sprintf("message deleted as poison pill (possible data loss): %s", err),
+		msg: fmt.Sprintf("The input stopped retrying an SQS message after repeated processing failures and deleted it from the queue. Data from that notification may be missing: %s", err),
 		at:  time.Now(),
 	}
 	h.update()
 }
 
-// ClearDisposition clears delete, finalize, and poison-pill conditions
-// after a successful end-to-end message completion (delete + finalize).
+// ClearDisposition clears delete, finalize, poison-pill, and processing
+// conditions after a successful end-to-end message completion (delete +
+// finalize). Resets the consecutive processing failure counter.
 func (h *sqsHealth) ClearDisposition() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	h.consecutiveProcFails = 0
+	delete(h.conditions, condProcess)
 	delete(h.conditions, condDelete)
 	delete(h.conditions, condFinalize)
 	delete(h.conditions, condPoison)
@@ -183,22 +229,22 @@ func (h *sqsHealth) ClearDisposition() {
 // publishes it if changed. Must be called with h.mu held.
 func (h *sqsHealth) update() {
 	if len(h.conditions) == 0 {
-		h.publish(status.Running, "input is running")
+		h.publish(status.Running, "Input is running")
 		return
 	}
-	// Pick the condition to report. Priority order: worker, receive,
-	// delete, finalize, poison.
 	msg := h.pickMessage()
 	h.publish(status.Degraded, msg)
 }
 
+// pickMessage returns the message from the highest-priority active condition.
+// Priority order: worker, receive, process, delete, finalize, poison.
 func (h *sqsHealth) pickMessage() string {
-	for _, key := range []condition{condWorker, condReceive, condDelete, condFinalize, condPoison} {
+	for _, key := range []condition{condWorker, condReceive, condProcess, condDelete, condFinalize, condPoison} {
 		if c, ok := h.conditions[key]; ok {
 			return c.msg
 		}
 	}
-	return "input is degraded"
+	return "Input is degraded"
 }
 
 // publish sends the status to the underlying reporter if it differs from
@@ -214,5 +260,5 @@ func (h *sqsHealth) publish(s status.Status, msg string) {
 }
 
 func isShutdownErr(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	return errors.Is(err, context.Canceled)
 }

--- a/x-pack/filebeat/input/awss3/health.go
+++ b/x-pack/filebeat/input/awss3/health.go
@@ -1,0 +1,218 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awss3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// defaultRecvFailThreshold is the number of consecutive ReceiveMessage
+// failures required before the input reports Degraded for receive errors.
+const defaultRecvFailThreshold = 3
+
+// sqsHealth aggregates health signals from the SQS reader, S3 processors,
+// and message disposition callbacks into a single coherent status for Fleet.
+//
+// It replaces the pattern of scattered UpdateStatus calls that race on one
+// reporter. Processing code reports events (Set*/Clear*); the aggregator
+// decides what state to publish based on active conditions.
+//
+// sqsHealth implements status.StatusReporter so it can be passed to
+// readSQSMessages (which expects that interface) without signature changes.
+type sqsHealth struct {
+	mu       sync.Mutex
+	reporter status.StatusReporter
+	log      *logp.Logger
+
+	conditions map[condition]healthCondition
+
+	consecutiveRecvFails int
+	recvFailThreshold    int
+
+	currentStatus status.Status
+	currentMsg    string
+}
+
+type condition string
+
+const (
+	condReceive  condition = "receive"
+	condWorker   condition = "worker"
+	condDelete   condition = "delete"
+	condFinalize condition = "finalize"
+	condPoison   condition = "poison"
+)
+
+type healthCondition struct {
+	msg string
+	at  time.Time
+}
+
+func newSQSHealth(reporter status.StatusReporter, log *logp.Logger) *sqsHealth {
+	return &sqsHealth{
+		reporter:          reporter,
+		log:               log,
+		conditions:        make(map[condition]healthCondition),
+		recvFailThreshold: defaultRecvFailThreshold,
+	}
+}
+
+// UpdateStatus satisfies status.StatusReporter. It is called by
+// readSQSMessages (which reports receive-level Degraded/Running) and by
+// lifecycle code (Starting, Configuring, Failed, Stopped).
+//
+// Lifecycle states pass through directly and reset runtime conditions.
+// Running from readSQSMessages clears the receive condition.
+// Degraded from readSQSMessages tracks consecutive receive failures.
+func (h *sqsHealth) UpdateStatus(s status.Status, msg string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	switch s {
+	case status.Starting, status.Configuring, status.Stopping, status.Stopped, status.Failed:
+		clear(h.conditions)
+		h.consecutiveRecvFails = 0
+		h.publish(s, msg)
+	case status.Running:
+		h.consecutiveRecvFails = 0
+		delete(h.conditions, condReceive)
+		h.update()
+	case status.Degraded:
+		h.consecutiveRecvFails++
+		if h.consecutiveRecvFails >= h.recvFailThreshold {
+			h.conditions[condReceive] = healthCondition{msg: msg, at: time.Now()}
+		}
+		h.update()
+	}
+}
+
+// SetWorkerError records a worker setup failure (for example pipeline
+// connection error). This is a persistent condition cleared only by a
+// successful lifecycle transition.
+func (h *sqsHealth) SetWorkerError(err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.conditions[condWorker] = healthCondition{
+		msg: fmt.Sprintf("worker setup failed: %s", err),
+		at:  time.Now(),
+	}
+	h.update()
+}
+
+// SetProcessingError records an S3 processing failure. Errors caused by
+// context cancellation (shutdown/reload) are suppressed.
+func (h *sqsHealth) SetProcessingError(err error) {
+	if isShutdownErr(err) {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	// Processing errors are transient per the design; the message will
+	// retry via visibility timeout. We do not set a condition for individual
+	// processing failures; they are logged and counted in metrics.
+	// Only poison pills and delete/finalize failures set conditions.
+}
+
+// SetDeleteFailed records a failure to delete an SQS message after
+// successful processing. This means the message will be reprocessed,
+// causing duplicates.
+func (h *sqsHealth) SetDeleteFailed(err error) {
+	if isShutdownErr(err) {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.conditions[condDelete] = healthCondition{
+		msg: fmt.Sprintf("SQS delete failed (message may be reprocessed): %s", err),
+		at:  time.Now(),
+	}
+	h.update()
+}
+
+// SetFinalizeFailed records a failure to finalize S3 objects after
+// successful processing and deletion.
+func (h *sqsHealth) SetFinalizeFailed(err error) {
+	if isShutdownErr(err) {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.conditions[condFinalize] = healthCondition{
+		msg: fmt.Sprintf("S3 finalization failed (manual cleanup required): %s", err),
+		at:  time.Now(),
+	}
+	h.update()
+}
+
+// RecordPoisonPill records that a message was deleted as a poison pill
+// (non-retryable error after max receives). This is a data-loss signal.
+func (h *sqsHealth) RecordPoisonPill(err error) {
+	if isShutdownErr(err) {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.conditions[condPoison] = healthCondition{
+		msg: fmt.Sprintf("message deleted as poison pill (possible data loss): %s", err),
+		at:  time.Now(),
+	}
+	h.update()
+}
+
+// ClearDisposition clears delete, finalize, and poison-pill conditions
+// after a successful end-to-end message completion (delete + finalize).
+func (h *sqsHealth) ClearDisposition() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.conditions, condDelete)
+	delete(h.conditions, condFinalize)
+	delete(h.conditions, condPoison)
+	h.update()
+}
+
+// update derives the aggregate status from active conditions and
+// publishes it if changed. Must be called with h.mu held.
+func (h *sqsHealth) update() {
+	if len(h.conditions) == 0 {
+		h.publish(status.Running, "input is running")
+		return
+	}
+	// Pick the condition to report. Priority order: worker, receive,
+	// delete, finalize, poison.
+	msg := h.pickMessage()
+	h.publish(status.Degraded, msg)
+}
+
+func (h *sqsHealth) pickMessage() string {
+	for _, key := range []condition{condWorker, condReceive, condDelete, condFinalize, condPoison} {
+		if c, ok := h.conditions[key]; ok {
+			return c.msg
+		}
+	}
+	return "input is degraded"
+}
+
+// publish sends the status to the underlying reporter if it differs from
+// the last published state. This replaces StatusReporterHelper's dedup.
+func (h *sqsHealth) publish(s status.Status, msg string) {
+	if s == h.currentStatus && msg == h.currentMsg {
+		return
+	}
+	h.currentStatus = s
+	h.currentMsg = msg
+	h.log.Debugw("health status", "status", s, "msg", msg)
+	h.reporter.UpdateStatus(s, msg)
+}
+
+func isShutdownErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/x-pack/filebeat/input/awss3/health_test.go
+++ b/x-pack/filebeat/input/awss3/health_test.go
@@ -147,9 +147,9 @@ func TestSQSHealth_ContextCanceledSuppressed(t *testing.T) {
 	h := newSQSHealth(r, logp.NewNopLogger())
 	h.UpdateStatus(status.Running, "Input is running")
 
-	// Shutdown errors should not set any conditions.
+	// Shutdown errors (context.Canceled only) should not set any conditions.
 	h.SetDeleteFailed(context.Canceled)
-	h.SetFinalizeFailed(context.DeadlineExceeded)
+	h.SetFinalizeFailed(context.Canceled)
 	h.RecordPoisonPill(context.Canceled)
 	h.SetProcessingError(context.Canceled)
 
@@ -205,10 +205,68 @@ func TestSQSHealth_ProcessingErrorDoesNotDegrade(t *testing.T) {
 	h := newSQSHealth(r, logp.NewNopLogger())
 	h.UpdateStatus(status.Running, "Input is running")
 
-	// Processing errors are transient (message will retry) — no status change.
+	// Below threshold: no status change.
+	h.SetProcessingError(errors.New("s3 download failed"))
 	h.SetProcessingError(errors.New("s3 download failed"))
 	if len(r.updates) != 1 {
-		t.Fatalf("want no status change from processing error, got %d: %+v", len(r.updates), r.updates)
+		t.Fatalf("want no status change from transient processing errors, got %d: %+v", len(r.updates), r.updates)
+	}
+}
+
+func TestSQSHealth_SustainedProcessingErrorDegrades(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	// Hit the threshold (3 consecutive).
+	h.SetProcessingError(errors.New("access denied"))
+	h.SetProcessingError(errors.New("access denied"))
+	h.SetProcessingError(errors.New("access denied"))
+	if len(r.updates) != 2 || r.updates[1].status != status.Degraded {
+		t.Fatalf("want Degraded after sustained processing failures, got %+v", r.updates)
+	}
+
+	// Successful disposition clears it.
+	h.ClearDisposition()
+	last := r.updates[len(r.updates)-1]
+	if last.status != status.Running {
+		t.Errorf("want Running after clear, got %v", last.status)
+	}
+}
+
+func TestSQSHealth_LatchAfterStopped(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+	h.UpdateStatus(status.Stopped, "Done")
+
+	n := len(r.updates)
+
+	// Further updates should be ignored.
+	h.ClearDisposition()
+	h.SetDeleteFailed(errors.New("fail"))
+	h.SetWorkerError(errors.New("fail"))
+	h.UpdateStatus(status.Running, "Input is running")
+
+	if len(r.updates) != n {
+		t.Fatalf("want no updates after Stopped, got %d (was %d): %+v", len(r.updates), n, r.updates[n:])
+	}
+}
+
+func TestSQSHealth_LatchAfterFailed(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+	h.UpdateStatus(status.Failed, "Broken")
+
+	n := len(r.updates)
+
+	h.ClearDisposition()
+	h.SetDeleteFailed(errors.New("fail"))
+	h.UpdateStatus(status.Running, "Input is running")
+
+	if len(r.updates) != n {
+		t.Fatalf("want no updates after Failed, got %d (was %d): %+v", len(r.updates), n, r.updates[n:])
 	}
 }
 

--- a/x-pack/filebeat/input/awss3/health_test.go
+++ b/x-pack/filebeat/input/awss3/health_test.go
@@ -1,0 +1,222 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awss3
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/management/status"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestSQSHealth_LifecyclePassthrough(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+
+	h.UpdateStatus(status.Starting, "Input starting")
+	h.UpdateStatus(status.Configuring, "Configuring")
+	h.UpdateStatus(status.Running, "Input is running")
+	h.UpdateStatus(status.Stopped, "Done")
+
+	if len(r.updates) != 4 {
+		t.Fatalf("want 4 updates, got %d: %+v", len(r.updates), r.updates)
+	}
+	if r.updates[0].status != status.Starting {
+		t.Errorf("updates[0]: got %v, want Starting", r.updates[0].status)
+	}
+	if r.updates[3].status != status.Stopped {
+		t.Errorf("updates[3]: got %v, want Stopped", r.updates[3].status)
+	}
+}
+
+func TestSQSHealth_ReceiveThreshold(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+
+	// Start as Running.
+	h.UpdateStatus(status.Running, "Input is running")
+	if len(r.updates) != 1 || r.updates[0].status != status.Running {
+		t.Fatalf("want Running, got %+v", r.updates)
+	}
+
+	// First two receive errors should NOT degrade (below threshold of 3).
+	h.UpdateStatus(status.Degraded, "SQS error 1")
+	h.UpdateStatus(status.Degraded, "SQS error 2")
+	if len(r.updates) != 1 {
+		t.Fatalf("want no new updates after 2 receive errors, got %d total: %+v", len(r.updates), r.updates)
+	}
+
+	// Third receive error hits threshold → Degraded.
+	h.UpdateStatus(status.Degraded, "SQS error 3")
+	if len(r.updates) != 2 {
+		t.Fatalf("want 2 updates after threshold hit, got %d: %+v", len(r.updates), r.updates)
+	}
+	if r.updates[1].status != status.Degraded {
+		t.Errorf("want Degraded, got %v", r.updates[1].status)
+	}
+
+	// Successful receive clears the condition → Running.
+	h.UpdateStatus(status.Running, "Input is running")
+	if len(r.updates) != 3 {
+		t.Fatalf("want 3 updates after receive OK, got %d: %+v", len(r.updates), r.updates)
+	}
+	if r.updates[2].status != status.Running {
+		t.Errorf("want Running after receive OK, got %v", r.updates[2].status)
+	}
+}
+
+func TestSQSHealth_TransientReceiveErrorStaysRunning(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	// Two errors then success → should stay Running the whole time.
+	h.UpdateStatus(status.Degraded, "error 1")
+	h.UpdateStatus(status.Degraded, "error 2")
+	h.UpdateStatus(status.Running, "Input is running")
+
+	// Only the initial Running should have been published (no state change).
+	if len(r.updates) != 1 {
+		t.Fatalf("want 1 update (initial Running), got %d: %+v", len(r.updates), r.updates)
+	}
+}
+
+func TestSQSHealth_DeleteFailureDegrades(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	h.SetDeleteFailed(errors.New("access denied"))
+	if len(r.updates) != 2 {
+		t.Fatalf("want 2 updates, got %d: %+v", len(r.updates), r.updates)
+	}
+	if r.updates[1].status != status.Degraded {
+		t.Errorf("want Degraded after delete fail, got %v", r.updates[1].status)
+	}
+
+	// ClearDisposition restores Running.
+	h.ClearDisposition()
+	if len(r.updates) != 3 {
+		t.Fatalf("want 3 updates, got %d: %+v", len(r.updates), r.updates)
+	}
+	if r.updates[2].status != status.Running {
+		t.Errorf("want Running after clear, got %v", r.updates[2].status)
+	}
+}
+
+func TestSQSHealth_FinalizeFailureDegrades(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	h.SetFinalizeFailed(errors.New("bucket gone"))
+	if len(r.updates) != 2 || r.updates[1].status != status.Degraded {
+		t.Fatalf("want Degraded, got %+v", r.updates)
+	}
+
+	h.ClearDisposition()
+	if r.updates[len(r.updates)-1].status != status.Running {
+		t.Errorf("want Running after clear, got %v", r.updates[len(r.updates)-1].status)
+	}
+}
+
+func TestSQSHealth_PoisonPillDegrades(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	h.RecordPoisonPill(errors.New("bad message"))
+	if len(r.updates) < 2 || r.updates[1].status != status.Degraded {
+		t.Fatalf("want Degraded after poison pill, got %+v", r.updates)
+	}
+
+	// Next successful delete clears the condition.
+	h.ClearDisposition()
+	last := r.updates[len(r.updates)-1]
+	if last.status != status.Running {
+		t.Errorf("want Running after clear, got %v", last.status)
+	}
+}
+
+func TestSQSHealth_ContextCanceledSuppressed(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	// Shutdown errors should not set any conditions.
+	h.SetDeleteFailed(context.Canceled)
+	h.SetFinalizeFailed(context.DeadlineExceeded)
+	h.RecordPoisonPill(context.Canceled)
+	h.SetProcessingError(context.Canceled)
+
+	if len(r.updates) != 1 {
+		t.Fatalf("want no status change from shutdown errors, got %d: %+v", len(r.updates), r.updates)
+	}
+}
+
+func TestSQSHealth_WorkerErrorDegrades(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	h.SetWorkerError(errors.New("pipeline connect failed"))
+	if len(r.updates) != 2 || r.updates[1].status != status.Degraded {
+		t.Fatalf("want Degraded after worker error, got %+v", r.updates)
+	}
+}
+
+func TestSQSHealth_ReceiveOKDoesNotClearDeleteCondition(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	// Set a delete failure condition.
+	h.SetDeleteFailed(errors.New("fail"))
+	if r.updates[len(r.updates)-1].status != status.Degraded {
+		t.Fatalf("want Degraded, got %+v", r.updates)
+	}
+
+	// Successful receive should NOT clear the delete condition.
+	h.UpdateStatus(status.Running, "Input is running")
+	last := r.updates[len(r.updates)-1]
+	if last.status != status.Degraded {
+		t.Errorf("want still Degraded after receive OK (delete condition persists), got %v", last.status)
+	}
+}
+
+func TestSQSHealth_Dedup(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+
+	// Publishing the same status+msg twice should only forward once.
+	h.UpdateStatus(status.Running, "Input is running")
+	h.UpdateStatus(status.Running, "Input is running")
+	if len(r.updates) != 1 {
+		t.Fatalf("want 1 update (dedup), got %d: %+v", len(r.updates), r.updates)
+	}
+}
+
+func TestSQSHealth_ProcessingErrorDoesNotDegrade(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	// Processing errors are transient (message will retry) — no status change.
+	h.SetProcessingError(errors.New("s3 download failed"))
+	if len(r.updates) != 1 {
+		t.Fatalf("want no status change from processing error, got %d: %+v", len(r.updates), r.updates)
+	}
+}
+
+// testReporter records all status updates without dedup.
+type testReporter struct {
+	updates []mgmtStatusUpdate
+}
+
+func (r *testReporter) UpdateStatus(s status.Status, msg string) {
+	r.updates = append(r.updates, mgmtStatusUpdate{status: s, msg: msg})
+}

--- a/x-pack/filebeat/input/awss3/input_benchmark_test.go
+++ b/x-pack/filebeat/input/awss3/input_benchmark_test.go
@@ -229,7 +229,7 @@ func benchmarkInputSQS(t *testing.T, workerCount int) testing.BenchmarkResult {
 		config.NumberOfWorkers = workerCount
 		sqsReader := newSQSReaderInput(config, aws.Config{}, paths.New())
 		sqsReader.log = log.Named("sqs")
-		sqsReader.status = &statusReporterHelperMock{}
+		sqsReader.health = newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger())
 		sqsReader.pipeline = newFakePipeline()
 		sqsReader.metrics = newInputMetrics(monitoring.NewRegistry(), workerCount, logp.NewNopLogger())
 		sqsReader.sqs, err = newConstantSQS()

--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -149,7 +149,7 @@ func TestRegionSelection(t *testing.T) {
 				MetricsRegistry: monitoring.NewRegistry(),
 			}
 
-			in.status = &statusReporterHelperMock{}
+			in.health = newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger())
 			// Run setup and verify that it put the correct region in awsConfig.Region
 			err := in.setup(inputCtx, &fakePipeline{})
 			in.cleanup()

--- a/x-pack/filebeat/input/awss3/sqs_input.go
+++ b/x-pack/filebeat/input/awss3/sqs_input.go
@@ -21,7 +21,6 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/management/status"
-	"github.com/elastic/beats/v7/x-pack/libbeat/statusreporterhelper"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -51,7 +50,7 @@ type sqsReaderInput struct {
 	workerWg sync.WaitGroup
 
 	// health status reporting
-	status status.StatusReporter
+	health *sqsHealth
 
 	path *paths.Path
 }
@@ -77,13 +76,13 @@ func (in *sqsReaderInput) Run(
 	inputContext v2.Context,
 	pipeline beat.Pipeline,
 ) error {
-	in.status = statusreporterhelper.New(inputContext, inputContext.Logger, "S3 via SQS")
-	in.status.UpdateStatus(status.Starting, "Input starting")
+	in.health = newSQSHealth(inputContext, inputContext.Logger.Named("health"))
+	in.health.UpdateStatus(status.Starting, "Input starting")
 
 	// Initialize everything for this run
 	err := in.setup(inputContext, pipeline)
 	if err != nil {
-		in.status.UpdateStatus(status.Failed, fmt.Sprintf("Setup failure: %s", err.Error()))
+		in.health.UpdateStatus(status.Failed, fmt.Sprintf("Setup failure: %s", err.Error()))
 		return err
 	}
 
@@ -91,7 +90,7 @@ func (in *sqsReaderInput) Run(
 	ctx := v2.GoContextFromCanceler(inputContext.Cancelation)
 	in.run(ctx)
 	in.cleanup()
-	in.status.UpdateStatus(status.Stopped, "Input execution ended")
+	in.health.UpdateStatus(status.Stopped, "Input execution ended")
 
 	return nil
 }
@@ -106,7 +105,7 @@ func (in *sqsReaderInput) setup(
 	in.log = inputContext.Logger.With("queue_url", in.config.QueueURL)
 	in.pipeline = pipeline
 
-	in.status.UpdateStatus(status.Configuring, "Configuring input")
+	in.health.UpdateStatus(status.Configuring, "Configuring input")
 	in.detectedRegion = getRegionFromQueueURL(in.config.QueueURL)
 	if in.config.RegionName != "" {
 		// Configured region always takes precedence
@@ -206,7 +205,7 @@ func (in *sqsReaderInput) readerLoop(ctx context.Context) {
 		// Block to wait for more requests if requestCount is zero
 		requestCount += channelRequestCount(ctx, in.workRequestChan, requestCount == 0)
 
-		msgs := readSQSMessages(ctx, in.log, in.status, in.sqs, in.metrics, requestCount, in.config.QueueURL)
+		msgs := readSQSMessages(ctx, in.log, in.health, in.sqs, in.metrics, requestCount, in.config.QueueURL)
 
 		for _, msg := range msgs {
 			select {
@@ -322,7 +321,7 @@ func (w *sqsWorker) processMessage(ctx context.Context, msg types.Message) {
 func (in *sqsReaderInput) startWorkers(ctx, graceCtx context.Context) {
 	// setting to a "running" state here before async worker launches commence.
 	// this is so a degraded state during async launch doesn't get overwritten by a "running" state.
-	in.status.UpdateStatus(status.Running, "Input is running")
+	in.health.UpdateStatus(status.Running, "Input is running")
 
 	// Start the worker goroutines that will fetch messages via workRequestChan
 	// and workResponseChan until the input shuts down.
@@ -333,7 +332,7 @@ func (in *sqsReaderInput) startWorkers(ctx, graceCtx context.Context) {
 			if err != nil {
 				in.log.Error(err)
 				// will likely cover auth failures, network connectivity errors
-				in.status.UpdateStatus(status.Degraded, fmt.Sprintf("An SQS worker's setup failed, error: %s", err.Error()))
+				in.health.SetWorkerError(err)
 				return
 			}
 			go worker.run(ctx, graceCtx)
@@ -367,7 +366,7 @@ func (in *sqsReaderInput) createEventProcessor() (sqsProcessor, error) {
 	}
 	return newSQSS3EventProcessor(in.log.Named("sqs_s3_event"), in.metrics,
 		in.sqs, script, in.config.VisibilityTimeout,
-		in.config.SQSMaxReceiveCount, s3EventHandlerFactory, in.status), nil
+		in.config.SQSMaxReceiveCount, s3EventHandlerFactory, in.health), nil
 }
 
 // Read all pending requests and return their count. If block is true,

--- a/x-pack/filebeat/input/awss3/sqs_s3_event.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/smithy-go"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
@@ -128,7 +127,7 @@ type sqsS3EventProcessor struct {
 	warnOnce             sync.Once
 	metrics              *inputMetrics
 	script               *script
-	status               status.StatusReporter
+	health               *sqsHealth
 }
 
 func newSQSS3EventProcessor(
@@ -139,7 +138,7 @@ func newSQSS3EventProcessor(
 	sqsVisibilityTimeout time.Duration,
 	maxReceiveCount int,
 	s3 s3ObjectHandlerFactory,
-	status status.StatusReporter,
+	health *sqsHealth,
 ) *sqsS3EventProcessor {
 	if metrics == nil {
 		// Metrics are optional. Initialize a stub.
@@ -153,7 +152,7 @@ func newSQSS3EventProcessor(
 		log:                  log,
 		metrics:              metrics,
 		script:               script,
-		status:               status,
+		health:               health,
 	}
 }
 
@@ -231,7 +230,7 @@ func (r sqsProcessingResult) Done() {
 	if processingErr == nil {
 		if msgDelErr := p.sqs.DeleteMessage(context.Background(), r.msg); msgDelErr != nil {
 			p.log.Errorf("failed deleting message from SQS queue (it may be reprocessed): %v", msgDelErr.Error())
-			r.processor.status.UpdateStatus(status.Degraded, fmt.Sprintf("Failed an attempt to delete an SQS message. Error: %s", msgDelErr.Error()))
+			p.health.SetDeleteFailed(msgDelErr)
 			return
 		}
 		if p.metrics != nil {
@@ -242,7 +241,9 @@ func (r sqsProcessingResult) Done() {
 		// SQS message finished and deleted, finalize s3 objects
 		if finalizeErr := r.finalizeS3Objects(); finalizeErr != nil {
 			p.log.Errorf("failed finalizing message from SQS queue (manual cleanup is required): %v", finalizeErr.Error())
-			r.processor.status.UpdateStatus(status.Degraded, fmt.Sprintf("Failed finalizing message from SQS queue. Manual cleanup is required. Error: %s", finalizeErr.Error()))
+			p.health.SetFinalizeFailed(finalizeErr)
+		} else {
+			p.health.ClearDisposition()
 		}
 		return
 	}
@@ -260,12 +261,12 @@ func (r sqsProcessingResult) Done() {
 		if msgDelErr := p.sqs.DeleteMessage(context.Background(), r.msg); msgDelErr != nil {
 			p.log.Errorf("failed processing SQS message (attempted to delete message): %v", processingErr.Error())
 			p.log.Errorf("failed deleting message from SQS queue (it may be reprocessed): %v", msgDelErr.Error())
-			r.processor.status.UpdateStatus(status.Degraded, fmt.Sprintf("Failed an attempt to delete an unprocessable SQS message. Error: %s", msgDelErr.Error()))
+			p.health.SetDeleteFailed(msgDelErr)
 			return
 		}
 		p.metrics.sqsMessagesDeletedTotal.Inc()
 		p.log.Errorf("failed processing SQS message (message was deleted): %v", processingErr)
-		r.processor.status.UpdateStatus(status.Degraded, fmt.Sprintf("Failed processing SQS message. Message was deleted. Processing error: %s", processingErr.Error()))
+		p.health.RecordPoisonPill(processingErr)
 		return
 	}
 
@@ -275,7 +276,6 @@ func (r sqsProcessingResult) Done() {
 	// after maximum receives is reached.
 	p.metrics.sqsMessagesReturnedTotal.Inc()
 	p.log.Errorf("failed processing SQS message (it will return to queue after visibility timeout): %v", processingErr)
-	r.processor.status.UpdateStatus(status.Degraded, fmt.Sprintf("Failed processing SQS message. Processing will be reattempted: %s", processingErr.Error()))
 }
 
 func (p *sqsS3EventProcessor) keepalive(ctx context.Context, log *logp.Logger, msg *types.Message) {
@@ -301,7 +301,6 @@ func (p *sqsS3EventProcessor) keepalive(ctx context.Context, log *logp.Logger, m
 						log.Warnw("Failed to extend message visibility timeout "+
 							"because SQS receipt handle is no longer valid. "+
 							"Stopping SQS message keepalive routine.", "error", err)
-						p.status.UpdateStatus(status.Degraded, fmt.Sprintf("An attempt to reset the SQS visibility timeout failed, %s", err.Error()))
 						return
 					}
 				}
@@ -453,9 +452,7 @@ func (p *sqsS3EventProcessor) processS3Events(
 			err = fmt.Errorf(
 				"failed processing S3 event for object key %q in bucket %q (object record %d of %d in SQS notification): %w",
 				event.S3.Object.Key, event.S3.Bucket.Name, i+1, len(s3Events), err)
-			// This single error is intentional as to not overwhelm the reader of the status reporting
-			// with a long message. More detailed information can be found in logs.
-			p.status.UpdateStatus(status.Degraded, fmt.Sprintf("S3 event processing failure: %s", err.Error()))
+			p.health.SetProcessingError(err)
 			errs = append(errs, err)
 		} else {
 			finalizers = append(finalizers, s3Processor.FinalizeS3Object)

--- a/x-pack/filebeat/input/awss3/sqs_s3_event_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event_test.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/go-concert/timed"
 )
@@ -43,7 +44,7 @@ func TestSQSS3EventProcessor(t *testing.T) {
 			mockAPI.EXPECT().DeleteMessage(gomock.Any(), gomock.Eq(&msg)).Return(nil),
 		)
 
-		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, &statusReporterHelperMock{})
+		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 		result := p.ProcessSQS(ctx, &msg, func(_ beat.Event) {})
 		require.NoError(t, result.processingErr)
 		result.Done()
@@ -67,7 +68,7 @@ func TestSQSS3EventProcessor(t *testing.T) {
 
 		mockAPI.EXPECT().DeleteMessage(gomock.Any(), gomock.Eq(&invalidBodyMsg)).Return(nil)
 
-		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, &statusReporterHelperMock{})
+		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 		result := p.ProcessSQS(ctx, &invalidBodyMsg, func(_ beat.Event) {})
 		require.Error(t, result.processingErr)
 		t.Log(result.processingErr)
@@ -88,7 +89,7 @@ func TestSQSS3EventProcessor(t *testing.T) {
 
 		mockAPI.EXPECT().DeleteMessage(gomock.Any(), gomock.Eq(&emptyRecordsMsg)).Return(nil)
 
-		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, &statusReporterHelperMock{})
+		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 		result := p.ProcessSQS(ctx, &emptyRecordsMsg, func(_ beat.Event) {})
 		require.NoError(t, result.processingErr)
 		result.Done()
@@ -118,7 +119,7 @@ func TestSQSS3EventProcessor(t *testing.T) {
 			mockS3Handler.EXPECT().FinalizeS3Object().Return(nil),
 		)
 
-		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, visibilityTimeout, 5, mockS3HandlerFactory, &statusReporterHelperMock{})
+		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, visibilityTimeout, 5, mockS3HandlerFactory, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 		result := p.ProcessSQS(ctx, &msg, func(_ beat.Event) {})
 		require.NoError(t, result.processingErr)
 		result.Done()
@@ -139,7 +140,7 @@ func TestSQSS3EventProcessor(t *testing.T) {
 			mockS3Handler.EXPECT().ProcessS3Object(gomock.Any(), gomock.Any()).Return(errors.New("fake connectivity problem")),
 		)
 
-		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, &statusReporterHelperMock{})
+		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 		result := p.ProcessSQS(ctx, &msg, func(_ beat.Event) {})
 		t.Log(result.processingErr)
 		require.Error(t, result.processingErr)
@@ -167,7 +168,7 @@ func TestSQSS3EventProcessor(t *testing.T) {
 			mockAPI.EXPECT().DeleteMessage(gomock.Any(), gomock.Eq(&msg)).Return(nil),
 		)
 
-		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, &statusReporterHelperMock{})
+		p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, time.Minute, 5, mockS3HandlerFactory, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 		result := p.ProcessSQS(ctx, &msg, func(_ beat.Event) {})
 		t.Log(result.eventCount)
 		require.Error(t, result.processingErr)
@@ -214,7 +215,7 @@ func TestSqsProcessor_keepalive(t *testing.T) {
 			mockAPI.EXPECT().ChangeMessageVisibility(gomock.Any(), gomock.Eq(&msg), gomock.Eq(visibilityTimeout)).
 				Times(1).Return(tc.Err)
 
-			p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, visibilityTimeout, 5, mockS3HandlerFactory, &statusReporterHelperMock{})
+			p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, mockAPI, nil, visibilityTimeout, 5, mockS3HandlerFactory, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 			p.keepalive(ctx, p.log, &msg)
 		})
 	}
@@ -222,7 +223,7 @@ func TestSqsProcessor_keepalive(t *testing.T) {
 
 func TestSqsProcessor_getS3Notifications(t *testing.T) {
 
-	p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, nil, nil, time.Minute, 5, nil, &statusReporterHelperMock{})
+	p := newSQSS3EventProcessor(logptest.NewTestingLogger(t, inputName), nil, nil, nil, time.Minute, 5, nil, newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()))
 
 	t.Run("s3 key is url unescaped", func(t *testing.T) {
 		msg, err := newSQSMessage(newS3Event("Happy+Face.jpg"))

--- a/x-pack/filebeat/input/awss3/sqs_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_test.go
@@ -89,8 +89,9 @@ func TestSQSReceiver(t *testing.T) {
 					return sqsProcessingResult{
 						keepaliveCancel: func() {},
 						processor: &sqsS3EventProcessor{
-							log: logger,
-							sqs: mockSQS,
+							log:    logger,
+							sqs:    mockSQS,
+							health: newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger()),
 						},
 					}
 				})
@@ -102,7 +103,7 @@ func TestSQSReceiver(t *testing.T) {
 		sqsReader.metrics = newInputMetrics(monitoring.NewRegistry(), 0, logp.NewNopLogger())
 		sqsReader.pipeline = &fakePipeline{}
 		sqsReader.msgHandler = mockMsgHandler
-		sqsReader.status = &statusReporterHelperMock{}
+		sqsReader.health = newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger())
 		sqsReader.run(ctx)
 
 		select {
@@ -151,7 +152,7 @@ func TestSQSReceiver(t *testing.T) {
 		sqsReader.msgHandler = mockMsgHandler
 		sqsReader.metrics = newInputMetrics(monitoring.NewRegistry(), 0, logp.NewNopLogger())
 		sqsReader.pipeline = &fakePipeline{}
-		sqsReader.status = &statusReporterHelperMock{}
+		sqsReader.health = newSQSHealth(&statusReporterHelperMock{}, logp.NewNopLogger())
 		sqsReader.run(ctx)
 	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/awss3: aggregate SQS health status reporting

Replace scattered per-event UpdateStatus calls in the SQS mode with a
centralized sqsHealth aggregator. The input now stays Running while making
forward progress despite bounded retryable failures, reports Degraded only
for sustained conditions needing operator action, filters out
context.Canceled from shutdown/reload, and clears Degraded only when the
specific causing condition resolves, not when an unrelated poll succeeds.

Key changes:
- New sqsHealth type (active-condition model with Set*/Clear* + recompute)
- Receive errors require 3 consecutive failures before degrading
- Transient S3 processing errors no longer degrade (message retries via
  visibility timeout are by design)
- Keepalive receipt-handle failures no longer degrade (message will retry)
- Successful message delete+finalize clears disposition conditions
- context.Canceled/DeadlineExceeded suppressed at all condition setters
- Subsumes StatusReporterHelper dedup with stricter (enum+msg) check

This commit covers the legacy SQS path only; v2 path follows separately.

Assisted-By: Cursor
```
> [!NOTE]
> This is PR one of two. This *can* be backported to branches listed if that path is chosen. I think it should be, but this is open to discussion. The second PR wires the v2 path with the same behaviour and cannot be backported to branches prior to 9.5.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #51692
- Closes #51820

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
