### PR TITLE
x-pack/filebeat/input/unifiedlogs: fix test log parsing for local logger

### DIFF
--- a/x-pack/filebeat/input/unifiedlogs/input_test.go
+++ b/x-pack/filebeat/input/unifiedlogs/input_test.go
@@ -362,13 +362,13 @@ func filterEndLogShowLogline(buf []byte) string {
 func filterLogCmdLine(buf []byte, cmd, cmdPrefix string) string {
 	scanner := bufio.NewScanner(bytes.NewBuffer(buf))
 	for scanner.Scan() {
-		text := scanner.Text()
-		parts := strings.Split(text, "\t")
-		if len(parts) != 4 {
+		// The message is the last field; the local logger prepends caller info.
+		parts := strings.Split(scanner.Text(), "\t")
+		if len(parts) < 4 {
 			continue
 		}
 
-		trimmed := strings.TrimPrefix(parts[3], cmdPrefix)
+		trimmed := strings.TrimPrefix(parts[len(parts)-1], cmdPrefix)
 		if strings.HasPrefix(trimmed, cmd) {
 			return trimmed
 		}


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat/input/unifiedlogs: fix test log parsing for local logger

The test helper filterLogCmdLine parsed the in-memory log buffer
expecting exactly four tab-separated fields, reading the command line
from the fourth. When the tests switched from logp.NewInMemory to
logp.NewInMemoryLocal in #51983, the development logger began inserting a
caller-info field before the message, producing five fields. The helper
matched nothing and returned an empty string, so every TestInput subtest
exhausted its 65s EventuallyWithT timeout and the package eventually hit
the 10m test timeout on macOS, panicking in TestBackfillAndStream.

Take the command line from the last tab-separated field so the helper
works regardless of how many structured fields the logger prepends.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Test-only change.

## How to test this PR locally

On a macOS runner:

```bash
cd x-pack/filebeat/input/unifiedlogs
go test -run 'TestInput|TestBackfillAndStream' -v ./...
```

## Related issues

- Relates #51983

## Logs

Failure on main ([run](https://github.com/elastic/beats/actions/runs/29832012207/job/88638839319)):

```
=== FAIL: x-pack/filebeat/input/unifiedlogs TestInput/Default_stream (65.01s)
    input_test.go:253:
        	Error:      	Not equal:
        	            	expected: "/usr/bin/log stream --style ndjson"
        	            	actual  : ""
    input_test.go:253:
        	Error:      	Condition never satisfied
...
=== FAIL: x-pack/filebeat/input/unifiedlogs TestBackfillAndStream (unknown)
panic: test timed out after 10m0s
```
