### PR TITLE
packetbeat: install Npcap once

### DIFF
--- a/changelog/fragments/1785513200-fix-packetbeat-npcap-install-race.yaml
+++ b/changelog/fragments/1785513200-fix-packetbeat-npcap-install-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Prevent Npcap setup failures when multiple Packetbeat receivers start concurrently
+component: packetbeat

--- a/packetbeat/beater/install_npcap.go
+++ b/packetbeat/beater/install_npcap.go
@@ -35,9 +35,11 @@ import (
 
 const installTimeout = 120 * time.Second
 
-// muInstall protects use of npcap.Installer. The only writes to npcap.Installer
-// are here and during init in x-pack/packetbeat/npcap/npcap_windows.go
-var muInstall sync.Mutex
+var (
+	// installOnce protects use of npcap.Installer.
+	installOnce     sync.Once
+	npcapInstallErr error
+)
 
 func installNpcap(b *beat.Beat, cfg *conf.C) error {
 	if !b.Info.ElasticLicensed {
@@ -56,6 +58,14 @@ func installNpcap(b *beat.Beat, cfg *conf.C) error {
 			log.Infof("npcap version: %s", npcapVersion)
 		}
 	}()
+
+	installOnce.Do(func() {
+		npcapInstallErr = installNpcapLocked(b, cfg)
+	})
+	return npcapInstallErr
+}
+
+func installNpcapLocked(b *beat.Beat, cfg *conf.C) error {
 	if !npcap.Upgradeable() {
 		npcap.Installer = nil
 		return nil
@@ -82,8 +92,6 @@ func installNpcap(b *beat.Beat, cfg *conf.C) error {
 	ctx, cancel := context.WithTimeout(context.Background(), installTimeout)
 	defer cancel()
 
-	muInstall.Lock()
-	defer muInstall.Unlock()
 	if npcap.Installer == nil {
 		return nil
 	}


### PR DESCRIPTION
## Proposed commit message

```text
Serialize the complete Npcap installation and cache its result. Every
caller now receives the same result.

Concurrent receivers could clear the package installer outside the
installation lock. This caused a data race and repeated installation
work.
```

## Checklist

- [x] The code follows the project style.
- [x] The code has comments where they are necessary.
- ~~The change does not require documentation updates.~~
- ~~The change does not require default configuration updates.~~
- [x] The Linux tests pass, and the package compiles for Windows.
- [x] I added a changelog fragment.

## Disruptive User Impact

None.
