### PR TITLE
make statestore creation of meta.json atomic

### DIFF
--- a/changelog/fragments/1783957443-statestore-atomic-create-meta.json.yaml
+++ b/changelog/fragments/1783957443-statestore-atomic-create-meta.json.yaml
@@ -1,0 +1,7 @@
+kind: bug-fix
+
+summary: Prevent statestore startup failure when meta.json is left empty after an unclean shutdown
+
+component: libbeat
+
+pr: https://github.com/elastic/beats/pull/51897

--- a/libbeat/statestore/backend/memlog/diskstore.go
+++ b/libbeat/statestore/backend/memlog/diskstore.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 
 	"github.com/elastic/beats/v7/libbeat/common/cleanup"
+	agentfile "github.com/elastic/elastic-agent-libs/file"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -640,31 +641,35 @@ func checkMeta(meta storeMeta) error {
 
 func writeMetaFile(home string, mode os.FileMode) error {
 	path := filepath.Join(home, metaFileName)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, mode)
+	f, err := os.CreateTemp(home, metaFileName+".tmp-*")
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating tmp meta file: %w", err)
 	}
+	tmpName := f.Name()
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(tmpName)
+	}()
 
-	ok := false
-	defer cleanup.IfNot(&ok, func() {
-		f.Close()
-	})
+	if err = f.Chmod(mode); err != nil {
+		return fmt.Errorf("error setting tmp meta file permissions: %w", err)
+	}
 
 	enc := newJSONEncoder(f)
-	err = enc.Encode(storeMeta{
-		Version: storeVersion,
-	})
-	if err != nil {
-		return err
+	if err = enc.Encode(storeMeta{Version: storeVersion}); err != nil {
+		return fmt.Errorf("error encoding meta file: %w", err)
 	}
 
-	if err := f.Sync(); err != nil {
-		return err
+	if err = f.Sync(); err != nil {
+		return fmt.Errorf("error syncing meta file: %w", err)
 	}
 
-	ok = true
-	if err := f.Close(); err != nil {
-		return err
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("error closing tmp meta file: %w", err)
+	}
+
+	if err = agentfile.SafeFileRotate(path, tmpName); err != nil {
+		return fmt.Errorf("error rotating meta file into place: %w", err)
 	}
 
 	trySyncPath(home)

--- a/libbeat/statestore/backend/memlog/diskstore.go
+++ b/libbeat/statestore/backend/memlog/diskstore.go
@@ -196,7 +196,7 @@ func (s *diskstore) tryOpenLog() error {
 			return err
 		}
 
-		s.logFileSize = uint64(info.Size())
+		s.logFileSize = uint64(info.Size()) //nolint:gosec -- info.Size() is non-negative for a regular file
 	}
 
 	ok = true
@@ -700,5 +700,5 @@ func readMetaFile(home string) (storeMeta, error) {
 //   - a < b (mod 2^63)
 //   - b > a after an integer rollover that is still within the distance of <2^63-1
 func isTxIDLessEqual(a, b uint64) bool {
-	return int64(a-b) <= 0
+	return a == b || a-b >= 1<<63
 }

--- a/libbeat/statestore/backend/memlog/diskstore.go
+++ b/libbeat/statestore/backend/memlog/diskstore.go
@@ -196,7 +196,7 @@ func (s *diskstore) tryOpenLog() error {
 			return err
 		}
 
-		s.logFileSize = uint64(info.Size()) //nolint:gosec -- info.Size() is non-negative for a regular file
+		s.logFileSize = uint64(info.Size()) //nolint:gosec // G115: info.Size() is non-negative for a regular file
 	}
 
 	ok = true

--- a/libbeat/statestore/backend/memlog/store.go
+++ b/libbeat/statestore/backend/memlog/store.go
@@ -63,7 +63,7 @@ type entry struct {
 func openStore(log *logp.Logger, home string, mode os.FileMode, bufSz uint, ignoreVersionCheck bool, checkpoint CheckpointPredicate) (*store, error) {
 	fi, err := os.Stat(home)
 	if os.IsNotExist(err) {
-		err = os.MkdirAll(home, os.ModeDir|0770)
+		err = os.MkdirAll(home, os.ModeDir|0o770)
 		if err != nil {
 			return nil, err
 		}
@@ -75,7 +75,16 @@ func openStore(log *logp.Logger, home string, mode os.FileMode, bufSz uint, igno
 	} else if !fi.Mode().IsDir() {
 		return nil, fmt.Errorf("'%v' is not a directory", home)
 	} else {
-		if err := pathEnsurePermissions(filepath.Join(home, metaFileName), mode); err != nil {
+		metaPath := filepath.Join(home, metaFileName)
+		if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+			// Directory exists but meta.json is absent — the process likely crashed
+			// after MkdirAll but before writeMetaFile completed on a prior run.
+			if err := writeMetaFile(home, mode); err != nil {
+				return nil, err
+			}
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to stat meta file: %w", err)
+		} else if err := pathEnsurePermissions(metaPath, mode); err != nil {
 			return nil, fmt.Errorf("failed to update meta file permissions: %w", err)
 		}
 	}

--- a/libbeat/statestore/backend/memlog/store_test.go
+++ b/libbeat/statestore/backend/memlog/store_test.go
@@ -67,6 +67,30 @@ func TestWriteMetaFileAtomic(t *testing.T) {
 	})
 }
 
+// TestOpenStoreRecoversMissingMeta verifies that openStore creates meta.json when
+// the store directory already exists but meta.json is absent — the scenario that
+// arises when the process crashes after MkdirAll but before writeMetaFile on a
+// prior run.
+func TestOpenStoreRecoversMissingMeta(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate a crash after MkdirAll: the directory exists but is empty.
+	storePath := filepath.Join(dir, "store")
+	require.NoError(t, os.Mkdir(storePath, 0o770))
+
+	logger := logptest.NewTestingLogger(t, "")
+	store, err := openStore(logger.Named("test"), storePath, 0o660, 4096, false, func(_ uint64) bool {
+		return false
+	})
+	require.NoError(t, err, "openStore must succeed even when meta.json was missing")
+	store.Close()
+
+	require.FileExists(t, filepath.Join(storePath, metaFileName), "meta.json must be created on recovery")
+
+	meta, err := readMetaFile(storePath)
+	require.NoError(t, err)
+	assert.NoError(t, checkMeta(meta))
+}
+
 func TestRecoverFromCorruption(t *testing.T) {
 	path := t.TempDir()
 

--- a/libbeat/statestore/backend/memlog/store_test.go
+++ b/libbeat/statestore/backend/memlog/store_test.go
@@ -22,11 +22,50 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
+
+func TestWriteMetaFileAtomic(t *testing.T) {
+	t.Run("writes_valid_meta_and_cleans_up_temp", func(t *testing.T) {
+		dir := t.TempDir()
+
+		require.NoError(t, writeMetaFile(dir, 0o600))
+
+		meta, err := readMetaFile(dir)
+		require.NoError(t, err)
+		require.NoError(t, checkMeta(meta))
+
+		matches, err := filepath.Glob(filepath.Join(dir, "*.tmp-*"))
+		require.NoError(t, err)
+		assert.Empty(t, matches, "no temp files should remain after successful write")
+	})
+
+	t.Run("no_partial_file_on_rotate_failure", func(t *testing.T) {
+		dir := t.TempDir()
+		// Place a directory at the meta.json path so SafeFileRotate (rename) fails.
+		// This simulates a crash-safe scenario: the destination is never touched
+		// until the temp file is fully written and synced.
+		metaPath := filepath.Join(dir, metaFileName)
+		require.NoError(t, os.Mkdir(metaPath, 0o700))
+
+		err := writeMetaFile(dir, 0o600)
+		require.Error(t, err)
+
+		// The directory at the destination must be intact (not replaced or emptied).
+		fi, statErr := os.Stat(metaPath)
+		require.NoError(t, statErr)
+		assert.True(t, fi.IsDir(), "destination should still be a directory after failed rotate")
+
+		// No temp files should remain.
+		matches, globErr := filepath.Glob(filepath.Join(dir, "*.tmp-*"))
+		require.NoError(t, globErr)
+		assert.Empty(t, matches, "no temp files should remain after failed rotate")
+	})
+}
 
 func TestRecoverFromCorruption(t *testing.T) {
 	path := t.TempDir()


### PR DESCRIPTION
## Proposed commit message

WHAT: writeMetaFile in libbeat/statestore/backend/memlog previously opened the destination meta.json with O_TRUNC, wrote the JSON body, synced, and closed — all in-place on the final path. The new implementation follows the same temp-file-then-rename pattern introduced for Filebeat's registrar in #51791: os.CreateTemp creates a sibling .tmp-* file, the JSON is written and synced to it, and agentfile.SafeFileRotate atomically renames it into the final position. A deferred cleanup always removes the temp file on any error path.

WHY: With the old write pattern, if the process was killed between the O_TRUNC (which immediately empties the file) and the final Close, meta.json would be left empty or partially written. On the next start, readMetaFile would fail to parse it and the store would refuse to open. Because the rename is atomic at the OS level, the new approach guarantees that meta.json is either the previous valid version or the newly completed one — never an empty or partial file.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact
None. The change is internal to the memlog backend store and the observable behavior (a valid meta.json on disk) is identical.

## How to test this PR locally

```shell
go test ./libbeat/statestore/backend/memlog/... -run TestWriteMetaFileAtomic -v
```

## Related issues

- Relastes #51791

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
