### PR TITLE
Fix cursor updates when using multiline with Journald and Kafka inputs

### DIFF
--- a/changelog/fragments/1783624000-fix-multiline-registry-update.yaml
+++ b/changelog/fragments/1783624000-fix-multiline-registry-update.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Fix offset commits when using multiline in Journald and Kafka inputs
+component: filebeat
+issue: https://github.com/elastic/beats/issues/51981

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -283,6 +283,10 @@ func initCheckpoint(log *logp.Logger, c cursor.Cursor) checkpoint {
 func getCursorUpdate(priv any) any {
 	switch v := priv.(type) {
 	case []any:
+		// This should never happen, but better safe than panic.
+		if len(v) == 0 {
+			return nil
+		}
 		return v[len(v)-1]
 	default:
 		return priv

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -248,7 +248,7 @@ func (inp *journald) Run(
 		}
 
 		event := entry.ToEvent()
-		if err := publisher.Publish(event, event.Private); err != nil {
+		if err := publisher.Publish(event, getCursorUpdate(event.Private)); err != nil {
 			msg := fmt.Sprintf("could not publish event: %s", err)
 			ctx.UpdateStatus(status.Failed, msg)
 			logger.Errorf("%s", msg)
@@ -275,6 +275,18 @@ func initCheckpoint(log *logp.Logger, c cursor.Cursor) checkpoint {
 	}
 
 	return cp
+}
+
+// getCursorUpdate returns the journald checkpoint to persist for a
+// published event. Multiline parsers aggregate per-line checkpoints in Private
+// as []any; the last entry is the furthest read position in the journal.
+func getCursorUpdate(priv any) any {
+	switch v := priv.(type) {
+	case []any:
+		return v[len(v)-1]
+	default:
+		return priv
+	}
 }
 
 // readerAdapter wraps journalread.Reader and adds two functionalities:

--- a/filebeat/input/journald/input_parsers_test.go
+++ b/filebeat/input/journald/input_parsers_test.go
@@ -175,3 +175,8 @@ func TestMultilineParserPreservesJournaldCheckpoint(t *testing.T) {
 	require.True(t, ok, "cursor update should be the last journal checkpoint")
 	require.Equal(t, wantCursor, cursorUpdate.Position)
 }
+
+func TestGetCursorUpdateEmptyPrivateSlice(t *testing.T) {
+	cursorUpdate := getCursorUpdate([]any{})
+	require.Nil(t, cursorUpdate, "empty aggregated Private values should not panic or produce a cursor update")
+}

--- a/filebeat/input/journald/input_parsers_test.go
+++ b/filebeat/input/journald/input_parsers_test.go
@@ -21,10 +21,19 @@ package journald
 
 import (
 	"context"
+	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalctl"
+	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalfield"
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/reader/parser"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/stretchr/testify/require"
 )
 
 // TestInputParsers ensures journald input support parsers,
@@ -100,4 +109,68 @@ func TestPartialMessageTag(t *testing.T) {
 	if tagsStrSlice[0] != "partial_message" {
 		t.Fatalf("expecting the tag 'partial_message', got %v instead", tagsStrSlice)
 	}
+}
+
+func TestMultilineParserPreservesJournaldCheckpoint(t *testing.T) {
+	const wantCursor = "cursor-from-last-line"
+	cursors := []string{"cursor-1", "cursor-2", wantCursor}
+	lines := []string{"line1", "line2", "line3"}
+	call := 0
+
+	mock := &journalReaderMock{
+		CloseFunc: func() error { return nil },
+		NextFunc: func(cancel v2.Canceler) (journalctl.JournalEntry, error) {
+			if call >= len(lines) {
+				return journalctl.JournalEntry{}, io.EOF
+			}
+			i := call
+			call++
+			now := time.Now()
+			return journalctl.JournalEntry{
+				Cursor:             cursors[i],
+				RealtimeTimestamp:  uint64(now.UnixMicro()),
+				MonotonicTimestamp: 42,
+				Fields:             map[string]any{"MESSAGE": lines[i]},
+			}, nil
+		},
+	}
+
+	ra := &readerAdapter{
+		r:         mock,
+		converter: journalfield.NewConverter(logp.NewNopLogger(), nil),
+		canceler:  t.Context(),
+	}
+
+	var parserCfg parser.Config
+	require.NoError(t, conf.MustNewConfigFrom(mapstr.M{
+		"parsers": []mapstr.M{
+			{
+				"multiline": mapstr.M{
+					"type":        "count",
+					"count_lines": 3,
+				},
+			},
+		},
+	}).Unpack(&parserCfg))
+
+	p := parserCfg.Create(ra, logp.NewNopLogger())
+	t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+	msg, err := p.Next()
+	require.NoError(t, err)
+	require.Equal(t, "line1\nline2\nline3", string(msg.Content))
+
+	privates, ok := msg.Private.([]any)
+	require.True(t, ok, "multiline output should aggregate Private values from each source line")
+	require.Len(t, privates, 3)
+
+	for i, want := range cursors {
+		cp, ok := privates[i].(checkpoint)
+		require.True(t, ok, "expected checkpoint at index %d", i)
+		require.Equal(t, want, cp.Position)
+	}
+
+	cursorUpdate, ok := getCursorUpdate(msg.Private).(checkpoint)
+	require.True(t, ok, "cursor update should be the last journal checkpoint")
+	require.Equal(t, wantCursor, cursorUpdate.Position)
 }

--- a/filebeat/input/journald/input_parsers_test.go
+++ b/filebeat/input/journald/input_parsers_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalctl"
 	"github.com/elastic/beats/v7/filebeat/input/journald/pkg/journalfield"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
@@ -33,7 +35,6 @@ import (
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
-	"github.com/stretchr/testify/require"
 )
 
 // TestInputParsers ensures journald input support parsers,

--- a/filebeat/input/kafka/input.go
+++ b/filebeat/input/kafka/input.go
@@ -113,9 +113,7 @@ func (input *kafkaInput) Run(ctx input.Context, pipeline beat.Pipeline) error {
 		EventListener: acker.ConnectionOnly(
 			acker.EventPrivateReporter(func(_ int, events []interface{}) {
 				for _, event := range events {
-					if meta, ok := event.(eventMeta); ok {
-						meta.ackHandler()
-					}
+					ackEventPrivate(event)
 				}
 			}),
 		),
@@ -221,6 +219,19 @@ func (input *kafkaInput) runConsumerGroup(log *logp.Logger, client beat.Client, 
 // been successfully sent.
 type eventMeta struct {
 	ackHandler func()
+}
+
+func ackEventPrivate(priv any) {
+	switch v := priv.(type) {
+	case eventMeta:
+		v.ackHandler()
+	case []any:
+		for _, el := range v {
+			if meta, ok := el.(eventMeta); ok {
+				meta.ackHandler()
+			}
+		}
+	}
 }
 
 func arrayForKafkaHeaders(headers []*sarama.RecordHeader) []string {

--- a/filebeat/input/kafka/input_test.go
+++ b/filebeat/input/kafka/input_test.go
@@ -22,6 +22,7 @@ package kafka
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
@@ -52,4 +53,29 @@ func AssertNotStartedInputCanBeDone(t *testing.T, configMap *conf.C) {
 
 	_, err = Plugin(logp.NewNopLogger()).Manager.Create(config)
 	require.NoError(t, err)
+}
+
+func TestAckEventPrivate(t *testing.T) {
+	var acked int
+	meta := eventMeta{ackHandler: func() { acked++ }}
+
+	ackEventPrivate(meta)
+	require.Equal(t, 1, acked)
+
+	// Ensure ackHandlers are called in order
+	ackedCh := make(chan int, 3)
+	ackEventPrivate([]any{
+		eventMeta{ackHandler: func() { ackedCh <- 0 }},
+		eventMeta{ackHandler: func() { ackedCh <- 1 }},
+		eventMeta{ackHandler: func() { ackedCh <- 2 }},
+	},
+	)
+
+	close(ackedCh)
+	require.Len(t, ackedCh, 3, "expecting exact 3 ack handlers to be called")
+
+	for i := range 3 {
+		ack := <-ackedCh
+		assert.Equal(t, i, ack, "expecting ack to be %d, got %d. The order or value is wrong", i, ack)
+	}
 }

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -107,7 +107,7 @@ func TestInput(t *testing.T) {
 			checkMatchingHeaders(t, event, msg.headers)
 
 			// emulating the pipeline (kafkaInput.Run)
-			ackEvents(event.Private)
+			ackEventPrivate(event.Private)
 		case <-timeout:
 			t.Fatal("timeout waiting for incoming events")
 		}
@@ -394,7 +394,7 @@ func TestSASLAuthentication(t *testing.T) {
 					checkMatchingHeaders(t, event, msg.headers)
 
 					// emulating the pipeline (kafkaInput.Run)
-					ackEvents(event.Private)
+					ackEventPrivate(event.Private)
 				case <-timeout:
 					t.Fatal("timeout waiting for incoming events")
 				}

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -107,11 +107,7 @@ func TestInput(t *testing.T) {
 			checkMatchingHeaders(t, event, msg.headers)
 
 			// emulating the pipeline (kafkaInput.Run)
-			meta, ok := event.Private.(eventMeta)
-			if !ok {
-				t.Fatal("could not get eventMeta and ack the message")
-			}
-			meta.ackHandler()
+			ackEvents(event.Private)
 		case <-timeout:
 			t.Fatal("timeout waiting for incoming events")
 		}
@@ -398,11 +394,7 @@ func TestSASLAuthentication(t *testing.T) {
 					checkMatchingHeaders(t, event, msg.headers)
 
 					// emulating the pipeline (kafkaInput.Run)
-					meta, ok := event.Private.(eventMeta)
-					if !ok {
-						t.Fatal("could not get eventMeta and ack the message")
-					}
-					meta.ackHandler()
+					ackEvents(event.Private)
 				case <-timeout:
 					t.Fatal("timeout waiting for incoming events")
 				}

--- a/libbeat/reader/multiline/message_buffer.go
+++ b/libbeat/reader/multiline/message_buffer.go
@@ -131,7 +131,12 @@ func (b *messageBuffer) finalize() reader.Message {
 	}
 
 	if len(b.privates) > 0 {
-		b.message.Private = append([]any(nil), b.privates...)
+		// Preserve the message.Private if multiline contains a single source message
+		if b.processedLines == 1 {
+			b.message.Private = b.privates[0]
+		} else {
+			b.message.Private = append([]any(nil), b.privates...)
+		}
 	}
 
 	// Copy message from existing content

--- a/libbeat/reader/multiline/message_buffer.go
+++ b/libbeat/reader/multiline/message_buffer.go
@@ -32,6 +32,7 @@ type messageBuffer struct {
 	truncated      int
 	err            error // last seen error
 	message        reader.Message
+	privates       []any
 }
 
 func newMessageBuffer(maxBytes, maxLines int, separator []byte, skipNewline bool) *messageBuffer {
@@ -67,6 +68,7 @@ func (b *messageBuffer) clear() {
 	b.processedLines = 0
 	b.truncated = 0
 	b.err = nil
+	b.privates = nil
 }
 
 // addLine adds the read content to the message
@@ -115,6 +117,7 @@ func (b *messageBuffer) addLine(m reader.Message) {
 	b.last = m.Content
 	b.message.Bytes += m.Bytes
 	b.message.AddFields(m.Fields)
+	b.privates = append(b.privates, m.Private)
 }
 
 // finalize writes the existing content into the returned message and resets all reader variables.
@@ -125,6 +128,10 @@ func (b *messageBuffer) finalize() reader.Message {
 
 	if b.numLines > 1 {
 		b.message.AddFlagsWithKey("log.flags", "multiline") //nolint:errcheck // It is safe to ignore the error.
+	}
+
+	if len(b.privates) > 0 {
+		b.message.Private = append([]any(nil), b.privates...)
 	}
 
 	// Copy message from existing content

--- a/libbeat/reader/multiline/message_buffer.go
+++ b/libbeat/reader/multiline/message_buffer.go
@@ -117,7 +117,9 @@ func (b *messageBuffer) addLine(m reader.Message) {
 	b.last = m.Content
 	b.message.Bytes += m.Bytes
 	b.message.AddFields(m.Fields)
-	b.privates = append(b.privates, m.Private)
+	if m.Private != nil {
+		b.privates = append(b.privates, m.Private)
+	}
 }
 
 // finalize writes the existing content into the returned message and resets all reader variables.

--- a/libbeat/reader/multiline/message_buffer_test.go
+++ b/libbeat/reader/multiline/message_buffer_test.go
@@ -69,13 +69,43 @@ func TestMessageBufferAddLine(t *testing.T) {
 }
 
 func TestMessageBufferPrivate(t *testing.T) {
-	buf := newMessageBuffer(1024, 5, []byte("\n"), false)
-	buf.addLine(reader.Message{Content: []byte("line1"), Bytes: 5, Private: "cursor-1"})
-	buf.addLine(reader.Message{Content: []byte("line2"), Bytes: 5, Private: "cursor-2"})
-	buf.addLine(reader.Message{Content: []byte("line3"), Bytes: 5, Private: "cursor-3"})
+	testcases := map[string]struct {
+		messages []reader.Message
+		expected any
+	}{
+		"preserves private value for one source message": {
+			messages: []reader.Message{
+				{Content: []byte("line1"), Bytes: 5, Private: "cursor-1"},
+			},
+			expected: "cursor-1",
+		},
+		"aggregates private values for multiple source messages": {
+			messages: []reader.Message{
+				{Content: []byte("line1"), Bytes: 5, Private: "cursor-1"},
+				{Content: []byte("line2"), Bytes: 5, Private: "cursor-2"},
+				{Content: []byte("line3"), Bytes: 5, Private: "cursor-3"},
+			},
+			expected: []any{"cursor-1", "cursor-2", "cursor-3"},
+		},
+	}
 
-	msg := buf.finalize()
-	assert.Equal(t, []any{"cursor-1", "cursor-2", "cursor-3"}, msg.Private)
+	for name, test := range testcases {
+		t.Run(name, func(t *testing.T) {
+			buf := newMessageBuffer(1024, 5, []byte("\n"), false)
+			for _, message := range test.messages {
+				buf.addLine(message)
+			}
+
+			msg := buf.finalize()
+			assert.Equal(
+				t,
+				test.expected,
+				msg.Private,
+				"Private should preserve scalar values for one source "+
+					"message and aggregate multiple source messages",
+			)
+		})
+	}
 }
 
 func TestFinalizeMessage(t *testing.T) {

--- a/libbeat/reader/multiline/message_buffer_test.go
+++ b/libbeat/reader/multiline/message_buffer_test.go
@@ -68,6 +68,16 @@ func TestMessageBufferAddLine(t *testing.T) {
 	}
 }
 
+func TestMessageBufferPrivate(t *testing.T) {
+	buf := newMessageBuffer(1024, 5, []byte("\n"), false)
+	buf.addLine(reader.Message{Content: []byte("line1"), Bytes: 5, Private: "cursor-1"})
+	buf.addLine(reader.Message{Content: []byte("line2"), Bytes: 5, Private: "cursor-2"})
+	buf.addLine(reader.Message{Content: []byte("line3"), Bytes: 5, Private: "cursor-3"})
+
+	msg := buf.finalize()
+	assert.Equal(t, []any{"cursor-1", "cursor-2", "cursor-3"}, msg.Private)
+}
+
 func TestFinalizeMessage(t *testing.T) {
 	testcases := map[string]struct {
 		maxBytes int

--- a/libbeat/reader/multiline/message_buffer_test.go
+++ b/libbeat/reader/multiline/message_buffer_test.go
@@ -73,6 +73,13 @@ func TestMessageBufferPrivate(t *testing.T) {
 		messages []reader.Message
 		expected any
 	}{
+		"preserves nil private value when no source message sets it": {
+			messages: []reader.Message{
+				{Content: []byte("line1"), Bytes: 5},
+				{Content: []byte("line2"), Bytes: 5},
+			},
+			expected: nil,
+		},
 		"preserves private value for one source message": {
 			messages: []reader.Message{
 				{Content: []byte("line1"), Bytes: 5, Private: "cursor-1"},


### PR DESCRIPTION
## Proposed commit message

```
The Journald and Kafka inputs use Message.Private to carry their cursor update. The Multiline parser ignored this field when aggregating messages, causing those inputs to not update their cursor for those events.

This commit fixes it by aggregating all Message.Private into a []any that populates the Message.Private of the aggregated message.

The Journald and Kafka inputs are updated to handle multiline events cursor updates correctly.

Assisted-By: Composer 2.5
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

~~## Disruptive User Impact~~

## How to test this PR locally

### Run the tests

```sh
go test -race -v -count=1 -run=TestMultilineParserPreservesJournaldCheckpoint ./filebeat/input/journald
go test -race -v -count=1 -run=TestAckEventPrivate ./filebeat/input/kafka
go test -race -v -count=1 -run=TestMessageBufferPrivate ./libbeat/reader/multiline
```

### Manual test

#### 1. Generate some Journald data

Create the following script called `num.sh`
```bash
#!/usr/bin/bash

count=0

while true; do
    printf '%04d\n' "$count"
    count=$(( (count + 1) % 10000 ))
    sleep 1
done
```

Then run it sending the output to the Journal
```sh
./num.sh | systemd-cat -t bar
```

#### 2. Start Filebeat with multiline
Using the following configuration file start Filebeat

<details><summary>filebeat.yml</summary>
<p>

```yaml
filebeat.inputs:
  - type: journald
    id: test-multiline
    seek: tail
    include_matches:
      match:
        - SYSLOG_IDENTIFIER=bar
    parsers:
      - multiline:
          type: count
          count_lines: 2

queue.mem:
  flush:
    timeout: 0s

output.console:
  enabled: true
```

</p>
</details> 

```sh
./filebeat
```

You'll start seeing the events in the terminal

#### 3. Look at the registry upadtes

Tail the registry operations log:
```
tail -F data/registry/filebeat/log.json | jq -S
```

You'll start seeing registry updates like:
```json
{
  "id": 53,
  "op": "set"
}
{
  "k": "journald::service-multiline::LOCAL_SYSTEM_JOURNAL",
  "v": {
    "cursor": {
      "monotonictimestamp": 25546223740,
      "position": "s=c21a4bb99b384aeab41b6d5874e37988;i=8285f;b=7cd30dac1a1f424186a2696de8a967e4;m=5f2ac707c;t=6579ecf4f9fbb;x=6db7d87a85e406e",
      "realtimetimestamp": 1785189454815163,
      "version": 1
    },
    "ttl": 1800000000000,
    "updated": [
      280444356490567,
      1785189455
    ]
  }
}
{
  "id": 54,
  "op": "set"
}
{
  "k": "journald::service-multiline::LOCAL_SYSTEM_JOURNAL",
  "v": {
    "cursor": {
      "monotonictimestamp": 25548226461,
      "position": "s=c21a4bb99b384aeab41b6d5874e37988;i=82861;b=7cd30dac1a1f424186a2696de8a967e4;m=5f2caff9d;t=6579ecf6e2edc;x=557dba4e6c820e24",
      "realtimetimestamp": 1785189456817884,
      "version": 1
    },
    "ttl": 1800000000000,
    "updated": [
      280444356322680,
      1785189457
    ]
  }
}
```

Observe that `cursor` is always populated.


## Related issues

- Fixes https://github.com/elastic/beats/issues/51981


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
