### PR TITLE
libbeat/autodiscover/kubernetes: synchronize leader election callbacks

### DIFF
--- a/changelog/fragments/1785512000-fix-kubernetes-leader-election-race.yaml
+++ b/changelog/fragments/1785512000-fix-kubernetes-leader-election-race.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Prevent stale autodiscover resources after Kubernetes leadership changes.
+
+component: libbeat

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -22,6 +22,8 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,6 +88,7 @@ type eventerManager struct {
 type leaderElectionManager struct {
 	leaderElection       leaderelection.LeaderElectionConfig
 	cancelLeaderElection context.CancelFunc
+	electorWg            sync.WaitGroup
 	logger               *logp.Logger
 }
 
@@ -287,8 +290,9 @@ func NewLeaderElectionManager(
 		Namespace: ns,
 	}
 
-	var eventID string
-	leaseId := lease.Name + "-" + lease.Namespace
+	// The elector can call the start and stop callbacks concurrently.
+	var eventID atomic.Pointer[string]
+	leaseID := lease.Name + "-" + lease.Namespace
 	lem.leaderElection = leaderelection.LeaderElectionConfig{
 		Lock: &resourcelock.LeaseLock{
 			LeaseMeta: lease,
@@ -303,13 +307,18 @@ func NewLeaderElectionManager(
 		RetryPeriod:     cfg.RetryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
-				eventID = fmt.Sprintf("%v-%v", leaseId, time.Now().UnixNano())
-				logger.Debugf("leader election lock GAINED, holder: %v, eventID: %v", id, eventID)
-				startLeading(uuid.String(), eventID)
+				startedID := fmt.Sprintf("%v-%v", leaseID, time.Now().UnixNano())
+				eventID.Store(&startedID)
+				logger.Debugf("leader election lock GAINED, holder: %v, eventID: %v", id, startedID)
+				startLeading(uuid.String(), startedID)
 			},
 			OnStoppedLeading: func() {
-				logger.Debugf("leader election lock LOST, holder: %v, eventID: %v", id, eventID)
-				stopLeading(uuid.String(), eventID)
+				var stoppedID string
+				if stored := eventID.Load(); stored != nil {
+					stoppedID = *stored
+				}
+				logger.Debugf("leader election lock LOST, holder: %v, eventID: %v", id, stoppedID)
+				stopLeading(uuid.String(), stoppedID)
 			},
 		},
 	}
@@ -344,6 +353,7 @@ func (p *leaderElectionManager) Start() {
 func (p *leaderElectionManager) Stop() {
 	if p.cancelLeaderElection != nil {
 		p.cancelLeaderElection()
+		p.electorWg.Wait()
 	}
 }
 
@@ -358,10 +368,11 @@ func (p *leaderElectionManager) startLeaderElectorIndefinitely(ctx context.Conte
 	le, err := leaderelection.NewLeaderElector(lec)
 	if err != nil {
 		p.logger.Errorf("error while creating Leader Elector: %v", err)
+		return
 	}
 	p.logger.Debugf("Starting Leader Elector")
 
-	go func() {
+	p.electorWg.Go(func() {
 		for {
 			le.Run(ctx)
 			select {
@@ -372,7 +383,7 @@ func (p *leaderElectionManager) startLeaderElectorIndefinitely(ctx context.Conte
 				// is still a candidate to get the lease.
 			}
 		}
-	}()
+	})
 }
 
 func ShouldPut(event mapstr.M, field string, value any, logger *logp.Logger) {

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,6 +92,58 @@ func TestLeaseConfigurableFields(t *testing.T) {
 	require.Equalf(t, cfg.LeaseDuration, leaseDuration, "lease duration should be the same as the one provided in the configuration.")
 	require.Equalf(t, cfg.RetryPeriod, retryPeriod, "retry period should be the same as the one provided in the configuration.")
 	require.Equalf(t, cfg.RenewDeadline, renewDeadline, "renew deadline should be the same as the one provided in the configuration.")
+}
+
+// TestLeaderElectionManagerStopWaitsForElector checks that Stop returns only after the
+// elector is done, so that the lease is released instead of being left behind to expire.
+func TestLeaderElectionManagerStopWaitsForElector(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	require.NoError(t, applyLease(client, createLease()), "the lease should be created")
+
+	id, err := uuid.NewV4()
+	require.NoError(t, err, "a uuid should be generated")
+
+	leading := make(chan struct{}, 1)
+	var stoppedLeading atomic.Bool
+
+	startLeadingFunc := func(uuid string, eventID string) {
+		select {
+		case leading <- struct{}{}:
+		default:
+		}
+	}
+	stopLeadingFunc := func(uuid string, eventID string) {
+		// A Stop that does not wait returns while this callback is still sleeping.
+		time.Sleep(100 * time.Millisecond)
+		stoppedLeading.Store(true)
+	}
+
+	cfg := Config{
+		Node:          "node-0",
+		LeaderLease:   leaseName,
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
+	}
+
+	le, err := NewLeaderElectionManager(id, &cfg, client, startLeadingFunc, stopLeadingFunc, logptest.NewTestingLogger(t, "kubernetes-test"))
+	require.NoError(t, err, "the leader election manager should be created")
+
+	le.Start()
+	select {
+	case <-leading:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the manager to become leader")
+	}
+
+	le.Stop()
+
+	assert.True(t, stoppedLeading.Load(), "Stop should wait for the stop leading callback to finish")
+
+	lease, err := client.CoordinationV1().Leases(namespace).Get(context.Background(), leaseName, metav1.GetOptions{})
+	require.NoError(t, err, "the lease should be readable")
+	require.NotNil(t, lease.Spec.HolderIdentity, "the lease should have a holder identity")
+	assert.Empty(t, *lease.Spec.HolderIdentity, "Stop should wait for the lease to be released")
 }
 
 // TestNewLeaderElectionManager will test the leader elector.


### PR DESCRIPTION
## Proposed commit message

```text
Create callback state for each leader elector and protect its event ID.
Wait for the elector goroutine during shutdown.

Leader-election callbacks can run concurrently. The old shared event ID
could become corrupt when one elector stopped while another started.

Stop cancelled the elector but did not wait for it, so the beat exited
before ReleaseOnCancel could release the lease. The lease then kept the
name of a dead instance until it expired.

`ReleaseOnCancel: true` did not work. The release runs in the elector
goroutine and does not use the cancelled context, so the beat exited
first and killed it. The lease kept pointing at the instance that just
went away, and no other instance could take over until the lease
expired, which is `leader_leaseduration` (15s by default).

Waiting keeps the beat alive until the lease is handed back, so another
instance can take over right away. In normal conditions this costs a few
milliseconds. If the API server does not answer, client-go caps the
release at `leader_renewdeadline` (10s by default).
```

## Checklist

- [x] The code follows the project style.
- [x] The code has comments where they are necessary.
- ~~The change does not require documentation updates.~~
- ~~The change does not require default configuration updates.~~
- [x] The package tests pass with the race detector.
- [x] I added a changelog fragment.

## Disruptive User Impact

None.

## How to test this PR locally

```bash
go test -v -race ./libbeat/autodiscover/providers/kubernetes/...
```

## Logs

```text
WARNING: DATA RACE
Write at 0x00c000068d30 by goroutine 60:
  kubernetes.NewLeaderElectionManager.func1()
      libbeat/autodiscover/providers/kubernetes/kubernetes.go:306
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run()
      client-go@v0.35.3/tools/leaderelection/leaderelection.go:220

Previous read at 0x00c000068d30 by goroutine 52:
  kubernetes.NewLeaderElectionManager.func1()
      libbeat/autodiscover/providers/kubernetes/kubernetes.go:308
  k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run()
      client-go@v0.35.3/tools/leaderelection/leaderelection.go:220
```
