### PR TITLE
dev-tools/mage: stop silently dropping -race when RACE_DETECTOR=true

### DIFF
--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -105,7 +105,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, fmt.Errorf("failed to unpack the auditd config: %w", err)
 	}
 
-	log := logp.NewLogger(moduleName)
+	log := base.Logger()
 	_, _, kernel, _ := kernelVersion()
 	log.Infof("auditd module is running as euid=%v on kernel=%v", os.Geteuid(), kernel)
 
@@ -396,7 +396,7 @@ func (ms *MetricSet) setPID(retries int) (err error) {
 	}
 
 	// run the SetPID logic in a retry loop, since the startup process can be fragile.
-	for i := 0; i < retries; i++ {
+	for range retries {
 		// This call will block on send, which isn't great, but the reply can *also* time out
 		// or return something like ENOBUFS.
 		err = ms.client.SetPID(libaudit.WaitForReply)
@@ -411,7 +411,7 @@ func (ms *MetricSet) setPID(retries int) (err error) {
 			// the netlink connection is losing data. Try to drain and send again.
 			// This is technically dropping data, but auditbeat is configured as best-effort anyway, and we'll drop events under high load anyway.
 			maxRecv := 10000
-			for i := 0; i < maxRecv; i++ {
+			for range maxRecv {
 				var retryOuter bool // hack because of how switch/break statements work
 				_, err = ms.client.Netlink.Receive(true, noParse)
 				switch {
@@ -968,7 +968,7 @@ func kernelVersion() (major, minor int, full string, err error) {
 			length = i
 			break
 		}
-		data[i] = byte(v)
+		data[i] = byte(v) //nolint:gosec // G115: kernel release uses ASCII bytes before the NUL terminator
 	}
 
 	release := string(data[:length])

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -181,14 +181,6 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 		return
 	}
 
-	if ms.config.Immutable && status.Enabled != auditLocked {
-		if err := ms.client.SetImmutable(libaudit.WaitForReply); err != nil {
-			reporter.Error(err)
-			ms.log.Errorw("Failure setting audit config as immutable", "error", err)
-			return
-		}
-	}
-
 	if ms.kernelLost.enabled {
 		client, err := libaudit.NewAuditClient(nil)
 		if err != nil {
@@ -388,6 +380,12 @@ func (ms *MetricSet) initClient() error {
 			return fmt.Errorf("failed to set audit PID. An audit process is already running (PID %d)", status.PID)
 		}
 		return fmt.Errorf("failed to set audit PID (current audit PID %d): %w", status.PID, err)
+	}
+
+	if ms.config.Immutable && status.Enabled != auditLocked {
+		if err := ms.client.SetImmutable(libaudit.WaitForReply); err != nil {
+			return fmt.Errorf("failed to set audit config as immutable: %w", err)
+		}
 	}
 	return nil
 }

--- a/auditbeat/module/file_integrity/kprobes/path.go
+++ b/auditbeat/module/file_integrity/kprobes/path.go
@@ -268,7 +268,8 @@ func (traverser *pTraverser) waitForWalk(ctx context.Context) error {
 		return nil
 	}
 
-	traverser.waitQueueChan = make(chan struct{})
+	waitQueueChan := make(chan struct{})
+	traverser.waitQueueChan = waitQueueChan
 	traverser.mtx.Unlock()
 
 	select {
@@ -279,7 +280,7 @@ func (traverser *pTraverser) waitForWalk(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	// statQueue is empty
-	case <-traverser.waitQueueChan:
+	case <-waitQueueChan:
 		return nil
 	// timeout
 	case <-time.After(traverser.sMatchTimeout):

--- a/auditbeat/module/file_integrity/kprobes/path_test.go
+++ b/auditbeat/module/file_integrity/kprobes/path_test.go
@@ -38,12 +38,12 @@ func Test_PathTraverser_newPathMonitor(t *testing.T) {
 
 	pTrav, err := newPathMonitor(ctx, newFixedThreadExecutor(ctx), 0, true)
 	require.NoError(t, err)
-	require.Equal(t, pTrav.sMatchTimeout, 5*time.Second)
+	require.Equal(t, 5*time.Second, pTrav.sMatchTimeout)
 	require.NoError(t, pTrav.Close())
 
 	pTrav, err = newPathMonitor(ctx, newFixedThreadExecutor(ctx), 2*time.Second, true)
 	require.NoError(t, err)
-	require.Equal(t, pTrav.sMatchTimeout, 2*time.Second)
+	require.Equal(t, 2*time.Second, pTrav.sMatchTimeout)
 	require.NoError(t, pTrav.Close())
 }
 
@@ -124,7 +124,7 @@ func (p *pathTestSuite) TestRecursiveWalkAsync() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -134,10 +134,12 @@ func (p *pathTestSuite) TestRecursiveWalkAsync() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -245,7 +247,7 @@ func (p *pathTestSuite) TestNonRecursiveWalkAsync() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -255,10 +257,12 @@ func (p *pathTestSuite) TestNonRecursiveWalkAsync() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -330,15 +334,13 @@ func (p *pathTestSuite) TestAddTraverserContextCancel() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for {
@@ -375,15 +377,13 @@ func (p *pathTestSuite) TestAddTimeout() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	select {
 	case err = <-errChan:
@@ -426,7 +426,7 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -436,10 +436,12 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -459,15 +461,13 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {
@@ -533,7 +533,7 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -543,10 +543,12 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -566,15 +568,13 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {
@@ -676,7 +676,11 @@ func (p *pathTraverserMock) AddPathToMonitor(ctx context.Context, path string) e
 
 func (p *pathTraverserMock) GetMonitorPath(ino uint64, major uint32, minor uint32, name string) (MonitorPath, bool) {
 	args := p.Called(ino, major, minor, name)
-	return args.Get(0).(MonitorPath), args.Bool(1)
+	mPath, ok := args.Get(0).(MonitorPath)
+	if !ok {
+		panic("unexpected mock return type for MonitorPath")
+	}
+	return mPath, args.Bool(1)
 }
 
 func (p *pathTraverserMock) WalkAsync(path string, depth uint32, tid uint32) {
@@ -685,7 +689,11 @@ func (p *pathTraverserMock) WalkAsync(path string, depth uint32, tid uint32) {
 
 func (p *pathTraverserMock) ErrC() <-chan error {
 	args := p.Called()
-	return args.Get(0).(<-chan error)
+	errC, ok := args.Get(0).(<-chan error)
+	if !ok {
+		panic("unexpected mock return type for ErrC")
+	}
+	return errC
 }
 
 func (p *pathTraverserMock) Close() error {

--- a/auditbeat/module/file_integrity/kprobes/path_test.go
+++ b/auditbeat/module/file_integrity/kprobes/path_test.go
@@ -51,6 +51,12 @@ type pathTestSuite struct {
 	suite.Suite
 }
 
+func (p *pathTestSuite) requireEmptyStatQueue(trav *pTraverser) {
+	trav.mtx.RLock()
+	defer trav.mtx.RUnlock()
+	p.Require().Empty(trav.statQueue, "statQueue should be empty after walk completes")
+}
+
 func Test_PathTraverser(t *testing.T) {
 	suite.Run(t, new(pathTestSuite))
 }
@@ -186,7 +192,7 @@ func (p *pathTestSuite) TestRecursiveWalkAsync() {
 	}
 
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestWalkAsyncTimeoutErr() {
@@ -307,7 +313,7 @@ func (p *pathTestSuite) TestNonRecursiveWalkAsync() {
 	}
 
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestAddTraverserContextCancel() {
@@ -339,7 +345,10 @@ func (p *pathTestSuite) TestAddTraverserContextCancel() {
 		if tries >= 4 {
 			p.Require().Fail("no path was added in 5 tries")
 		}
-		if len(pTrav.statQueue) == 0 {
+		pTrav.mtx.RLock()
+		statQueueEmpty := len(pTrav.statQueue) == 0
+		pTrav.mtx.RUnlock()
+		if statQueueEmpty {
 			tries++
 			time.Sleep(1 * time.Second)
 			continue
@@ -490,7 +499,7 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 	err = <-errChan
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestNonRecursiveAdd() {
@@ -597,7 +606,7 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 	err = <-errChan
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestStatErrAtRootAdd() {

--- a/changelog/fragments/1785512000-fix-kubernetes-leader-election-race.yaml
+++ b/changelog/fragments/1785512000-fix-kubernetes-leader-election-race.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Fix a leader election data race and wait for lease release on shutdown.
+
+component: libbeat

--- a/changelog/fragments/1785512500-fix-auditd-setimmutable-race.yaml
+++ b/changelog/fragments/1785512500-fix-auditd-setimmutable-race.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Set audit immutable config before starting the event receive loop to avoid concurrent netlink reads.
+
+component: auditbeat

--- a/changelog/fragments/1785513000-fix-kprobes-path-traverser-race.yaml
+++ b/changelog/fragments/1785513000-fix-kprobes-path-traverser-race.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Synchronize kprobes path traverser wait-for-ack signaling between walk and event consumer.
+
+component: auditbeat

--- a/changelog/fragments/1785513000-fix-synthexec-jsonreader-race.yaml
+++ b/changelog/fragments/1785513000-fix-synthexec-jsonreader-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix a race closing the synthetics JSON pipe before the child process is started
+component: heartbeat

--- a/changelog/fragments/1785513100-fix-packetbeat-sniffer-cancel-race.yaml
+++ b/changelog/fragments/1785513100-fix-packetbeat-sniffer-cancel-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix data race between packetbeat sniffer Run and Stop
+component: packetbeat

--- a/changelog/fragments/1785513200-fix-packetbeat-npcap-install-race.yaml
+++ b/changelog/fragments/1785513200-fix-packetbeat-npcap-install-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Install Npcap at most once so concurrent packetbeat receivers do not race on it
+component: packetbeat

--- a/changelog/fragments/1785520000-fix-etw-flexible-array-bounds.yaml
+++ b/changelog/fragments/1785520000-fix-etw-flexible-array-bounds.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Bound ETW flexible array reads to the enumeration buffer instead of using unchecked pointer arithmetic
+component: libbeat

--- a/changelog/fragments/1785520100-fix-pdh-string-conversion-bounds.yaml
+++ b/changelog/fragments/1785520100-fix-pdh-string-conversion-bounds.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix truncated Windows performance counter lists when a counter path contains characters outside the basic multilingual plane
+component: metricbeat

--- a/changelog/fragments/1785520200-fix-pdh-wildcard-expansion-retry.yaml
+++ b/changelog/fragments/1785520200-fix-pdh-wildcard-expansion-retry.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Return the retried counter path expansion instead of the unexpanded wildcard when the Windows PDH API needs a second call
+component: metricbeat

--- a/dev-tools/mage/gotest.go
+++ b/dev-tools/mage/gotest.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -359,6 +360,21 @@ func InstallGoTestTools() error {
 	)
 }
 
+// raceDetectorArgs returns the "go test" flags for a race-detector request.
+// DEV_OS/DEV_ARCH default to the host so CI, which sets only RACE_DETECTOR,
+// still runs -race; an unsupported platform errors instead of silently skipping.
+func raceDetectorArgs(race bool) ([]string, error) {
+	if !race {
+		return nil, nil
+	}
+	devOS := EnvOr("DEV_OS", runtime.GOOS)
+	devArch := EnvOr("DEV_ARCH", runtime.GOARCH)
+	if !testbin.RaceDetectorSupported(devOS, devArch) {
+		return nil, fmt.Errorf("race detector requested but not supported on %s/%s", devOS, devArch)
+	}
+	return []string{"-race"}, nil
+}
+
 // GoTest invokes "go test" and reports the results to stdout. It returns an
 // error if there was any failure executing the tests or if there were any
 // test failures.
@@ -394,19 +410,9 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		gotestsumArgs = append(gotestsumArgs, "--jsonfile", params.OutputFile+".json")
 	}
 
-	var testArgs []string
-
-	if params.Race {
-		// Only pass -race on platforms that support it; the predicate is shared
-		// with the test binary builder (testbin) to keep the two in sync.
-		devOS := os.Getenv("DEV_OS")
-		devArch := os.Getenv("DEV_ARCH")
-		if testbin.RaceDetectorSupported(devOS, devArch) {
-			testArgs = append(testArgs, "-race")
-		} else {
-			//nolint:gosec // G706: DEV_OS/DEV_ARCH are trusted build-time env vars, not untrusted input
-			log.Printf("Warning: skipping -race flag for unsupported platform %s/%s\n", devOS, devArch)
-		}
+	testArgs, err := raceDetectorArgs(params.Race)
+	if err != nil {
+		return err
 	}
 	if len(params.Tags) > 0 {
 		params := strings.Join(params.Tags, ",")
@@ -459,7 +465,7 @@ func GoTest(ctx context.Context, params GoTestArgs) error {
 		goTest.Stderr = output
 	}
 
-	err := goTest.Run()
+	err = goTest.Run()
 
 	var goTestErr *exec.ExitError
 	if err != nil {

--- a/dev-tools/mage/gotest_test.go
+++ b/dev-tools/mage/gotest_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +29,8 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/dev-tools/testbin"
 )
 
 const envGoTestHelper = "GOTEST_WANT_HELPER"
@@ -142,6 +145,49 @@ func TestGoTest_CaptureOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRaceDetectorArgs(t *testing.T) {
+	t.Run("race disabled adds no flag", func(t *testing.T) {
+		args, err := raceDetectorArgs(false)
+		require.NoError(t, err, "a disabled race detector must never error")
+		assert.Empty(t, args, "no -race flag expected when the race detector is disabled")
+	})
+
+	t.Run("unset DEV_OS/DEV_ARCH default to the host", func(t *testing.T) {
+		// Regression for CI: RACE_DETECTOR=true with DEV_OS/DEV_ARCH empty must
+		// resolve to the host, not the empty "/" that made RaceDetectorSupported
+		// report false and silently drop -race. The unsupported-host path is
+		// covered by the explicit linux/386 case below.
+		if !testbin.RaceDetectorSupported(runtime.GOOS, runtime.GOARCH) {
+			t.Skip("host platform does not support the race detector")
+		}
+		t.Setenv("DEV_OS", "")
+		t.Setenv("DEV_ARCH", "")
+
+		args, err := raceDetectorArgs(true)
+		require.NoError(t, err, "the host platform supports the race detector")
+		assert.Equal(t, []string{"-race"}, args,
+			"unset DEV_OS/DEV_ARCH must default to the host and apply -race")
+	})
+
+	t.Run("supported explicit platform gets -race", func(t *testing.T) {
+		t.Setenv("DEV_OS", "linux")
+		t.Setenv("DEV_ARCH", "amd64")
+
+		args, err := raceDetectorArgs(true)
+		require.NoError(t, err, "linux/amd64 supports the race detector")
+		assert.Equal(t, []string{"-race"}, args, "-race expected on a supported platform")
+	})
+
+	t.Run("unsupported explicit platform fails loudly", func(t *testing.T) {
+		t.Setenv("DEV_OS", "linux")
+		t.Setenv("DEV_ARCH", "386")
+
+		args, err := raceDetectorArgs(true)
+		require.Error(t, err, "requesting the race detector on an unsupported platform must return an error")
+		assert.Empty(t, args, "no -race flag should be returned on error")
+	})
 }
 
 func TestGoTest_Helper_OK(t *testing.T) {

--- a/filebeat/beater/signalwait.go
+++ b/filebeat/beater/signalwait.go
@@ -18,13 +18,14 @@
 package beater
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 type signalWait struct {
-	count   int // number of potential 'alive' signals
+	count   atomic.Int32 // number of potential 'alive' signals
 	signals chan struct{}
 }
 
@@ -37,16 +38,16 @@ func newSignalWait() *signalWait {
 }
 
 func (s *signalWait) Wait() {
-	if s.count == 0 {
+	if s.count.Load() == 0 {
 		return
 	}
 
 	<-s.signals
-	s.count--
+	s.count.Add(-1)
 }
 
 func (s *signalWait) Add(fn signaler) {
-	s.count++
+	s.count.Add(1)
 	go func() {
 		fn()
 		var v struct{}

--- a/heartbeat/monitors/signalwait.go
+++ b/heartbeat/monitors/signalwait.go
@@ -18,13 +18,14 @@
 package monitors
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 type signalWait struct {
-	count   int // number of potential 'alive' signals
+	count   atomic.Int32 // number of potential 'alive' signals
 	signals chan struct{}
 }
 
@@ -37,16 +38,16 @@ func NewSignalWait() *signalWait {
 }
 
 func (s *signalWait) Wait() {
-	if s.count == 0 {
+	if s.count.Load() == 0 {
 		return
 	}
 
 	<-s.signals
-	s.count--
+	s.count.Add(-1)
 }
 
 func (s *signalWait) Add(fn signaler) {
-	s.count++
+	s.count.Add(1)
 	go func() {
 		fn()
 		var v struct{}

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -779,6 +779,16 @@ func wait(t *testing.T, test func() bool) {
 	}
 }
 
+func activeRunnerCount(runners []*mockRunner) int {
+	count := 0
+	for _, r := range runners {
+		if r.started && !r.stopped {
+			count++
+		}
+	}
+	return count
+}
+
 func check(t *testing.T, runners []*mockRunner, expected *conf.C, started, stopped bool) {
 	t.Helper()
 	for _, r := range runners {
@@ -952,8 +962,6 @@ func TestAutodiscoverMetadataCleanup(t *testing.T) {
 	// Wait for configs to be processed
 	wait(t, func() bool { return len(adapter.Runners()) == 2 })
 
-	// check that configs and metadata exist
-	assert.Len(t, autodiscover.configs["mock:foo"], 2)
 	metaKeys := autodiscover.meta.Keys()
 	assert.Len(t, metaKeys, 2, "Should have 2 metadata entries for id foo")
 
@@ -976,8 +984,6 @@ func TestAutodiscoverMetadataCleanup(t *testing.T) {
 	})
 	// Wait for configs to be processed
 	wait(t, func() bool { return len(adapter.Runners()) == 4 })
-	assert.Len(t, autodiscover.configs["mock:foo"], 2)
-	assert.Len(t, autodiscover.configs["mock:bar"], 2)
 	metaKeys = autodiscover.meta.Keys()
 	assert.Len(t, metaKeys, 4, "Should have 4 metadata entries total")
 
@@ -992,9 +998,9 @@ func TestAutodiscoverMetadataCleanup(t *testing.T) {
 		},
 	})
 
-	// Wait for some configs to be removed from active configs
+	// Wait until foo runners stop while bar keeps running
 	wait(t, func() bool {
-		return len(autodiscover.configs["mock:foo"]) == 0 && len(autodiscover.configs["mock:bar"]) == 2
+		return activeRunnerCount(adapter.Runners()) == 2
 	})
 
 	// Wait for debounce period so the worker can run the metadata GC
@@ -1014,9 +1020,8 @@ func TestAutodiscoverMetadataCleanup(t *testing.T) {
 		},
 	})
 
-	// Wait for all configs to be removed
 	wait(t, func() bool {
-		return len(autodiscover.configs["mock:bar"]) == 0
+		return activeRunnerCount(adapter.Runners()) == 0
 	})
 
 	// Without active configs, metadata should be cleaned up

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -377,9 +377,7 @@ func (p *leaderElectionManager) startLeaderElectorIndefinitely(ctx context.Conte
 	}
 	p.logger.Debugf("Starting Leader Elector")
 
-	p.electorWg.Add(1)
-	go func() {
-		defer p.electorWg.Done()
+	p.electorWg.Go(func() {
 		for {
 			le.Run(ctx)
 			select {
@@ -390,7 +388,7 @@ func (p *leaderElectionManager) startLeaderElectorIndefinitely(ctx context.Conte
 				// is still a candidate to get the lease.
 			}
 		}
-	}()
+	})
 }
 
 func ShouldPut(event mapstr.M, field string, value any, logger *logp.Logger) {

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -22,6 +22,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,6 +87,7 @@ type eventerManager struct {
 type leaderElectionManager struct {
 	leaderElection       leaderelection.LeaderElectionConfig
 	cancelLeaderElection context.CancelFunc
+	electorWg            sync.WaitGroup
 	logger               *logp.Logger
 }
 
@@ -287,8 +289,13 @@ func NewLeaderElectionManager(
 		Namespace: ns,
 	}
 
-	var eventID string
-	leaseId := lease.Name + "-" + lease.Namespace
+	// The elector calls OnStartedLeading and OnStoppedLeading from different
+	// goroutines, so eventID needs a lock to pass the current term's ID between them.
+	var (
+		eventMu sync.Mutex
+		eventID string
+	)
+	leaseID := lease.Name + "-" + lease.Namespace
 	lem.leaderElection = leaderelection.LeaderElectionConfig{
 		Lock: &resourcelock.LeaseLock{
 			LeaseMeta: lease,
@@ -303,13 +310,19 @@ func NewLeaderElectionManager(
 		RetryPeriod:     cfg.RetryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
-				eventID = fmt.Sprintf("%v-%v", leaseId, time.Now().UnixNano())
-				logger.Debugf("leader election lock GAINED, holder: %v, eventID: %v", id, eventID)
-				startLeading(uuid.String(), eventID)
+				startedID := fmt.Sprintf("%v-%v", leaseID, time.Now().UnixNano())
+				eventMu.Lock()
+				eventID = startedID
+				eventMu.Unlock()
+				logger.Debugf("leader election lock GAINED, holder: %v, eventID: %v", id, startedID)
+				startLeading(uuid.String(), startedID)
 			},
 			OnStoppedLeading: func() {
-				logger.Debugf("leader election lock LOST, holder: %v, eventID: %v", id, eventID)
-				stopLeading(uuid.String(), eventID)
+				eventMu.Lock()
+				stoppedID := eventID
+				eventMu.Unlock()
+				logger.Debugf("leader election lock LOST, holder: %v, eventID: %v", id, stoppedID)
+				stopLeading(uuid.String(), stoppedID)
 			},
 		},
 	}
@@ -344,6 +357,8 @@ func (p *leaderElectionManager) Start() {
 func (p *leaderElectionManager) Stop() {
 	if p.cancelLeaderElection != nil {
 		p.cancelLeaderElection()
+		// Wait so ReleaseOnCancel can release the lease before shutdown continues.
+		p.electorWg.Wait()
 	}
 }
 
@@ -358,10 +373,13 @@ func (p *leaderElectionManager) startLeaderElectorIndefinitely(ctx context.Conte
 	le, err := leaderelection.NewLeaderElector(lec)
 	if err != nil {
 		p.logger.Errorf("error while creating Leader Elector: %v", err)
+		return
 	}
 	p.logger.Debugf("Starting Leader Elector")
 
+	p.electorWg.Add(1)
 	go func() {
+		defer p.electorWg.Done()
 		for {
 			le.Run(ctx)
 			select {

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -532,6 +532,9 @@ func testInputMetrics(t *testing.T, beatInfo beat.Info, clientCfg beat.ClientCon
 		},
 	)
 	require.NoError(t, err)
+	// The pipeline's reaper logs through the test logger, so it has to be joined
+	// before the test ends.
+	defer func() { _ = pipeline.Disconnect(t.Context()) }()
 
 	c, err := pipeline.ConnectWith(clientCfg)
 	require.NoError(t, err, "pipeline.ConnectWith failed")

--- a/libbeat/publisher/pipeline/output_process_test.go
+++ b/libbeat/publisher/pipeline/output_process_test.go
@@ -48,6 +48,13 @@ func TestOutputReload(t *testing.T) {
 		"network_client": newMockNetworkClient,
 	}
 
+	// Each iteration publishes ~15k events across ~400 output reloads, which race
+	// instrumentation makes expensive enough to threaten the package test timeout.
+	maxCount := 25
+	if raceBuildEnabled {
+		maxCount = 5
+	}
+
 	for name, ctor := range tests {
 		t.Run(name, func(t *testing.T) {
 			testutil.SeedPRNG(t)
@@ -108,7 +115,7 @@ func TestOutputReload(t *testing.T) {
 				return waitUntilTrue(timeout, func() bool {
 					return uint64(numEventsToPublish) == publishedCount.Load()
 				})
-			}, &quick.Config{MaxCount: 25})
+			}, &quick.Config{MaxCount: maxCount})
 
 			if err != nil {
 				t.Error(err)

--- a/libbeat/publisher/pipeline/queue_reader.go
+++ b/libbeat/publisher/pipeline/queue_reader.go
@@ -46,13 +46,15 @@ func makeQueueReader() queueReader {
 	return qr
 }
 
+// run dispatches queue reads until the request channel is closed. Nothing joins
+// this goroutine, so it must not log once shutdown has started: the logger can
+// outlive whoever owns it, which in tests means writing into a finished test.
 func (qr *queueReader) run(logger *logp.Logger) {
 	logger.Debug("pipeline event consumer queue reader: start")
 	for {
 		req, ok := <-qr.req
 		if !ok {
 			// The request channel is closed, we're shutting down
-			logger.Debug("pipeline event consumer queue reader: stop")
 			return
 		}
 		queueBatch, _ := req.queue.Get(req.batchSize)
@@ -73,7 +75,6 @@ func (qr *queueReader) run(logger *logp.Logger) {
 			if batch != nil {
 				batch.Release()
 			}
-			logger.Debug("pipeline event consumer queue reader: stop")
 			return
 		}
 	}

--- a/libbeat/publisher/pipeline/racedetector_off_test.go
+++ b/libbeat/publisher/pipeline/racedetector_off_test.go
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !race
+
+package pipeline
+
+const raceBuildEnabled = false

--- a/libbeat/publisher/pipeline/racedetector_on_test.go
+++ b/libbeat/publisher/pipeline/racedetector_on_test.go
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build race
+
+package pipeline
+
+const raceBuildEnabled = true

--- a/libbeat/reader/etw/eventrenderer.go
+++ b/libbeat/reader/etw/eventrenderer.go
@@ -186,7 +186,7 @@ func renderStructArray(cache providerCache, eventInfo *cachedEventInfo, propInfo
 	}
 
 	result := make([]any, arraySize)
-	for j := 0; j < arraySize; j++ {
+	for j := range arraySize {
 		value, err := renderStruct(cache, eventInfo, propInfo, r, ptrSize, buf, bufferPools)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse struct member %d: %w", j, err)
@@ -219,7 +219,7 @@ func renderSimpleArray(cache providerCache, eventInfo *cachedEventInfo, propInfo
 	}
 
 	result := make([]any, count)
-	for i := uint32(0); i < count; i++ {
+	for i := range count {
 		// For each array element, process it as a single property
 		value, err := renderSingleProperty(cache, eventInfo, propInfo, r, ptrSize, buf, mapInfo, cachedMapInfo, bufferPools)
 		if err != nil {
@@ -374,8 +374,8 @@ func convertFileTimeToGoTime(fileTime64 uint64) time.Time {
 	}
 
 	fileTime := windows.Filetime{
-		HighDateTime: uint32(fileTime64 >> 32),            //nolint:gosec // High part of the 64-bit FileTime
-		LowDateTime:  uint32(fileTime64 & math.MaxUint32), //nolint:gosec // Low part of the 64-bit FileTime
+		HighDateTime: uint32(fileTime64 >> 32),            // High part of the 64-bit FileTime
+		LowDateTime:  uint32(fileTime64 & math.MaxUint32), // Low part of the 64-bit FileTime
 	}
 
 	return time.Unix(0, fileTime.Nanoseconds()).UTC()
@@ -473,8 +473,8 @@ retryLoop:
 			ptrSize,
 			propInfo.InType,
 			propInfo.OutType,
-			uint16(propertyLength),
-			uint16(len(*buf)), //nolint:gosec // This is the length of the user data buffer
+			uint16(propertyLength), //nolint:gosec // G115: property length comes from ETW metadata and fits TdhFormatProperty's uint16 parameter
+			uint16(len(*buf)),      //nolint:gosec // This is the length of the user data buffer
 			dataPtr,
 			&formattedDataSize,
 			&formattedData[0],

--- a/libbeat/reader/etw/eventrenderer.go
+++ b/libbeat/reader/etw/eventrenderer.go
@@ -94,11 +94,9 @@ func (p *eventRenderer) render() (RenderedEtwEvent, error) {
 
 	// Parse ExtendedData if present
 	if p.r.ExtendedDataCount > 0 && p.r.ExtendedData != nil {
-		for i := 0; i < int(p.r.ExtendedDataCount); i++ {
-			item := (*EventHeaderExtendedDataItem)(unsafe.Pointer(
-				uintptr(unsafe.Pointer(p.r.ExtendedData)) + uintptr(i)*unsafe.Sizeof(*p.r.ExtendedData),
-			))
-			event.ExtendedData[i] = renderExtendedData(item)
+		items := unsafe.Slice(p.r.ExtendedData, int(p.r.ExtendedDataCount))
+		for i := range items {
+			event.ExtendedData[i] = renderExtendedData(&items[i])
 			event.extendedDataMap[event.ExtendedData[i].ExtType] = i // Map the extended data type to its index
 		}
 	}
@@ -253,7 +251,7 @@ func getPropertyLength(eventInfo *cachedEventInfo, propInfo *cachedPropertyInfo,
 		// Length is specified by another property - use the property index
 		var dataDescriptor PropertyDataDescriptor
 		lengthPropIndex := propInfo.getLengthPropertyIndex()
-		nameProp := eventInfo.ParsedInfo.getEventPropertyInfoAtIndex(uint32(lengthPropIndex))
+		nameProp := eventInfo.ParsedInfo.getEventPropertyInfoAtIndex(eventInfo.InfoBuf, uint32(lengthPropIndex))
 		if nameProp == nil {
 			return 0, fmt.Errorf("property length is defined by another property, but no property found at index %d", lengthPropIndex)
 		}
@@ -269,7 +267,7 @@ func getPropertyLength(eventInfo *cachedEventInfo, propInfo *cachedPropertyInfo,
 		// Count is specified by another property - use the property index
 		var dataDescriptor PropertyDataDescriptor
 		countPropIndex := propInfo.getCountPropertyIndex()
-		nameProp := eventInfo.ParsedInfo.getEventPropertyInfoAtIndex(uint32(countPropIndex))
+		nameProp := eventInfo.ParsedInfo.getEventPropertyInfoAtIndex(eventInfo.InfoBuf, uint32(countPropIndex))
 		if nameProp == nil {
 			return 0, fmt.Errorf("property count is defined by another property, but no property found at index %d", countPropIndex)
 		}
@@ -307,7 +305,7 @@ func getElementLength(eventInfo *cachedEventInfo, propInfo *cachedPropertyInfo, 
 		// Length is specified by another property - use the property index
 		var dataDescriptor PropertyDataDescriptor
 		lengthPropIndex := propInfo.getLengthPropertyIndex()
-		nameProp := eventInfo.ParsedInfo.getEventPropertyInfoAtIndex(uint32(lengthPropIndex))
+		nameProp := eventInfo.ParsedInfo.getEventPropertyInfoAtIndex(eventInfo.InfoBuf, uint32(lengthPropIndex))
 		if nameProp == nil {
 			return 0, fmt.Errorf("property length is defined by another property, but no property found at index %d", lengthPropIndex)
 		}

--- a/libbeat/reader/etw/manifest_provider_cache.go
+++ b/libbeat/reader/etw/manifest_provider_cache.go
@@ -114,9 +114,11 @@ func (cache *manifestProviderCache) initKeywords() error {
 		return fmt.Errorf("no keywords found for provider %s", cache.guid)
 	}
 
-	it := uintptr(unsafe.Pointer(&pfInfoArr.FieldInfoArray[0]))
-	for i := uint32(0); i < pfInfoArr.NumberOfElements; i++ {
-		pfInfo := *(*ProviderFieldInfo)(unsafe.Pointer(it + uintptr(i)*unsafe.Sizeof(pfInfoArr.FieldInfoArray[0])))
+	fields, err := flexArrayFromBuffer[ProviderFieldInfo](buf, unsafe.Offsetof(ProviderFieldInfoArray{}.FieldInfoArray), pfInfoArr.NumberOfElements)
+	if err != nil {
+		return fmt.Errorf("TdhEnumerateProviderFieldInformation failed: %w", err)
+	}
+	for _, pfInfo := range fields {
 		cache.keywords[pfInfo.Value] = &cachedProviderKeyword{
 			Name:        getStringFromBufferOffset(buf, pfInfo.NameOffset),
 			Description: getStringFromBufferOffset(buf, pfInfo.DescriptionOffset),
@@ -157,7 +159,7 @@ func (cache *manifestProviderCache) initEvent(r *EventRecord) error {
 		OpcodeName:            getStringFromBufferOffset(buf, info.OpcodeNameOffset),
 		EventMessage:          getStringFromBufferOffset(buf, info.EventMessageOffset),
 		ProviderMessage:       getStringFromBufferOffset(buf, info.ProviderMessageOffset),
-		BinaryXML:             getEventInfoBinaryXML(info),
+		BinaryXML:             getEventInfoBinaryXML(buf, info),
 		ActivityIDName:        getStringFromBufferOffset(buf, info.ActivityIDNameOffset),
 		RelatedActivityIDName: getStringFromBufferOffset(buf, info.RelatedActivityIDNameOffset),
 	}
@@ -235,12 +237,11 @@ func getProviderEventDescriptors(guid *windows.GUID) ([]EventDescriptor, error) 
 		return nil, errors.New("no events found for provider")
 	}
 
-	descriptors := make([]EventDescriptor, prInfo.NumberOfEvents)
-	it := uintptr(unsafe.Pointer(&prInfo.EventDescriptorsArray[0]))
-	for i := uint32(0); i < prInfo.NumberOfEvents; i++ {
-		descriptors[i] = *(*EventDescriptor)(unsafe.Pointer(it + uintptr(i)*unsafe.Sizeof(prInfo.EventDescriptorsArray[0])))
+	descriptors, err := flexArrayFromBuffer[EventDescriptor](buf, unsafe.Offsetof(ProviderEventInfo{}.EventDescriptorsArray), prInfo.NumberOfEvents)
+	if err != nil {
+		return nil, fmt.Errorf("TdhEnumerateManifestProviderEvents failed: %w", err)
 	}
-	return descriptors, nil
+	return append([]EventDescriptor(nil), descriptors...), nil
 }
 
 var dataIdxRegexp = regexp.MustCompile(`%(\d+)`)
@@ -269,20 +270,23 @@ func compileEventMessageTemplate(eventMessage string) (*template.Template, error
 }
 
 func getStringFromBufferOffset(buf []byte, offset uint32) string {
-	if offset == 0 || len(buf) == 0 {
+	if offset == 0 || len(buf) == 0 || int(offset) >= len(buf) {
 		return ""
 	}
 	ptr := unsafe.Add(unsafe.Pointer(&buf[0]), offset)
 	return strings.TrimSpace(windows.UTF16PtrToString((*uint16)(ptr)))
 }
 
-func getEventInfoBinaryXML(info *TraceEventInfo) string {
+func getEventInfoBinaryXML(buf []byte, info *TraceEventInfo) string {
 	if info == nil || info.BinaryXMLOffset == 0 || info.BinaryXMLSize == 0 {
 		return ""
 	}
+	end := uintptr(info.BinaryXMLOffset) + uintptr(info.BinaryXMLSize)
+	if end > uintptr(len(buf)) {
+		return ""
+	}
 	var result string
-	ptr := unsafe.Add(unsafe.Pointer(info), info.BinaryXMLOffset)
-	data := unsafe.Slice((*byte)(ptr), info.BinaryXMLSize)
+	data := unsafe.Slice((*byte)(unsafe.Add(unsafe.Pointer(&buf[0]), info.BinaryXMLOffset)), int(info.BinaryXMLSize))
 	if isPrintable(data) {
 		result = string(data)
 	} else {
@@ -322,7 +326,7 @@ func getEventInfoProperties(buf []byte, info *TraceEventInfo) []*cachedPropertyI
 	}
 	infos := make([]*cachedPropertyInfo, info.TopLevelPropertyCount)
 	for i := uint32(0); i < info.TopLevelPropertyCount; i++ {
-		prInfo := info.getEventPropertyInfoAtIndex(i)
+		prInfo := info.getEventPropertyInfoAtIndex(buf, i)
 		infos[i] = parseEventPropertyInfo(buf, info, prInfo)
 	}
 	return infos
@@ -393,7 +397,7 @@ func parseEventPropertyInfo(buf []byte, info *TraceEventInfo, prInfo *EventPrope
 		}
 
 		for i := startIndex; i < lastIndex; i++ {
-			memberInfo := info.getEventPropertyInfoAtIndex(uint32(i))
+			memberInfo := info.getEventPropertyInfoAtIndex(buf, uint32(i))
 			if memberInfo == nil {
 				continue // Skip invalid property info
 			}
@@ -462,9 +466,11 @@ func parseEventMapBuffer(mapName string, buf []byte, mapInfo *EventMapInfo) *cac
 		return parsed
 	}
 
-	it := uintptr(unsafe.Pointer(&mapInfo.MapEntryArray[0]))
-	for i := uint32(0); i < mapInfo.EntryCount; i++ {
-		mapEntry := (*EventMapEntry)(unsafe.Pointer(it + uintptr(i)*unsafe.Sizeof(EventMapEntry{})))
+	entries, err := flexArrayFromBuffer[EventMapEntry](buf, unsafe.Offsetof(EventMapInfo{}.MapEntryArray), mapInfo.EntryCount)
+	if err != nil {
+		return parsed
+	}
+	for _, mapEntry := range entries {
 		var entryKey any
 		switch {
 		case parsed.IsPattern:

--- a/libbeat/reader/etw/provider.go
+++ b/libbeat/reader/etw/provider.go
@@ -120,9 +120,11 @@ func guidFromProviderName(providerName string) (windows.GUID, error) {
 		return windows.GUID{}, fmt.Errorf("no providers found")
 	}
 
-	it := uintptr(unsafe.Pointer(&pEnum.TraceProviderInfoArray[0]))
-	for i := uintptr(0); i < uintptr(pEnum.NumberOfProviders); i++ {
-		pInfo := (*TraceProviderInfo)(unsafe.Pointer(it + i*unsafe.Sizeof(pEnum.TraceProviderInfoArray[0])))
+	providers, err := flexArrayFromBuffer[TraceProviderInfo](buf, unsafe.Offsetof(ProviderEnumerationInfo{}.TraceProviderInfoArray), pEnum.NumberOfProviders)
+	if err != nil {
+		return windows.GUID{}, fmt.Errorf("failed to enumerate providers: %w", err)
+	}
+	for _, pInfo := range providers {
 		name := getStringFromBufferOffset(buf, pInfo.ProviderNameOffset)
 
 		// If a match is found, return the corresponding GUID.

--- a/libbeat/reader/etw/provider_test.go
+++ b/libbeat/reader/etw/provider_test.go
@@ -94,8 +94,9 @@ func TestGUIDFromProviderName_GUIDNotFound(t *testing.T) {
 		// It's placed after ProviderEnumerationInfo and TraceProviderInfo
 		nameOffset := unsafe.Sizeof(ProviderEnumerationInfo{}) + unsafe.Sizeof(TraceProviderInfo{})
 
-		// Convert pBuffer to a byte slice starting at the calculated offset for the name
-		byteBuffer := (*[1 << 30]byte)(unsafe.Pointer(pBuffer))[:]
+		// Keep the view inside the caller's buffer so the race detector's
+		// checkptr instrumentation can validate the writes below.
+		byteBuffer := unsafe.Slice((*byte)(unsafe.Pointer(pBuffer)), *pBufferSize)
 		// Copy the UTF-16 encoded name into the buffer
 		for i, char := range utf16ProviderName {
 			binary.LittleEndian.PutUint16(byteBuffer[nameOffset+(uintptr(i)*2):], char)
@@ -146,8 +147,9 @@ func TestGUIDFromProviderName_Success(t *testing.T) {
 		// It's placed after ProviderEnumerationInfo and TraceProviderInfo
 		nameOffset := unsafe.Sizeof(ProviderEnumerationInfo{}) + unsafe.Sizeof(TraceProviderInfo{})
 
-		// Convert pBuffer to a byte slice starting at the calculated offset for the name
-		byteBuffer := (*[1 << 30]byte)(unsafe.Pointer(pBuffer))[:]
+		// Keep the view inside the caller's buffer so the race detector's
+		// checkptr instrumentation can validate the writes below.
+		byteBuffer := unsafe.Slice((*byte)(unsafe.Pointer(pBuffer)), *pBufferSize)
 		// Copy the UTF-16 encoded name into the buffer
 		for i, char := range utf16ProviderName {
 			binary.LittleEndian.PutUint16(byteBuffer[nameOffset+(uintptr(i)*2):], char)

--- a/libbeat/reader/etw/provider_test.go
+++ b/libbeat/reader/etw/provider_test.go
@@ -84,7 +84,7 @@ func TestGUIDFromProviderName_GUIDNotFound(t *testing.T) {
 		// Calculate size needed for the provider name string
 		nameSize := (len(utf16ProviderName) + 1) * 2 // +1 for null-terminator
 
-		requiredSize := uint32(unsafe.Sizeof(ProviderEnumerationInfo{}) + unsafe.Sizeof(TraceProviderInfo{}) + uintptr(nameSize))
+		requiredSize := uint32(unsafe.Sizeof(ProviderEnumerationInfo{}) + unsafe.Sizeof(TraceProviderInfo{}) + uintptr(nameSize)) //nolint:gosec // G115: test buffer size is a small fixed layout
 		if *pBufferSize < requiredSize {
 			*pBufferSize = requiredSize
 			return ERROR_INSUFFICIENT_BUFFER
@@ -137,7 +137,7 @@ func TestGUIDFromProviderName_Success(t *testing.T) {
 		// Calculate size needed for the provider name string
 		nameSize := (len(utf16ProviderName) + 1) * 2 // +1 for null-terminator
 
-		requiredSize := uint32(unsafe.Sizeof(ProviderEnumerationInfo{}) + unsafe.Sizeof(TraceProviderInfo{}) + uintptr(nameSize))
+		requiredSize := uint32(unsafe.Sizeof(ProviderEnumerationInfo{}) + unsafe.Sizeof(TraceProviderInfo{}) + uintptr(nameSize)) //nolint:gosec // G115: test buffer size is a small fixed layout
 		if *pBufferSize < requiredSize {
 			*pBufferSize = requiredSize
 			return ERROR_INSUFFICIENT_BUFFER

--- a/libbeat/reader/etw/session_integration_test.go
+++ b/libbeat/reader/etw/session_integration_test.go
@@ -30,8 +30,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -71,7 +73,7 @@ func createETLSessionConfig(sessionName string) Config {
 
 // ETWCallbackMeasurer counts ETW callback invocations safely
 type ETWCallbackMeasurer struct {
-	count int64
+	count atomic.Int64
 }
 
 // InjectableCallback returns a callback function that measures event processing performance
@@ -79,7 +81,7 @@ func (m *ETWCallbackMeasurer) InjectableCallback(session *Session) func(record *
 	return func(record *EventRecord) uintptr {
 		_, err := session.RenderEvent(record)
 		if err == nil || errors.Is(err, ErrUnprocessableEvent) {
-			atomic.AddInt64(&m.count, 1)
+			m.count.Add(1)
 		}
 		return 0
 	}
@@ -87,12 +89,12 @@ func (m *ETWCallbackMeasurer) InjectableCallback(session *Session) func(record *
 
 // Reset resets the counter for a new measurement
 func (m *ETWCallbackMeasurer) Reset() {
-	atomic.StoreInt64(&m.count, 0)
+	m.count.Store(0)
 }
 
 // GetCount returns the current count safely
 func (m *ETWCallbackMeasurer) GetCount() int64 {
-	return atomic.LoadInt64(&m.count)
+	return m.count.Load()
 }
 
 // Test Infrastructure
@@ -301,8 +303,15 @@ func TestETLGoldenFile(t *testing.T) {
 
 // collectEventsFromETL processes an ETL file and returns all rendered events
 func collectEventsFromETL(t *testing.T, session *Session) []RenderedEtwEvent {
+	// The consumer runs the callback on its own goroutine while this one polls
+	// for progress below.
+	var mu sync.Mutex
 	var events []RenderedEtwEvent
-	var eventCount int
+	snapshot := func() []RenderedEtwEvent {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(events)
+	}
 
 	session.Callback = func(record *EventRecord) uintptr {
 		event, err := session.RenderEvent(record)
@@ -313,8 +322,9 @@ func collectEventsFromETL(t *testing.T, session *Session) []RenderedEtwEvent {
 			t.Errorf("Failed to render event: %v", err)
 			return 1
 		}
+		mu.Lock()
 		events = append(events, event)
-		eventCount++
+		mu.Unlock()
 		return 0
 	}
 
@@ -343,17 +353,18 @@ func collectEventsFromETL(t *testing.T, session *Session) []RenderedEtwEvent {
 	})
 
 	// Wait for events to be processed
-	for eventCount == 0 {
+	for len(snapshot()) == 0 {
 		time.Sleep(100 * time.Millisecond)
 	}
 	time.Sleep(2 * time.Second)
 
-	if len(events) == 0 {
+	collected := snapshot()
+	if len(collected) == 0 {
 		t.Fatal("No events were processed from the ETL file")
 	}
 
-	t.Logf("Processed %d events from ETL file for golden file comparison", len(events))
-	return events
+	t.Logf("Processed %d events from ETL file for golden file comparison", len(collected))
+	return collected
 }
 
 // validateEventDataQuality checks for data quality issues in events
@@ -526,7 +537,7 @@ func compareRenderedEvents(actual, expected RenderedEtwEvent, eventIndex int) []
 }
 
 // comparePropertyValues compares two property values recursively
-func comparePropertyValues(actual, expected interface{}) bool {
+func comparePropertyValues(actual, expected any) bool {
 	actualJSON, err1 := json.Marshal(actual)
 	expectedJSON, err2 := json.Marshal(expected)
 	return err1 == nil && err2 == nil && string(actualJSON) == string(expectedJSON)

--- a/libbeat/reader/etw/syscall_tdh.go
+++ b/libbeat/reader/etw/syscall_tdh.go
@@ -206,18 +206,29 @@ type TraceEventInfo struct {
 	EventPropertyInfoArray      [anysizeArray]EventPropertyInfo
 }
 
-func (info *TraceEventInfo) getEventPropertyInfoAtIndex(i uint32) *EventPropertyInfo {
+// flexArrayFromBuffer returns a slice view over count elements of T in buf at arrayOffset.
+func flexArrayFromBuffer[T any](buf []byte, arrayOffset uintptr, count uint32) ([]T, error) {
+	if count == 0 {
+		return nil, nil
+	}
+	elemSize := unsafe.Sizeof(*new(T))
+	end := arrayOffset + uintptr(count)*elemSize
+	if end > uintptr(len(buf)) || end < arrayOffset {
+		return nil, fmt.Errorf("buffer too small for %d elements", count)
+	}
+	return unsafe.Slice((*T)(unsafe.Add(unsafe.Pointer(&buf[0]), arrayOffset)), int(count)), nil
+}
+
+func (info *TraceEventInfo) getEventPropertyInfoAtIndex(buf []byte, i uint32) *EventPropertyInfo {
 	if i >= info.PropertyCount {
 		return nil
 	}
-
-	// Compute the pointer to the i-th EventPropertyInfo safely,
-	// simulating C-style flexible array access using offset arithmetic.
-	eventPropertyInfoPtr := uintptr(unsafe.Pointer(info)) +
-		unsafe.Offsetof(info.EventPropertyInfoArray) +
-		uintptr(i)*unsafe.Sizeof(EventPropertyInfo{})
-
-	return (*EventPropertyInfo)(unsafe.Pointer(eventPropertyInfoPtr))
+	offset := unsafe.Offsetof(TraceEventInfo{}.EventPropertyInfoArray) + uintptr(i)*unsafe.Sizeof(EventPropertyInfo{})
+	end := offset + unsafe.Sizeof(EventPropertyInfo{})
+	if end > uintptr(len(buf)) {
+		return nil
+	}
+	return (*EventPropertyInfo)(unsafe.Add(unsafe.Pointer(&buf[0]), offset))
 }
 
 // https://learn.microsoft.com/en-us/windows/win32/api/tdh/ns-tdh-provider_event_info

--- a/metricbeat/helper/windows/pdh/pdh_query_windows.go
+++ b/metricbeat/helper/windows/pdh/pdh_query_windows.go
@@ -116,12 +116,12 @@ func (q *Query) GetCounterPaths(counterPath string) ([]string, error) {
 		return paths, err
 	}
 	//check if Windows installed language is not ENG, the ExpandWildCardPath will return either one of the errors below.
-	if err == PDH_CSTATUS_NO_OBJECT || err == PDH_CSTATUS_NO_COUNTER {
+	if errors.Is(err, PDH_CSTATUS_NO_OBJECT) || errors.Is(err, PDH_CSTATUS_NO_COUNTER) {
 		handle, err := q.AddEnglishCounter(counterPath)
 		if err != nil {
 			return nil, err
 		}
-		defer PdhRemoveCounter(handle)
+		defer func() { _ = PdhRemoveCounter(handle) }()
 		info, err := PdhGetCounterInfo(handle)
 		if err != nil {
 			return nil, err
@@ -187,10 +187,10 @@ func (q *Query) GetFormattedCounterValues() (map[string][]CounterValue, error) {
 func (q *Query) GetCountersAndInstances(objectName string) ([]string, []string, error) {
 	counters, instances, err := PdhEnumObjectItems(objectName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to retrieve counter and instance list for %s: %w", objectName, err)
+		return nil, nil, fmt.Errorf("unable to retrieve counter and instance list for %s: %w", objectName, err)
 	}
 	if len(counters) == 0 && len(instances) == 0 {
-		return nil, nil, fmt.Errorf("Unable to retrieve counter and instance list for %s", objectName)
+		return nil, nil, fmt.Errorf("unable to retrieve counter and instance list for %s", objectName)
 	}
 	return UTF16ToStringArray(counters), UTF16ToStringArray(instances), nil
 }
@@ -217,7 +217,7 @@ func (q *Query) ExpandWildCardPath(wildCardPath string) ([]string, error) {
 		return UTF16ToStringArray(expdPaths), nil
 	} else {
 		if expdPaths, err = PdhExpandWildCardPath(utfPath); err != nil {
-			if err == PDH_MORE_DATA {
+			if errors.Is(err, PDH_MORE_DATA) {
 				if expdPaths, err = PdhExpandWildCardPath(utfPath); err != nil {
 					return nil, err
 				}
@@ -234,7 +234,7 @@ func (q *Query) ExpandWildCardPath(wildCardPath string) ([]string, error) {
 				return UTF16ToStringArray(expdPaths), nil
 			}
 		} else {
-			return paths, err
+			return paths, nil
 		}
 	}
 

--- a/metricbeat/helper/windows/pdh/pdh_query_windows.go
+++ b/metricbeat/helper/windows/pdh/pdh_query_windows.go
@@ -27,7 +27,7 @@ import (
 	"slices"
 	"strings"
 	"syscall"
-	"unsafe"
+	"unicode/utf16"
 
 	"golang.org/x/sys/windows"
 )
@@ -346,23 +346,24 @@ func getPDHFormat(format string) PdhCounterFormat {
 }
 
 // UTF16ToStringArray converts list of Windows API NULL terminated strings  to Go string array.
+// The list ends at the first empty string, as in the Win32 MULTI_SZ convention.
 func UTF16ToStringArray(buf []uint16) []string {
 	var strings []string
-	nextLineStart := 0
-	stringLine := UTF16PtrToString(&buf[0])
-	for stringLine != "" {
-		strings = append(strings, stringLine)
-		nextLineStart += len([]rune(stringLine)) + 1
-		remainingBuf := buf[nextLineStart:]
-		stringLine = UTF16PtrToString(&remainingBuf[0])
+	for len(buf) > 0 && buf[0] != 0 {
+		end := 0
+		for end < len(buf) && buf[end] != 0 {
+			end++
+		}
+		strings = append(strings, string(utf16.Decode(buf[:end])))
+		if end == len(buf) {
+			break
+		}
+		buf = buf[end+1:]
 	}
 	return strings
 }
 
 // UTF16PtrToString converts Windows API LPTSTR (pointer to string) to Go string.
 func UTF16PtrToString(s *uint16) string {
-	if s == nil {
-		return ""
-	}
-	return syscall.UTF16ToString((*[1 << 29]uint16)(unsafe.Pointer(s))[0:])
+	return windows.UTF16PtrToString(s)
 }

--- a/metricbeat/helper/windows/pdh/pdh_query_windows.go
+++ b/metricbeat/helper/windows/pdh/pdh_query_windows.go
@@ -231,7 +231,7 @@ func (q *Query) ExpandWildCardPath(wildCardPath string) ([]string, error) {
 		if len(paths) == 1 && strings.Contains(paths[0], "*") && paths[0] == wildCardPath {
 			expdPaths, err = PdhExpandWildCardPath(utfPath)
 			if err == nil {
-				return paths, err
+				return UTF16ToStringArray(expdPaths), nil
 			}
 		} else {
 			return paths, err

--- a/metricbeat/module/system/ntp/ntp.go
+++ b/metricbeat/module/system/ntp/ntp.go
@@ -35,6 +35,7 @@ var (
 	_ mb.ReportingMetricSetV2Error = (*MetricSet)(nil)
 )
 
+// ntpQueryProvider implementations must be safe for concurrent use.
 type ntpQueryProvider interface {
 	query(host string, options ntp.QueryOptions) (*ntp.Response, error)
 	validate(*ntp.Response) error

--- a/metricbeat/module/system/ntp/ntp_test.go
+++ b/metricbeat/module/system/ntp/ntp_test.go
@@ -20,6 +20,7 @@ package ntp
 import (
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -94,7 +95,7 @@ func TestFetchOffset_Error(t *testing.T) {
 }
 
 type ntpValidationFailed struct {
-	Called int
+	called atomic.Int32
 }
 
 func (n *ntpValidationFailed) query(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
@@ -102,7 +103,7 @@ func (n *ntpValidationFailed) query(host string, opt ntp.QueryOptions) (*ntp.Res
 }
 
 func (n *ntpValidationFailed) validate(_ *ntp.Response) error {
-	n.Called++
+	n.called.Add(1)
 	return errors.New("ntp validation error")
 }
 
@@ -117,7 +118,7 @@ func TestFetchOffset_ValidationError(t *testing.T) {
 		ntpMetricSet.queryProvider = queryProvider
 
 		events, errs := mbtest.ReportingFetchV2Error(ntpMetricSet)
-		assert.Equal(t, 2, queryProvider.Called, "expected validate to be called twice, called %d times", queryProvider.Called)
+		assert.Equal(t, int32(2), queryProvider.called.Load(), "expected validate to be called twice, called %d times", queryProvider.called.Load())
 		require.Empty(t, events, "expected no events, got %v", events)
 		require.Empty(t, errs, "expected no errors, got: %v", errs)
 	})
@@ -135,7 +136,7 @@ func TestFetchOffset_ValidationError(t *testing.T) {
 		ntpMetricSet.queryProvider = queryProvider
 
 		_, errs := mbtest.ReportingFetchV2Error(ntpMetricSet)
-		assert.Equal(t, 0, queryProvider.Called, "expected validate to be NOT called, called %d times", queryProvider.Called)
+		assert.Equal(t, int32(0), queryProvider.called.Load(), "expected validate to be NOT called, called %d times", queryProvider.called.Load())
 		require.Empty(t, errs, "expected no errors, got: %v", errs)
 	})
 

--- a/metricbeat/module/system/ntp/ntp_test.go
+++ b/metricbeat/module/system/ntp/ntp_test.go
@@ -41,8 +41,8 @@ func (n *ntpSuccess) validate(_ *ntp.Response) error {
 	return nil
 }
 
-func getTestConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getTestConfig() map[string]any {
+	return map[string]any{
 		"module":      "system",
 		"metricsets":  []string{"ntp"},
 		"ntp.servers": []string{"0.time.tom.com", "1.time.tom.com"},

--- a/packetbeat/beater/install_npcap.go
+++ b/packetbeat/beater/install_npcap.go
@@ -37,7 +37,11 @@ const installTimeout = 120 * time.Second
 
 // muInstall protects use of npcap.Installer. The only writes to npcap.Installer
 // are here and during init in x-pack/packetbeat/npcap/npcap_windows.go
-var muInstall sync.Mutex
+var (
+	muInstall       sync.Mutex
+	npcapInstalled  bool
+	npcapInstallErr error
+)
 
 func installNpcap(b *beat.Beat, cfg *conf.C) error {
 	if !b.Info.ElasticLicensed {
@@ -56,6 +60,18 @@ func installNpcap(b *beat.Beat, cfg *conf.C) error {
 			log.Infof("npcap version: %s", npcapVersion)
 		}
 	}()
+
+	muInstall.Lock()
+	defer muInstall.Unlock()
+	if npcapInstalled {
+		return npcapInstallErr
+	}
+	npcapInstalled = true
+	npcapInstallErr = installNpcapLocked(b, cfg)
+	return npcapInstallErr
+}
+
+func installNpcapLocked(b *beat.Beat, cfg *conf.C) error {
 	if !npcap.Upgradeable() {
 		npcap.Installer = nil
 		return nil
@@ -82,8 +98,6 @@ func installNpcap(b *beat.Beat, cfg *conf.C) error {
 	ctx, cancel := context.WithTimeout(context.Background(), installTimeout)
 	defer cancel()
 
-	muInstall.Lock()
-	defer muInstall.Unlock()
 	if npcap.Installer == nil {
 		return nil
 	}

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -47,7 +48,8 @@ import (
 type Sniffer struct {
 	sniffers []sniffer
 	closers  []func()
-	cancel   func()
+	cancelMu sync.Mutex
+	cancel   context.CancelFunc
 	log      *logp.Logger
 }
 
@@ -220,7 +222,9 @@ func validateAfPacketConfig(cfg *config.InterfaceConfig) error {
 // Worker instances are instantiated as needed.
 func (s *Sniffer) Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
+	s.cancelMu.Lock()
 	s.cancel = cancel
+	s.cancelMu.Unlock()
 	g, ctx := errgroup.WithContext(ctx)
 	for i := range s.sniffers {
 		c := &s.sniffers[i]
@@ -528,9 +532,12 @@ func (s *Sniffer) Stop() {
 		s.log.Debugf("sending closing to %s", c.config.Device)
 		c.state.Store(snifferClosing)
 	}
-	if s.cancel != nil {
+	s.cancelMu.Lock()
+	cancel := s.cancel
+	s.cancelMu.Unlock()
+	if cancel != nil {
 		s.log.Debug("cancelling sniffers")
-		s.cancel()
+		cancel()
 	}
 }
 

--- a/packetbeat/sniffer/sniffer_test.go
+++ b/packetbeat/sniffer/sniffer_test.go
@@ -22,12 +22,16 @@ package sniffer
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/packetbeat/config"
 	"github.com/elastic/beats/v7/packetbeat/decoder"
+	"github.com/elastic/beats/v7/packetbeat/flows"
+	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -180,3 +184,90 @@ func TestEnsureDecoderReplaceErrorKeepsCurrentCleanup(t *testing.T) {
 	cleanup()
 	assert.Equal(t, 1, cleanupCalls)
 }
+
+func TestSnifferStopRunLifecycle(t *testing.T) {
+	t.Parallel()
+
+	s := newTestFileSniffer(t)
+
+	s.Stop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run()
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Run should return cleanly after Stop-before-Run")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after Stop-before-Run")
+	}
+
+	for i := 0; i < 2; i++ {
+		s.Stop()
+	}
+}
+
+func TestSnifferConcurrentStopRun(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		s := newTestFileSniffer(t)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- s.Run()
+		}()
+
+		for j := 0; j < 10; j++ {
+			s.Stop()
+		}
+
+		select {
+		case err := <-done:
+			assert.NoError(t, err, "Run should return cleanly after concurrent Stop calls")
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Run did not return after concurrent Stop calls on iteration %d", i)
+		}
+	}
+}
+
+func newTestFileSniffer(t *testing.T) *Sniffer {
+	t.Helper()
+
+	logger := logp.NewLogger("sniffer_test")
+	decoders := map[string]Decoders{
+		"": func(dl layers.LinkType, _ string, _ int) (*decoder.Decoder, func(), error) {
+			dec, err := decoder.New(nil, dl, discardICMP{}, discardICMP{}, discardTCP{}, discardUDP{}, false, logger)
+			if err != nil {
+				return nil, nil, err
+			}
+			return dec, func() {}, nil
+		},
+	}
+	interfaces := []config.InterfaceConfig{{
+		File: "../tests/system/pcaps/http_x_forwarded_for.pcap",
+		Loop: 1000,
+	}}
+	s, err := New("test", true, "", decoders, interfaces, nil, logger)
+	require.NoError(t, err, "creating a file-backed sniffer should succeed")
+	return s
+}
+
+// The lifecycle tests only need a decoder that drains the pcap without
+// panicking, so every protocol processor discards what it is handed.
+type (
+	discardTCP  struct{}
+	discardUDP  struct{}
+	discardICMP struct{}
+)
+
+func (discardTCP) Process(_ *flows.FlowID, _ *layers.TCP, _ *protos.Packet) {}
+
+func (discardUDP) Process(_ *flows.FlowID, _ *protos.Packet) {}
+
+func (discardICMP) ProcessICMPv4(_ *flows.FlowID, _ *layers.ICMPv4, _ *protos.Packet) {}
+
+func (discardICMP) ProcessICMPv6(_ *flows.FlowID, _ *layers.ICMPv6, _ *protos.Packet) {}

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_test.go
@@ -6,6 +6,7 @@ package awscloudwatch
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,11 +16,20 @@ import (
 )
 
 type clock struct {
+	mu   sync.Mutex
 	time time.Time
 }
 
 func (c *clock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.time
+}
+
+func (c *clock) set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.time = t
 }
 
 type receiveTestStep struct {
@@ -196,7 +206,7 @@ func TestReceive(t *testing.T) {
 		if test.configOverrides != nil {
 			test.configOverrides(&p.config)
 		}
-		clock.time = test.startTime
+		clock.set(test.startTime)
 		go p.receive(ctx, test.logGroupIDs, clock.now)
 		for _, step := range test.steps {
 			for i, expected := range step.expected {
@@ -204,7 +214,7 @@ func TestReceive(t *testing.T) {
 				if i+1 == len(step.expected) && !step.nextTime.Equal(time.Time{}) {
 					// On the last request of the step, we advance the clock if a
 					// time is set
-					clock.time = step.nextTime
+					clock.set(step.nextTime)
 				}
 				response := <-p.workResponseChan
 				assert.Equalf(t, expected, response, "%v: step %v response %v doesn't match", test.name, stepIndex, i)

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 type clock struct {
@@ -189,7 +189,7 @@ func TestReceive(t *testing.T) {
 		cfg.LogGroupName = "LogGroup"
 
 		handler, err := newStateHandler(nil, cfg, createTestInputStore())
-		assert.Nil(t, err)
+		assert.NoError(t, err, "newStateHandler should succeed")
 
 		p := &cloudwatchPoller{
 			workRequestChan: make(chan struct{}),
@@ -197,7 +197,7 @@ func TestReceive(t *testing.T) {
 			// so we can guarantee that clock updates happen when cwPoller has already
 			// decided on its output
 			workResponseChan: make(chan workResponse),
-			log:              logp.NewLogger("test"),
+			log:              logptest.NewTestingLogger(t, ""),
 			stateHandler:     handler,
 		}
 

--- a/x-pack/filebeat/input/awss3/input_benchmark_test.go
+++ b/x-pack/filebeat/input/awss3/input_benchmark_test.go
@@ -30,6 +30,7 @@ import (
 
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -112,7 +113,7 @@ func newS3PagerConstant(listPrefix string) *s3PagerConstant {
 		currentIndex: 0,
 	}
 
-	for i := 0; i < totalListingObjectsForInputS3; i++ {
+	for i := range totalListingObjectsForInputS3 {
 		ret.objects = append(ret.objects, s3Types.Object{
 			Key:          aws.String(fmt.Sprintf("%s-%d.json.gz", listPrefix, i)),
 			ETag:         aws.String(fmt.Sprintf("etag-%s-%d", listPrefix, i)),
@@ -313,7 +314,7 @@ func TestBenchmarkInputSQS(t *testing.T) {
 
 func benchmarkInputS3(t *testing.T, numberOfWorkers int) testing.BenchmarkResult {
 	return testing.Benchmark(func(b *testing.B) {
-		log := logp.NewLogger(inputName)
+		log := logptest.NewTestingLogger(t, inputName)
 		log.Infof("benchmark with %d number of workers", numberOfWorkers)
 
 		metrics := newInputMetrics(monitoring.NewRegistry(), numberOfWorkers, logp.NewNopLogger())
@@ -336,7 +337,7 @@ func benchmarkInputS3(t *testing.T, numberOfWorkers int) testing.BenchmarkResult
 
 		errChan := make(chan error)
 		wg := new(sync.WaitGroup)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			wg.Add(1)
 			go func(i int, wg *sync.WaitGroup) {
 				defer wg.Done()
@@ -402,6 +403,9 @@ func benchmarkInputS3(t *testing.T, numberOfWorkers int) testing.BenchmarkResult
 }
 
 func TestBenchmarkInputS3(t *testing.T) {
+	if raceBuildEnabled {
+		t.Skip("too slow under the race detector: the worker counts below scale to 1024 pollers per case, and instrumented throughput numbers are meaningless anyway")
+	}
 
 	results := []testing.BenchmarkResult{
 		benchmarkInputS3(t, 1),

--- a/x-pack/filebeat/input/awss3/racedetector_off_test.go
+++ b/x-pack/filebeat/input/awss3/racedetector_off_test.go
@@ -1,0 +1,12 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !race
+
+package awss3
+
+const (
+	raceBuildEnabled = false
+	raceTimeoutScale = 1
+)

--- a/x-pack/filebeat/input/awss3/racedetector_on_test.go
+++ b/x-pack/filebeat/input/awss3/racedetector_on_test.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build race
+
+package awss3
+
+const (
+	raceBuildEnabled = true
+	// Race instrumentation slows decoding by roughly an order of magnitude, so
+	// deadlines meant as safety nets have to grow with it.
+	raceTimeoutScale = 10
+)

--- a/x-pack/filebeat/input/awss3/s3_objects_test.go
+++ b/x-pack/filebeat/input/awss3/s3_objects_test.go
@@ -423,7 +423,9 @@ func testProcessS3ObjectError(t testing.TB, file, contentType string, numEvents 
 func _testProcessS3Object(t testing.TB, file, contentType string, numEvents int, expectErr bool, selectors []fileSelectorConfig) []beat.Event {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	// Decoding stops silently once this context expires, which shows up as a
+	// short event count rather than an error, so keep the budget generous.
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout*raceTimeoutScale)
 	defer cancel()
 
 	ctrl, ctx := gomock.WithContext(ctx, t)

--- a/x-pack/filebeat/input/azureblobstorage/input_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/input_test.go
@@ -774,7 +774,7 @@ func Test_StorageClient(t *testing.T) {
 				case <-timeout.C:
 					t.Errorf("timed out waiting for %d events", len(tt.expected))
 					cancel()
-					return
+					break wait
 				case got := <-chanClient.Channel:
 					var val interface{}
 					var err error
@@ -788,6 +788,12 @@ func Test_StorageClient(t *testing.T) {
 						break wait
 					}
 				}
+			}
+
+			// Wait for scheduler and job goroutines to finish before the subtest
+			// returns; they log through inputCtx.Logger backed by this *testing.T.
+			if err := g.Wait(); err != nil {
+				assert.ErrorIs(t, err, context.Canceled, "input run should stop after cancel")
 			}
 		})
 	}

--- a/x-pack/filebeat/input/azureblobstorage/input_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/input_test.go
@@ -41,25 +41,26 @@ const (
 	beatsGzJSONContainer        = "beatsgzjsoncontainer"
 	beatsJSONWithArrayContainer = "beatsjsonwitharraycontainer"
 	beatsCSVContainer           = "beatscsvcontainer"
+	fakeAccountKey              = "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q=="
 )
 
 func Test_StorageClient(t *testing.T) {
 	tests := []struct {
 		name          string
-		baseConfig    map[string]interface{}
+		baseConfig    map[string]any
 		mockHandler   func() http.Handler
 		expected      map[string]bool
 		expectedError error
 	}{
 		{
 			name: "SingleContainerWithPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -74,13 +75,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleContainerWithoutPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -95,13 +96,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoContainersWithPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -121,13 +122,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoContainersWithoutPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -147,13 +148,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleContainerPoll_InvalidContainerErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": "azuretest",
 					},
@@ -165,13 +166,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleContainerWithoutPoll_InvalidBucketErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": "azuretest",
 					},
@@ -183,13 +184,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoContainersWithPoll_InvalidBucketErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": "azurenew",
 					},
@@ -204,13 +205,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleBucketWithPoll_InvalidConfigValue",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         5100,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -222,13 +223,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoBucketWithPoll_InvalidConfigValue",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         5100,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -243,13 +244,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsJSONContainer,
 					},
@@ -264,13 +265,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadOctetStreamJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsMultilineJSONContainer,
 					},
@@ -284,13 +285,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadNdJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsNdJSONContainer,
 					},
@@ -304,13 +305,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadMultilineGzJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsGzJSONContainer,
 					},
@@ -324,13 +325,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadJSONWithRootAsArray",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsJSONWithArrayContainer,
 					},
@@ -346,14 +347,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByTimeStampEpoch",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"timestamp_epoch":                     1663157564,
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -367,18 +368,18 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByFileSelectorRegexSingle",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "docs/",
 					},
 				},
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -391,13 +392,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByFileSelectorRegexMulti",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "docs/",
 					},
@@ -405,7 +406,7 @@ func Test_StorageClient(t *testing.T) {
 						"regex": "data",
 					},
 				},
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -419,19 +420,19 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ExpandEventListFromField",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"expand_event_list_from_field":        "Events",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "events-array",
 					},
 				},
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsJSONContainer,
 					},
@@ -445,16 +446,16 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "MultiContainerWithMultiFileSelectors",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
-						"file_selectors": []map[string]interface{}{
+						"file_selectors": []map[string]any{
 							{
 								"regex": "docs/",
 							},
@@ -462,7 +463,7 @@ func Test_StorageClient(t *testing.T) {
 					},
 					{
 						"name": beatsContainer2,
-						"file_selectors": []map[string]interface{}{
+						"file_selectors": []map[string]any{
 							{
 								"regex": "data_3",
 							},
@@ -478,13 +479,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "CustomContentTypeUnsupported",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":                  beatsGzJSONContainer,
 						"content_type":          "application/xyz-plain",
@@ -499,13 +500,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "CustomContentTypeSupported",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":         beatsGzJSONContainer,
 						"content_type": "application/x-gzip",
@@ -523,13 +524,13 @@ func Test_StorageClient(t *testing.T) {
 			// content-type already exists and we are not overriding it.
 			// So we expect a successful run.
 			name: "CustomContentTypeIgnored",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":         beatsNdJSONContainer,
 						"content_type": "application/xyz-plain",
@@ -545,14 +546,14 @@ func Test_StorageClient(t *testing.T) {
 		{
 			// This checks if the root level content-type specifications are respected.
 			name: "CustomContentTypeAtRootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"content_type":                        "application/x-gzip",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsGzJSONContainer,
 					},
@@ -566,13 +567,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadCSVContainerLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":                       beatsCSVContainer,
 						"decoding.codec.csv.enabled": true,
@@ -588,15 +589,15 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadCSVRootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"decoding.codec.csv.enabled":          true,
 				"decoding.codec.csv.comma":            " ",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsCSVContainer,
 					},
@@ -610,14 +611,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "BatchSizeGlobal",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"batch_size":                          3,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -632,13 +633,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "BatchContainberLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":       beatsContainer,
 						"batch_size": 3,
@@ -654,14 +655,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByPathPrefix_NotFoundErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"path_prefix":                         "docs/",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer2,
 					},
@@ -673,14 +674,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByPathPrefix_RootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"path_prefix":                         "docs/",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -693,13 +694,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByPathPrefix_ContainerLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":        beatsContainer,
 						"path_prefix": "docs/",
@@ -776,11 +777,13 @@ func Test_StorageClient(t *testing.T) {
 					cancel()
 					break wait
 				case got := <-chanClient.Channel:
-					var val interface{}
+					var val any
 					var err error
 					val, err = got.Fields.GetValue("message")
 					assert.NoError(t, err)
-					assert.True(t, tt.expected[strings.ReplaceAll(val.(string), "\r\n", "\n")])
+					msg, ok := val.(string)
+					assert.True(t, ok, "message field should be a string")
+					assert.True(t, tt.expected[strings.ReplaceAll(msg, "\r\n", "\n")])
 					assert.Equal(t, tt.expectedError, err)
 					receivedCount += 1
 					if receivedCount == len(tt.expected) {
@@ -806,13 +809,13 @@ func TestConcurrency(t *testing.T) {
 			serv := httptest.NewServer(mock.AzureConcurrencyServer())
 			t.Cleanup(serv.Close)
 
-			cfg := conf.MustNewConfigFrom(map[string]interface{}{
+			cfg := conf.MustNewConfigFrom(map[string]any{
 				"account_name":                        "beatsblobnew",
-				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
+				"auth.shared_credentials.account_key": fakeAccountKey,
 				"max_workers":                         workers,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": mock.ConcurrencyContainer,
 					},
@@ -879,14 +882,14 @@ type publisher struct {
 	stop    func([]beat.Event)
 	events  []beat.Event
 	mu      sync.Mutex
-	cursors []map[string]interface{}
+	cursors []map[string]any
 }
 
-func (p *publisher) Publish(e beat.Event, cursor interface{}) error {
+func (p *publisher) Publish(e beat.Event, cursor any) error {
 	p.mu.Lock()
 	p.events = append(p.events, e)
 	if cursor != nil {
-		var c map[string]interface{}
+		var c map[string]any
 		chkpt, ok := cursor.(*Checkpoint)
 		if !ok {
 			return fmt.Errorf("invalid cursor type for testing: %T", cursor)

--- a/x-pack/filebeat/input/azureblobstorage/mock/mock.go
+++ b/x-pack/filebeat/input/azureblobstorage/mock/mock.go
@@ -19,12 +19,9 @@ const (
 
 //nolint:errcheck // We can ignore as response writer errors cannot be handled in this scenario
 func AzureStorageServer() http.Handler {
-	var pathPrefix string
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.Split(strings.TrimLeft(r.URL.Path, "/"), "/")
-		if r.URL.RawQuery != "" {
-			pathPrefix = r.URL.Query().Get("prefix")
-		}
+		pathPrefix := r.URL.Query().Get("prefix")
 
 		w.Header().Set(contentType, jsonType)
 		if r.Method == http.MethodGet {
@@ -48,16 +45,11 @@ func AzureStorageServer() http.Handler {
 				}
 
 				w.Header().Set(contentType, xmlType)
-				w.Write([]byte(fetchContainer[containerName]))
+				w.Write([]byte(filterListingByPrefix(fetchContainer[containerName], pathPrefix)))
 				return
 			case 2:
 				if Containers[path[0]] && availableBlobs[path[0]][path[1]] {
-					if pathPrefix != "" && !strings.HasPrefix(path[1], pathPrefix) {
-						w.WriteHeader(http.StatusNotFound)
-						w.Write([]byte("resource not found"))
-					} else {
-						w.Write([]byte(blobs[path[0]][path[1]]))
-					}
+					w.Write([]byte(blobs[path[0]][path[1]]))
 					return
 				}
 			case 3:
@@ -183,4 +175,41 @@ func hasKeyWithPrefix(data map[string]bool, prefix string) bool {
 		}
 	}
 	return false
+}
+
+// filterListingByPrefix returns a container listing XML containing only blobs
+// whose names match prefix. An empty prefix returns the full listing.
+func filterListingByPrefix(listing, prefix string) string {
+	if prefix == "" {
+		return listing
+	}
+
+	var out strings.Builder
+	rest := listing
+	for {
+		start := strings.Index(rest, "<Blob>")
+		if start == -1 {
+			out.WriteString(rest)
+			break
+		}
+		out.WriteString(rest[:start])
+		rest = rest[start:]
+		end := strings.Index(rest, "</Blob>")
+		if end == -1 {
+			out.WriteString(rest)
+			break
+		}
+		blob := rest[:end+len("</Blob>")]
+		rest = rest[end+len("</Blob>"):]
+
+		nameStart := strings.Index(blob, "<Name>") + len("<Name>")
+		nameEnd := strings.Index(blob, "</Name>")
+		if nameStart < len("<Name>") || nameEnd == -1 {
+			continue
+		}
+		if strings.HasPrefix(blob[nameStart:nameEnd], prefix) {
+			out.WriteString(blob)
+		}
+	}
+	return out.String()
 }

--- a/x-pack/filebeat/input/azureblobstorage/mock/mock.go
+++ b/x-pack/filebeat/input/azureblobstorage/mock/mock.go
@@ -98,6 +98,7 @@ func AzureStorageFileServer() http.Handler {
 					case "txn1.csv":
 						w.Header().Set(contentType, "text/csv")
 					}
+					//nolint:gosec // G705 false positive: test HTTP mock serving static fixture bytes
 					w.Write(data)
 					return
 				}
@@ -127,6 +128,7 @@ func AzureFileServerNoContentType() http.Handler {
 				if availableFileBlobs[path[0]][path[1]] {
 					absPath, _ := filepath.Abs("testdata/" + path[1])
 					data, _ := os.ReadFile(absPath)
+					//nolint:gosec // G705 false positive: test HTTP mock serving static fixture bytes
 					w.Write(data)
 					return
 				}

--- a/x-pack/filebeat/input/cometd/input_test.go
+++ b/x-pack/filebeat/input/cometd/input_test.go
@@ -12,6 +12,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -65,6 +67,116 @@ func TestMakeEventFailure(t *testing.T) {
 		Private: "DEMOBODYFAIL",
 	}
 	assert.NotEqual(t, event, makeEvent("DEMOCHANNEL", "DEMOID", "DEMOBODY"))
+}
+
+const payloadFormatEnvVar = "BEATS_COMETD_PAYLOAD_FORMAT"
+
+// connectResponses maps a Salesforce payload format to a /meta/connect response using it.
+var connectResponses = map[string]string{
+	"payload": `[{"data": {"payload": {"CountryIso": "IN"}, "event": {"replayId":1234}}, "channel": "channel_name"}]`,
+	"sobject": `[{"data": {"sobject": {"CountryIso": "IN"}, "event": {"replayId":1234}}, "channel": "channel_name"}]`,
+}
+
+func TestInputPayloadFormats(t *testing.T) {
+	// github.com/elastic/bayeux keeps subscription state in unsynchronized package globals
+	// and its connect goroutine outlives Stop(), so two clients in one test binary race
+	// under -race no matter how the tests are ordered.
+	for format := range connectResponses {
+		t.Run(format, func(t *testing.T) {
+			//nolint:gosec // subprocess re-exec of this test binary with fixed args
+			cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestInputPayloadFormatsProcess$", "-test.count=1")
+			cmd.Env = append(os.Environ(), payloadFormatEnvVar+"="+format)
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "payload format %q subprocess failed:\n%s", format, out)
+		})
+	}
+}
+
+func TestInputPayloadFormatsProcess(t *testing.T) {
+	format := os.Getenv(payloadFormatEnvVar)
+	if format == "" {
+		t.Skip("subprocess helper for TestInputPayloadFormats")
+	}
+	connectResponse, ok := connectResponses[format]
+	require.True(t, ok, "unknown payload format %q", format)
+	runInputPayloadFormatCase(t, connectResponse)
+}
+
+func runInputPayloadFormatCase(t *testing.T, connectResponse string) {
+	t.Helper()
+
+	eventsCh := make(chan beat.Event)
+	defer close(eventsCh)
+
+	outlet := &mockedOutleter{
+		onEventHandler: func(event beat.Event) bool {
+			eventsCh <- event
+			return true
+		},
+	}
+	connector := &mockedConnector{
+		outlet: outlet,
+	}
+
+	var expected bay.MaybeMsg
+	expected.Msg.Data.Event.ReplayID = 1234
+	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
+	expected.Msg.Channel = "channel_name"
+
+	config := map[string]any{
+		"channel_name":              "channel_name",
+		"auth.oauth2.client.id":     "client.id",
+		"auth.oauth2.client.secret": "client.secret",
+		"auth.oauth2.user":          "user",
+		"auth.oauth2.password":      "password",
+	}
+
+	// The server serves each request on its own goroutine.
+	var connectEventSent atomic.Bool
+
+	r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_ = r.ParseForm()
+		if getTokenHandler(w, r) {
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		data := getBayData(body)
+
+		switch data.Channel {
+		case "/meta/handshake":
+			_, _ = w.Write([]byte(`[{"ext":{"replay":true,"payload.format":true},"minimumVersion":"1.0","clientId":"client_id","supportedConnectionTypes":["long-polling"],"channel":"/meta/handshake","version":"1.0","successful":true}]`))
+			return
+		case "/meta/connect":
+			if connectEventSent.Swap(true) {
+				_, _ = w.Write([]byte(`{}`))
+				return
+			}
+			_, _ = w.Write([]byte(connectResponse))
+			return
+		case "/meta/subscribe":
+			_, _ = w.Write([]byte(`[{"clientId": "client_id", "channel": "/meta/subscribe", "subscription": "channel_name", "successful":true}]`))
+			return
+		default:
+		}
+	})
+	server := httptest.NewServer(r)
+	defer server.Close()
+	serverURL = server.URL
+	config["auth.oauth2.token_url"] = serverURL + "/token"
+
+	cfg := conf.MustNewConfigFrom(config)
+
+	var inputContext finput.Context
+
+	logger := logptest.NewTestingLogger(t, "")
+	input, err := NewInput(cfg, connector, inputContext, logger)
+	require.NoError(t, err, "NewInput for payload format case")
+	require.NotNil(t, input, "input for payload format case")
+
+	input.Run()
+	assertEventMatches(t, expected, <-eventsCh)
+	input.Stop()
 }
 
 func TestSingleInput(t *testing.T) {
@@ -245,122 +357,6 @@ func TestWait(t *testing.T) {
 	case <-workerCtx.Done():
 	case <-time.After(time.Second): // let input.Stop() be executed.
 		require.NoError(t, fmt.Errorf("input is not stopped."))
-	}
-}
-
-func TestMultiInput(t *testing.T) {
-	expectedHTTPEventCount = 2
-	defer atomic.StoreUint64(&called, 0)
-	eventsCh := make(chan beat.Event)
-	defer close(eventsCh)
-
-	outlet := &mockedOutleter{
-		onEventHandler: func(event beat.Event) bool {
-			eventsCh <- event
-			return true
-		},
-	}
-	connector := &mockedConnector{
-		outlet: outlet,
-	}
-
-	var expected1 bay.MaybeMsg
-	expected1.Msg.Data.Event.ReplayID = 1234
-	expected1.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
-	expected1.Msg.Channel = "channel_name"
-
-	config := map[string]interface{}{
-		"channel_name":              "channel_name",
-		"auth.oauth2.client.id":     "client.id",
-		"auth.oauth2.client.secret": "client.secret",
-		"auth.oauth2.user":          "user",
-		"auth.oauth2.password":      "password",
-	}
-
-	// create Server
-	r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("content-type", "application/json")
-		_ = r.ParseForm()
-		if getTokenHandler(w, r) {
-			return
-		}
-		body, _ := io.ReadAll(r.Body)
-		data := getBayData(body)
-
-		switch data.Channel {
-		case "/meta/handshake":
-			_, _ = w.Write([]byte(`[{"ext":{"replay":true,"payload.format":true},"minimumVersion":"1.0","clientId":"client_id","supportedConnectionTypes":["long-polling"],"channel":"/meta/handshake","version":"1.0","successful":true}]`))
-			return
-		case "/meta/connect":
-			if called < uint64(expectedHTTPEventCount) { //nolint:gosec //Safe to ignore in tests
-				//nolint:staticcheck //Safe to ignore in tests
-				if called == 0 {
-					atomic.AddUint64(&called, 1)
-					_, _ = w.Write([]byte(`[{"data": {"payload": {"CountryIso": "IN"}, "event": {"replayId":1234}}, "channel": "channel_name"}]`))
-					return
-				} else if called == 1 {
-					atomic.AddUint64(&called, 1)
-					_, _ = w.Write([]byte(`[{"data": {"sobject": {"CountryIso": "IN"}, "event": {"replayId":1234}}, "channel": "channel_name"}]`))
-					return
-				}
-			}
-			_, _ = w.Write([]byte(`{}`))
-			return
-		case "/meta/subscribe":
-			//nolint:staticcheck //Safe to ignore in tests
-			if called == 0 {
-				_, _ = w.Write([]byte(`[{"clientId": "client_id", "channel": "/meta/subscribe", "subscription": "channel_name", "successful":true}]`))
-			} else if called == 1 {
-				_, _ = w.Write([]byte(`[{"clientId": "client_id", "channel": "/meta/subscribe", "subscription": "channel_name1", "successful":true}]`))
-			}
-			return
-		default:
-		}
-	})
-	server := httptest.NewServer(r)
-	defer server.Close()
-	serverURL = server.URL
-	config["auth.oauth2.token_url"] = serverURL + "/token"
-
-	// get common config
-	cfg1 := conf.MustNewConfigFrom(config)
-	config["channel_name"] = "channel_name1"
-	cfg2 := conf.MustNewConfigFrom(config)
-
-	var inputContext finput.Context
-
-	logger := logptest.NewTestingLogger(t, "")
-	// initialize inputs
-	input1, err := NewInput(cfg1, connector, inputContext, logger)
-	require.NoError(t, err)
-	require.NotNil(t, input1)
-
-	input2, err := NewInput(cfg2, connector, inputContext, logger)
-	require.NoError(t, err)
-	require.NotNil(t, input2)
-
-	require.Equal(t, 0, bay.GetConnectedCount())
-
-	got := 0
-	go func() {
-		// run input
-		input1.Run()
-		defer input1.Stop()
-
-		// run input
-		input2.Run()
-		defer input2.Stop()
-
-		for _, event := range []beat.Event{<-eventsCh, <-eventsCh} {
-			message, err := event.GetValue("message")
-			require.NoError(t, err)
-			require.Equal(t, string(expected1.Msg.Data.Payload), message)
-			got++
-		}
-	}()
-	time.Sleep(time.Second)
-	if got < 2 {
-		require.NoError(t, fmt.Errorf("not able to get events."))
 	}
 }
 

--- a/x-pack/filebeat/input/cometd/input_test.go
+++ b/x-pack/filebeat/input/cometd/input_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input/inputtest"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -40,6 +39,7 @@ var (
 )
 
 func TestInputDone(t *testing.T) {
+	//nolint:gosec // test fixture credentials, not real secrets
 	config := mapstr.M{
 		"channel_name":              "channel_channel",
 		"auth.oauth2.client.id":     "DEMOCLIENTID",
@@ -201,7 +201,7 @@ func TestSingleInput(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",
@@ -260,7 +260,7 @@ func TestInputStop_Wait(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",
@@ -290,16 +290,14 @@ func TestInputStop_Wait(t *testing.T) {
 	var waitForEventCollection sync.WaitGroup
 	var waitForConnections sync.WaitGroup
 	waitForEventCollection.Add(1)
-	waitForConnections.Add(1)
-	go func() {
+	waitForConnections.Go(func() {
 		require.Equal(t, 1, bay.GetConnectedCount()) // current open channels count should be 1
 		event := <-eventsCh
 		assertEventMatches(t, expected, event) // wait for single event
 		waitForEventCollection.Done()
 		time.Sleep(100 * time.Millisecond)           // let input.Stop() be executed.
 		require.Equal(t, 0, bay.GetConnectedCount()) // current open channels count should be 0
-		waitForConnections.Done()
-	}()
+	})
 
 	waitForEventCollection.Wait()
 	input.Wait()
@@ -308,7 +306,7 @@ func TestInputStop_Wait(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	conf := defaultConfig()
-	logger := logp.NewLogger("test")
+	logger := logptest.NewTestingLogger(t, "")
 	authParams := bay.AuthenticationParameters{}
 	inputCtx, cancelInputCtx := context.WithCancel(context.Background())
 	workerCtx, workerCancel := context.WithCancel(inputCtx)
@@ -333,7 +331,7 @@ func TestStop(t *testing.T) {
 
 func TestWait(t *testing.T) {
 	conf := defaultConfig()
-	logger := logp.NewLogger("test")
+	logger := logptest.NewTestingLogger(t, "")
 	authParams := bay.AuthenticationParameters{}
 	inputCtx, cancelInputCtx := context.WithCancel(context.Background())
 	workerCtx, workerCancel := context.WithCancel(inputCtx)
@@ -421,7 +419,7 @@ func TestMultiEventForEOFRetryHandlerInput(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",
@@ -493,7 +491,7 @@ func TestMultiEventForEOFRetryHandlerInput(t *testing.T) {
 	close(eventsCh)
 
 	go func() {
-		for j := 0; j < expectedEventCount; j++ {
+		for range expectedEventCount {
 			event := <-eventsCh
 			assertEventMatches(t, expected, event)
 		}
@@ -506,7 +504,7 @@ func TestMultiEventForEOFRetryHandlerInput(t *testing.T) {
 func newTestServer(URL string, handler http.Handler) (*httptest.Server, error) {
 	server := httptest.NewUnstartedServer(handler)
 	if URL != "" {
-		l, err := net.Listen("tcp", URL)
+		l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", URL)
 		if err != nil {
 			return nil, err
 		}
@@ -539,7 +537,7 @@ func TestNegativeCases(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -47,7 +47,7 @@ type SynthexecTimeout string
 var SynthexecTimeoutKey = SynthexecTimeout("synthexec_timeout")
 
 // ProjectJob will run a single journey by name from the given project.
-func ProjectJob(ctx context.Context, projectPath string, params func() map[string]interface{}, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {
+func ProjectJob(ctx context.Context, projectPath string, params func() map[string]any, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {
 	// Run the command in the given projectPath, use '.' as the first arg since the command runs
 	// in the correct dir
 	cmdFactory, err := projectCommandFactory(projectPath, extraArgs...)
@@ -79,7 +79,7 @@ func projectCommandFactory(projectPath string, args ...string) (func() *SynthCmd
 }
 
 // InlineJourneyJob returns a job that runs the given source as a single journey.
-func InlineJourneyJob(ctx context.Context, script string, params func() map[string]interface{}, fields stdfields.StdMonitorFields, extraArgs ...string) jobs.Job {
+func InlineJourneyJob(ctx context.Context, script string, params func() map[string]any, fields stdfields.StdMonitorFields, extraArgs ...string) jobs.Job {
 	newCmd := func() *SynthCmd {
 		return &SynthCmd{exec.Command("elastic-synthetics", append(extraArgs, "--inline")...)} //nolint:gosec,noctx // we are safely building a command here, users can add args at their own risk
 	}
@@ -90,7 +90,7 @@ func InlineJourneyJob(ctx context.Context, script string, params func() map[stri
 // startCmdJob adapts commands into a heartbeat job. This is a little awkward given that the command's output is
 // available via a sequence of events in the multiplexer, while heartbeat jobs are tail recursive continuations.
 // Here, we adapt one to the other, where each recursive job pulls another item off the chan until none are left.
-func startCmdJob(ctx context.Context, newCmd func() *SynthCmd, stdinStr *string, params func() map[string]interface{}, filterJourneys FilterJourneyConfig, sFields stdfields.StdMonitorFields) jobs.Job {
+func startCmdJob(ctx context.Context, newCmd func() *SynthCmd, stdinStr *string, params func() map[string]any, filterJourneys FilterJourneyConfig, sFields stdfields.StdMonitorFields) jobs.Job {
 	return func(event *beat.Event) ([]jobs.Job, error) {
 		senr := newStreamEnricher(sFields)
 		// Prefer the published monitor.check_group (set by the summarizer's
@@ -174,7 +174,7 @@ func runCmd(
 	ctx context.Context,
 	cmd *SynthCmd,
 	stdinStr *string,
-	params func() map[string]interface{},
+	params func() map[string]any,
 	filterJourneys FilterJourneyConfig,
 	sFields stdfields.StdMonitorFields,
 	traceID string,
@@ -235,30 +235,25 @@ func runCmd(
 	if err != nil {
 		return nil, fmt.Errorf("could not open stdout pipe: %w", err)
 	}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err := scanToSynthEvents(stdoutPipe, stdoutToSynthEvent, mpx.writeSynthEvent)
 		if err != nil {
 			//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
 			logp.L().Warn("could not scan stdout events from synthetics: %s", err)
 		}
-
-		wg.Done()
-	}()
+	})
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
 		return nil, fmt.Errorf("could not open stderr pipe: %w", err)
 	}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err := scanToSynthEvents(stderrPipe, stderrToSynthEvent, mpx.writeSynthEvent)
 		if err != nil {
 			//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
 			logp.L().Warn("could not scan stderr events from synthetics: %s", err)
 		}
-		wg.Done()
-	}()
+	})
 
 	// This use of channels for results is awkward, but required for the thread locking below
 	cmdStarted := make(chan error)
@@ -289,8 +284,7 @@ func runCmd(
 
 	// Send the test results into the output. Start before this goroutine so
 	// jsonReader is not closed while cmd.Start reads its fd from ExtraFiles.
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		defer jsonReader.Close()
 
 		// We don't use scanToSynthEvents here because all lines here will be JSON
@@ -310,9 +304,7 @@ func runCmd(
 
 			mpx.writeSynthEvent(&se)
 		}
-
-		wg.Done()
-	}()
+	})
 
 	// Get timeout from parent ctx
 	timeout, _ := ctx.Value(SynthexecTimeoutKey).(time.Duration)

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -260,7 +260,35 @@ func runCmd(
 		wg.Done()
 	}()
 
-	// Send the test results into the output
+	// This use of channels for results is awkward, but required for the thread locking below
+	cmdStarted := make(chan error)
+	cmdDone := make(chan error)
+	go func() {
+		// We must idle this thread and ensure it is not killed while the external program is running
+		// see https://github.com/golang/go/issues/27505#issuecomment-713706104 . Otherwise, the Pdeathsig
+		// could cause the subprocess to die prematurely
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err = cmd.Start()
+
+		cmdStarted <- err
+
+		err := cmd.Wait()
+		cmdDone <- err
+	}()
+
+	err = <-cmdStarted
+	if err != nil {
+		//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
+		logp.L().Warn("Could not start command %s: %s", cmd, err)
+		_ = jsonWriter.Close()
+		_ = jsonReader.Close()
+		wg.Wait()
+		return nil, err
+	}
+
+	// Send the test results into the output. Start before this goroutine so
+	// jsonReader is not closed while cmd.Start reads its fd from ExtraFiles.
 	wg.Add(1)
 	go func() {
 		defer jsonReader.Close()
@@ -285,30 +313,6 @@ func runCmd(
 
 		wg.Done()
 	}()
-
-	// This use of channels for results is awkward, but required for the thread locking below
-	cmdStarted := make(chan error)
-	cmdDone := make(chan error)
-	go func() {
-		// We must idle this thread and ensure it is not killed while the external program is running
-		// see https://github.com/golang/go/issues/27505#issuecomment-713706104 . Otherwise, the Pdeathsig
-		// could cause the subprocess to die prematurely
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-		err = cmd.Start()
-
-		cmdStarted <- err
-
-		err := cmd.Wait()
-		cmdDone <- err
-	}()
-
-	err = <-cmdStarted
-	if err != nil {
-		//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
-		logp.L().Warn("Could not start command %s: %s", cmd, err)
-		return nil, err
-	}
 
 	// Get timeout from parent ctx
 	timeout, _ := ctx.Value(SynthexecTimeoutKey).(time.Duration)

--- a/x-pack/libbeat/reader/parquet/parquet_test.go
+++ b/x-pack/libbeat/reader/parquet/parquet_test.go
@@ -31,6 +31,9 @@ func TestParquetWithRandomData(t *testing.T) {
 	testCases := []struct {
 		columns int
 		rows    int
+		// skipUnderRace marks shapes whose record count makes the instrumented
+		// arrow readers exceed the package test timeout.
+		skipUnderRace bool
 	}{
 		{
 			columns: 10,
@@ -53,8 +56,9 @@ func TestParquetWithRandomData(t *testing.T) {
 			rows:    1000,
 		},
 		{
-			columns: 15,
-			rows:    10000,
+			columns:       15,
+			rows:          10000,
+			skipUnderRace: true,
 		},
 	}
 
@@ -62,6 +66,9 @@ func TestParquetWithRandomData(t *testing.T) {
 	for i, tc := range testCases {
 		name := fmt.Sprintf("Test parquet files with rows=%d, and columns=%d", tc.rows, tc.columns)
 		t.Run(name, func(t *testing.T) {
+			if tc.skipUnderRace && raceBuildEnabled {
+				t.Skip("too slow under the race detector: BatchSize 1 reads every row through the instrumented arrow readers")
+			}
 			tempDir := t.TempDir()
 			fName := fmt.Sprintf("%s/%s_%d.parquet", tempDir, "test", i)
 			data := createRandomParquet(t, fName, tc.columns, tc.rows)

--- a/x-pack/libbeat/reader/parquet/parquet_test.go
+++ b/x-pack/libbeat/reader/parquet/parquet_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +20,6 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
@@ -62,7 +61,6 @@ func TestParquetWithRandomData(t *testing.T) {
 		},
 	}
 
-	logp.TestingSetup()
 	for i, tc := range testCases {
 		name := fmt.Sprintf("Test parquet files with rows=%d, and columns=%d", tc.rows, tc.columns)
 		t.Run(name, func(t *testing.T) {
@@ -121,7 +119,7 @@ func createRandomParquet(t testing.TB, fname string, numCols int, numRows int) m
 	data := make(map[string]bool)
 	// creates a new Arrow schema
 	fields := make([]arrow.Field, 0, numCols)
-	for i := 0; i < numCols; i++ {
+	for i := range numCols {
 		fieldType := arrow.PrimitiveTypes.Int32
 		field := arrow.Field{Name: fmt.Sprintf("col%d", i), Type: fieldType, Nullable: true}
 		fields = append(fields, field)
@@ -142,22 +140,21 @@ func createRandomParquet(t testing.TB, fname string, numCols int, numRows int) m
 	memoryPool := memory.NewGoAllocator()
 
 	// uses a fixed seed value of 1 for generating random data
-	seed := int64(1)
-	r := rand.New(rand.NewSource(seed))
+	r := rand.New(rand.NewPCG(1, 0))
 
 	// generates random data for writing to the parquet file
 	for rowIdx := int64(0); rowIdx < int64(numRows); rowIdx++ {
 		// creates an Arrow record with random data
 		var recordColumns []arrow.Array
-		for colIdx := 0; colIdx < numCols; colIdx++ {
-			randData := []int32{r.Int31()}
+		for range numCols {
+			randData := []int32{r.Int32()}
 			builder := array.NewInt32Builder(memoryPool)
 			builder.AppendValues(randData, nil)
 			columnArray := array.NewInt32Data(builder.NewArray().Data())
 			builder.Release()
 			recordColumns = append(recordColumns, columnArray)
 		}
-		record := array.NewRecord(schema, recordColumns, 1)
+		record := array.NewRecordBatch(schema, recordColumns, 1)
 		val, err := record.MarshalJSON()
 		if err != nil {
 			t.Fatalf("Failed to marshal record to JSON: %v", err)
@@ -200,7 +197,6 @@ func TestParquetWithFiles(t *testing.T) {
 		},
 	}
 
-	logp.TestingSetup()
 	for _, tc := range testCases {
 		name := fmt.Sprintf("Test parquet files with source file=%s, and target comparison file=%s", tc.parquetFile, tc.jsonFile)
 		t.Run(name, func(t *testing.T) {
@@ -264,7 +260,7 @@ func readAndCompareParquetFile(t *testing.T, cfg *Config, file *os.File, data ma
 		// asserts of number of rows read is the same as the number of rows from the input file
 		assert.Equal(t, rows, rowCount)
 	} else {
-		assert.EqualValues(t, rowCount, maxRowsToCompare)
+		assert.Equal(t, rowCount, maxRowsToCompare, "row count should match maxRowsToCompare limit")
 	}
 	// closes the stream reader and asserts that there are no errors
 	err = sReader.Close()

--- a/x-pack/libbeat/reader/parquet/racedetector_off_test.go
+++ b/x-pack/libbeat/reader/parquet/racedetector_off_test.go
@@ -1,0 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !race
+
+package parquet
+
+const raceBuildEnabled = false

--- a/x-pack/libbeat/reader/parquet/racedetector_on_test.go
+++ b/x-pack/libbeat/reader/parquet/racedetector_on_test.go
@@ -1,0 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build race
+
+package parquet
+
+const raceBuildEnabled = true

--- a/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent_test.go
@@ -22,6 +22,39 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
+func waitAndCollectConcurrentMapMetrics(client *azure.BatchClient, wg *sync.WaitGroup) ([]azure.Metric, error) {
+	metricsCh := client.ResourceConfigurations.MetricDefinitionsChan
+	errorCh := client.ResourceConfigurations.ErrorChan
+
+	go func() {
+		wg.Wait()
+		client.Log.Infof("All collections finished. Closing channels ")
+		close(metricsCh)
+		close(errorCh)
+	}()
+
+	var collectedMetrics []azure.Metric
+	var collectedErr error
+	metricsOpen := true
+	errorOpen := true
+	for metricsOpen || errorOpen {
+		select {
+		case resMetricDefinition, ok := <-metricsCh:
+			if !ok {
+				metricsOpen = false
+			} else {
+				collectedMetrics = append(collectedMetrics, resMetricDefinition...)
+			}
+		case err, ok := <-errorCh:
+			if ok && err != nil {
+				collectedErr = err
+			}
+			errorOpen = false
+		}
+	}
+	return collectedMetrics, collectedErr
+}
+
 func TestConcurrentMapMetricsWithConfiguredTimegrain(t *testing.T) {
 	resource := MockResourceExpanded()
 	metricDefinitions := armmonitor.MetricDefinitionCollection{
@@ -41,40 +74,8 @@ func TestConcurrentMapMetricsWithConfiguredTimegrain(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			if client.ResourceConfigurations.ErrorChan != nil {
-				close(client.ResourceConfigurations.ErrorChan)
-			}
-		}()
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
-
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-		assert.Error(t, error)
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
+		assert.EqualError(t, err, "invalid resource ID", "unexpected error from concurrentMapMetrics")
 		assert.Equal(t, collectedMetrics, []azure.Metric(nil))
 		m.AssertExpectations(t)
 	})
@@ -89,39 +90,9 @@ func TestConcurrentMapMetricsWithConfiguredTimegrain(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			close(client.ResourceConfigurations.ErrorChan)
-		}()
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-
-		assert.NoError(t, error)
+		assert.NoError(t, err)
 		assert.Equal(t, collectedMetrics[0].ResourceId, "123")
 		assert.Equal(t, collectedMetrics[0].Namespace, "namespace")
 		assert.Equal(t, collectedMetrics[0].Names, []string{"TotalRequests", "Capacity", "BytesRead"})
@@ -142,38 +113,8 @@ func TestConcurrentMapMetricsWithConfiguredTimegrain(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			close(client.ResourceConfigurations.ErrorChan)
-		}()
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
-
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-		assert.NoError(t, error)
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
+		assert.NoError(t, err)
 
 		assert.True(t, len(collectedMetrics) > 0)
 		assert.Equal(t, collectedMetrics[0].ResourceId, "123")
@@ -204,40 +145,8 @@ func TestConcurrentMapMetricsNoConfiguredTimegrain(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			if client.ResourceConfigurations.ErrorChan != nil {
-				close(client.ResourceConfigurations.ErrorChan)
-			}
-		}()
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
-
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-		assert.Error(t, error)
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
+		assert.EqualError(t, err, "invalid resource ID", "unexpected error from concurrentMapMetrics")
 		assert.Equal(t, collectedMetrics, []azure.Metric(nil))
 		m.AssertExpectations(t)
 	})
@@ -252,39 +161,9 @@ func TestConcurrentMapMetricsNoConfiguredTimegrain(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			close(client.ResourceConfigurations.ErrorChan)
-		}()
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-
-		assert.NoError(t, error)
+		assert.NoError(t, err)
 
 		// we should have two groups, one per first timegrain value
 		assert.Len(t, collectedMetrics, 2)
@@ -320,38 +199,8 @@ func TestConcurrentMapMetricsNoConfiguredTimegrain(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			close(client.ResourceConfigurations.ErrorChan)
-		}()
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
-
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-		assert.NoError(t, error)
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
+		assert.NoError(t, err)
 
 		assert.True(t, len(collectedMetrics) > 0)
 

--- a/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper_concurrent_test.go
@@ -93,12 +93,12 @@ func TestConcurrentMapMetricsWithConfiguredTimegrain(t *testing.T) {
 		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 
 		assert.NoError(t, err)
-		assert.Equal(t, collectedMetrics[0].ResourceId, "123")
-		assert.Equal(t, collectedMetrics[0].Namespace, "namespace")
-		assert.Equal(t, collectedMetrics[0].Names, []string{"TotalRequests", "Capacity", "BytesRead"})
-		assert.Equal(t, collectedMetrics[0].Aggregations, "Average")
-		assert.Equal(t, collectedMetrics[0].Dimensions, []azure.Dimension{{Name: "location", Value: "West Europe"}})
-		assert.Equal(t, collectedMetrics[0].TimeGrain, oneHrDuration)
+		assert.Equal(t, "123", collectedMetrics[0].ResourceId)
+		assert.Equal(t, "namespace", collectedMetrics[0].Namespace)
+		assert.Equal(t, []string{"TotalRequests", "Capacity", "BytesRead"}, collectedMetrics[0].Names)
+		assert.Equal(t, "Average", collectedMetrics[0].Aggregations)
+		assert.Equal(t, []azure.Dimension{{Name: "location", Value: "West Europe"}}, collectedMetrics[0].Dimensions)
+		assert.Equal(t, oneHrDuration, collectedMetrics[0].TimeGrain)
 		m.AssertExpectations(t)
 	})
 	t.Run("return all metrics when specific metric names and aggregations were configured", func(t *testing.T) {
@@ -116,13 +116,13 @@ func TestConcurrentMapMetricsWithConfiguredTimegrain(t *testing.T) {
 		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 		assert.NoError(t, err)
 
-		assert.True(t, len(collectedMetrics) > 0)
-		assert.Equal(t, collectedMetrics[0].ResourceId, "123")
-		assert.Equal(t, collectedMetrics[0].Namespace, "namespace")
-		assert.Equal(t, collectedMetrics[0].Names, []string{"TotalRequests", "Capacity"})
-		assert.Equal(t, collectedMetrics[0].Aggregations, "Average")
-		assert.Equal(t, collectedMetrics[0].Dimensions, []azure.Dimension{{Name: "location", Value: "West Europe"}})
-		assert.Equal(t, collectedMetrics[0].TimeGrain, oneHrDuration)
+		assert.NotEmpty(t, collectedMetrics)
+		assert.Equal(t, "123", collectedMetrics[0].ResourceId)
+		assert.Equal(t, "namespace", collectedMetrics[0].Namespace)
+		assert.Equal(t, []string{"TotalRequests", "Capacity"}, collectedMetrics[0].Names)
+		assert.Equal(t, "Average", collectedMetrics[0].Aggregations)
+		assert.Equal(t, []azure.Dimension{{Name: "location", Value: "West Europe"}}, collectedMetrics[0].Dimensions)
+		assert.Equal(t, oneHrDuration, collectedMetrics[0].TimeGrain)
 		m.AssertExpectations(t)
 	})
 }
@@ -172,17 +172,17 @@ func TestConcurrentMapMetricsNoConfiguredTimegrain(t *testing.T) {
 		for _, collectedMetric := range collectedMetrics {
 			switch collectedMetric.TimeGrain {
 			case oneMinuteDuration:
-				assert.Equal(t, collectedMetric.ResourceId, "123")
-				assert.Equal(t, collectedMetric.Namespace, "namespace")
-				assert.Equal(t, collectedMetric.Names, []string{"Capacity"})
-				assert.Equal(t, collectedMetric.Aggregations, "Average")
-				assert.Equal(t, collectedMetric.Dimensions, []azure.Dimension{{Name: "location", Value: "West Europe"}})
+				assert.Equal(t, "123", collectedMetric.ResourceId)
+				assert.Equal(t, "namespace", collectedMetric.Namespace)
+				assert.Equal(t, []string{"Capacity"}, collectedMetric.Names)
+				assert.Equal(t, "Average", collectedMetric.Aggregations)
+				assert.Equal(t, []azure.Dimension{{Name: "location", Value: "West Europe"}}, collectedMetric.Dimensions)
 			case thirtyMinuteDuration:
-				assert.Equal(t, collectedMetric.ResourceId, "123")
-				assert.Equal(t, collectedMetric.Namespace, "namespace")
-				assert.Equal(t, collectedMetric.Names, []string{"TotalRequests", "BytesRead"})
-				assert.Equal(t, collectedMetric.Aggregations, "Average")
-				assert.Equal(t, collectedMetric.Dimensions, []azure.Dimension{{Name: "location", Value: "West Europe"}})
+				assert.Equal(t, "123", collectedMetric.ResourceId)
+				assert.Equal(t, "namespace", collectedMetric.Namespace)
+				assert.Equal(t, []string{"TotalRequests", "BytesRead"}, collectedMetric.Names)
+				assert.Equal(t, "Average", collectedMetric.Aggregations)
+				assert.Equal(t, []azure.Dimension{{Name: "location", Value: "West Europe"}}, collectedMetric.Dimensions)
 			}
 		}
 		m.AssertExpectations(t)
@@ -202,7 +202,7 @@ func TestConcurrentMapMetricsNoConfiguredTimegrain(t *testing.T) {
 		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 		assert.NoError(t, err)
 
-		assert.True(t, len(collectedMetrics) > 0)
+		assert.NotEmpty(t, collectedMetrics)
 
 		// we should have two groups, one per first timegrain value
 		assert.Len(t, collectedMetrics, 2)
@@ -211,17 +211,17 @@ func TestConcurrentMapMetricsNoConfiguredTimegrain(t *testing.T) {
 		for _, collectedMetric := range collectedMetrics {
 			switch collectedMetric.TimeGrain {
 			case oneMinuteDuration:
-				assert.Equal(t, collectedMetric.ResourceId, "123")
-				assert.Equal(t, collectedMetric.Namespace, "namespace")
-				assert.Equal(t, collectedMetric.Names, []string{"Capacity"})
-				assert.Equal(t, collectedMetric.Aggregations, "Average")
-				assert.Equal(t, collectedMetric.Dimensions, []azure.Dimension{{Name: "location", Value: "West Europe"}})
+				assert.Equal(t, "123", collectedMetric.ResourceId)
+				assert.Equal(t, "namespace", collectedMetric.Namespace)
+				assert.Equal(t, []string{"Capacity"}, collectedMetric.Names)
+				assert.Equal(t, "Average", collectedMetric.Aggregations)
+				assert.Equal(t, []azure.Dimension{{Name: "location", Value: "West Europe"}}, collectedMetric.Dimensions)
 			case thirtyMinuteDuration:
-				assert.Equal(t, collectedMetric.ResourceId, "123")
-				assert.Equal(t, collectedMetric.Namespace, "namespace")
-				assert.Equal(t, collectedMetric.Names, []string{"TotalRequests"})
-				assert.Equal(t, collectedMetric.Aggregations, "Average")
-				assert.Equal(t, collectedMetric.Dimensions, []azure.Dimension{{Name: "location", Value: "West Europe"}})
+				assert.Equal(t, "123", collectedMetric.ResourceId)
+				assert.Equal(t, "namespace", collectedMetric.Namespace)
+				assert.Equal(t, []string{"TotalRequests"}, collectedMetric.Names)
+				assert.Equal(t, "Average", collectedMetric.Aggregations)
+				assert.Equal(t, []azure.Dimension{{Name: "location", Value: "West Europe"}}, collectedMetric.Dimensions)
 			}
 		}
 

--- a/x-pack/metricbeat/module/azure/storage/client_helper_concurrent_test.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper_concurrent_test.go
@@ -20,6 +20,39 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
+func waitAndCollectConcurrentMapMetrics(client *azure.BatchClient, wg *sync.WaitGroup) ([]azure.Metric, error) {
+	metricsCh := client.ResourceConfigurations.MetricDefinitionsChan
+	errorCh := client.ResourceConfigurations.ErrorChan
+
+	go func() {
+		wg.Wait()
+		client.Log.Infof("All collections finished. Closing channels ")
+		close(metricsCh)
+		close(errorCh)
+	}()
+
+	var collectedMetrics []azure.Metric
+	var collectedErr error
+	metricsOpen := true
+	errorOpen := true
+	for metricsOpen || errorOpen {
+		select {
+		case resMetricDefinition, ok := <-metricsCh:
+			if !ok {
+				metricsOpen = false
+			} else {
+				collectedMetrics = append(collectedMetrics, resMetricDefinition...)
+			}
+		case err, ok := <-errorCh:
+			if ok && err != nil {
+				collectedErr = err
+			}
+			errorOpen = false
+		}
+	}
+	return collectedMetrics, collectedErr
+}
+
 func TestConcurrentMapMetrics(t *testing.T) {
 	resource := MockResource()
 	metricDefinitions := armmonitor.MetricDefinitionCollection{
@@ -45,44 +78,10 @@ func TestConcurrentMapMetrics(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			if client.ResourceConfigurations.ErrorChan != nil {
-				close(client.ResourceConfigurations.ErrorChan)
-			}
-		}()
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
-
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-
-		assert.Error(t, error)
-		assert.Equal(t, error.Error(), "no metric definitions were found for resource 123 and namespace Microsoft.Storage/storageAccounts")
-		assert.Equal(t, collectedMetrics, []azure.Metric(nil))
+		assert.EqualError(t, err, "no metric definitions were found for resource 123 and namespace Microsoft.Storage/storageAccounts", "unexpected error from concurrentMapMetrics")
+		assert.Empty(t, collectedMetrics, "no metrics should be collected when the definitions lookup fails")
 		m.AssertExpectations(t)
 	})
 	t.Run("return mapped metrics correctly", func(t *testing.T) {
@@ -95,40 +94,9 @@ func TestConcurrentMapMetrics(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		concurrentMapMetrics(client, []*armresources.GenericResourceExpanded{resource}, resourceConfig, &wg)
-		go func() {
-			wg.Wait() // Wait for all the resource collection goroutines to finish
-			// Once all the goroutines are done, close the channels
-			client.Log.Infof("All collections finished. Closing channels ")
-			close(client.ResourceConfigurations.MetricDefinitionsChan)
-			close(client.ResourceConfigurations.ErrorChan)
-		}()
+		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 
-		var collectedMetrics []azure.Metric
-		var error error
-		for {
-			select {
-			case resMetricDefinition, ok := <-client.ResourceConfigurations.MetricDefinitionsChan:
-				if !ok {
-					client.ResourceConfigurations.MetricDefinitionsChan = nil
-				} else {
-					collectedMetrics = append(collectedMetrics, resMetricDefinition...)
-				}
-			case err, ok := <-client.ResourceConfigurations.ErrorChan:
-				if ok && err != nil {
-					// Handle error received from error channel
-					error = err
-				}
-				// Error channel is closed, stop error handling
-				client.ResourceConfigurations.ErrorChan = nil
-			}
-
-			// Break the loop when both Data and Error channels are closed
-			if client.ResourceConfigurations.MetricDefinitionsChan == nil && client.ResourceConfigurations.ErrorChan == nil {
-				break
-			}
-		}
-
-		assert.NoError(t, error)
+		assert.NoError(t, err)
 		assert.Equal(t, collectedMetrics[0].ResourceId, "123")
 		assert.Equal(t, collectedMetrics[0].Namespace, "Microsoft.Storage/storageAccounts")
 		assert.Equal(t, collectedMetrics[1].ResourceId, "123")

--- a/x-pack/metricbeat/module/azure/storage/client_helper_concurrent_test.go
+++ b/x-pack/metricbeat/module/azure/storage/client_helper_concurrent_test.go
@@ -97,23 +97,23 @@ func TestConcurrentMapMetrics(t *testing.T) {
 		collectedMetrics, err := waitAndCollectConcurrentMapMetrics(client, &wg)
 
 		assert.NoError(t, err)
-		assert.Equal(t, collectedMetrics[0].ResourceId, "123")
-		assert.Equal(t, collectedMetrics[0].Namespace, "Microsoft.Storage/storageAccounts")
-		assert.Equal(t, collectedMetrics[1].ResourceId, "123")
-		assert.Equal(t, collectedMetrics[1].Namespace, "Microsoft.Storage/storageAccounts")
-		assert.Equal(t, collectedMetrics[0].Dimensions, []azure.Dimension(nil))
-		assert.Equal(t, collectedMetrics[1].Dimensions, []azure.Dimension(nil))
+		assert.Equal(t, "123", collectedMetrics[0].ResourceId)
+		assert.Equal(t, "Microsoft.Storage/storageAccounts", collectedMetrics[0].Namespace)
+		assert.Equal(t, "123", collectedMetrics[1].ResourceId)
+		assert.Equal(t, "Microsoft.Storage/storageAccounts", collectedMetrics[1].Namespace)
+		assert.Equal(t, []azure.Dimension(nil), collectedMetrics[0].Dimensions)
+		assert.Equal(t, []azure.Dimension(nil), collectedMetrics[1].Dimensions)
 
 		//order of elements can be different when running the test
-		assert.Equal(t, len(collectedMetrics), 4)
+		assert.Len(t, collectedMetrics, 4)
 		for _, metricValue := range collectedMetrics {
-			assert.Equal(t, metricValue.Aggregations, "Average")
-			assert.Equal(t, len(metricValue.Names), 1)
+			assert.Equal(t, "Average", metricValue.Aggregations)
+			assert.Len(t, metricValue.Names, 1)
 			assert.Contains(t, []string{"TotalRequests", "Capacity"}, metricValue.Names[0])
 			if reflect.DeepEqual(metricValue.Names, []string{"Capacity"}) {
-				assert.Equal(t, metricValue.TimeGrain, "PT1H")
+				assert.Equal(t, "PT1H", metricValue.TimeGrain)
 			} else {
-				assert.Equal(t, metricValue.TimeGrain, "PT5M")
+				assert.Equal(t, "PT5M", metricValue.TimeGrain)
 			}
 		}
 		m.AssertExpectations(t)


### PR DESCRIPTION
## Proposed commit message

```
The libbeat unit-test pipeline, and every other beat pipeline, sets
RACE_DETECTOR=true, yet the race detector never actually ran. In
dev-tools/mage GoTest, -race was only appended when
testbin.RaceDetectorSupported(os.Getenv("DEV_OS"), os.Getenv("DEV_ARCH"))
returned true. DEV_OS/DEV_ARCH are read with no default (unlike
config.go, which falls back to linux/amd64) and are set nowhere in
.buildkite, the Makefile, or the magefiles. So in CI DEV_ARCH="",
RaceDetectorSupported("", "") returned false, and -race was dropped with
only a log.Printf warning. RACE_DETECTOR=true was effectively a no-op and
every data race in unit tests was invisible in CI.

This change:

- Defaults DEV_OS/DEV_ARCH to runtime.GOOS/runtime.GOARCH when the env
  vars are empty, so -race is applied on the actual host whenever the
  race detector is requested.
- Extracts the decision into raceDetectorArgs and turns a race request on
  an unsupported platform into a hard error instead of a silent skip, so
  a misconfigured race build fails loudly rather than passing green
  without ever exercising the detector.
- Adds a unit test covering the host-default, supported, and unsupported
  platform cases.

The fix lives in the shared GoTest, so it applies uniformly to every
beat's unit-test job that sets RACE_DETECTOR=true (libbeat, filebeat,
metricbeat, heartbeat, auditbeat, packetbeat, winlogbeat, and their
x-pack counterparts). Integration tests are unchanged: they gate on
INTEG_RACE_DETECTOR, which is set in no pipeline.

Because -race now runs where it was previously dropped, unit-test jobs
may surface pre-existing data races (the intended outcome) and, on
platforms where -race is newly enabled (notably Windows amd64), require a
working cgo/C toolchain on the CI image.

Relates #51282, which introduced the shared RaceDetectorSupported gating.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Build/test tooling only, no user-visible change; `skip-changelog` applied.

## Disruptive User Impact

N/A

## How to test this PR locally

On linux/amd64 with `DEV_OS`/`DEV_ARCH` unset, confirm `-race` is now emitted:

```bash
cd dev-tools
env -u DEV_OS -u DEV_ARCH RACE_DETECTOR=true mage -v goUnitTest 2>&1 | grep -m1 'exec: gotestsum'
# exec: gotestsum ... -- -race ./...
```

## Related issues

- Relates #51282
