### PR TITLE
updated filterLogCmdLine to support addCaller = true

### DIFF
--- a/x-pack/filebeat/input/unifiedlogs/input_test.go
+++ b/x-pack/filebeat/input/unifiedlogs/input_test.go
@@ -364,13 +364,17 @@ func filterLogCmdLine(buf []byte, cmd, cmdPrefix string) string {
 	for scanner.Scan() {
 		text := scanner.Text()
 		parts := strings.Split(text, "\t")
-		if len(parts) != 4 {
+		// Console log format: time\tlevel\tlogger[\tcaller]\tmessage
+		// The caller field is optional, so the message may be at parts[3] or parts[4].
+		if len(parts) < 4 {
 			continue
 		}
 
-		trimmed := strings.TrimPrefix(parts[3], cmdPrefix)
-		if strings.HasPrefix(trimmed, cmd) {
-			return trimmed
+		for _, part := range parts[3:] {
+			trimmed := strings.TrimPrefix(part, cmdPrefix)
+			if trimmed != part && strings.HasPrefix(trimmed, cmd) {
+				return trimmed
+			}
 		}
 	}
 	return ""

--- a/x-pack/filebeat/input/unifiedlogs/input_test.go
+++ b/x-pack/filebeat/input/unifiedlogs/input_test.go
@@ -54,7 +54,7 @@ func (p *publisher) Publish(e beat.Event, cursor any) error {
 }
 
 func TestInput(t *testing.T) {
-	archivePath, err := openArchive()
+	archivePath, err := openArchive(t)
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(archivePath) })
 
@@ -144,7 +144,7 @@ func TestInput(t *testing.T) {
 			name: "With end date",
 			skip: func(t *testing.T) bool {
 				const sequoiaPrefix = "15."
-				version, err := exec.Command("sw_vers", "-productVersion").CombinedOutput()
+				version, err := exec.CommandContext(t.Context(), "sw_vers", "-productVersion").CombinedOutput()
 				if err != nil {
 					t.Fatalf("failed to get macOS version: %v", err)
 					return true
@@ -265,7 +265,7 @@ func TestInput(t *testing.T) {
 }
 
 func TestBackfillAndStream(t *testing.T) {
-	archivePath, err := openArchive()
+	archivePath, err := openArchive(t)
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(archivePath) })
 
@@ -287,7 +287,8 @@ func TestBackfillAndStream(t *testing.T) {
 	expectedLogStreamCmd := "/usr/bin/log stream --style ndjson --info --debug --backtrace --signpost --mach-continuous-time"
 
 	_, cursorInput := newCursorInput(cfg)
-	input := cursorInput.(*input)
+	input, ok := cursorInput.(*input)
+	require.True(t, ok, "cursorInput is not *input")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -390,11 +391,11 @@ func eventsAndCursorAssertN(n int) func(collect *assert.CollectT, events []beat.
 	}
 }
 
-func openArchive() (string, error) {
-	return extractTarGz(path.Join("testdata", "test.logarchive.tar.gz"))
+func openArchive(t *testing.T) (string, error) {
+	return extractTarGz(t, path.Join("testdata", "test.logarchive.tar.gz"))
 }
 
-func extractTarGz(tarGzPath string) (string, error) {
+func extractTarGz(t *testing.T, tarGzPath string) (string, error) {
 	// Create a temporary directory
 	tempDir, err := os.MkdirTemp("", "extracted-*")
 	if err != nil {
@@ -402,7 +403,7 @@ func extractTarGz(tarGzPath string) (string, error) {
 	}
 
 	// Use the 'tar' command to extract the .tar.gz file
-	cmd := exec.Command("tar", "-xzf", tarGzPath, "-C", tempDir)
+	cmd := exec.CommandContext(t.Context(), "tar", "-xzf", tarGzPath, "-C", tempDir)
 
 	// Run the command
 	if err := cmd.Run(); err != nil {
@@ -414,6 +415,6 @@ func extractTarGz(tarGzPath string) (string, error) {
 
 func testMetricsRegistry() *monitoring.Registry {
 	reg := inputmon.NewMetricsRegistry(
-		"", "", monitoring.NewRegistry(), logp.NewLogger("test"))
+		"", "", monitoring.NewRegistry(), logp.NewNopLogger())
 	return reg
 }


### PR DESCRIPTION
## Proposed commit message

filterLogCmdLine in the unifiedlogs integration test was scanning log lines from an in-memory logger and requiring exactly 4 tab-separated fields (time\tlevel\tlogger\tmessage). When the deprecated logp.NewInMemory was replaced with logp.NewInMemoryLocal (as suggested by the linter), the logger gained an additional caller field, producing 5-field lines (time\tlevel\tlogger\tcaller\tmessage). The strict len(parts) != 4 check caused the scanner to skip every line, so the filter always returned "" and every TestInput sub-test timed out after 60 s.

The fix relaxes the check to len(parts) < 4 and scans all fields from index 3 onward, so the message is found whether or not the caller field is present.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None, testing code.

## How to test this PR locally

```
go test -timeout 600s ./x-pack/filebeat/input/unifiedlogs/
```

## Related issues

- Relates #51983

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
