### PR TITLE
fix(synthetics): bake Playwright browsers into heartbeat image

### DIFF
--- a/changelog/fragments/1785872781-fix-heartbeat-image-synthetics-browser-install.yaml
+++ b/changelog/fragments/1785872781-fix-heartbeat-image-synthetics-browser-install.yaml
@@ -1,0 +1,25 @@
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Bake Synthetics browser binaries into the heartbeat Docker image
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  npm 12 no longer runs a dependency's `install` lifecycle script during `npm i` by
+  default, so the transitive playwright-chromium `install` hook that used to download
+  the Playwright browsers into the heartbeat image during build stopped running. As a
+  result the image shipped with no browsers and all Synthetics browser monitors failed
+  with "browserType.launch: Executable doesn't exist at
+  .../chromium_headless_shell-<rev>/...". The image build now installs the browsers
+  explicitly with the bundled Playwright CLI after `npm i`, independent of npm's
+  install-script policy.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: heartbeat
+
+# PR URL; optional; the PR number that added the changeset.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+issue: https://github.com/elastic/beats/issues/52439

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -156,6 +156,11 @@ RUN echo \
 
 USER {{ .user }}
 RUN (npm i -g --loglevel verbose --production --engine-strict  @elastic/synthetics@stack_release || sh -c 'tail -n +1 ${NPM_CONFIG_PREFIX}/_logs/* && exit 1')
+# npm >= 12 blocks dependency install scripts by default, so playwright-chromium's
+# install hook no longer downloads browsers during `npm i`. Install them explicitly
+# with the bundled Playwright CLI (same revision synthetics expects).
+RUN HOME={{ $beatHome }} node "$(npm root -g)/@elastic/synthetics/node_modules/playwright-core/cli.js" install chromium && \
+    test -d {{ $beatHome }}/.cache/ms-playwright
 {{- end }}
 
 {{- if (and (eq .BeatName "heartbeat") (contains .from "ubi10-minimal")) }}
@@ -235,6 +240,11 @@ USER {{ .user }}
 # If this fails dump the NPM logs
 RUN npm i -g --loglevel verbose --production --engine-strict @elastic/synthetics@stack_release || sh -c 'tail -n +1 /root/.npm/_logs/* && exit 1'
 RUN chmod ug+rwX -R $NODE_PATH
+# npm >= 12 blocks dependency install scripts by default, so playwright-chromium's
+# install hook no longer downloads browsers during `npm i`. Install them explicitly
+# with the bundled Playwright CLI (same revision synthetics expects).
+RUN HOME={{ $beatHome }} node "$(npm root -g)/@elastic/synthetics/node_modules/playwright-core/cli.js" install chromium && \
+    test -d {{ $beatHome }}/.cache/ms-playwright
 
 USER root
 


### PR DESCRIPTION
## 📝 Summary

The standalone `heartbeat` Docker image ships **with no Playwright browser binaries**, so Synthetics browser monitors fail at launch with `Executable doesn't exist at .../chromium_headless_shell-<rev>/...`.

Fixes #52439.

## 🎯 Root cause

[#52141](https://github.com/elastic/beats/pull/52141) bumped npm to 12.0.1. npm 12 blocks dependency install scripts by default, so `playwright-chromium`'s install hook no longer downloads browsers during `npm i -g @elastic/synthetics`.

## 🔧 Changes

After `npm i -g @elastic/synthetics@stack_release`, explicitly install browsers with the bundled Playwright CLI in **both** heartbeat variants, and assert the cache directory exists:

```dockerfile
RUN HOME={{ $beatHome }} node "$(npm root -g)/@elastic/synthetics/node_modules/playwright-core/cli.js" install chromium && \
    test -d {{ $beatHome }}/.cache/ms-playwright
```

Independent of npm's install-script allowlist; matches Playwright's explicit-install guidance ([microsoft/playwright#41083](https://github.com/microsoft/playwright/issues/41083)).

## ✅ Testing

Verified end-to-end on parallel `elastic-agent-complete:9.5.0` with the same RUN: browsers baked, inline journey `1 passed`.

## 🔗 Related

- elastic/elastic-agent#15993 / elastic/elastic-agent#15994

## Backport

**8.19 / 9.3 / 9.4 / 9.5** (branches that received #52141).