### PR TITLE
memqueue: fix data race in TestFlushSettingsBlockPartialBatches

### DIFF
--- a/libbeat/publisher/queue/memqueue/runloop_test.go
+++ b/libbeat/publisher/queue/memqueue/runloop_test.go
@@ -53,16 +53,11 @@ func TestFlushSettingsDoNotBlockFullBatches(t *testing.T) {
 
 	producer := newProducer(broker, nil, nil)
 	rl := broker.runLoop
-	// iterLock is used to ensure distinct runIteration calls can never overlap
 	iterLock := sync.Mutex{}
 	for i := range 100 {
 		// Pair each publish call with an iteration of the run loop so we
 		// get a response.
-		go func() {
-			iterLock.Lock()
-			rl.runIteration()
-			iterLock.Unlock()
-		}()
+		go runIterationLocked(rl, &iterLock)
 		_, ok := producer.Publish(i)
 		require.True(t, ok, "Queue publish call must succeed")
 	}
@@ -76,11 +71,8 @@ func TestFlushSettingsDoNotBlockFullBatches(t *testing.T) {
 		// there's a logical error.
 		_, _ = broker.Get(100)
 	}()
-	// Still have to lock here even though we aren't running asynchronously,
-	// since it's possible that the last asynchronous call is still running.
-	iterLock.Lock()
-	rl.runIteration()
-	iterLock.Unlock()
+	// Lock: the last asynchronous iteration above may still be running.
+	runIterationLocked(rl, &iterLock)
 	assert.Nil(t, rl.pendingGetRequest, "Queue should have no pending get request since the request should succeed immediately")
 	assert.Equal(t, 100, rl.consumedCount, "Queue should have a consumedCount of 100 after a consumer requested all its events")
 }
@@ -102,10 +94,11 @@ func TestFlushSettingsBlockPartialBatches(t *testing.T) {
 
 	producer := newProducer(broker, nil, nil)
 	rl := broker.runLoop
+	iterLock := sync.Mutex{}
 	for range 100 {
 		// Pair each publish call with an iteration of the run loop so we
 		// get a response.
-		go rl.runIteration()
+		go runIterationLocked(rl, &iterLock)
 		_, ok := producer.Publish("some event")
 		require.True(t, ok, "Queue publish call must succeed")
 	}
@@ -117,7 +110,8 @@ func TestFlushSettingsBlockPartialBatches(t *testing.T) {
 		// there's a logical error.
 		_, _ = broker.Get(101)
 	}()
-	rl.runIteration()
+	// Lock: the last asynchronous iteration above may still be running.
+	runIterationLocked(rl, &iterLock)
 	assert.NotNil(t, rl.pendingGetRequest, "Queue should have a pending get request since the queue doesn't have the requested event count")
 	assert.Equal(t, 0, rl.consumedCount, "Queue should have a consumedCount of 0 since the Get request couldn't be completely filled")
 
@@ -125,6 +119,7 @@ func TestFlushSettingsBlockPartialBatches(t *testing.T) {
 	go func() {
 		_, _ = producer.Publish("some event")
 	}()
+	// No lock needed: the asynchronous iterations above have all finished.
 	rl.runIteration()
 	assert.Nil(t, rl.pendingGetRequest, "Queue should have no pending get request since adding an event should unblock the previous one")
 	assert.Equal(t, 101, rl.consumedCount, "Queue should have a consumedCount of 101 after adding an event unblocked the pending get request")
@@ -229,6 +224,12 @@ func TestObserverRemoveEvents(t *testing.T) {
 	// It should have deleted 25 events, so we expect the size to be 25 * 123.
 	assertRegistryUint(t, reg, "queue.removed.events", deleteCount, "Deleting from the queue should report the removed events")
 	assertRegistryUint(t, reg, "queue.removed.bytes", deleteCount*123, "Deleting from the queue should report the removed bytes")
+}
+
+func runIterationLocked[T any](rl *runLoop[T], lock *sync.Mutex) {
+	lock.Lock()
+	defer lock.Unlock()
+	rl.runIteration()
 }
 
 func assertRegistryUint(t *testing.T, reg *monitoring.Registry, key string, expected uint64, message string) {


### PR DESCRIPTION
## Proposed commit message

```
runLoop is single-goroutine by design, but the test drove runIteration
from 100 goroutines with no synchronization between them.

Serialize the iterations with a mutex, matching the fix already applied
to the sibling TestFlushSettingsDoNotBlockFullBatches in #45033.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Test-only change; `skip-changelog` applied.

## Disruptive User Impact

None.

## How to test this PR locally

```bash
timeout 3m script/stresstest.sh --race ./libbeat/publisher/queue/memqueue "^TestFlushSettingsBlockPartialBatches$" -p 16
```

## Related issues

- Relates https://github.com/elastic/beats/pull/45033

## Logs

Race report before the fix:

```
==================
WARNING: DATA RACE
Previous write at 0x00c0000c0538 by goroutine 109:
  memqueue.(*runLoop[...]).handleInsert() runloop.go:239
  memqueue.(*runLoop[...]).runIteration() runloop.go:147
  memqueue.TestFlushSettingsBlockPartialBatches.gowrap1() runloop_test.go:108
Goroutine 109 (finished) ...
==================
--- FAIL: TestFlushSettingsBlockPartialBatches (0.00s)
    testing.go:1712: race detected during execution of test
FAIL
```

After the fix, stress-tested clean:

```
2m55s: 2752 runs so far, 0 failures, 16 active
```
