### PR TITLE
Restore ingest-dev version-bump triggers to main after dry-run testing

### DIFF
--- a/.buildkite/version-bump-pipeline.yml
+++ b/.buildkite/version-bump-pipeline.yml
@@ -27,14 +27,13 @@ steps:
     label: ":rocket: Trigger ingest-dev minor/major release"
     if: build.env("WORKFLOW") == "minor" || build.env("WORKFLOW") == "major"
     build:
-      branch: "refs/pull/8918/head"
+      branch: "main"
       message: "Version bump beats to ${NEW_VERSION} (${WORKFLOW})"
       env:
         REPOSITORY: "beats"
         RELEASE_TYPE: "${WORKFLOW}"
         CURRENT_RELEASE: "${NEW_VERSION}"
         DISABLE_DEV_ISSUE: "true"
-        DRY_RUN: "true"
         REVIEWERS: "elastic/elastic-agent-release"
 
   - trigger: ingest-dev-pipeline-release-patch
@@ -42,13 +41,12 @@ steps:
     label: ":rocket: Trigger ingest-dev patch release"
     if: build.env("WORKFLOW") == "patch"
     build:
-      branch: "refs/pull/8918/head"
+      branch: "main"
       message: "Version bump beats to ${NEW_VERSION} (patch)"
       env:
         REPOSITORY: "beats"
         CURRENT_RELEASE: "${NEW_VERSION}"
         DISABLE_DEV_ISSUE: "true"
-        DRY_RUN: "true"
         REVIEWERS: "elastic/elastic-agent-release"
 
   - block: "Ready to fetch for DRA artifacts?"


### PR DESCRIPTION
## Summary

- Restore ingest-dev version-bump triggers to `branch: "main"` after successful integration testing against ingest-dev PR 8918
- Remove temporary `DRY_RUN: "true"` overrides so production bumps run for real

## Test plan

- [ ] Confirm trigger `build.branch` is `main` for minor/major and patch steps
- [ ] Confirm `DRY_RUN` is absent from trigger env
- [ ] Spot-check that a dry pipeline parse / review matches elastic-agent and fleet-server production contract

Related issue: https://github.com/elastic/observability-robots/issues/3404
