### PR TITLE
x-pack/filebeat/input/awss3: exclude backup-prefixed keys from polling

### DIFF
--- a/changelog/fragments/1783988471-exclude-backup-prefix-from-polling.yaml
+++ b/changelog/fragments/1783988471-exclude-backup-prefix-from-polling.yaml
@@ -1,0 +1,8 @@
+kind: bug-fix
+summary: Fix S3 polling input to exclude same-bucket backup objects from listing.
+description: |
+  When same-bucket backup is configured with the default empty
+  bucket_list_prefix, backup objects are listed alongside source objects
+  and reprocessed indefinitely. Exclude keys matching the backup prefix
+  from listing results when the backup destination is the same bucket.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-aws-s3.md
+++ b/docs/reference/filebeat/filebeat-input-aws-s3.md
@@ -548,7 +548,7 @@ Naming of the backed up files can be controlled with `backup_to_bucket_prefix`.
 
 ### `backup_to_bucket_prefix` [_backup_to_bucket_prefix]
 
-This prefix will be prepended to the object key when backing it up to another (or the same) bucket.
+This prefix is prepended to the object key using string concatenation when backing it up to another (or the same) bucket. For example, with `backup_to_bucket_prefix: processed/` and an object key `logs/data.json`, the backup key is `processed/logs/data.json`. No path separator is inserted automatically. Include a trailing `/` in the prefix if you want the backup to appear in a subdirectory.
 
 
 ### `non_aws_backup_to_bucket_name` [_non_aws_backup_to_bucket_name]

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -190,9 +190,11 @@ func (c *backupConfig) GetBucketName() string {
 	return c.NonAWSBackupToBucketName
 }
 
-// backupPrefixToExclude returns the backup prefix that should be excluded from
-// listing results when the backup destination is the same bucket and the backup
-// prefix falls within the listing scope. Returns "" when no exclusion is needed.
+// backupPrefixToExclude returns the key prefix that should be excluded from
+// listing results to avoid reprocessing Filebeat-created backup objects. The
+// backup key is constructed as backupPrefix + originalKey, and all source keys
+// start with listPrefix, so the common prefix of all backups is
+// backupPrefix + listPrefix. Returns "" when no exclusion is needed.
 func (c *config) backupPrefixToExclude() string {
 	if c.BackupConfig.BackupToBucketPrefix == "" {
 		return ""
@@ -203,10 +205,11 @@ func (c *config) backupPrefixToExclude() string {
 	if !sameBucket {
 		return ""
 	}
-	if !strings.HasPrefix(c.BackupConfig.BackupToBucketPrefix, c.BucketListPrefix) {
+	generatedBackupPrefix := c.BackupConfig.BackupToBucketPrefix + c.BucketListPrefix
+	if !strings.HasPrefix(generatedBackupPrefix, c.BucketListPrefix) {
 		return ""
 	}
-	return c.BackupConfig.BackupToBucketPrefix
+	return generatedBackupPrefix
 }
 
 // fileSelectorConfig defines reader configuration that applies to a subset

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -190,6 +190,25 @@ func (c *backupConfig) GetBucketName() string {
 	return c.NonAWSBackupToBucketName
 }
 
+// backupPrefixToExclude returns the backup prefix that should be excluded from
+// listing results when the backup destination is the same bucket and the backup
+// prefix falls within the listing scope. Returns "" when no exclusion is needed.
+func (c *config) backupPrefixToExclude() string {
+	if c.BackupConfig.BackupToBucketPrefix == "" {
+		return ""
+	}
+	sameBucket := (c.BackupConfig.BackupToBucketArn != "" &&
+		(c.BackupConfig.BackupToBucketArn == c.BucketARN || c.BackupConfig.BackupToBucketArn == c.AccessPointARN)) ||
+		(c.BackupConfig.NonAWSBackupToBucketName != "" && c.BackupConfig.NonAWSBackupToBucketName == c.NonAWSBucketName)
+	if !sameBucket {
+		return ""
+	}
+	if !strings.HasPrefix(c.BackupConfig.BackupToBucketPrefix, c.BucketListPrefix) {
+		return ""
+	}
+	return c.BackupConfig.BackupToBucketPrefix
+}
+
 // fileSelectorConfig defines reader configuration that applies to a subset
 // of S3 objects whose URL matches the given regex.
 type fileSelectorConfig struct {

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -847,7 +847,7 @@ func TestBackupPrefixToExclude(t *testing.T) {
 					BackupToBucketPrefix: "logs/processed/",
 				},
 			},
-			want: "logs/processed/",
+			want: "logs/processed/logs/",
 		},
 		{
 			name: "same bucket, backup prefix outside list prefix scope",

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -798,3 +798,99 @@ func TestS3ConfigModifierHostnameImmutable(t *testing.T) {
 		})
 	}
 }
+
+func TestBackupPrefixToExclude(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config
+		want string
+	}{
+		{
+			name: "no backup configured",
+			cfg: config{
+				BucketARN:        "arn:aws:s3:::my-bucket",
+				BucketListPrefix: "",
+			},
+			want: "",
+		},
+		{
+			name: "different bucket",
+			cfg: config{
+				BucketARN:        "arn:aws:s3:::my-bucket",
+				BucketListPrefix: "",
+				BackupConfig: backupConfig{
+					BackupToBucketArn:    "arn:aws:s3:::other-bucket",
+					BackupToBucketPrefix: "processed/",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "same bucket, empty list prefix",
+			cfg: config{
+				BucketARN:        "arn:aws:s3:::my-bucket",
+				BucketListPrefix: "",
+				BackupConfig: backupConfig{
+					BackupToBucketArn:    "arn:aws:s3:::my-bucket",
+					BackupToBucketPrefix: "processed/",
+				},
+			},
+			want: "processed/",
+		},
+		{
+			name: "same bucket, backup prefix within list prefix scope",
+			cfg: config{
+				BucketARN:        "arn:aws:s3:::my-bucket",
+				BucketListPrefix: "logs/",
+				BackupConfig: backupConfig{
+					BackupToBucketArn:    "arn:aws:s3:::my-bucket",
+					BackupToBucketPrefix: "logs/processed/",
+				},
+			},
+			want: "logs/processed/",
+		},
+		{
+			name: "same bucket, backup prefix outside list prefix scope",
+			cfg: config{
+				BucketARN:        "arn:aws:s3:::my-bucket",
+				BucketListPrefix: "logs/",
+				BackupConfig: backupConfig{
+					BackupToBucketArn:    "arn:aws:s3:::my-bucket",
+					BackupToBucketPrefix: "archived/",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "same bucket via access point ARN",
+			cfg: config{
+				AccessPointARN:   "arn:aws:s3:us-east-1:123456789:accesspoint/ap",
+				BucketListPrefix: "",
+				BackupConfig: backupConfig{
+					BackupToBucketArn:    "arn:aws:s3:us-east-1:123456789:accesspoint/ap",
+					BackupToBucketPrefix: "done/",
+				},
+			},
+			want: "done/",
+		},
+		{
+			name: "same non-AWS bucket",
+			cfg: config{
+				NonAWSBucketName: "minio-bucket",
+				BucketListPrefix: "",
+				BackupConfig: backupConfig{
+					NonAWSBackupToBucketName: "minio-bucket",
+					BackupToBucketPrefix:     "backup/",
+				},
+			},
+			want: "backup/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.backupPrefixToExclude()
+			assert.Equal(t, tt.want, got, "backupPrefixToExclude() mismatch")
+		})
+	}
+}

--- a/x-pack/filebeat/input/awss3/s3_input.go
+++ b/x-pack/filebeat/input/awss3/s3_input.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -267,6 +268,7 @@ func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) 
 	bucketName := getBucketNameFromARN(in.config.getBucketARN())
 
 	isStateValid := in.filterProvider.getApplierFunc()
+	excludePrefix := in.config.backupPrefixToExclude()
 
 	errorBackoff := backoff.NewEqualJitterBackoff(1, 120)
 	circuitBreaker := 0
@@ -304,6 +306,10 @@ func (in *s3PollerInput) readerLoop(ctx context.Context, workChan chan<- state) 
 		// Metrics
 		in.metrics.s3ObjectsListedTotal.Add(uint64(totListedObjects))
 		for _, object := range page.Contents {
+			if excludePrefix != "" && strings.HasPrefix(*object.Key, excludePrefix) {
+				continue
+			}
+
 			state := newState(bucketName, *object.Key, *object.ETag, *object.LastModified)
 
 			if in.strategy.ShouldSkipObject(state, isStateValid) {

--- a/x-pack/filebeat/input/awss3/s3_test.go
+++ b/x-pack/filebeat/input/awss3/s3_test.go
@@ -273,6 +273,120 @@ func TestS3Poller(t *testing.T) {
 		waitForChannel(t, deleteDone, 3*testTimeout)
 	})
 
+	t.Run("Same-bucket backup objects are excluded from listing", func(t *testing.T) {
+		store := openTestStatestore()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*testTimeout)
+		defer cancel()
+
+		ctrl, ctx := gomock.WithContext(ctx, t)
+		defer ctrl.Finish()
+
+		mockAPI := NewMockS3API(ctrl)
+		mockPager := NewMockS3Pager(ctrl)
+		pipeline := newFakePipeline()
+
+		backupDone := make(chan struct{})
+
+		mockAPI.EXPECT().
+			ListObjectsPaginator(gomock.Eq(bucket), gomock.Eq(""), gomock.Any()).
+			Times(1).
+			DoAndReturn(func(_, _, _ string) s3Pager {
+				return mockPager
+			})
+
+		hasMoreCalls := 0
+		mockPager.EXPECT().
+			HasMorePages().
+			Times(2).
+			DoAndReturn(func() bool {
+				hasMoreCalls++
+				return hasMoreCalls == 1
+			})
+
+		mockPager.EXPECT().
+			NextPage(gomock.Any()).
+			Times(1).
+			DoAndReturn(func(_ context.Context, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+				return &s3.ListObjectsV2Output{
+					Contents: []types.Object{
+						{
+							ETag:         aws.String("etag1"),
+							Key:          aws.String("input.log"),
+							LastModified: aws.Time(time.Now()),
+						},
+						{
+							ETag:         aws.String("etag2"),
+							Key:          aws.String("processed/input.log"),
+							LastModified: aws.Time(time.Now()),
+						},
+						{
+							ETag:         aws.String("etag3"),
+							Key:          aws.String("processed/processed/input.log"),
+							LastModified: aws.Time(time.Now()),
+						},
+					},
+				}, nil
+			})
+
+		// Only the source object should be fetched.
+		mockAPI.EXPECT().
+			GetObject(gomock.Any(), gomock.Eq(""), gomock.Eq(bucket), gomock.Eq("input.log")).
+			Times(1).
+			DoAndReturn(func(_ context.Context, _ string, _ string, _ string) (*s3.GetObjectOutput, error) {
+				return &s3.GetObjectOutput{
+					Body: io.NopCloser(strings.NewReader("hello\n")),
+				}, nil
+			})
+
+		// Finalization copies the source object to the backup prefix.
+		mockAPI.EXPECT().
+			CopyObject(gomock.Any(), gomock.Eq(""), gomock.Eq(bucket), gomock.Eq(bucket), gomock.Eq("input.log"), gomock.Eq("processed/input.log")).
+			Times(1).
+			DoAndReturn(func(_ context.Context, _ string, _ string, _ string, _ string, _ string) (*s3.CopyObjectOutput, error) {
+				close(backupDone)
+				return &s3.CopyObjectOutput{}, nil
+			})
+
+		// The backup-prefixed keys must NOT trigger GetObject. gomock will
+		// fail the test if an unexpected GetObject call is made.
+
+		backupCfg := backupConfig{
+			BackupToBucketArn:    bucket,
+			BackupToBucketPrefix: "processed/",
+		}
+
+		cfg := config{
+			NumberOfWorkers:    numberOfWorkers,
+			BucketListInterval: pollInterval,
+			BucketARN:          bucket,
+			BucketListPrefix:   "",
+			BackupConfig:       backupCfg,
+		}
+		log := logptest.NewTestingLogger(t, inputName)
+
+		s3ObjProc := newS3ObjectProcessorFactory(nil, mockAPI, nil, backupCfg, logp.NewNopLogger())
+		registry, err := newStateRegistry(nil, store, "", cfg.LexicographicalOrdering, cfg.LexicographicalLookbackKeys)
+		require.NoError(t, err, "registry creation must succeed")
+
+		poller := &s3PollerInput{
+			log:             log,
+			config:          cfg,
+			s3:              mockAPI,
+			pipeline:        pipeline,
+			s3ObjectHandler: s3ObjProc,
+			registry:        registry,
+			provider:        "provider",
+			metrics:         newInputMetrics(monitoring.NewRegistry(), 0, logp.NewNopLogger()),
+			filterProvider:  newFilterProvider(&cfg),
+			strategy:        newPollingStrategy(cfg.LexicographicalOrdering, log),
+			status:          &statusReporterHelperMock{},
+		}
+
+		poller.runPoll(ctx)
+		waitForChannel(t, backupDone, 3*testTimeout)
+	})
+
 	t.Run("restart bucket scan after paging errors", func(t *testing.T) {
 		// Change the restart limit to 2 consecutive errors, so the test doesn't
 		// take too long to run

--- a/x-pack/filebeat/input/awss3/v2_input.go
+++ b/x-pack/filebeat/input/awss3/v2_input.go
@@ -271,6 +271,7 @@ func (in *inputV2) runPolling(ctx context.Context, log *logp.Logger, st status.S
 		Status:          st,
 		BucketARN:       in.config.getBucketARN(),
 		ListPrefix:      in.config.BucketListPrefix,
+		ExcludePrefix:   in.config.backupPrefixToExclude(),
 		ListInterval:    in.config.BucketListInterval,
 		NumWorkers:      in.config.NumberOfWorkers,
 		Region:          awsCfg.Region,

--- a/x-pack/filebeat/input/awss3/v2_polling.go
+++ b/x-pack/filebeat/input/awss3/v2_polling.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +35,7 @@ type pollingDiscoveryV2 struct {
 	bucketARN      string
 	bucketName     string
 	listPrefix     string
+	excludePrefix  string
 	listInterval   time.Duration
 	numWorkers     int
 	region         string
@@ -52,6 +54,7 @@ type pollingDiscoveryV2Config struct {
 	Status          status.StatusReporter
 	BucketARN       string
 	ListPrefix      string
+	ExcludePrefix   string
 	ListInterval    time.Duration
 	NumWorkers      int
 	Region          string
@@ -71,6 +74,7 @@ func newPollingDiscoveryV2(cfg pollingDiscoveryV2Config) *pollingDiscoveryV2 {
 		bucketARN:      cfg.BucketARN,
 		bucketName:     getBucketNameFromARN(cfg.BucketARN),
 		listPrefix:     cfg.ListPrefix,
+		excludePrefix:  cfg.ExcludePrefix,
 		listInterval:   cfg.ListInterval,
 		numWorkers:     cfg.NumWorkers,
 		region:         cfg.Region,
@@ -220,6 +224,10 @@ func (p *pollingDiscoveryV2) listObjects(ctx context.Context, workChan chan<- st
 		p.metrics.s3ObjectsListedTotal.Add(uint64(len(page.Contents)))
 
 		for _, obj := range page.Contents {
+			if p.excludePrefix != "" && strings.HasPrefix(*obj.Key, p.excludePrefix) {
+				continue
+			}
+
 			st := newState(p.bucketName, *obj.Key, *obj.ETag, *obj.LastModified)
 
 			if p.strategy.ShouldSkipObject(st, isStateValid) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/awss3: exclude backup-prefixed keys from polling

When same-bucket backup is configured and bucket_list_prefix is empty
(the default), the S3 listing returns backup objects alongside source
objects. Because each backup has a new key, ETag, and LastModified, the
state registry never recognises it as already processed. This causes
infinite reprocessing: each poll cycle processes its own prior backup
output and creates a deeper copy.

Exclude keys that start with the configured backup prefix from the
listing results when the backup destination is the same bucket and the
prefix falls within the listing scope. This applies to both the v1
poller (s3_input.go) and v2 poller (v2_polling.go).

Fixes #51852
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #51852

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
