### PR TITLE
[winlogbeat] Honor configured event language

### DIFF
--- a/changelog/fragments/1784556644-fix-winlogbeat-publisher-locale.yaml
+++ b/changelog/fragments/1784556644-fix-winlogbeat-publisher-locale.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Honor the configured language when rendering Windows events
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/sdh-beats/issues/7332

--- a/winlogbeat/sys/wineventlog/publisher_metadata.go
+++ b/winlogbeat/sys/wineventlog/publisher_metadata.go
@@ -35,6 +35,14 @@ type PublisherMetadata struct {
 	Handle EvtHandle // Handle to the publisher metadata from EvtOpenPublisherMetadata.
 }
 
+type openPublisherMetadataFunc func(
+	session EvtHandle,
+	publisherIdentity *uint16,
+	logFilePath *uint16,
+	locale uint32,
+	flags uint32,
+) (EvtHandle, error)
+
 // Close releases the publisher metadata handle.
 func (m *PublisherMetadata) Close() error {
 	return m.Handle.Close()
@@ -43,6 +51,15 @@ func (m *PublisherMetadata) Close() error {
 // NewPublisherMetadata opens the publisher's metadata. Close must be called on
 // the returned PublisherMetadata to release its handle.
 func NewPublisherMetadata(session EvtHandle, name string, locale uint32) (*PublisherMetadata, error) {
+	return newPublisherMetadata(_EvtOpenPublisherMetadata, session, name, locale)
+}
+
+func newPublisherMetadata(
+	openPublisherMetadata openPublisherMetadataFunc,
+	session EvtHandle,
+	name string,
+	locale uint32,
+) (*PublisherMetadata, error) {
 	var publisherName, logFile *uint16
 	if info, err := os.Stat(name); err == nil && info.Mode().IsRegular() {
 		logFile, err = syscall.UTF16PtrFromString(name)
@@ -56,7 +73,7 @@ func NewPublisherMetadata(session EvtHandle, name string, locale uint32) (*Publi
 		}
 	}
 
-	handle, err := _EvtOpenPublisherMetadata(session, publisherName, logFile, 0, 0)
+	handle, err := openPublisherMetadata(session, publisherName, logFile, locale, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed in EvtOpenPublisherMetadata: %w", err)
 	}

--- a/winlogbeat/sys/wineventlog/publisher_metadata_test.go
+++ b/winlogbeat/sys/wineventlog/publisher_metadata_test.go
@@ -26,6 +26,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewPublisherMetadataUsesLocale(t *testing.T) {
+	const expectedLocale = uint32(0x0409)
+
+	var actualLocale uint32
+	metadata, err := newPublisherMetadata(
+		func(_ EvtHandle, _, _ *uint16, locale, _ uint32) (EvtHandle, error) {
+			actualLocale = locale
+			return EvtHandle(1), nil
+		},
+		NilHandle,
+		"Microsoft-Windows-PowerShell",
+		expectedLocale,
+	)
+	if !assert.NoError(t, err, "NewPublisherMetadata should succeed") {
+		return
+	}
+
+	assert.Equal(t, expectedLocale, actualLocale, "configured locale should be passed to EvtOpenPublisherMetadata")
+	assert.Equal(t, "Microsoft-Windows-PowerShell", metadata.Name, "publisher name should be preserved")
+}
+
 func TestPublisherMetadata(t *testing.T) {
 	// Modern Application
 	testPublisherMetadata(t, "Microsoft-Windows-PowerShell")


### PR DESCRIPTION
## Proposed commit message

Pass the configured locale to `EvtOpenPublisherMetadata` so Windows events render in the requested language.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective
- [x] I have added an entry in `./changelog/fragments`

## Disruptive User Impact

None.

## How to test this PR locally

- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/wineventlog.test.exe ./winlogbeat/sys/wineventlog`
- On a non-English Windows host, configure `language: 1033` and confirm messages render in English.

## Related issues

- Closes elastic/sdh-beats#7332