### PR TITLE
remove redundant trySyncPath call

### DIFF
--- a/libbeat/statestore/backend/memlog/diskstore.go
+++ b/libbeat/statestore/backend/memlog/diskstore.go
@@ -439,7 +439,7 @@ func updateActiveMarker(log *logp.Logger, homePath, checkpointFilePath string) e
 		log.Errorf("Failed to remove old temporary active.dat.tmp file: %v", err)
 		return err
 	}
-	if err := os.WriteFile(tmpLink, []byte(checkpointFilePath), 0600); err != nil {
+	if err := os.WriteFile(tmpLink, []byte(checkpointFilePath), 0o600); err != nil {
 		log.Errorf("Failed to write temporary pointer file: %v", err)
 		return err
 	}
@@ -672,7 +672,6 @@ func writeMetaFile(home string, mode os.FileMode) error {
 		return fmt.Errorf("error rotating meta file into place: %w", err)
 	}
 
-	trySyncPath(home)
 	return nil
 }
 


### PR DESCRIPTION
## Proposed commit message

writeMetaFile ended with an explicit trySyncPath(home) call to fsync the parent directory after rotating the meta file into place. agentfile.SafeFileRotate already performs that same best-effort directory sync internally (via SyncParent), so the trailing call was redundant. Remove it.

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. SafeFileRotate already performs the directory sync; removing the duplicate call has no observable effect.

## How to test this PR locally

```
go test ./libbeat/statestore/backend/memlog/...
```

## Related issues

- #51897

## Use cases



## Screenshots



## Logs


