### PR TITLE
[metricbeat] Fix test_cpu KeyError when host.cpu field is absent on macOS

### DIFF
--- a/changelog/fragments/1784641457-drosiek-fix-test-cpu.yaml
+++ b/changelog/fragments/1784641457-drosiek-fix-test-cpu.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix test_cpu KeyError when host.cpu field is absent on macOS
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -154,7 +154,8 @@ class Test(metricbeat.BaseTest):
             cpu = evt["system"]["cpu"]
             self.assert_fields_for_platform(SYSTEM_CPU, cpu)
         else:
-            host_cpu = evt["host"]["cpu"]
+            host_cpu = evt.get("host", {}).get("cpu")
+            self.assertIsNotNone(host_cpu, "Expected 'system.cpu' or 'host.cpu' in event, got: {}".format(sorted(evt.keys())))
             self.assertCountEqual(self.de_dot(
                 SYSTEM_CPU_HOST_FIELDS), host_cpu.keys())
 

--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -155,7 +155,9 @@ class Test(metricbeat.BaseTest):
             self.assert_fields_for_platform(SYSTEM_CPU, cpu)
         else:
             host_cpu = evt.get("host", {}).get("cpu")
-            self.assertIsNotNone(host_cpu, "Expected 'system.cpu' or 'host.cpu' in event, got: {}".format(sorted(evt.keys())))
+            self.assertIsNotNone(
+                host_cpu,
+                "Expected 'system.cpu' or 'host.cpu' in event, got: {}".format(sorted(evt.keys())))
             self.assertCountEqual(self.de_dot(
                 SYSTEM_CPU_HOST_FIELDS), host_cpu.keys())
 


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

**WHAT:** Replace bare `evt["host"]["cpu"]` access in `test_system.py::test_cpu` with a safe `dict.get()` lookup. When neither `system.cpu` nor `host.cpu` is present in the event, the test now fails with a descriptive message listing the actual top-level keys received instead of a bare `KeyError`.

**WHY:** On macOS CI runners the system metricset occasionally emits a CPU event that contains neither the `system.cpu` nor the `host.cpu` subfield. The `else` branch assumed `host.cpu` must exist whenever `system` is absent, causing an unhandled `KeyError` and a misleading failure that obscures the real problem.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~ (test-only change; the fix is the test itself)
- [ ] ~~I have added an entry in `./changelog/fragments` using the changelog tool.~~ (test-only change)

## Disruptive User Impact

None. Test-only change.

## How to test this PR locally

Requires a macOS host with a metricbeat binary built locally:

```
cd metricbeat
make unit-tests
```

The failure is intermittent; running under the stress script may help reproduce it:

```
script/stresstest.sh metricbeat/module/system/test_system.py::Test::test_cpu
```

## Related issues

- Relates #52126 (observed failing in CI against this unrelated PR)

## Use cases

Previously: flaky `KeyError: 'cpu'` crash with no context about what the event actually contained.
After: deterministic `AssertionError` with the actual event keys printed, making the root cause immediately visible.

## Logs

```
FAILED module/system/test_system.py::Test::test_cpu - KeyError: 'cpu'
module/system/test_system.py:157: KeyError
```
