### PR TITLE
handle PreInit error case for runReady.Close

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -312,6 +312,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	// Start the check-in loop, so Filebeat can respond to Elastic Agent,
 	// but it won't start any inputs/output
 	if err := b.Manager.PreInit(); err != nil {
+		fb.runReady.Close()
 		return err
 	}
 

--- a/filebeat/beater/stop_test.go
+++ b/filebeat/beater/stop_test.go
@@ -18,11 +18,60 @@
 package beater
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/filebeat/fileset"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/beatmonitoring"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
+
+// TestRunClosesRunReadyOnPreInitFailure guards against the regression in
+// commit 00068f7 where the defer fb.runReady.Close() was placed after the
+// PreInit call, leaving runReady unclosed when PreInit fails.  An unclosed
+// runReady causes StopWithContext to wait the full five-second timeout.
+func TestRunClosesRunReadyOnPreInitFailure(t *testing.T) {
+	preInitErr := errors.New("preinit failed")
+	fb := &Filebeat{
+		done:           make(chan struct{}),
+		runReady:       &closeOnce{ch: make(chan struct{})},
+		logger:         logp.NewNopLogger(),
+		moduleRegistry: new(fileset.ModuleRegistry),
+	}
+	b := &beat.Beat{
+		Info:       beat.Info{Logger: logp.NewNopLogger()},
+		Manager:    &preinitFailManager{err: preInitErr},
+		Monitoring: beatmonitoring.NewMonitoring(),
+	}
+
+	err := fb.Run(b)
+	require.ErrorIs(t, err, preInitErr)
+
+	select {
+	case <-fb.runReady.ch:
+		// runReady was closed — StopWithContext will not block
+	default:
+		t.Fatal("runReady was not closed after PreInit failure; StopWithContext would wait five seconds")
+	}
+}
+
+// preinitFailManager is a management.Manager stub whose PreInit returns an
+// error.  Only the methods called by Run before PreInit are implemented; any
+// other call panics, catching unexpected code paths during the test.
+type preinitFailManager struct {
+	management.Manager // zero-valued; panics on any unimplemented method
+	err                error
+}
+
+func (m *preinitFailManager) Enabled() bool { return true }
+func (m *preinitFailManager) PreInit() error { return m.err }
+func (m *preinitFailManager) RegisterDiagnosticHook(_, _, _, _ string, _ management.DiagnosticHook) {
+}
 
 // TestStopWaitsForRunReady proves that Stop does not close the done channel
 // until Run has closed runReady (i.e., reached waitFinished.Wait).

--- a/filebeat/beater/stop_test.go
+++ b/filebeat/beater/stop_test.go
@@ -68,7 +68,7 @@ type preinitFailManager struct {
 	err                error
 }
 
-func (m *preinitFailManager) Enabled() bool { return true }
+func (m *preinitFailManager) Enabled() bool  { return true }
 func (m *preinitFailManager) PreInit() error { return m.err }
 func (m *preinitFailManager) RegisterDiagnosticHook(_, _, _, _ string, _ management.DiagnosticHook) {
 }


### PR DESCRIPTION
## Proposed commit message

### WHAT

filebeat/beater: close runReady on Manager.PreInit failure

PR #51864 (commit 00068f7) reordered the defers in Filebeat.Run so that defer fb.runReady.Close() runs before the managerEarlyStop defer (correct LIFO ordering to avoid a 5-second wait when the manager's stop callback calls StopWithContext). However, both defers were placed after the b.Manager.PreInit() call. If PreInit returns an error, Run exits before either defer is registered, leaving runReady.ch permanently unclosed.

An unclosed runReady.ch means any subsequent call to StopWithContext (e.g. via a SIGINT-triggered Manager.Stop that invokes the beat stop callback) will wait the full 5-second timeout before proceeding, rather than returning immediately.

### WHY

Restores the invariant from before #51864: runReady is closed regardless of how Run exits. The fix adds an explicit fb.runReady.Close() on the PreInit error return path, which is the one path the deferred close cannot reach. A new unit test TestRunClosesRunReadyOnPreInitFailure directly asserts the channel is closed after Run returns due to a PreInit error; confirmed to fail against the buggy code and pass with the fix.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. This is an internal shutdown-sequencing fix. The only observable change is that Elastic Agent-managed Filebeat instances where PreInit fails will no longer incur a spurious 5-second delay during shutdown.

## How to test this PR locally

```shell
go test ./filebeat/beater/ -run "TestRunClosesRunReadyOnPreInitFailure|TestStopWaitsForRunReady" -v -count=1 -race
```

## Related issues

- Relates #51864
- Related #51800
- Closes #51893

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
