### PR TITLE
filebeat: stop module fileset tests from deleting each other's ingest pipelines

### DIFF
--- a/filebeat/conftest.py
+++ b/filebeat/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 
 import pytest
@@ -12,17 +13,45 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../libbeat/tests/system
 # current serial semantics (fixed ports, shared fixtures, etc.).
 _PARALLEL_SAFE_TESTS = ("test_modules.py", "test_xpack_modules.py")
 
+# parameterized.expand names each fileset case after its position and its first
+# parameter, the module: ``test_fileset_file_025_postgresql``. The fileset is
+# not part of the name, so the module is the finest key available here.
+_FILESET_CASE = re.compile(r"test_fileset_file_\d+_([a-z0-9]+)")
+
+
+def _fileset_group(nodeid):
+    """Return the xdist group for a module fileset test, None if unrecognized."""
+    match = _FILESET_CASE.search(nodeid)
+    if match is None:
+        return None
+    return "module-" + match.group(1)
+
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     """
-    Pin every non-module system test to a single xdist worker.
+    Assign xdist groups so parallel workers cannot corrupt each other's state.
 
     When the suite runs in parallel (``-n`` with ``--dist loadgroup``), tests
     sharing an ``xdist_group`` are guaranteed to run on the same worker.
-    Assigning all non-module tests to one shared group keeps them serial (as
-    today) while leaving the module fileset tests free to distribute across
-    workers. Without pytest-xdist this hook is a no-op.
+    Without pytest-xdist this hook is a no-op.
+
+    Non-module tests all share one group, keeping their existing serial
+    semantics (fixed ports, shared fixtures, etc.).
+
+    Module fileset tests get one group per module. A worker's Elasticsearch
+    index is its own, but a module's ingest pipelines are cluster-global and
+    every test case starts a Filebeat that loads them. That is safe when the
+    loads succeed, since they are idempotent PUTs, but ``LoadPipelines``
+    (filebeat/fileset/pipelines.go) rolls back on a failed load by *deleting*
+    the pipelines it loaded. A transient failure in one worker therefore
+    deletes pipelines a concurrent worker is actively ingesting through,
+    which surfaces as either "Pipeline processor configured for non-existent
+    pipeline [...]" on the indexed documents or, when the deleted pipeline is
+    the fileset's entry point, as events that never get indexed at all and a
+    test that times out waiting for its index to appear. Confining a module to
+    one worker serializes those loads and removes the race. Different modules
+    still run in parallel, which is where the bulk of the speedup comes from.
 
     ``tryfirst`` is required: pytest-xdist's worker turns the ``xdist_group``
     marker into the ``@group`` nodeid suffix it schedules on from its own
@@ -37,5 +66,10 @@ def pytest_collection_modifyitems(config, items):
         return
     for item in items:
         if any(name in item.nodeid for name in _PARALLEL_SAFE_TESTS):
+            # Fall back to the serial group for anything in a module test file
+            # that is not a recognized fileset case: sharing pipelines across
+            # workers is the hazard, so an unknown case must not run free.
+            item.add_marker(pytest.mark.xdist_group(
+                _fileset_group(item.nodeid) or "serial"))
             continue
         item.add_marker(pytest.mark.xdist_group("serial"))

--- a/x-pack/filebeat/conftest.py
+++ b/x-pack/filebeat/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 
 import pytest
@@ -14,17 +15,45 @@ sys.path.append(os.path.join(os.path.dirname(__file__), './tests/system'))
 # current serial semantics (fixed ports, shared fixtures, etc.).
 _PARALLEL_SAFE_TESTS = ("test_modules.py", "test_xpack_modules.py")
 
+# parameterized.expand names each fileset case after its position and its first
+# parameter, the module: ``test_fileset_file_025_postgresql``. The fileset is
+# not part of the name, so the module is the finest key available here.
+_FILESET_CASE = re.compile(r"test_fileset_file_\d+_([a-z0-9]+)")
+
+
+def _fileset_group(nodeid):
+    """Return the xdist group for a module fileset test, None if unrecognized."""
+    match = _FILESET_CASE.search(nodeid)
+    if match is None:
+        return None
+    return "module-" + match.group(1)
+
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     """
-    Pin every non-module system test to a single xdist worker.
+    Assign xdist groups so parallel workers cannot corrupt each other's state.
 
     When the suite runs in parallel (``-n`` with ``--dist loadgroup``), tests
     sharing an ``xdist_group`` are guaranteed to run on the same worker.
-    Assigning all non-module tests to one shared group keeps them serial (as
-    today) while leaving the module fileset tests free to distribute across
-    workers. Without pytest-xdist this hook is a no-op.
+    Without pytest-xdist this hook is a no-op.
+
+    Non-module tests all share one group, keeping their existing serial
+    semantics (fixed ports, shared fixtures, etc.).
+
+    Module fileset tests get one group per module. A worker's Elasticsearch
+    index is its own, but a module's ingest pipelines are cluster-global and
+    every test case starts a Filebeat that loads them. That is safe when the
+    loads succeed, since they are idempotent PUTs, but ``LoadPipelines``
+    (filebeat/fileset/pipelines.go) rolls back on a failed load by *deleting*
+    the pipelines it loaded. A transient failure in one worker therefore
+    deletes pipelines a concurrent worker is actively ingesting through,
+    which surfaces as either "Pipeline processor configured for non-existent
+    pipeline [...]" on the indexed documents or, when the deleted pipeline is
+    the fileset's entry point, as events that never get indexed at all and a
+    test that times out waiting for its index to appear. Confining a module to
+    one worker serializes those loads and removes the race. Different modules
+    still run in parallel, which is where the bulk of the speedup comes from.
 
     ``tryfirst`` is required: pytest-xdist's worker turns the ``xdist_group``
     marker into the ``@group`` nodeid suffix it schedules on from its own
@@ -39,5 +68,10 @@ def pytest_collection_modifyitems(config, items):
         return
     for item in items:
         if any(name in item.nodeid for name in _PARALLEL_SAFE_TESTS):
+            # Fall back to the serial group for anything in a module test file
+            # that is not a recognized fileset case: sharing pipelines across
+            # workers is the hazard, so an unknown case must not run free.
+            item.add_marker(pytest.mark.xdist_group(
+                _fileset_group(item.nodeid) or "serial"))
             continue
         item.add_marker(pytest.mark.xdist_group("serial"))


### PR DESCRIPTION
## Proposed commit message

The module fileset tests were left ungrouped so pytest-xdist could spread them across workers, on the reasoning that each worker uses its own Elasticsearch index. That holds for indices, but a module's ingest pipelines are cluster-global, and every fileset test case starts a Filebeat that loads them.

Concurrent loads are normally harmless, since they are idempotent PUTs, but LoadPipelines (filebeat/fileset/pipelines.go) rolls back a partially loaded fileset by deleting the pipelines it just loaded. When two workers run test cases for the same module at once, a transient load failure in one deletes pipelines the other is actively ingesting through.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability. (fixes tests)
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Fixes CI