### PR TITLE
[Heartbeat][POC] Resolve config secrets from HashiCorp Vault at the edge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -236,6 +236,7 @@ require (
 	github.com/elastic/entcollect v0.0.0-20260720203654-e61fb8788d9a
 	github.com/elastic/gokrb5/v8 v8.0.0-20251105095404-23cc45e6a102
 	github.com/elastic/lumberjack v0.0.0-20260715013204-c5b60bbeaaab
+	github.com/hashicorp/vault/api v1.15.0
 	github.com/jimlambrt/gldap v0.1.14
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.156.0
@@ -281,8 +282,14 @@ require (
 )
 
 require (
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v7 v7.0.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,7 @@ github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcy
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58 h1:rDLE+tSW60VzRD7v5I+DU22Mjhmm+mfLc5Xl5dHkx6w=
 github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
+github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -275,6 +276,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/bluekeyes/go-gitdiff v0.7.1 h1:graP4ElLRshr8ecu0UtqfNTCHrtSyZd3DABQm/DWesQ=
@@ -285,6 +287,8 @@ github.com/cavaliergopher/rpm v1.2.0 h1:s0h+QeVK252QFTolkhGiMeQ1f+tMeIMhGl8B1HUm
 github.com/cavaliergopher/rpm v1.2.0/go.mod h1:R0q3vTqa7RUvPofAZYrnjJ63hh2vngjFfphuXiExVos=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cenkalti/backoff/v7 v7.0.0 h1:ZP+QAaaOnVUHo+ufFpZ835hbT3x2fy+h2lecVEosZ6A=
@@ -463,6 +467,7 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -553,6 +558,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
+github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
@@ -681,12 +688,21 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 h1:om4Al8Oy7kCm/B86rLCLah4Dt5Aa0Fr5rYBG60OzwHQ=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
+github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=
+github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
+github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
+github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
+github.com/hashicorp/go-sockaddr v1.0.7 h1:G+pTkSO01HpR5qCxg7lxfsFEZaG+C0VssTy/9dbT+Fw=
+github.com/hashicorp/go-sockaddr v1.0.7/go.mod h1:FZQbEYa1pxkQ7WLpyXJ6cbjpT8q0YgQaK/JakXqGyWw=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -694,8 +710,12 @@ github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaX
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
+github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/nomad/api v0.0.0-20260528135333-5b027732945f h1:sdf4a6FF3tC1/c0buuizLAwZa/xLu4gWD87qWrzQLvo=
 github.com/hashicorp/nomad/api v0.0.0-20260528135333-5b027732945f/go.mod h1:Kr8imJwigbQ/50BqVae2+JL+AyX+FnzbnuCoIFb6iYg=
+github.com/hashicorp/vault/api v1.15.0 h1:O24FYQCWwhwKnF7CuSqP30S51rTV7vz1iACXE/pj5DA=
+github.com/hashicorp/vault/api v1.15.0/go.mod h1:+5YTO09JGn0u+b6ySD/LLVf8WkJCPLAL2Vkmrn2+CM8=
 github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 h1:S4qyfL2sEm5Budr4KVMyEniCy+PbS55651I/a+Kn/NQ=
 github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95/go.mod h1:QiyDdbZLaJ/mZP4Zwc9g2QsfaEA4o7XvvgZegSci5/E=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -794,6 +814,7 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11 h1:YFh+sjyJTMQSYjKwM4dFKhJPJC/wfo98tPUc17HdoYw=
 github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11/go.mod h1:Ah2dBMoxZEqk118as2T4u4fjfXarE0pPnMJaArZQZsI=
+github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -801,6 +822,7 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-ieproxy v0.0.1 h1:qiyop7gCflfhwCzGyeT0gro3sF9AIg9HU98JORTkqfI=
 github.com/mattn/go-ieproxy v0.0.1/go.mod h1:pYabZ6IHcRpFh7vIaLfK7rdcWgFEb3SFJ6/gNWuh88E=
+github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -829,10 +851,13 @@ github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8D
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
+github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -937,6 +962,7 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/poy/eachers v0.0.0-20181020210610-23942921fe77 h1:SNdqPRvRsVmYR0gKqFvrUKhFizPJ6yDiGQ++VAJIoDg=
@@ -983,6 +1009,9 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
+github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/samuel/go-parser v0.0.0-20130731160455-ca8abbf65d0e h1:hUGyBE/4CXRPThr4b6kt+f1CN90no4Fs5CNrYOKYSIg=
 github.com/samuel/go-parser v0.0.0-20130731160455-ca8abbf65d0e/go.mod h1:Sb6li54lXV0yYEjI4wX8cucdQ9gqUJV3+Ngg3l9g30I=
 github.com/samuel/go-thrift v0.0.0-20140522043831-2187045faa54 h1:jbchLJWyhKcmOjkbC4zDvT/n5EEd7g6hnnF760rEyRA=
@@ -1412,6 +1441,7 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -39,6 +39,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/processors/add_formatted_index"
 	"github.com/elastic/beats/v7/libbeat/processors/util"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipetool"
+	"github.com/elastic/beats/v7/libbeat/vault"
 )
 
 // HBRunnerFactory is used for validating generated configurations and creating
@@ -142,6 +143,15 @@ func (f *RunnerFactory) GetHashFunc(c *conf.C) (plugin.HashConfigFunc, error) {
 func (f *RunnerFactory) Create(p beat.Pipeline, c *conf.C) (cfgfile.Runner, error) {
 	// Only for backwards-compatible monitors.d loading
 	c, err := stdfields.UnnestStream(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve any per-monitor HashiCorp Vault connection: expands
+	// ${vault/<path>#<field>} references using a process-wide, cached Vault
+	// client (built once and shared across all monitors) and strips the `vault`
+	// field so the monitor plugin never sees it.
+	c, err = vault.ResolveConfig(c, f.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -64,6 +64,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue"
+	"github.com/elastic/beats/v7/libbeat/vault"
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/file"
@@ -833,10 +834,27 @@ func (b *Beat) configure(settings Settings) error {
 
 	if settings.DisableConfigResolver {
 		config.OverwriteConfigOpts(obfuscateConfigOpts())
-	} else if store != nil {
+	} else {
 		// TODO: Allow the options to be more flexible for dynamic changes
 		// note that if the store is nil it should be excluded as an option
-		config.OverwriteConfigOpts(configOptsWithKeystore(store))
+		var opts []ucfg.Option
+		if store != nil {
+			opts = configOptsWithKeystore(store)
+		} else {
+			opts = []ucfg.Option{ucfg.PathSep("."), ucfg.ResolveEnv, ucfg.VarExp}
+		}
+
+		// Wire a HashiCorp Vault resolver into the process-global config options
+		// when a `vault:` block is configured. This lets any ${vault/<path>#<field>}
+		// reference in any monitor/stream/top-level config value be resolved from
+		// Vault at config-unpack time, mirroring the keystore resolver pattern.
+		if vaultOpt, ok, verr := vault.NewResolverOption(cfg, b.Info.Logger); verr != nil {
+			return fmt.Errorf("could not initialize the vault config resolver: %w", verr)
+		} else if ok {
+			opts = append(opts, vaultOpt)
+		}
+
+		config.OverwriteConfigOpts(opts)
 	}
 
 	b.keystore = store

--- a/libbeat/vault/resolver.go
+++ b/libbeat/vault/resolver.go
@@ -61,7 +61,7 @@ var (
 
 func connKey(c Config) string {
 	h := sha256.Sum256([]byte(strings.Join([]string{
-		c.Address, c.Namespace, c.AuthMethod, c.Token, c.RoleID, c.SecretID, c.KVMount,
+		c.Name, c.Address, c.Namespace, c.AuthMethod, c.Token, c.RoleID, c.SecretID, c.KVMount,
 		c.SecretRefreshInterval, c.Version,
 	}, "\x00")))
 	return hex.EncodeToString(h[:])
@@ -97,13 +97,19 @@ const refPrefix = "vault/"
 
 const defaultKVMount = "secret"
 
-// Config is the vault connection. It can be provided either as a structured
-// block (standalone heartbeat.yml) or, under Fleet, as a single base64-encoded
-// JSON string so the whole connection is one $co.elastic.secret{...} value
-// (see NewResolverOption). The json tags match the base64/JSON form Kibana
-// produces.
+// Config is a single vault connection. Multiple connections may be configured
+// (as an array); each is addressed by Name in references of the form
+// ${vault/<name>@<path>#<field>}. A reference without "<name>@" uses the default
+// connection. Config may be provided as a structured block (standalone
+// heartbeat.yml) or, under Fleet, as a base64-encoded JSON value (a single
+// object or an array) so it can be one $co.elastic.secret{...} value. The json
+// tags match the base64/JSON form Kibana produces.
 type Config struct {
 	Enabled bool `config:"enabled" json:"enabled"`
+
+	// Name addresses this connection in references (${vault/<name>@...}). Empty
+	// means the default connection.
+	Name string `config:"name" json:"name"`
 
 	Address   string `config:"address" json:"address"`
 	Namespace string `config:"namespace" json:"namespace"`
@@ -147,22 +153,121 @@ func (c Config) refreshInterval() time.Duration {
 	return d
 }
 
-// decodeBase64Config decodes a base64-encoded JSON vault connection. This is
-// the form delivered by Fleet, where the whole connection is stored as a single
-// Fleet secret and injected as one opaque string — base64 avoids any YAML
-// formatting issues in the agent policy.
-func decodeBase64Config(s string) (Config, error) {
-	var c Config
+// decodeConfigs decodes a base64-encoded JSON vault connection. This is the form
+// delivered by Fleet, where the connection(s) are stored as a single Fleet
+// secret and injected as one opaque string — base64 avoids any YAML formatting
+// issues in the agent policy. The JSON may be a single object or an array of
+// connections.
+func decodeConfigs(s string) ([]Config, error) {
 	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(s))
 	if err != nil {
-		return c, fmt.Errorf("vault: config is not valid base64: %w", err)
+		return nil, fmt.Errorf("vault: config is not valid base64: %w", err)
 	}
-	if err := json.Unmarshal(decoded, &c); err != nil {
-		return c, fmt.Errorf("vault: decoded config is not valid JSON: %w", err)
+	// Array of connections first, then a single object.
+	var arr []Config
+	if err := json.Unmarshal(decoded, &arr); err == nil {
+		for i := range arr {
+			arr[i].Enabled = true // a delivered connection is enabled
+		}
+		return arr, nil
 	}
-	// Presence of a delivered connection implies it is enabled.
-	c.Enabled = true
-	return c, nil
+	var one Config
+	if err := json.Unmarshal(decoded, &one); err != nil {
+		return nil, fmt.Errorf("vault: decoded config is not valid JSON: %w", err)
+	}
+	one.Enabled = true
+	return []Config{one}, nil
+}
+
+// parseConfigs reads the `vault` field as one or more connections. It accepts a
+// base64 string (Fleet form), a single object, or an array of objects
+// (standalone heartbeat.yml).
+func parseConfigs(cfg *config.C) ([]Config, error) {
+	if s, err := cfg.String("vault", -1); err == nil && s != "" {
+		return decodeConfigs(s)
+	}
+	var arrWrap struct {
+		Vault []Config `config:"vault"`
+	}
+	if err := cfg.Unpack(&arrWrap); err == nil && len(arrWrap.Vault) > 0 {
+		return arrWrap.Vault, nil
+	}
+	sub, err := cfg.Child("vault", -1)
+	if err != nil {
+		return nil, fmt.Errorf("vault: reading config block: %w", err)
+	}
+	var one Config
+	if err := sub.Unpack(&one); err != nil {
+		return nil, fmt.Errorf("vault: invalid config: %w", err)
+	}
+	return []Config{one}, nil
+}
+
+// dispatcher routes ${vault/[<name>@]<path>#<field>} references to the resolver
+// of the named connection (empty name = default).
+type dispatcher struct {
+	byName map[string]*resolver
+}
+
+// buildDispatcher builds (or reuses cached) resolvers for the enabled
+// connections, indexed by name. Returns nil when nothing is enabled.
+func buildDispatcher(configs []Config, log *logp.Logger) (*dispatcher, error) {
+	d := &dispatcher{byName: map[string]*resolver{}}
+	var enabled []Config
+	for _, c := range configs {
+		if !c.Enabled {
+			continue
+		}
+		enabled = append(enabled, c)
+		r, err := GetResolver(c, log)
+		if err != nil {
+			return nil, err
+		}
+		d.byName[c.Name] = r
+	}
+	if len(enabled) == 0 {
+		return nil, nil
+	}
+	// A single connection is also the default, so unqualified references work.
+	if _, ok := d.byName[""]; !ok && len(enabled) == 1 {
+		d.byName[""] = d.byName[enabled[0].Name]
+	}
+	return d, nil
+}
+
+func (d *dispatcher) resolve(key string) (string, parse.Config, error) {
+	noop := parse.NoopConfig
+	if !strings.HasPrefix(key, refPrefix) {
+		return "", noop, ucfg.ErrMissing
+	}
+	spec := strings.TrimPrefix(key, refPrefix)
+
+	name := ""
+	if at := strings.Index(spec, "@"); at >= 0 {
+		name = spec[:at]
+		spec = spec[at+1:]
+	}
+
+	hash := strings.LastIndex(spec, "#")
+	if hash < 0 {
+		return "", noop, fmt.Errorf(
+			"vault: reference %q must be vault/[<connection>@]<path>#<field>", key)
+	}
+	path := strings.Trim(spec[:hash], "/")
+	field := spec[hash+1:]
+	if path == "" || field == "" {
+		return "", noop, fmt.Errorf("vault: reference %q has an empty path or field", key)
+	}
+
+	r, ok := d.byName[name]
+	if !ok {
+		return "", noop, fmt.Errorf("vault: no connection named %q for reference %q", name, key)
+	}
+	val, err := r.read(path, field)
+	if err != nil {
+		return "", noop, err
+	}
+	return val, noop, nil
 }
 
 type cacheEntry struct {
@@ -182,85 +287,57 @@ type resolver struct {
 	cache map[string]cacheEntry
 }
 
-// NewResolverOption reads the `vault:` block from the given config and, when it
-// is present and enabled, returns a go-ucfg resolver option plus ok=true. When
-// the block is absent or disabled it returns ok=false and the caller should
-// leave the config options unchanged.
+// NewResolverOption reads the `vault:` config (one or more connections) and,
+// when present and enabled, returns a go-ucfg resolver option plus ok=true. When
+// absent or nothing is enabled it returns ok=false and the caller should leave
+// the config options unchanged.
 func NewResolverOption(cfg *config.C, log *logp.Logger) (ucfg.Option, bool, error) {
 	if cfg == nil || !cfg.HasField("vault") {
 		return nil, false, nil
 	}
 
-	var c Config
-	// Fleet delivers the whole connection as a single base64-encoded JSON string
-	// (a $co.elastic.secret{...} value). Standalone heartbeat.yml can instead use
-	// a structured block. Detect the string form first.
-	if s, serr := cfg.String("vault", -1); serr == nil && s != "" {
-		decoded, derr := decodeBase64Config(s)
-		if derr != nil {
-			return nil, false, derr
-		}
-		c = decoded
-	} else {
-		sub, cerr := cfg.Child("vault", -1)
-		if cerr != nil {
-			return nil, false, fmt.Errorf("vault: reading config block: %w", cerr)
-		}
-		if uerr := sub.Unpack(&c); uerr != nil {
-			return nil, false, fmt.Errorf("vault: invalid config: %w", uerr)
-		}
-	}
-	if !c.Enabled {
-		return nil, false, nil
-	}
-
-	r, err := GetResolver(c, log)
+	configs, err := parseConfigs(cfg)
 	if err != nil {
 		return nil, false, err
 	}
-	return ucfg.Resolve(r.resolve), true, nil
+	d, err := buildDispatcher(configs, log)
+	if err != nil {
+		return nil, false, err
+	}
+	if d == nil {
+		return nil, false, nil
+	}
+	return ucfg.Resolve(d.resolve), true, nil
 }
 
 // ResolveConfig handles the per-monitor delivery form: under Fleet, each monitor
-// carries its own `vault` connection (as a base64 string). When present, the
-// shared resolver for that connection is looked up (built once, cached), the
-// monitor's ${vault/<path>#<field>} references are resolved in place, and the
-// `vault` field is stripped so the monitor plugin never sees it. Monitors
-// without a `vault` field are returned unchanged.
+// carries its own `vault` connection(s) (as a base64 string, single or array).
+// The shared resolver for each connection is looked up (built once, cached), the
+// monitor's ${vault/[<name>@]<path>#<field>} references are resolved in place,
+// and the `vault` field is stripped so the monitor plugin never sees it.
+// Monitors without a `vault` field are returned unchanged.
 func ResolveConfig(raw *config.C, log *logp.Logger) (*config.C, error) {
 	if raw == nil || !raw.HasField("vault") {
 		return raw, nil
 	}
 
-	var c Config
-	if s, err := raw.String("vault", -1); err == nil && s != "" {
-		decoded, derr := decodeBase64Config(s)
-		if derr != nil {
-			return nil, derr
-		}
-		c = decoded
-	} else {
-		sub, cerr := raw.Child("vault", -1)
-		if cerr != nil {
-			return nil, fmt.Errorf("vault: reading monitor connection: %w", cerr)
-		}
-		if uerr := sub.Unpack(&c); uerr != nil {
-			return nil, fmt.Errorf("vault: invalid monitor connection: %w", uerr)
-		}
+	configs, err := parseConfigs(raw)
+	if err != nil {
+		return nil, err
+	}
+	d, err := buildDispatcher(configs, log)
+	if err != nil {
+		return nil, err
 	}
 
 	// Resolve the monitor's ${vault/...} references using the shared (cached)
-	// resolver. config.C.Unpack always uses the process-global options, so drop
+	// resolvers. config.C.Unpack always uses the process-global options, so drop
 	// to the underlying ucfg config to add the per-monitor vault resolver.
 	var m map[string]interface{}
-	if c.Enabled {
-		r, err := GetResolver(c, log)
-		if err != nil {
-			return nil, err
-		}
+	if d != nil {
 		opts := []ucfg.Option{
 			ucfg.PathSep("."),
-			ucfg.Resolve(r.resolve),
+			ucfg.Resolve(d.resolve),
 			ucfg.ResolveEnv,
 			ucfg.VarExp,
 		}
@@ -370,36 +447,6 @@ func authenticate(client *vaultapi.Client, c Config) error {
 		return fmt.Errorf("vault: unknown auth_method %q", c.AuthMethod)
 	}
 	return nil
-}
-
-// resolve is the go-ucfg resolver callback. It only handles keys prefixed with
-// "vault/"; anything else returns ucfg.ErrMissing so the next resolver (keystore
-// / env) gets a chance.
-func (r *resolver) resolve(key string) (string, parse.Config, error) {
-	// parse.NoopConfig prevents the resolved secret from being re-interpreted by
-	// the ucfg parser (e.g. a value that happens to contain ${...} or commas).
-	noop := parse.NoopConfig
-
-	if !strings.HasPrefix(key, refPrefix) {
-		return "", noop, ucfg.ErrMissing
-	}
-
-	spec := strings.TrimPrefix(key, refPrefix)
-	hash := strings.LastIndex(spec, "#")
-	if hash < 0 {
-		return "", noop, fmt.Errorf("vault: reference %q must be of the form vault/<path>#<field>", key)
-	}
-	path := strings.Trim(spec[:hash], "/")
-	field := spec[hash+1:]
-	if path == "" || field == "" {
-		return "", noop, fmt.Errorf("vault: reference %q has an empty path or field", key)
-	}
-
-	val, err := r.read(path, field)
-	if err != nil {
-		return "", noop, err
-	}
-	return val, noop, nil
 }
 
 func (r *resolver) read(path, field string) (string, error) {

--- a/libbeat/vault/resolver.go
+++ b/libbeat/vault/resolver.go
@@ -1,0 +1,250 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package vault provides a go-ucfg config resolver that expands references of
+// the form ${vault/<path>#<field>} to secret values fetched at runtime from a
+// HashiCorp Vault server.
+//
+// The resolver is wired into the process-global config options next to the
+// keystore resolver, so any ${vault/...} reference in any monitor, stream or
+// top-level config value is transparently resolved during config unpack. The
+// plaintext secret only ever lives in the Heartbeat process memory; it is never
+// written to disk or shipped anywhere.
+//
+// This is a proof-of-concept. Placement (oss vs x-pack), token lease renewal,
+// additional auth methods and TTL-based cache expiry are follow-ups.
+package vault
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	vaultapi "github.com/hashicorp/vault/api"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/parse"
+)
+
+// refPrefix is the sentinel that routes a config reference to this resolver.
+// A reference looks like ${vault/<secret-path>#<field>}, e.g.
+// ${vault/myapp/creds#password}. We deliberately use '/' and '#' (rather than
+// ':') because ':' is the go-ucfg default-value operator and would break
+// parsing, and because '/' and '#' are outside Kibana's param-substitution
+// character class, so Kibana passes the token through untouched.
+const refPrefix = "vault/"
+
+const defaultKVMount = "secret"
+
+// Config is the top-level `vault:` block read once at Beat startup.
+type Config struct {
+	Enabled bool `config:"enabled"`
+
+	Address   string `config:"address"`
+	Namespace string `config:"namespace"`
+
+	// AuthMethod is "token" or "approle" (default "approle" when role_id is set,
+	// otherwise "token").
+	AuthMethod string `config:"auth_method"`
+	Token      string `config:"token"`
+	RoleID     string `config:"role_id"`
+	SecretID   string `config:"secret_id"`
+
+	// KVMount is the KV v2 secrets-engine mount path (default "secret").
+	KVMount string `config:"kv_mount"`
+
+	// TLSSkipVerify disables TLS verification. Intended for local/dev only.
+	TLSSkipVerify bool `config:"tls_skip_verify"`
+}
+
+// resolver reads secrets from Vault and memoizes them for the process lifetime.
+type resolver struct {
+	client *vaultapi.Client
+	mount  string
+	log    *logp.Logger
+
+	mu    sync.Mutex
+	cache map[string]string
+}
+
+// NewResolverOption reads the `vault:` block from the given config and, when it
+// is present and enabled, returns a go-ucfg resolver option plus ok=true. When
+// the block is absent or disabled it returns ok=false and the caller should
+// leave the config options unchanged.
+func NewResolverOption(cfg *config.C, log *logp.Logger) (ucfg.Option, bool, error) {
+	if cfg == nil || !cfg.HasField("vault") {
+		return nil, false, nil
+	}
+
+	sub, err := cfg.Child("vault", -1)
+	if err != nil {
+		return nil, false, fmt.Errorf("vault: reading config block: %w", err)
+	}
+
+	var c Config
+	if err := sub.Unpack(&c); err != nil {
+		return nil, false, fmt.Errorf("vault: invalid config: %w", err)
+	}
+	if !c.Enabled {
+		return nil, false, nil
+	}
+
+	r, err := newResolver(c, log)
+	if err != nil {
+		return nil, false, err
+	}
+	return ucfg.Resolve(r.resolve), true, nil
+}
+
+func newResolver(c Config, log *logp.Logger) (*resolver, error) {
+	if log == nil {
+		log = logp.NewLogger("vault")
+	} else {
+		log = log.Named("vault")
+	}
+
+	if c.Address == "" {
+		return nil, fmt.Errorf("vault: address is required")
+	}
+
+	apiCfg := vaultapi.DefaultConfig()
+	apiCfg.Address = c.Address
+	if c.TLSSkipVerify {
+		if err := apiCfg.ConfigureTLS(&vaultapi.TLSConfig{Insecure: true}); err != nil {
+			return nil, fmt.Errorf("vault: configuring TLS: %w", err)
+		}
+	}
+
+	client, err := vaultapi.NewClient(apiCfg)
+	if err != nil {
+		return nil, fmt.Errorf("vault: creating client: %w", err)
+	}
+	if c.Namespace != "" {
+		client.SetNamespace(c.Namespace)
+	}
+
+	authMethod := c.AuthMethod
+	if authMethod == "" {
+		if c.RoleID != "" {
+			authMethod = "approle"
+		} else {
+			authMethod = "token"
+		}
+	}
+
+	switch authMethod {
+	case "token":
+		if c.Token == "" {
+			return nil, fmt.Errorf("vault: token auth requires a token")
+		}
+		client.SetToken(c.Token)
+	case "approle":
+		if c.RoleID == "" || c.SecretID == "" {
+			return nil, fmt.Errorf("vault: approle auth requires role_id and secret_id")
+		}
+		secret, err := client.Logical().WriteWithContext(context.Background(), "auth/approle/login", map[string]interface{}{
+			"role_id":   c.RoleID,
+			"secret_id": c.SecretID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("vault: approle login failed: %w", err)
+		}
+		if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
+			return nil, fmt.Errorf("vault: approle login returned no client token")
+		}
+		client.SetToken(secret.Auth.ClientToken)
+	default:
+		return nil, fmt.Errorf("vault: unknown auth_method %q", authMethod)
+	}
+
+	mount := c.KVMount
+	if mount == "" {
+		mount = defaultKVMount
+	}
+
+	log.Infof("initialized HashiCorp Vault resolver (address=%s, kv_mount=%s, auth=%s)", c.Address, mount, authMethod)
+
+	return &resolver{
+		client: client,
+		mount:  mount,
+		log:    log,
+		cache:  map[string]string{},
+	}, nil
+}
+
+// resolve is the go-ucfg resolver callback. It only handles keys prefixed with
+// "vault/"; anything else returns ucfg.ErrMissing so the next resolver (keystore
+// / env) gets a chance.
+func (r *resolver) resolve(key string) (string, parse.Config, error) {
+	// parse.NoopConfig prevents the resolved secret from being re-interpreted by
+	// the ucfg parser (e.g. a value that happens to contain ${...} or commas).
+	noop := parse.NoopConfig
+
+	if !strings.HasPrefix(key, refPrefix) {
+		return "", noop, ucfg.ErrMissing
+	}
+
+	spec := strings.TrimPrefix(key, refPrefix)
+	hash := strings.LastIndex(spec, "#")
+	if hash < 0 {
+		return "", noop, fmt.Errorf("vault: reference %q must be of the form vault/<path>#<field>", key)
+	}
+	path := strings.Trim(spec[:hash], "/")
+	field := spec[hash+1:]
+	if path == "" || field == "" {
+		return "", noop, fmt.Errorf("vault: reference %q has an empty path or field", key)
+	}
+
+	val, err := r.read(path, field)
+	if err != nil {
+		return "", noop, err
+	}
+	return val, noop, nil
+}
+
+func (r *resolver) read(path, field string) (string, error) {
+	cacheKey := path + "#" + field
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if v, ok := r.cache[cacheKey]; ok {
+		return v, nil
+	}
+
+	secret, err := r.client.KVv2(r.mount).Get(context.Background(), path)
+	if err != nil {
+		return "", fmt.Errorf("vault: reading %s/%s: %w", r.mount, path, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return "", fmt.Errorf("vault: no data at %s/%s", r.mount, path)
+	}
+
+	raw, ok := secret.Data[field]
+	if !ok {
+		return "", fmt.Errorf("vault: field %q not found at %s/%s", field, r.mount, path)
+	}
+
+	val := fmt.Sprintf("%v", raw)
+	r.cache[cacheKey] = val
+	// Never log the secret value itself.
+	r.log.Debugf("resolved vault reference %s/%s#%s", r.mount, path, field)
+	return val, nil
+}

--- a/libbeat/vault/resolver.go
+++ b/libbeat/vault/resolver.go
@@ -31,6 +31,8 @@ package vault
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -53,25 +55,47 @@ const refPrefix = "vault/"
 
 const defaultKVMount = "secret"
 
-// Config is the top-level `vault:` block read once at Beat startup.
+// Config is the vault connection. It can be provided either as a structured
+// block (standalone heartbeat.yml) or, under Fleet, as a single base64-encoded
+// JSON string so the whole connection is one $co.elastic.secret{...} value
+// (see NewResolverOption). The json tags match the base64/JSON form Kibana
+// produces.
 type Config struct {
-	Enabled bool `config:"enabled"`
+	Enabled bool `config:"enabled" json:"enabled"`
 
-	Address   string `config:"address"`
-	Namespace string `config:"namespace"`
+	Address   string `config:"address" json:"address"`
+	Namespace string `config:"namespace" json:"namespace"`
 
 	// AuthMethod is "token" or "approle" (default "approle" when role_id is set,
 	// otherwise "token").
-	AuthMethod string `config:"auth_method"`
-	Token      string `config:"token"`
-	RoleID     string `config:"role_id"`
-	SecretID   string `config:"secret_id"`
+	AuthMethod string `config:"auth_method" json:"auth_method"`
+	Token      string `config:"token" json:"token"`
+	RoleID     string `config:"role_id" json:"role_id"`
+	SecretID   string `config:"secret_id" json:"secret_id"`
 
 	// KVMount is the KV v2 secrets-engine mount path (default "secret").
-	KVMount string `config:"kv_mount"`
+	KVMount string `config:"kv_mount" json:"kv_mount"`
 
 	// TLSSkipVerify disables TLS verification. Intended for local/dev only.
-	TLSSkipVerify bool `config:"tls_skip_verify"`
+	TLSSkipVerify bool `config:"tls_skip_verify" json:"tls_skip_verify"`
+}
+
+// decodeBase64Config decodes a base64-encoded JSON vault connection. This is
+// the form delivered by Fleet, where the whole connection is stored as a single
+// Fleet secret and injected as one opaque string — base64 avoids any YAML
+// formatting issues in the agent policy.
+func decodeBase64Config(s string) (Config, error) {
+	var c Config
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(s))
+	if err != nil {
+		return c, fmt.Errorf("vault: config is not valid base64: %w", err)
+	}
+	if err := json.Unmarshal(decoded, &c); err != nil {
+		return c, fmt.Errorf("vault: decoded config is not valid JSON: %w", err)
+	}
+	// Presence of a delivered connection implies it is enabled.
+	c.Enabled = true
+	return c, nil
 }
 
 // resolver reads secrets from Vault and memoizes them for the process lifetime.
@@ -93,14 +117,24 @@ func NewResolverOption(cfg *config.C, log *logp.Logger) (ucfg.Option, bool, erro
 		return nil, false, nil
 	}
 
-	sub, err := cfg.Child("vault", -1)
-	if err != nil {
-		return nil, false, fmt.Errorf("vault: reading config block: %w", err)
-	}
-
 	var c Config
-	if err := sub.Unpack(&c); err != nil {
-		return nil, false, fmt.Errorf("vault: invalid config: %w", err)
+	// Fleet delivers the whole connection as a single base64-encoded JSON string
+	// (a $co.elastic.secret{...} value). Standalone heartbeat.yml can instead use
+	// a structured block. Detect the string form first.
+	if s, serr := cfg.String("vault", -1); serr == nil && s != "" {
+		decoded, derr := decodeBase64Config(s)
+		if derr != nil {
+			return nil, false, derr
+		}
+		c = decoded
+	} else {
+		sub, cerr := cfg.Child("vault", -1)
+		if cerr != nil {
+			return nil, false, fmt.Errorf("vault: reading config block: %w", cerr)
+		}
+		if uerr := sub.Unpack(&c); uerr != nil {
+			return nil, false, fmt.Errorf("vault: invalid config: %w", uerr)
+		}
 	}
 	if !c.Enabled {
 		return nil, false, nil

--- a/libbeat/vault/resolver.go
+++ b/libbeat/vault/resolver.go
@@ -35,9 +35,11 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	vaultapi "github.com/hashicorp/vault/api"
 
@@ -60,6 +62,7 @@ var (
 func connKey(c Config) string {
 	h := sha256.Sum256([]byte(strings.Join([]string{
 		c.Address, c.Namespace, c.AuthMethod, c.Token, c.RoleID, c.SecretID, c.KVMount,
+		c.SecretRefreshInterval, c.Version,
 	}, "\x00")))
 	return hex.EncodeToString(h[:])
 }
@@ -117,6 +120,31 @@ type Config struct {
 
 	// TLSSkipVerify disables TLS verification. Intended for local/dev only.
 	TLSSkipVerify bool `config:"tls_skip_verify" json:"tls_skip_verify"`
+
+	// SecretRefreshInterval is how long a resolved secret is cached before it is
+	// re-read from Vault — the cache-invalidation window that lets rotated
+	// secrets be picked up without restarting. A Go duration string, e.g. "5m".
+	// Defaults to defaultRefreshInterval.
+	SecretRefreshInterval string `config:"secret_refresh_interval" json:"secret_refresh_interval"`
+
+	// Version is an opaque value bumped by the control plane (e.g. when a user
+	// clicks "Refresh secrets"). It is part of the connection identity, so a new
+	// version yields a fresh resolver with an empty cache — the next read
+	// re-fetches from Vault. This is what makes a manual refresh force an update.
+	Version string `config:"version" json:"version"`
+}
+
+const defaultRefreshInterval = 5 * time.Minute
+
+func (c Config) refreshInterval() time.Duration {
+	if c.SecretRefreshInterval == "" {
+		return defaultRefreshInterval
+	}
+	d, err := time.ParseDuration(c.SecretRefreshInterval)
+	if err != nil || d <= 0 {
+		return defaultRefreshInterval
+	}
+	return d
 }
 
 // decodeBase64Config decodes a base64-encoded JSON vault connection. This is
@@ -137,14 +165,21 @@ func decodeBase64Config(s string) (Config, error) {
 	return c, nil
 }
 
-// resolver reads secrets from Vault and memoizes them for the process lifetime.
+type cacheEntry struct {
+	value     string
+	expiresAt time.Time
+}
+
+// resolver reads secrets from Vault and caches them for secret_refresh_interval.
 type resolver struct {
-	client *vaultapi.Client
-	mount  string
-	log    *logp.Logger
+	client          *vaultapi.Client
+	cfg             Config // retained so the token can be re-established on expiry
+	mount           string
+	refreshInterval time.Duration
+	log             *logp.Logger
 
 	mu    sync.Mutex
-	cache map[string]string
+	cache map[string]cacheEntry
 }
 
 // NewResolverOption reads the `vault:` block from the given config and, when it
@@ -273,38 +308,8 @@ func newResolver(c Config, log *logp.Logger) (*resolver, error) {
 		client.SetNamespace(c.Namespace)
 	}
 
-	authMethod := c.AuthMethod
-	if authMethod == "" {
-		if c.RoleID != "" {
-			authMethod = "approle"
-		} else {
-			authMethod = "token"
-		}
-	}
-
-	switch authMethod {
-	case "token":
-		if c.Token == "" {
-			return nil, fmt.Errorf("vault: token auth requires a token")
-		}
-		client.SetToken(c.Token)
-	case "approle":
-		if c.RoleID == "" || c.SecretID == "" {
-			return nil, fmt.Errorf("vault: approle auth requires role_id and secret_id")
-		}
-		secret, err := client.Logical().WriteWithContext(context.Background(), "auth/approle/login", map[string]interface{}{
-			"role_id":   c.RoleID,
-			"secret_id": c.SecretID,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("vault: approle login failed: %w", err)
-		}
-		if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
-			return nil, fmt.Errorf("vault: approle login returned no client token")
-		}
-		client.SetToken(secret.Auth.ClientToken)
-	default:
-		return nil, fmt.Errorf("vault: unknown auth_method %q", authMethod)
+	if err := authenticate(client, c); err != nil {
+		return nil, err
 	}
 
 	mount := c.KVMount
@@ -312,14 +317,59 @@ func newResolver(c Config, log *logp.Logger) (*resolver, error) {
 		mount = defaultKVMount
 	}
 
-	log.Infof("initialized HashiCorp Vault resolver (address=%s, kv_mount=%s, auth=%s)", c.Address, mount, authMethod)
+	r := &resolver{
+		client:          client,
+		cfg:             c,
+		mount:           mount,
+		refreshInterval: c.refreshInterval(),
+		log:             log,
+		cache:           map[string]cacheEntry{},
+	}
+	log.Infof("initialized HashiCorp Vault resolver (address=%s, kv_mount=%s, auth=%s, refresh=%s)",
+		c.Address, mount, authMethodOf(c), r.refreshInterval)
+	return r, nil
+}
 
-	return &resolver{
-		client: client,
-		mount:  mount,
-		log:    log,
-		cache:  map[string]string{},
-	}, nil
+// authMethodOf returns the effective auth method (defaults to approle when a
+// role_id is present, otherwise token).
+func authMethodOf(c Config) string {
+	if c.AuthMethod != "" {
+		return c.AuthMethod
+	}
+	if c.RoleID != "" {
+		return "approle"
+	}
+	return "token"
+}
+
+// authenticate establishes the client token from the configured auth method. It
+// is used both on initial connect and to re-authenticate when the token expires.
+func authenticate(client *vaultapi.Client, c Config) error {
+	switch authMethodOf(c) {
+	case "token":
+		if c.Token == "" {
+			return fmt.Errorf("vault: token auth requires a token")
+		}
+		client.SetToken(c.Token)
+	case "approle":
+		if c.RoleID == "" || c.SecretID == "" {
+			return fmt.Errorf("vault: approle auth requires role_id and secret_id")
+		}
+		secret, err := client.Logical().WriteWithContext(context.Background(), "auth/approle/login", map[string]interface{}{
+			"role_id":   c.RoleID,
+			"secret_id": c.SecretID,
+		})
+		if err != nil {
+			return fmt.Errorf("vault: approle login failed: %w", err)
+		}
+		if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
+			return fmt.Errorf("vault: approle login returned no client token")
+		}
+		client.SetToken(secret.Auth.ClientToken)
+	default:
+		return fmt.Errorf("vault: unknown auth_method %q", c.AuthMethod)
+	}
+	return nil
 }
 
 // resolve is the go-ucfg resolver callback. It only handles keys prefixed with
@@ -358,26 +408,52 @@ func (r *resolver) read(path, field string) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if v, ok := r.cache[cacheKey]; ok {
-		return v, nil
+	// Serve from cache until secret_refresh_interval elapses; after that the
+	// secret is re-read so a rotated value is picked up without a restart.
+	if e, ok := r.cache[cacheKey]; ok && time.Now().Before(e.expiresAt) {
+		return e.value, nil
 	}
 
+	val, err := r.fetch(path, field)
+	if err != nil {
+		return "", err
+	}
+
+	r.cache[cacheKey] = cacheEntry{value: val, expiresAt: time.Now().Add(r.refreshInterval)}
+	// Never log the secret value itself.
+	r.log.Debugf("resolved vault reference %s/%s#%s (cached %s)", r.mount, path, field, r.refreshInterval)
+	return val, nil
+}
+
+// fetch reads a single field from Vault, re-authenticating once if the token has
+// expired (403), so a long-lived Heartbeat survives token/lease expiry.
+func (r *resolver) fetch(path, field string) (string, error) {
 	secret, err := r.client.KVv2(r.mount).Get(context.Background(), path)
+	if err != nil && isPermissionError(err) {
+		r.log.Debugf("vault token rejected, re-authenticating")
+		if aerr := authenticate(r.client, r.cfg); aerr != nil {
+			return "", fmt.Errorf("vault: re-authentication failed: %w", aerr)
+		}
+		secret, err = r.client.KVv2(r.mount).Get(context.Background(), path)
+	}
 	if err != nil {
 		return "", fmt.Errorf("vault: reading %s/%s: %w", r.mount, path, err)
 	}
 	if secret == nil || secret.Data == nil {
 		return "", fmt.Errorf("vault: no data at %s/%s", r.mount, path)
 	}
-
 	raw, ok := secret.Data[field]
 	if !ok {
 		return "", fmt.Errorf("vault: field %q not found at %s/%s", field, r.mount, path)
 	}
+	return fmt.Sprintf("%v", raw), nil
+}
 
-	val := fmt.Sprintf("%v", raw)
-	r.cache[cacheKey] = val
-	// Never log the secret value itself.
-	r.log.Debugf("resolved vault reference %s/%s#%s", r.mount, path, field)
-	return val, nil
+// isPermissionError reports whether err is a Vault 401/403 (expired/invalid token).
+func isPermissionError(err error) bool {
+	var respErr *vaultapi.ResponseError
+	if errors.As(err, &respErr) {
+		return respErr.StatusCode == 401 || respErr.StatusCode == 403
+	}
+	return false
 }

--- a/libbeat/vault/resolver.go
+++ b/libbeat/vault/resolver.go
@@ -31,7 +31,9 @@ package vault
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -44,6 +46,43 @@ import (
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/parse"
 )
+
+// registry caches one resolver (Vault client + secret cache) per unique
+// connection for the lifetime of the process. Many monitors share the same
+// Vault connection, so the client is built once and the resolved-secret cache
+// is shared across every monitor — a monitor run never re-fetches a secret that
+// another monitor already resolved.
+var (
+	registry   = map[string]*resolver{}
+	registryMu sync.Mutex
+)
+
+func connKey(c Config) string {
+	h := sha256.Sum256([]byte(strings.Join([]string{
+		c.Address, c.Namespace, c.AuthMethod, c.Token, c.RoleID, c.SecretID, c.KVMount,
+	}, "\x00")))
+	return hex.EncodeToString(h[:])
+}
+
+// GetResolver returns the shared resolver for a connection, building (and
+// caching) the Vault client on first use and reusing it for every subsequent
+// monitor that uses the same connection.
+func GetResolver(c Config, log *logp.Logger) (*resolver, error) {
+	key := connKey(c)
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if r, ok := registry[key]; ok {
+		return r, nil
+	}
+	r, err := newResolver(c, log)
+	if err != nil {
+		return nil, err
+	}
+	registry[key] = r
+	return r, nil
+}
 
 // refPrefix is the sentinel that routes a config reference to this resolver.
 // A reference looks like ${vault/<secret-path>#<field>}, e.g.
@@ -140,11 +179,71 @@ func NewResolverOption(cfg *config.C, log *logp.Logger) (ucfg.Option, bool, erro
 		return nil, false, nil
 	}
 
-	r, err := newResolver(c, log)
+	r, err := GetResolver(c, log)
 	if err != nil {
 		return nil, false, err
 	}
 	return ucfg.Resolve(r.resolve), true, nil
+}
+
+// ResolveConfig handles the per-monitor delivery form: under Fleet, each monitor
+// carries its own `vault` connection (as a base64 string). When present, the
+// shared resolver for that connection is looked up (built once, cached), the
+// monitor's ${vault/<path>#<field>} references are resolved in place, and the
+// `vault` field is stripped so the monitor plugin never sees it. Monitors
+// without a `vault` field are returned unchanged.
+func ResolveConfig(raw *config.C, log *logp.Logger) (*config.C, error) {
+	if raw == nil || !raw.HasField("vault") {
+		return raw, nil
+	}
+
+	var c Config
+	if s, err := raw.String("vault", -1); err == nil && s != "" {
+		decoded, derr := decodeBase64Config(s)
+		if derr != nil {
+			return nil, derr
+		}
+		c = decoded
+	} else {
+		sub, cerr := raw.Child("vault", -1)
+		if cerr != nil {
+			return nil, fmt.Errorf("vault: reading monitor connection: %w", cerr)
+		}
+		if uerr := sub.Unpack(&c); uerr != nil {
+			return nil, fmt.Errorf("vault: invalid monitor connection: %w", uerr)
+		}
+	}
+
+	// Resolve the monitor's ${vault/...} references using the shared (cached)
+	// resolver. config.C.Unpack always uses the process-global options, so drop
+	// to the underlying ucfg config to add the per-monitor vault resolver.
+	var m map[string]interface{}
+	if c.Enabled {
+		r, err := GetResolver(c, log)
+		if err != nil {
+			return nil, err
+		}
+		opts := []ucfg.Option{
+			ucfg.PathSep("."),
+			ucfg.Resolve(r.resolve),
+			ucfg.ResolveEnv,
+			ucfg.VarExp,
+		}
+		if err := (*ucfg.Config)(raw).Unpack(&m, opts...); err != nil {
+			return nil, fmt.Errorf("vault: resolving monitor references: %w", err)
+		}
+	} else if err := raw.Unpack(&m); err != nil {
+		return nil, err
+	}
+
+	// The connection is consumed here; the monitor plugin must not see it.
+	delete(m, "vault")
+
+	resolved, err := config.NewConfigFrom(m)
+	if err != nil {
+		return nil, fmt.Errorf("vault: rebuilding monitor config: %w", err)
+	}
+	return resolved, nil
 }
 
 func newResolver(c Config, log *logp.Logger) (*resolver, error) {

--- a/libbeat/vault/resolver.go
+++ b/libbeat/vault/resolver.go
@@ -55,13 +55,13 @@ import (
 // is shared across every monitor — a monitor run never re-fetches a secret that
 // another monitor already resolved.
 var (
-	registry   = map[string]*resolver{}
+	registry   = map[string]Resolver{}
 	registryMu sync.Mutex
 )
 
 func connKey(c Config) string {
 	h := sha256.Sum256([]byte(strings.Join([]string{
-		c.Name, c.Address, c.Namespace, c.AuthMethod, c.Token, c.RoleID, c.SecretID, c.KVMount,
+		c.Type, c.Name, c.Address, c.Namespace, c.AuthMethod, c.Token, c.RoleID, c.SecretID, c.KVMount,
 		c.SecretRefreshInterval, c.Version,
 	}, "\x00")))
 	return hex.EncodeToString(h[:])
@@ -70,7 +70,7 @@ func connKey(c Config) string {
 // GetResolver returns the shared resolver for a connection, building (and
 // caching) the Vault client on first use and reusing it for every subsequent
 // monitor that uses the same connection.
-func GetResolver(c Config, log *logp.Logger) (*resolver, error) {
+func GetResolver(c Config, log *logp.Logger) (Resolver, error) {
 	key := connKey(c)
 
 	registryMu.Lock()
@@ -97,6 +97,10 @@ const refPrefix = "vault/"
 
 const defaultKVMount = "secret"
 
+// ProviderHashiCorpVault is the only implemented secret-provider backend. New
+// backends add their own constant and a case in newResolver.
+const ProviderHashiCorpVault = "hashicorp_vault"
+
 // Config is a single vault connection. Multiple connections may be configured
 // (as an array); each is addressed by Name in references of the form
 // ${vault/<name>@<path>#<field>}. A reference without "<name>@" uses the default
@@ -106,6 +110,12 @@ const defaultKVMount = "secret"
 // tags match the base64/JSON form Kibana produces.
 type Config struct {
 	Enabled bool `config:"enabled" json:"enabled"`
+
+	// Type selects the secret-provider backend. Only "hashicorp_vault" is
+	// implemented; empty defaults to it. Adding a provider (CyberArk, Azure Key
+	// Vault, AWS Secrets Manager) means a new Resolver impl plus a case in
+	// newResolver — references, caching and dispatch are provider-agnostic.
+	Type string `config:"type" json:"type"`
 
 	// Name addresses this connection in references (${vault/<name>@...}). Empty
 	// means the default connection.
@@ -206,13 +216,13 @@ func parseConfigs(cfg *config.C) ([]Config, error) {
 // dispatcher routes ${vault/[<name>@]<path>#<field>} references to the resolver
 // of the named connection (empty name = default).
 type dispatcher struct {
-	byName map[string]*resolver
+	byName map[string]Resolver
 }
 
 // buildDispatcher builds (or reuses cached) resolvers for the enabled
 // connections, indexed by name. Returns nil when nothing is enabled.
 func buildDispatcher(configs []Config, log *logp.Logger) (*dispatcher, error) {
-	d := &dispatcher{byName: map[string]*resolver{}}
+	d := &dispatcher{byName: map[string]Resolver{}}
 	var enabled []Config
 	for _, c := range configs {
 		if !c.Enabled {
@@ -358,7 +368,36 @@ func ResolveConfig(raw *config.C, log *logp.Logger) (*config.C, error) {
 	return resolved, nil
 }
 
-func newResolver(c Config, log *logp.Logger) (*resolver, error) {
+// Resolver reads a secret field for one connection. Each provider backend
+// implements it; the registry, dispatcher and cache treat every provider
+// uniformly, so only newResolver knows about concrete backends.
+type Resolver interface {
+	read(path, field string) (string, error)
+}
+
+// providerTypeOf returns the connection's backend, defaulting to HashiCorp Vault
+// when unset (older blobs, or a single-provider deployment).
+func providerTypeOf(c Config) string {
+	if c.Type == "" {
+		return ProviderHashiCorpVault
+	}
+	return c.Type
+}
+
+// newResolver builds the resolver for a connection's provider type. This switch is
+// the single extension point for new backends.
+func newResolver(c Config, log *logp.Logger) (Resolver, error) {
+	switch providerTypeOf(c) {
+	case ProviderHashiCorpVault:
+		return newVaultResolver(c, log)
+	default:
+		return nil, fmt.Errorf("vault: unknown provider type %q", c.Type)
+	}
+}
+
+// newVaultResolver builds a HashiCorp Vault resolver: a Vault API client
+// authenticated per the connection, with a TTL secret cache.
+func newVaultResolver(c Config, log *logp.Logger) (*resolver, error) {
 	if log == nil {
 		log = logp.NewLogger("vault")
 	} else {

--- a/libbeat/vault/resolver_test.go
+++ b/libbeat/vault/resolver_test.go
@@ -22,8 +22,84 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/go-ucfg"
 )
+
+// TestGetResolverCachesClient verifies the Vault client is built once per
+// connection and shared across monitors (never rebuilt per monitor run).
+func TestGetResolverCachesClient(t *testing.T) {
+	c := Config{Enabled: true, Address: "http://127.0.0.1:8200", AuthMethod: "token", Token: "t", KVMount: "secret"}
+
+	r1, err := GetResolver(c, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r2, err := GetResolver(c, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r1 != r2 {
+		t.Fatal("expected the same cached resolver for the same connection")
+	}
+
+	other := c
+	other.Address = "http://127.0.0.1:8201"
+	r3, err := GetResolver(other, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r3 == r1 {
+		t.Fatal("expected a distinct resolver for a different connection")
+	}
+}
+
+// TestResolveConfigStripsVault verifies the per-monitor `vault` field is
+// consumed (removed) and non-vault fields are preserved. A config with no
+// ${vault/..} refs never triggers a Vault read.
+func TestResolveConfigStripsVault(t *testing.T) {
+	blob := base64.StdEncoding.EncodeToString(
+		[]byte(`{"address":"http://127.0.0.1:8200","auth_method":"token","token":"t","kv_mount":"secret"}`))
+	raw, err := config.NewConfigFrom(map[string]interface{}{
+		"type":  "http",
+		"name":  "m1",
+		"urls":  []string{"http://example.com"},
+		"vault": blob,
+	})
+	if err != nil {
+		t.Fatalf("build config: %v", err)
+	}
+
+	out, err := ResolveConfig(raw, nil)
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	if out.HasField("vault") {
+		t.Fatal("expected the vault field to be stripped")
+	}
+	var got struct {
+		Name string   `config:"name"`
+		URLs []string `config:"urls"`
+	}
+	if err := out.Unpack(&got); err != nil {
+		t.Fatalf("unpack resolved: %v", err)
+	}
+	if got.Name != "m1" || len(got.URLs) != 1 || got.URLs[0] != "http://example.com" {
+		t.Fatalf("non-vault fields not preserved: %+v", got)
+	}
+}
+
+// TestResolveConfigNoVault returns configs without a vault field unchanged.
+func TestResolveConfigNoVault(t *testing.T) {
+	raw, _ := config.NewConfigFrom(map[string]interface{}{"type": "http", "name": "m2"})
+	out, err := ResolveConfig(raw, nil)
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	if out != raw {
+		t.Fatal("expected the same config instance when no vault field is present")
+	}
+}
 
 // TestDecodeBase64Config verifies the Fleet delivery form: the whole connection
 // arrives as one base64-encoded JSON string (a single Fleet secret).

--- a/libbeat/vault/resolver_test.go
+++ b/libbeat/vault/resolver_test.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package vault
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elastic/go-ucfg"
+)
+
+// TestResolveRouting verifies the parsing/routing done before any network call:
+// non-vault keys fall through with ErrMissing, and malformed references error
+// out. These paths never touch the Vault client, so a zero-value resolver is
+// sufficient.
+func TestResolveRouting(t *testing.T) {
+	r := &resolver{cache: map[string]string{}}
+
+	tests := []struct {
+		name      string
+		key       string
+		wantMiss  bool // expect ucfg.ErrMissing (fall through to next resolver)
+		wantError bool // expect a (non-ErrMissing) error
+	}{
+		{name: "non-vault key falls through", key: "output.elasticsearch.password", wantMiss: true},
+		{name: "empty key falls through", key: "", wantMiss: true},
+		{name: "missing hash separator", key: "vault/myapp/creds", wantError: true},
+		{name: "empty path", key: "vault/#password", wantError: true},
+		{name: "empty field", key: "vault/myapp/creds#", wantError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := r.resolve(tc.key)
+			switch {
+			case tc.wantMiss:
+				if !errors.Is(err, ucfg.ErrMissing) {
+					t.Fatalf("key %q: expected ucfg.ErrMissing, got %v", tc.key, err)
+				}
+			case tc.wantError:
+				if err == nil || errors.Is(err, ucfg.ErrMissing) {
+					t.Fatalf("key %q: expected a parse error, got %v", tc.key, err)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveUsesCache verifies a cached value is returned without a client call.
+func TestResolveUsesCache(t *testing.T) {
+	r := &resolver{cache: map[string]string{"myapp/creds#password": "cached-secret"}}
+
+	v, _, err := r.resolve("vault/myapp/creds#password")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "cached-secret" {
+		t.Fatalf("expected cached-secret, got %q", v)
+	}
+}

--- a/libbeat/vault/resolver_test.go
+++ b/libbeat/vault/resolver_test.go
@@ -150,7 +150,7 @@ func TestDecodeConfigs(t *testing.T) {
 // non-vault keys fall through with ErrMissing, and malformed references error
 // out. These paths never touch a Vault client.
 func TestResolveRouting(t *testing.T) {
-	d := &dispatcher{byName: map[string]*resolver{}}
+	d := &dispatcher{byName: map[string]Resolver{}}
 
 	tests := []struct {
 		name      string
@@ -189,7 +189,7 @@ func TestResolveUsesCache(t *testing.T) {
 	r := &resolver{cache: map[string]cacheEntry{
 		"myapp/creds#password": {value: "cached-secret", expiresAt: time.Now().Add(time.Hour)},
 	}}
-	d := &dispatcher{byName: map[string]*resolver{"": r}}
+	d := &dispatcher{byName: map[string]Resolver{"": r}}
 
 	v, _, err := d.resolve("vault/myapp/creds#password")
 	if err != nil {
@@ -209,7 +209,7 @@ func TestDispatchByName(t *testing.T) {
 	staging := &resolver{cache: map[string]cacheEntry{
 		"db#password": {value: "staging-pw", expiresAt: time.Now().Add(time.Hour)},
 	}}
-	d := &dispatcher{byName: map[string]*resolver{"prod": prod, "staging": staging, "": prod}}
+	d := &dispatcher{byName: map[string]Resolver{"prod": prod, "staging": staging, "": prod}}
 
 	cases := map[string]string{
 		"vault/prod@db#password":    "prod-pw",
@@ -269,5 +269,29 @@ func TestExpiredCacheIsRefetched(t *testing.T) {
 	// Expired entry -> read() must not return "stale"; it re-fetches and errors.
 	if v, err := r.read("myapp/creds", "password"); err == nil {
 		t.Fatalf("expected a re-fetch error for an expired entry, got value %q", v)
+	}
+}
+
+// TestProviderTypeDispatch verifies newResolver routes by provider type: an empty
+// type defaults to HashiCorp Vault, and an unknown type is rejected. This is the
+// seam other secret-provider backends plug into.
+func TestProviderTypeDispatch(t *testing.T) {
+	if got := providerTypeOf(Config{}); got != ProviderHashiCorpVault {
+		t.Fatalf("empty type should default to %q, got %q", ProviderHashiCorpVault, got)
+	}
+	if got := providerTypeOf(Config{Type: "cyberark"}); got != "cyberark" {
+		t.Fatalf("explicit type should be returned, got %q", got)
+	}
+
+	// The default/known provider builds a resolver (token auth makes no network call).
+	if _, err := newResolver(
+		Config{Address: "http://127.0.0.1:8200", AuthMethod: "token", Token: "t"}, nil,
+	); err != nil {
+		t.Fatalf("default provider should build: %v", err)
+	}
+
+	// An unimplemented provider type is rejected rather than silently ignored.
+	if _, err := newResolver(Config{Type: "bogus", Address: "http://127.0.0.1:8200"}, nil); err == nil {
+		t.Fatal("expected an error for an unknown provider type")
 	}
 }

--- a/libbeat/vault/resolver_test.go
+++ b/libbeat/vault/resolver_test.go
@@ -18,11 +18,38 @@
 package vault
 
 import (
+	"encoding/base64"
 	"errors"
 	"testing"
 
 	"github.com/elastic/go-ucfg"
 )
+
+// TestDecodeBase64Config verifies the Fleet delivery form: the whole connection
+// arrives as one base64-encoded JSON string (a single Fleet secret).
+func TestDecodeBase64Config(t *testing.T) {
+	jsonCfg := `{"address":"https://vault.internal:8200","auth_method":"approle","role_id":"r1","secret_id":"s1","kv_mount":"secret"}`
+	b64 := base64.StdEncoding.EncodeToString([]byte(jsonCfg))
+
+	c, err := decodeBase64Config(b64)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !c.Enabled {
+		t.Fatal("expected Enabled=true for a delivered connection")
+	}
+	if c.Address != "https://vault.internal:8200" || c.AuthMethod != "approle" ||
+		c.RoleID != "r1" || c.SecretID != "s1" || c.KVMount != "secret" {
+		t.Fatalf("decoded config mismatch: %+v", c)
+	}
+
+	if _, err := decodeBase64Config("not!base64!!"); err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+	if _, err := decodeBase64Config(base64.StdEncoding.EncodeToString([]byte("not json"))); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
 
 // TestResolveRouting verifies the parsing/routing done before any network call:
 // non-vault keys fall through with ErrMissing, and malformed references error

--- a/libbeat/vault/resolver_test.go
+++ b/libbeat/vault/resolver_test.go
@@ -105,16 +105,20 @@ func TestResolveConfigNoVault(t *testing.T) {
 	}
 }
 
-// TestDecodeBase64Config verifies the Fleet delivery form: the whole connection
-// arrives as one base64-encoded JSON string (a single Fleet secret).
-func TestDecodeBase64Config(t *testing.T) {
+// TestDecodeConfigs verifies the Fleet delivery form: the connection(s) arrive
+// as one base64-encoded JSON value — a single object or an array.
+func TestDecodeConfigs(t *testing.T) {
 	jsonCfg := `{"address":"https://vault.internal:8200","auth_method":"approle","role_id":"r1","secret_id":"s1","kv_mount":"secret"}`
 	b64 := base64.StdEncoding.EncodeToString([]byte(jsonCfg))
 
-	c, err := decodeBase64Config(b64)
+	cs, err := decodeConfigs(b64)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(cs) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(cs))
+	}
+	c := cs[0]
 	if !c.Enabled {
 		t.Fatal("expected Enabled=true for a delivered connection")
 	}
@@ -123,20 +127,30 @@ func TestDecodeBase64Config(t *testing.T) {
 		t.Fatalf("decoded config mismatch: %+v", c)
 	}
 
-	if _, err := decodeBase64Config("not!base64!!"); err == nil {
+	// Array form (multiple connections).
+	arrJSON := `[{"name":"prod","address":"https://p:8200","auth_method":"token","token":"t"},` +
+		`{"name":"staging","address":"https://s:8200","auth_method":"token","token":"t"}]`
+	arr, err := decodeConfigs(base64.StdEncoding.EncodeToString([]byte(arrJSON)))
+	if err != nil {
+		t.Fatalf("array decode: %v", err)
+	}
+	if len(arr) != 2 || arr[0].Name != "prod" || arr[1].Name != "staging" {
+		t.Fatalf("array decode mismatch: %+v", arr)
+	}
+
+	if _, err := decodeConfigs("not!base64!!"); err == nil {
 		t.Fatal("expected error for invalid base64")
 	}
-	if _, err := decodeBase64Config(base64.StdEncoding.EncodeToString([]byte("not json"))); err == nil {
+	if _, err := decodeConfigs(base64.StdEncoding.EncodeToString([]byte("not json"))); err == nil {
 		t.Fatal("expected error for invalid JSON")
 	}
 }
 
 // TestResolveRouting verifies the parsing/routing done before any network call:
 // non-vault keys fall through with ErrMissing, and malformed references error
-// out. These paths never touch the Vault client, so a zero-value resolver is
-// sufficient.
+// out. These paths never touch a Vault client.
 func TestResolveRouting(t *testing.T) {
-	r := &resolver{cache: map[string]cacheEntry{}}
+	d := &dispatcher{byName: map[string]*resolver{}}
 
 	tests := []struct {
 		name      string
@@ -149,11 +163,12 @@ func TestResolveRouting(t *testing.T) {
 		{name: "missing hash separator", key: "vault/myapp/creds", wantError: true},
 		{name: "empty path", key: "vault/#password", wantError: true},
 		{name: "empty field", key: "vault/myapp/creds#", wantError: true},
+		{name: "unknown connection name", key: "vault/nope@myapp/creds#password", wantError: true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := r.resolve(tc.key)
+			_, _, err := d.resolve(tc.key)
 			switch {
 			case tc.wantMiss:
 				if !errors.Is(err, ucfg.ErrMissing) {
@@ -168,19 +183,47 @@ func TestResolveRouting(t *testing.T) {
 	}
 }
 
-// TestResolveUsesCache verifies a non-expired cached value is returned without a
-// client call.
+// TestResolveUsesCache verifies a non-expired cached value is returned via the
+// default connection without a client call.
 func TestResolveUsesCache(t *testing.T) {
 	r := &resolver{cache: map[string]cacheEntry{
 		"myapp/creds#password": {value: "cached-secret", expiresAt: time.Now().Add(time.Hour)},
 	}}
+	d := &dispatcher{byName: map[string]*resolver{"": r}}
 
-	v, _, err := r.resolve("vault/myapp/creds#password")
+	v, _, err := d.resolve("vault/myapp/creds#password")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if v != "cached-secret" {
 		t.Fatalf("expected cached-secret, got %q", v)
+	}
+}
+
+// TestDispatchByName verifies references route to the named connection, and the
+// default (no name@) routes to the default connection.
+func TestDispatchByName(t *testing.T) {
+	prod := &resolver{cache: map[string]cacheEntry{
+		"db#password": {value: "prod-pw", expiresAt: time.Now().Add(time.Hour)},
+	}}
+	staging := &resolver{cache: map[string]cacheEntry{
+		"db#password": {value: "staging-pw", expiresAt: time.Now().Add(time.Hour)},
+	}}
+	d := &dispatcher{byName: map[string]*resolver{"prod": prod, "staging": staging, "": prod}}
+
+	cases := map[string]string{
+		"vault/prod@db#password":    "prod-pw",
+		"vault/staging@db#password": "staging-pw",
+		"vault/db#password":         "prod-pw", // default
+	}
+	for key, want := range cases {
+		v, _, err := d.resolve(key)
+		if err != nil {
+			t.Fatalf("%q: unexpected error: %v", key, err)
+		}
+		if v != want {
+			t.Fatalf("%q: got %q, want %q", key, v, want)
+		}
 	}
 }
 

--- a/libbeat/vault/resolver_test.go
+++ b/libbeat/vault/resolver_test.go
@@ -21,8 +21,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"testing"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
 
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-ucfg"
 )
 
@@ -132,7 +136,7 @@ func TestDecodeBase64Config(t *testing.T) {
 // out. These paths never touch the Vault client, so a zero-value resolver is
 // sufficient.
 func TestResolveRouting(t *testing.T) {
-	r := &resolver{cache: map[string]string{}}
+	r := &resolver{cache: map[string]cacheEntry{}}
 
 	tests := []struct {
 		name      string
@@ -164,9 +168,12 @@ func TestResolveRouting(t *testing.T) {
 	}
 }
 
-// TestResolveUsesCache verifies a cached value is returned without a client call.
+// TestResolveUsesCache verifies a non-expired cached value is returned without a
+// client call.
 func TestResolveUsesCache(t *testing.T) {
-	r := &resolver{cache: map[string]string{"myapp/creds#password": "cached-secret"}}
+	r := &resolver{cache: map[string]cacheEntry{
+		"myapp/creds#password": {value: "cached-secret", expiresAt: time.Now().Add(time.Hour)},
+	}}
 
 	v, _, err := r.resolve("vault/myapp/creds#password")
 	if err != nil {
@@ -174,5 +181,50 @@ func TestResolveUsesCache(t *testing.T) {
 	}
 	if v != "cached-secret" {
 		t.Fatalf("expected cached-secret, got %q", v)
+	}
+}
+
+// TestRefreshInterval verifies parsing + defaulting of secret_refresh_interval.
+func TestRefreshInterval(t *testing.T) {
+	cases := map[string]time.Duration{
+		"":        defaultRefreshInterval,
+		"30s":     30 * time.Second,
+		"10m":     10 * time.Minute,
+		"garbage": defaultRefreshInterval,
+		"0s":      defaultRefreshInterval,
+		"-5m":     defaultRefreshInterval,
+	}
+	for in, want := range cases {
+		if got := (Config{SecretRefreshInterval: in}).refreshInterval(); got != want {
+			t.Fatalf("refreshInterval(%q) = %s, want %s", in, got, want)
+		}
+	}
+}
+
+// TestExpiredCacheIsRefetched verifies an expired cache entry is not served; the
+// read path re-fetches (and here fails, since no client is configured), proving
+// the TTL gate is applied rather than returning the stale value.
+func TestExpiredCacheIsRefetched(t *testing.T) {
+	apiCfg := vaultapi.DefaultConfig()
+	apiCfg.Address = "http://127.0.0.1:1" // unreachable -> fetch errors instead of returning stale
+	client, err := vaultapi.NewClient(apiCfg)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	client.SetToken("t")
+
+	r := &resolver{
+		client:          client,
+		cfg:             Config{Address: apiCfg.Address, AuthMethod: "token", Token: "t"},
+		mount:           "secret",
+		refreshInterval: time.Minute,
+		log:             logp.NewLogger("test"),
+		cache: map[string]cacheEntry{
+			"myapp/creds#password": {value: "stale", expiresAt: time.Now().Add(-time.Minute)},
+		},
+	}
+	// Expired entry -> read() must not return "stale"; it re-fetches and errors.
+	if v, err := r.read("myapp/creds", "password"); err == nil {
+		t.Fatalf("expected a re-fetch error for an expired entry, got value %q", v)
 	}
 }


### PR DESCRIPTION
## 🔐 POC: Resolve Heartbeat config secrets from HashiCorp Vault at the edge

> **Proof of concept** — companion to the Kibana Synthetics POC. Opening as a draft to align on the approach before hardening.

### 🎯 What & why
Synthetics users today put secrets into Kibana global params as plaintext key/value pairs. This POC lets a monitor field reference a secret in **HashiCorp Vault** instead, and resolves it **at the edge, inside Heartbeat** — so the plaintext secret **never touches Kibana or Elasticsearch** and stays inside the customer's trust boundary.

This is the Datadog/Dynatrace "edge resolution" model, and it lands the secret-fetch in Go — the one ecosystem where HashiCorp ships an **official** client (`github.com/hashicorp/vault/api`).

### 🧩 How it works
A reference looks like:

```
${vault/<secret-path>#<field>}      e.g. ${vault/myapp/creds#password}
```

- A new global **`vault:`** config block (address + auth) is read once at startup, mirroring the keystore block.
- A **go-ucfg resolver** is wired into the process-global config options right next to the existing keystore resolver in `libbeat/cmd/instance/beat.go`. Because those options are process-global, **any** `${vault/...}` reference in **any** monitor, stream, or top-level config value is resolved transparently during config unpack — zero per-monitor plumbing, including browser `params` before they are handed to the `elastic-synthetics` subprocess.
- `/` and `#` are deliberate: they sit outside Kibana's param grammar, so Kibana forwards the token untouched (see companion Kibana PR).

### ✅ Tested end-to-end (locally)
Against a real `vault server -dev` + a lightweight HTTP monitor whose auth header is `${vault/myapp/creds#password}`:
- The echo target received the **exact** secret from Vault (`X-Secret='s3cr3t-from-vault'`).
- The monitor reports **`status: up`** (server returns 200 only when the secret matches).
- Unit tests cover reference routing/parsing and the in-memory cache.

### 📦 Config example
```yaml
vault:
  enabled: true
  address: "https://vault.internal:8200"
  auth_method: approle       # or "token"
  role_id: "${VAULT_ROLE_ID}"
  secret_id: "${VAULT_SECRET_ID}"
  kv_mount: secret

heartbeat.monitors:
  - type: http
    urls: ["https://api.internal/health"]
    check.request.headers:
      Authorization: 'Bearer ${vault/myapp/api#token}'
```

### 🔒 Security notes
- Plaintext secrets live only in Heartbeat process memory; never persisted, never sent to Kibana/ES.
- Values are resolved with `parse.NoopConfig` so a secret can't be re-interpreted by the config parser.
- Secret values are never logged.

### 🚧 Follow-ups (out of scope for the POC)
- Token/AppRole lease renewal + TTL-based cache expiry.
- Additional auth methods (Kubernetes, TLS cert).
- Delivering the `vault:` connection config to Heartbeat under **Elastic Agent** (Fleet private locations).
- Changelog fragment + `NOTICE.txt` regeneration for the new dependency.
- Placement/licensing review (oss libbeat vs x-pack via a resolver-registration hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
