### PR TITLE
fix unknown type for map[string]string in otelmap

### DIFF
--- a/changelog/fragments/1785946345-fix-unknown-type-for-map[string]string-in-otelmap.yaml
+++ b/changelog/fragments/1785946345-fix-unknown-type-for-map[string]string-in-otelmap.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix unknown type for map[string]string in otelmap
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: all
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/libbeat/otel/otelmap/otelmap.go
+++ b/libbeat/otel/otelmap/otelmap.go
@@ -118,6 +118,12 @@ func FromValue(dst pcommon.Value, value any) error {
 		return FromMapstr(dst.SetEmptyMap(), v)
 	case map[string]any:
 		return FromMapstr(dst.SetEmptyMap(), v)
+	case map[string]string:
+		fromStringMap(dst.SetEmptyMap(), v)
+		return nil
+	case map[string]int:
+		fromIntMap(dst.SetEmptyMap(), v)
+		return nil
 	case []mapstr.M:
 		return fromMapSlice(dst.SetEmptySlice(), v)
 	case []map[string]any:
@@ -225,6 +231,10 @@ func putIntoMap(key string, val any, dst pcommon.Map) error {
 		return FromMapstr(dst.PutEmptyMap(key), v)
 	case map[string]any:
 		return FromMapstr(dst.PutEmptyMap(key), v)
+	case map[string]string:
+		fromStringMap(dst.PutEmptyMap(key), v)
+	case map[string]int:
+		fromIntMap(dst.PutEmptyMap(key), v)
 	default:
 		return FromValue(dst.PutEmpty(key), val)
 	}
@@ -403,6 +413,12 @@ func fromReflective(dst pcommon.Value, value any) error {
 		return FromMapstr(dst.SetEmptyMap(), m)
 	case reflect.Slice, reflect.Array:
 		return fromReflectiveSlice(dst.SetEmptySlice(), ref)
+	case reflect.Map:
+		if ref.Type().Key().Kind() != reflect.String {
+			dst.SetStr(fmt.Sprintf("unknown type: %T", value))
+			return nil
+		}
+		return fromReflectiveMap(dst.SetEmptyMap(), ref)
 	case reflect.Pointer, reflect.Interface:
 		if ref.IsNil() {
 			return nil
@@ -419,6 +435,31 @@ func fromReflectiveSlice(dst pcommon.Slice, ref reflect.Value) error {
 	dst.EnsureCapacity(n)
 	for i := range n {
 		if err := FromValue(dst.AppendEmpty(), ref.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fromStringMap(dst pcommon.Map, src map[string]string) {
+	dst.EnsureCapacity(len(src))
+	for k, v := range src {
+		dst.PutStr(k, v)
+	}
+}
+
+func fromIntMap(dst pcommon.Map, src map[string]int) {
+	dst.EnsureCapacity(len(src))
+	for k, v := range src {
+		dst.PutInt(k, int64(v))
+	}
+}
+
+func fromReflectiveMap(dst pcommon.Map, ref reflect.Value) error {
+	dst.EnsureCapacity(ref.Len())
+	iter := ref.MapRange()
+	for iter.Next() {
+		if err := putIntoMap(iter.Key().String(), iter.Value().Interface(), dst); err != nil {
 			return err
 		}
 	}

--- a/libbeat/otel/otelmap/otelmap_test.go
+++ b/libbeat/otel/otelmap/otelmap_test.go
@@ -415,9 +415,37 @@ func TestFromMapstrNamedPrimitivesInSlice(t *testing.T) {
 func TestUnknownType(t *testing.T) {
 	dst := pcommon.NewMap()
 	require.NoError(t, FromMapstr(dst, mapstr.M{
-		"unknown_map": map[string]int{"key": 42},
+		"unknown_map": map[int]string{1: "one"},
 	}))
-	assert.Equal(t, map[string]any{"unknown_map": "unknown type: map[string]int"}, dst.AsRaw())
+	assert.Equal(t, map[string]any{"unknown_map": "unknown type: map[int]string"}, dst.AsRaw())
+}
+
+// TestFromReflectiveMapStringKeyed pins the expected behavior for
+// reflect.Map values with string keys that are not mapstr.M or map[string]any
+// (e.g. map[string]string, map[string]int).
+func TestFromReflectiveMapStringKeyed(t *testing.T) {
+	type Severity string
+	input := mapstr.M{
+		"labels":        map[string]string{"env": "prod", "region": "us-east"},
+		"counters":      map[string]int{"a": 1, "b": 2},
+		"named_values":  map[string]Severity{"log": "warn", "alert": "error"},
+		"nested":        map[string]map[string]int{"inner": {"x": 1}},
+		"heterogeneous": map[string]any{"n": 42, "s": "hello", "b": true},
+	}
+	want := map[string]any{
+		"labels":   map[string]any{"env": "prod", "region": "us-east"},
+		"counters": map[string]any{"a": int64(1), "b": int64(2)},
+		"named_values": map[string]any{
+			"log":   "warn",
+			"alert": "error",
+		},
+		"nested":        map[string]any{"inner": map[string]any{"x": int64(1)}},
+		"heterogeneous": map[string]any{"n": int64(42), "s": "hello", "b": true},
+	}
+
+	dst := pcommon.NewMap()
+	require.NoError(t, FromMapstr(dst, input))
+	assert.Equal(t, want, dst.AsRaw())
 }
 
 func TestFromMapstrComplex(t *testing.T) {


### PR DESCRIPTION
## Proposed commit message

fromReflective in libbeat/otel/otelmap/otelmap.go handled reflect.String, reflect.Bool, the signed/unsigned int kinds, floats, complex, structs, slices/arrays, pointers, and interfaces, but had no reflect.Map branch. Any map value whose static type wasn't mapstr.M or map[string]any (e.g. map[string]string, map[string]int, map[string]MyNamedString, map[string]map[string]int) fell through putIntoMap → FromValue → fromReflective and hit the default, which stringified the value as "unknown type: map[string]…". That silently corrupted otherwise-representable data in the OTel output path.

WHAT

• Added a case reflect.Map: branch to fromReflective. It requires the key kind to be reflect.String (which covers named string types like type Severity string) and delegates to a new fromReflectiveMap helper that recurses through putIntoMap, so nested values still take the efficient typed Put* paths. Non-string keys keep the existing "unknown type: …" fallback, since pcommon.Map keys are strings.

• Added fast-path cases for map[string]string and map[string]int to both FromValue and putIntoMap, backed by two non-reflective helpers (fromStringMap, fromIntMap). These two shapes are the most common in Beats event payloads (labels, headers, counters), so avoiding reflection here matters for allocation/CPU under load.

• Added TestFromReflectiveMapStringKeyed covering map[string]string, map[string]int, a named-value type (map[string]Severity), nested map[string]map[string]int, and heterogeneous map[string]any — all now round-trip to the expected nested map instead of "unknown type: …".

• Retargeted TestUnknownType from map[string]int (which is now correctly supported) to map[int]string, which is genuinely unrepresentable in pcommon.Map and pins the graceful fallback preserved by the fix.

WHY

Documents traveling the OTel output path from mapstr.M were being turned into strings that read "unknown type: map[string]string" when a producer used any typed string→X map instead of map[string]any/mapstr.M. Fixing at fromReflective covers everything the typed switch misses in one place; adding the two typed fast paths keeps the hot cases off the reflection path.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.  Users will get correct types in events instead of "unknown type: map[string]string"

## How to test this PR locally

```
go test ./libbeat/otel/otelmap/...
```

## Related issues

- Closes #52460 

## Use cases



## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
