### PR TITLE
osquerybeat: accept packs mixing native interval and unscheduled queries

### DIFF
--- a/changelog/fragments/1784900000-osquerybeat-allow-native-unscheduled-pack-mix.yaml
+++ b/changelog/fragments/1784900000-osquerybeat-allow-native-unscheduled-pack-mix.yaml
@@ -1,0 +1,12 @@
+kind: bug-fix
+summary: Accept osquery packs mixing interval-scheduled and unscheduled queries again
+description: >
+  Pack schedule-mode validation introduced with RRULE scheduling rejected packs
+  that mix native interval queries with unscheduled queries, failing the whole
+  policy and blocking agent upgrades. Such packs commonly exist because query
+  names containing dots are split into nested maps by config parsing, leaving a
+  query without interval or SQL. These packs are accepted again with a warning
+  identifying the unscheduled queries. Mixing rrule_schedule with other schedule
+  modes is still rejected.
+component: osquerybeat
+issue: https://github.com/elastic/beats/issues/51450

--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -365,6 +365,10 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) (err error) {
 		if err := config.ValidatePackQueriesAfterMerge(pack); err != nil {
 			return fmt.Errorf("osquery.packs[%q]: %w", packName, err)
 		}
+		if names := config.UnscheduledQueryNamesInNativePack(pack); len(names) > 0 {
+			p.log.Warnf("osquery.packs[%q]: queries %v have no interval or rrule_schedule; "+
+				"if a query name contains dots it is split by config parsing and the query will not run, rename it without dots", packName, names)
+		}
 	}
 
 	// Iterate inputs for Osquery configuration for backwards compatibility

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -826,7 +826,9 @@ func TestSet_PackConflictingScheduleDefaultsRejected(t *testing.T) {
 	}
 }
 
-func TestSet_PackMixedQueryScheduleModesRejected(t *testing.T) {
+func TestSet_PackMixedNativeUnscheduledAccepted(t *testing.T) {
+	// Native interval mixed with unscheduled queries must not fail policy application;
+	// see https://github.com/elastic/beats/issues/51450
 	logger := logp.NewLogger("config_test")
 	cfgp := NewConfigPlugin(logger)
 	inputs := []config.InputConfig{
@@ -840,6 +842,37 @@ func TestSet_PackMixedQueryScheduleModesRejected(t *testing.T) {
 						Queries: map[string]config.Query{
 							"native": {Query: "select 1", NativeSchedule: config.NativeSchedule{Interval: 60}},
 							"idle":   {Query: "select 2"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := cfgp.Set(inputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfgp.Count() != 2 {
+		t.Fatalf("expected 2 queries registered, got %d", cfgp.Count())
+	}
+}
+
+func TestSet_PackMixedRRuleScheduleModesRejected(t *testing.T) {
+	logger := logp.NewLogger("config_test")
+	cfgp := NewConfigPlugin(logger)
+	inputs := []config.InputConfig{
+		{
+			Name:       "osquery-manager-1",
+			Type:       "osquery",
+			Datastream: config.DatastreamConfig{Namespace: "default"},
+			Osquery: &config.OsqueryConfig{
+				Packs: map[string]config.Pack{
+					"mixed": {
+						Queries: map[string]config.Query{
+							"native": {Query: "select 1", NativeSchedule: config.NativeSchedule{Interval: 60}},
+							"rrule": {Query: "select 2", RRuleSchedule: &config.RRuleScheduleConfig{
+								RRule:     "FREQ=DAILY",
+								StartDate: "2024-01-01T00:00:00Z",
+							}},
 						},
 					},
 				},

--- a/x-pack/osquerybeat/internal/config/pack_schedule.go
+++ b/x-pack/osquerybeat/internal/config/pack_schedule.go
@@ -7,6 +7,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"sort"
 )
 
 var (
@@ -18,9 +19,11 @@ var (
 	// default_native_schedule.interval and an enabled default_rrule_schedule.
 	ErrPackConflictingScheduleDefaults = errors.New("pack cannot define both default_native_schedule.interval and default_rrule_schedule")
 
-	// ErrPackMixedScheduleModes is returned when queries in a pack without schedule
-	// defaults use different schedule modes (native interval vs rrule_schedule vs unscheduled).
-	ErrPackMixedScheduleModes = errors.New("pack queries must share the same schedule mode (all native interval, all rrule_schedule, or all unscheduled)")
+	// ErrPackMixedScheduleModes is returned when a pack mixes rrule_schedule queries
+	// with native interval or unscheduled queries. Mixing native interval and
+	// unscheduled queries is tolerated for backwards compatibility; see
+	// UnscheduledQueryNamesInNativePack.
+	ErrPackMixedScheduleModes = errors.New("pack cannot mix rrule_schedule queries with native interval or unscheduled queries")
 
 	// ErrPackQueryViolatesPackScheduleDefault is returned when a query's schedule
 	// does not match the pack's default_native_schedule or default rrule_schedule.
@@ -79,7 +82,11 @@ func queryPackScheduleMode(q Query) packQueryScheduleMode {
 // ValidatePackQueriesAfterMerge checks the pack's queries after MergeQueryWithPackScheduleDefaults.
 // When the pack sets default_native_schedule.interval, every query must use native scheduling.
 // When the pack sets an enabled default rrule_schedule, every query must use RRULE scheduling.
-// Otherwise, all queries must share one mode: native, RRULE, or unscheduled.
+// Otherwise, RRULE queries must not be mixed with native or unscheduled queries.
+// A mix of native interval and unscheduled queries is accepted for backwards
+// compatibility: policies in the field contain such packs, commonly because query
+// names with dots are split into nested maps by config parsing, leaving a query
+// without interval or SQL (https://github.com/elastic/beats/issues/51450).
 func ValidatePackQueriesAfterMerge(pack Pack) error {
 	hasNativeDefault := pack.DefaultNativeSchedule.Interval > 0
 	hasRRuleDefault := pack.DefaultRRuleSchedule != nil && pack.DefaultRRuleSchedule.IsEnabled()
@@ -97,15 +104,39 @@ func ValidatePackQueriesAfterMerge(pack Pack) error {
 	for _, q := range pack.Queries {
 		modes[queryPackScheduleMode(q)] = struct{}{}
 	}
-	if len(modes) > 1 {
+	if _, hasRRule := modes[packQueryScheduleRRule]; hasRRule && len(modes) > 1 {
 		return ErrPackMixedScheduleModes
 	}
 	return nil
 }
 
+// UnscheduledQueryNamesInNativePack returns the sorted names of unscheduled queries
+// in a pack that also contains native interval queries. Such packs pass
+// ValidatePackQueriesAfterMerge for backwards compatibility, but the unscheduled
+// queries have no interval of their own; callers should warn so the misconfiguration
+// is visible. A common cause is pack query names containing dots, which config
+// parsing splits into nested maps (https://github.com/elastic/beats/issues/51450).
+func UnscheduledQueryNamesInNativePack(pack Pack) []string {
+	var unscheduled []string
+	hasNative := false
+	for qname, q := range pack.Queries {
+		switch queryPackScheduleMode(q) {
+		case packQueryScheduleNative:
+			hasNative = true
+		case packQueryScheduleUnscheduled:
+			unscheduled = append(unscheduled, qname)
+		}
+	}
+	if !hasNative || len(unscheduled) == 0 {
+		return nil
+	}
+	sort.Strings(unscheduled)
+	return unscheduled
+}
+
 // MergeQueryWithPackScheduleDefaults applies pack-level schedule defaults to a query.
 // Query-level fields take precedence for filling fields, but the merged pack must still
-// pass ValidatePackQueriesAfterMerge (same schedule mode for all queries, aligned with pack defaults).
+// pass ValidatePackQueriesAfterMerge (no RRULE mixed with other modes, aligned with pack defaults).
 // Returns an error if the merged query violates ValidateQueryScheduleMode.
 func MergeQueryWithPackScheduleDefaults(pack Pack, q Query) (Query, error) {
 	if err := ValidateQueryScheduleMode(q); err != nil {

--- a/x-pack/osquerybeat/internal/config/pack_schedule_test.go
+++ b/x-pack/osquerybeat/internal/config/pack_schedule_test.go
@@ -291,14 +291,15 @@ func TestValidatePackQueriesAfterMerge(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("reject mixed native and unscheduled with no pack defaults", func(t *testing.T) {
+	t.Run("allow mixed native and unscheduled with no pack defaults", func(t *testing.T) {
+		// Accepted for backwards compatibility; see https://github.com/elastic/beats/issues/51450
 		err := ValidatePackQueriesAfterMerge(Pack{
 			Queries: map[string]Query{
 				"a": {Query: "select 1", NativeSchedule: NativeSchedule{Interval: 60}},
 				"b": {Query: "select 2"},
 			},
 		})
-		assert.ErrorIs(t, err, ErrPackMixedScheduleModes)
+		assert.NoError(t, err)
 	})
 
 	t.Run("reject mixed native and rrule with no pack defaults", func(t *testing.T) {
@@ -306,6 +307,16 @@ func TestValidatePackQueriesAfterMerge(t *testing.T) {
 			Queries: map[string]Query{
 				"a": {Query: "select 1", NativeSchedule: NativeSchedule{Interval: 60}},
 				"b": {Query: "select 2", RRuleSchedule: rrule},
+			},
+		})
+		assert.ErrorIs(t, err, ErrPackMixedScheduleModes)
+	})
+
+	t.Run("reject mixed rrule and unscheduled with no pack defaults", func(t *testing.T) {
+		err := ValidatePackQueriesAfterMerge(Pack{
+			Queries: map[string]Query{
+				"a": {Query: "select 1", RRuleSchedule: rrule},
+				"b": {Query: "select 2"},
 			},
 		})
 		assert.ErrorIs(t, err, ErrPackMixedScheduleModes)
@@ -342,5 +353,48 @@ func TestValidatePackQueriesAfterMerge(t *testing.T) {
 		}
 		err := ValidatePackQueriesAfterMerge(p)
 		assert.ErrorIs(t, err, ErrPackQueryViolatesPackScheduleDefault)
+	})
+}
+
+func TestUnscheduledQueryNamesInNativePack(t *testing.T) {
+	rrule := &RRuleScheduleConfig{RRule: "FREQ=DAILY", StartDate: "2024-01-01T00:00:00Z"}
+
+	t.Run("returns sorted unscheduled names when mixed with native", func(t *testing.T) {
+		names := UnscheduledQueryNamesInNativePack(Pack{
+			Queries: map[string]Query{
+				"native1": {Query: "select 1", NativeSchedule: NativeSchedule{Interval: 60}},
+				"zz":      {Query: "select 2"},
+				"aa":      {Query: "select 3"},
+			},
+		})
+		assert.Equal(t, []string{"aa", "zz"}, names)
+	})
+
+	t.Run("nil when all native", func(t *testing.T) {
+		names := UnscheduledQueryNamesInNativePack(Pack{
+			Queries: map[string]Query{
+				"a": {Query: "select 1", NativeSchedule: NativeSchedule{Interval: 60}},
+			},
+		})
+		assert.Nil(t, names)
+	})
+
+	t.Run("nil when all unscheduled", func(t *testing.T) {
+		names := UnscheduledQueryNamesInNativePack(Pack{
+			Queries: map[string]Query{
+				"a": {Query: "select 1"},
+				"b": {Query: "select 2"},
+			},
+		})
+		assert.Nil(t, names)
+	})
+
+	t.Run("nil for rrule pack", func(t *testing.T) {
+		names := UnscheduledQueryNamesInNativePack(Pack{
+			Queries: map[string]Query{
+				"a": {Query: "select 1", RRuleSchedule: rrule},
+			},
+		})
+		assert.Nil(t, names)
 	})
 }


### PR DESCRIPTION
## Proposed commit message

Pack schedule-mode validation added with RRULE scheduling (#48767) rejected packs mixing native interval queries with unscheduled ones. This fails the whole policy application, puts the osquery component into a permanent FAILED state, and blocks agent upgrades to 9.5.0 (see elastic/elastic-agent#15814).

Such packs exist in the field. A common cause is pack query names containing dots (e.g. `Tibet.D` from the community osx-attacks pack): config parsing splits the name into a nested map, leaving a ghost query without interval or SQL that the validation classifies as unscheduled.

This change accepts the native/unscheduled mix again, matching pre-9.5 behavior, and logs a warning naming the unscheduled queries so the misconfiguration is visible. Packs mixing `rrule_schedule` with other schedule modes are still rejected, which is the conflict the validation was introduced for.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/beats/blob/main/CONTRIBUTING.md#changelog)

## Related issues

- Fixes #51450
- Relates elastic/elastic-agent#15814