### PR TITLE
filebeat/input/net: prevent shutdown hangs with blocked outputs

### DIFF
--- a/changelog/fragments/1785228000-fix-net-input-shutdown-hang.yaml
+++ b/changelog/fragments/1785228000-fix-net-input-shutdown-hang.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix TCP and UDP inputs hanging during shutdown
+component: filebeat

--- a/filebeat/input/net/nettest/net.go
+++ b/filebeat/input/net/nettest/net.go
@@ -36,7 +36,13 @@ import (
 // A new line ('\n') is added at the end of each entry.
 // There is a 100ms delay between sends, errors are logged, but not retried.
 func RunUDPClient(t *testing.T, address string, data []string) {
-	conn, err := net.Dial("udp", address)
+	RunUDPClientWithDelay(t, address, data, 100*time.Millisecond)
+}
+
+// RunUDPClientWithDelay is RunUDPClient with a configurable delay between sends.
+func RunUDPClientWithDelay(t *testing.T, address string, data []string, delay time.Duration) {
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "udp", address)
 	if err != nil {
 		t.Errorf("cannot create connection: %s", err)
 	}
@@ -47,10 +53,10 @@ func RunUDPClient(t *testing.T, address string, data []string) {
 		_, err = conn.Write([]byte(data + "\n"))
 		if err != nil {
 			t.Logf("Error sending data: %s, skipping to next entry", err)
-			time.Sleep(time.Second)
+			time.Sleep(10 * delay)
 			continue
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(delay)
 	}
 }
 
@@ -59,6 +65,11 @@ func RunUDPClient(t *testing.T, address string, data []string) {
 // A new line ('\n') is added at the end of each entry.
 // There is a 100ms delay between sends. Failing to send will fail the test
 func RunTCPClient(t *testing.T, address string, data []string) {
+	RunTCPClientWithDelay(t, address, data, 100*time.Millisecond)
+}
+
+// RunTCPClientWithDelay is RunTCPClient with a configurable delay between sends.
+func RunTCPClientWithDelay(t *testing.T, address string, data []string, delay time.Duration) {
 	var conn net.Conn
 	var err error
 
@@ -69,7 +80,8 @@ FOR:
 	for {
 		select {
 		case <-ticker:
-			conn, err = net.Dial("tcp", address)
+			var dialer net.Dialer
+			conn, err = dialer.DialContext(t.Context(), "tcp", address)
 			if err == nil {
 				break FOR
 			}
@@ -88,7 +100,7 @@ FOR:
 			t.Errorf("Failed to send data: %s", err)
 			return
 		}
-		time.Sleep(100 * time.Millisecond) // Simulate delay between messages
+		time.Sleep(delay) // Simulate delay between messages
 	}
 }
 
@@ -113,7 +125,11 @@ func GetHTTPInputMetrics(t *testing.T, inputID, addr string) NetInputMetrics {
 		t.Fatalf("cannot parse URL: %s", err)
 	}
 
-	data, err := http.Get(fullURL)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fullURL, nil)
+	if err != nil {
+		t.Fatalf("cannot create metrics request: %s", err)
+	}
+	data, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("cannot fetch metrics: %s", err)
 	}

--- a/filebeat/input/net/tcp/input.go
+++ b/filebeat/input/net/tcp/input.go
@@ -129,10 +129,13 @@ func (s *server) Run(ctx input.Context, evtChan chan<- netinput.DataMetadata, m 
 						"truncated", metadata.Truncated)
 				}
 
-				evtChan <- netinput.DataMetadata{
+				select {
+				case evtChan <- netinput.DataMetadata{
 					Data:      data,
 					Metadata:  metadata,
 					Timestamp: now,
+				}:
+				case <-ctx.Cancelation.Done():
 				}
 			},
 			split,

--- a/filebeat/input/net/tcp/input_test.go
+++ b/filebeat/input/net/tcp/input_test.go
@@ -32,8 +32,9 @@ import (
 	netinput "github.com/elastic/beats/v7/filebeat/input/net"
 	"github.com/elastic/beats/v7/filebeat/input/net/nettest"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	"github.com/stretchr/testify/assert"
@@ -58,7 +59,7 @@ func TestInput(t *testing.T) {
 	v2Ctx := v2.Context{
 		ID:              t.Name(),
 		Cancelation:     ctx,
-		Logger:          logp.NewNopLogger(),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}
 
@@ -100,6 +101,53 @@ func TestInput(t *testing.T) {
 	}
 }
 
+func TestInputStopsWhenPipelineIsBlocked(t *testing.T) {
+	goroutines := resources.NewGoroutinesChecker()
+	defer goroutines.Check(t)
+
+	serverAddr := ephemeralTCPAddr(t)
+	inp, err := configure(conf.MustNewConfigFrom(map[string]any{
+		"host": serverAddr,
+	}))
+	if err != nil {
+		t.Fatalf("cannot create input: %s", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	v2Ctx := v2.Context{
+		ID:              t.Name(),
+		Cancelation:     ctx,
+		Logger:          logptest.NewTestingLogger(t, ""),
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+
+	metrics := inp.InitMetrics("tcp", v2Ctx.MetricsRegistry, v2Ctx.Logger)
+	c := make(chan netinput.DataMetadata)
+
+	runReturned := make(chan struct{})
+	go func() {
+		defer close(runReturned)
+		if err := inp.Run(v2Ctx, c, metrics); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("input exited with error: %s", err)
+			}
+		}
+	}()
+
+	nettest.RunTCPClient(t, serverAddr, []string{"foo", "bar"})
+
+	nettest.RequireNetMetricsCount(t, v2Ctx.MetricsRegistry, 30*time.Second, 1, 0, 3)
+
+	cancel()
+
+	select {
+	case <-runReturned:
+	case <-t.Context().Done():
+		t.Fatal("input Run did not return before the test context was cancelled")
+	}
+}
+
 func BenchmarkInput(b *testing.B) {
 	serverAddr := ephemeralTCPAddr(b)
 
@@ -116,7 +164,7 @@ func BenchmarkInput(b *testing.B) {
 	v2Ctx := v2.Context{
 		ID:              b.Name(),
 		Cancelation:     ctx,
-		Logger:          logp.NewNopLogger(),
+		Logger:          logptest.NewTestingLogger(b, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}
 

--- a/filebeat/input/net/tcp/input_test.go
+++ b/filebeat/input/net/tcp/input_test.go
@@ -34,6 +34,7 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
@@ -118,7 +119,7 @@ func TestInputStopsWhenPipelineIsBlocked(t *testing.T) {
 	v2Ctx := v2.Context{
 		ID:              t.Name(),
 		Cancelation:     ctx,
-		Logger:          logptest.NewTestingLogger(t, ""),
+		Logger:          logp.NewNopLogger(),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}
 

--- a/filebeat/input/net/udp/input.go
+++ b/filebeat/input/net/udp/input.go
@@ -92,6 +92,7 @@ func (s *server) Test(_ input.TestContext) error {
 }
 
 func (s *server) InitMetrics(id string, reg *monitoring.Registry, logger *logp.Logger) netinput.Metrics {
+	//nolint:gosec // read_buffer is a byte size, never negative
 	s.metrics = netmetrics.NewUDP(reg, s.Host, uint64(s.ReadBuffer), time.Second, logger)
 	return s.metrics
 }
@@ -116,10 +117,13 @@ func (s *server) Run(ctx input.Context, evtChan chan<- netinput.DataMetadata, me
 			"remote_address", remoteAddr,
 			"truncated", metadata.Truncated)
 
-		evtChan <- netinput.DataMetadata{
+		select {
+		case evtChan <- netinput.DataMetadata{
 			Data:      data,
 			Metadata:  metadata,
 			Timestamp: now,
+		}:
+		case <-ctx.Cancelation.Done():
 		}
 	}, logger)
 

--- a/filebeat/input/net/udp/input_test.go
+++ b/filebeat/input/net/udp/input_test.go
@@ -30,11 +30,13 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/zaptest/observer"
+
 	netinput "github.com/elastic/beats/v7/filebeat/input/net"
 	"github.com/elastic/beats/v7/filebeat/input/net/nettest"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
@@ -61,7 +63,7 @@ func TestInput(t *testing.T) {
 	v2Ctx := v2.Context{
 		ID:              t.Name(),
 		Cancelation:     ctx,
-		Logger:          logp.NewNopLogger(),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}
 
@@ -107,6 +109,75 @@ func TestInput(t *testing.T) {
 	}
 }
 
+func waitForUDPServerAddress(t *testing.T, observedLogs *observer.ObservedLogs) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	for {
+		const listenLogPrefix = "Started listening for UDP connection on: "
+		for _, entry := range observedLogs.FilterMessageSnippet(listenLogPrefix).All() {
+			if addr, ok := strings.CutPrefix(entry.Message, listenLogPrefix); ok {
+				return addr
+			}
+		}
+
+		err := ctx.Err()
+		if err != nil {
+			t.Fatalf("UDP server did not log its listening address: %s", ctx.Err())
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func TestInputStopsWhenPipelineIsBlocked(t *testing.T) {
+	serverAddr := "127.0.0.1:0"
+	inp, err := configure(conf.MustNewConfigFrom(map[string]any{
+		"host": serverAddr,
+	}))
+	if err != nil {
+		t.Fatalf("cannot create input: %s", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	logger, observedLogs := logptest.NewTestingLoggerWithObserver(t, "")
+	v2Ctx := v2.Context{
+		ID:              t.Name(),
+		Cancelation:     ctx,
+		Logger:          logger,
+		MetricsRegistry: monitoring.NewRegistry(),
+	}
+
+	metrics := inp.InitMetrics("udp", v2Ctx.MetricsRegistry, v2Ctx.Logger)
+	c := make(chan netinput.DataMetadata)
+
+	runReturned := make(chan struct{})
+	go func() {
+		defer close(runReturned)
+		if err := inp.Run(v2Ctx, c, metrics); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("input exited with error: %s", err)
+			}
+		}
+	}()
+
+	serverAddr = waitForUDPServerAddress(t, observedLogs)
+
+	nettest.RunUDPClient(t, serverAddr, []string{"foo", "bar", "baz"})
+
+	// Wait until at least one datagram was received
+	nettest.RequireNetMetricsCount(t, v2Ctx.MetricsRegistry, 30*time.Second, 1, 0, 4)
+
+	cancel()
+
+	select {
+	case <-runReturned:
+	case <-t.Context().Done():
+		t.Fatal("input Run did not return before the test context was cancelled")
+	}
+}
+
 // TestInputOversizedDatagram sends a datagram larger than max_message_size and
 // checks the input keeps running. On Windows an oversized read returns a nil
 // RemoteAddr, which used to panic the input while formatting the debug log
@@ -127,7 +198,7 @@ func TestInputOversizedDatagram(t *testing.T) {
 	v2Ctx := v2.Context{
 		ID:              t.Name(),
 		Cancelation:     ctx,
-		Logger:          logp.NewNopLogger(),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}
 

--- a/filebeat/input/netmetrics/netmetrics.go
+++ b/filebeat/input/netmetrics/netmetrics.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
@@ -135,7 +136,10 @@ type netMetrics struct {
 	arrivalPeriod   metrics.Sample     // histogram of the elapsed time between packet arrivals
 	processingTime  metrics.Sample     // histogram of the elapsed time between packet receipt and publication
 	eventsPublished *monitoring.Uint   // number of events published
-	lastPacket      time.Time
+
+	// lastPacketMu guards lastPacket: EventReceived is called concurrently.
+	lastPacketMu sync.Mutex
+	lastPacket   time.Time
 }
 
 func newNetMetrics(reg *monitoring.Registry) netMetrics {
@@ -162,14 +166,15 @@ func (n *netMetrics) EventReceived(len int, timestamp time.Time) {
 		return
 	}
 
+	n.lastPacketMu.Lock()
 	if !n.lastPacket.IsZero() {
 		n.arrivalPeriod.Update(timestamp.Sub(n.lastPacket).Nanoseconds())
 	}
-
 	n.lastPacket = timestamp
+	n.lastPacketMu.Unlock()
 
 	n.packets.Add(1)
-	n.bytes.Add(uint64(len)) // nolint:gosec // length is never negative
+	n.bytes.Add(uint64(len)) //nolint:gosec // length is never negative
 }
 
 // EventPublished updates all metrics related to published events.
@@ -185,23 +190,23 @@ func (n *netMetrics) EventPublished(start time.Time) {
 }
 
 // Registry returns the monitoring registry of the metricset.
-func (m *netMetrics) Registry() *monitoring.Registry {
-	if m == nil {
+func (n *netMetrics) Registry() *monitoring.Registry {
+	if n == nil {
 		return nil
 	}
 
-	return m.monitorRegistry
+	return n.monitorRegistry
 }
 
 // Close closes the metricset and unregister the metrics.
-func (m *netMetrics) Close() {
-	if m == nil {
+func (n *netMetrics) Close() {
+	if n == nil {
 		return
 	}
-	if m.done != nil {
+	if n.done != nil {
 		// Shut down poller and wait until done before unregistering metrics.
-		m.done <- struct{}{}
+		n.done <- struct{}{}
 	}
 
-	m.monitorRegistry = nil
+	n.monitorRegistry = nil
 }

--- a/filebeat/tests/integration/netInputs_test.go
+++ b/filebeat/tests/integration/netInputs_test.go
@@ -58,9 +58,10 @@ func TestNetInputs(t *testing.T) {
 				"../../filebeat.test",
 			)
 
-			// DO NOT USE 'localhost', the UDP client does work when using it.
-			addr := "127.0.0.1:4242"
-			cfg := getConfig(t, map[string]any{"addr": addr}, "netInputs", tc.cfgFile)
+			cfg := getConfig(t, map[string]any{
+				"addr":     "127.0.0.1:0",
+				"httpPort": 0,
+			}, "netInputs", tc.cfgFile)
 
 			filebeat.WriteConfigFile(cfg)
 			filebeat.Start()
@@ -72,6 +73,7 @@ func TestNetInputs(t *testing.T) {
 				20*time.Second,
 				"not all workers have started",
 			)
+			addr := fmt.Sprintf("127.0.0.1:%d", filebeat.SocketListeningPort(30*time.Second))
 
 			tc.runClientFn(t, addr, tc.data)
 
@@ -96,21 +98,21 @@ func TestNetInputsCanReadWithBlockedOutput(t *testing.T) {
 		events      int
 		expectedInQ int
 		numWorkers  int
-		runClientFn func(t *testing.T, addr string, data []string)
+		runClientFn func(*testing.T, string, []string, time.Duration)
 	}{
 		"TCP": {
 			cfgFile:     "es.yml",
 			input:       "tcp",
 			events:      500, // That needs to be more than can be published
 			numWorkers:  5,
-			runClientFn: nettest.RunTCPClient,
+			runClientFn: nettest.RunTCPClientWithDelay,
 		},
 		"UDP": {
 			cfgFile:     "es.yml",
 			input:       "udp",
 			events:      500, // That needs to be more than can be published
 			numWorkers:  5,
-			runClientFn: nettest.RunUDPClient,
+			runClientFn: nettest.RunUDPClientWithDelay,
 		},
 	}
 	for name, tc := range testCases {
@@ -138,14 +140,13 @@ func TestNetInputsCanReadWithBlockedOutput(t *testing.T) {
 			proxy, proxyURL := integration.NewDisablingProxy(t, esAddr)
 			proxy.Disable()
 
-			// DO NOT USE 'localhost', the UDP client does work when using it.
-			addr := "127.0.0.1:4242"
 			cfg := getConfig(t, map[string]any{
 				"id":         id,
 				"input":      tc.input,
-				"addr":       addr,
+				"addr":       "127.0.0.1:0",
 				"esHost":     proxyURL,
 				"numWorkers": tc.numWorkers,
+				"httpPort":   0,
 			}, "netInputs", tc.cfgFile)
 
 			filebeat.WriteConfigFile(cfg)
@@ -155,8 +156,10 @@ func TestNetInputsCanReadWithBlockedOutput(t *testing.T) {
 				5*time.Second,
 				"not all workers have started",
 			)
+			addr := fmt.Sprintf("127.0.0.1:%d", filebeat.SocketListeningPort(30*time.Second))
+			httpPort := filebeat.MonitoringPort(30 * time.Second)
 
-			tc.runClientFn(t, addr, data)
+			tc.runClientFn(t, addr, data, 5*time.Millisecond)
 
 			// Ensure the events are in the publishing pipeline.
 			// The events are logged when they enter the publishing pipeline.
@@ -171,7 +174,7 @@ func TestNetInputsCanReadWithBlockedOutput(t *testing.T) {
 				time.Second,
 				"cannot find output error in the logs")
 
-			m := nettest.GetHTTPInputMetrics(t, id.String(), "http://127.0.0.1:5066")
+			m := nettest.GetHTTPInputMetrics(t, id.String(), fmt.Sprintf("http://127.0.0.1:%d", httpPort))
 
 			// The number of events published is equal to the queue size
 			expectPublished := 32

--- a/filebeat/tests/integration/testdata/netInputs/es.yml
+++ b/filebeat/tests/integration/testdata/netInputs/es.yml
@@ -20,7 +20,7 @@ queue.mem:
 
 http:
   enabled: true
-  port: 5066
+  port: {{.httpPort}}
 
 logging:
   level: debug

--- a/filebeat/tests/integration/testdata/netInputs/tcp.yml
+++ b/filebeat/tests/integration/testdata/netInputs/tcp.yml
@@ -15,7 +15,7 @@ queue.mem:
 
 http:
   enabled: true
-  port: 5066
+  port: {{.httpPort}}
 
 logging:
   level: debug

--- a/filebeat/tests/integration/testdata/netInputs/udp.yml
+++ b/filebeat/tests/integration/testdata/netInputs/udp.yml
@@ -15,7 +15,7 @@ queue.mem:
 
 http:
   enabled: true
-  port: 5066
+  port: {{.httpPort}}
 
 logging:
   level: debug


### PR DESCRIPTION
## Proposed commit message

```text
Prevent TCP and UDP read handlers from blocking forever while sending
to the publishing channel after cancellation. Publishing workers stop
without draining this channel when outputs are blocked and the memory
queue is full, so network handlers must abandon pending data during
shutdown.

Pending data is discarded only after cancellation. Additionally, protect
concurrent last-packet metric updates made by TCP connection handlers.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

The input regression tests exercise cancellation while the event channel is blocked:

```bash
cd filebeat
go test -v -race -run '^TestInputStopsWhenPipelineIsBlocked$' ./input/net/tcp ./input/net/udp
```

The integration tests exercise normal delivery and shutdown with a saturated pipeline:

```bash
cd filebeat
go test -v -race -tags integration -run '^TestNetInputs(CanReadWithBlockedOutput)?$' ./tests/integration
```

The regression tests were also run for five minutes each with the race detector, producing 6,580 TCP runs, 6,977 UDP runs, and 23 integration runs with zero failures:

```bash
timeout 5m script/stresstest.sh --race ./filebeat/input/net/tcp '^TestInputStopsWhenPipelineIsBlocked$' -p 32 -failfast
timeout 5m script/stresstest.sh --race ./filebeat/input/net/udp '^TestInputStopsWhenPipelineIsBlocked$' -p 32 -failfast
timeout 5m script/stresstest.sh --tags integration --race ./filebeat/tests/integration '^TestNetInputsCanReadWithBlockedOutput$' -p 1 -failfast
```

## Related issues

- Closes https://github.com/elastic/beats/issues/51487 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/51488 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/52082 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/52083 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/52084 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/52132 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/52133 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/52134 ([filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804))
- Closes https://github.com/elastic/beats/issues/52006 ([filebeat build 34604](https://buildkite.com/elastic/filebeat/builds/34604))
- Closes https://github.com/elastic/beats/issues/52007 ([filebeat build 34604](https://buildkite.com/elastic/filebeat/builds/34604))
- Closes https://github.com/elastic/beats/issues/52008 ([filebeat build 34604](https://buildkite.com/elastic/filebeat/builds/34604))

## Logs

Root-cause evidence from two failing CI runs ([filebeat build 34604](https://buildkite.com/elastic/filebeat/builds/34604) and [filebeat build 34804](https://buildkite.com/elastic/filebeat/builds/34804)). Both suites died on the package timeout while the UDP subtest was stuck in `Stop()`:

```text
panic: test timed out after 15m0s
	running tests:
		TestNetInputsCanReadWithBlockedOutput (4m40s)
		TestNetInputsCanReadWithBlockedOutput/UDP (3m49s)

goroutine ... [chan receive, 4 minutes]:
os/exec.(*Cmd).Wait(...)
github.com/elastic/beats/v7/libbeat/tests/integration.(*BeatProc).stopNonsynced.func1()
	libbeat/tests/integration/framework.go:326
github.com/elastic/beats/v7/filebeat/tests/integration.TestNetInputsCanReadWithBlockedOutput.func1(...)
	filebeat/tests/integration/netInputs_test.go:202
```

The hung Filebeat's log shows the input never finished stopping: all publish workers exited after the watchdog force-disconnected the pipeline, leaving the UDP read handler blocked in the channel send with no receiver, and the process kept running until killed ~3 minutes later:

```text
04:27:33.203 info Received signal "interrupt", stopping
04:27:33.203 info Stopping input: 6952597339350344616
04:27:35.204 warn Beater did not return within 2s of being told to stop; forcing publisher pipeline disconnect
04:27:35.204 debug [Worker 0] finished publish loop
04:27:35.204 debug [Worker 1] finished publish loop
04:27:35.204 debug [Worker 2] finished publish loop
04:27:35.204 debug [Worker 3] finished publish loop
04:27:35.204 debug [Worker 4] finished publish loop
04:27:42.832 info Non-zero metrics in the last 30s   <- keeps running, never exits
```

The July 16 failure stack shows the three filestream tests in #52006, #52007, and #52008 still blocked in `testing.(*T).Parallel`; the July 21 stack shows the same state for the six filestream tests in #52082, #52083, #52084, #52132, #52133, and #52134. In each run, the UDP shutdown hang consumed the package timeout before those parallel tests started.
