### PR TITLE
x-pack/filebeat/input/streaming: add configurable User-Agent header

### DIFF
--- a/changelog/fragments/1783565292-streaming-user-agent.yaml
+++ b/changelog/fragments/1783565292-streaming-user-agent.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Add configurable User-Agent header to the CrowdStrike streaming input.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-streaming.md
+++ b/docs/reference/filebeat/filebeat-input-streaming.md
@@ -260,6 +260,9 @@ resource_origins:
 
 
 ### `user_agent` [user-agent-streaming]
+```{applies_to}
+stack: ga 9.4+
+```
 
 An optional string that overrides the default `User-Agent` header sent on all outbound HTTP requests. This only applies when `stream_type` is `crowdstrike`. The header is set on discover, firehose, session refresh, and OAuth2 token requests.
 

--- a/docs/reference/filebeat/filebeat-input-streaming.md
+++ b/docs/reference/filebeat/filebeat-input-streaming.md
@@ -259,6 +259,17 @@ resource_origins:
 ```
 
 
+### `user_agent` [user-agent-streaming]
+
+An optional string that overrides the default `User-Agent` header sent on all outbound HTTP requests. This only applies when `stream_type` is `crowdstrike`. The header is set on discover, firehose, session refresh, and OAuth2 token requests.
+
+When not set, the Elastic Agent's built-in user agent string is used.
+
+```yaml
+user_agent: "Elastic-crowdstrike/4.0.0"
+```
+
+
 ### `program` [program-streaming]
 
 The CEL program that is executed on each message received. This field should ideally be present but if not the default program given below is used.

--- a/x-pack/filebeat/input/streaming/config.go
+++ b/x-pack/filebeat/input/streaming/config.go
@@ -63,6 +63,11 @@ type config struct {
 	// domain as the configured URL. Entries here extend the set
 	// of accepted origins.
 	ResourceOrigins []string `config:"resource_origins"`
+	// UserAgent overrides the default User-Agent header sent on
+	// all outbound HTTP requests (discover, firehose, session
+	// refresh, and OAuth2 token fetch). When empty, the Elastic
+	// Agent's built-in user agent string is used.
+	UserAgent string `config:"user_agent"`
 }
 
 type redact struct {

--- a/x-pack/filebeat/input/streaming/config.go
+++ b/x-pack/filebeat/input/streaming/config.go
@@ -64,9 +64,9 @@ type config struct {
 	// of accepted origins.
 	ResourceOrigins []string `config:"resource_origins"`
 	// UserAgent overrides the default User-Agent header sent on
-	// all outbound HTTP requests (discover, firehose, session
-	// refresh, and OAuth2 token fetch). When empty, the Elastic
-	// Agent's built-in user agent string is used.
+	// all outbound CrowdStrike HTTP requests (discover, firehose,
+	// session refresh, and OAuth2 token fetch). When empty, the
+	// Elastic Agent's built-in user agent string is used.
 	UserAgent string `config:"user_agent"`
 }
 

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -197,6 +197,11 @@ func NewFalconHoseFollower(ctx context.Context, env v2.Context, cfg config, curs
 		s.allowedOrigins = append(s.allowedOrigins, o)
 	}
 
+	ua := cfg.UserAgent
+	if ua == "" {
+		ua = env.Agent.UserAgent
+	}
+
 	// Build the auth transport before zeroing timeouts for the streaming
 	// client. The oauth2 token endpoint needs normal request timeouts;
 	// moving this after the timeout zeroing will cause auth requests to
@@ -210,7 +215,7 @@ func NewFalconHoseFollower(ctx context.Context, env v2.Context, cfg config, curs
 		now = time.Now
 	}
 	s.authTransport = &rateLimitTransport{
-		base:     authClient.Transport,
+		base:     userAgentTransport{ua: ua, base: authClient.Transport},
 		timeout:  authClient.Timeout,
 		maxRetry: 3,
 		wait:     60 * time.Second,
@@ -225,8 +230,25 @@ func NewFalconHoseFollower(ctx context.Context, env v2.Context, cfg config, curs
 		stat.UpdateStatus(status.Failed, "failed to configure client: "+err.Error())
 		return nil, err
 	}
+	s.plainClient.Transport = userAgentTransport{ua: ua, base: s.plainClient.Transport}
 
 	return &s, nil
+}
+
+var _ http.RoundTripper = userAgentTransport{}
+
+// userAgentTransport wraps an http.RoundTripper and unconditionally
+// sets the User-Agent header on every outgoing request. It overwrites
+// Go's default "Go-http-client/1.1" which http.Client.Do sets before
+// calling RoundTrip.
+type userAgentTransport struct {
+	ua   string
+	base http.RoundTripper
+}
+
+func (t userAgentTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("User-Agent", t.ua)
+	return t.base.RoundTrip(r)
 }
 
 // FollowStream receives, processes and publishes events from the subscribed

--- a/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
@@ -12,11 +12,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
@@ -24,8 +24,6 @@ import (
 )
 
 func TestFollowSession_FirehoseHTTPError(t *testing.T) {
-	logp.TestingSetup()
-
 	tests := []struct {
 		name       string
 		statusCode int
@@ -118,8 +116,6 @@ func TestFollowSession_DiscoverGETFailureIsTransient(t *testing.T) {
 }
 
 func TestFollowSession_NonObjectMessage(t *testing.T) {
-	logp.TestingSetup()
-
 	validEvent := `{"metadata":{"eventType":"TestEvent","offset":1},"event":{"TestField":"value"}}`
 
 	tests := []struct {
@@ -173,6 +169,129 @@ func TestFollowSession_NonObjectMessage(t *testing.T) {
 				t.Errorf("expected %d published events, got %d", tt.wantPublished, pub.published())
 			}
 		})
+	}
+}
+
+func TestUserAgentTransport(t *testing.T) {
+	const want = "Elastic-crowdstrike/4.0.0"
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+	}))
+	defer srv.Close()
+
+	cli := srv.Client()
+	cli.Transport = userAgentTransport{ua: want, base: cli.Transport}
+
+	// http.Client.Do sets "Go-http-client/1.1" before RoundTrip;
+	// the transport must overwrite it.
+	req, err := http.NewRequestWithContext(t.Context(), "GET", srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := cli.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if got != want {
+		t.Errorf("User-Agent = %q; want %q", got, want)
+	}
+}
+
+func TestFollowSession_UserAgent(t *testing.T) {
+	const want = "Elastic-crowdstrike/4.0.0"
+
+	type requestRecord struct {
+		path      string
+		userAgent string
+	}
+	var (
+		mu       sync.Mutex
+		requests []requestRecord
+	)
+	record := func(r *http.Request) {
+		mu.Lock()
+		requests = append(requests, requestRecord{path: r.URL.Path, userAgent: r.Header.Get("User-Agent")})
+		mu.Unlock()
+	}
+
+	firehoseSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/firehose"):
+			// Send one event then EOF to end the session cleanly.
+			fmt.Fprintln(w, `{"metadata":{"eventType":"Test","offset":1},"event":{"field":"value"}}`)
+		case strings.HasPrefix(r.URL.Path, "/refresh"):
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer firehoseSrv.Close()
+
+	discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.Header().Set("Content-Type", "application/json")
+		// refreshActiveSessionInterval is short but refreshSessionWait
+		// clamps to a 15s floor, so no refresh fires during the test.
+		resp := map[string]any{
+			"resources": []map[string]any{
+				{
+					"dataFeedURL": firehoseSrv.URL + "/firehose",
+					"sessionToken": map[string]any{
+						"token":      "test-token",
+						"expiration": "2099-01-01T00:00:00Z",
+					},
+					"refreshActiveSessionURL":      firehoseSrv.URL + "/refresh",
+					"refreshActiveSessionInterval": 1,
+				},
+			},
+			"meta": map[string]any{},
+		}
+		b, _ := json.Marshal(resp)
+		_, _ = w.Write(b)
+	}))
+	defer discoverSrv.Close()
+
+	// Build clients wrapped with the userAgentTransport, matching the
+	// production wiring in NewFalconHoseFollower.
+	authClient := discoverSrv.Client()
+	authClient.Transport = userAgentTransport{ua: want, base: authClient.Transport}
+	plainClient := firehoseSrv.Client()
+	plainClient.Transport = userAgentTransport{ua: want, base: plainClient.Transport}
+
+	pub := new(countingPublisher)
+	s := newTestStreamWithPublisher(t, discoverSrv.URL, plainClient, pub)
+
+	state := map[string]any{}
+	_, err := s.followSession(context.Background(), authClient, state)
+	if err != nil {
+		t.Fatalf("followSession() unexpected error: %v", err)
+	}
+
+	// Check that the discover and firehose requests carried the custom
+	// User-Agent. We don't assert on refresh because the goroutine may
+	// or may not fire within the test window.
+	mu.Lock()
+	defer mu.Unlock()
+	var sawDiscover, sawFirehose bool
+	for _, r := range requests {
+		if r.userAgent != want {
+			t.Errorf("request to %s had User-Agent = %q; want %q", r.path, r.userAgent, want)
+		}
+		switch {
+		case r.path == "/" || r.path == "":
+			sawDiscover = true
+		case strings.HasPrefix(r.path, "/firehose"):
+			sawFirehose = true
+		}
+	}
+	if !sawDiscover {
+		t.Error("no discover request recorded")
+	}
+	if !sawFirehose {
+		t.Error("no firehose request recorded")
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/streaming: add configurable User-Agent header

Add a user_agent config field and a transport-level decorator that
sets the User-Agent header on all outbound HTTP requests made by
the CrowdStrike streaming input (discover, firehose, session
refresh, and OAuth2 token fetch). The decorator unconditionally
overwrites Go's default "Go-http-client/1.1" which http.Client.Do
sets before calling RoundTrip.

When user_agent is empty, the Elastic Agent's built-in user agent
string is used as the default.

This is needed for CrowdStrike technology partner compliance, which
requires a User-Agent identifying the integration and version on
every API request.
```

> [!WARNING]
> Currently marked for back-port. To be discussed.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For elastic/integrations#14136

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
