### PR TITLE
docs/filebeat: fix growing snippet contradicting its own instruction

### DIFF
--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -446,7 +446,7 @@ file_identity.fingerprint: ~
 
       ```yaml
       file_identity.fingerprint:
-        growing: true
+        growing: false
       ```
 
 
@@ -704,7 +704,7 @@ When the limit is reached, newly discovered files are queued and started in the 
 This configuration option applies per input. You can use this option to indirectly set higher priorities on certain inputs by assigning a higher limit of harvesters.
 
 ### `include_file_owner_name` [filestream-input-include_file_owner_name]
-```yaml {applies_to}
+```{applies_to}
 stack: ga 9.3
 ```
 
@@ -712,7 +712,7 @@ Includes the log file owner to `log.file` metadata.
 This option is not supported on Windows.
 
 ### `include_file_owner_group_name` [filestream-input-include_file_owner_group_name]
-```yaml {applies_to}
+```{applies_to}
 stack: ga 9.3
 ```
 
@@ -720,7 +720,7 @@ Includes the log file group to `log.file` metadata.
 This option is not supported on Windows.
 
 ### `include_file_fingerprint` [filestream-input-include_file_fingerprint]
-```yaml {applies_to}
+```{applies_to}
 stack: ga 9.5.0
 ```
 Controls whether `log.file.fingerprint` is added to published events. Only takes effect when `file_identity.fingerprint` is configured. Defaults to `true`. The file path (`log.file.path`) is always present in events regardless of this setting.


### PR DESCRIPTION
## Proposed commit message

```
The `growing` option told readers to set it to `false` to restore the
pre-9.5 behavior, then showed a snippet setting it to `true`. The
equivalent passage in file-identity.md already showed `false`.

Also drops a stray `yaml` tag from three `applies_to` directives in the
same file. The docs-builder ignores it, so the rendered page is
unchanged, but it reads as if the block were a config sample.
```
