### PR TITLE
Fix FIPS check to exact-match fips140=on, not substring

### DIFF
--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -914,8 +914,11 @@ func checkFIPS(t *testing.T, beatName, path string) {
 			require.True(t, strings.HasPrefix(setting.Value, "v1.0.0"), "GOFIPS140 must reference the certified module version, got %q", setting.Value)
 			continue
 		case "DefaultGODEBUG":
-			if strings.Contains(setting.Value, "fips140=on") {
-				foundFIPSDefault = true
+			for _, entry := range strings.Split(setting.Value, ",") {
+				if key, val, ok := strings.Cut(entry, "="); ok && key == "fips140" && val == "on" {
+					foundFIPSDefault = true
+					break
+				}
 			}
 			continue
 		}

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -901,7 +901,7 @@ func checkFIPS(t *testing.T, beatName, path string) {
 	info, err := buildinfo.ReadFile(binaryPath)
 	require.NoError(t, err)
 
-	testutils.CheckFIPSBuildInfo(t, info.Settings)
+	testutils.RequireFIPSBuildInfo(t, info.Settings)
 }
 
 // inspector is a file contents inspector. It vets the contents of the file

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -901,13 +901,7 @@ func checkFIPS(t *testing.T, beatName, path string) {
 	info, err := buildinfo.ReadFile(binaryPath)
 	require.NoError(t, err)
 
-	fips := testutils.CheckFIPSBuildInfo(info.Settings)
-
-	require.True(t, fips.TagsFound, "Did not find -tags within binary version information")
-	require.True(t, fips.TagsHaveRequireFIPS, "-tags did not contain requirefips")
-	require.True(t, fips.GOFIPS140Found, "Did not find GOFIPS140 within binary version information")
-	require.True(t, fips.GOFIPS140IsCertified, "GOFIPS140 must reference the certified module version, got %q", fips.GOFIPS140Value)
-	require.True(t, fips.DefaultGODEBUGHasFIPSOn, "Did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
+	testutils.CheckFIPSBuildInfo(t, info.Settings)
 }
 
 // inspector is a file contents inspector. It vets the contents of the file

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/testing/testutils"
 )
 
 const (
@@ -900,33 +901,13 @@ func checkFIPS(t *testing.T, beatName, path string) {
 	info, err := buildinfo.ReadFile(binaryPath)
 	require.NoError(t, err)
 
-	foundTags := false
-	foundFIPS := false
-	foundFIPSDefault := false
-	for _, setting := range info.Settings {
-		switch setting.Key {
-		case "-tags":
-			foundTags = true
-			require.Contains(t, setting.Value, "requirefips")
-			continue
-		case "GOFIPS140":
-			foundFIPS = true
-			require.True(t, strings.HasPrefix(setting.Value, "v1.0.0"), "GOFIPS140 must reference the certified module version, got %q", setting.Value)
-			continue
-		case "DefaultGODEBUG":
-			for _, entry := range strings.Split(setting.Value, ",") {
-				if key, val, ok := strings.Cut(entry, "="); ok && key == "fips140" && val == "on" {
-					foundFIPSDefault = true
-					break
-				}
-			}
-			continue
-		}
-	}
+	fips := testutils.CheckFIPSBuildInfo(info.Settings)
 
-	require.True(t, foundTags, "Did not find -tags within binary version information")
-	require.True(t, foundFIPS, "Did not find GOFIPS140 within binary version information")
-	require.True(t, foundFIPSDefault, "Did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
+	require.True(t, fips.TagsFound, "Did not find -tags within binary version information")
+	require.True(t, fips.TagsHaveRequireFIPS, "-tags did not contain requirefips")
+	require.True(t, fips.GOFIPS140Found, "Did not find GOFIPS140 within binary version information")
+	require.True(t, fips.GOFIPS140IsCertified, "GOFIPS140 must reference the certified module version, got %q", fips.GOFIPS140Value)
+	require.True(t, fips.DefaultGODEBUGHasFIPSOn, "Did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
 }
 
 // inspector is a file contents inspector. It vets the contents of the file

--- a/testing/go-ech/ech.go
+++ b/testing/go-ech/ech.go
@@ -22,7 +22,6 @@ package ech
 import (
 	"debug/buildinfo"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v8"
 
 	"github.com/elastic/beats/v7/libbeat/tests/integration"
+	"github.com/elastic/beats/v7/testing/testutils"
 )
 
 // VerifyEnvVars ensures that the env vars to connect to ES are set, and that the ES_HOST starts with https
@@ -55,31 +55,13 @@ func VerifyFIPSBinary(t *testing.T, binaryPath string) {
 	info, err := buildinfo.ReadFile(binaryPath)
 	assert.NoError(t, err)
 
-	var foundTags, foundFIPS, foundFIPSDefault bool
-	for _, setting := range info.Settings {
-		switch setting.Key {
-		case "-tags":
-			foundTags = true
-			assert.Contains(t, setting.Value, "requirefips")
-			continue
-		case "GOFIPS140":
-			foundFIPS = true
-			assert.True(t, strings.HasPrefix(setting.Value, "v1.0.0"), "GOFIPS140 must reference the certified module version, got %q", setting.Value)
-			continue
-		case "DefaultGODEBUG":
-			for _, entry := range strings.Split(setting.Value, ",") {
-				if key, val, ok := strings.Cut(entry, "="); ok && key == "fips140" && val == "on" {
-					foundFIPSDefault = true
-					break
-				}
-			}
-			continue
-		}
-	}
+	fips := testutils.CheckFIPSBuildInfo(info.Settings)
 
-	assert.True(t, foundTags, "did not find build tags")
-	assert.True(t, foundFIPS, "did not find GOFIPS140 within binary version information")
-	assert.True(t, foundFIPSDefault, "did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
+	assert.True(t, fips.TagsFound, "did not find build tags")
+	assert.True(t, fips.TagsHaveRequireFIPS, "-tags did not contain requirefips")
+	assert.True(t, fips.GOFIPS140Found, "did not find GOFIPS140 within binary version information")
+	assert.True(t, fips.GOFIPS140IsCertified, "GOFIPS140 must reference the certified module version, got %q", fips.GOFIPS140Value)
+	assert.True(t, fips.DefaultGODEBUGHasFIPSOn, "did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
 	if t.Failed() {
 		t.Fatal("Unable to verify FIPS binary.") // stop test if non-FIPS binary is used.
 	}

--- a/testing/go-ech/ech.go
+++ b/testing/go-ech/ech.go
@@ -55,7 +55,7 @@ func VerifyFIPSBinary(t *testing.T, binaryPath string) {
 	info, err := buildinfo.ReadFile(binaryPath)
 	require.NoError(t, err, "unable to read build info from %s", binaryPath)
 
-	testutils.CheckFIPSBuildInfo(t, info.Settings)
+	testutils.RequireFIPSBuildInfo(t, info.Settings)
 }
 
 // RunSmokeTest runs the beat on binaryPath with the passed config, and ensures that data ends up in Elasticsearch.

--- a/testing/go-ech/ech.go
+++ b/testing/go-ech/ech.go
@@ -67,8 +67,11 @@ func VerifyFIPSBinary(t *testing.T, binaryPath string) {
 			assert.True(t, strings.HasPrefix(setting.Value, "v1.0.0"), "GOFIPS140 must reference the certified module version, got %q", setting.Value)
 			continue
 		case "DefaultGODEBUG":
-			if strings.Contains(setting.Value, "fips140=on") {
-				foundFIPSDefault = true
+			for _, entry := range strings.Split(setting.Value, ",") {
+				if key, val, ok := strings.Cut(entry, "="); ok && key == "fips140" && val == "on" {
+					foundFIPSDefault = true
+					break
+				}
 			}
 			continue
 		}

--- a/testing/go-ech/ech.go
+++ b/testing/go-ech/ech.go
@@ -53,18 +53,9 @@ func VerifyEnvVars(t *testing.T) {
 func VerifyFIPSBinary(t *testing.T, binaryPath string) {
 	t.Helper()
 	info, err := buildinfo.ReadFile(binaryPath)
-	assert.NoError(t, err)
+	require.NoError(t, err, "unable to read build info from %s", binaryPath)
 
-	fips := testutils.CheckFIPSBuildInfo(info.Settings)
-
-	assert.True(t, fips.TagsFound, "did not find build tags")
-	assert.True(t, fips.TagsHaveRequireFIPS, "-tags did not contain requirefips")
-	assert.True(t, fips.GOFIPS140Found, "did not find GOFIPS140 within binary version information")
-	assert.True(t, fips.GOFIPS140IsCertified, "GOFIPS140 must reference the certified module version, got %q", fips.GOFIPS140Value)
-	assert.True(t, fips.DefaultGODEBUGHasFIPSOn, "did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
-	if t.Failed() {
-		t.Fatal("Unable to verify FIPS binary.") // stop test if non-FIPS binary is used.
-	}
+	testutils.CheckFIPSBuildInfo(t, info.Settings)
 }
 
 // RunSmokeTest runs the beat on binaryPath with the passed config, and ensures that data ends up in Elasticsearch.

--- a/testing/testutils/fips_build_info.go
+++ b/testing/testutils/fips_build_info.go
@@ -20,43 +20,53 @@ package testutils
 import (
 	"runtime/debug"
 	"strings"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// FIPSBuildInfo captures the FIPS-related settings found in a binary's build info.
-type FIPSBuildInfo struct {
-	TagsFound               bool
-	TagsHaveRequireFIPS     bool
-	GOFIPS140Found          bool
-	GOFIPS140Value          string
-	GOFIPS140IsCertified    bool // value starts with the certified module version, e.g. "v1.0.0"
-	DefaultGODEBUGFound     bool
-	DefaultGODEBUGHasFIPSOn bool
+// fipsCheckT is the subset of *testing.T that CheckFIPSBuildInfo needs. It's kept as
+// an interface (rather than *testing.T directly) so this package's own tests can
+// exercise the failure paths with a fake, instead of failing the enclosing test run.
+type fipsCheckT interface {
+	Helper()
+	Errorf(format string, args ...any)
+	Failed() bool
+	FailNow()
 }
 
-// CheckFIPSBuildInfo scans a binary's build settings (as reported by debug/buildinfo)
-// for the markers that indicate a FIPS-compliant build: the "requirefips" build tag,
-// a GOFIPS140 setting referencing the certified module version, and a DefaultGODEBUG
-// setting that enables fips140=on at runtime.
-func CheckFIPSBuildInfo(settings []debug.BuildSetting) FIPSBuildInfo {
-	var info FIPSBuildInfo
+// CheckFIPSBuildInfo asserts that a binary's build settings (as reported by
+// debug/buildinfo) contain the markers of a FIPS-compliant build: the
+// "requirefips" build tag, a GOFIPS140 setting referencing the certified
+// module version, and a DefaultGODEBUG setting that enables fips140=on at
+// runtime. All markers are checked before the test is failed, so a single
+// run reports every missing marker instead of just the first.
+func CheckFIPSBuildInfo(t fipsCheckT, settings []debug.BuildSetting) {
+	t.Helper()
+
+	var foundTags, foundFIPS, foundFIPSDefault bool
 	for _, setting := range settings {
 		switch setting.Key {
 		case "-tags":
-			info.TagsFound = true
-			info.TagsHaveRequireFIPS = strings.Contains(setting.Value, "requirefips")
+			foundTags = true
+			assert.Contains(t, setting.Value, "requirefips")
 		case "GOFIPS140":
-			info.GOFIPS140Found = true
-			info.GOFIPS140Value = setting.Value
-			info.GOFIPS140IsCertified = strings.HasPrefix(setting.Value, "v1.0.0")
+			foundFIPS = true
+			assert.True(t, strings.HasPrefix(setting.Value, "v1.0.0"), "GOFIPS140 must reference the certified module version, got %q", setting.Value)
 		case "DefaultGODEBUG":
-			info.DefaultGODEBUGFound = true
 			for entry := range strings.SplitSeq(setting.Value, ",") {
 				if key, val, ok := strings.Cut(entry, "="); ok && key == "fips140" && val == "on" {
-					info.DefaultGODEBUGHasFIPSOn = true
+					foundFIPSDefault = true
 					break
 				}
 			}
 		}
 	}
-	return info
+
+	assert.True(t, foundTags, "did not find -tags within binary version information")
+	assert.True(t, foundFIPS, "did not find GOFIPS140 within binary version information")
+	assert.True(t, foundFIPSDefault, "did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
+
+	if t.Failed() {
+		t.FailNow()
+	}
 }

--- a/testing/testutils/fips_build_info.go
+++ b/testing/testutils/fips_build_info.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testutils
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// FIPSBuildInfo captures the FIPS-related settings found in a binary's build info.
+type FIPSBuildInfo struct {
+	TagsFound               bool
+	TagsHaveRequireFIPS     bool
+	GOFIPS140Found          bool
+	GOFIPS140Value          string
+	GOFIPS140IsCertified    bool // value starts with the certified module version, e.g. "v1.0.0"
+	DefaultGODEBUGFound     bool
+	DefaultGODEBUGHasFIPSOn bool
+}
+
+// CheckFIPSBuildInfo scans a binary's build settings (as reported by debug/buildinfo)
+// for the markers that indicate a FIPS-compliant build: the "requirefips" build tag,
+// a GOFIPS140 setting referencing the certified module version, and a DefaultGODEBUG
+// setting that enables fips140=on at runtime.
+func CheckFIPSBuildInfo(settings []debug.BuildSetting) FIPSBuildInfo {
+	var info FIPSBuildInfo
+	for _, setting := range settings {
+		switch setting.Key {
+		case "-tags":
+			info.TagsFound = true
+			info.TagsHaveRequireFIPS = strings.Contains(setting.Value, "requirefips")
+		case "GOFIPS140":
+			info.GOFIPS140Found = true
+			info.GOFIPS140Value = setting.Value
+			info.GOFIPS140IsCertified = strings.HasPrefix(setting.Value, "v1.0.0")
+		case "DefaultGODEBUG":
+			info.DefaultGODEBUGFound = true
+			for entry := range strings.SplitSeq(setting.Value, ",") {
+				if key, val, ok := strings.Cut(entry, "="); ok && key == "fips140" && val == "on" {
+					info.DefaultGODEBUGHasFIPSOn = true
+					break
+				}
+			}
+		}
+	}
+	return info
+}

--- a/testing/testutils/fips_build_info.go
+++ b/testing/testutils/fips_build_info.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// fipsCheckT is the subset of *testing.T that CheckFIPSBuildInfo needs. It's kept as
+// fipsCheckT is the subset of *testing.T that RequireFIPSBuildInfo needs. It's kept as
 // an interface (rather than *testing.T directly) so this package's own tests can
 // exercise the failure paths with a fake, instead of failing the enclosing test run.
 type fipsCheckT interface {
@@ -34,13 +34,13 @@ type fipsCheckT interface {
 	FailNow()
 }
 
-// CheckFIPSBuildInfo asserts that a binary's build settings (as reported by
+// RequireFIPSBuildInfo asserts that a binary's build settings (as reported by
 // debug/buildinfo) contain the markers of a FIPS-compliant build: the
 // "requirefips" build tag, a GOFIPS140 setting referencing the certified
 // module version, and a DefaultGODEBUG setting that enables fips140=on at
 // runtime. All markers are checked before the test is failed, so a single
 // run reports every missing marker instead of just the first.
-func CheckFIPSBuildInfo(t fipsCheckT, settings []debug.BuildSetting) {
+func RequireFIPSBuildInfo(t fipsCheckT, settings []debug.BuildSetting) {
 	t.Helper()
 
 	var foundTags, foundFIPS, foundFIPSDefault bool

--- a/testing/testutils/fips_build_info_test.go
+++ b/testing/testutils/fips_build_info_test.go
@@ -18,24 +18,44 @@
 package testutils
 
 import (
+	"fmt"
 	"runtime/debug"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+// fakeT is a minimal fipsCheckT that records failures instead of stopping the
+// goroutine, so failure paths can be asserted on directly.
+type fakeT struct {
+	failed bool
+	errors []string
+}
+
+func (f *fakeT) Helper() {}
+
+func (f *fakeT) Errorf(format string, args ...any) {
+	f.failed = true
+	f.errors = append(f.errors, fmt.Sprintf(format, args...))
+}
+
+func (f *fakeT) Failed() bool { return f.failed }
+
+func (f *fakeT) FailNow() {}
+
 func TestCheckFIPSBuildInfo(t *testing.T) {
 	tests := []struct {
-		name       string
-		godebug    string
-		wantFIPSOn bool
+		name     string
+		godebug  string
+		wantPass bool
 	}{
-		{name: "fips140=on", godebug: "fips140=on,tlsmlkem=0", wantFIPSOn: true},
-		{name: "fips140=on last", godebug: "tlsmlkem=0,fips140=on", wantFIPSOn: true},
-		{name: "fips140=only is not fips140=on", godebug: "fips140=only,tlsmlkem=0", wantFIPSOn: false},
-		{name: "fips140=off", godebug: "fips140=off", wantFIPSOn: false},
-		{name: "no fips140 entry", godebug: "tlsmlkem=0", wantFIPSOn: false},
-		{name: "empty", godebug: "", wantFIPSOn: false},
+		{name: "fips140=on", godebug: "fips140=on,tlsmlkem=0", wantPass: true},
+		{name: "fips140=on last", godebug: "tlsmlkem=0,fips140=on", wantPass: true},
+		{name: "fips140=only is not fips140=on", godebug: "fips140=only,tlsmlkem=0", wantPass: false},
+		{name: "fips140=off", godebug: "fips140=off", wantPass: false},
+		{name: "no fips140 entry", godebug: "tlsmlkem=0", wantPass: false},
+		{name: "empty", godebug: "", wantPass: false},
 	}
 
 	for _, tc := range tests {
@@ -46,23 +66,22 @@ func TestCheckFIPSBuildInfo(t *testing.T) {
 				{Key: "DefaultGODEBUG", Value: tc.godebug},
 			}
 
-			result := CheckFIPSBuildInfo(settings)
+			ft := &fakeT{}
+			CheckFIPSBuildInfo(ft, settings)
 
-			require.True(t, result.TagsFound)
-			require.True(t, result.TagsHaveRequireFIPS)
-			require.True(t, result.GOFIPS140Found)
-			require.True(t, result.GOFIPS140IsCertified)
-			require.True(t, result.DefaultGODEBUGFound)
-			require.Equal(t, tc.wantFIPSOn, result.DefaultGODEBUGHasFIPSOn)
+			require.Equal(t, !tc.wantPass, ft.failed, "errors: %v", ft.errors)
 		})
 	}
 }
 
 func TestCheckFIPSBuildInfo_MissingSettings(t *testing.T) {
-	result := CheckFIPSBuildInfo(nil)
+	ft := &fakeT{}
+	CheckFIPSBuildInfo(ft, nil)
 
-	require.False(t, result.TagsFound)
-	require.False(t, result.GOFIPS140Found)
-	require.False(t, result.DefaultGODEBUGFound)
-	require.False(t, result.DefaultGODEBUGHasFIPSOn)
+	require.True(t, ft.failed)
+	require.Len(t, ft.errors, 3, "expected all three markers to be reported missing, got: %v", ft.errors)
+	joined := strings.Join(ft.errors, "\n")
+	require.Contains(t, joined, "did not find -tags within binary version information")
+	require.Contains(t, joined, "did not find GOFIPS140 within binary version information")
+	require.Contains(t, joined, "did not find fips140=on in DefaultGODEBUG — binary will not enforce FIPS mode at runtime (check GOFIPS140 env at build time)")
 }

--- a/testing/testutils/fips_build_info_test.go
+++ b/testing/testutils/fips_build_info_test.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testutils
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckFIPSBuildInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		godebug    string
+		wantFIPSOn bool
+	}{
+		{name: "fips140=on", godebug: "fips140=on,tlsmlkem=0", wantFIPSOn: true},
+		{name: "fips140=on last", godebug: "tlsmlkem=0,fips140=on", wantFIPSOn: true},
+		{name: "fips140=only is not fips140=on", godebug: "fips140=only,tlsmlkem=0", wantFIPSOn: false},
+		{name: "fips140=off", godebug: "fips140=off", wantFIPSOn: false},
+		{name: "no fips140 entry", godebug: "tlsmlkem=0", wantFIPSOn: false},
+		{name: "empty", godebug: "", wantFIPSOn: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := []debug.BuildSetting{
+				{Key: "-tags", Value: "requirefips"},
+				{Key: "GOFIPS140", Value: "v1.0.0"},
+				{Key: "DefaultGODEBUG", Value: tc.godebug},
+			}
+
+			result := CheckFIPSBuildInfo(settings)
+
+			require.True(t, result.TagsFound)
+			require.True(t, result.TagsHaveRequireFIPS)
+			require.True(t, result.GOFIPS140Found)
+			require.True(t, result.GOFIPS140IsCertified)
+			require.True(t, result.DefaultGODEBUGFound)
+			require.Equal(t, tc.wantFIPSOn, result.DefaultGODEBUGHasFIPSOn)
+		})
+	}
+}
+
+func TestCheckFIPSBuildInfo_MissingSettings(t *testing.T) {
+	result := CheckFIPSBuildInfo(nil)
+
+	require.False(t, result.TagsFound)
+	require.False(t, result.GOFIPS140Found)
+	require.False(t, result.DefaultGODEBUGFound)
+	require.False(t, result.DefaultGODEBUGHasFIPSOn)
+}

--- a/testing/testutils/fips_build_info_test.go
+++ b/testing/testutils/fips_build_info_test.go
@@ -44,7 +44,7 @@ func (f *fakeT) Failed() bool { return f.failed }
 
 func (f *fakeT) FailNow() {}
 
-func TestCheckFIPSBuildInfo(t *testing.T) {
+func TestRequireFIPSBuildInfo(t *testing.T) {
 	tests := []struct {
 		name     string
 		godebug  string
@@ -67,16 +67,16 @@ func TestCheckFIPSBuildInfo(t *testing.T) {
 			}
 
 			ft := &fakeT{}
-			CheckFIPSBuildInfo(ft, settings)
+			RequireFIPSBuildInfo(ft, settings)
 
 			require.Equal(t, !tc.wantPass, ft.failed, "errors: %v", ft.errors)
 		})
 	}
 }
 
-func TestCheckFIPSBuildInfo_MissingSettings(t *testing.T) {
+func TestRequireFIPSBuildInfo_MissingSettings(t *testing.T) {
 	ft := &fakeT{}
-	CheckFIPSBuildInfo(ft, nil)
+	RequireFIPSBuildInfo(ft, nil)
 
 	require.True(t, ft.failed)
 	require.Len(t, ft.errors, 3, "expected all three markers to be reported missing, got: %v", ft.errors)


### PR DESCRIPTION
ensure that we do not matches `fips140=only` isntead of `fips140=on`

based on fleet-server review: https://github.com/elastic/fleet-server/pull/7332#discussion_r3545691286