### PR TITLE
Honor path_style for non-AWS S3 buckets

### DIFF
--- a/changelog/fragments/1784190638-fix-awss3-non-aws-path-style.yaml
+++ b/changelog/fragments/1784190638-fix-awss3-non-aws-path-style.yaml
@@ -41,7 +41,7 @@ component: filebeat
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/beats/pull/52003
 
 # AUTOMATED
 # OPTIONAL to manually add other issue URLs

--- a/changelog/fragments/1784190638-fix-awss3-non-aws-path-style.yaml
+++ b/changelog/fragments/1784190638-fix-awss3-non-aws-path-style.yaml
@@ -1,0 +1,50 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Honor path_style for non-AWS S3 buckets in the aws-s3 input
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  When using non_aws_bucket_name with a custom endpoint, the aws-s3 input
+  always marked the endpoint hostname immutable, forcing path-style requests
+  and ignoring path_style. This broke S3-compatible providers that require
+  virtual-hosted addressing, which returned VirtualHostDomainRequired. 
+  The hostname is now kept mutable for non-AWS buckets so path_style is honored.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -232,12 +232,12 @@ func (rc *readerConfig) Validate() error {
 }
 
 type scriptConfig struct {
-	Source            string                 `config:"source"`                               // Inline script to execute.
-	File              string                 `config:"file"`                                 // Source file.
-	Files             []string               `config:"files"`                                // Multiple source files.
-	Params            map[string]interface{} `config:"params"`                               // Parameters to pass to script.
-	Timeout           time.Duration          `config:"timeout" validate:"min=0"`             // Execution timeout.
-	MaxCachedSessions int                    `config:"max_cached_sessions" validate:"min=0"` // Max. number of cached VM sessions.
+	Source            string         `config:"source"`                               // Inline script to execute.
+	File              string         `config:"file"`                                 // Source file.
+	Files             []string       `config:"files"`                                // Multiple source files.
+	Params            map[string]any `config:"params"`                               // Parameters to pass to script.
+	Timeout           time.Duration  `config:"timeout" validate:"min=0"`             // Execution timeout.
+	MaxCachedSessions int            `config:"max_cached_sessions" validate:"min=0"` // Max. number of cached VM sessions.
 }
 
 // Validate returns an error if one (and only one) option is not set.

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -305,8 +305,11 @@ func (c config) s3ConfigModifier(o *s3.Options) {
 		//nolint:staticcheck // haven't migrated to the new interface yet
 		o.EndpointResolver = s3.EndpointResolverFromURL(c.AWSConfig.Endpoint,
 			func(e *awssdk.Endpoint) {
-				// The S3 hostname is immutable in bucket polling mode, mutable otherwise.
-				e.HostnameImmutable = (c.getBucketARN() != "")
+				// The S3 hostname is immutable only for AWS bucket/access-point
+				// polling. For non-AWS S3-compatible storage the hostname must
+				// stay mutable so the SDK can honor path_style (virtual-hosted
+				// addressing when path_style is false).
+				e.HostnameImmutable = (c.getBucketARN() != "" && c.NonAWSBucketName == "")
 			})
 	}
 	o.UsePathStyle = c.PathStyle

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -667,7 +667,7 @@ func TestConfig(t *testing.T) {
 			if tc.expectedCfg == nil {
 				t.Fatal("missing expected config in test case")
 			}
-			assert.EqualValues(t, tc.expectedCfg(tc.queueURL, tc.s3Bucket, tc.s3AccessPoint, tc.nonAWSS3Bucket), c)
+			assert.Equal(t, tc.expectedCfg(tc.queueURL, tc.s3Bucket, tc.s3AccessPoint, tc.nonAWSS3Bucket), c)
 		})
 	}
 }
@@ -787,7 +787,9 @@ func TestS3ConfigModifierHostnameImmutable(t *testing.T) {
 			var o s3.Options
 			c.s3ConfigModifier(&o)
 
+			//nolint:staticcheck // s3ConfigModifier uses the deprecated EndpointResolver; test it as configured
 			require.NotNil(t, o.EndpointResolver, "endpoint resolver should be set when endpoint is configured")
+			//nolint:staticcheck // s3ConfigModifier uses the deprecated EndpointResolver; test it as configured
 			ep, err := o.EndpointResolver.ResolveEndpoint("us-east-1", s3.EndpointResolverOptions{})
 			require.NoError(t, err)
 

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/assert"
 
@@ -727,6 +728,71 @@ func TestIsValidAccessPointARN(t *testing.T) {
 			if result != tc.expected {
 				t.Errorf("expected %v, got %v for ARN: %s", tc.expected, result, tc.arn)
 			}
+		})
+	}
+}
+
+func TestS3ConfigModifierHostnameImmutable(t *testing.T) {
+	const endpoint = "https://obs.sa-brazil-1.myhuaweicloud.com"
+
+	testCases := []struct {
+		name             string
+		config           config
+		pathStyle        bool
+		wantImmutable    bool
+		wantUsePathStyle bool
+	}{
+		{
+			// Non-AWS S3-compatible storage (e.g. Huawei OBS) with the default
+			// path_style: false must keep the hostname mutable so the SDK can
+			// use virtual-hosted addressing.
+			name:             "non-AWS bucket keeps hostname mutable",
+			config:           config{NonAWSBucketName: "bucket-cts-organization", RegionName: "sa-brazil-1"},
+			pathStyle:        false,
+			wantImmutable:    false,
+			wantUsePathStyle: false,
+		},
+		{
+			// Non-AWS bucket with path_style: true still ends up path-style,
+			// but the decision is delegated to UsePathStyle rather than forced
+			// via HostnameImmutable.
+			name:             "non-AWS bucket with path_style true",
+			config:           config{NonAWSBucketName: "bucket-cts-organization", RegionName: "sa-brazil-1"},
+			pathStyle:        true,
+			wantImmutable:    false,
+			wantUsePathStyle: true,
+		},
+		{
+			name:             "AWS bucket ARN keeps hostname immutable",
+			config:           config{BucketARN: "arn:aws:s3:::my-bucket"},
+			pathStyle:        false,
+			wantImmutable:    true,
+			wantUsePathStyle: false,
+		},
+		{
+			name:             "access point ARN keeps hostname immutable",
+			config:           config{AccessPointARN: "arn:aws:s3:us-east-1:123456789012:accesspoint/my-ap"},
+			pathStyle:        false,
+			wantImmutable:    true,
+			wantUsePathStyle: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.config
+			c.AWSConfig.Endpoint = endpoint
+			c.PathStyle = tc.pathStyle
+
+			var o s3.Options
+			c.s3ConfigModifier(&o)
+
+			require.NotNil(t, o.EndpointResolver, "endpoint resolver should be set when endpoint is configured")
+			ep, err := o.EndpointResolver.ResolveEndpoint("us-east-1", s3.EndpointResolverOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantImmutable, ep.HostnameImmutable, "HostnameImmutable")
+			assert.Equal(t, tc.wantUsePathStyle, o.UsePathStyle, "UsePathStyle")
 		})
 	}
 }

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -733,7 +733,7 @@ func TestIsValidAccessPointARN(t *testing.T) {
 }
 
 func TestS3ConfigModifierHostnameImmutable(t *testing.T) {
-	const endpoint = "https://obs.sa-brazil-1.myhuaweicloud.com"
+	const endpoint = "https://obs.example.com"
 
 	testCases := []struct {
 		name             string
@@ -743,11 +743,11 @@ func TestS3ConfigModifierHostnameImmutable(t *testing.T) {
 		wantUsePathStyle bool
 	}{
 		{
-			// Non-AWS S3-compatible storage (e.g. Huawei OBS) with the default
-			// path_style: false must keep the hostname mutable so the SDK can
-			// use virtual-hosted addressing.
+			// Non-AWS S3-compatible storage with the default path_style: false
+			// must keep the hostname mutable so the SDK can use virtual-hosted
+			// addressing.
 			name:             "non-AWS bucket keeps hostname mutable",
-			config:           config{NonAWSBucketName: "bucket-cts-organization", RegionName: "sa-brazil-1"},
+			config:           config{NonAWSBucketName: "my-non-aws-bucket", RegionName: "us-east-1"},
 			pathStyle:        false,
 			wantImmutable:    false,
 			wantUsePathStyle: false,
@@ -757,7 +757,7 @@ func TestS3ConfigModifierHostnameImmutable(t *testing.T) {
 			// but the decision is delegated to UsePathStyle rather than forced
 			// via HostnameImmutable.
 			name:             "non-AWS bucket with path_style true",
-			config:           config{NonAWSBucketName: "bucket-cts-organization", RegionName: "sa-brazil-1"},
+			config:           config{NonAWSBucketName: "my-non-aws-bucket", RegionName: "us-east-1"},
 			pathStyle:        true,
 			wantImmutable:    false,
 			wantUsePathStyle: true,


### PR DESCRIPTION

## Proposed commit message

The aws-s3 input set `HostnameImmutable = (getBucketARN() != "")` when a custom
endpoint was configured. `getBucketARN()` also returns the bucket name for
`non_aws_bucket_name`, so any non-AWS S3-compatible bucket with a custom
endpoint ended up with `HostnameImmutable=true`. In the AWS SDK v2 an immutable
hostname forces path-style requests and ignores `path_style` parameter.

This broke providers that require virtual-hosted addressing (e.g. Huawei Cloud
OBS): every `ListObjectsV2` failed with `VirtualHostDomainRequired` (403) and no
data was ingested, with no config-side workaround.

The fix is  scope the immutable hostname to AWS bucket-ARN / access-point polling only:

```go
e.HostnameImmutable = (c.getBucketARN() != "" && c.NonAWSBucketName == "")
```

For non-AWS buckets the hostname is now mutable, so `path_style` controls
addressing: virtual-hosted when `path_style: false` (default), path-style when
`path_style: true`.

## Disruptive user impact

`path_style` now takes effect for non-AWS buckets where it was previously
ignored. Non-AWS users who relied on the old forced path-style
behavior and did not set `path_style` may need to set `path_style: true`.
But this fixes a real bug.


## Related SDH

- https://github.com/elastic/sdh-beats/issues/7374