### PR TITLE
input-cursor: open the registry store only when an input needs it

### DIFF
--- a/changelog/fragments/1785600000-input-cursor-lazy-store.yaml
+++ b/changelog/fragments/1785600000-input-cursor-lazy-store.yaml
@@ -1,0 +1,37 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Open a cursor input's registry store only when an input of that type runs
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  Filebeat opened a registry store and started a registry cleanup goroutine for
+  every registered cursor input type at startup, whether or not any input of that
+  type was configured. A Beat collecting a single input therefore carried nine
+  open stores and nine idle goroutines for input types it never ran. Both are now
+  created when the first input of that type is configured.
+
+  A registry that cannot be opened is now reported when the input starts rather
+  than when Filebeat starts, so it fails only the inputs that need it instead of
+  the whole Beat.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/filebeat/input/v2/input-cursor/manager.go
+++ b/filebeat/input/v2/input-cursor/manager.go
@@ -21,12 +21,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/elastic/go-concert/unison"
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
-	"github.com/elastic/beats/v7/libbeat/features"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -63,10 +63,16 @@ type InputManager struct {
 	// that will be used to collect events from each source.
 	Configure func(cfg *conf.C, log *logp.Logger) ([]Source, Input, error)
 
-	initedFull   bool
-	initErr      error
-	store        *store
-	cleanerGroup unison.Group // saved from Init() for deferred cleaner start
+	// mu guards the deferred setup below. Inputs are created from several
+	// reload paths — static config, central management, autodiscovery — which
+	// can run concurrently for one input type.
+	mu         sync.Mutex
+	initedFull bool
+	initErr    error
+	store      *store
+	// cleanerGroup is the task group Init was given, held until an input is
+	// created and cleared once the cleaner is running.
+	cleanerGroup unison.Group
 }
 
 // Source describe a source the input can collect data from.
@@ -82,7 +88,7 @@ var (
 )
 
 // init initializes the state store with a full init (reading all states).
-// For ES-backed inputs, this is deferred until Create() where the inputID is known.
+// Caller holds cim.mu.
 func (cim *InputManager) init(inputID string) error {
 	if cim.initedFull {
 		return nil
@@ -102,24 +108,43 @@ func (cim *InputManager) init(inputID string) error {
 	return nil
 }
 
-// Init starts background processes for deleting old entries from the
-// persistent store if mode is ModeRun.
-// For ES-backed inputs, store creation is deferred to Create() where the
-// inputID is known, so Init() only saves the group for later use.
+// Init records the task group the registry cleanup process will run in. Opening
+// the store and starting that process are deferred to Create.
+//
+// v2.Loader.Init calls Init on every registered plugin, but a Beat instantiates
+// inputs for only a few of them: eager setup here cost one open registry store
+// and one idle cleanup goroutine per input type the Beat never runs. That is
+// paid per Beat, and elastic-agent runs one Beat receiver per input stream.
+//
+// Deferring also means a registry that cannot be opened now fails the inputs
+// that need it rather than the whole Beat. Elasticsearch-backed inputs already
+// worked this way, since they cannot open the store until Create gives them the
+// input ID.
 func (cim *InputManager) Init(group unison.Group) error {
-	if features.IsElasticsearchStateStoreEnabledForInput(cim.Type) {
-		cim.cleanerGroup = group
-		return nil
-	}
+	cim.mu.Lock()
+	defer cim.mu.Unlock()
 
-	if err := cim.init(""); err != nil {
+	cim.cleanerGroup = group
+	return nil
+}
+
+// setup opens the store and starts the registry cleanup process, once per
+// manager. Caller holds cim.mu.
+func (cim *InputManager) setup(inputID string) error {
+	if err := cim.init(inputID); err != nil {
 		return err
 	}
+
+	if cim.cleanerGroup == nil {
+		return nil
+	}
+	group := cim.cleanerGroup
+	cim.cleanerGroup = nil
 	return cim.startCleaner(group)
 }
 
 // startCleaner launches the background cleaner goroutine that removes stale
-// entries from the persistent store.
+// entries from the persistent store. Caller holds cim.mu.
 func (cim *InputManager) startCleaner(group unison.Group) error {
 	log := cim.Logger.With("input_type", cim.Type)
 
@@ -169,17 +194,11 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 		return nil, err
 	}
 
-	if err := cim.init(settings.ID); err != nil {
+	cim.mu.Lock()
+	err := cim.setup(settings.ID)
+	cim.mu.Unlock()
+	if err != nil {
 		return nil, err
-	}
-
-	// For ES-backed inputs, the cleaner is deferred from Init() to here
-	// because the store isn't created until init() is called with the inputID.
-	if cim.cleanerGroup != nil {
-		if err := cim.startCleaner(cim.cleanerGroup); err != nil {
-			return nil, err
-		}
-		cim.cleanerGroup = nil
 	}
 
 	sources, inp, err := cim.Configure(config, cim.Logger)

--- a/filebeat/input/v2/input-cursor/manager_test.go
+++ b/filebeat/input/v2/input-cursor/manager_test.go
@@ -70,9 +70,10 @@ func TestManager_Init(t *testing.T) {
 		manager := cleanerManager(t, createSampleStore(t, nil), &grp)
 
 		require.Nil(t, manager.store, "Init must not open the registry store")
-		goroutines.WaitUntilOriginalCount()
+		_, err := goroutines.WaitUntilOriginalCount()
+		require.NoError(t, err, "Init must not start the store cleanup goroutine")
 
-		_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{"id": "my-input-id"}))
+		_, err = manager.Create(conf.MustNewConfigFrom(map[string]any{"id": "my-input-id"}))
 		require.NoError(t, err)
 		require.NotNil(t, manager.store, "Create must open the registry store")
 	})

--- a/filebeat/input/v2/input-cursor/manager_test.go
+++ b/filebeat/input/v2/input-cursor/manager_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/features"
 	pubtest "github.com/elastic/beats/v7/libbeat/publisher/testing"
+	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -56,19 +57,52 @@ type stringSource string
 func TestManager_Init(t *testing.T) {
 	// Integration style tests for the InputManager and the state garbage collector
 
+	// Init is called for every registered input type, but most of them are never
+	// configured. Opening a registry store and starting a cleanup goroutine for
+	// each is a per-Beat cost paid for inputs that never run, and elastic-agent
+	// runs one Beat receiver per input stream.
+	t.Run("no store is opened and no goroutine started until an input is created", func(t *testing.T) {
+		goroutines := resources.NewGoroutinesChecker()
+
+		var grp unison.TaskGroup
+		//nolint:errcheck // We don't need the error from grp.Stop()
+		defer grp.Stop()
+		manager := cleanerManager(t, createSampleStore(t, nil), &grp)
+
+		require.Nil(t, manager.store, "Init must not open the registry store")
+		goroutines.WaitUntilOriginalCount()
+
+		_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{"id": "my-input-id"}))
+		require.NoError(t, err)
+		require.NotNil(t, manager.store, "Create must open the registry store")
+	})
+
+	// The store is opened with the input ID, which is only known once a config
+	// has been unpacked in Create.
+	t.Run("the store is opened with the created input's ID", func(t *testing.T) {
+		stateStore := createSampleStore(t, map[string]state{
+			"test::mykey": {Cursor: "value1"},
+		})
+
+		var grp unison.TaskGroup
+		//nolint:errcheck // We don't need the error from grp.Stop()
+		defer grp.Stop()
+		manager := cleanerManager(t, stateStore, &grp)
+
+		_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{"id": "my-input-id"}))
+		require.NoError(t, err)
+
+		snap := storeMemorySnapshot(manager.store)
+		assert.Contains(t, snap, "test::mykey")
+		assert.Equal(t, "value1", snap["test::mykey"].Cursor)
+	})
+
 	t.Run("stopping the taskgroup kills internal go-routines", func(t *testing.T) {
 		numRoutines := runtime.NumGoroutine()
 
 		var grp unison.TaskGroup
-		store := createSampleStore(t, nil)
-		manager := &InputManager{
-			Logger:              logptest.NewTestingLogger(t, "test"),
-			StateStore:          store,
-			Type:                "test",
-			DefaultCleanTimeout: 10 * time.Millisecond,
-		}
-
-		err := manager.Init(&grp)
+		manager := cleanerManager(t, createSampleStore(t, nil), &grp)
+		_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{}))
 		require.NoError(t, err)
 
 		time.Sleep(200 * time.Millisecond)
@@ -93,57 +127,83 @@ func TestManager_Init(t *testing.T) {
 		var grp unison.TaskGroup
 		//nolint:errcheck // We don't need the error from grp.Stop()
 		defer grp.Stop()
-		manager := &InputManager{
-			Logger:              logptest.NewTestingLogger(t, "test"),
-			StateStore:          store,
-			Type:                "test",
-			DefaultCleanTimeout: 10 * time.Millisecond,
-		}
+		manager := cleanerManager(t, store, &grp)
 
-		err := manager.Init(&grp)
+		_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{}))
 		require.NoError(t, err)
 
 		for len(store.snapshot()) > 0 {
 			time.Sleep(1 * time.Millisecond)
 		}
 	})
+
+	// Two reload paths — static config, central management, autodiscovery — can
+	// create inputs of one type concurrently, and each of those is now what
+	// opens the store and starts the cleaner.
+	t.Run("concurrent Create opens one store and starts one cleaner", func(t *testing.T) {
+		var grp unison.TaskGroup
+		//nolint:errcheck // We don't need the error from grp.Stop()
+		defer grp.Stop()
+		manager := cleanerManager(t, createSampleStore(t, nil), &grp)
+
+		var wg sync.WaitGroup
+		for i := range 8 {
+			wg.Go(func() {
+				_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{
+					"id": fmt.Sprintf("input-%d", i),
+				}))
+				assert.NoError(t, err)
+			})
+		}
+		wg.Wait()
+
+		require.NotNil(t, manager.store)
+		assert.Nil(t, manager.cleanerGroup, "the cleaner must have been started exactly once")
+	})
 }
 
-func TestManager_InitDefersStoreForES(t *testing.T) {
-	// Verify that ES-backed inputs defer store creation from Init() to Create().
-	t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "test")
-	features.ReinitForTest()
-	t.Cleanup(func() { features.ReinitForTest() }) // restore after test
-
-	data := map[string]state{
-		"test::mykey": {Cursor: "value1"},
-	}
-	stateStore := createSampleStore(t, data)
-
-	var grp unison.TaskGroup
-	defer grp.Stop() //nolint:errcheck // We don't need the error from grp.Stop()
+// cleanerManager builds an initialised InputManager whose Create succeeds, with
+// a clean timeout short enough for the garbage collector to act within a test.
+func cleanerManager(t *testing.T, store statestore.States, grp unison.Group) *InputManager {
+	t.Helper()
 
 	manager := &InputManager{
 		Logger:              logptest.NewTestingLogger(t, "test"),
-		StateStore:          stateStore,
+		StateStore:          store,
 		Type:                "test",
-		DefaultCleanTimeout: 30 * time.Minute,
+		DefaultCleanTimeout: 10 * time.Millisecond,
 		Configure: func(cfg *conf.C, log *logp.Logger) ([]Source, Input, error) {
 			return sourceList("mykey"), &fakeTestInput{}, nil
 		},
 	}
+	require.NoError(t, manager.Init(grp))
+	return manager
+}
 
-	// Init() should not create a store for ES-backed inputs.
-	err := manager.Init(&grp)
-	require.NoError(t, err)
-	assert.Nil(t, manager.store, "store should be nil after Init() for ES-backed inputs")
+// TestManager_InitDefersStoreForES covers the Elasticsearch-backed store, which
+// has always been opened from Create because it needs the input ID. All input
+// types now take that path; this pins that the ES-specific store still reaches
+// it, since SetID is a no-op for the file-backed backends and only matters here.
+func TestManager_InitDefersStoreForES(t *testing.T) {
+	t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "test")
+	features.ReinitForTest()
+	t.Cleanup(func() { features.ReinitForTest() }) // restore after test
 
-	// Create() should create the store with the inputID.
-	_, err = manager.Create(conf.MustNewConfigFrom(map[string]any{
+	stateStore := createSampleStore(t, map[string]state{
+		"test::mykey": {Cursor: "value1"},
+	})
+
+	var grp unison.TaskGroup
+	defer grp.Stop() //nolint:errcheck // We don't need the error from grp.Stop()
+	manager := cleanerManager(t, stateStore, &grp)
+
+	require.Nil(t, manager.store, "store should be nil after Init()")
+
+	_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{
 		"id": "my-input-id",
 	}))
 	require.NoError(t, err)
-	assert.NotNil(t, manager.store, "store should be created after Create()")
+	require.NotNil(t, manager.store, "store should be created after Create()")
 
 	snap := storeMemorySnapshot(manager.store)
 	assert.Contains(t, snap, "test::mykey")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

`v2.Loader.Init` calls `Manager.Init` on every registered input plugin, and registration happens at import time regardless of what is configured. `input-cursor.InputManager.Init` used that call to open a registry store and start a `timed.Periodic` cleanup goroutine, so a Beat carried one of each for every cursor input type it never instantiated: `cel`, `httpjson`, `gcs`, `azureblobstorage`, `o365audit`, `salesforce`, `streaming`, `winlog`, plus`journald` on Linux and `unifiedlogs` on macOS.

That is per Beat, and elastic-agent runs one filebeatreceiver (a whole Beat) per input stream. A receiver collecting a single filestream held 9 open registry stores and 9 idle cleanup goroutines for input types it has no path to: filestream uses `input-logfile`, not `input-cursor`.

`Init` now records the task group and returns; the store and the cleanup process are opened by `Create`, which runs only when an input of that type is configured. This is the path Elasticsearch-backed inputs already took, they cannot open the store until `Create` supplies the input ID, so the deferral machinery already existed and the change removes the `IsElasticsearchStateStoreEnabledForInput` branch that gated it. It is safe for the file-backed registries because `SetID` is a no-op for `memlog` and `otelstorage`.

Deferring moves setup onto a concurrent path: `filebeat.go` hands one loader to four independent consumers, the crawler, the central-management and module `RunnerList`s, and autodiscover — so two inputs of one type can be created at once. `Create` now writes `store`, `initedFull` and `cleanerGroup` where it previously only read them, so a mutex guards that setup. Without it the store is opened twice and the cleaner started twice; the Elasticsearch-backed path had this hole already and is fixed by the same change.

Measured with `BenchmarkNReceiverFootprint`, idle, one file per receiver: **24.0 → 15.0 goroutines per receiver** (50 receivers: 1,204 → 754). A receiver that does run a cursor input goes from 9 stores and cleaners to 1.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

One behaviour change: **a registry that cannot be opened is now reported when the input starts, not when the Beat starts.** A corrupt or unreadable registry used to fail Filebeat startup outright; it now fails only the inputs that need it, and
other inputs keep running. This matches what Elasticsearch-backed inputs already did. It is in the changelog.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #52353 