### PR TITLE
otel: convert float32 to float64 by direct widening

### DIFF
--- a/changelog/fragments/1774789200-otel-float32-direct-conversion.yaml
+++ b/changelog/fragments/1774789200-otel-float32-direct-conversion.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix float32 to float64 conversion in the OTel output path to widen directly instead of round-tripping through a decimal string, matching the go-structform encoder used by the Beats ES output path.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: beats
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/elastic/beats/issues/51294

--- a/libbeat/otel/otelmap/otelmap.go
+++ b/libbeat/otel/otelmap/otelmap.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -463,14 +462,12 @@ func isFloat64WholeNumber(f float64) bool {
 	return frac == 0 && -preciseMax <= f && f <= preciseMax
 }
 
-// float32ToFloat64 converts a float32 to float64 using the float32's shortest
-// decimal representation. This matches the Beats go-structform encoder, which
-// serializes float32 values at float32 precision (e.g. float32(3.14) → "3.14",
-// not "3.140000104904175"). Skipping this round-trip causes observable divergence
-// between the beats ES output path and the OTel path for the same float32 input.
+// float32ToFloat64 widens a float32 to float64 by direct bit-pattern
+// conversion. This matches the current Beats go-structform encoder (see
+// OnFloat32 in elastic/go-structform), which also converts via float64(v)
+// rather than round-tripping through a decimal string.
 func float32ToFloat64(v float32) float64 {
-	f64, _ := strconv.ParseFloat(strconv.FormatFloat(float64(v), 'g', -1, 32), 64)
-	return f64
+	return float64(v)
 }
 
 func setFloat32Value(dst pcommon.Value, v float32) {

--- a/libbeat/otel/otelmap/otelmap_test.go
+++ b/libbeat/otel/otelmap/otelmap_test.go
@@ -119,6 +119,18 @@ func TestFromMapstrSliceDouble(t *testing.T) {
 	assert.Equal(t, map[string]any{"slice": want}, dst.AsRaw())
 }
 
+func TestFloat32ToFloat64(t *testing.T) {
+	// direct bit-pattern widening, not a decimal round-trip: float32(3.14)
+	// does not have an exact float64 representation, so widening it must
+	// produce the same "noisy" digits float64(float32(3.14)) does, not the
+	// shortest decimal string that reads back as 3.14. Compare bit patterns
+	// rather than assert.Equal/InDelta, since we're asserting exact equality,
+	// not closeness within a tolerance.
+	want := math.Float64bits(float64(float32(3.14)))
+	got := math.Float64bits(float32ToFloat64(3.14))
+	assert.Equal(t, want, got)
+}
+
 func TestFromMapstrBool(t *testing.T) {
 	tests := map[string]struct {
 		mapstr_val  any


### PR DESCRIPTION
*Made with AI assistance (Claude). I verified this by tracing the actual go-structform code and running the affected test suite myself -- see Verification below.*

Fixes #51294.

## Problem

`float32ToFloat64()` in `libbeat/otel/otelmap/otelmap.go` converts via `strconv.ParseFloat(strconv.FormatFloat(float64(v), 'g', -1, 32), 64)` -- a decimal round-trip. The comment on the function claims this matches "the Beats go-structform encoder, which serializes float32 values at float32 precision."

That's no longer accurate. I checked `elastic/go-structform`'s `json/visitor.go` (the version pinned in `go.mod`, `v0.0.12`): `OnFloat32` converts via a plain `float64(f)` widening, not a decimal round-trip (this has been the case since [PR #48](https://github.com/elastic/go-structform/pull/48), 2024-08-22). So this shim was matching a divergence that doesn't exist in the encoder anymore, while introducing a real one: the decimal round-trip finds a float64 that *prints* the same as the float32's shortest representation, which is not the same as a numerically correct widening.

Per the referenced discussion ([#50303 review comment](https://github.com/elastic/beats/pull/50303#discussion_r3344557999)), @efd6 already flagged this as the wrong approach.

## Fix

Replaced the round-trip with a direct `float64(v)` conversion, matching the current go-structform behavior.

## Verification

- Traced `elastic/go-structform`'s `json/visitor.go` at the version pinned in `go.mod` (`v0.0.12`) to confirm `OnFloat32` uses direct widening, not a decimal round-trip.
- Ran the full `libbeat/otel/otelmap` test suite -- all passing.
- Added `TestFloat32ToFloat64`, asserting `float32ToFloat64(3.14) == float64(float32(3.14))` (`3.140000104904175`, not `3.14`). Confirmed this test fails against the old implementation (asserted `3.14` back) and passes against the fix.
- `go vet` and `gofmt` clean on the changed files.
- Added a changelog fragment per the repo's convention.