### PR TITLE
libbeat: seccomp: make MustRegisterPolicy idempotent

### DIFF
--- a/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
+++ b/.buildkite/x-pack/pipeline.xpack.heartbeat.yml
@@ -236,6 +236,41 @@ steps:
           - github_commit_status:
               context: "x-pack/heartbeat: Win 2022 Unit Tests"
 
+  - group: "Extended Tests"
+    key: "x-pack-heartbeat-extended-linux-arm-tests"
+    if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*arm.*/
+
+    steps:
+      - label: ":ubuntu: x-pack/heartbeat: Ubuntu arm64 Unit Tests"
+        key: "extended-arm64-unit-test"
+        if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*arm.*/
+        command: |
+          set -euo pipefail
+          echo "~~~ Installing @elastic/synthetics"
+          npm install -g @elastic/synthetics
+          echo "~~~ Running tests"
+          cd x-pack/heartbeat
+          mage build unitTest
+        retry:
+          automatic:
+            - limit: 1
+        agents:
+          provider: "aws"
+          image: "${AWS_IMAGE_UBUNTU_ARM_64}"
+          instanceType: "${AWS_ARM_INSTANCE_TYPE}"
+        artifact_paths:
+          - "x-pack/heartbeat/build/*.xml"
+          - "x-pack/heartbeat/build/*.json"
+        plugins:
+          - test-collector#v1.10.2:
+              files: "x-pack/heartbeat/build/TEST-*.xml"
+              format: "junit"
+              branches: "main"
+              debug: true
+        notify:
+          - github_commit_status:
+              context: "x-pack/heartbeat: Ubuntu arm64 Unit Tests"
+
   - group: "Extended Windows Tests"
     key: "x-pack-heartbeat-extended-win-tests"
     if: build.env("BUILDKITE_PULL_REQUEST") == "false" || build.env("GITHUB_PR_LABELS") =~ /.*[Ww]indows.*/

--- a/changelog/fragments/1784110000-hbreceiver-arm64-seccomp-reregistration.yaml
+++ b/changelog/fragments/1784110000-hbreceiver-arm64-seccomp-reregistration.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix panic with multiple heartbeat receivers
+component: heartbeat

--- a/libbeat/common/seccomp/seccomp.go
+++ b/libbeat/common/seccomp/seccomp.go
@@ -18,10 +18,11 @@
 package seccomp
 
 import (
-	"fmt"
-	"runtime"
-
 	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"slices"
 
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -41,25 +42,41 @@ var (
 	registeredPolicy *seccomp.Policy
 )
 
-// MustRegisterPolicy registers a seccomp policy to use instead of the default
-// policy. This can be used to register an application specific seccomp policy
-// that is tailored to the specific system calls that the application requires.
-// It panics if a policy has already been registered or if the given policy
+// MustRegisterPolicy registers an application-specific seccomp policy in place
+// of the default one. Re-registering an identical policy is a no-op, so it is
+// safe to call more than once (e.g. when a component is re-initialized in the
+// same process). It panics if a different policy is already registered or if p
 // is invalid.
 func MustRegisterPolicy(p *seccomp.Policy) {
 	if p == nil {
 		panic(errors.New("seccomp policy cannot be nil"))
 	}
 
-	if registeredPolicy != nil {
-		panic(errors.New("a seccomp policy is already registered"))
-	}
-
 	// Ensure that the policy is valid and usable.
 	if _, err := p.Assemble(); err != nil {
 		panic(fmt.Errorf("failed to register seccomp policy: %w", err))
 	}
+
+	if registeredPolicy != nil && !policiesEqual(registeredPolicy, p) {
+		panic(errors.New("a different seccomp policy is already registered"))
+	}
+
 	registeredPolicy = p
+}
+
+// policiesEqual reports whether a and b would install the same seccomp filter.
+func policiesEqual(a, b *seccomp.Policy) bool {
+	if a.DefaultAction != b.DefaultAction || len(a.Syscalls) != len(b.Syscalls) {
+		return false
+	}
+	for i := range a.Syscalls {
+		if a.Syscalls[i].Action != b.Syscalls[i].Action ||
+			!slices.Equal(a.Syscalls[i].Names, b.Syscalls[i].Names) ||
+			!reflect.DeepEqual(a.Syscalls[i].NamesWithCondtions, b.Syscalls[i].NamesWithCondtions) {
+			return false
+		}
+	}
+	return true
 }
 
 // LoadFilter loads a seccomp system call filter into the kernel for this

--- a/libbeat/common/seccomp/seccomp.go
+++ b/libbeat/common/seccomp/seccomp.go
@@ -20,7 +20,6 @@ package seccomp
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"runtime"
 	"slices"
 
@@ -48,6 +47,12 @@ var (
 // same process). It panics if a different policy is already registered or if p
 // is invalid.
 func MustRegisterPolicy(p *seccomp.Policy) {
+	registerPolicy(&registeredPolicy, p)
+}
+
+// registerPolicy validates p and stores it in *dst. It panics if p is nil,
+// invalid, or would install a different filter than the policy already in *dst.
+func registerPolicy(dst **seccomp.Policy, p *seccomp.Policy) {
 	if p == nil {
 		panic(errors.New("seccomp policy cannot be nil"))
 	}
@@ -57,26 +62,28 @@ func MustRegisterPolicy(p *seccomp.Policy) {
 		panic(fmt.Errorf("failed to register seccomp policy: %w", err))
 	}
 
-	if registeredPolicy != nil && !policiesEqual(registeredPolicy, p) {
+	if *dst != nil && !policiesEqual(*dst, p) {
 		panic(errors.New("a different seccomp policy is already registered"))
 	}
 
-	registeredPolicy = p
+	*dst = p
 }
 
 // policiesEqual reports whether a and b would install the same seccomp filter.
 func policiesEqual(a, b *seccomp.Policy) bool {
-	if a.DefaultAction != b.DefaultAction || len(a.Syscalls) != len(b.Syscalls) {
+	if a.DefaultAction != b.DefaultAction {
 		return false
 	}
-	for i := range a.Syscalls {
-		if a.Syscalls[i].Action != b.Syscalls[i].Action ||
-			!slices.Equal(a.Syscalls[i].Names, b.Syscalls[i].Names) ||
-			!reflect.DeepEqual(a.Syscalls[i].NamesWithCondtions, b.Syscalls[i].NamesWithCondtions) {
-			return false
-		}
-	}
-	return true
+	return slices.EqualFunc(a.Syscalls, b.Syscalls, func(x, y seccomp.SyscallGroup) bool {
+		return x.Action == y.Action &&
+			slices.Equal(x.Names, y.Names) &&
+			slices.EqualFunc(x.NamesWithCondtions, y.NamesWithCondtions, nameWithConditionsEqual)
+	})
+}
+
+// nameWithConditionsEqual reports whether two conditional syscall matches are equal.
+func nameWithConditionsEqual(a, b seccomp.NameWithConditions) bool {
+	return a.Name == b.Name && slices.Equal(a.Conditions, b.Conditions)
 }
 
 // LoadFilter loads a seccomp system call filter into the kernel for this

--- a/libbeat/common/seccomp/seccomp_test.go
+++ b/libbeat/common/seccomp/seccomp_test.go
@@ -25,50 +25,123 @@ import (
 	"github.com/elastic/go-seccomp-bpf"
 )
 
-func TestMustRegisterPolicy(t *testing.T) {
-	policyA := testPolicy(seccomp.ActionErrno, []string{"read", "write"})
-	policyASame := testPolicy(seccomp.ActionErrno, []string{"read", "write"})
-	policyB := testPolicy(seccomp.ActionAllow, []string{"read"})
-
-	t.Run("registers first policy", func(t *testing.T) {
-		resetRegisteredPolicyForTest(t)
-		MustRegisterPolicy(policyA)
-		assert.Same(t, policyA, registeredPolicy, "registered policy pointer")
-	})
-
-	t.Run("re-registering an identical policy is a no-op", func(t *testing.T) {
-		resetRegisteredPolicyForTest(t)
-		MustRegisterPolicy(policyA)
-		assert.NotPanics(t, func() { MustRegisterPolicy(policyASame) })
-	})
-
-	t.Run("panics on a different policy", func(t *testing.T) {
-		resetRegisteredPolicyForTest(t)
-		MustRegisterPolicy(policyA)
-		assert.PanicsWithError(t, "a different seccomp policy is already registered",
-			func() { MustRegisterPolicy(policyB) })
-	})
-
-	t.Run("panics on a nil policy", func(t *testing.T) {
-		resetRegisteredPolicyForTest(t)
-		assert.PanicsWithError(t, "seccomp policy cannot be nil",
-			func() { MustRegisterPolicy(nil) })
-	})
+// registerStep is a single registerPolicy call within a test case.
+type registerStep struct {
+	policy    *seccomp.Policy
+	wantPanic string // empty means the registration must succeed
 }
 
-func resetRegisteredPolicyForTest(t *testing.T) {
-	t.Helper()
-	registeredPolicy = nil
+// TestRegisterPolicy exercises the registration logic through a local pointer,
+// so it never touches the registeredPolicy global.
+func TestRegisterPolicy(t *testing.T) {
+	t.Parallel()
+
+	// Two independently constructed policies that install the same filter.
+	policyA := namesPolicy(seccomp.ActionErrno, seccomp.ActionAllow, "read", "write")
+	policyAIdentical := namesPolicy(seccomp.ActionErrno, seccomp.ActionAllow, "read", "write")
+
+	// Variations on policyA that each install a different filter.
+	policyDifferentDefault := namesPolicy(seccomp.ActionAllow, seccomp.ActionAllow, "read", "write")
+	policyDifferentNames := namesPolicy(seccomp.ActionErrno, seccomp.ActionAllow, "read")
+	policyDifferentGroupAction := namesPolicy(seccomp.ActionErrno, seccomp.ActionTrap, "read", "write")
+
+	// Conditional policies exercising NamesWithCondtions: two identical, one
+	// differing only in the argument value it matches on.
+	policyConditions := conditionPolicy(1)
+	policyConditionsIdentical := conditionPolicy(1)
+	policyConditionsDifferent := conditionPolicy(2)
+
+	const (
+		alreadyRegistered = "a different seccomp policy is already registered"
+		cannotBeNil       = "seccomp policy cannot be nil"
+	)
+
+	tests := []struct {
+		name  string
+		steps []registerStep
+	}{
+		{
+			name:  "re-registering an identical policy is a no-op",
+			steps: []registerStep{{policy: policyA}, {policy: policyAIdentical}},
+		},
+		{
+			name:  "re-registering an identical conditional policy is a no-op",
+			steps: []registerStep{{policy: policyConditions}, {policy: policyConditionsIdentical}},
+		},
+		{
+			name:  "panics on a different default action",
+			steps: []registerStep{{policy: policyA}, {policy: policyDifferentDefault, wantPanic: alreadyRegistered}},
+		},
+		{
+			name:  "panics on different names",
+			steps: []registerStep{{policy: policyA}, {policy: policyDifferentNames, wantPanic: alreadyRegistered}},
+		},
+		{
+			name:  "panics on the same names with a different action",
+			steps: []registerStep{{policy: policyA}, {policy: policyDifferentGroupAction, wantPanic: alreadyRegistered}},
+		},
+		{
+			name:  "panics on different syscall conditions",
+			steps: []registerStep{{policy: policyConditions}, {policy: policyConditionsDifferent, wantPanic: alreadyRegistered}},
+		},
+		{
+			name:  "panics on a nil policy",
+			steps: []registerStep{{policy: nil, wantPanic: cannotBeNil}},
+		},
+		{
+			name: "panics on an invalid policy",
+			steps: []registerStep{{
+				policy:    &seccomp.Policy{DefaultAction: seccomp.ActionErrno},
+				wantPanic: "failed to register seccomp policy: syscalls must not be empty",
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var current *seccomp.Policy
+			for i, step := range tc.steps {
+				if step.wantPanic != "" {
+					assert.PanicsWithError(t, step.wantPanic,
+						func() { registerPolicy(&current, step.policy) }, "step %d", i)
+					continue
+				}
+				registerPolicy(&current, step.policy)
+				assert.Same(t, step.policy, current, "step %d: stored policy pointer", i)
+			}
+		})
+	}
+
+	// Call MustRegisterPolicy directly
+	assert.PanicsWithError(t, cannotBeNil, func() { MustRegisterPolicy(nil) })
 }
 
-func testPolicy(defaultAction seccomp.Action, names []string) *seccomp.Policy {
+// namesPolicy builds a policy with a single syscall group matching names.
+func namesPolicy(defaultAction, groupAction seccomp.Action, names ...string) *seccomp.Policy {
 	return &seccomp.Policy{
 		DefaultAction: defaultAction,
-		Syscalls: []seccomp.SyscallGroup{
-			{
-				Action: seccomp.ActionAllow,
-				Names:  names,
-			},
-		},
+		Syscalls: []seccomp.SyscallGroup{{
+			Action: groupAction,
+			Names:  names,
+		}},
+	}
+}
+
+// conditionPolicy builds a policy whose single group matches "write" only when
+// its first argument equals value, exercising the NamesWithCondtions field.
+func conditionPolicy(value uint64) *seccomp.Policy {
+	return &seccomp.Policy{
+		DefaultAction: seccomp.ActionErrno,
+		Syscalls: []seccomp.SyscallGroup{{
+			Action: seccomp.ActionAllow,
+			NamesWithCondtions: []seccomp.NameWithConditions{{
+				Name: "write",
+				Conditions: seccomp.ArgumentConditions{{
+					Argument:  0,
+					Operation: seccomp.Equal,
+					Value:     value,
+				}},
+			}},
+		}},
 	}
 }

--- a/libbeat/common/seccomp/seccomp_test.go
+++ b/libbeat/common/seccomp/seccomp_test.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package seccomp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/go-seccomp-bpf"
+)
+
+func TestMustRegisterPolicy(t *testing.T) {
+	policyA := testPolicy(seccomp.ActionErrno, []string{"read", "write"})
+	policyASame := testPolicy(seccomp.ActionErrno, []string{"read", "write"})
+	policyB := testPolicy(seccomp.ActionAllow, []string{"read"})
+
+	t.Run("registers first policy", func(t *testing.T) {
+		resetRegisteredPolicyForTest(t)
+		MustRegisterPolicy(policyA)
+		assert.Same(t, policyA, registeredPolicy, "registered policy pointer")
+	})
+
+	t.Run("re-registering an identical policy is a no-op", func(t *testing.T) {
+		resetRegisteredPolicyForTest(t)
+		MustRegisterPolicy(policyA)
+		assert.NotPanics(t, func() { MustRegisterPolicy(policyASame) })
+	})
+
+	t.Run("panics on a different policy", func(t *testing.T) {
+		resetRegisteredPolicyForTest(t)
+		MustRegisterPolicy(policyA)
+		assert.PanicsWithError(t, "a different seccomp policy is already registered",
+			func() { MustRegisterPolicy(policyB) })
+	})
+
+	t.Run("panics on a nil policy", func(t *testing.T) {
+		resetRegisteredPolicyForTest(t)
+		assert.PanicsWithError(t, "seccomp policy cannot be nil",
+			func() { MustRegisterPolicy(nil) })
+	})
+}
+
+func resetRegisteredPolicyForTest(t *testing.T) {
+	t.Helper()
+	registeredPolicy = nil
+}
+
+func testPolicy(defaultAction seccomp.Action, names []string) *seccomp.Policy {
+	return &seccomp.Policy{
+		DefaultAction: defaultAction,
+		Syscalls: []seccomp.SyscallGroup{
+			{
+				Action: seccomp.ActionAllow,
+				Names:  names,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Proposed commit message

```
libbeat: seccomp: make MustRegisterPolicy idempotent

MustRegisterPolicy panicked on any second call. This crashed the
hbreceiver when the collector rebuilt a pipeline in the same process:
NewBeat() re-runs heartbeat module initialization, and on arm64 that
re-registers a full seccomp policy (the amd64/386 path already uses the
idempotent ModifyDefaultPolicy).

Re-registering an identical policy is now a no-op. Registering a
different policy still panics, preserving the invariant that a process
installs a single seccomp filter.

The bug was arm64-only, and it slipped through CI because
x-pack/heartbeat had no arm64 unit-test stage.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

Unit regression test (runs on any architecture):

```bash
go test ./libbeat/common/seccomp/
```

Locally, run heartbeat on arm:

```yaml
receivers:
  heartbeatreceiver/r1: {path.home: /tmp/hb-r1, heartbeat: {monitors: [{type: tcp, id: r1, schedule: "@every 60s", hosts: ["localhost:0"]}]}}
  heartbeatreceiver/r2: {path.home: /tmp/hb-r2, heartbeat: {monitors: [{type: tcp, id: r2, schedule: "@every 60s", hosts: ["localhost:0"]}]}}
exporters: {debug: {verbosity: basic}}
service:
  pipelines: {logs: {receivers: [heartbeatreceiver/r1, heartbeatreceiver/r2], exporters: [debug]}}
```

## Related issues

- Closes #52002
- Relates #51834
