### PR TITLE
fix: correct typos and grammar in error messages and docs

### DIFF
--- a/heartbeat/monitors/active/icmp/stdloop.go
+++ b/heartbeat/monitors/active/icmp/stdloop.go
@@ -334,7 +334,7 @@ func (l *stdICMPLoop) sendEchoRequest(addr *net.IPAddr) (*requestContext, error)
 		proto = protocolIPv6ICMP
 		typ = ipv6.ICMPTypeEchoRequest
 	} else {
-		return nil, fmt.Errorf("%v is unknown ip address", addr)
+		return nil, fmt.Errorf("%v is an unknown IP address", addr)
 	}
 
 	id := requestID{

--- a/libbeat/common/fmtstr/formatstring.go
+++ b/libbeat/common/fmtstr/formatstring.go
@@ -111,7 +111,7 @@ var (
 	errUnexpectedOperator = errors.New("unexpected formatter operator")
 	errMissingClose       = errors.New("missing closing '}'")
 	errEmptyFormat        = errors.New("empty format expansion")
-	errParamsOpsMismatch  = errors.New("more parameters then ops parsed")
+	errParamsOpsMismatch  = errors.New("more parameters than ops parsed")
 )
 
 // Compile compiles an input format string into a StringFormatter. The variable

--- a/metricbeat/module/kubernetes/state_storageclass/README.md
+++ b/metricbeat/module/kubernetes/state_storageclass/README.md
@@ -2,7 +2,7 @@
 
 This metricset connects to kube-state-metrics endpoint to retrieve and report Storage Class metrics.
 
-Interestingly enough kube-state-metrics does not repport annotations, we are unable to inform which storage class is default. We can consider enriching adding that info, or contributing back to kube-state-metrics to add annotations.
+Interestingly enough kube-state-metrics does not report annotations, we are unable to inform which storage class is default. We can consider enriching adding that info, or contributing back to kube-state-metrics to add annotations.
 
 ## Version history
 


### PR DESCRIPTION
Fixes three user-facing text issues identified in #52314: corrects `then` → `than` in a libbeat formatter error message, adds missing article and fixes capitalization in a Heartbeat ICMP error string, and corrects `repport` → `report` in the Kubernetes state_storageclass README.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._