### PR TITLE
x-pack/filebeat/input/awss3: stabilise SQS receive degraded message

### DIFF
--- a/changelog/fragments/1784498235-sqs-health-stable-receive-message.yaml
+++ b/changelog/fragments/1784498235-sqs-health-stable-receive-message.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Use a stable status message for SQS receive errors to prevent update churn during sustained outages.
+component: filebeat

--- a/x-pack/filebeat/input/awss3/health.go
+++ b/x-pack/filebeat/input/awss3/health.go
@@ -108,7 +108,10 @@ func (h *sqsHealth) UpdateStatus(s status.Status, msg string) {
 	case status.Degraded:
 		h.consecutiveRecvFails++
 		if h.consecutiveRecvFails >= h.recvFailThreshold {
-			h.conditions[condReceive] = healthCondition{msg: msg, at: time.Now()}
+			h.conditions[condReceive] = healthCondition{
+				msg: "The input cannot reach SQS: messages are not being collected. Check network connectivity, AWS credentials, and queue permissions.",
+				at:  time.Now(),
+			}
 		}
 		h.update()
 	}

--- a/x-pack/filebeat/input/awss3/health_test.go
+++ b/x-pack/filebeat/input/awss3/health_test.go
@@ -200,6 +200,42 @@ func TestSQSHealth_Dedup(t *testing.T) {
 	}
 }
 
+func TestSQSHealth_ReceiveErrorMessageIsStable(t *testing.T) {
+	r := &testReporter{}
+	h := newSQSHealth(r, logp.NewNopLogger())
+	h.UpdateStatus(status.Running, "Input is running")
+
+	// Cross threshold with first batch of errors (3 different messages).
+	h.UpdateStatus(status.Degraded, "SQS error: request-id-1")
+	h.UpdateStatus(status.Degraded, "SQS error: request-id-2")
+	h.UpdateStatus(status.Degraded, "SQS error: request-id-3")
+	if len(r.updates) != 2 || r.updates[1].status != status.Degraded {
+		t.Fatalf("want Degraded after threshold, got %+v", r.updates)
+	}
+
+	// Further errors with varying messages should NOT produce additional
+	// updates because the published condition message is stable.
+	h.UpdateStatus(status.Degraded, "SQS error: request-id-4")
+	h.UpdateStatus(status.Degraded, "SQS error: request-id-5")
+	h.UpdateStatus(status.Degraded, "SQS error: request-id-6")
+	if len(r.updates) != 2 {
+		t.Fatalf("want no churn from varying error messages, got %d: %+v", len(r.updates), r.updates)
+	}
+
+	// A higher-priority condition surfacing while already Degraded DOES
+	// produce a new update (the message changes without leaving Degraded).
+	h.SetWorkerError(errors.New("pipeline broken"))
+	if len(r.updates) != 3 {
+		t.Fatalf("want new update when higher-priority condition fires, got %d: %+v", len(r.updates), r.updates)
+	}
+	if r.updates[2].status != status.Degraded {
+		t.Errorf("want Degraded, got %v", r.updates[2].status)
+	}
+	if r.updates[2].msg == r.updates[1].msg {
+		t.Errorf("want different message after condition change, but both are %q", r.updates[2].msg)
+	}
+}
+
 func TestSQSHealth_ProcessingErrorDoesNotDegrade(t *testing.T) {
 	r := &testReporter{}
 	h := newSQSHealth(r, logp.NewNopLogger())


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/awss3: stabilise SQS receive degraded message

Use a fixed status message for the receive-failure condition instead
of forwarding the raw AWS SDK error text, which varies per retry
(different request IDs, timestamps). This eliminates spurious
repeated Degraded updates to Fleet during a sustained SQS outage
while still allowing the message to change when a more severe
condition becomes active (for example a worker setup failure
supersedes ongoing receive errors).
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #52042

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
