### PR TITLE
[beatreceiver] Remove exception for packetbeat when setting `shutdown_timeout`

### DIFF
--- a/x-pack/libbeat/cmd/instance/beat.go
+++ b/x-pack/libbeat/cmd/instance/beat.go
@@ -93,18 +93,14 @@ func NewBeatForReceiver(settings instance.Settings, receiverConfig map[string]an
 	}
 
 	// Set the default shutdown timeout to 5s. The beat default is 1s, which can be too short for the otel pipeline.
-	// Packetbeat is excluded because its shutdown_timeout has different semantics.
-	// See https://github.com/elastic/beats/issues/52031
-	if b.Info.Beat != "packetbeat" {
-		switch beatSection := receiverConfig[b.Info.Beat].(type) {
-		case map[string]any:
-			if _, alreadySet := beatSection["shutdown_timeout"]; !alreadySet {
-				beatSection["shutdown_timeout"] = receiverPublisherCloseTimeout.String()
-			}
-		case nil:
-			receiverConfig[b.Info.Beat] = map[string]any{
-				"shutdown_timeout": receiverPublisherCloseTimeout.String(),
-			}
+	switch beatSection := receiverConfig[b.Info.Beat].(type) {
+	case map[string]any:
+		if _, alreadySet := beatSection["shutdown_timeout"]; !alreadySet {
+			beatSection["shutdown_timeout"] = receiverPublisherCloseTimeout.String()
+		}
+	case nil:
+		receiverConfig[b.Info.Beat] = map[string]any{
+			"shutdown_timeout": receiverPublisherCloseTimeout.String(),
 		}
 	}
 

--- a/x-pack/libbeat/cmd/instance/beat_test.go
+++ b/x-pack/libbeat/cmd/instance/beat_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/elastic/beats/v7/filebeat/cmd"
 	"github.com/elastic/beats/v7/filebeat/input/log"
-	libbeatinstance "github.com/elastic/beats/v7/libbeat/cmd/instance"
 	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/x-pack/otel/otelmanager"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -83,25 +82,6 @@ type: "log"`)
 		require.NoError(t, err)
 		assert.False(t, log.AllowDeprecatedUse(cfg))
 	})
-}
-
-func TestNewBeatForReceiverDoesNotSetPacketbeatShutdownTimeout(t *testing.T) {
-	cfg := map[string]any{
-		"packetbeat": map[string]any{},
-		"path.home":  t.TempDir(),
-	}
-
-	_, err := NewBeatForReceiver(
-		libbeatinstance.Settings{Name: "packetbeat"},
-		cfg,
-		consumertest.NewNop(),
-		"testcomponent",
-		zapcore.NewNopCore(),
-	)
-	require.NoError(t, err)
-
-	assert.NotContains(t, cfg["packetbeat"], "shutdown_timeout",
-		"packetbeat must retain its own shutdown timeout semantics")
 }
 
 func TestNewBeatForReceiverMetricLoggingDefault(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
We did not set `shutdown_timeout` field on packetbeat receiver as it had a different semantic meaning. See issue https://github.com/elastic/beats/pull/52005

But this has been fixed in https://github.com/elastic/beats/pull/52005, hence removing this exception
<!-- Mandatory
Explain here the changes you made on the PR.

