### PR TITLE
managerEarlyStop before runReady close

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -272,10 +272,6 @@ func (fb *Filebeat) loadModulesPipelines(b *beat.Beat) error {
 func (fb *Filebeat) Run(b *beat.Beat) error {
 	var err error
 	config := fb.config
-	// Close runReady so that Shutdown doesn't have to wait no
-	// matter how we exit from Run.
-	defer fb.runReady.Close()
-
 	if b.Manager != nil {
 		b.Manager.RegisterDiagnosticHook("input_metrics", "Metrics from active inputs.",
 			"input_metrics.json", "application/json", func() []byte {
@@ -327,6 +323,14 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 			managerEarlyStop()
 		}
 	}()
+
+	// Close runReady so that Stop does not block waiting for Run to reach its
+	// ready state, regardless of how Run exits. This must be deferred after
+	// the managerEarlyStop defer above so that it runs first in LIFO order:
+	// managerEarlyStop calls Stop, which waits on runReady.ch, so runReady
+	// must be closed before Stop is called to avoid a 5-second timeout on
+	// every early-exit error path.
+	defer fb.runReady.Close()
 
 	registryMigrator := registrar.NewMigrator(config.Registry, fb.logger, b.Info.Paths)
 	if err := registryMigrator.Run(); err != nil {


### PR DESCRIPTION
## Proposed commit message
Fix defer ordering bug in Filebeat.Run that caused a 5-second hang on every early-exit error path.

WHAT: Move defer fb.runReady.Close() from the top of Run() to just after the managerEarlyStop defer.

Go defers execute in LIFO order. Previously defer fb.runReady.Close() was set up first (line 277), which meant it ran last — after managerEarlyStop(). managerEarlyStop() calls b.Manager.Stop(), which triggers the stop callback, which calls beater.Stop() → StopWithContext(context.Background()). That function blocks up to 5 seconds waiting for runReady.ch to be closed. But runReady.ch was only closed by the later defer, creating a deadlock that always timed out.

By deferring runReady.Close() after the managerEarlyStop defer, it now runs before it in LIFO order. When managerEarlyStop() calls Stop(), runReady.ch is already closed and Stop() returns immediately.

WHY: The system test test_stopping_empty_path configures a log input with paths: [], which causes crawler.Start() to fail and Run() to exit early. On this early-exit path managerEarlyStop is non-nil and gets called in its defer, triggering the 5-second hang before the error is logged. The test's 7-second window (2s sleep + 5s wait) was being exhausted before logp.Critical("Exiting: ...") was ever written to the log file.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. This only affects the internal shutdown sequencing on error paths inside Run().

## How to test this PR locally


```shell
go test ./filebeat/beater/... -run TestStop -v
```

For the full system test (requires a built filebeat binary):

```shell
cd filebeat && pytest tests/system/test_shutdown.py::Test::test_stopping_empty_path -v
```

## Related issues

- Relates #51800

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
