### PR TITLE
[text-auditor] Batch fix clear user-facing typo/grammar strings in runtime and

### DIFF
--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -427,7 +427,7 @@ func (r *msgRef) fail(msg *message, err error) {
 
 	// drop event if it exceeds size larger than max_message_bytes
 	case strings.Contains(err.Error(), "Attempt to produce message larger than configured Producer.MaxMessageBytes"):
-		r.client.log.Errorf("Kafka (topic=%v): dropping message as it exceeds max_mesage_bytes:", msg.topic)
+		r.client.log.Errorf("Kafka (topic=%v): dropping message as it exceeds max_message_bytes:", msg.topic)
 		r.client.observer.PermanentErrors(1)
 
 	case isAuthError(err):


### PR DESCRIPTION
## Proposed commit message

This PR fixes the documentation issue reported in #52333: corrects `max_mesage_bytes` to `max_message_bytes` in `libbeat/outputs/kafka/client.go`.

Fixes #52333

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

## How to test this PR locally

## Related issues

-

## Use cases

## Screenshots

## Logs

Fixes #52333