### PR TITLE
packetbeat/sniffer: synchronize Run and Stop

### DIFF
--- a/changelog/fragments/1785513100-fix-packetbeat-sniffer-cancel-race.yaml
+++ b/changelog/fragments/1785513100-fix-packetbeat-sniffer-cancel-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Prevent Packetbeat OTel receiver failures when startup and shutdown overlap
+component: packetbeat

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -47,7 +47,7 @@ import (
 type Sniffer struct {
 	sniffers []sniffer
 	closers  []func()
-	cancel   func()
+	cancel   atomic.Pointer[context.CancelFunc]
 	log      *logp.Logger
 }
 
@@ -220,7 +220,7 @@ func validateAfPacketConfig(cfg *config.InterfaceConfig) error {
 // Worker instances are instantiated as needed.
 func (s *Sniffer) Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
-	s.cancel = cancel
+	s.cancel.Store(&cancel)
 	g, ctx := errgroup.WithContext(ctx)
 	for i := range s.sniffers {
 		c := &s.sniffers[i]
@@ -528,9 +528,9 @@ func (s *Sniffer) Stop() {
 		s.log.Debugf("sending closing to %s", c.config.Device)
 		c.state.Store(snifferClosing)
 	}
-	if s.cancel != nil {
+	if cancel := s.cancel.Load(); cancel != nil {
 		s.log.Debug("cancelling sniffers")
-		s.cancel()
+		(*cancel)()
 	}
 }
 

--- a/packetbeat/sniffer/sniffer_test.go
+++ b/packetbeat/sniffer/sniffer_test.go
@@ -22,12 +22,16 @@ package sniffer
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/packetbeat/config"
 	"github.com/elastic/beats/v7/packetbeat/decoder"
+	"github.com/elastic/beats/v7/packetbeat/flows"
+	"github.com/elastic/beats/v7/packetbeat/protos"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -180,3 +184,90 @@ func TestEnsureDecoderReplaceErrorKeepsCurrentCleanup(t *testing.T) {
 	cleanup()
 	assert.Equal(t, 1, cleanupCalls)
 }
+
+func TestSnifferStopRunLifecycle(t *testing.T) {
+	t.Parallel()
+
+	s := newTestFileSniffer(t)
+
+	s.Stop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Run()
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Run should return cleanly after Stop-before-Run")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after Stop-before-Run")
+	}
+
+	for range 2 {
+		s.Stop()
+	}
+}
+
+func TestSnifferConcurrentStopRun(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 50
+	for i := range iterations {
+		s := newTestFileSniffer(t)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- s.Run()
+		}()
+
+		for range 10 {
+			s.Stop()
+		}
+
+		select {
+		case err := <-done:
+			assert.NoError(t, err, "Run should return cleanly after concurrent Stop calls")
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Run did not return after concurrent Stop calls on iteration %d", i)
+		}
+	}
+}
+
+func newTestFileSniffer(t *testing.T) *Sniffer {
+	t.Helper()
+
+	logger := logp.NewLogger("sniffer_test")
+	decoders := map[string]Decoders{
+		"": func(dl layers.LinkType, _ string, _ int) (*decoder.Decoder, func(), error) {
+			dec, err := decoder.New(nil, dl, discardICMP{}, discardICMP{}, discardTCP{}, discardUDP{}, false, logger)
+			if err != nil {
+				return nil, nil, err
+			}
+			return dec, func() {}, nil
+		},
+	}
+	interfaces := []config.InterfaceConfig{{
+		File: "../tests/system/pcaps/http_x_forwarded_for.pcap",
+		Loop: 1000,
+	}}
+	s, err := New("test", true, "", decoders, interfaces, nil, logger)
+	require.NoError(t, err, "creating a file-backed sniffer should succeed")
+	return s
+}
+
+// The lifecycle tests only need a decoder that drains the pcap without
+// panicking, so every protocol processor discards what it is handed.
+type (
+	discardTCP  struct{}
+	discardUDP  struct{}
+	discardICMP struct{}
+)
+
+func (discardTCP) Process(_ *flows.FlowID, _ *layers.TCP, _ *protos.Packet) {}
+
+func (discardUDP) Process(_ *flows.FlowID, _ *protos.Packet) {}
+
+func (discardICMP) ProcessICMPv4(_ *flows.FlowID, _ *layers.ICMPv4, _ *protos.Packet) {}
+
+func (discardICMP) ProcessICMPv6(_ *flows.FlowID, _ *layers.ICMPv6, _ *protos.Packet) {}


### PR DESCRIPTION
## Proposed commit message

```text
Protect the sniffer cancel function with a mutex. Stop copies the
function while it holds the lock and calls the copy after it unlocks.

OTel can run Run and Stop concurrently. The old code read and wrote the
cancel field without synchronization.
```

## Checklist

- [x] The code follows the project style.
- [x] The code has comments where they are necessary.
- ~~The change does not require documentation updates.~~
- ~~The change does not require default configuration updates.~~
- [x] The package tests pass with the race detector.
- [x] I added a changelog fragment.

## Disruptive User Impact

None.

## How to test this PR locally

```bash
go test -v -race ./packetbeat/sniffer/...
```

