### PR TITLE
feat: add `drop_fields` processor to OTel Beat processor

### DIFF
--- a/x-pack/otel/processor/beatprocessor/README.md
+++ b/x-pack/otel/processor/beatprocessor/README.md
@@ -22,6 +22,7 @@ Here are the currently supported processors:
 - [add_host_metadata]
 - [add_kubernetes_metadata]
 - [detect_mime_type]
+- [drop_fields]
 
 ## Default processors in Beat receivers
 
@@ -209,6 +210,20 @@ processors:
 
 You can configure the processor using the options supported by the [detect_mime_type] processor.
 
+## Using the `drop_fields` processor
+
+To use the [drop_fields] processor, configure the processor as follows:
+
+```yaml
+processors:
+  beat:
+    processors:
+      - drop_fields:
+          fields: ["field.to.drop"]
+```
+
+You can configure the processor using the options supported by the [drop_fields] processor.
+
 [Beat processors]: https://www.elastic.co/docs/reference/beats/filebeat/filtering-enhancing-data#using-processors
 [Filebeat receiver]: https://github.com/elastic/beats/tree/main/x-pack/filebeat/fbreceiver
 [Metricbeat receiver]: https://github.com/elastic/beats/tree/main/x-pack/metricbeat/mbreceiver
@@ -218,5 +233,6 @@ You can configure the processor using the options supported by the [detect_mime_
 [add_host_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-host-metadata
 [add_kubernetes_metadata]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata
 [detect_mime_type]: https://www.elastic.co/docs/reference/beats/filebeat/detect-mime-type
+[drop_fields]: https://www.elastic.co/docs/reference/beats/filebeat/drop-fields
 [indexers]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata#_indexers
 [matchers]: https://www.elastic.co/docs/reference/beats/filebeat/add-kubernetes-metadata#_matchers

--- a/x-pack/otel/processor/beatprocessor/processor.go
+++ b/x-pack/otel/processor/beatprocessor/processor.go
@@ -33,6 +33,7 @@ var allowedProcessors = []string{
 	"add_host_metadata",
 	"add_kubernetes_metadata",
 	"detect_mime_type",
+	"drop_fields",
 }
 
 type beatProcessor struct {

--- a/x-pack/otel/processor/beatprocessor/processor_test.go
+++ b/x-pack/otel/processor/beatprocessor/processor_test.go
@@ -163,6 +163,17 @@ func TestCreateProcessor(t *testing.T) {
 		assert.Equal(t, "detect_mime_type", processor.String()[:len("detect_mime_type")])
 	})
 
+	t.Run("valid drop_fields processor config returns processor", func(t *testing.T) {
+		processor, err := createProcessor(map[string]any{
+			"drop_fields": map[string]any{
+				"fields": []string{"field.to.drop"},
+			},
+		}, testLogger())
+		require.NoError(t, err)
+		require.NotNil(t, processor)
+		assert.Equal(t, "drop_fields", processor.String()[:len("drop_fields")])
+	})
+
 	t.Run("when condition is honored and processor is skipped when condition is false", func(t *testing.T) {
 		processor, err := createProcessor(map[string]any{
 			"add_fields": map[string]any{


### PR DESCRIPTION
## Proposed commit message

Add [`drop_fields`](https://www.elastic.co/docs/reference/beats/filebeat/drop-fields) processor to the OTel Beat processor.

This allows users to use the `drop_fields` processor outside of the Beat receivers anywhere in the EDOT Collector pipeline.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

# Related Issues

- For https://github.com/elastic/elastic-agent/issues/15694
