### PR TITLE
x-pack/heartbeat/synthexec: start result reads after command start

### DIFF
--- a/changelog/fragments/1785513000-fix-synthexec-jsonreader-race.yaml
+++ b/changelog/fragments/1785513000-fix-synthexec-jsonreader-race.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Prevent browser monitors from failing when the synthetics process exits during startup
+component: heartbeat

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -47,7 +47,7 @@ type SynthexecTimeout string
 var SynthexecTimeoutKey = SynthexecTimeout("synthexec_timeout")
 
 // ProjectJob will run a single journey by name from the given project.
-func ProjectJob(ctx context.Context, projectPath string, params func() map[string]interface{}, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {
+func ProjectJob(ctx context.Context, projectPath string, params func() map[string]any, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {
 	// Run the command in the given projectPath, use '.' as the first arg since the command runs
 	// in the correct dir
 	cmdFactory, err := projectCommandFactory(projectPath, extraArgs...)
@@ -79,7 +79,7 @@ func projectCommandFactory(projectPath string, args ...string) (func() *SynthCmd
 }
 
 // InlineJourneyJob returns a job that runs the given source as a single journey.
-func InlineJourneyJob(ctx context.Context, script string, params func() map[string]interface{}, fields stdfields.StdMonitorFields, extraArgs ...string) jobs.Job {
+func InlineJourneyJob(ctx context.Context, script string, params func() map[string]any, fields stdfields.StdMonitorFields, extraArgs ...string) jobs.Job {
 	newCmd := func() *SynthCmd {
 		return &SynthCmd{exec.Command("elastic-synthetics", append(extraArgs, "--inline")...)} //nolint:gosec,noctx // we are safely building a command here, users can add args at their own risk
 	}
@@ -90,7 +90,7 @@ func InlineJourneyJob(ctx context.Context, script string, params func() map[stri
 // startCmdJob adapts commands into a heartbeat job. This is a little awkward given that the command's output is
 // available via a sequence of events in the multiplexer, while heartbeat jobs are tail recursive continuations.
 // Here, we adapt one to the other, where each recursive job pulls another item off the chan until none are left.
-func startCmdJob(ctx context.Context, newCmd func() *SynthCmd, stdinStr *string, params func() map[string]interface{}, filterJourneys FilterJourneyConfig, sFields stdfields.StdMonitorFields) jobs.Job {
+func startCmdJob(ctx context.Context, newCmd func() *SynthCmd, stdinStr *string, params func() map[string]any, filterJourneys FilterJourneyConfig, sFields stdfields.StdMonitorFields) jobs.Job {
 	return func(event *beat.Event) ([]jobs.Job, error) {
 		senr := newStreamEnricher(sFields)
 		// Prefer the published monitor.check_group (set by the summarizer's
@@ -174,7 +174,7 @@ func runCmd(
 	ctx context.Context,
 	cmd *SynthCmd,
 	stdinStr *string,
-	params func() map[string]interface{},
+	params func() map[string]any,
 	filterJourneys FilterJourneyConfig,
 	sFields stdfields.StdMonitorFields,
 	traceID string,
@@ -235,34 +235,54 @@ func runCmd(
 	if err != nil {
 		return nil, fmt.Errorf("could not open stdout pipe: %w", err)
 	}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err := scanToSynthEvents(stdoutPipe, stdoutToSynthEvent, mpx.writeSynthEvent)
 		if err != nil {
 			//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
 			logp.L().Warn("could not scan stdout events from synthetics: %s", err)
 		}
-
-		wg.Done()
-	}()
+	})
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
 		return nil, fmt.Errorf("could not open stderr pipe: %w", err)
 	}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err := scanToSynthEvents(stderrPipe, stderrToSynthEvent, mpx.writeSynthEvent)
 		if err != nil {
 			//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
 			logp.L().Warn("could not scan stderr events from synthetics: %s", err)
 		}
-		wg.Done()
+	})
+
+	// This use of channels for results is awkward, but required for the thread locking below
+	cmdStarted := make(chan error)
+	cmdDone := make(chan error, 1)
+	go func() {
+		// We must idle this thread and ensure it is not killed while the external program is running
+		// see https://github.com/golang/go/issues/27505#issuecomment-713706104 . Otherwise, the Pdeathsig
+		// could cause the subprocess to die prematurely
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err = cmd.Start()
+
+		cmdStarted <- err
+
+		err := cmd.Wait()
+		cmdDone <- err
 	}()
 
-	// Send the test results into the output
-	wg.Add(1)
-	go func() {
+	err = <-cmdStarted
+	if err != nil {
+		//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
+		logp.L().Warn("Could not start command %s: %s", cmd, err)
+		_ = jsonWriter.Close()
+		_ = jsonReader.Close()
+		return nil, err
+	}
+
+	// Start the command before this reader because cmd.Start reads ExtraFiles.
+	wg.Go(func() {
 		defer jsonReader.Close()
 
 		// We don't use scanToSynthEvents here because all lines here will be JSON
@@ -282,33 +302,7 @@ func runCmd(
 
 			mpx.writeSynthEvent(&se)
 		}
-
-		wg.Done()
-	}()
-
-	// This use of channels for results is awkward, but required for the thread locking below
-	cmdStarted := make(chan error)
-	cmdDone := make(chan error)
-	go func() {
-		// We must idle this thread and ensure it is not killed while the external program is running
-		// see https://github.com/golang/go/issues/27505#issuecomment-713706104 . Otherwise, the Pdeathsig
-		// could cause the subprocess to die prematurely
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-		err = cmd.Start()
-
-		cmdStarted <- err
-
-		err := cmd.Wait()
-		cmdDone <- err
-	}()
-
-	err = <-cmdStarted
-	if err != nil {
-		//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
-		logp.L().Warn("Could not start command %s: %s", cmd, err)
-		return nil, err
-	}
+	})
 
 	// Get timeout from parent ctx
 	timeout, _ := ctx.Value(SynthexecTimeoutKey).(time.Duration)

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -281,7 +281,7 @@ func runCmd(
 		return nil, err
 	}
 
-	// Start the command before this reader because cmd.Start reads ExtraFiles.
+	// After cmd.Start: ExtraFiles must stay open until the child inherits them.
 	wg.Go(func() {
 		defer jsonReader.Close()
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
@@ -26,6 +26,7 @@ import (
 	hbconfig "github.com/elastic/beats/v7/heartbeat/config"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -138,7 +139,7 @@ func TestJsonToSynthEvent(t *testing.T) {
 					Index:  0,
 					Status: "succeeded",
 				},
-				Payload: map[string]interface{}{
+				Payload: map[string]any{
 					"source":      "async ({page, params}) => {await page.goto('http://www.elastic.co')}",
 					"duration_ms": float64(3472),
 					"url":         "https://www.elastic.co/",
@@ -267,6 +268,29 @@ func TestRunTimeoutExitCodeCmd(t *testing.T) {
 		require.Len(t, stdoutEvents, 1)
 		require.Equal(t, "CMD_TIMEOUT", synthEvents[0].Error.Code)
 	})
+}
+
+func TestRunCmdStartFailure(t *testing.T) {
+	const deadline = 30*time.Second
+	ctx := context.WithValue(t.Context(), SynthexecTimeoutKey, 2*deadline)
+	cmd := exec.CommandContext(ctx, "/dev/null/no-such-binary")
+
+	goroutines := resources.NewGoroutinesChecker()
+
+	returned := make(chan error, 1)
+	go func() {
+		_, err := runCmd(ctx, &SynthCmd{cmd}, nil, nil, FilterJourneyConfig{}, stdfields.StdMonitorFields{}, "")
+		returned <- err
+	}()
+
+	select {
+	case err := <-returned:
+		require.Error(t, err, "runCmd should report that the command could not be started")
+	case <-time.After(deadline):
+		require.Fail(t, "runCmd blocked instead of returning the start error")
+	}
+
+	goroutines.Check(t)
 }
 
 func runAndCollect(t *testing.T, cmd *exec.Cmd, stdinStr string, cmdTimeout time.Duration) []*SynthEvent {


### PR DESCRIPTION
## Proposed commit message

```text
Start the command before the results reader can close its pipe. If
command startup fails, close both pipe ends and wait for the output
scanners.

cmd.Start reads each ExtraFiles descriptor during startup. The previous
order let the reader close a descriptor during that read.
```

## Checklist

- [x] The code follows the project style.
- [x] The code has comments where they are necessary.
- ~~The change does not require documentation updates.~~
- ~~The change does not require default configuration updates.~~
- [x] The package tests pass with the race detector.
- [x] I added a changelog fragment.

## Disruptive User Impact

None.

## How to test this PR locally

```bash
go test -v -race ./x-pack/heartbeat/monitors/browser/synthexec/...
```

## Logs

```text
WARNING: DATA RACE
Write at 0x00c000532010 by goroutine 80:
  os.(*File).Close()
  synthexec.runCmd.func3()
      x-pack/heartbeat/monitors/browser/synthexec/synthexec.go:266

Previous read at 0x00c000532010 by goroutine 81:
  os.(*File).Fd()
  os.startProcess()
  os/exec.(*Cmd).Start()
  synthexec.runCmd.func4()
      x-pack/heartbeat/monitors/browser/synthexec/synthexec.go:298
```
