### PR TITLE
filestream: identify files in logs by path, not fingerprint

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -763,7 +763,7 @@ func (s *fileScanner) GetFiles(opts loginp.FileScanOptions) (map[string]loginp.F
 			fileID := fd.FileID()
 			if knownFilename, exists := uniqueIDs[fileID]; exists {
 				scanMetrics.FilesNoIngestTarget++
-				s.log.Warnf("%q points to an already known ingest target %q [%s==%s]. Skipping", fd.Filename, knownFilename, fileID, fileID)
+				s.log.Warnf("%q points to an already known ingest target %q. Skipping", fd.Filename, knownFilename)
 				continue
 			}
 			uniqueIDs[fileID] = fd.Filename

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -74,6 +74,14 @@ func (f fileSource) Name() string {
 	return f.fileID
 }
 
+// LogPath returns the path used in logs.
+func (f fileSource) LogPath() string {
+	if f.newPath != "" {
+		return f.newPath
+	}
+	return f.oldPath
+}
+
 // newFileIdentifier creates a new state identifier for a log input.
 func newFileIdentifier(ns *conf.Namespace, suffix string, log *logp.Logger) (fileIdentifier, error) {
 	if ns == nil {

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -27,7 +27,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.uber.org/zap"
 	"golang.org/x/text/transform"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
@@ -245,11 +244,10 @@ func (inp *filestream) Run(
 		return fmt.Errorf("not file source")
 	}
 
-	log := ctx.Logger.WithLazy(zap.String("path", fs.newPath), zap.String("state-id", src.Name()))
-	state := initState(log, cursor, fs)
+	state := initState(ctx.Logger, cursor, fs)
 	if state.EOF {
 		// TODO: change it to debug once GZIP isn't experimental anymore.
-		log.Infof("GZIP file already read to EOF, not reading it again, file name '%s'",
+		ctx.Logger.Infof("GZIP file already read to EOF, not reading it again, file name '%s'",
 			fs.newPath)
 		return nil
 	}
@@ -258,9 +256,9 @@ func (inp *filestream) Run(
 	// (upstream behavior). When read_until_eof is enabled, it "resets" the
 	// reader via startReadUntilEOF by swapping in a fresh, read_until_eof-scoped
 	// context so the drain read can proceed past ctx.Cancelation.
-	r, startReadUntilEOF, truncated, err := inp.open(log, ctx.Cancelation, fs, state.Offset)
+	r, startReadUntilEOF, truncated, err := inp.open(ctx.Logger, ctx.Cancelation, fs, state.Offset)
 	if err != nil {
-		log.Errorf("File could not be opened for reading: %v", err)
+		ctx.Logger.Errorf("File could not be opened for reading: %v", err)
 		return err
 	}
 
@@ -287,16 +285,16 @@ func (inp *filestream) Run(
 	}
 
 	defer func() {
-		log.Debug("Closing reader of filestream")
+		ctx.Logger.Debug("Closing reader of filestream")
 		if err := r.Close(); err != nil {
-			log.Errorf("Error stopping filestream reader: %v", err)
+			ctx.Logger.Errorf("Error stopping filestream reader: %v", err)
 		}
 	}()
 
 	// The caller of Run already reports the error and filters out errors that
 	// must not be reported, like 'context cancelled'.
 	err = inp.readFromSource(
-		ctx, log, r, fs.newPath, state, publisher, fs.desc.GZIP, metricsOffset, metrics,
+		ctx, ctx.Logger, r, fs.newPath, state, publisher, fs.desc.GZIP, metricsOffset, metrics,
 		startReadUntilEOF)
 	if err != nil {
 		// First handle actual errors
@@ -305,7 +303,7 @@ func (inp *filestream) Run(
 		}
 
 		if inp.deleterConfig.Enabled {
-			if err := inp.deleteFile(ctx, log, cursor, fs.newPath); err != nil {
+			if err := inp.deleteFile(ctx, ctx.Logger, cursor, fs.newPath); err != nil {
 				return fmt.Errorf("cannot remove file '%s': %w", fs.newPath, err)
 			}
 		}

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -261,7 +261,7 @@ func (hg *defaultHarvesterGroup) Start(ctx inputv2.Context, src Source) {
 // If the harvester limit has been reached, the harvester will wait until it can
 // be started. Restart does not block.
 func (hg *defaultHarvesterGroup) Restart(ctx inputv2.Context, src Source) {
-	ctx.Logger.Debugf("Restarting harvester for %s", src)
+	ctx.Logger.Debugf("Restarting harvester for file %q", src.LogPath())
 
 	if err := hg.tg.Go(startHarvester(ctx, hg, src, true, hg.metrics, hg.inputID)); err != nil {
 		ctx.Logger.Warnf(
@@ -283,6 +283,7 @@ func startHarvester(
 	inputID string,
 ) func(context.Context) error {
 	srcID := hg.identifier.ID(src)
+	logPath := src.LogPath()
 	// rd is this harvester's registration handle; all key-dependent steps go through it rather than
 	// srcID because a migration can re-key the registration at any time.
 	var rd *reader
@@ -294,7 +295,7 @@ func startHarvester(
 			// set, the spawned goroutine blocks on a semaphore until a slot is available. Without
 			// this early check, repeated file events would spawn goroutines that wait on the
 			// semaphore only to discover (after acquiring it) that a harvester is already running.
-			ctx.Logger.Debugf("Harvester already running for %s", srcID)
+			ctx.Logger.Debugf("Harvester already running for file %q", logPath)
 			return nil
 		}
 	}
@@ -302,7 +303,7 @@ func startHarvester(
 	return func(canceler context.Context) (err error) {
 		defer func() {
 			if v := recover(); v != nil {
-				err = fmt.Errorf("harvester panic for source %q: %+v\n%s", srcID, v, debug.Stack())
+				err = fmt.Errorf("harvester panic for file %q: %+v\n%s", logPath, v, debug.Stack())
 				if rd != nil {
 					rd.remove()
 				}
@@ -318,7 +319,7 @@ func startHarvester(
 		}()
 
 		// We clone the logger here where we need it to avoid redundant copies that increase memory pressure.
-		ctx.Logger = ctx.Logger.With("source_file", srcID)
+		ctx.Logger = ctx.Logger.With("source_file", logPath)
 
 		if restart {
 			// Stop the previous harvester and take its place.
@@ -326,7 +327,7 @@ func startHarvester(
 			rd = hg.readers.reserve(srcID)
 			if rd == nil {
 				// Another Start raced in; leave the source to it.
-				ctx.Logger.Debugf("Harvester already running for %s", srcID)
+				ctx.Logger.Debugf("Harvester already running for file %q", logPath)
 				return nil
 			}
 		}
@@ -405,7 +406,7 @@ func startHarvester(
 			}
 
 			hg.notifyObserver(canceler, rd.currentID(), st.Offset)
-			ctx.Logger.Debugf("Harvester '%s' closed with offset: %d", srcID, st.Offset)
+			ctx.Logger.Debugf("Harvester closed with offset: %d", st.Offset)
 		}()
 
 		ctx.Logger.Debugf("Starting harvester for file. offset %v", resource.cursor)
@@ -427,7 +428,7 @@ func startHarvester(
 
 // Continue starts a new Harvester with the state information from a different Source.
 func (hg *defaultHarvesterGroup) Continue(ctx inputv2.Context, previous, next Source) {
-	ctx.Logger.Debugf("Continue harvester for file prev=%s, next=%s", previous.Name(), next.Name())
+	ctx.Logger.Debugf("Continue harvester for file, previous=%q next=%q", previous.LogPath(), next.LogPath())
 	prevID := hg.identifier.ID(previous)
 	nextID := hg.identifier.ID(next)
 

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -79,6 +79,8 @@ type InputManager struct {
 // the source in the persistent state store.
 type Source interface {
 	Name() string
+	// LogPath returns the path used in logs.
+	LogPath() string
 }
 
 var errNoInputRunner = errors.New("no input runner available")

--- a/filebeat/input/filestream/internal/input-logfile/manager_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager_test.go
@@ -47,6 +47,10 @@ func (s *testSource) Name() string {
 	return s.name
 }
 
+func (s *testSource) LogPath() string {
+	return s.name
+}
+
 type noopProspector struct{}
 
 func (m noopProspector) Init(_, _ StoreUpdater, _ func(Source) string) error {

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -28,14 +28,10 @@ import (
 // is deferred via [logp.Logger.WithLazy], so the underlying core only pays
 // for the fields if a message is actually emitted.
 func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent) *logp.Logger {
-	fields := make([]zap.Field, 0, 6)
+	fields := make([]zap.Field, 0, 4)
 	fields = append(fields,
 		zap.String("operation", event.Op.String()),
-		zap.String("source_file", event.SrcID),
 	)
-	if fp := event.Descriptor.Fingerprint; fp.Complete() {
-		fields = append(fields, zap.String("fingerprint", fp.Sum))
-	}
 	if info := event.Descriptor.Info; info != nil {
 		if osID := info.GetOSState().Identifier(); osID != "" {
 			fields = append(fields, zap.String("os_id", osID))

--- a/filebeat/input/filestream/logger_test.go
+++ b/filebeat/input/filestream/logger_test.go
@@ -18,6 +18,7 @@
 package filestream
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,8 +56,8 @@ func TestLoggerWithEvent(t *testing.T) {
 			loggerLevel: zapcore.InfoLevel,
 			emit:        func(l *logp.Logger) { l.Warnf("hello") },
 			wantEntries: 1,
-			wantFields:  map[string]string{"operation": "create", "source_file": "src-1"},
-			wantAbsent:  []string{"fingerprint", "os_id", "new_path", "old_path"},
+			wantFields:  map[string]string{"operation": "create"},
+			wantAbsent:  []string{"source_file", "fingerprint", "os_id", "new_path", "old_path"},
 		},
 		{
 			name:        "warnf with all event fields populates every key",
@@ -65,13 +66,11 @@ func TestLoggerWithEvent(t *testing.T) {
 			emit:        func(l *logp.Logger) { l.Warnf("hello") },
 			wantEntries: 1,
 			wantFields: map[string]string{
-				"operation":   "rename",
-				"source_file": "src-2",
-				"fingerprint": "abc123",
-				"new_path":    "/var/log/new.log",
-				"old_path":    "/var/log/old.log",
+				"operation": "rename",
+				"new_path":  "/var/log/new.log",
+				"old_path":  "/var/log/old.log",
 			},
-			wantAbsent: []string{"os_id"},
+			wantAbsent: []string{"source_file", "fingerprint", "os_id"},
 		},
 		{
 			name:        "debugf is a no-op when debug logging is disabled",
@@ -86,7 +85,8 @@ func TestLoggerWithEvent(t *testing.T) {
 			loggerLevel: zapcore.DebugLevel,
 			emit:        func(l *logp.Logger) { l.Debugf("noisy %d", 1) },
 			wantEntries: 1,
-			wantFields:  map[string]string{"operation": "create", "source_file": "src-1"},
+			wantFields:  map[string]string{"operation": "create"},
+			wantAbsent:  []string{"source_file", "fingerprint"},
 		},
 	}
 
@@ -119,4 +119,71 @@ func TestLoggerWithEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLoggerWithEventAllocs guards the per-FS-event enrichment allocation
+// count: the fields slice plus the WithLazy logger clone.
+func TestLoggerWithEventAllocs(t *testing.T) {
+	logger := logp.NewNopLogger()
+	event := loginp.FSEvent{
+		Op:      loginp.OpRename,
+		SrcID:   "filestream::my-input-id::fingerprint::2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
+		NewPath: "/var/log/new.log",
+		OldPath: "/var/log/old.log",
+		Descriptor: loginp.FileDescriptor{
+			Fingerprint: loginp.FingerprintID{
+				Sum: "2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
+			},
+		},
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		loggerWithEvent(logger, event)
+	})
+	assert.LessOrEqual(t, allocs, 8.0, "loggerWithEvent allocated more than expected")
+}
+
+func BenchmarkLoggerWithEvent(b *testing.B) {
+	event := loginp.FSEvent{
+		Op:      loginp.OpWrite,
+		SrcID:   "filestream::my-input-id::fingerprint::2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
+		NewPath: "/var/log/app/application.log",
+		Descriptor: loginp.FileDescriptor{
+			Fingerprint: loginp.FingerprintID{
+				Sum: "2edc986847e209b4016e141a6dc8716d3207350f416969382d431539bf292e4a",
+			},
+		},
+	}
+
+	b.Run("debug_suppressed", func(b *testing.B) {
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(io.Discard),
+			zapcore.InfoLevel,
+		)
+		logger, err := logp.NewZapLogger(zap.New(core))
+		require.NoError(b, err, "constructing zap logger")
+
+		b.ReportAllocs()
+		for b.Loop() {
+			log := loggerWithEvent(logger, event)
+			log.Debugf("File %s has been updated", event.NewPath)
+		}
+	})
+
+	b.Run("emitted", func(b *testing.B) {
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(io.Discard),
+			zapcore.DebugLevel,
+		)
+		logger, err := logp.NewZapLogger(zap.New(core))
+		require.NoError(b, err, "constructing zap logger")
+
+		b.ReportAllocs()
+		for b.Loop() {
+			log := loggerWithEvent(logger, event)
+			log.Debugf("File %s has been updated", event.NewPath)
+		}
+	})
 }

--- a/filebeat/tests/integration/filestream_fingerprint_test.go
+++ b/filebeat/tests/integration/filestream_fingerprint_test.go
@@ -246,6 +246,14 @@ func TestFilestreamGrowingFingerprint(t *testing.T) {
 		[]byte(generateLines("gzip header line", 1)), gziptest.CorruptNone)
 	require.NoError(t, os.WriteFile(file4, headerGZ, 0644), "failed to write gzipped file")
 
+	// The scanner reports the colliding duplicates by path only, never by the
+	// raw fingerprint material.
+	filebeat.WaitLogsContains(
+		"points to an already known ingest target",
+		10*time.Second,
+		"expected the duplicate ingest targets to be reported",
+	)
+
 	// With growing_fingerprint, small files ARE ingested immediately (unlike regular fingerprint)
 	// Due to collision (same content = same fingerprint), only ONE file's entry is created
 	// but events ARE published. We wait for EOF on the first detected file.
@@ -315,6 +323,13 @@ func TestFilestreamGrowingFingerprint(t *testing.T) {
 	// 21 (previous) + 3 files × 20 new lines = 81 events.
 	filebeat.WaitPublishedEvents(15*time.Second, 81)
 
+	// Harvester logs identify files by path in the source_file field.
+	filebeat.WaitLogsContainsFromBeginning(
+		`"source_file":"`+strings.ReplaceAll(file1, `\`, `\\`)+`"`,
+		10*time.Second,
+		"harvester logs must carry the file path in source_file",
+	)
+
 	// ===== Phase 4: Stop Filebeat =====
 	filebeat.Stop()
 
@@ -327,6 +342,12 @@ func TestFilestreamGrowingFingerprint(t *testing.T) {
 	assertSingleSHA256RegistryEntry(t, tempDir, file3)
 	assertGrowingRegistryEntry(t, tempDir, file4)
 	assertGrowingRegistryEntry(t, tempDir, file5)
+
+	// The raw fingerprint material (hex of the file content, here the shared
+	// header all growing raws start with) and the removed state-id field must
+	// never appear in the logs.
+	assertLogsDoNotContain(t, tempDir, hex.EncodeToString([]byte(headerContent)))
+	assertLogsDoNotContain(t, tempDir, `"state-id"`)
 }
 
 // TestFilestreamGrowingFingerprint_update_while_stopped verifies growing
@@ -1896,4 +1917,20 @@ func assertGrowingRegistryEntry(t *testing.T, tempDir, filePath string) {
 	assert.Empty(t, final,
 		"expected no active final entries for %q; got a final entry — file is treated as final, not growing",
 		filePath)
+}
+
+// assertLogsDoNotContain fails if s is found anywhere in the Filebeat logs.
+func assertLogsDoNotContain(t *testing.T, tempDir, s string) {
+	t.Helper()
+	glob := filepath.Join(tempDir, fmt.Sprintf("filebeat-%d*.ndjson", time.Now().Year()))
+	files, err := filepath.Glob(glob)
+	require.NoError(t, err, "failed to glob log files")
+	require.NotEmpty(t, files, "no filebeat log file found")
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		require.NoErrorf(t, err, "failed to read log file %q", f)
+		if strings.Contains(string(data), s) {
+			t.Errorf("log file %q must not contain %q", f, s)
+		}
+	}
 }

--- a/filebeat/tests/integration/filestream_gzip_test.go
+++ b/filebeat/tests/integration/filestream_gzip_test.go
@@ -816,7 +816,7 @@ logging.level: debug
 	require.NoError(t, err, "could not write gzip file to disk")
 
 	// wait filebeat to pick up the file and see it's the same as the plain file.
-	wantLine := fmt.Sprintf("\\\"%s\\\" points to an already known ingest target \\\"%s\\\" [e64ff2da367b082e1dcc38ec48215bff55925bd408f718f107e50ecf426fe3c3==e64ff2da367b082e1dcc38ec48215bff55925bd408f718f107e50ecf426fe3c3]. Skipping",
+	wantLine := fmt.Sprintf("\\\"%s\\\" points to an already known ingest target \\\"%s\\\". Skipping",
 		logPathGZ, logPathPlain)
 	filebeat.WaitLogsContainsFromBeginning(
 		wantLine,


### PR DESCRIPTION
## Proposed commit message

```
filestream: identify files in logs by path, not fingerprint

The filestream input logged fingerprint-derived identifiers on every FS
event and harvester: the source_file field carried the registry key, a
fingerprint field carried the SHA-256 sum, and input.Run added path and
state-id fields on top. Two log sites leaked raw growing fingerprint
material.

Identify files in logs by their path instead. The fingerprint and
state-id fields are gone, source_file now carries the file path via the
new Source.LogPath, harvester messages reference the path, input.Run
reuses the harvester logger instead of cloning it again, and the
duplicate-ingest-target warning logs only the colliding paths.

Registry keys in diagnostic logs are kept as-is: since the growing
fingerprint is persisted as hash+length, keys always embed a SHA-256
hash and never raw content, so they are safe to log and stay
correlatable with the registry.

Benchmarks (benchstat, n=10, old=main, new=this change).

Per-event logger enrichment (BenchmarkLoggerWithEvent):

                                    │   old.txt   │               new.txt               │
                                    │   sec/op    │   sec/op     vs base                │
LoggerWithEvent/debug_suppressed-14   300.8n ± 2%   273.6n ± 2%   -9.06% (p=0.000 n=10)
LoggerWithEvent/emitted-14            1.382µ ± 1%   1.087µ ± 2%  -21.38% (p=0.000 n=10)
geomean                               644.8n        545.2n       -15.44%

                                    │   old.txt    │               new.txt                │
                                    │     B/op     │     B/op      vs base                │
LoggerWithEvent/debug_suppressed-14     816.0 ± 0%     688.0 ± 0%  -15.69% (p=0.000 n=10)
LoggerWithEvent/emitted-14            2.007Ki ± 0%   1.881Ki ± 0%   -6.28% (p=0.000 n=10)
geomean                               1.265Ki        1.124Ki       -11.11%

                                    │  old.txt   │               new.txt               │
                                    │ allocs/op  │ allocs/op   vs base                 │
LoggerWithEvent/debug_suppressed-14   9.000 ± 0%   9.000 ± 0%       ~ (p=1.000 n=10) ¹
LoggerWithEvent/emitted-14            14.00 ± 0%   14.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               11.22        11.22       +0.00%
¹ all samples are equal

End-to-end (BenchmarkFilestream):

                                      │   old.txt   │              new.txt               │
                                      │   sec/op    │   sec/op     vs base               │
Filestream/1000_files/fingerprint-14    32.60m ± 5%   32.43m ± 7%       ~ (p=0.796 n=10)
Filestream/10000_files/fingerprint-14   348.9m ± 5%   340.5m ± 5%       ~ (p=0.436 n=10)
Filestream/1000_files/growing-14        28.08m ± 4%   27.13m ± 7%  -3.39% (p=0.043 n=10)
Filestream/10000_files/growing-14       336.2m ± 8%   324.2m ± 7%       ~ (p=0.143 n=10)
geomean                                 101.8m        99.28m       -2.47%

                                      │   old.txt    │               new.txt               │
                                      │     B/op     │     B/op      vs base               │
Filestream/1000_files/fingerprint-14    42.39Mi ± 1%   41.74Mi ± 1%  -1.53% (p=0.000 n=10)
Filestream/10000_files/fingerprint-14   422.9Mi ± 0%   416.0Mi ± 0%  -1.61% (p=0.000 n=10)
Filestream/1000_files/growing-14        22.79Mi ± 0%   22.14Mi ± 0%  -2.83% (p=0.000 n=10)
Filestream/10000_files/growing-14       226.4Mi ± 0%   220.0Mi ± 0%  -2.85% (p=0.000 n=10)
geomean                                 98.07Mi        95.90Mi       -2.21%

                                      │   old.txt   │              new.txt               │
                                      │  allocs/op  │  allocs/op   vs base               │
Filestream/1000_files/fingerprint-14    380.2k ± 0%   371.1k ± 0%  -2.38% (p=0.000 n=10)
Filestream/10000_files/fingerprint-14   3.798M ± 0%   3.708M ± 0%  -2.36% (p=0.000 n=10)
Filestream/1000_files/growing-14        203.9k ± 0%   194.9k ± 0%  -4.42% (p=0.000 n=10)
Filestream/10000_files/growing-14       2.037M ± 0%   1.947M ± 0%  -4.42% (p=0.000 n=10)
geomean                                 880.0k        850.1k       -3.40%

Co-authored-by: Anderson Queiroz <anderson.queiroz@elastic.co>
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

Only **Filebeat's own log output** changes.

## How to test this PR locally

Two identical files below the fingerprint threshold trigger the duplicate-ingest-target warning; `resend_on_touch` plus a `touch` triggers the harvester-restart debug log.

```shell
mkdir -p /tmp/leak-demo/{home,in,out}
printf 'login user=alice password=hunter2 token=SECRET-0001\n' > /tmp/leak-demo/in/a.log
cp /tmp/leak-demo/in/a.log /tmp/leak-demo/in/b.log

cat > /tmp/leak-demo/filebeat.yml <<EOF
filebeat.inputs:
  - type: filestream
    id: leak-demo
    paths:
      - /tmp/leak-demo/in/*.log
    file_identity.fingerprint: ~
    prospector.scanner.check_interval: 1s
    prospector.scanner.resend_on_touch: true
path.home: /tmp/leak-demo/home
output.file:
  path: /tmp/leak-demo/out
  filename: events
logging.level: debug
EOF

filebeat --strict.perms=false -c /tmp/leak-demo/filebeat.yml &
sleep 5
touch /tmp/leak-demo/in/a.log   # resend_on_touch => truncate event => harvester Restart
sleep 4
kill %1
```

Count the file's content in Filebeat's logs:

```shell
rawhex=$(printf 'login user=alice password=hunter2 token=SECRET-0001\n' | xxd -p | tr -d '\n')
grep -oh "$rawhex" /tmp/leak-demo/home/logs/filebeat-2*.ndjson | wc -l
```

On `main` this prints `21`, on this branch `0`.

## Related issues

- Closes https://github.com/elastic/beats/issues/50725
- Closes https://github.com/elastic/beats/pull/51099
