### PR TITLE
Docs: Update `applies_to` version for Kafka input settings

### DIFF
--- a/docs/reference/filebeat/filebeat-input-kafka.md
+++ b/docs/reference/filebeat/filebeat-input-kafka.md
@@ -98,7 +98,7 @@ How long to wait before retrying a failed read. Default is 2s.
 
 ### `timeout` [_timeout_2]
 ```{applies_to}
-stack: ga 9.5
+stack: ga 9.3+
 ```
 
 The network timeout for the connection to the Kafka brokers, applied to the dial, read, and write deadlines. Increase this for consumers reading across higher-latency links (for example cross-region or WAN), where a large fetch response may not be fully read within the default deadline. Default is 30s.
@@ -106,7 +106,7 @@ The network timeout for the connection to the Kafka brokers, applied to the dial
 
 ### `keep_alive` [_keep_alive]
 ```{applies_to}
-stack: ga 9.5
+stack: ga 9.3+
 ```
 
 The keep-alive period for the active network connection to the Kafka brokers. Default is 0s (disabled).
@@ -114,7 +114,7 @@ The keep-alive period for the active network connection to the Kafka brokers. De
 
 ### `session_timeout` [_session_timeout]
 ```{applies_to}
-stack: ga 9.5
+stack: ga 9.3+
 ```
 
 The consumer group session timeout. If the broker receives no heartbeat from a consumer within this period, the consumer is removed from the group and a rebalance is triggered. Consumers on higher-latency links may need a larger value to avoid spurious rebalances. Default is 10s.
@@ -122,7 +122,7 @@ The consumer group session timeout. If the broker receives no heartbeat from a c
 
 ### `heartbeat_interval` [_heartbeat_interval]
 ```{applies_to}
-stack: ga 9.5
+stack: ga 9.3+
 ```
 
 How often the consumer sends heartbeats to the broker. This must be lower than `session_timeout`, and is typically set to no more than a third of that value. Default is 3s.


### PR DESCRIPTION
Updated the `applies_to` versions for `timeout`, `keep_alive`, `session_timeout`, and `heartbeat_interval` settings (added in https://github.com/elastic/beats/pull/51173) in the Kafka input documentation as these settings were backported to `9.4` (https://github.com/elastic/beats/pull/51769) and `9.3` (https://github.com/elastic/beats/pull/51770).

Docs

## Proposed commit message

This PR updates the `applies_to` version for `timeout`, `keep_alive`, `session_timeout`, and `heartbeat_interval` settings in the Kafka input documentation as these settings were backported to 9.3.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
