### PR TITLE
filebeat: wait for expected events to be searchable in module tests

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -296,6 +296,11 @@ class Test(BaseTest):
         self.wait_until(lambda: self.es.indices.exists(index=self.index_name),
                         name="indices present for {}".format(test_file))
 
+        # The index existing does not mean every event is searchable yet, so
+        # wait for the expected documents before querying. Otherwise the
+        # comparison below races ingestion and sees a partial result.
+        self._wait_for_indexed_events(test_file)
+
         self.es.indices.refresh(index=self.index_name)
         # Loads the first 100 events to be checked
         res = self.es.search(index=self.index_name, query={"match_all": {}},
@@ -340,6 +345,29 @@ class Test(BaseTest):
             if proc.poll() is None:
                 proc.kill()
             proc.wait()
+
+    def _wait_for_indexed_events(self, test_file):
+        """Wait for the expected number of events to become searchable.
+
+        Filebeat having exited (--once) or having been stopped only guarantees
+        that every event was published and acknowledged, not that Elasticsearch
+        has finished making all of them searchable.
+        """
+        expected = self._expected_event_count(test_file)
+        if expected is None:
+            # No golden file to count, or running with GENERATE: nothing to
+            # wait for, keep the previous behaviour.
+            return
+
+        deadline = time.monotonic() + MODULE_INGEST_TIMEOUT
+        count = self._indexed_event_count()
+        while count < expected and time.monotonic() < deadline:
+            time.sleep(0.5)
+            count = self._indexed_event_count()
+
+        assert count >= expected, \
+            "expected {} events indexed for {} but only {} were indexed after {}s".format(
+                expected, test_file, count, MODULE_INGEST_TIMEOUT)
 
     def _expected_event_count(self, test_file):
         if os.getenv("GENERATE"):


### PR DESCRIPTION
## Proposed commit message

`test_modules.py` searches Elasticsearch for a fileset's events as soon as Filebeat has exited (`--once`) or has been stopped. Filebeat exiting only guarantees that every event was published and acknowledged, not that Elasticsearch has finished making them all searchable, so the query can observe a partial result and the count comparison in `_test_expected_events` fails with e.g. `expected 8 events to compare but got 7`.

The non-`--once` branch (journald, filestream) already polls `_indexed_event_count()` against `_expected_event_count()` via `_wait_for_events_then_stop`, but the `--once` branch has no equivalent synchronization: it waits only for the index to *exist* before refreshing and searching, and index existence can precede the completion of indexing.

This adds `_wait_for_indexed_events`, which polls the indexed document count up to the expected count, bounded by the existing `MODULE_INGEST_TIMEOUT`, and calls it for every input type right after the index-existence check. When no expected count is available (no golden file, or `GENERATE` is set) the wait is skipped, preserving the current behaviour. If the documents never arrive, the assertion now names both counts, which distinguishes "events were never ingested" from a golden-file comparison mismatch.

### Why this is an indexing race

The partial counts in the reported failures are arbitrary rather than consistently short by one — 7 of 8 and 2 of 4 for iis, 2 of 3 for mysql, 11 of 15 for auditd — which is the signature of reading while indexing is still in progress rather than of a parser bug or a stale golden file. In each case the golden file and the input fixture agree (e.g. `iis/error/test/iis_error_url.log` has exactly 8 lines and its golden has exactly 8 entries), and every one of them is on the `--once` path.

The failures became noticeably more frequent after the module fileset tests were parallelized across pytest-xdist workers (#51794): the workers now contend for a single Elasticsearch, which widens the window between Filebeat exiting and all of its documents becoming searchable.

This is also the fix recommended by the automated triage analysis on #52272.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `./changelog/fragments`~~ — test-only change, no user-facing impact

## How to test this PR locally

The change is exercised by the existing module fileset tests, on both branches of the input selection:

```
# --once path (the one being fixed)
cd filebeat && mage pythonIntegTest

# non---once path, to confirm the added wait is a no-op when
# _wait_for_events_then_stop already polled
cd filebeat && mage pythonIntegTestLogAsFilestream
```

The helper itself was verified against a stubbed Elasticsearch client covering: all documents already searchable (returns immediately, no polling), partial then complete (the flake — now passes), more documents than expected (does not hang), never complete (bounded wait, then an assertion naming both counts), no golden file, and `GENERATE` mode.

`autopep8 -d --max-line-length 120` reports no diff.

## Related issues

- Closes #52228
- Closes #52272
- Closes #52294
- Closes #52188

Note that #52311 (`test_fileset_file_071_system`) is **not** fixed by this change: it is a field-comparison failure on a `.journal` fixture, which is a different problem on the already-polling code path.
