### PR TITLE
Fix typo in GCP BigQuery client error messages

### DIFF
--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -123,7 +123,7 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err erro
 
 	client, err := bigquery.NewClient(ctx, m.config.ProjectID, opt...)
 	if err != nil {
-		return fmt.Errorf("gerror creating bigquery client: %w", err)
+		return fmt.Errorf("error creating BigQuery client: %w", err)
 	}
 
 	defer client.Close()

--- a/x-pack/metricbeat/module/gcp/carbon/carbon.go
+++ b/x-pack/metricbeat/module/gcp/carbon/carbon.go
@@ -106,7 +106,7 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err erro
 
 	client, err := bigquery.NewClient(ctx, m.config.ProjectID, opt...)
 	if err != nil {
-		return fmt.Errorf("gerror creating bigquery client: %w", err)
+		return fmt.Errorf("error creating BigQuery client: %w", err)
 	}
 
 	defer client.Close()


### PR DESCRIPTION
## Proposed commit message

Fix misspelled GCP BigQuery client error strings in Metricbeat billing and carbon modules (`gerror` -> `error`, capitalize BigQuery).

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the changelog tool.~~

## Disruptive User Impact

None. Only user-visible change is corrected wording in two error messages.

## How to test this PR locally

Confirm the updated strings in:

- `x-pack/metricbeat/module/gcp/billing/billing.go`
- `x-pack/metricbeat/module/gcp/carbon/carbon.go`

Optional: force BigQuery client creation to fail and check the error text.

## Related issues

Fixes #51894
