### PR TITLE
filebeat/filestream: run the real processing chain in the input test pipeline

### DIFF
--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -39,6 +40,9 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/filebeat/testing/gziptest"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/publisher/processing"
+	publishertest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile/encoding"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
@@ -598,7 +602,7 @@ func createFilestreamTestRunner(b testing.TB, logger *logp.Logger, testID string
 	if collectEvents {
 		out = make([]beat.Event, 0, eventLimit)
 	}
-	connector, events := newTestPipeline(eventLimit, collectEvents)
+	connector, events := newTestPipeline(b, logger, eventLimit, collectEvents)
 	go func() {
 		defer cancel()
 		for event := range events {
@@ -606,7 +610,10 @@ func createFilestreamTestRunner(b testing.TB, logger *logp.Logger, testID string
 		}
 	}()
 
+	// The pipeline is closed here rather than through t.Cleanup because
+	// benchmarks call this once per iteration.
 	return func(t testing.TB) []beat.Event {
+		defer func() { require.NoError(t, connector.Close(), "failed closing the test pipeline") }()
 		err := input.Run(v2ctx, connector)
 		require.NoError(b, err)
 		return out
@@ -648,54 +655,69 @@ func (s *testStore) CleanupInterval() time.Duration {
 	return time.Second
 }
 
-func newTestPipeline(eventLimit int64, collectEvents bool) (pc beat.PipelineConnector, out <-chan beat.Event) {
+func newTestPipeline(t testing.TB, logger *logp.Logger, eventLimit int64, collectEvents bool) (p *testPipeline, out <-chan beat.Event) {
+	support, err := processing.MakeDefaultSupport(true, nil)(beat.Info{Logger: logger}, logger, conf.NewConfig())
+	require.NoError(t, err, "failed building the event processing support")
+
 	var chBuf int64
 	if collectEvents {
 		chBuf = eventLimit
 	}
 	ch := make(chan beat.Event, chBuf)
-	return &testPipeline{limit: eventLimit, out: ch, collect: collectEvents}, ch
+	p = &testPipeline{out: ch, collect: collectEvents, support: support}
+	p.limit.Store(eventLimit)
+	p.ConnectFunc = func(cfg beat.ClientConfig) (beat.Client, error) {
+		procs, err := support.Create(cfg.Processing, false)
+		if err != nil {
+			return nil, err
+		}
+		return &publishertest.FakeClient{
+			PublishFunc: func(event beat.Event) {
+				processed, err := procs.Run(&event)
+				if err != nil {
+					t.Errorf("event processing failed: %v", err)
+					return
+				}
+				if processed != nil {
+					p.publish(*processed)
+				}
+			},
+			CloseFunc: func() error {
+				return processors.Close(procs)
+			},
+		}, nil
+	}
+	return p, ch
 }
 
+// testPipeline applies ClientConfig processing without beat builtin fields.
 type testPipeline struct {
-	limit   int64
+	publishertest.FakeConnector
+	limit   atomic.Int64
+	mu      sync.Mutex
 	out     chan beat.Event
 	collect bool
+	support processing.Supporter
 }
 
-func (p *testPipeline) ConnectWith(beat.ClientConfig) (beat.Client, error) {
-	return p.Connect()
-}
-func (p *testPipeline) Connect() (beat.Client, error) {
-	return &testClient{p}, nil
+func (p *testPipeline) Close() error {
+	return p.support.Close()
 }
 
-func (p *testPipeline) Disconnect(ctx context.Context) error {
-	return nil
-}
-
-type testClient struct {
-	testPipeline *testPipeline
-}
-
-func (c *testClient) Publish(event beat.Event) {
-	newLimit := atomic.AddInt64(&c.testPipeline.limit, -1)
-	if newLimit < 0 {
+func (p *testPipeline) publish(event beat.Event) {
+	// Serialize collectors so the last sender cannot close out ahead of another.
+	if p.collect {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+	}
+	remaining := p.limit.Add(-1)
+	if remaining < 0 {
 		return
 	}
-	if c.testPipeline.collect {
-		c.testPipeline.out <- event
+	if p.collect {
+		p.out <- event
 	}
-	if newLimit == 0 {
-		close(c.testPipeline.out)
+	if remaining == 0 {
+		close(p.out)
 	}
-}
-
-func (c *testClient) PublishAll(events []beat.Event) {
-	for _, e := range events {
-		c.Publish(e)
-	}
-}
-func (c *testClient) Close() error {
-	return nil
 }


### PR DESCRIPTION
## Proposed commit message

```text
The filestream test pipeline previously discarded the ClientConfig passed by
the input and sent events directly to a channel. Input-selected publisher
processing was therefore absent from tests and BenchmarkFilestream, which
understated the per-event work filestream performs in production.

Build the normal processing program from ClientConfig and run every test event
through it. Reuse the publisher test connector and client fakes while keeping
collection lock-free when benchmarks do not retain events.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None.

## How to test this PR locally

```shell
go test -race ./filebeat/input/filestream/
go test -run '^$' -bench 'BenchmarkFilestream/1_file' -benchmem ./filebeat/input/filestream/
```

## Related issues

- Relates #49221

## Use cases

Filestream tests and benchmarks now exercise the event processing requested through `beat.ClientConfig`, matching the per-event path used in production.
