### PR TITLE
[fbreceiver] Ignore cgo DNS goroutines in goleak leak checker on macOS

### DIFF
--- a/changelog/fragments/1784641462-drosiek-fix-fbreceiver-goleak.yaml
+++ b/changelog/fragments/1784641462-drosiek-fix-fbreceiver-goleak.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Ignore cgo DNS goroutines in goleak leak checker to fix flaky fbreceiver tests on macOS
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/otel/oteltest/oteltest.go
+++ b/x-pack/otel/oteltest/oteltest.go
@@ -246,6 +246,8 @@ func VerifyNoLeaks(t *testing.T) {
 		// loop on first use and never stops it, since a real heartbeat process
 		// runs the loop forever. See heartbeat/monitors/active/icmp/stdloop.go.
 		goleak.IgnoreAnyFunction("github.com/elastic/beats/v7/heartbeat/monitors/active/icmp.(*stdICMPLoop).runICMPRecv"),
+		// On macOS, cgo-based DNS lookups (res_nsearch) can outlive the test on slow CI networking.
+		goleak.IgnoreAnyFunction("net.cgoResSearch"),
 	}
 
 	goleak.VerifyNone(t, skipped...)


### PR DESCRIPTION
<!-- Type of change: Bug -->

## Proposed commit message

**WHAT:** Add `goleak.IgnoreAnyFunction("net.cgoResSearch")` to the skip list in `oteltest.VerifyNoLeaks`. This is the same pattern already used for `net.(*netFD).connect` and `net/http.(*Transport).startDialConnForLocked`.

**WHY:** `TestLeak`, `TestNewReceiver`, and `TestMultipleReceivers` in `x-pack/filebeat/fbreceiver` fail intermittently on `macos-15-intel` CI runners. The goroutine leak checker detects a goroutine stuck for ~1 minute in a cgo DNS `res_nsearch` syscall (`net.cgoResSearch` → `syscall.syscalln`). This is a networking/infrastructure issue on the runner where a DNS lookup issued during the test never returns — not a real leak in production code. The filter is narrow and targets only that specific cgo DNS frame.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~ (test infrastructure change; the leak only manifests on macOS CI)
- [ ] ~~I have added an entry in `./changelog/fragments` using the changelog tool.~~ (test-only change)

## Disruptive User Impact

None. Test infrastructure change only.

## How to test this PR locally

The DNS hang only occurs on restricted macOS CI networking and is not reliably reproducible locally. Verify that the existing `fbreceiver` tests still pass:

```
cd x-pack/filebeat
go test ./fbreceiver/... -v -count=1
```

## Related issues

- Relates #52126 (observed failing in CI against this unrelated PR)

## Logs

```
=== FAIL: x-pack/filebeat/fbreceiver TestLeak/unhealthy_consumer (6.73s)
    oteltest.go:251: found unexpected goroutines:
        [Goroutine 54 in state syscall, 1 minutes, with syscall.syscalln on top of the stack:
        syscall.syscalln(...)
        internal/syscall/unix.ResNsearch(...)
        net._C_res_nsearch(...)
        net.cgoResSearch(...)
        net.resSearch.func1()
        net.doBlockingWithCtx[...].func1()
        ]
```
