### PR TITLE
feat: add `detect_mime_type` processor to OTel Beat processor

### DIFF
--- a/x-pack/otel/processor/beatprocessor/README.md
+++ b/x-pack/otel/processor/beatprocessor/README.md
@@ -21,6 +21,7 @@ Here are the currently supported processors:
 - [add_fields]
 - [add_host_metadata]
 - [add_kubernetes_metadata]
+- [detect_mime_type]
 
 ## Default processors in Beat receivers
 
@@ -193,6 +194,21 @@ You can configure the Kubernetes metadata enrichment using the options supported
 Note that you need to explicitly configure at least one [indexer][indexers] and at least one [matcher][matchers] for the enrichment to work.
 In the example above, the `container` indexer and the `logs_path` matcher are configured.
 
+## Using the `detect_mime_type` processor
+
+To use the [detect_mime_type] processor, configure the processor as follows:
+
+```yaml
+processors:
+  beat:
+    processors:
+      - detect_mime_type:
+          field: http.request.body.content
+          target: http.request.mime_type
+```
+
+You can configure the processor using the options supported by the [detect_mime_type] processor.
+
 [Beat processors]: https://www.elastic.co/docs/reference/beats/filebeat/filtering-enhancing-data#using-processors
 [Filebeat receiver]: https://github.com/elastic/beats/tree/main/x-pack/filebeat/fbreceiver
 [Metricbeat receiver]: https://github.com/elastic/beats/tree/main/x-pack/metricbeat/mbreceiver
@@ -201,5 +217,6 @@ In the example above, the `container` indexer and the `logs_path` matcher are co
 [add_fields]: https://www.elastic.co/docs/reference/beats/filebeat/add-fields
 [add_host_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-host-metadata
 [add_kubernetes_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata
+[detect_mime_type]: https://www.elastic.co/docs/reference/beats/filebeat/detect-mime-type
 [indexers]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata#_indexers
 [matchers]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata#_matchers

--- a/x-pack/otel/processor/beatprocessor/processor.go
+++ b/x-pack/otel/processor/beatprocessor/processor.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.opentelemetry.io/collector/component"
 
@@ -22,6 +23,17 @@ import (
 	"go.opentelemetry.io/collector/processor"
 	"go.uber.org/zap"
 )
+
+// allowedProcessors is the list of Beat processor names that may be configured
+// in the OTel Beat processor.
+var allowedProcessors = []string{
+	"add_cloud_metadata",
+	"add_docker_metadata",
+	"add_fields",
+	"add_host_metadata",
+	"add_kubernetes_metadata",
+	"detect_mime_type",
+}
 
 type beatProcessor struct {
 	logger     *zap.Logger
@@ -78,9 +90,7 @@ func createProcessor(processorNameAndConfig map[string]any, logpLogger *logp.Log
 			return nil, fmt.Errorf("failed to create config for processor '%s': %w", processorName, configError)
 		}
 
-		switch processorName {
-		case "add_host_metadata", "add_cloud_metadata", "add_docker_metadata", "add_kubernetes_metadata", "add_fields":
-		default:
+		if !slices.Contains(allowedProcessors, processorName) {
 			return nil, fmt.Errorf("invalid processor name '%s'", processorName)
 		}
 

--- a/x-pack/otel/processor/beatprocessor/processor_test.go
+++ b/x-pack/otel/processor/beatprocessor/processor_test.go
@@ -149,6 +149,18 @@ func TestCreateProcessor(t *testing.T) {
 		assert.Equal(t, "add_kubernetes_metadata", processor.String()[:len("add_kubernetes_metadata")])
 	})
 
+	t.Run("valid detect_mime_type processor config returns processor", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{
+			"detect_mime_type": map[string]any{
+				"field":  "http.request.body.content",
+				"target": "http.request.mime_type",
+			},
+		}, testLogger())
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		assert.Equal(t, "detect_mime_type", processor.String()[:len("detect_mime_type")])
+	})
+
 	t.Run("when condition is honored and processor is skipped when condition is false", func(t *testing.T) {
 		processor, err := createProcessor(map[string]any{
 			"add_fields": map[string]any{


### PR DESCRIPTION
## Proposed commit message

Add [`detect_mime_type`](https://www.elastic.co/docs/reference/beats/filebeat/detect-mime-type) processor to the OTel Beat processor.

This allows users to use the `detect_mime_type` processor outside of the Beat receivers anywhere in the EDOT Collector pipeline.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

# Related Issues

- For https://github.com/elastic/elastic-agent/issues/15694
