### PR TITLE
x-pack/filebeat/input/{cel,entityanalytics,http_endpoint,httpjson}: do not log Authorization header in request traces

### DIFF
--- a/changelog/fragments/1784758682-no-auth-trace-logs.yaml
+++ b/changelog/fragments/1784758682-no-auth-trace-logs.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Remove Authorization headers from CEL, Entity Analytics, HTTP Endpoint, and HTTP JSON input request trace logs.
+component: filebeat

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1232,7 +1232,7 @@ func newClient(ctx context.Context, cfg config, log *logp.Logger, reg *monitorin
 		traceLogger := zap.New(core)
 
 		maxBodyLen := cfg.Resource.Tracer.MaxSize * 1e6 / 10 // 10% of file max
-		trace = httplog.NewLoggingRoundTripper(c.Transport, traceLogger, maxBodyLen, log)
+		trace = httplog.NewLoggingRoundTripper(c.Transport, traceLogger, maxBodyLen, []string{"Authorization"}, log)
 		c.Transport = trace
 	} else if cfg.Resource.Tracer != nil {
 		// We have a trace log name, but we are not enabled,

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -5,6 +5,7 @@
 package cel
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -45,19 +46,20 @@ var runRemote = flag.Bool("run_remote", false, "run tests using remote endpoints
 var userAgent = useragent.UserAgent("Filebeat", version.GetDefaultVersion(), "", "", "")
 
 var inputTests = []struct {
-	name          string
-	remote        bool
-	server        func(*testing.T, http.HandlerFunc, map[string]interface{})
-	handler       http.HandlerFunc
-	config        map[string]interface{}
-	time          func() time.Time
-	persistCursor map[string]interface{}
-	want          []map[string]interface{}
-	wantCursor    []map[string]interface{}
-	wantErr       error
-	prepare       func() error
-	wantFile      string
-	wantNoFile    string
+	name                string
+	remote              bool
+	server              func(*testing.T, http.HandlerFunc, map[string]interface{})
+	handler             http.HandlerFunc
+	config              map[string]interface{}
+	time                func() time.Time
+	persistCursor       map[string]interface{}
+	want                []map[string]interface{}
+	wantCursor          []map[string]interface{}
+	wantErr             error
+	prepare             func() error
+	wantFile            string
+	wantNoFile          string
+	wantTraceNotContain []string
 }{
 	// Autonomous tests (no FS or net dependency).
 	{
@@ -2223,6 +2225,130 @@ var inputTests = []struct {
 		},
 	},
 
+	// Auth header sanitization in trace logs.
+	{
+		name: "trace_sanitize_basic_auth",
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+			s := httptest.NewServer(h)
+			config["resource.url"] = s.URL
+			t.Cleanup(s.Close)
+		},
+		config: map[string]interface{}{
+			"interval":                 1,
+			"auth.basic.user":          "test_client",
+			"auth.basic.password":      "secret_password",
+			"resource.tracer.enabled":  true,
+			"resource.tracer.filename": "cel/logs/http-request-trace-*.ndjson",
+			"program": `
+	get(state.url).Body.as(body, {
+		"events": [body.decode_json()]
+	})
+	`,
+		},
+		handler: tokenAuthHandler(
+			fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("test_client:secret_password"))),
+			defaultHandler(http.MethodGet, ""),
+		),
+		want: []map[string]interface{}{
+			{
+				"hello": []interface{}{
+					map[string]interface{}{
+						"world": "moon",
+					},
+					map[string]interface{}{
+						"space": []interface{}{
+							map[string]interface{}{
+								"cake": "pumpkin",
+							},
+						},
+					},
+				},
+			},
+		},
+		wantFile:            filepath.Join("cel", "logs", "http-request-trace-test_id_trace_sanitize_basic_auth.ndjson"),
+		wantTraceNotContain: []string{"Authorization"},
+	},
+	{
+		name: "trace_sanitize_token_auth",
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+			s := httptest.NewServer(h)
+			config["resource.url"] = s.URL
+			t.Cleanup(s.Close)
+		},
+		config: map[string]interface{}{
+			"interval":                 1,
+			"auth.token.type":          "Token",
+			"auth.token.value":         "sssh_super_secret_token",
+			"resource.tracer.enabled":  true,
+			"resource.tracer.filename": "cel/logs/http-request-trace-*.ndjson",
+			"program": `
+	get(state.url).Body.as(body, {
+		"events": [body.decode_json()]
+	})
+	`,
+		},
+		handler: tokenAuthHandler(
+			"Token sssh_super_secret_token",
+			defaultHandler(http.MethodGet, ""),
+		),
+		want: []map[string]interface{}{
+			{
+				"hello": []interface{}{
+					map[string]interface{}{
+						"world": "moon",
+					},
+					map[string]interface{}{
+						"space": []interface{}{
+							map[string]interface{}{
+								"cake": "pumpkin",
+							},
+						},
+					},
+				},
+			},
+		},
+		wantFile:            filepath.Join("cel", "logs", "http-request-trace-test_id_trace_sanitize_token_auth.ndjson"),
+		wantTraceNotContain: []string{"Authorization"},
+	},
+	{
+		name: "trace_sanitize_oauth2",
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+			s := httptest.NewServer(h)
+			config["resource.url"] = s.URL
+			config["auth.oauth2.token_url"] = s.URL + "/token"
+			t.Cleanup(s.Close)
+		},
+		config: map[string]interface{}{
+			"interval":                  1,
+			"auth.oauth2.client.id":     "a_client_id",
+			"auth.oauth2.client.secret": "a_client_secret",
+			"auth.oauth2.endpoint_params": map[string]interface{}{
+				"param1": "v1",
+			},
+			"auth.oauth2.scopes":       []string{"scope1", "scope2"},
+			"resource.tracer.enabled":  true,
+			"resource.tracer.filename": "cel/logs/http-request-trace-*.ndjson",
+			"program": `
+	post(state.url, '', '').Body.as(body, {
+		"events": body.decode_json()
+	})
+	`,
+		},
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			if r.UserAgent() != userAgent {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(fmt.Sprintf("unexpected UA: %s", r.UserAgent())))
+				return
+			}
+			oauth2Handler(w, r)
+		},
+		want: []map[string]interface{}{
+			{"hello": "world"},
+		},
+		wantFile:            filepath.Join("cel", "logs", "http-request-trace-test_id_trace_sanitize_oauth2.ndjson"),
+		wantTraceNotContain: []string{"Authorization"},
+	},
+
 	// Multi-step requests.
 	{
 		name:   "simple_multistep_GET_request",
@@ -2661,6 +2787,17 @@ func TestInput(t *testing.T) {
 				}
 				if len(paths) != 0 {
 					t.Errorf("unexpected files found: %v", paths)
+				}
+			}
+			if len(test.wantTraceNotContain) > 0 && test.wantFile != "" {
+				traceData, err := os.ReadFile(filepath.Join(tempDir, test.wantFile))
+				if err != nil {
+					t.Fatalf("failed to read trace file for content check: %v", err)
+				}
+				for _, s := range test.wantTraceNotContain {
+					if bytes.Contains(traceData, []byte(s)) {
+						t.Errorf("trace log must not contain %q", s)
+					}
 				}
 			}
 			if test.wantErr != nil {

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
@@ -653,7 +653,7 @@ func requestTrace(ctx context.Context, cli *http.Client, cfg graphConf, log *log
 	traceLogger := zap.New(core)
 
 	maxBodyLen := max(1, cfg.Tracer.MaxSize) * 1e6 / 10 // 10% of file max
-	cli.Transport = httplog.NewLoggingRoundTripper(cli.Transport, traceLogger, maxBodyLen, log)
+	cli.Transport = httplog.NewLoggingRoundTripper(cli.Transport, traceLogger, maxBodyLen, []string{"Authorization"}, log)
 	return cli
 }
 

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
@@ -225,7 +225,7 @@ func requestTrace(ctx context.Context, cli *http.Client, cfg conf, log *logp.Log
 	traceLogger := zap.New(core)
 
 	maxBodyLen := cfg.Tracer.MaxSize * 1e6 / 10 // 10% of file max
-	cli.Transport = httplog.NewLoggingRoundTripper(cli.Transport, traceLogger, maxBodyLen, log)
+	cli.Transport = httplog.NewLoggingRoundTripper(cli.Transport, traceLogger, maxBodyLen, []string{"Authorization"}, log)
 	return cli
 }
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -241,7 +241,7 @@ func requestTrace(ctx context.Context, cli *http.Client, cfg conf, log *logp.Log
 	traceLogger := zap.New(core)
 
 	maxBodyLen := cfg.Tracer.MaxSize * 1e6 / 10 // 10% of file max
-	cli.Transport = httplog.NewLoggingRoundTripper(cli.Transport, traceLogger, maxBodyLen, log)
+	cli.Transport = httplog.NewLoggingRoundTripper(cli.Transport, traceLogger, maxBodyLen, []string{"Authorization"}, log)
 	return cli
 }
 

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -387,7 +387,7 @@ func (h *handler) logRequest(txID string, r *http.Request, status int, respBody 
 	h.log.Debugw("new request trace transaction", "id", txID)
 	// Limit request logging body size to 10kiB.
 	const maxBodyLen = 10 * (1 << 10)
-	httplog.LogRequest(h.reqLogger.With(zap.String("transaction.id", txID)), r, maxBodyLen, extra...)
+	httplog.LogRequest(h.reqLogger.With(zap.String("transaction.id", txID)), r, []string{"Authorization"}, maxBodyLen, extra...)
 	if scheme != "" {
 		r.URL.Scheme = scheme
 	}

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -389,7 +389,7 @@ func newNetHTTPClient(ctx context.Context, cfg *requestConfig, log *logp.Logger,
 		traceLogger := zap.New(core)
 
 		maxBodyLen := cfg.Tracer.MaxSize * 1e6 / 10 // 10% of file max
-		netHTTPClient.Transport = httplog.NewLoggingRoundTripper(netHTTPClient.Transport, traceLogger, maxBodyLen, log)
+		netHTTPClient.Transport = httplog.NewLoggingRoundTripper(netHTTPClient.Transport, traceLogger, maxBodyLen, []string{"Authorization"}, log)
 	} else if cfg.Tracer != nil {
 		// We have a trace log name, but we are not enabled,
 		// so remove all trace logs we own.

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -5,6 +5,7 @@
 package httpjson
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -31,14 +32,15 @@ import (
 )
 
 var testCases = []struct {
-	name           string
-	setupServer    func(testing.TB, http.HandlerFunc, map[string]interface{})
-	baseConfig     map[string]interface{}
-	handler        http.HandlerFunc
-	expected       []string
-	expectedFile   string
-	expectedNoFile string
-	wantErr        error
+	name                    string
+	setupServer             func(testing.TB, http.HandlerFunc, map[string]interface{})
+	baseConfig              map[string]interface{}
+	handler                 http.HandlerFunc
+	expected                []string
+	expectedFile            string
+	expectedNoFile          string
+	expectedTraceNotContain []string
+	wantErr                 error
 
 	skipReason string
 }{
@@ -688,6 +690,102 @@ var testCases = []struct {
 		},
 		handler:  tokenAuthHandler("ApiToken secret-api-token", "X-API-Key", defaultHandler(http.MethodGet, "", "")),
 		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+
+	// Auth header sanitization in trace logs.
+	{
+		name: "trace_sanitize_basic_auth",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                1,
+			"request.method":          http.MethodGet,
+			"auth.basic.user":         "test_user",
+			"auth.basic.password":     "test_password",
+			"request.tracer.enabled":  true,
+			"request.tracer.filename": "httpjson/logs/http-request-trace-*.ndjson",
+		},
+		handler:                 tokenAuthHandler("Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ=", "", defaultHandler(http.MethodGet, "", "")),
+		expected:                []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+		expectedFile:            filepath.Join("httpjson", "logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi.ndjson"),
+		expectedTraceNotContain: []string{"Authorization"},
+	},
+	{
+		name: "trace_sanitize_oauth2",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			config["auth.oauth2.token_url"] = server.URL + "/token"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                  1,
+			"request.method":            http.MethodPost,
+			"auth.oauth2.client.id":     "a_client_id",
+			"auth.oauth2.client.secret": "a_client_secret",
+			"auth.oauth2.endpoint_params": map[string]interface{}{
+				"param1": "v1",
+			},
+			"auth.oauth2.scopes":      []string{"scope1", "scope2"},
+			"request.tracer.enabled":  true,
+			"request.tracer.filename": "httpjson/logs/http-request-trace-*.ndjson",
+		},
+		handler:                 oauth2Handler,
+		expected:                []string{`{"hello": "world"}`},
+		expectedFile:            filepath.Join("httpjson", "logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi.ndjson"),
+		expectedTraceNotContain: []string{"Authorization"},
+	},
+	{
+		name: "trace_sanitize_aws_auth",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                   1,
+			"request.method":             http.MethodGet,
+			"auth.aws.access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+			"auth.aws.secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			"auth.aws.default_region":    "us-east-1",
+			"auth.aws.service_name":      "guardduty",
+			"request.tracer.enabled":     true,
+			"request.tracer.filename":    "httpjson/logs/http-request-trace-*.ndjson",
+		},
+		handler:                 awsAuthHandler("AKIAIOSFODNN7EXAMPLE", defaultHandler(http.MethodGet, "", "")),
+		expected:                []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+		expectedFile:            filepath.Join("httpjson", "logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi.ndjson"),
+		expectedTraceNotContain: []string{"Authorization"},
+	},
+	{
+		name: "trace_sanitize_file_auth",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			dir := t.TempDir()
+			secret := "file-secret"
+			path := filepath.Join(dir, "auth_token")
+			if err := os.WriteFile(path, []byte(secret+"\n"), 0o600); err != nil {
+				t.Fatalf("failed to write auth token: %v", err)
+			}
+			config["auth.file.path"] = path
+			config["auth.file.prefix"] = "Bearer "
+			config["auth.file.refresh_interval"] = "100ms"
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                1,
+			"request.method":          http.MethodGet,
+			"request.tracer.enabled":  true,
+			"request.tracer.filename": "httpjson/logs/http-request-trace-*.ndjson",
+		},
+		handler:                 tokenAuthHandler("Bearer file-secret", "", defaultHandler(http.MethodGet, "", "")),
+		expected:                []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+		expectedFile:            filepath.Join("httpjson", "logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi.ndjson"),
+		expectedTraceNotContain: []string{"Authorization"},
 	},
 	{
 		name: "request_transforms_can_access_state_from_previous_transforms",
@@ -1747,6 +1845,17 @@ func TestInput(t *testing.T) {
 				}
 				if len(paths) != 0 {
 					t.Errorf("unexpected files found: %v", paths)
+				}
+			}
+			if len(test.expectedTraceNotContain) > 0 && test.expectedFile != "" {
+				traceData, err := os.ReadFile(filepath.Join(tempDir, test.expectedFile))
+				if err != nil {
+					t.Fatalf("failed to read trace file for content check: %v", err)
+				}
+				for _, s := range test.expectedTraceNotContain {
+					if bytes.Contains(traceData, []byte(s)) {
+						t.Errorf("trace log must not contain %q", s)
+					}
 				}
 			}
 			assert.NoError(t, g.Wait())

--- a/x-pack/filebeat/input/internal/httplog/roundtripper.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -155,18 +156,22 @@ func SanitizeFileName(name string) string {
 
 // NewLoggingRoundTripper returns a LoggingRoundTripper that logs requests and
 // responses to the provided logger. Transaction creation is logged to log.
-func NewLoggingRoundTripper(next http.RoundTripper, logger *zap.Logger, maxBodyLen int, log *logp.Logger) *LoggingRoundTripper {
+// Header names matching strings in sensitive are not logged.
+func NewLoggingRoundTripper(next http.RoundTripper, logger *zap.Logger, maxBodyLen int, sensitive []string, log *logp.Logger) *LoggingRoundTripper {
 	return &LoggingRoundTripper{
-		transport:  next,
-		maxBodyLen: maxBodyLen,
-		txLog:      logger,
-		txBaseID:   newID(),
-		log:        log,
+		sensitiveHeaders: sensitive,
+		transport:        next,
+		maxBodyLen:       maxBodyLen,
+		txLog:            logger,
+		txBaseID:         newID(),
+		log:              log,
 	}
 }
 
 // LoggingRoundTripper is an http.RoundTripper that logs requests and responses.
 type LoggingRoundTripper struct {
+	sensitiveHeaders []string
+
 	transport   http.RoundTripper
 	maxBodyLen  int           // The maximum length of a body. Longer bodies will be truncated.
 	txLog       *zap.Logger   // Destination logger.
@@ -226,7 +231,7 @@ func (rt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		)
 	}
 
-	req, respParts, errorsMessages := logRequest(log, req, rt.maxBodyLen)
+	req, respParts, errorsMessages := logRequest(log, req, rt.maxBodyLen, rt.sensitiveHeaders)
 
 	resp, err := rt.transport.RoundTrip(req)
 	if err != nil {
@@ -251,7 +256,7 @@ func (rt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		zap.Bool("http.response.body.truncated", rt.maxBodyLen < len(body)),
 		zap.Int("http.response.body.bytes", len(body)),
 		zap.String("http.response.mime_type", resp.Header.Get("Content-Type")),
-		zap.Any("http.response.header", resp.Header),
+		zap.Any("http.response.header", redactHeaders(resp.Header, rt.sensitiveHeaders)),
 	)
 	switch len(errorsMessages) {
 	case 0:
@@ -284,12 +289,13 @@ func (rt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 //	http.request.header
 //
 // Additional fields in extra will also be logged.
-func LogRequest(log *zap.Logger, req *http.Request, maxBodyLen int, extra ...zapcore.Field) *http.Request {
-	req, _, _ = logRequest(log, req, maxBodyLen, extra...)
+// Header names matching strings in sensitive are not logged.
+func LogRequest(log *zap.Logger, req *http.Request, sensitive []string, maxBodyLen int, extra ...zapcore.Field) *http.Request {
+	req, _, _ = logRequest(log, req, maxBodyLen, nil, extra...)
 	return req
 }
 
-func logRequest(log *zap.Logger, req *http.Request, maxBodyLen int, extra ...zapcore.Field) (_ *http.Request, parts []zapcore.Field, errorsMessages []string) {
+func logRequest(log *zap.Logger, req *http.Request, maxBodyLen int, sensitive []string, extra ...zapcore.Field) (_ *http.Request, parts []zapcore.Field, errorsMessages []string) {
 	reqParts := append([]zapcore.Field{
 		zap.String("url.original", req.URL.String()),
 		zap.String("url.scheme", req.URL.Scheme),
@@ -298,7 +304,7 @@ func logRequest(log *zap.Logger, req *http.Request, maxBodyLen int, extra ...zap
 		zap.String("url.port", req.URL.Port()),
 		zap.String("url.query", req.URL.RawQuery),
 		zap.String("http.request.method", req.Method),
-		zap.Any("http.request.header", req.Header),
+		zap.Any("http.request.header", redactHeaders(req.Header, sensitive)),
 		zap.String("user_agent.original", req.Header.Get("User-Agent")),
 	}, extra...)
 
@@ -355,6 +361,17 @@ func newID() string {
 	var data [8]byte
 	binary.LittleEndian.PutUint64(data[:], uint64(time.Now().UnixNano()))
 	return base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(data[:])
+}
+
+func redactHeaders(h http.Header, sensitive []string) http.Header {
+	if len(sensitive) == 0 {
+		return h
+	}
+	h = maps.Clone(h)
+	for _, s := range sensitive {
+		delete(h, s)
+	}
+	return h
 }
 
 // copyBody is derived from drainBody in net/http/httputil/dump.go

--- a/x-pack/filebeat/input/internal/httplog/roundtripper.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper.go
@@ -291,7 +291,7 @@ func (rt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 // Additional fields in extra will also be logged.
 // Header names matching strings in sensitive are not logged.
 func LogRequest(log *zap.Logger, req *http.Request, sensitive []string, maxBodyLen int, extra ...zapcore.Field) *http.Request {
-	req, _, _ = logRequest(log, req, maxBodyLen, nil, extra...)
+	req, _, _ = logRequest(log, req, maxBodyLen, sensitive, extra...)
 	return req
 }
 

--- a/x-pack/filebeat/input/internal/httplog/roundtripper_test.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper_test.go
@@ -5,10 +5,16 @@
 package httplog
 
 import (
+	"bytes"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/paths"
@@ -495,6 +501,81 @@ func TestCleanTraceFilesNonexistent(t *testing.T) {
 
 	log := logptest.NewTestingLogger(t, "test")
 	CleanTraceFiles(primary, log)
+}
+
+func TestLogRequestRedactsSensitiveHeaders(t *testing.T) {
+	tests := []struct {
+		name        string
+		headers     http.Header
+		sensitive   []string
+		wantAbsent  []string
+		wantPresent []string
+	}{
+		{
+			name: "authorization_redacted",
+			headers: http.Header{
+				"Authorization": []string{"Bearer secret-token"},
+				"Content-Type":  []string{"application/json"},
+			},
+			sensitive:   []string{"Authorization"},
+			wantAbsent:  []string{"Authorization", "secret-token"},
+			wantPresent: []string{"Content-Type", "application/json"},
+		},
+		{
+			name: "multiple_sensitive_headers",
+			headers: http.Header{
+				"Authorization": []string{"Basic dXNlcjpwYXNz"},
+				"X-Api-Key":     []string{"key-12345"},
+				"Accept":        []string{"*/*"},
+			},
+			sensitive:   []string{"Authorization", "X-Api-Key"},
+			wantAbsent:  []string{"dXNlcjpwYXNz", "key-12345"},
+			wantPresent: []string{"Accept"},
+		},
+		{
+			name: "no_sensitive_headers",
+			headers: http.Header{
+				"Authorization": []string{"Bearer visible"},
+				"Content-Type":  []string{"text/plain"},
+			},
+			sensitive:   nil,
+			wantAbsent:  nil,
+			wantPresent: []string{"Authorization", "visible"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			core := zapcore.NewCore(
+				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+				zapcore.AddSync(&buf),
+				zap.DebugLevel,
+			)
+			logger := zap.New(core)
+
+			req, err := http.NewRequest(http.MethodGet, "http://example.com/test", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header = tt.headers
+
+			LogRequest(logger, req, tt.sensitive, 1024)
+			logger.Sync()
+
+			output := buf.String()
+			for _, s := range tt.wantAbsent {
+				if strings.Contains(output, s) {
+					t.Errorf("log output must not contain %q", s)
+				}
+			}
+			for _, s := range tt.wantPresent {
+				if !strings.Contains(output, s) {
+					t.Errorf("log output must contain %q", s)
+				}
+			}
+		})
+	}
 }
 
 func sameError(a, b error) bool {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

See title.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
