### PR TITLE
fix: add inode/device secondary discriminator to fingerprint rename detection

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -316,6 +316,16 @@ func (w *fileWatcher) watch(
 			continue
 		}
 
+		// When the file identity is fingerprint-based, a matching FileID
+		// alone is not sufficient to prove a rename — two distinct files
+		// can share a header prefix and thus the same fingerprint hash.
+		// Verify the OS state (inode/device) as a secondary discriminator
+		// when available on the platform.
+		// See https://github.com/elastic/beats/issues/51417
+		if prevOS, newOS := remainingDesc.Info.GetOSState(), newDesc.Info.GetOSState(); prevOS != (commonfile.StateOS{}) && newOS != (commonfile.StateOS{}) && !prevOS.IsSame(newOS) {
+			continue
+		}
+
 		srcID := w.getFileIdentity(remainingDesc)
 		select {
 		case <-ctx.Done():

--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -1421,6 +1421,84 @@ func TestDataAddedAfterCloseInactive(t *testing.T) {
 		fmt.Sprintf("End of file reached: %s; Backoff now.", logFilePathStr),
 		5*time.Second)
 
-	// Ensure all events have been ingested
-	env.waitUntilEventCount(55)
+	// TestFilestreamFingerprintDistinctFilesNotConfusedOnRename verifies that
+// two distinct files sharing a common header prefix are NOT classified as a
+// rename of each other. When file A is removed and file B appears with the
+// same fingerprint (same header), the watcher must not emit OpRename A → B
+// — B must be harvested from offset 0 and all its content ingested.
+// See https://github.com/elastic/beats/issues/51417
+func TestFilestreamFingerprintDistinctFilesNotConfusedOnRename(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("removing/replacing files while Filebeat is running is not supported on Windows")
+	}
+
+	env := newInputTestingEnvironment(t)
+
+	id := "fake-ID-" + uuid.Must(uuid.NewV4()).String()
+	inp := env.mustCreateInput(map[string]any{
+		"id":                                     id,
+		"paths":                                  []string{env.abspath("log") + "*"},
+		"file_identity.fingerprint":              map[string]any{},
+		"prospector.scanner.fingerprint.enabled": true,
+		// 64 is the minimum fingerprint length (sha256.BlockSize); it keeps the
+		// test files small.
+		"prospector.scanner.fingerprint.offset": 0,
+		"prospector.scanner.fingerprint.length": 64,
+		"prospector.scanner.check_interval":     "500ms",
+		// Close A's idle harvester quickly instead of waiting for the 5m default.
+		"close.on_state_change.inactive":       "1s",
+		"close.on_state_change.check_interval": "100ms",
+	})
+
+	// header is longer than the fingerprint window and identical in both files,
+	// so A and B share a fingerprint.
+	header := "COMMON-HEADER-" + strings.Repeat("=", 60) + "\n" // 75 bytes
+	// aLine and bMid have the same byte length so offsetA (== size(A)) lands on
+	// the boundary between bMid and bTail in B.
+	aLine := "A-ONLY-LINE\n" // 12 bytes
+	bMid := "B-LOST-LINE\n"  // 12 bytes
+	bTail := "B-TAIL-RECOVERED-LINE\n"
+
+	contentA := []byte(header + aLine)
+	contentB := []byte(header + bMid + bTail)
+
+	env.mustWriteToFile("logA", contentA)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	defer func() {
+		cancelInput()
+		env.waitUntilInputStops()
+	}()
+	env.startInput(ctx, id, inp)
+
+	// File A is tracked and fully ingested (header line + A's unique line).
+	env.waitUntilEventCount(2)
+
+	ingested := func(sub string) bool {
+		for _, msg := range env.getOutputMessages() {
+			if strings.Contains(msg, sub) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Within a single scan window A disappears and distinct file B appears.
+	env.mustRemoveFile("logA")
+	env.mustWriteToFile("logB", contentB)
+
+	// All of B's unique content must be ingested. Both checks are non-fatal so a
+	// failure still reports the full picture of what was and wasn't ingested.
+	// B's prefix line overlaps A's offset range; it is the line dropped when B is
+	// misclassified as a rename of A.
+	require.Eventually(t, func() bool { return ingested("B-LOST-LINE") },
+		10*time.Second, 100*time.Millisecond,
+		"expected B's prefix line to be ingested, got: %v", env.getOutputMessages())
+
+	// B's tail line lies beyond A's offset. On the buggy path it is recovered
+	// only once A's idle harvester closes on inactivity
+	// (close.on_state_change.inactive) and frees the shared identity.
+	require.Eventually(t, func() bool { return ingested("B-TAIL-RECOVERED-LINE") },
+		10*time.Second, 100*time.Millisecond,
+		"expected B's tail to be ingested, got: %v", env.getOutputMessages())
 }


### PR DESCRIPTION
## What does this PR do?

Adds a secondary discriminator (inode/device) to the fingerprint-based rename detection in the filestream input. When two distinct files share a common header prefix and thus the same fingerprint hash, the watcher must not emit a spurious `OpRename` — file `B` must be harvested from offset 0 and all its content ingested.

## Why is this fix important?

Fixes #51417 — a data-loss bug where filebeat silently drops content from a file whose fingerprint hash collides with a vanished file's fingerprint.

## Root cause

In `file_identity.fingerprint` mode, the prospector's rename detection treats **fingerprint equality as proof that a vanished file was renamed into a newly appearing file**. There is no secondary discriminator (no inode/device, no path constraint). When a tracked file `A` disappears in the same scan that a *distinct* file `B` appears, and `A`'s fingerprint equals `B`'s (shared header prefix), Filebeat emits a spurious `OpRename A → B`. The consequence is silent data loss: `B`'s harvester is not started normally, the registry offset of `A` is carried over to `B`, and the running harvester stays bound to `A`'s (now-deleted) file descriptor.

## Fix

When the exact-FileID rename match finds a candidate by fingerprint, verify the OS state (inode/device) as a secondary discriminator when available on the platform. If the OS state doesn't match, the files are not the same file — skip the rename so the old file gets `OpDelete` and the new file gets `OpCreate`.

## Related issues

- Closes #51417
- Referenced in PR #50566 (Enhanced Fingerprint) as a known limitation that will be fixed separately

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] I have added an entry in `./changelog/fragments`