### PR TITLE
libbeat/common: add map[string]string fast path in event normalization

### DIFF
--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -166,14 +166,14 @@ func (e *GenericEventConverter) normalizeValue(value any, keys ...string) (any, 
 		value = times
 	}
 
-	switch value.(type) {
+	switch v := value.(type) {
 	case encoding.TextMarshaler:
-		if reflect.ValueOf(value).Kind() == reflect.Pointer && reflect.ValueOf(value).IsNil() {
+		if reflect.ValueOf(v).Kind() == reflect.Pointer && reflect.ValueOf(v).IsNil() {
 			return nil, nil
 		}
-		text, err := value.(encoding.TextMarshaler).MarshalText()
+		text, err := v.MarshalText()
 		if err != nil {
-			return nil, []error{fmt.Errorf("key=%v: error converting %T to string: %w", joinKeys(keys...), value, err)}
+			return nil, []error{fmt.Errorf("key=%v: error converting %T to string: %w", joinKeys(keys...), v, err)}
 		}
 		return string(text), nil
 	case string, []string:
@@ -182,24 +182,23 @@ func (e *GenericEventConverter) normalizeValue(value any, keys ...string) (any, 
 	case []int, []int8, []int16, []int32, []int64:
 	case uint, uint8, uint16, uint32:
 	case uint64:
-		return value.(uint64) &^ (1 << 63), nil
+		return v &^ (1 << 63), nil
 	case []uint, []uint8, []uint16, []uint32:
 	case []uint64:
-		arr := value.([]uint64)
 		mask := false
-		for _, v := range arr {
-			if v >= (1 << 63) {
+		for _, u := range v {
+			if u >= (1 << 63) {
 				mask = true
 				break
 			}
 		}
 		if !mask {
-			return value, nil
+			return v, nil
 		}
 
-		tmp := make([]uint64, len(arr))
-		for i, v := range arr {
-			tmp[i] = v &^ (1 << 63)
+		tmp := make([]uint64, len(v))
+		for i, u := range v {
+			tmp[i] = u &^ (1 << 63)
 		}
 		return tmp, nil
 
@@ -209,45 +208,51 @@ func (e *GenericEventConverter) normalizeValue(value any, keys ...string) (any, 
 	case []complex64, []complex128:
 	case Time, []Time:
 	case mapstr.M:
-		return e.normalizeMap(value.(mapstr.M), keys...)
+		return e.normalizeMap(v, keys...)
 	case []mapstr.M:
-		return e.normalizeMapStrSlice(value.([]mapstr.M), keys...)
+		return e.normalizeMapStrSlice(v, keys...)
 	case map[string]any:
-		return e.normalizeMap(value.(map[string]any), keys...)
+		return e.normalizeMap(v, keys...)
 	case []map[string]any:
-		return e.normalizeMapStringSlice(value.([]map[string]any), keys...)
+		return e.normalizeMapStringSlice(v, keys...)
+	case map[string]string:
+		out := make(mapstr.M, len(v))
+		for key, s := range v {
+			out[key] = s
+		}
+		return out, nil
 	default:
-		v := reflect.ValueOf(value)
+		rv := reflect.ValueOf(v)
 
-		switch v.Type().Kind() {
+		switch rv.Type().Kind() {
 		case reflect.Pointer:
 			// Dereference pointers.
-			return e.normalizeValue(followPointer(value), keys...)
+			return e.normalizeValue(followPointer(v), keys...)
 		case reflect.Bool:
-			return v.Bool(), nil
+			return rv.Bool(), nil
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return v.Int(), nil
+			return rv.Int(), nil
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return v.Uint() &^ (1 << 63), nil
+			return rv.Uint() &^ (1 << 63), nil
 		case reflect.Float32, reflect.Float64:
-			return v.Float(), nil
+			return rv.Float(), nil
 		case reflect.Complex64, reflect.Complex128:
-			return v.Complex(), nil
+			return rv.Complex(), nil
 		case reflect.String:
-			return v.String(), nil
+			return rv.String(), nil
 		case reflect.Array, reflect.Slice:
-			return e.normalizeSlice(v, keys...)
+			return e.normalizeSlice(rv, keys...)
 		case reflect.Map, reflect.Struct:
 			var m mapstr.M
-			err := marshalUnmarshal(value, &m)
+			err := marshalUnmarshal(v, &m)
 			if err != nil {
-				return m, []error{fmt.Errorf("key=%v: error converting %T to mapstr.M: %w", joinKeys(keys...), value, err)}
+				return m, []error{fmt.Errorf("key=%v: error converting %T to mapstr.M: %w", joinKeys(keys...), v, err)}
 			}
 			return m, nil
 		default:
 			// Drop Uintptr, UnsafePointer, Chan, Func, Interface, and any other
 			// types not specifically handled above.
-			return nil, []error{fmt.Errorf("key=%v: error unsupported type=%T value=%#v", joinKeys(keys...), value, value)}
+			return nil, []error{fmt.Errorf("key=%v: error unsupported type=%T value=%#v", joinKeys(keys...), v, v)}
 		}
 	}
 

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -296,11 +296,11 @@ func TestNormalizeValue(t *testing.T) {
 		"uint64 masked":                     {uint64(1<<63 + 10), uint64(10)},
 		"string value":                      {"hello", "hello"},
 		"map to mapstr.M":                   {map[string]any{"foo": "bar"}, mapstr.M{"foo": "bar"}},
+		"map[string]string to mapstr.M":     {map[string]string{"foo": "bar"}, mapstr.M{"foo": "bar"}},
 
 		// Other map types are converted using marshalUnmarshal which will lose
 		// type information for arrays which become []interface{} and numbers
 		// which all become float64.
-		"map[string]string to mapstr.M":   {map[string]string{"foo": "bar"}, mapstr.M{"foo": "bar"}},
 		"map[string][]string to mapstr.M": {map[string][]string{"list": {"foo", "bar"}}, mapstr.M{"list": []any{"foo", "bar"}}},
 
 		"array of strings":         {[]string{"foo", "bar"}, []string{"foo", "bar"}},
@@ -421,15 +421,15 @@ func TestNormalizeTime(t *testing.T) {
 // Uses TextMarshaler interface.
 func BenchmarkConvertToGenericEventNetString(b *testing.B) {
 	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		g.Convert(mapstr.M{"key": NetString("hola")})
 	}
 }
 
-// Uses reflection.
+// Uses the map[string]string fast path.
 func BenchmarkConvertToGenericEventMapStringString(b *testing.B) {
 	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		g.Convert(mapstr.M{"key": map[string]string{"greeting": "hola"}})
 	}
 }
@@ -437,7 +437,7 @@ func BenchmarkConvertToGenericEventMapStringString(b *testing.B) {
 // Uses recursion to step into the nested mapstr.M.
 func BenchmarkConvertToGenericEventMapStr(b *testing.B) {
 	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		g.Convert(mapstr.M{"key": map[string]any{"greeting": "hola"}})
 	}
 }
@@ -445,7 +445,7 @@ func BenchmarkConvertToGenericEventMapStr(b *testing.B) {
 // No reflection required.
 func BenchmarkConvertToGenericEventStringSlice(b *testing.B) {
 	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		g.Convert(mapstr.M{"key": []string{"foo", "bar"}})
 	}
 }
@@ -454,7 +454,7 @@ func BenchmarkConvertToGenericEventStringSlice(b *testing.B) {
 func BenchmarkConvertToGenericEventCustomStringSlice(b *testing.B) {
 	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
 	type myString string
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		g.Convert(mapstr.M{"key": []myString{"foo", "bar"}})
 	}
 }
@@ -463,7 +463,7 @@ func BenchmarkConvertToGenericEventCustomStringSlice(b *testing.B) {
 func BenchmarkConvertToGenericEventStringPointer(b *testing.B) {
 	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
 	val := "foo"
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		g.Convert(mapstr.M{"key": &val})
 	}
 }


### PR DESCRIPTION
## Proposed commit message

```
normalizeValue converted map[string]string via the reflection fallback,
which round-trips the map through a JSON marshal/unmarshal to normalize
its types. String keys and values are already in their normalized form,
and converting a map[string]string to a mapstr.M forces a fresh map
allocation regardless, so copying the entries directly carries no
ownership hazard and no behavior change.

Add an explicit map[string]string case to normalizeValue that copies the
entries into a presized mapstr.M, mirroring the existing map[string]any
handling. Output is identical to the previous JSON round-trip.

benchstat (BenchmarkConvertToGenericEventMapStringString, n=10):

                                        │     old      │                 new                 │
                                        │    sec/op    │   sec/op     vs base                │
ConvertToGenericEventMapStringString-14   1084.5n ± 4%   440.7n ± 5%  -59.36% (p=0.000 n=10)

                                        │     old      │                 new                  │
                                        │     B/op     │     B/op      vs base                │
ConvertToGenericEventMapStringString-14   1.634Ki ± 0%   1.328Ki ± 0%  -18.71% (p=0.000 n=10)

                                        │     old     │                new                 │
                                        │  allocs/op  │ allocs/op   vs base                │
ConvertToGenericEventMapStringString-14   20.000 ± 0%   9.000 ± 0%  -55.00% (p=0.000 n=10)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

```bash
cd libbeat/common
go test -run 'TestNormalizeValue' -count=1 ./...
go test -run '^$' -bench '^BenchmarkConvertToGenericEventMapStringString$' -benchmem -count=10 ./...
```

## Related issues

- Closes #50167
