### PR TITLE
[metricbeat] Guard all bare `evt["system"]` accesses in test_system.py

### DIFF
--- a/metricbeat/module/system/test_system.py
+++ b/metricbeat/module/system/test_system.py
@@ -178,6 +178,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
             cpu_stats = evt["system"]["cpu"]
             self.assert_fields_for_platform(SYSTEM_CPU_ALL, cpu_stats)
 
@@ -198,6 +199,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
             core_stats = evt["system"]["core"]
             if sys.platform == metricbeat.P_LINUX and not is_cpuinfo_supported():
                 for f in SYSTEM_CORE_CPUINFO_FIELDS:
@@ -224,6 +226,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
             core_stats = evt["system"]["core"]
             if sys.platform == metricbeat.P_LINUX and not is_cpuinfo_supported():
                 for f in SYSTEM_CORE_CPUINFO_FIELDS:
@@ -246,6 +249,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
         self.assert_fields_are_documented(evt)
+        self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
 
         cpu = evt["system"]["load"]
         self.assertCountEqual(self.de_dot(SYSTEM_LOAD_FIELDS), cpu.keys())
@@ -303,6 +307,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
             filesystem = evt["system"]["filesystem"]
             self.assert_fields_for_platform(SYSTEM_FILESYSTEM, filesystem)
 
@@ -322,6 +327,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
         self.assert_fields_are_documented(evt)
+        self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
 
         fsstat = evt["system"]["fsstat"]
         self.assertCountEqual(SYSTEM_FSSTAT_FIELDS, fsstat.keys())
@@ -342,6 +348,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
         self.assert_fields_are_documented(evt)
+        self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
 
         memory = evt["system"]["memory"]
         # these fields may not be on the event depending on the host system
@@ -419,6 +426,7 @@ class Test(metricbeat.BaseTest):
             # we've encoutered an event. Turn off the flag
             only_errors_encountered = False
 
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
             summary = evt["system"]["process"]["summary"]
             assert isinstance(summary["total"], int)
 
@@ -464,6 +472,7 @@ class Test(metricbeat.BaseTest):
             # we've encoutered an event. Turn off the flag
             only_errors_encountered = False
 
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
             process = evt["system"]["process"]
             # Not all process will have 'cmdline' due to permission issues,
             # especially on Windows. Therefore we ensure at least some of
@@ -537,6 +546,7 @@ class Test(metricbeat.BaseTest):
 
             found_cwd |= "working_directory" in evt["process"]
 
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
             process = evt["system"]["process"]
             found_fd |= "fd" in process
             found_env |= "env" in process
@@ -609,6 +619,7 @@ class Test(metricbeat.BaseTest):
 
         for evt in output:
             self.assert_fields_are_documented(evt)
+            self.assertIn("system", evt, f"expected 'system' key in event, got: {list(evt.keys())}")
 
             summary = evt["system"]["socket"]["summary"]
             a = summary["all"]


### PR DESCRIPTION
## Proposed commit message

**WHAT:** Add `assertIn("system", evt, ...)` before every unguarded `evt["system"][...]` subscript access in `metricbeat/module/system/test_system.py`.

**WHY:** On macOS CI runners the system metricset occasionally emits events that lack the `system` key entirely. Any test that does a bare `evt["system"][subkey]` without first checking for the key's presence crashes with an opaque `KeyError: 'system'` that hides the real event structure. PR #52138 introduced this guard for `test_cpu`; this PR applies the same pattern to all remaining unguarded sites in the file.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~ (test-only change; the fix is the test itself)
- [ ] ~~I have added an entry in `./changelog/fragments` using the changelog tool.~~ (test-only change)

## Disruptive User Impact

None. Test-only change.

## How to test this PR locally

Requires a macOS host with a metricbeat binary built locally:

```
cd metricbeat
make unit-tests
```

The failure is intermittent on macOS CI; the guard converts a silent `KeyError` into a descriptive `AssertionError` that prints the actual top-level keys of the event.

## Related issues

- Follows up #52138 (`test_cpu` guard) — same root cause, remaining sites
- Relates #52126 (original flakiness report)

## Use cases

Previously: `KeyError: 'system'` with no context about what the event actually contained, causing a misleading and hard-to-diagnose CI failure.

After: deterministic `AssertionError` listing the actual event keys, making it immediately clear whether the metricset emitted a partial/ECS-mapped event or something unexpected.

## Sites fixed

| Test | Line |
|---|---|
| `test_cpu_ticks_option` | 181 |
| `test_core` | 201 |
| `test_core_with_cpu_ticks` | 227 |
| `test_load` | 250 |
| `test_filesystem` | 306 |
| `test_fsstat` | 326 |
| `test_memory` | 346 |
| `test_process_summary` | 422 |
| `test_process` | 467 |
| `test_process_unix` | 540 |
| `test_socket_summary` | 613 |
