### PR TITLE
Add benchmarks for per-receiver goroutine and memory footprint

### DIFF
--- a/x-pack/filebeat/fbreceiver/receiver_footprint_bench_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_footprint_bench_test.go
@@ -226,7 +226,11 @@ func dumpIdleGoroutines(b *testing.B, nReceivers int) {
 		return
 	}
 
-	f, err := os.Create(filepath.Join(dir, fmt.Sprintf("goroutines-%d.txt", nReceivers)))
+	root, err := os.OpenRoot(dir)
+	require.NoError(b, err)
+	defer root.Close()
+
+	f, err := root.Create(fmt.Sprintf("goroutines-%d.txt", nReceivers))
 	require.NoError(b, err)
 	defer f.Close()
 

--- a/x-pack/filebeat/fbreceiver/receiver_footprint_bench_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_footprint_bench_test.go
@@ -22,12 +22,13 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
+	"github.com/elastic/beats/v7/filebeat/input/filestream"
 	"github.com/elastic/beats/v7/x-pack/otel/oteltest"
 )
 
-// BenchmarkNReceiverFootprint measures the steady-state resource footprint of N
-// filebeatreceiver instances, each running one filestream input over its own
-// small log file, all sharing a single path.data. That is the layout
+// BenchmarkNReceiverIdleFootprint measures the steady-state resource footprint
+// of N filebeatreceiver instances, each running one filestream input over its
+// own small log file, all sharing a single path.data. That is the layout
 // elastic-agent produces: one receiver per input stream, every receiver of a
 // component pointed at the same BeatDataPath(comp.ID).
 //
@@ -40,7 +41,7 @@ import (
 //   - goroutines/receiver : resident goroutines per additional receiver
 //   - heap-B/receiver     : live heap bytes retained per receiver
 //   - goroutines          : absolute goroutine count of the idle fleet
-func BenchmarkNReceiverFootprint(b *testing.B) {
+func BenchmarkNReceiverIdleFootprint(b *testing.B) {
 	for _, n := range []int{1, 10, 50} {
 		b.Run(fmt.Sprintf("receivers=%d", n), func(b *testing.B) {
 			benchNReceiverFootprint(b, n, 1)
@@ -76,7 +77,7 @@ func benchNReceiverFootprint(b *testing.B, nReceivers, filesPerReceiver int) {
 
 	var goroutinesPer, heapPer, heapPerFile, goroutines float64
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		// A fresh data dir per iteration so every receiver re-reads its file
 		// from offset 0 instead of resuming a registry from the last iteration.
 		dataDir := b.TempDir()
@@ -183,19 +184,28 @@ func startFleet(
 							"id":      fmt.Sprintf("footprint-%d", r),
 							"enabled": true,
 							"paths":   []string{path},
+							// Everything else is left at its default, most
+							// importantly the fingerprint file identity: the
+							// footprint worth tracking is the one the default
+							// configuration produces. writeBenchLogFiles keeps
+							// every file above DefaultFingerprintSize so each
+							// one is actually harvested.
 							"prospector": map[string]any{
 								"scanner": map[string]any{
 									"check_interval": "100ms",
-									"fingerprint":    map[string]any{"enabled": false},
 								},
 							},
-							"file_identity": map[string]any{"native": nil},
 						},
 					},
 				},
 				"logging":   map[string]any{"level": "error"},
 				"path.home": homeDir,
 				"path.data": dataDir,
+				// Run under the OtelManager, as a receiver started by
+				// elastic-agent does. It marks the beat as under agent, which
+				// changes what the pipeline builds — the footprint is only
+				// meaningful if it is measured in that mode.
+				"management.otel.enabled": true,
 			},
 		}
 
@@ -207,7 +217,7 @@ func startFleet(
 
 	return func() {
 		for _, rcvr := range receivers {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			shutdownCtx, cancel := context.WithTimeout(b.Context(), 60*time.Second)
 			require.NoError(b, rcvr.Shutdown(shutdownCtx))
 			cancel()
 		}
@@ -241,6 +251,11 @@ func dumpIdleGoroutines(b *testing.B, nReceivers int) {
 
 // writeBenchLogFiles writes count log files for one receiver into their own
 // subdirectory and returns the glob matching them.
+//
+// The receiver and file numbers are part of every line so that no two files
+// share a fingerprint, and each file is required to be larger than
+// DefaultFingerprintSize — below that the default fingerprint identity cannot
+// take a file, and it would simply never be harvested.
 func writeBenchLogFiles(b *testing.B, dir string, receiver, count, lines int) string {
 	b.Helper()
 
@@ -252,13 +267,18 @@ func writeBenchLogFiles(b *testing.B, dir string, receiver, count, lines int) st
 		f, err := os.Create(path)
 		require.NoError(b, err)
 
+		written := 0
 		for l := range lines {
-			_, err := fmt.Fprintf(f, "receiver %d file %d line %d: a log line of a fairly typical length\n",
+			c, err := fmt.Fprintf(f, "receiver %d file %d line %d: a log line of a fairly typical length\n",
 				receiver, n, l)
 			require.NoError(b, err)
+			written += c
 		}
 		require.NoError(b, f.Sync())
 		require.NoError(b, f.Close())
+
+		require.Greaterf(b, int64(written), filestream.DefaultFingerprintSize,
+			"file %s is too small to be fingerprinted, increase linesPerFile", path)
 	}
 
 	return filepath.Join(rcvrDir, "*.log")

--- a/x-pack/filebeat/fbreceiver/receiver_footprint_bench_test.go
+++ b/x-pack/filebeat/fbreceiver/receiver_footprint_bench_test.go
@@ -1,0 +1,274 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fbreceiver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+
+	"github.com/elastic/beats/v7/x-pack/otel/oteltest"
+)
+
+// BenchmarkNReceiverFootprint measures the steady-state resource footprint of N
+// filebeatreceiver instances, each running one filestream input over its own
+// small log file, all sharing a single path.data. That is the layout
+// elastic-agent produces: one receiver per input stream, every receiver of a
+// component pointed at the same BeatDataPath(comp.ID).
+//
+// Unlike BenchmarkNReceivers this does not measure throughput. It measures what
+// each additional receiver costs once its file has been fully ingested and the
+// input is idle (open and tailed), which is the state a real deployment spends
+// almost all of its time in.
+//
+// Reported metrics (lower is better):
+//   - goroutines/receiver : resident goroutines per additional receiver
+//   - heap-B/receiver     : live heap bytes retained per receiver
+//   - goroutines          : absolute goroutine count of the idle fleet
+func BenchmarkNReceiverFootprint(b *testing.B) {
+	for _, n := range []int{1, 10, 50} {
+		b.Run(fmt.Sprintf("receivers=%d", n), func(b *testing.B) {
+			benchNReceiverFootprint(b, n, 1)
+		})
+	}
+}
+
+// BenchmarkNReceiverRegistryFootprint measures how registry state scales with
+// the number of receivers sharing one path.data.
+//
+// It exists because readStates loads every key carrying the input type's prefix,
+// not just the keys belonging to the input doing the loading. With a private
+// in-memory view per receiver, N receivers each hold all N receivers' states —
+// quadratic in the receiver count. Giving each receiver enough files that the
+// state table dominates the heap makes that scaling visible.
+//
+// Reported metric:
+//   - heap-B/file : live heap bytes per tracked file across the whole fleet.
+//     Flat as receivers are added means the state table is shared; growing
+//     linearly means each receiver holds a private copy.
+func BenchmarkNReceiverRegistryFootprint(b *testing.B) {
+	const filesPerReceiver = 300
+	for _, n := range []int{2, 10} {
+		b.Run(fmt.Sprintf("receivers=%d", n), func(b *testing.B) {
+			benchNReceiverFootprint(b, n, filesPerReceiver)
+		})
+	}
+}
+
+func benchNReceiverFootprint(b *testing.B, nReceivers, filesPerReceiver int) {
+	const linesPerFile = 50
+	wantEvents := int64(nReceivers * filesPerReceiver * linesPerFile)
+
+	var goroutinesPer, heapPer, heapPerFile, goroutines float64
+
+	for i := 0; i < b.N; i++ {
+		// A fresh data dir per iteration so every receiver re-reads its file
+		// from offset 0 instead of resuming a registry from the last iteration.
+		dataDir := b.TempDir()
+		homeDir := b.TempDir()
+		logDir := b.TempDir()
+
+		// Each receiver gets its own subdirectory so its glob matches only its
+		// own files, exactly as one receiver per input stream would be configured.
+		paths := make([]string, nReceivers)
+		for r := range nReceivers {
+			paths[r] = writeBenchLogFiles(b, logDir, r, filesPerReceiver, linesPerFile)
+		}
+
+		host := &oteltest.MockHost{}
+		factory := NewFactoryWithSettings(Settings{Home: homeDir, Data: dataDir})
+
+		// First pass: ingest everything so the registry on disk ends up holding
+		// every receiver's state, then shut the fleet down. This is what makes
+		// the measured pass realistic — a receiver in a long-running deployment
+		// almost always starts against a registry that already describes all of
+		// its co-tenants, and that is the state each one loads into memory.
+		sink := &countingLogsConsumer{}
+		stopFleet := startFleet(b, factory, host, sink, paths, homeDir, dataDir)
+		require.Eventually(b,
+			func() bool { return sink.count.Load() >= wantEvents },
+			180*time.Second, 50*time.Millisecond,
+			"all receivers should fully ingest their files")
+		stopFleet()
+
+		runtime.GC()
+		baseGoroutines := runtime.NumGoroutine()
+		var base runtime.MemStats
+		runtime.ReadMemStats(&base)
+
+		// Second pass: restart against the warm registry and measure. The files
+		// are already at EOF, so nothing is re-ingested; what is measured is what
+		// the fleet retains simply by being up.
+		restartSink := &countingLogsConsumer{}
+		stopFleet = startFleet(b, factory, host, restartSink, paths, homeDir, dataDir)
+		time.Sleep(fleetSettleTime)
+
+		runtime.GC()
+		runtime.GC()
+		idleGoroutines := runtime.NumGoroutine()
+		var idle runtime.MemStats
+		runtime.ReadMemStats(&idle)
+
+		dumpIdleGoroutines(b, nReceivers)
+
+		// A GC between the two snapshots can leave the idle fleet holding less
+		// than the baseline, so the difference is taken as signed rather than
+		// underflowing uint64.
+		var heapDelta float64
+		if idle.HeapAlloc > base.HeapAlloc {
+			heapDelta = float64(idle.HeapAlloc - base.HeapAlloc)
+		}
+		goroutinesPer = float64(idleGoroutines-baseGoroutines) / float64(nReceivers)
+		heapPer = heapDelta / float64(nReceivers)
+		heapPerFile = heapDelta / float64(nReceivers*filesPerReceiver)
+		goroutines = float64(idleGoroutines)
+
+		stopFleet()
+	}
+
+	b.ReportMetric(goroutinesPer, "goroutines/receiver")
+	b.ReportMetric(heapPer, "heap-B/receiver")
+	b.ReportMetric(goroutines, "goroutines")
+	if filesPerReceiver > 1 {
+		b.ReportMetric(heapPerFile, "heap-B/file")
+	}
+}
+
+// fleetSettleTime is how long the restarted fleet is given to reach steady
+// state: prospectors complete their first scan, harvesters open their files and
+// park at EOF, and the publisher pipelines go quiet.
+const fleetSettleTime = 10 * time.Second
+
+// startFleet starts one receiver per path, each with its own filestream input
+// but all sharing homeDir and dataDir, and returns a function that shuts them
+// all down. Sharing dataDir is the point: elastic-agent gives every receiver of
+// a component the same path.data.
+func startFleet(
+	b *testing.B,
+	factory receiver.Factory,
+	host component.Host,
+	sink *countingLogsConsumer,
+	paths []string,
+	homeDir, dataDir string,
+) func() {
+	b.Helper()
+
+	receivers := make([]receiver.Logs, 0, len(paths))
+	for r, path := range paths {
+		rcvrSettings := receiver.Settings{}
+		rcvrSettings.ID = component.NewIDWithName(factory.Type(), fmt.Sprintf("bench%d", r))
+		rcvrSettings.Logger = zap.NewNop()
+
+		cfg := &Config{
+			Beatconfig: map[string]any{
+				"filebeat": map[string]any{
+					"inputs": []map[string]any{
+						{
+							"type":    "filestream",
+							"id":      fmt.Sprintf("footprint-%d", r),
+							"enabled": true,
+							"paths":   []string{path},
+							"prospector": map[string]any{
+								"scanner": map[string]any{
+									"check_interval": "100ms",
+									"fingerprint":    map[string]any{"enabled": false},
+								},
+							},
+							"file_identity": map[string]any{"native": nil},
+						},
+					},
+				},
+				"logging":   map[string]any{"level": "error"},
+				"path.home": homeDir,
+				"path.data": dataDir,
+			},
+		}
+
+		rcvr, err := factory.CreateLogs(b.Context(), rcvrSettings, cfg, sink)
+		require.NoError(b, err)
+		require.NoError(b, rcvr.Start(b.Context(), host))
+		receivers = append(receivers, rcvr)
+	}
+
+	return func() {
+		for _, rcvr := range receivers {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			require.NoError(b, rcvr.Shutdown(shutdownCtx))
+			cancel()
+		}
+	}
+}
+
+// dumpIdleGoroutines writes the idle fleet's goroutine profile to the path in
+// FBRECEIVER_GOROUTINE_DUMP (with the receiver count appended), so the
+// per-receiver goroutine cost can be attributed to the code that creates it.
+// It is a no-op unless that variable is set.
+func dumpIdleGoroutines(b *testing.B, nReceivers int) {
+	b.Helper()
+
+	dir := os.Getenv("FBRECEIVER_GOROUTINE_DUMP")
+	if dir == "" {
+		return
+	}
+
+	f, err := os.Create(filepath.Join(dir, fmt.Sprintf("goroutines-%d.txt", nReceivers)))
+	require.NoError(b, err)
+	defer f.Close()
+
+	// debug=1 aggregates identical stacks with a count, which is what makes the
+	// per-receiver breakdown readable.
+	require.NoError(b, pprof.Lookup("goroutine").WriteTo(f, 1))
+}
+
+// writeBenchLogFiles writes count log files for one receiver into their own
+// subdirectory and returns the glob matching them.
+func writeBenchLogFiles(b *testing.B, dir string, receiver, count, lines int) string {
+	b.Helper()
+
+	rcvrDir := filepath.Join(dir, fmt.Sprintf("receiver-%d", receiver))
+	require.NoError(b, os.MkdirAll(rcvrDir, 0o750))
+
+	for n := range count {
+		path := filepath.Join(rcvrDir, fmt.Sprintf("bench-%d.log", n))
+		f, err := os.Create(path)
+		require.NoError(b, err)
+
+		for l := range lines {
+			_, err := fmt.Fprintf(f, "receiver %d file %d line %d: a log line of a fairly typical length\n",
+				receiver, n, l)
+			require.NoError(b, err)
+		}
+		require.NoError(b, f.Sync())
+		require.NoError(b, f.Close())
+	}
+
+	return filepath.Join(rcvrDir, "*.log")
+}
+
+// countingLogsConsumer counts delivered log records without ever blocking, so
+// the receivers reach idle instead of stalling on a slow sink.
+type countingLogsConsumer struct{ count atomic.Int64 }
+
+func (c *countingLogsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (c *countingLogsConsumer) ConsumeLogs(_ context.Context, ld plog.Logs) error {
+	c.count.Add(int64(ld.LogRecordCount()))
+	return nil
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Adds the benchmarks for determining the footprint in memory and goroutines a single fbreceiver uses when its running a single `filestream` input.

Will be used across the improvements to fbreceiver to resolve this overall change - #52349

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability. (benchmark!)
- ~~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

#### Idle footprint: N=1, 10, 50. ~35s total.
`go test ./x-pack/filebeat/fbreceiver/ -run '^$' -bench BenchmarkNReceiverFootprint -benchtime 1x`

#### Registry memory on a warm restart: N=2, 10. ~45s.
`go test ./x-pack/filebeat/fbreceiver/ -run '^$' -bench BenchmarkNReceiverRegistryFootprint -benchtime 1x`

#### One size only — note the trailing $, or receivers=1 also matches 10
`go test ./x-pack/filebeat/fbreceiver/ -run '^$' -bench 'BenchmarkNReceiverFootprint/receivers=10$' -benchtime 1x`

#### Both benchmarks
`go test ./x-pack/filebeat/fbreceiver/ -run '^$' -bench 'BenchmarkNReceiver' -benchtime 1x`

#### See the fleet's goroutines, aggregated by stack
`FBRECEIVER_GOROUTINE_DUMP=/tmp/dump go test ./x-pack/filebeat/fbreceiver/ -run '^$' -bench 'BenchmarkNReceiverFootprint/receivers=50$' -benchtime 1x`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #52349

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

#### Idle footprint: N=1, 10, 50. ~35s total.
```
$ go test ./x-pack/filebeat/fbreceiver/ -run '^$' -bench BenchmarkNReceiverFootprint -benchtime 1x
goos: darwin
goarch: arm64
pkg: github.com/elastic/beats/v7/x-pack/filebeat/fbreceiver
cpu: Apple M2 Pro
BenchmarkNReceiverFootprint/receivers=1-12                     1        10122316416 ns/op               28.00 goroutines                24.00 goroutines/receiver             9048 heap-B/receiver
BenchmarkNReceiverFootprint/receivers=10-12                    1        10153694500 ns/op              244.0 goroutines         24.00 goroutines/receiver            96299 heap-B/receiver
BenchmarkNReceiverFootprint/receivers=50-12                    1        10418230459 ns/op             1204 goroutines           24.00 goroutines/receiver           163955 heap-B/receiver
PASS
ok      github.com/elastic/beats/v7/x-pack/filebeat/fbreceiver  32.370s
```

#### Registry memory on a warm restart: N=2, 10. ~45s.
```
$ go test ./x-pack/filebeat/fbreceiver/ -run '^$' -bench BenchmarkNReceiverRegistryFootprint -benchtime 1x
goos: darwin
goarch: arm64
pkg: github.com/elastic/beats/v7/x-pack/filebeat/fbreceiver
cpu: Apple M2 Pro
BenchmarkNReceiverRegistryFootprint/receivers=2-12                     1        13166291083 ns/op               52.00 goroutines                24.00 goroutines/receiver             7280 heap-B/file     2184096 heap-B/receiver
BenchmarkNReceiverRegistryFootprint/receivers=10-12                    1        25700077458 ns/op              244.0 goroutines         24.00 goroutines/receiver            17017 heap-B/file     5105036 heap-B/receiver
PASS
ok      github.com/elastic/beats/v7/x-pack/filebeat/fbreceiver  40.758s
```