### PR TITLE
Add FIPS 140-3 compliance test for beat binaries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.9.0
 	github.com/elastic/elastic-agent-autodiscover v0.10.3-0.20260423154939-e990715f9426
-	github.com/elastic/elastic-agent-libs v0.46.2-0.20260717103017-7f523dc354ff
+	github.com/elastic/elastic-agent-libs v0.46.2-0.20260717120524-f4b911dbb113
 	github.com/elastic/elastic-agent-system-metrics v0.14.4
 	github.com/elastic/go-elasticsearch/v8 v8.19.0
 	github.com/elastic/go-freelru v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.9.0
 	github.com/elastic/elastic-agent-autodiscover v0.10.3-0.20260423154939-e990715f9426
-	github.com/elastic/elastic-agent-libs v0.46.1
+	github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383
 	github.com/elastic/elastic-agent-system-metrics v0.14.4
 	github.com/elastic/go-elasticsearch/v8 v8.19.0
 	github.com/elastic/go-freelru v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/ebpfevents v0.9.0
 	github.com/elastic/elastic-agent-autodiscover v0.10.3-0.20260423154939-e990715f9426
-	github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383
+	github.com/elastic/elastic-agent-libs v0.46.2-0.20260717103017-7f523dc354ff
 	github.com/elastic/elastic-agent-system-metrics v0.14.4
 	github.com/elastic/go-elasticsearch/v8 v8.19.0
 	github.com/elastic/go-freelru v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,8 @@ github.com/elastic/elastic-agent-client/v7 v7.18.1 h1:WnM53JjaukeysrAuiTyrhDPmFx
 github.com/elastic/elastic-agent-client/v7 v7.18.1/go.mod h1:uDpSGZ+YCKgqgtkwCA0qjwX0gU/wmixDsVbPjY3GkPs=
 github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383 h1:OJN61CFsxlAQk8nPXVBNuHFgLoqx/bKdl35Y6LM4T/U=
 github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
+github.com/elastic/elastic-agent-libs v0.46.2-0.20260717103017-7f523dc354ff h1:kdTUyCPXF19aWqFO31GMddDjAvcoUCwAlLJCBnpITr0=
+github.com/elastic/elastic-agent-libs v0.46.2-0.20260717103017-7f523dc354ff/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
 github.com/elastic/elastic-agent-system-metrics v0.14.4 h1:XGGepNVOxhtfJmanQsgqCAZESIJtyDIFOKErOaVzFEw=
 github.com/elastic/elastic-agent-system-metrics v0.14.4/go.mod h1:NyNMrdqMfznb/Zy8EmIAHlJpX6HuRlNW+bBL9UN7WQY=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/elastic/elastic-agent-autodiscover v0.10.3-0.20260423154939-e990715f9
 github.com/elastic/elastic-agent-autodiscover v0.10.3-0.20260423154939-e990715f9426/go.mod h1:HyjdiEVP/A7iMN0jeac2EoUohpHKAZIFRDQsvPDg2Dw=
 github.com/elastic/elastic-agent-client/v7 v7.18.1 h1:WnM53JjaukeysrAuiTyrhDPmFxJG07ZAByc2TrkcKcs=
 github.com/elastic/elastic-agent-client/v7 v7.18.1/go.mod h1:uDpSGZ+YCKgqgtkwCA0qjwX0gU/wmixDsVbPjY3GkPs=
-github.com/elastic/elastic-agent-libs v0.46.1 h1:1dVRKOaGWBxqDQPb/NCtoJHI8Nx3QbJOmr4v6y+UdKQ=
-github.com/elastic/elastic-agent-libs v0.46.1/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
+github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383 h1:OJN61CFsxlAQk8nPXVBNuHFgLoqx/bKdl35Y6LM4T/U=
+github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
 github.com/elastic/elastic-agent-system-metrics v0.14.4 h1:XGGepNVOxhtfJmanQsgqCAZESIJtyDIFOKErOaVzFEw=
 github.com/elastic/elastic-agent-system-metrics v0.14.4/go.mod h1:NyNMrdqMfznb/Zy8EmIAHlJpX6HuRlNW+bBL9UN7WQY=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=

--- a/go.sum
+++ b/go.sum
@@ -381,10 +381,8 @@ github.com/elastic/elastic-agent-autodiscover v0.10.3-0.20260423154939-e990715f9
 github.com/elastic/elastic-agent-autodiscover v0.10.3-0.20260423154939-e990715f9426/go.mod h1:HyjdiEVP/A7iMN0jeac2EoUohpHKAZIFRDQsvPDg2Dw=
 github.com/elastic/elastic-agent-client/v7 v7.18.1 h1:WnM53JjaukeysrAuiTyrhDPmFxJG07ZAByc2TrkcKcs=
 github.com/elastic/elastic-agent-client/v7 v7.18.1/go.mod h1:uDpSGZ+YCKgqgtkwCA0qjwX0gU/wmixDsVbPjY3GkPs=
-github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383 h1:OJN61CFsxlAQk8nPXVBNuHFgLoqx/bKdl35Y6LM4T/U=
-github.com/elastic/elastic-agent-libs v0.46.2-0.20260717100343-cd43f21eb383/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
-github.com/elastic/elastic-agent-libs v0.46.2-0.20260717103017-7f523dc354ff h1:kdTUyCPXF19aWqFO31GMddDjAvcoUCwAlLJCBnpITr0=
-github.com/elastic/elastic-agent-libs v0.46.2-0.20260717103017-7f523dc354ff/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
+github.com/elastic/elastic-agent-libs v0.46.2-0.20260717120524-f4b911dbb113 h1:aAbg0Tj2arqi+kyUWPXOlM+1Vj7ItDf/eW0RTTMm7n8=
+github.com/elastic/elastic-agent-libs v0.46.2-0.20260717120524-f4b911dbb113/go.mod h1:axkpqDCCzAky6G4D/cklgtZQa3jTNGAMVHVkU0u6YbU=
 github.com/elastic/elastic-agent-system-metrics v0.14.4 h1:XGGepNVOxhtfJmanQsgqCAZESIJtyDIFOKErOaVzFEw=
 github.com/elastic/elastic-agent-system-metrics v0.14.4/go.mod h1:NyNMrdqMfznb/Zy8EmIAHlJpX6HuRlNW+bBL9UN7WQY=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=

--- a/testing/testutils/fips_compliance_test.go
+++ b/testing/testutils/fips_compliance_test.go
@@ -39,30 +39,20 @@ var azidentityViolation = map[string][]fipsscan.KnownViolation{
 // the dependency is unavoidable rather than removing it.
 var knownViolations = map[string]map[string][]fipsscan.KnownViolation{
 	module + "/x-pack/filebeat": {"": {
-		// x/crypto/pkcs12 is used by multiple Azure libraries: azidentity (via libbeat
-		// identity federation), Azure Event Hub AMQP AAD auth, and legacy ADAL.
-		{Imported: "golang.org/x/crypto/pkcs12", Reason: "Azure libraries (azidentity, AMQP AAD, ADAL) use x/crypto/pkcs12 for certificate handling"},
+		// Multiple Azure libraries (azidentity, AMQP AAD, ADAL) and Google S2A
+		// use x/crypto; go-ldap uses x/crypto/md4 for NTLM authentication.
+		{Imported: "golang.org/x/crypto", Reason: "Azure libs and Google S2A use x/crypto; go-ldap uses x/crypto/md4 for NTLM — none in FIPS 140-3 scope"},
 		// Entity analytics Active Directory provider: go-ldap bundles NTLM
 		// (MD4/MD5/DES) which is not FIPS-approved.
 		{Imported: "github.com/Azure/go-ntlmssp", Reason: "go-ldap bundles NTLM for Active Directory auth; NTLM relies on MD4/MD5/DES — none FIPS-approved"},
-		{Imported: "golang.org/x/crypto/md4", Reason: "go-ldap uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved"},
-		// GCS input: Google S2A TLS library uses x/crypto for ChaCha20-Poly1305,
-		// HKDF, and handshake parsing — none covered by Go's FIPS 140-3 module.
-		{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
-		{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
-		{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
 	}},
 
 	module + "/x-pack/metricbeat": {"": {
-		// All beats: azidentity → x/crypto/pkcs12 via libbeat identity federation.
-		{Imported: "golang.org/x/crypto/pkcs12", Reason: "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation"},
+		// azidentity and Google S2A use x/crypto.
+		{Imported: "golang.org/x/crypto", Reason: "Azure libs and Google S2A use x/crypto — none in FIPS 140-3 scope"},
 		// MySQL module: go-sql-driver uses filippo.io/edwards25519 for Ed25519
 		// client authentication, which is not in FIPS 140-3 scope.
 		{Imported: "filippo.io/edwards25519", Reason: "MySQL driver uses filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope"},
-		// GCP modules: Google S2A TLS library uses x/crypto.
-		{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
-		{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
-		{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
 	}},
 
 	module + "/x-pack/auditbeat":   azidentityViolation,

--- a/testing/testutils/fips_compliance_test.go
+++ b/testing/testutils/fips_compliance_test.go
@@ -1,0 +1,128 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build requirefips
+
+package testutils_test
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/testing/fipsscan"
+)
+
+const module = "github.com/elastic/beats/v7"
+
+// knownViolations maps each beat binary to its accepted non-FIPS imports.
+// Violations shared across all beats (e.g. azidentity) are listed explicitly
+// per binary so the set for each beat is self-contained and auditable.
+var knownViolations = map[string][]fipsscan.KnownViolation{
+	module + "/x-pack/filebeat": {
+		{
+			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		},
+		{
+			Importer: "github.com/Azure/azure-amqp-common-go/v4/aad",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "Azure Event Hub AMQP AAD auth library uses x/crypto/pkcs12 for certificate handling",
+		},
+		{
+			Importer: "github.com/Azure/go-autorest/autorest/adal",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "Azure ADAL (legacy auth) uses x/crypto/pkcs12 for certificate handling",
+		},
+		{
+			Importer: "github.com/go-ldap/ldap/v3",
+			Imported: "github.com/Azure/go-ntlmssp",
+			Reason:   "Entity analytics Active Directory provider uses go-ldap which bundles NTLM; NTLM relies on MD4/MD5/DES — none FIPS-approved",
+		},
+		{
+			Importer: "github.com/go-ldap/ldap/v3",
+			Imported: "golang.org/x/crypto/md4",
+			Reason:   "Entity analytics Active Directory provider uses go-ldap which uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved",
+		},
+		{
+			Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
+			Imported: "golang.org/x/crypto/chacha20poly1305",
+			Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto; pulled in by GCS input",
+		},
+		{
+			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+			Imported: "golang.org/x/crypto/cryptobyte",
+			Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing; pulled in by GCS input",
+		},
+		{
+			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+			Imported: "golang.org/x/crypto/hkdf",
+			Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation; pulled in by GCS input",
+		},
+	},
+	module + "/x-pack/metricbeat": {
+		{
+			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		},
+		{
+			Importer: "github.com/go-sql-driver/mysql",
+			Imported: "filippo.io/edwards25519",
+			Reason:   "MySQL driver imports filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope",
+		},
+		{
+			Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
+			Imported: "golang.org/x/crypto/chacha20poly1305",
+			Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto; pulled in by GCP modules",
+		},
+		{
+			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+			Imported: "golang.org/x/crypto/cryptobyte",
+			Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing; pulled in by GCP modules",
+		},
+		{
+			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+			Imported: "golang.org/x/crypto/hkdf",
+			Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation; pulled in by GCP modules",
+		},
+	},
+	module + "/x-pack/auditbeat": {
+		{
+			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		},
+	},
+	module + "/x-pack/heartbeat": {
+		{
+			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		},
+	},
+	module + "/x-pack/packetbeat": {
+		{
+			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		},
+	},
+}
+
+var beats = []string{
+	module + "/x-pack/filebeat",
+	module + "/x-pack/metricbeat",
+	module + "/x-pack/auditbeat",
+	module + "/x-pack/heartbeat",
+	module + "/x-pack/packetbeat",
+}
+
+func TestFIPSFullyCompliant(t *testing.T) {
+	for _, binary := range beats {
+		binary := binary
+		t.Run(binary[len(module+"/x-pack/"):], func(t *testing.T) {
+			fipsscan.CheckModule(t, []string{binary}, nil, knownViolations)
+		})
+	}
+}

--- a/testing/testutils/fips_compliance_test.go
+++ b/testing/testutils/fips_compliance_test.go
@@ -25,101 +25,77 @@ var skipBinaries = []string{
 	module + "/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate", // code-generation script, not shipped
 }
 
+// azidentityViolation is the shared azidentity → x/crypto/pkcs12 violation
+// present in every beat via x-pack/libbeat's Azure/AWS identity federation.
+var azidentityViolation = []fipsscan.KnownViolation{
+	{
+		Imported: "golang.org/x/crypto/pkcs12",
+		Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+	},
+}
+
 // knownViolations documents accepted non-FIPS imports per binary and component.
 // Outer key: binary import path, or "" to match all binaries.
 // Inner key: component package path or prefix that pulls in the violation, or "" to match any.
 // Any violation not listed here will fail the test — add an entry with a Reason
 // explaining why the dependency is unavoidable rather than removing it.
 var knownViolations = map[string]map[string][]fipsscan.KnownViolation{
-	// Shared: x-pack/libbeat's identity federation pulls in azidentity, which
-	// uses x/crypto/pkcs12 for certificate-based auth. Present in every beat.
-	"": {
-		module + "/x-pack/libbeat/common/identityfederation": {
-			{
-				Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-				Imported: "golang.org/x/crypto/pkcs12",
-				Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
-			},
-		},
-	},
-
 	module + "/x-pack/filebeat": {
+		// x-pack/libbeat's identity federation pulls in azidentity → x/crypto/pkcs12.
+		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
 		// Azure Event Hub input: AMQP AAD auth and legacy ADAL use x/crypto/pkcs12.
 		module + "/x-pack/filebeat/input/azureeventhub": {
-			{
-				Importer: "github.com/Azure/azure-amqp-common-go/v4/aad",
-				Imported: "golang.org/x/crypto/pkcs12",
-				Reason:   "Azure Event Hub AMQP AAD auth library uses x/crypto/pkcs12 for certificate handling",
-			},
-			{
-				Importer: "github.com/Azure/go-autorest/autorest/adal",
-				Imported: "golang.org/x/crypto/pkcs12",
-				Reason:   "Azure ADAL (legacy auth) uses x/crypto/pkcs12 for certificate handling",
-			},
+			{Imported: "golang.org/x/crypto/pkcs12", Reason: "Azure AMQP AAD auth and legacy ADAL use x/crypto/pkcs12 for certificate handling"},
 		},
 		// Entity analytics Active Directory provider: go-ldap bundles NTLM
 		// (MD4/MD5/DES) which is not FIPS-approved.
 		module + "/x-pack/filebeat/input/entityanalytics": {
-			{
-				Importer: "github.com/go-ldap/ldap/v3",
-				Imported: "github.com/Azure/go-ntlmssp",
-				Reason:   "go-ldap bundles NTLM for Active Directory auth; NTLM relies on MD4/MD5/DES — none FIPS-approved",
-			},
-			{
-				Importer: "github.com/go-ldap/ldap/v3",
-				Imported: "golang.org/x/crypto/md4",
-				Reason:   "go-ldap uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved",
-			},
+			{Imported: "github.com/Azure/go-ntlmssp", Reason: "go-ldap bundles NTLM for Active Directory auth; NTLM relies on MD4/MD5/DES — none FIPS-approved"},
+			{Imported: "golang.org/x/crypto/md4", Reason: "go-ldap uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved"},
 		},
 		// GCS input: Google S2A TLS library uses x/crypto for ChaCha20-Poly1305,
 		// HKDF, and handshake parsing — none covered by Go's FIPS 140-3 module.
 		module + "/x-pack/filebeat/input/gcs": {
-			{
-				Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
-				Imported: "golang.org/x/crypto/chacha20poly1305",
-				Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto",
-			},
-			{
-				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-				Imported: "golang.org/x/crypto/cryptobyte",
-				Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing",
-			},
-			{
-				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-				Imported: "golang.org/x/crypto/hkdf",
-				Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation",
-			},
+			{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
+			{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
+			{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
 		},
 	},
 
 	module + "/x-pack/metricbeat": {
+		// x-pack/libbeat's identity federation pulls in azidentity → x/crypto/pkcs12.
+		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
 		// MySQL module: go-sql-driver uses filippo.io/edwards25519 for Ed25519
 		// client authentication, which is not in FIPS 140-3 scope.
 		module + "/metricbeat/module/mysql": {
-			{
-				Importer: "github.com/go-sql-driver/mysql",
-				Imported: "filippo.io/edwards25519",
-				Reason:   "MySQL driver uses filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope",
-			},
+			{Imported: "filippo.io/edwards25519", Reason: "MySQL driver uses filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope"},
 		},
 		// GCP modules: Google S2A TLS library uses x/crypto — same as filebeat GCS.
 		module + "/x-pack/metricbeat/module/gcp": {
-			{
-				Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
-				Imported: "golang.org/x/crypto/chacha20poly1305",
-				Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto",
-			},
-			{
-				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-				Imported: "golang.org/x/crypto/cryptobyte",
-				Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing",
-			},
-			{
-				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-				Imported: "golang.org/x/crypto/hkdf",
-				Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation",
-			},
+			{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
+			{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
+			{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
 		},
+	},
+
+	module + "/x-pack/auditbeat": {
+		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
+	},
+
+	module + "/x-pack/heartbeat": {
+		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
+	},
+
+	module + "/x-pack/packetbeat": {
+		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
+	},
+
+	module + "/x-pack/osquerybeat": {
+		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
+	},
+
+	module + "/x-pack/winlogbeat": {
+		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
 	},
 }
 

--- a/testing/testutils/fips_compliance_test.go
+++ b/testing/testutils/fips_compliance_test.go
@@ -22,7 +22,6 @@ var skipBinaries = []string{
 	module + "/x-pack/filebeat/processors/decode_cef/cef/cmd/cef2json",         // developer tool, not shipped
 	module + "/x-pack/heartbeat/monitors/browser/synthexec/testcmd",            // test helper, not shipped
 	module + "/x-pack/metricbeat/scripts/msetlists",                            // code-generation script, not shipped
-	module + "/x-pack/osquerybeat/ext/osquery-extension",                       // osquery extension, ships separately from the beat binary
 	module + "/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate", // code-generation script, not shipped
 }
 

--- a/testing/testutils/fips_compliance_test.go
+++ b/testing/testutils/fips_compliance_test.go
@@ -14,9 +14,21 @@ import (
 
 const module = "github.com/elastic/beats/v7"
 
-// knownViolations maps each beat binary to its accepted non-FIPS imports.
-// Violations shared across all beats (e.g. azidentity) are listed explicitly
-// per binary so the set for each beat is self-contained and auditable.
+// skipBinaries are package main programs under x-pack/ that are not shipping
+// beat binaries and should be excluded from FIPS scanning.
+var skipBinaries = []string{
+	module + "/x-pack/libbeat",                                                 // mock binary used to test libbeat itself
+	module + "/x-pack/filebeat/input/netflow/decoder/examples",                 // example program, not shipped
+	module + "/x-pack/filebeat/processors/decode_cef/cef/cmd/cef2json",         // developer tool, not shipped
+	module + "/x-pack/heartbeat/monitors/browser/synthexec/testcmd",            // test helper, not shipped
+	module + "/x-pack/metricbeat/scripts/msetlists",                            // code-generation script, not shipped
+	module + "/x-pack/osquerybeat/ext/osquery-extension",                       // osquery extension, ships separately from the beat binary
+	module + "/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate", // code-generation script, not shipped
+}
+
+// knownViolations documents accepted non-FIPS imports per binary. Any violation
+// not listed here will fail the test — add an entry with a Reason explaining why
+// the dependency is unavoidable rather than removing it.
 var knownViolations = map[string][]fipsscan.KnownViolation{
 	module + "/x-pack/filebeat": {
 		{
@@ -108,21 +120,22 @@ var knownViolations = map[string][]fipsscan.KnownViolation{
 			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
 		},
 	},
-}
-
-var beats = []string{
-	module + "/x-pack/filebeat",
-	module + "/x-pack/metricbeat",
-	module + "/x-pack/auditbeat",
-	module + "/x-pack/heartbeat",
-	module + "/x-pack/packetbeat",
+	module + "/x-pack/osquerybeat": {
+		{
+			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		},
+	},
+	module + "/x-pack/winlogbeat": {
+		{
+			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			Imported: "golang.org/x/crypto/pkcs12",
+			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		},
+	},
 }
 
 func TestFIPSFullyCompliant(t *testing.T) {
-	for _, binary := range beats {
-		binary := binary
-		t.Run(binary[len(module+"/x-pack/"):], func(t *testing.T) {
-			fipsscan.CheckModule(t, []string{binary}, nil, knownViolations)
-		})
-	}
+	fipsscan.CheckModule(t, []string{module + "/x-pack/..."}, skipBinaries, nil, knownViolations)
 }

--- a/testing/testutils/fips_compliance_test.go
+++ b/testing/testutils/fips_compliance_test.go
@@ -27,76 +27,49 @@ var skipBinaries = []string{
 
 // azidentityViolation is the shared azidentity → x/crypto/pkcs12 violation
 // present in every beat via x-pack/libbeat's Azure/AWS identity federation.
-var azidentityViolation = []fipsscan.KnownViolation{
-	{
+var azidentityViolation = map[string][]fipsscan.KnownViolation{
+	"": {{
 		Imported: "golang.org/x/crypto/pkcs12",
 		Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
-	},
+	}},
 }
 
-// knownViolations documents accepted non-FIPS imports per binary and component.
-// Outer key: binary import path, or "" to match all binaries.
-// Inner key: component package path or prefix that pulls in the violation, or "" to match any.
-// Any violation not listed here will fail the test — add an entry with a Reason
-// explaining why the dependency is unavoidable rather than removing it.
+// knownViolations documents accepted non-FIPS imports per binary. Any violation
+// not listed here will fail the test — add an entry with a Reason explaining why
+// the dependency is unavoidable rather than removing it.
 var knownViolations = map[string]map[string][]fipsscan.KnownViolation{
-	module + "/x-pack/filebeat": {
-		// x-pack/libbeat's identity federation pulls in azidentity → x/crypto/pkcs12.
-		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
-		// Azure Event Hub input: AMQP AAD auth and legacy ADAL use x/crypto/pkcs12.
-		module + "/x-pack/filebeat/input/azureeventhub": {
-			{Imported: "golang.org/x/crypto/pkcs12", Reason: "Azure AMQP AAD auth and legacy ADAL use x/crypto/pkcs12 for certificate handling"},
-		},
+	module + "/x-pack/filebeat": {"": {
+		// x/crypto/pkcs12 is used by multiple Azure libraries: azidentity (via libbeat
+		// identity federation), Azure Event Hub AMQP AAD auth, and legacy ADAL.
+		{Imported: "golang.org/x/crypto/pkcs12", Reason: "Azure libraries (azidentity, AMQP AAD, ADAL) use x/crypto/pkcs12 for certificate handling"},
 		// Entity analytics Active Directory provider: go-ldap bundles NTLM
 		// (MD4/MD5/DES) which is not FIPS-approved.
-		module + "/x-pack/filebeat/input/entityanalytics": {
-			{Imported: "github.com/Azure/go-ntlmssp", Reason: "go-ldap bundles NTLM for Active Directory auth; NTLM relies on MD4/MD5/DES — none FIPS-approved"},
-			{Imported: "golang.org/x/crypto/md4", Reason: "go-ldap uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved"},
-		},
+		{Imported: "github.com/Azure/go-ntlmssp", Reason: "go-ldap bundles NTLM for Active Directory auth; NTLM relies on MD4/MD5/DES — none FIPS-approved"},
+		{Imported: "golang.org/x/crypto/md4", Reason: "go-ldap uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved"},
 		// GCS input: Google S2A TLS library uses x/crypto for ChaCha20-Poly1305,
 		// HKDF, and handshake parsing — none covered by Go's FIPS 140-3 module.
-		module + "/x-pack/filebeat/input/gcs": {
-			{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
-			{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
-			{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
-		},
-	},
+		{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
+		{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
+		{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
+	}},
 
-	module + "/x-pack/metricbeat": {
-		// x-pack/libbeat's identity federation pulls in azidentity → x/crypto/pkcs12.
-		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
+	module + "/x-pack/metricbeat": {"": {
+		// All beats: azidentity → x/crypto/pkcs12 via libbeat identity federation.
+		{Imported: "golang.org/x/crypto/pkcs12", Reason: "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation"},
 		// MySQL module: go-sql-driver uses filippo.io/edwards25519 for Ed25519
 		// client authentication, which is not in FIPS 140-3 scope.
-		module + "/metricbeat/module/mysql": {
-			{Imported: "filippo.io/edwards25519", Reason: "MySQL driver uses filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope"},
-		},
-		// GCP modules: Google S2A TLS library uses x/crypto — same as filebeat GCS.
-		module + "/x-pack/metricbeat/module/gcp": {
-			{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
-			{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
-			{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
-		},
-	},
+		{Imported: "filippo.io/edwards25519", Reason: "MySQL driver uses filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope"},
+		// GCP modules: Google S2A TLS library uses x/crypto.
+		{Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto"},
+		{Imported: "golang.org/x/crypto/cryptobyte", Reason: "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing"},
+		{Imported: "golang.org/x/crypto/hkdf", Reason: "Google S2A TLS library uses x/crypto/hkdf for key derivation"},
+	}},
 
-	module + "/x-pack/auditbeat": {
-		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
-	},
-
-	module + "/x-pack/heartbeat": {
-		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
-	},
-
-	module + "/x-pack/packetbeat": {
-		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
-	},
-
-	module + "/x-pack/osquerybeat": {
-		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
-	},
-
-	module + "/x-pack/winlogbeat": {
-		module + "/x-pack/libbeat/common/identityfederation": azidentityViolation,
-	},
+	module + "/x-pack/auditbeat":   azidentityViolation,
+	module + "/x-pack/heartbeat":   azidentityViolation,
+	module + "/x-pack/packetbeat":  azidentityViolation,
+	module + "/x-pack/osquerybeat": azidentityViolation,
+	module + "/x-pack/winlogbeat":  azidentityViolation,
 }
 
 func TestFIPSFullyCompliant(t *testing.T) {

--- a/testing/testutils/fips_compliance_test.go
+++ b/testing/testutils/fips_compliance_test.go
@@ -17,120 +17,108 @@ const module = "github.com/elastic/beats/v7"
 // skipBinaries are package main programs under x-pack/ that are not shipping
 // beat binaries and should be excluded from FIPS scanning.
 var skipBinaries = []string{
-	module + "/x-pack/libbeat",                                                 // mock binary used to test libbeat itself
-	module + "/x-pack/filebeat/input/netflow/decoder/examples",                 // example program, not shipped
-	module + "/x-pack/filebeat/processors/decode_cef/cef/cmd/cef2json",         // developer tool, not shipped
-	module + "/x-pack/heartbeat/monitors/browser/synthexec/testcmd",            // test helper, not shipped
-	module + "/x-pack/metricbeat/scripts/msetlists",                            // code-generation script, not shipped
+	module + "/x-pack/libbeat",                                                  // mock binary used to test libbeat itself
+	module + "/x-pack/filebeat/input/netflow/decoder/examples",                  // example program, not shipped
+	module + "/x-pack/filebeat/processors/decode_cef/cef/cmd/cef2json",          // developer tool, not shipped
+	module + "/x-pack/heartbeat/monitors/browser/synthexec/testcmd",             // test helper, not shipped
+	module + "/x-pack/metricbeat/scripts/msetlists",                             // code-generation script, not shipped
 	module + "/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate", // code-generation script, not shipped
 }
 
-// knownViolations documents accepted non-FIPS imports per binary. Any violation
-// not listed here will fail the test — add an entry with a Reason explaining why
-// the dependency is unavoidable rather than removing it.
-var knownViolations = map[string][]fipsscan.KnownViolation{
+// knownViolations documents accepted non-FIPS imports per binary and component.
+// Outer key: binary import path, or "" to match all binaries.
+// Inner key: component package path or prefix that pulls in the violation, or "" to match any.
+// Any violation not listed here will fail the test — add an entry with a Reason
+// explaining why the dependency is unavoidable rather than removing it.
+var knownViolations = map[string]map[string][]fipsscan.KnownViolation{
+	// Shared: x-pack/libbeat's identity federation pulls in azidentity, which
+	// uses x/crypto/pkcs12 for certificate-based auth. Present in every beat.
+	"": {
+		module + "/x-pack/libbeat/common/identityfederation": {
+			{
+				Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+				Imported: "golang.org/x/crypto/pkcs12",
+				Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+			},
+		},
+	},
+
 	module + "/x-pack/filebeat": {
-		{
-			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		// Azure Event Hub input: AMQP AAD auth and legacy ADAL use x/crypto/pkcs12.
+		module + "/x-pack/filebeat/input/azureeventhub": {
+			{
+				Importer: "github.com/Azure/azure-amqp-common-go/v4/aad",
+				Imported: "golang.org/x/crypto/pkcs12",
+				Reason:   "Azure Event Hub AMQP AAD auth library uses x/crypto/pkcs12 for certificate handling",
+			},
+			{
+				Importer: "github.com/Azure/go-autorest/autorest/adal",
+				Imported: "golang.org/x/crypto/pkcs12",
+				Reason:   "Azure ADAL (legacy auth) uses x/crypto/pkcs12 for certificate handling",
+			},
 		},
-		{
-			Importer: "github.com/Azure/azure-amqp-common-go/v4/aad",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "Azure Event Hub AMQP AAD auth library uses x/crypto/pkcs12 for certificate handling",
+		// Entity analytics Active Directory provider: go-ldap bundles NTLM
+		// (MD4/MD5/DES) which is not FIPS-approved.
+		module + "/x-pack/filebeat/input/entityanalytics": {
+			{
+				Importer: "github.com/go-ldap/ldap/v3",
+				Imported: "github.com/Azure/go-ntlmssp",
+				Reason:   "go-ldap bundles NTLM for Active Directory auth; NTLM relies on MD4/MD5/DES — none FIPS-approved",
+			},
+			{
+				Importer: "github.com/go-ldap/ldap/v3",
+				Imported: "golang.org/x/crypto/md4",
+				Reason:   "go-ldap uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved",
+			},
 		},
-		{
-			Importer: "github.com/Azure/go-autorest/autorest/adal",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "Azure ADAL (legacy auth) uses x/crypto/pkcs12 for certificate handling",
-		},
-		{
-			Importer: "github.com/go-ldap/ldap/v3",
-			Imported: "github.com/Azure/go-ntlmssp",
-			Reason:   "Entity analytics Active Directory provider uses go-ldap which bundles NTLM; NTLM relies on MD4/MD5/DES — none FIPS-approved",
-		},
-		{
-			Importer: "github.com/go-ldap/ldap/v3",
-			Imported: "golang.org/x/crypto/md4",
-			Reason:   "Entity analytics Active Directory provider uses go-ldap which uses x/crypto/md4 for NTLM; MD4 is not FIPS-approved",
-		},
-		{
-			Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
-			Imported: "golang.org/x/crypto/chacha20poly1305",
-			Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto; pulled in by GCS input",
-		},
-		{
-			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-			Imported: "golang.org/x/crypto/cryptobyte",
-			Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing; pulled in by GCS input",
-		},
-		{
-			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-			Imported: "golang.org/x/crypto/hkdf",
-			Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation; pulled in by GCS input",
+		// GCS input: Google S2A TLS library uses x/crypto for ChaCha20-Poly1305,
+		// HKDF, and handshake parsing — none covered by Go's FIPS 140-3 module.
+		module + "/x-pack/filebeat/input/gcs": {
+			{
+				Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
+				Imported: "golang.org/x/crypto/chacha20poly1305",
+				Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto",
+			},
+			{
+				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+				Imported: "golang.org/x/crypto/cryptobyte",
+				Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing",
+			},
+			{
+				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+				Imported: "golang.org/x/crypto/hkdf",
+				Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation",
+			},
 		},
 	},
+
 	module + "/x-pack/metricbeat": {
-		{
-			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		// MySQL module: go-sql-driver uses filippo.io/edwards25519 for Ed25519
+		// client authentication, which is not in FIPS 140-3 scope.
+		module + "/metricbeat/module/mysql": {
+			{
+				Importer: "github.com/go-sql-driver/mysql",
+				Imported: "filippo.io/edwards25519",
+				Reason:   "MySQL driver uses filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope",
+			},
 		},
-		{
-			Importer: "github.com/go-sql-driver/mysql",
-			Imported: "filippo.io/edwards25519",
-			Reason:   "MySQL driver imports filippo.io/edwards25519 for Ed25519 client authentication; not in FIPS 140-3 scope",
-		},
-		{
-			Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
-			Imported: "golang.org/x/crypto/chacha20poly1305",
-			Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto; pulled in by GCP modules",
-		},
-		{
-			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-			Imported: "golang.org/x/crypto/cryptobyte",
-			Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing; pulled in by GCP modules",
-		},
-		{
-			Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
-			Imported: "golang.org/x/crypto/hkdf",
-			Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation; pulled in by GCP modules",
-		},
-	},
-	module + "/x-pack/auditbeat": {
-		{
-			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
-		},
-	},
-	module + "/x-pack/heartbeat": {
-		{
-			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
-		},
-	},
-	module + "/x-pack/packetbeat": {
-		{
-			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
-		},
-	},
-	module + "/x-pack/osquerybeat": {
-		{
-			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
-		},
-	},
-	module + "/x-pack/winlogbeat": {
-		{
-			Importer: "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-			Imported: "golang.org/x/crypto/pkcs12",
-			Reason:   "azidentity uses x/crypto/pkcs12 for certificate-based auth; pulled in by x-pack/libbeat Azure/AWS identity federation",
+		// GCP modules: Google S2A TLS library uses x/crypto — same as filebeat GCS.
+		module + "/x-pack/metricbeat/module/gcp": {
+			{
+				Importer: "github.com/google/s2a-go/internal/record/internal/aeadcrypter",
+				Imported: "golang.org/x/crypto/chacha20poly1305",
+				Reason:   "Google S2A TLS library implements ChaCha20-Poly1305 via x/crypto",
+			},
+			{
+				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+				Imported: "golang.org/x/crypto/cryptobyte",
+				Reason:   "Google S2A TLS library uses x/crypto/cryptobyte for handshake parsing",
+			},
+			{
+				Importer: "github.com/google/s2a-go/internal/record/internal/halfconn",
+				Imported: "golang.org/x/crypto/hkdf",
+				Reason:   "Google S2A TLS library uses x/crypto/hkdf for key derivation",
+			},
 		},
 	},
 }


### PR DESCRIPTION
# Add FIPS 140-3 compliance test

## Proposed commit message

Adds `testing/testutils/fips_compliance_test.go` which scans every shipping binary under `x-pack/` for non-FIPS crypto imports at PR time.

The test is gated by `-tags requirefips` and uses `fipsscan.CheckModule` from `elastic-agent-libs`. Binaries are auto-discovered from `x-pack/...` — no manual list to maintain. Non-shipping programs (tools, examples, generators) are excluded via `skipBinaries`. Accepted violations are documented in `knownViolations` with a reason; anything undocumented fails the test.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- ~~I have added an entry in `./changelog/fragments`~~

## How to test this PR locally

```bash
go test -tags requirefips -run TestFIPSFullyCompliant ./testing/testutils/
```
