### PR TITLE
Fix journald input on journalctl older than 245 with facility filters

### DIFF
--- a/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
+++ b/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
@@ -1,3 +1,6 @@
 kind: bug-fix
-summary: Fix the journald input failing to collect any events on systems with journalctl older than 245 (e.g. RHEL 8) when facility filters are configured, by falling back to SYSLOG_FACILITY matches
+summary: >-
+  Fix the journald input failing to collect any events on systems with
+  journalctl older than 245 (e.g. RHEL 8) when facility filters are
+  configured, by falling back to SYSLOG_FACILITY matches
 component: filebeat

--- a/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
+++ b/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
@@ -2,5 +2,5 @@ kind: bug-fix
 summary: >-
   Fix the journald input failing to collect any events on systems with
   journalctl older than 245 (e.g. RHEL 8) when facility filters are
-  configured, by falling back to SYSLOG_FACILITY matches
+  configured, by using SYSLOG_FACILITY matches instead of `--facility`
 component: filebeat

--- a/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
+++ b/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix the journald input failing to collect any events on systems with journalctl older than 245 (e.g. RHEL 8) when facility filters are configured, by falling back to SYSLOG_FACILITY matches
+component: filebeat

--- a/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
+++ b/changelog/fragments/1784830745-journald-facility-old-journalctl.yaml
@@ -1,6 +1,9 @@
 kind: bug-fix
-summary: >-
-  Fix the journald input failing to collect any events on systems with
-  journalctl older than 245 (e.g. RHEL 8) when facility filters are
-  configured, by using SYSLOG_FACILITY matches instead of `--facility`
+summary: Fix journald input facility filters on journalctl older than 245
+description: >-
+  The journald input passed `--facility` to journalctl unconditionally, but
+  the flag only exists on journalctl >= 245, so on older systems (e.g. RHEL 8)
+  configurations with `facilities` set collected no events. Facilities are now
+  passed as SYSLOG_FACILITY matches, which are supported on every version and
+  are what `--facility` translates to internally.
 component: filebeat

--- a/filebeat/input/journald/config.go
+++ b/filebeat/input/journald/config.go
@@ -22,6 +22,7 @@
 package journald
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -100,6 +101,21 @@ type config struct {
 	// it defaults to `journalctl`, which assumes that the `journalctl`
 	// binary is available in the system's `PATH` environment variable.
 	JournalctlPath string `config:"journalctl_path"`
+}
+
+// Validate checks the configuration. It is called by go-ucfg when
+// the configuration is unpacked.
+func (c config) Validate() error {
+	// Facilities are passed to journalctl as SYSLOG_FACILITY=N matches,
+	// which journalctl does not range-check (unlike its `--facility` flag),
+	// so an out-of-range value would silently match nothing.
+	for _, facility := range c.Facilities {
+		if facility < 0 || facility > 23 {
+			return fmt.Errorf("facility %d is invalid, it must be in the range 0-23", facility)
+		}
+	}
+
+	return nil
 }
 
 // bwcIncludeMatches is a wrapper that accepts include_matches configuration

--- a/filebeat/input/journald/config.go
+++ b/filebeat/input/journald/config.go
@@ -106,10 +106,12 @@ type config struct {
 func (c config) Validate() error {
 	// Facilities are passed to journalctl as SYSLOG_FACILITY=N matches,
 	// which journalctl does not range-check (unlike its `--facility` flag),
-	// so an out-of-range value would silently match nothing.
+	// so an out-of-range value would silently match nothing. The accepted
+	// range mirrors `--facility`, which allows up to LOG_FACMASK >> 3 (127)
+	// even though only 0-23 are standardized.
 	for _, facility := range c.Facilities {
-		if facility < 0 || facility > 23 {
-			return fmt.Errorf("facility %d is invalid, it must be in the range 0-23", facility)
+		if facility < 0 || facility > 127 {
+			return fmt.Errorf("facility %d is invalid, it must be in the range 0-127", facility)
 		}
 	}
 

--- a/filebeat/input/journald/config.go
+++ b/filebeat/input/journald/config.go
@@ -26,13 +26,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-ucfg"
 
 	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalctl"
 	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalfield"
 
-	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/reader/parser"
 )
 
@@ -120,7 +118,13 @@ func (c config) Validate() error {
 
 // bwcIncludeMatches is a wrapper that accepts include_matches configuration
 // from 7.x to allow old config to remain compatible.
-type bwcIncludeMatches journalfield.IncludeMatches
+type bwcIncludeMatches struct {
+	journalfield.IncludeMatches
+
+	// legacyFormat records that the deprecated 7.x array format was used,
+	// so a deprecation warning can be logged once a logger is available.
+	legacyFormat bool
+}
 
 func (im *bwcIncludeMatches) Unpack(c *ucfg.Config) error {
 	// Handle 7.x config format in a backwards compatible manner. Old format:
@@ -131,16 +135,11 @@ func (im *bwcIncludeMatches) Unpack(c *ucfg.Config) error {
 			return err
 		}
 		im.Matches = append(im.Matches, matches...)
-
-		includeMatchesWarnOnce.Do(func() {
-			// TODO: use a local logger here
-			logp.NewLogger("journald").Warn(cfgwarn.Deprecate("", "Please migrate your journald input's "+
-				"include_matches config to the new more expressive format."))
-		})
+		im.legacyFormat = true
 		return nil
 	}
 
-	return c.Unpack((*journalfield.IncludeMatches)(im))
+	return c.Unpack(&im.IncludeMatches)
 }
 
 func defaultConfig() config {

--- a/filebeat/input/journald/config_test.go
+++ b/filebeat/input/journald/config_test.go
@@ -61,3 +61,41 @@ include_matches:
 		verify(t, yaml)
 	})
 }
+
+func TestConfigValidateFacilities(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "valid facilities",
+			yaml: "facilities: [0, 4, 23]",
+		},
+		{
+			name:    "negative facility",
+			yaml:    "facilities: [-1]",
+			wantErr: "facility -1 is invalid",
+		},
+		{
+			name:    "facility above 23",
+			yaml:    "facilities: [24]",
+			wantErr: "facility 24 is invalid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := conf.NewConfigWithYAML([]byte(tc.yaml), "source")
+			require.NoError(t, err)
+
+			config := defaultConfig()
+			err = c.Unpack(&config)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/filebeat/input/journald/config_test.go
+++ b/filebeat/input/journald/config_test.go
@@ -70,7 +70,7 @@ func TestConfigValidateFacilities(t *testing.T) {
 	}{
 		{
 			name: "valid facilities",
-			yaml: "facilities: [0, 4, 23]",
+			yaml: "facilities: [0, 4, 23, 127]",
 		},
 		{
 			name:    "negative facility",
@@ -78,9 +78,9 @@ func TestConfigValidateFacilities(t *testing.T) {
 			wantErr: "facility -1 is invalid",
 		},
 		{
-			name:    "facility above 23",
-			yaml:    "facilities: [24]",
-			wantErr: "facility 24 is invalid",
+			name:    "facility above 127",
+			yaml:    "facilities: [128]",
+			wantErr: "facility 128 is invalid",
 		},
 	}
 

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalfield"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	cursor "github.com/elastic/beats/v7/filebeat/input/v2/input-cursor"
+	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/reader"
@@ -99,10 +100,17 @@ var cursorVersion = 1
 
 func (p pathSource) Name() string { return string(p) }
 
-func Configure(cfg *conf.C, _ *logp.Logger) ([]cursor.Source, cursor.Input, error) {
+func Configure(cfg *conf.C, logger *logp.Logger) ([]cursor.Source, cursor.Input, error) {
 	config := defaultConfig()
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, nil, err
+	}
+
+	if config.Matches.legacyFormat {
+		includeMatchesWarnOnce.Do(func() {
+			logger.Warn(cfgwarn.Deprecate("", "Please migrate your journald input's "+
+				"include_matches config to the new more expressive format."))
+		})
 	}
 
 	paths := config.Paths
@@ -145,7 +153,7 @@ func Configure(cfg *conf.C, _ *logp.Logger) ([]cursor.Source, cursor.Input, erro
 		ID:                 config.ID,
 		Since:              config.Since,
 		Seek:               config.Seek,
-		Matches:            journalfield.IncludeMatches(config.Matches),
+		Matches:            config.Matches.IncludeMatches,
 		Units:              config.Units,
 		Transports:         config.Transports,
 		Identifiers:        config.Identifiers,

--- a/filebeat/input/journald/pkg/journalctl/reader.go
+++ b/filebeat/input/journald/pkg/journalctl/reader.go
@@ -131,40 +131,46 @@ func maybeAddBootAll(args []string, supportsBootAll bool) []string {
 	return append(args, "--boot", "all")
 }
 
-// journalctlSupportsBootAll reports whether `--boot all` should be used.
-// On any detection failure, it safely falls back to false.
-func journalctlSupportsBootAll(logger *logp.Logger, factory JctlFactory) bool {
+// Minimum systemd/journalctl versions required by optional CLI capabilities.
+const (
+	// `--boot all` was introduced in systemd v242.
+	minVersionBootAll = 242
+	// `--facility` was introduced in systemd v245.
+	minVersionFacility = 245
+)
+
+// journalctlVersion returns the systemd version of the installed journalctl
+// binary by parsing the first line of `journalctl --version`.
+// On any detection failure it returns 0 and a non-nil error, callers must
+// treat this as a version that supports none of the optional capabilities.
+func journalctlVersion(logger *logp.Logger, factory JctlFactory) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 	jctl, err := factory(ctx, logger, "--version")
 	if err != nil {
-		logger.Warnf("cannot call journalctl to get its version: %s. Omitting '--boot all'", err)
-		return false
+		return 0, fmt.Errorf("cannot call journalctl to get its version: %w", err)
 	}
 
 	defer jctl.Kill() //nolint:errcheck // there is nothing we can do with this error
 
 	out, err := jctl.Next(ctx)
 	if err != nil {
-		logger.Warnf("cannot read journalctl output: %s", err)
-		return false
+		return 0, fmt.Errorf("cannot read journalctl output: %w", err)
 	}
 	// first line: "systemd 239 (239-82.el8_10.2)"
 	firstLine := strings.SplitN(string(out), "\n", 2)[0]
 	fields := strings.Fields(firstLine)
 	if len(fields) < 2 {
-		logger.Warnf("journalctl version invalid format: %q", strings.TrimSpace(string(out)))
-		return false
+		return 0, fmt.Errorf("journalctl version invalid format: %q", strings.TrimSpace(string(out)))
 	}
 
 	version, err := strconv.Atoi(fields[1])
 	if err != nil {
-		logger.Warnf("cannot convert journalctl version to int: %s", err)
-		return false
+		return 0, fmt.Errorf("cannot convert journalctl version to int: %w", err)
 	}
 
 	logger.Debugf("journalctl version: %d", version)
-	return version >= 242
+	return version, nil
 }
 
 // handleSeekAndCursor returns the correct arguments for seek and cursor.
@@ -269,11 +275,26 @@ func New(
 		args = append(args, fmt.Sprintf("_TRANSPORT=%s", m))
 	}
 
+	version, err := journalctlVersion(logger, newJctl)
+	if err != nil {
+		logger.Warnf("cannot detect journalctl version, assuming an old version: %s", err)
+	}
+	supportsBootAll := version >= minVersionBootAll
+	supportsFacility := version >= minVersionFacility
+
+	if len(facilities) > 0 && !supportsFacility {
+		logger.Warnf("journalctl does not support '--facility' (it requires systemd >= %d), using SYSLOG_FACILITY matches instead", minVersionFacility)
+	}
 	for _, facility := range facilities {
-		args = append(args, "--facility", fmt.Sprintf("%d", facility))
+		if supportsFacility {
+			args = append(args, "--facility", fmt.Sprintf("%d", facility))
+		} else {
+			// Matches on the same field are ORed by journalctl, which is
+			// the same semantics as repeated `--facility` flags.
+			args = append(args, fmt.Sprintf("SYSLOG_FACILITY=%d", facility))
+		}
 	}
 
-	supportsBootAll := journalctlSupportsBootAll(logger, newJctl)
 	extraArgs := handleSeekAndCursor(mode, since, cursor, supportsBootAll)
 
 	r := Reader{

--- a/filebeat/input/journald/pkg/journalctl/reader.go
+++ b/filebeat/input/journald/pkg/journalctl/reader.go
@@ -131,44 +131,40 @@ func maybeAddBootAll(args []string, supportsBootAll bool) []string {
 	return append(args, "--boot", "all")
 }
 
-// Minimum systemd/journalctl versions required by optional CLI capabilities.
-const (
-	// `--boot all` was introduced in systemd v242.
-	minVersionBootAll = 242
-)
-
-// journalctlVersion returns the systemd version of the installed journalctl
-// binary by parsing the first line of `journalctl --version`.
-// On any detection failure it returns 0 and a non-nil error, callers must
-// treat this as a version that supports none of the optional capabilities.
-func journalctlVersion(logger *logp.Logger, factory JctlFactory) (int, error) {
+// journalctlSupportsBootAll reports whether `--boot all` should be used.
+// On any detection failure, it safely falls back to false.
+func journalctlSupportsBootAll(logger *logp.Logger, factory JctlFactory) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 	jctl, err := factory(ctx, logger, "--version")
 	if err != nil {
-		return 0, fmt.Errorf("cannot call journalctl to get its version: %w", err)
+		logger.Warnf("cannot call journalctl to get its version: %s. Omitting '--boot all'", err)
+		return false
 	}
 
 	defer jctl.Kill() //nolint:errcheck // there is nothing we can do with this error
 
 	out, err := jctl.Next(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("cannot read journalctl output: %w", err)
+		logger.Warnf("cannot read journalctl output: %s", err)
+		return false
 	}
 	// first line: "systemd 239 (239-82.el8_10.2)"
 	firstLine := strings.SplitN(string(out), "\n", 2)[0]
 	fields := strings.Fields(firstLine)
 	if len(fields) < 2 {
-		return 0, fmt.Errorf("journalctl version invalid format: %q", strings.TrimSpace(string(out)))
+		logger.Warnf("journalctl version invalid format: %q", strings.TrimSpace(string(out)))
+		return false
 	}
 
 	version, err := strconv.Atoi(fields[1])
 	if err != nil {
-		return 0, fmt.Errorf("cannot convert journalctl version to int: %w", err)
+		logger.Warnf("cannot convert journalctl version to int: %s", err)
+		return false
 	}
 
 	logger.Debugf("journalctl version: %d", version)
-	return version, nil
+	return version >= 242
 }
 
 // handleSeekAndCursor returns the correct arguments for seek and cursor.
@@ -273,12 +269,6 @@ func New(
 		args = append(args, fmt.Sprintf("_TRANSPORT=%s", m))
 	}
 
-	version, err := journalctlVersion(logger, newJctl)
-	if err != nil {
-		logger.Warnf("cannot detect journalctl version, assuming an old version: %s", err)
-	}
-	supportsBootAll := version >= minVersionBootAll
-
 	// SYSLOG_FACILITY matches are used instead of `--facility` because the
 	// flag only exists on journalctl >= 245 and is implemented as exactly
 	// these matches. Matches on the same field are ORed by journalctl, which
@@ -287,6 +277,7 @@ func New(
 		args = append(args, fmt.Sprintf("SYSLOG_FACILITY=%d", facility))
 	}
 
+	supportsBootAll := journalctlSupportsBootAll(logger, newJctl)
 	extraArgs := handleSeekAndCursor(mode, since, cursor, supportsBootAll)
 
 	r := Reader{

--- a/filebeat/input/journald/pkg/journalctl/reader.go
+++ b/filebeat/input/journald/pkg/journalctl/reader.go
@@ -135,8 +135,6 @@ func maybeAddBootAll(args []string, supportsBootAll bool) []string {
 const (
 	// `--boot all` was introduced in systemd v242.
 	minVersionBootAll = 242
-	// `--facility` was introduced in systemd v245.
-	minVersionFacility = 245
 )
 
 // journalctlVersion returns the systemd version of the installed journalctl
@@ -280,19 +278,13 @@ func New(
 		logger.Warnf("cannot detect journalctl version, assuming an old version: %s", err)
 	}
 	supportsBootAll := version >= minVersionBootAll
-	supportsFacility := version >= minVersionFacility
 
-	if len(facilities) > 0 && !supportsFacility {
-		logger.Warnf("journalctl does not support '--facility' (it requires systemd >= %d), using SYSLOG_FACILITY matches instead", minVersionFacility)
-	}
+	// SYSLOG_FACILITY matches are used instead of `--facility` because the
+	// flag only exists on journalctl >= 245 and is implemented as exactly
+	// these matches. Matches on the same field are ORed by journalctl, which
+	// is the same semantics as repeated `--facility` flags.
 	for _, facility := range facilities {
-		if supportsFacility {
-			args = append(args, "--facility", fmt.Sprintf("%d", facility))
-		} else {
-			// Matches on the same field are ORed by journalctl, which is
-			// the same semantics as repeated `--facility` flags.
-			args = append(args, fmt.Sprintf("SYSLOG_FACILITY=%d", facility))
-		}
+		args = append(args, fmt.Sprintf("SYSLOG_FACILITY=%d", facility))
 	}
 
 	extraArgs := handleSeekAndCursor(mode, since, cursor, supportsBootAll)

--- a/filebeat/input/journald/pkg/journalctl/reader_test.go
+++ b/filebeat/input/journald/pkg/journalctl/reader_test.go
@@ -62,7 +62,7 @@ func TestEventWithNonStringData(t *testing.T) {
 				KillFunc: func() error { return nil },
 			}
 			r := Reader{
-				logger: logp.NewNopLogger(),
+				logger: logptest.NewTestingLogger(t, ""),
 				jctl:   &mock,
 			}
 
@@ -326,7 +326,7 @@ func TestFacilityArgs(t *testing.T) {
 			}
 
 			r, err := New(
-				logp.NewNopLogger(),
+				logptest.NewTestingLogger(t, ""),
 				t.Context(),
 				nil,
 				nil,

--- a/filebeat/input/journald/pkg/journalctl/reader_test.go
+++ b/filebeat/input/journald/pkg/journalctl/reader_test.go
@@ -252,19 +252,16 @@ func fakeJournalctl(t *testing.T, version int) string {
 
 func TestJournalctlVersion(t *testing.T) {
 	tests := []struct {
-		name         string
-		version      int
-		invalidPath  bool
-		wantErr      bool
-		wantBootAll  bool
-		wantFacility bool
+		name        string
+		version     int
+		invalidPath bool
+		wantErr     bool
+		wantBootAll bool
 	}{
-		{name: "v239 (RHEL8) gets no optional flags", version: 239},
+		{name: "v239 (RHEL8) does not get --boot all", version: 239},
 		{name: "v241 does not get --boot all", version: 241},
-		{name: "v242 gets --boot all but not --facility", version: 242, wantBootAll: true},
-		{name: "v244 does not get --facility", version: 244, wantBootAll: true},
-		{name: "v245 gets --boot all and --facility", version: 245, wantBootAll: true, wantFacility: true},
-		{name: "v250 gets --boot all and --facility", version: 250, wantBootAll: true, wantFacility: true},
+		{name: "v242 gets --boot all", version: 242, wantBootAll: true},
+		{name: "v250 gets --boot all", version: 250, wantBootAll: true},
 		{name: "invalid binary path falls back safely", invalidPath: true, wantErr: true},
 	}
 
@@ -285,40 +282,20 @@ func TestJournalctlVersion(t *testing.T) {
 			if gotBootAll := got >= minVersionBootAll; gotBootAll != tc.wantBootAll {
 				t.Errorf("version %d: wantBootAll=%v but got=%v", tc.version, tc.wantBootAll, gotBootAll)
 			}
-			if gotFacility := got >= minVersionFacility; gotFacility != tc.wantFacility {
-				t.Errorf("version %d: wantFacility=%v but got=%v", tc.version, tc.wantFacility, gotFacility)
-			}
 		})
 	}
 }
 
 func TestFacilityArgs(t *testing.T) {
-	tests := []struct {
-		name    string
-		version int
-		want    []string
-		notWant []string
-	}{
-		{
-			name:    "journalctl >= 245 uses --facility",
-			version: 245,
-			want:    []string{"--facility 4", "--facility 10"},
-			notWant: []string{"SYSLOG_FACILITY"},
-		},
-		{
-			name:    "journalctl < 245 falls back to SYSLOG_FACILITY matches",
-			version: 239,
-			want:    []string{"SYSLOG_FACILITY=4", "SYSLOG_FACILITY=10"},
-			notWant: []string{"--facility"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	// Facilities are always passed as SYSLOG_FACILITY matches regardless of
+	// the journalctl version: `--facility` only exists on journalctl >= 245
+	// and is implemented as exactly these matches.
+	for _, version := range []int{239, 250} {
+		t.Run(fmt.Sprintf("version %d", version), func(t *testing.T) {
 			f := func(_ input.Canceler, _ *logp.Logger, s ...string) (Jctl, error) {
 				return &JctlMock{
 					NextFunc: func(canceler input.Canceler) ([]byte, error) {
-						ret := fmt.Sprintf("systemd %d (%d-test)\n+PAM +AUDIT", tc.version, tc.version)
+						ret := fmt.Sprintf("systemd %d (%d-test)\n+PAM +AUDIT", version, version)
 						return []byte(ret), nil
 					},
 					KillFunc: func() error { return nil },
@@ -344,15 +321,13 @@ func TestFacilityArgs(t *testing.T) {
 			}
 
 			argsStr := strings.Join(r.args, " ")
-			for _, want := range tc.want {
+			for _, want := range []string{"SYSLOG_FACILITY=4", "SYSLOG_FACILITY=10"} {
 				if !strings.Contains(argsStr, want) {
 					t.Errorf("expected %q in args %q", want, argsStr)
 				}
 			}
-			for _, notWant := range tc.notWant {
-				if strings.Contains(argsStr, notWant) {
-					t.Errorf("did not expect %q in args %q", notWant, argsStr)
-				}
+			if strings.Contains(argsStr, "--facility") {
+				t.Errorf("did not expect \"--facility\" in args %q", argsStr)
 			}
 		})
 	}

--- a/filebeat/input/journald/pkg/journalctl/reader_test.go
+++ b/filebeat/input/journald/pkg/journalctl/reader_test.go
@@ -62,7 +62,7 @@ func TestEventWithNonStringData(t *testing.T) {
 				KillFunc: func() error { return nil },
 			}
 			r := Reader{
-				logger: logp.L(),
+				logger: logp.NewNopLogger(),
 				jctl:   &mock,
 			}
 

--- a/filebeat/input/journald/pkg/journalctl/reader_test.go
+++ b/filebeat/input/journald/pkg/journalctl/reader_test.go
@@ -250,19 +250,18 @@ func fakeJournalctl(t *testing.T, version int) string {
 	return path
 }
 
-func TestJournalctlVersion(t *testing.T) {
+func TestJournalctlSupportsBootAll(t *testing.T) {
 	tests := []struct {
 		name        string
 		version     int
 		invalidPath bool
-		wantErr     bool
 		wantBootAll bool
 	}{
-		{name: "v239 (RHEL8) does not get --boot all", version: 239},
-		{name: "v241 does not get --boot all", version: 241},
+		{name: "v239 (RHEL8) does not get --boot all", version: 239, wantBootAll: false},
+		{name: "v241 does not get --boot all", version: 241, wantBootAll: false},
 		{name: "v242 gets --boot all", version: 242, wantBootAll: true},
 		{name: "v250 gets --boot all", version: 250, wantBootAll: true},
-		{name: "invalid binary path falls back safely", invalidPath: true, wantErr: true},
+		{name: "invalid binary path falls back safely", invalidPath: true, wantBootAll: false},
 	}
 
 	for _, tc := range tests {
@@ -275,12 +274,9 @@ func TestJournalctlVersion(t *testing.T) {
 			}
 
 			logger := logptest.NewFileLogger(t, filepath.Join("..", "..", "..", "..", "build"))
-			got, err := journalctlVersion(logger.Logger, NewFactory("", path))
-			if tc.wantErr != (err != nil) {
-				t.Fatalf("wantErr=%v, got error: %v", tc.wantErr, err)
-			}
-			if gotBootAll := got >= minVersionBootAll; gotBootAll != tc.wantBootAll {
-				t.Errorf("version %d: wantBootAll=%v but got=%v", tc.version, tc.wantBootAll, gotBootAll)
+			got := journalctlSupportsBootAll(logger.Logger, NewFactory("", path))
+			if got != tc.wantBootAll {
+				t.Errorf("version %d: wantBootAll=%v but got=%v", tc.version, tc.wantBootAll, got)
 			}
 		})
 	}

--- a/filebeat/input/journald/pkg/journalctl/reader_test.go
+++ b/filebeat/input/journald/pkg/journalctl/reader_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -249,18 +250,22 @@ func fakeJournalctl(t *testing.T, version int) string {
 	return path
 }
 
-func TestJournalctlSupportsBootAll(t *testing.T) {
+func TestJournalctlVersion(t *testing.T) {
 	tests := []struct {
-		name        string
-		version     int
-		invalidPath bool
-		wantBootAll bool
+		name         string
+		version      int
+		invalidPath  bool
+		wantErr      bool
+		wantBootAll  bool
+		wantFacility bool
 	}{
-		{name: "v239 (RHEL8) does not get --boot all", version: 239, wantBootAll: false},
-		{name: "v241 does not get --boot all", version: 241, wantBootAll: false},
-		{name: "v242 gets --boot all", version: 242, wantBootAll: true},
-		{name: "v250 gets --boot all", version: 250, wantBootAll: true},
-		{name: "invalid binary path falls back safely", invalidPath: true, wantBootAll: false},
+		{name: "v239 (RHEL8) gets no optional flags", version: 239},
+		{name: "v241 does not get --boot all", version: 241},
+		{name: "v242 gets --boot all but not --facility", version: 242, wantBootAll: true},
+		{name: "v244 does not get --facility", version: 244, wantBootAll: true},
+		{name: "v245 gets --boot all and --facility", version: 245, wantBootAll: true, wantFacility: true},
+		{name: "v250 gets --boot all and --facility", version: 250, wantBootAll: true, wantFacility: true},
+		{name: "invalid binary path falls back safely", invalidPath: true, wantErr: true},
 	}
 
 	for _, tc := range tests {
@@ -273,9 +278,81 @@ func TestJournalctlSupportsBootAll(t *testing.T) {
 			}
 
 			logger := logptest.NewFileLogger(t, filepath.Join("..", "..", "..", "..", "build"))
-			got := journalctlSupportsBootAll(logger.Logger, NewFactory("", path))
-			if got != tc.wantBootAll {
-				t.Errorf("version %d: wantBootAll=%v but got=%v", tc.version, tc.wantBootAll, got)
+			got, err := journalctlVersion(logger.Logger, NewFactory("", path))
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("wantErr=%v, got error: %v", tc.wantErr, err)
+			}
+			if gotBootAll := got >= minVersionBootAll; gotBootAll != tc.wantBootAll {
+				t.Errorf("version %d: wantBootAll=%v but got=%v", tc.version, tc.wantBootAll, gotBootAll)
+			}
+			if gotFacility := got >= minVersionFacility; gotFacility != tc.wantFacility {
+				t.Errorf("version %d: wantFacility=%v but got=%v", tc.version, tc.wantFacility, gotFacility)
+			}
+		})
+	}
+}
+
+func TestFacilityArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		version int
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "journalctl >= 245 uses --facility",
+			version: 245,
+			want:    []string{"--facility 4", "--facility 10"},
+			notWant: []string{"SYSLOG_FACILITY"},
+		},
+		{
+			name:    "journalctl < 245 falls back to SYSLOG_FACILITY matches",
+			version: 239,
+			want:    []string{"SYSLOG_FACILITY=4", "SYSLOG_FACILITY=10"},
+			notWant: []string{"--facility"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := func(_ input.Canceler, _ *logp.Logger, s ...string) (Jctl, error) {
+				return &JctlMock{
+					NextFunc: func(canceler input.Canceler) ([]byte, error) {
+						ret := fmt.Sprintf("systemd %d (%d-test)\n+PAM +AUDIT", tc.version, tc.version)
+						return []byte(ret), nil
+					},
+					KillFunc: func() error { return nil },
+				}, nil
+			}
+
+			r, err := New(
+				logp.NewNopLogger(),
+				t.Context(),
+				nil,
+				nil,
+				nil,
+				journalfield.IncludeMatches{},
+				[]int{4, 10},
+				SeekHead,
+				"",
+				0,
+				"",
+				false,
+				f)
+			if err != nil {
+				t.Fatalf("did not expect an error when calling New: %s", err)
+			}
+
+			argsStr := strings.Join(r.args, " ")
+			for _, want := range tc.want {
+				if !strings.Contains(argsStr, want) {
+					t.Errorf("expected %q in args %q", want, argsStr)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(argsStr, notWant) {
+					t.Errorf("did not expect %q in args %q", notWant, argsStr)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Proposed commit message

journalctl only supports the `--facility` flag since systemd v245, but the journald input passed it unconditionally whenever `facilities` was configured. On older systems (e.g. RHEL 8, which ships systemd 239) journalctl exits immediately with `unrecognized option '--facility'` and the input restarts it in an endless backoff loop, silently collecting no events. The System integration configures facility filters on both of its journald streams, so those streams collect nothing on RHEL 8.

Instead of gating the flag on the journalctl version, facilities are now always passed as `SYSLOG_FACILITY=N` journal field matches. Every journalctl version supports field matches, and `--facility` is implemented internally as exactly these matches: matches on the same field are ORed together, the same semantics as repeated `--facility` flags. Because journalctl does not range-check field matches the way it range-checks `--facility`, the input's config now validates that each facility is within 0-127 (the range `--facility` accepts), so an out-of-range value fails at config time instead of silently matching nothing.

While moving config validation around, the deprecation warning for the legacy 7.x `include_matches` array format was also moved out of `Unpack` (which had to use a package-global logger) into `Configure`, where the input's logger is available.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

On journalctl >= 245 the selected events are unchanged (only the journalctl command line differs). On older versions, configurations with `facilities` set go from collecting nothing (journalctl crash loop) to collecting the requested events. Configurations with a facility outside 0-127 now fail config validation; previously such values made journalctl (>= 245) exit with an error at runtime.

## How to test this PR locally

On a host/container with systemd < 245 (e.g. RHEL 8 / ubi8), run Filebeat with:

```yaml
filebeat.inputs:
  - type: journald
    id: test-facility
    facilities: [4, 10]
```

Without this patch journalctl exits with code 1 (`unrecognized option '--facility'`) in a restart loop and no events are ingested. With the patch, Filebeat invokes journalctl with `SYSLOG_FACILITY=4 SYSLOG_FACILITY=10` matches (on every journalctl version) and ingests events.

Unit tests: `go test ./filebeat/input/journald/...`

## Related issues

- Relates https://github.com/elastic/beats/issues/37086
- Same class of bug as #48152 (`--boot all` on journalctl < 242)
- Integration-side mitigation: elastic/integrations#20303
