### PR TITLE
auditbeat/kprobes: synchronize the path traverser wait channel

### DIFF
--- a/auditbeat/module/file_integrity/kprobes/path.go
+++ b/auditbeat/module/file_integrity/kprobes/path.go
@@ -268,7 +268,8 @@ func (traverser *pTraverser) waitForWalk(ctx context.Context) error {
 		return nil
 	}
 
-	traverser.waitQueueChan = make(chan struct{})
+	waitQueueChan := make(chan struct{})
+	traverser.waitQueueChan = waitQueueChan
 	traverser.mtx.Unlock()
 
 	select {
@@ -279,7 +280,7 @@ func (traverser *pTraverser) waitForWalk(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	// statQueue is empty
-	case <-traverser.waitQueueChan:
+	case <-waitQueueChan:
 		return nil
 	// timeout
 	case <-time.After(traverser.sMatchTimeout):

--- a/auditbeat/module/file_integrity/kprobes/path_test.go
+++ b/auditbeat/module/file_integrity/kprobes/path_test.go
@@ -38,17 +38,23 @@ func Test_PathTraverser_newPathMonitor(t *testing.T) {
 
 	pTrav, err := newPathMonitor(ctx, newFixedThreadExecutor(ctx), 0, true)
 	require.NoError(t, err)
-	require.Equal(t, pTrav.sMatchTimeout, 5*time.Second)
+	require.Equal(t, 5*time.Second, pTrav.sMatchTimeout)
 	require.NoError(t, pTrav.Close())
 
 	pTrav, err = newPathMonitor(ctx, newFixedThreadExecutor(ctx), 2*time.Second, true)
 	require.NoError(t, err)
-	require.Equal(t, pTrav.sMatchTimeout, 2*time.Second)
+	require.Equal(t, 2*time.Second, pTrav.sMatchTimeout)
 	require.NoError(t, pTrav.Close())
 }
 
 type pathTestSuite struct {
 	suite.Suite
+}
+
+func (p *pathTestSuite) requireEmptyStatQueue(trav *pTraverser) {
+	trav.mtx.RLock()
+	defer trav.mtx.RUnlock()
+	p.Require().Empty(trav.statQueue, "statQueue should be empty after walk completes")
 }
 
 func Test_PathTraverser(t *testing.T) {
@@ -118,7 +124,7 @@ func (p *pathTestSuite) TestRecursiveWalkAsync() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -128,10 +134,12 @@ func (p *pathTestSuite) TestRecursiveWalkAsync() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -186,7 +194,7 @@ func (p *pathTestSuite) TestRecursiveWalkAsync() {
 	}
 
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestWalkAsyncTimeoutErr() {
@@ -239,7 +247,7 @@ func (p *pathTestSuite) TestNonRecursiveWalkAsync() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -249,10 +257,12 @@ func (p *pathTestSuite) TestNonRecursiveWalkAsync() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -307,7 +317,7 @@ func (p *pathTestSuite) TestNonRecursiveWalkAsync() {
 	}
 
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestAddTraverserContextCancel() {
@@ -324,22 +334,23 @@ func (p *pathTestSuite) TestAddTraverserContextCancel() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for {
 		if tries >= 4 {
 			p.Require().Fail("no path was added in 5 tries")
 		}
-		if len(pTrav.statQueue) == 0 {
+		pTrav.mtx.RLock()
+		statQueueEmpty := len(pTrav.statQueue) == 0
+		pTrav.mtx.RUnlock()
+		if statQueueEmpty {
 			tries++
 			time.Sleep(1 * time.Second)
 			continue
@@ -366,15 +377,13 @@ func (p *pathTestSuite) TestAddTimeout() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	select {
 	case err = <-errChan:
@@ -417,7 +426,7 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -427,10 +436,12 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -450,15 +461,13 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {
@@ -490,7 +499,7 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 	err = <-errChan
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestNonRecursiveAdd() {
@@ -524,7 +533,7 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 	mounts, err := getAllMountPoints()
 	p.Require().NoError(err)
 
-	p.Require().Equal(len(createdPathsOrder), len(createdPathsWithDepth))
+	p.Require().Len(createdPathsWithDepth, len(createdPathsOrder))
 
 	expectedStatQueue := make([]statMatch, 0, len(createdPathsOrder))
 	for _, path := range createdPathsOrder {
@@ -534,10 +543,12 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 		info, err := os.Lstat(path)
 		p.Require().NoError(err)
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		p.Require().True(ok, "expected *syscall.Stat_t from Lstat on %q", path)
 		mnt := mounts.getMountByPath(path)
 		p.Require().NotNil(mnt)
 		expectedStatQueue = append(expectedStatQueue, statMatch{
-			ino:        info.Sys().(*syscall.Stat_t).Ino,
+			ino:        stat.Ino,
 			major:      mnt.DeviceMajor,
 			minor:      mnt.DeviceMinor,
 			depth:      depth,
@@ -557,15 +568,13 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {
@@ -597,7 +606,7 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 	err = <-errChan
 	p.Require().NoError(err)
-	p.Require().Empty(pTrav.statQueue)
+	p.requireEmptyStatQueue(pTrav)
 }
 
 func (p *pathTestSuite) TestStatErrAtRootAdd() {
@@ -667,7 +676,11 @@ func (p *pathTraverserMock) AddPathToMonitor(ctx context.Context, path string) e
 
 func (p *pathTraverserMock) GetMonitorPath(ino uint64, major uint32, minor uint32, name string) (MonitorPath, bool) {
 	args := p.Called(ino, major, minor, name)
-	return args.Get(0).(MonitorPath), args.Bool(1)
+	mPath, ok := args.Get(0).(MonitorPath)
+	if !ok {
+		panic("unexpected mock return type for MonitorPath")
+	}
+	return mPath, args.Bool(1)
 }
 
 func (p *pathTraverserMock) WalkAsync(path string, depth uint32, tid uint32) {
@@ -676,7 +689,11 @@ func (p *pathTraverserMock) WalkAsync(path string, depth uint32, tid uint32) {
 
 func (p *pathTraverserMock) ErrC() <-chan error {
 	args := p.Called()
-	return args.Get(0).(<-chan error)
+	errC, ok := args.Get(0).(<-chan error)
+	if !ok {
+		panic("unexpected mock return type for ErrC")
+	}
+	return errC
 }
 
 func (p *pathTraverserMock) Close() error {

--- a/changelog/fragments/1785513000-fix-kprobes-path-traverser-race.yaml
+++ b/changelog/fragments/1785513000-fix-kprobes-path-traverser-race.yaml
@@ -1,0 +1,5 @@
+kind: bug-fix
+
+summary: Prevent file integrity monitoring failures when path discovery and event processing overlap.
+
+component: auditbeat


### PR DESCRIPTION
## Proposed commit message

```text
Copy the path-traverser wait channel while the mutex is locked. Wait on
the copy after the mutex is unlocked.

The event consumer can close and clear the field while another
goroutine waits for a path walk. Reading the field after unlock caused
a data race.
```

## Checklist

- [x] The code follows the project style.
- [x] The code has comments where they are necessary.
- ~~The change does not require documentation updates.~~
- ~~The change does not require default configuration updates.~~
- [x] The package tests pass with the race detector.
- [x] I added a changelog fragment.

## Disruptive User Impact

None.

## How to test this PR locally

```bash
go test -v -race ./auditbeat/module/file_integrity/kprobes/...
```

## Logs

```text
WARNING: DATA RACE
Write at 0x00c000390180 by goroutine 127:
  kprobes.(*pTraverser).GetMonitorPath()
      auditbeat/module/file_integrity/kprobes/path.go:128
  kprobes.(*pathTestSuite).TestNonRecursiveAdd()
      auditbeat/module/file_integrity/kprobes/path_test.go:572

Previous read at 0x00c000390180 by goroutine 128:
  kprobes.(*pTraverser).waitForWalk()
      auditbeat/module/file_integrity/kprobes/path.go:282
  kprobes.(*pTraverser).walk()
      auditbeat/module/file_integrity/kprobes/path.go:303
  kprobes.(*pTraverser).AddPathToMonitor.func1()
      auditbeat/module/file_integrity/kprobes/path.go:324
```
