### PR TITLE
Increase flaky wait_until timeouts in macOS system tests

### DIFF
--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -174,6 +174,6 @@ class Test(BaseTest):
         msg = "No paths were defined for input"
         self.wait_until(
             lambda: self.log_contains_count(msg) >= 1,
-            max_timeout=5)
+            max_timeout=15)
 
         filebeat.check_wait(exit_code=1)

--- a/x-pack/auditbeat/tests/system/auditbeat_xpack.py
+++ b/x-pack/auditbeat/tests/system/auditbeat_xpack.py
@@ -26,7 +26,7 @@ class AuditbeatXPackTest(MetricbeatTest):
         )
 
     # Adapted from metricbeat.py
-    def check_metricset(self, module, metricset, fields=[], extras={}, errors_allowed=False, warnings_allowed=False):
+    def check_metricset(self, module, metricset, fields=[], extras={}, errors_allowed=False, warnings_allowed=False, max_timeout=20):
         """
         Method to test a metricset for its fields
         """
@@ -39,7 +39,7 @@ class AuditbeatXPackTest(MetricbeatTest):
             "extras": extras,
         }])
         proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0)
+        self.wait_until(lambda: self.output_lines() > 0, max_timeout=max_timeout)
         proc.check_kill_and_wait()
 
         if not warnings_allowed:

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -76,7 +76,7 @@ class Test(AuditbeatXPackTest):
         # errors_allowed|warnings_allowed=True - Disabling hashing causes the dataset to add an error to the event
         # and log a warning. That should not fail the test.
         self.check_metricset("system", "process", COMMON_FIELDS + fields, {"process.hash.max_file_size": 1},
-                             errors_allowed=True, warnings_allowed=True)
+                             errors_allowed=True, warnings_allowed=True, max_timeout=40)
 
     @unittest.skipUnless(sys.platform.startswith('linux'), "Only implemented for Linux")
     def test_metricset_user(self):


### PR DESCRIPTION
`test_stopping_empty_path` and `test_metricset_process` intermittently timed out on macOS CI runners when the host was under load: filebeat missed a `5s` window to flush its first log line, and process enumeration missed a `20s` window by ~`90ms`. Both are `wait_until() `timeouts, not logic bugs.

failing checks:

- https://github.com/elastic/beats/actions/runs/29004335912/job/86085056101?pr=51827
- https://github.com/elastic/beats/actions/runs/29004335912/job/86085056083?pr=51827