### PR TITLE
libbeat/common: add opt-in in-place event normalization

### DIFF
--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -39,13 +39,17 @@ type EventConverter interface {
 type GenericEventConverter struct {
 	log      *logp.Logger
 	keepNull bool
+	inPlace  bool
 }
 
-// NewGenericEventConverter creates an EventConverter with the given configuration options
-func NewGenericEventConverter(keepNull bool, logger *logp.Logger) *GenericEventConverter {
+// NewGenericEventConverter creates an EventConverter with the given configuration
+// options. With inPlace it reuses the maps of the event that it converts instead
+// of copying them, so the caller must exclusively own every reachable map.
+func NewGenericEventConverter(keepNull, inPlace bool, logger *logp.Logger) *GenericEventConverter {
 	return &GenericEventConverter{
 		log:      logger.Named("event"),
 		keepNull: keepNull,
+		inPlace:  inPlace,
 	}
 }
 
@@ -69,7 +73,12 @@ func (e *GenericEventConverter) Convert(m mapstr.M) mapstr.M {
 func (e *GenericEventConverter) normalizeMap(m mapstr.M, keys ...string) (mapstr.M, []error) {
 	var errs []error
 
-	out := make(mapstr.M, len(m))
+	reuse := e.inPlace && m != nil
+	out := m
+	if !reuse {
+		out = make(mapstr.M, len(m))
+	}
+
 	for key, value := range m {
 		v, err := e.normalizeValue(value, append(keys, key)...)
 		if len(err) > 0 {
@@ -80,6 +89,9 @@ func (e *GenericEventConverter) normalizeMap(m mapstr.M, keys ...string) (mapstr
 		if !e.keepNull && v == nil {
 			if e.log.IsDebug() {
 				e.log.Debugf("Dropped nil value from event where key=%v", joinKeys(append(keys, key)...))
+			}
+			if reuse {
+				delete(out, key)
 			}
 			continue
 		}

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -39,6 +39,7 @@ type EventConverter interface {
 type GenericEventConverter struct {
 	log      *logp.Logger
 	keepNull bool
+	inPlace  bool
 }
 
 // NewGenericEventConverter creates an EventConverter with the given configuration options
@@ -47,6 +48,15 @@ func NewGenericEventConverter(keepNull bool, logger *logp.Logger) *GenericEventC
 		log:      logger.Named("event"),
 		keepNull: keepNull,
 	}
+}
+
+// NewGenericEventConverterInPlace creates a converter that reuses input maps.
+// Callers must exclusively own every reachable map: producer state and other
+// events must not reference them. Slices are still rebuilt.
+func NewGenericEventConverterInPlace(keepNull bool, logger *logp.Logger) *GenericEventConverter {
+	e := NewGenericEventConverter(keepNull, logger)
+	e.inPlace = true
+	return e
 }
 
 // Convert normalizes the types contained in the given mapstr.M.
@@ -63,13 +73,20 @@ func (e *GenericEventConverter) Convert(m mapstr.M) mapstr.M {
 	return event
 }
 
-// normalizeMap normalizes each element contained in the given map. If an error
-// occurs during normalization, processing of m will continue, and all errors
-// are returned at the end.
+// normalizeMap normalizes each element contained in the given map. Unless the
+// converter normalizes in place, the result is a copy and m is left untouched.
+// If an error occurs during normalization, processing of m will continue, and
+// all errors are returned at the end.
 func (e *GenericEventConverter) normalizeMap(m mapstr.M, keys ...string) (mapstr.M, []error) {
 	var errs []error
 
-	out := make(mapstr.M, len(m))
+	// Preserve the copying mode's nil-to-empty normalization.
+	reuse := e.inPlace && m != nil
+	out := m
+	if !reuse {
+		out = make(mapstr.M, len(m))
+	}
+
 	for key, value := range m {
 		v, err := e.normalizeValue(value, append(keys, key)...)
 		if len(err) > 0 {
@@ -80,6 +97,9 @@ func (e *GenericEventConverter) normalizeMap(m mapstr.M, keys ...string) (mapstr
 		if !e.keepNull && v == nil {
 			if e.log.IsDebug() {
 				e.log.Debugf("Dropped nil value from event where key=%v", joinKeys(append(keys, key)...))
+			}
+			if reuse {
+				delete(out, key)
 			}
 			continue
 		}

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
@@ -332,6 +333,55 @@ func TestNormalizeValue(t *testing.T) {
 	})
 }
 
+func TestNormalizeInPlace(t *testing.T) {
+	ts := time.Date(2026, 4, 13, 9, 23, 18, 0, time.UTC)
+	input := func() mapstr.M {
+		return mapstr.M{
+			"str":     "value",
+			"dropped": nil,
+			"ts":      ts,
+			"nested":  mapstr.M{"n": 1, "dropped": nil},
+			"list":    []mapstr.M{{"l": "a", "dropped": nil}, nil},
+			"nilList": []mapstr.M(nil),
+			"nilMap":  mapstr.M(nil),
+		}
+	}
+	want := mapstr.M{
+		"str":     "value",
+		"ts":      Time(ts),
+		"nested":  mapstr.M{"n": 1},
+		"list":    []mapstr.M{{"l": "a"}, {}},
+		"nilList": []mapstr.M{},
+		"nilMap":  mapstr.M{},
+	}
+
+	t.Run("copying leaves the input untouched", func(t *testing.T) {
+		in := input()
+		g := NewGenericEventConverter(false, logptest.NewTestingLogger(t, ""))
+
+		out := g.Convert(in)
+
+		assert.Equal(t, want, out)
+		assert.Equal(t, input(), in, "Convert must not modify the map it was given")
+
+		nested, ok := out["nested"].(mapstr.M)
+		require.True(t, ok, "nested map must stay a mapstr.M")
+		out["added"] = true
+		nested["added"] = true
+		assert.Equal(t, input(), in, "the converted event must not share maps with the input")
+	})
+
+	t.Run("in place normalizes the input itself", func(t *testing.T) {
+		in := input()
+		g := NewGenericEventConverterInPlace(false, logptest.NewTestingLogger(t, ""))
+
+		out := g.Convert(in)
+
+		assert.Equal(t, want, out)
+		assert.Equal(t, want, in, "NormalizeInPlace must normalize the map it was given")
+	})
+}
+
 func TestNormalizeMapError(t *testing.T) {
 	badInputs := []mapstr.M{
 		{"func": func() {}},
@@ -416,6 +466,52 @@ func TestNormalizeTime(t *testing.T) {
 
 	assert.Equal(t, time.UTC, time.Time(utcCommonTime).Location())
 	assert.True(t, now.Equal(time.Time(utcCommonTime)))
+}
+
+var benchmarkConvertEventResult mapstr.M
+
+// BenchmarkConvertEvent measures normalization of an already-built event.
+func BenchmarkConvertEvent(b *testing.B) {
+	event := mapstr.M{
+		"message": "2026-01-02T03:04:05.000Z INFO [publisher] pipeline/output.go:143 Connecting to backoff(elasticsearch(http://localhost:9200))",
+		"log": mapstr.M{
+			"level":  "info",
+			"logger": "publisher",
+			"offset": 12345,
+			"file":   mapstr.M{"path": "/var/log/filebeat/filebeat.log"},
+		},
+		"host": mapstr.M{
+			"name":         "host-01",
+			"architecture": "x86_64",
+			"ip":           []string{"10.0.0.4", "fe80::1"},
+			"os": mapstr.M{
+				"family": "debian", "kernel": "6.1.0", "name": "Ubuntu",
+				"platform": "ubuntu", "type": "linux", "version": "22.04.3 LTS",
+			},
+		},
+		"agent": mapstr.M{
+			"type": "filebeat", "version": "9.2.0", "name": "host-01",
+			"id": "8a4f500d-a42a-4f1d-b8c9-1a2b3c4d5e6f",
+		},
+		"ecs":    mapstr.M{"version": "8.11.0"},
+		"input":  mapstr.M{"type": "filestream"},
+		"event":  mapstr.M{"dataset": "filebeat.log", "module": "beat"},
+		"labels": mapstr.M{"env": "prod", "team": "platform"},
+	}
+	cases := map[string]func(bool, *logp.Logger) *GenericEventConverter{
+		"copy":     NewGenericEventConverter,
+		"in place": NewGenericEventConverterInPlace,
+	}
+
+	for name, newConverter := range cases {
+		b.Run(name, func(b *testing.B) {
+			g := newConverter(false, logptest.NewTestingLogger(b, ""))
+			b.ReportAllocs()
+			for b.Loop() {
+				benchmarkConvertEventResult = g.Convert(event)
+			}
+		})
+	}
 }
 
 // Uses TextMarshaler interface.

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -24,106 +24,124 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-func TestConvertNestedMapStr(t *testing.T) {
-	logp.TestingSetup()
+// normalizationModes are the two ways the converter builds its result. Both
+// must return the same event for the same input.
+var normalizationModes = []struct {
+	name    string
+	inPlace bool
+}{
+	{"copy", false},
+	{"in place", true},
+}
 
-	type io struct {
-		Input  mapstr.M
-		Output mapstr.M
+// forEachMode runs fn once per normalization mode. Converting in place leaves
+// the input normalized, so a shared input reaches later modes already converted.
+func forEachMode(t *testing.T, keepNull bool, fn func(t *testing.T, g *GenericEventConverter)) {
+	t.Helper()
+	for _, mode := range normalizationModes {
+		t.Run(mode.name, func(t *testing.T) {
+			fn(t, NewGenericEventConverter(keepNull, mode.inPlace,
+				logptest.NewTestingLogger(t, "")))
+		})
 	}
+}
 
-	type String string
+func TestConvertNestedMapStr(t *testing.T) {
+	type myString string
 
-	tests := []io{
+	tests := []struct {
+		in   mapstr.M
+		want mapstr.M
+	}{
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": mapstr.M{
 					"key1": "value1",
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": mapstr.M{
 					"key1": "value1",
 				},
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": mapstr.M{
-					"key1": String("value1"),
+					"key1": myString("value1"),
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": mapstr.M{
 					"key1": "value1",
 				},
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": mapstr.M{
 					"key1": []string{"value1", "value2"},
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": mapstr.M{
 					"key1": []string{"value1", "value2"},
 				},
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": mapstr.M{
-					"key1": []String{"value1", "value2"},
+					"key1": []myString{"value1", "value2"},
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": mapstr.M{
 					"key1": []any{"value1", "value2"},
 				},
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"@timestamp": MustParseTime("2015-03-01T12:34:56.123Z"),
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"@timestamp": MustParseTime("2015-03-01T12:34:56.123Z"),
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"env":  nil,
 				"key2": uintptr(88),
 				"key3": func() { t.Log("hello") },
 			},
-			Output: mapstr.M{},
+			want: mapstr.M{},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": []mapstr.M{
-					{"keyX": []String{"value1", "value2"}},
+					{"keyX": []myString{"value1", "value2"}},
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": []mapstr.M{
 					{"keyX": []any{"value1", "value2"}},
 				},
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": []any{
 					mapstr.M{"key1": []string{"value1", "value2"}},
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": []any{
 					mapstr.M{"key1": []string{"value1", "value2"}},
 				},
@@ -135,28 +153,25 @@ func TestConvertNestedMapStr(t *testing.T) {
 		},
 	}
 
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(t, ""))
-	for i, test := range tests {
-		assert.Equal(t, test.Output, g.Convert(test.Input), "Test case %d", i)
-	}
+	forEachMode(t, false, func(t *testing.T, g *GenericEventConverter) {
+		for i, test := range tests {
+			assert.Equal(t, test.want, g.Convert(test.in), "Test case %d", i)
+		}
+	})
 }
 
 func TestConvertNestedStruct(t *testing.T) {
-	logp.TestingSetup()
-
-	type io struct {
-		Input  mapstr.M
-		Output mapstr.M
-	}
-
 	type TestStruct struct {
 		A string
 		B int
 	}
 
-	tests := []io{
+	tests := []struct {
+		in   mapstr.M
+		want mapstr.M
+	}{
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": mapstr.M{
 					"key1": TestStruct{
 						A: "hello",
@@ -164,7 +179,7 @@ func TestConvertNestedStruct(t *testing.T) {
 					},
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": mapstr.M{
 					"key1": mapstr.M{
 						"A": "hello",
@@ -174,7 +189,7 @@ func TestConvertNestedStruct(t *testing.T) {
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": []any{
 					TestStruct{
 						A: "hello",
@@ -182,7 +197,7 @@ func TestConvertNestedStruct(t *testing.T) {
 					},
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": []any{
 					mapstr.M{
 						"A": "hello",
@@ -193,73 +208,73 @@ func TestConvertNestedStruct(t *testing.T) {
 		},
 	}
 
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(t, ""))
-	for i, test := range tests {
-		assert.Equal(t, test.Output, g.Convert(test.Input), "Test case %v", i)
-	}
+	forEachMode(t, false, func(t *testing.T, g *GenericEventConverter) {
+		for i, test := range tests {
+			assert.Equal(t, test.want, g.Convert(test.in), "Test case %v", i)
+		}
+	})
 }
 
 func TestConvertWithNullEmission(t *testing.T) {
-	logp.TestingSetup()
-
-	type io struct {
-		Input  mapstr.M
-		Output mapstr.M
-	}
-
 	type TestStruct struct {
 		A any
 	}
 
-	tests := []io{
+	tests := []struct {
+		in   mapstr.M
+		want mapstr.M
+	}{
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": mapstr.M{
 					"key1": nil,
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": mapstr.M{
 					"key1": nil,
 				},
 			},
 		},
 		{
-			Input: mapstr.M{
+			in: mapstr.M{
 				"key": TestStruct{
 					A: nil,
 				},
 			},
-			Output: mapstr.M{
+			want: mapstr.M{
 				"key": mapstr.M{
 					"A": nil,
 				},
 			},
-		}}
-
-	g := NewGenericEventConverter(true, logptest.NewTestingLogger(t, ""))
-	for i, test := range tests {
-		assert.Equal(t, test.Output, g.Convert(test.Input), "Test case %v", i)
+		},
 	}
+
+	forEachMode(t, true, func(t *testing.T, g *GenericEventConverter) {
+		for i, test := range tests {
+			assert.Equal(t, test.want, g.Convert(test.in), "Test case %v", i)
+		}
+	})
 }
 
 func TestNormalizeValue(t *testing.T) {
-	logp.TestingSetup()
-
 	type testCase struct{ in, out any }
 
-	runTests := func(check func(t *testing.T, a, b any), tests map[string]testCase) {
-		g := NewGenericEventConverter(false, logptest.NewTestingLogger(t, ""))
-		for name, test := range tests {
-			t.Run(name, func(t *testing.T) {
-				out, err := g.normalizeValue(test.in)
-				if err != nil {
-					t.Error(err)
-					return
+	runTests := func(group string, check func(t *testing.T, a, b any), tests map[string]testCase) {
+		t.Run(group, func(t *testing.T) {
+			forEachMode(t, false, func(t *testing.T, g *GenericEventConverter) {
+				for name, test := range tests {
+					t.Run(name, func(t *testing.T) {
+						out, err := g.normalizeValue(test.in)
+						if err != nil {
+							t.Error(err)
+							return
+						}
+						check(t, test.out, out)
+					})
 				}
-				check(t, test.out, out)
 			})
-		}
+		})
 	}
 
 	checkEq := func(t *testing.T, a, b any) {
@@ -283,7 +298,7 @@ func TestNormalizeValue(t *testing.T) {
 	type myuint uint8
 	type myuint64 uint64
 
-	runTests(checkEq, map[string]testCase{
+	runTests("exact", checkEq, map[string]testCase{
 		"nil":                               {nil, nil},
 		"pointers are dereferenced":         {&someString, someString},
 		"drop nil string pointer":           {nilStringPtr, nil},
@@ -326,27 +341,78 @@ func TestNormalizeValue(t *testing.T) {
 		"array of custom uint64 masked": {[]myuint64{1<<63 + 64}, []any{uint64(64)}},
 	})
 
-	runTests(checkDelta, map[string]testCase{
+	runTests("in delta", checkDelta, map[string]testCase{
 		"float32 value": {float32(1), float64(1)},
 		"float64 value": {float64(1), float64(1)},
 	})
 }
 
-func TestNormalizeMapError(t *testing.T) {
-	badInputs := []mapstr.M{
-		{"func": func() {}},
-		{"chan": make(chan struct{})},
-		{"uintptr": uintptr(123)},
-	}
-
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(t, ""))
-	for i, in := range badInputs {
-		_, errs := g.normalizeMap(in, "bad.type")
-		if assert.Len(t, errs, 1) {
-			t.Log(errs[0])
-			assert.Contains(t, errs[0].Error(), "key=bad.type", "Test case %v", i)
+func TestNormalizeInPlace(t *testing.T) {
+	ts := time.Date(2026, 4, 13, 9, 23, 18, 0, time.UTC)
+	input := func() mapstr.M {
+		return mapstr.M{
+			"str":     "value",
+			"dropped": nil,
+			"ts":      ts,
+			"nested":  mapstr.M{"n": 1, "dropped": nil},
+			"list":    []mapstr.M{{"l": "a", "dropped": nil}, nil},
+			"nilList": []mapstr.M(nil),
+			"nilMap":  mapstr.M(nil),
 		}
 	}
+	want := mapstr.M{
+		"str":     "value",
+		"ts":      Time(ts),
+		"nested":  mapstr.M{"n": 1},
+		"list":    []mapstr.M{{"l": "a"}, {}},
+		"nilList": []mapstr.M{},
+		"nilMap":  mapstr.M{},
+	}
+
+	t.Run("copying leaves the input untouched", func(t *testing.T) {
+		in := input()
+		g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(t, ""))
+
+		out := g.Convert(in)
+
+		assert.Equal(t, want, out, "the input must be normalized")
+		assert.Equal(t, input(), in, "Convert must not modify the map it was given")
+
+		nested, ok := out["nested"].(mapstr.M)
+		require.True(t, ok, "nested map must stay a mapstr.M")
+		out["added"] = true
+		nested["added"] = true
+		assert.Equal(t, input(), in, "the converted event must not share maps with the input")
+	})
+
+	t.Run("in place normalizes the input itself", func(t *testing.T) {
+		in := input()
+		g := NewGenericEventConverter(false, true, logptest.NewTestingLogger(t, ""))
+
+		out := g.Convert(in)
+
+		assert.Equal(t, want, out, "the input must be normalized")
+		assert.Equal(t, want, in, "converting in place must normalize the map it was given")
+	})
+}
+
+func TestNormalizeMapError(t *testing.T) {
+	forEachMode(t, false, func(t *testing.T, g *GenericEventConverter) {
+		// Rebuilt per mode: converting in place drops the offending keys, so a
+		// second pass over the same maps would report no errors at all.
+		badInputs := []mapstr.M{
+			{"func": func() {}},
+			{"chan": make(chan struct{})},
+			{"uintptr": uintptr(123)},
+		}
+
+		for i, in := range badInputs {
+			_, errs := g.normalizeMap(in, "bad.type")
+			if assert.Len(t, errs, 1) {
+				assert.Contains(t, errs[0].Error(), "key=bad.type", "Test case %v", i)
+			}
+		}
+	})
 }
 
 func TestJoinKeys(t *testing.T) {
@@ -403,7 +469,7 @@ func TestNormalizeTime(t *testing.T) {
 	}
 
 	now := time.Now().In(ny)
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(t, ""))
+	g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(t, ""))
 	v, errs := g.normalizeValue(now, "@timestamp")
 	if len(errs) > 0 {
 		t.Fatal(errs)
@@ -418,9 +484,57 @@ func TestNormalizeTime(t *testing.T) {
 	assert.True(t, now.Equal(time.Time(utcCommonTime)))
 }
 
+// BenchmarkConvertEvent measures normalization of a realistic event. Every
+// iteration converts a fresh one, otherwise the in place converter would spend
+// all but the first iteration on an already normalized event.
+func BenchmarkConvertEvent(b *testing.B) {
+	newEvent := func() mapstr.M {
+		return mapstr.M{
+			"message": "2026-01-02T03:04:05.000Z INFO [publisher] pipeline/output.go:143 Connecting to backoff(elasticsearch(http://localhost:9200))",
+			"log": mapstr.M{
+				"level":  "info",
+				"logger": "publisher",
+				"offset": 12345,
+				"file":   mapstr.M{"path": "/var/log/filebeat/filebeat.log"},
+			},
+			"host": mapstr.M{
+				"name":         "host-01",
+				"architecture": "x86_64",
+				"ip":           []string{"10.0.0.4", "fe80::1"},
+				"os": mapstr.M{
+					"family": "debian", "kernel": "6.1.0", "name": "Ubuntu",
+					"platform": "ubuntu", "type": "linux", "version": "22.04.3 LTS",
+				},
+			},
+			"agent": mapstr.M{
+				"type": "filebeat", "version": "9.2.0", "name": "host-01",
+				"id": "8a4f500d-a42a-4f1d-b8c9-1a2b3c4d5e6f",
+			},
+			"ecs":    mapstr.M{"version": "8.11.0"},
+			"input":  mapstr.M{"type": "filestream"},
+			"event":  mapstr.M{"dataset": "filebeat.log", "module": "beat"},
+			"labels": mapstr.M{"env": "prod", "team": "platform"},
+		}
+	}
+
+	for _, mode := range normalizationModes {
+		b.Run(mode.name, func(b *testing.B) {
+			g := NewGenericEventConverter(false, mode.inPlace, logptest.NewTestingLogger(b, ""))
+			b.ReportAllocs()
+			for b.Loop() {
+				b.StopTimer()
+				event := newEvent()
+				b.StartTimer()
+
+				g.Convert(event)
+			}
+		})
+	}
+}
+
 // Uses TextMarshaler interface.
 func BenchmarkConvertToGenericEventNetString(b *testing.B) {
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
+	g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(b, ""))
 	for b.Loop() {
 		g.Convert(mapstr.M{"key": NetString("hola")})
 	}
@@ -428,7 +542,7 @@ func BenchmarkConvertToGenericEventNetString(b *testing.B) {
 
 // Uses the map[string]string fast path.
 func BenchmarkConvertToGenericEventMapStringString(b *testing.B) {
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
+	g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(b, ""))
 	for b.Loop() {
 		g.Convert(mapstr.M{"key": map[string]string{"greeting": "hola"}})
 	}
@@ -436,7 +550,7 @@ func BenchmarkConvertToGenericEventMapStringString(b *testing.B) {
 
 // Uses recursion to step into the nested mapstr.M.
 func BenchmarkConvertToGenericEventMapStr(b *testing.B) {
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
+	g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(b, ""))
 	for b.Loop() {
 		g.Convert(mapstr.M{"key": map[string]any{"greeting": "hola"}})
 	}
@@ -444,7 +558,7 @@ func BenchmarkConvertToGenericEventMapStr(b *testing.B) {
 
 // No reflection required.
 func BenchmarkConvertToGenericEventStringSlice(b *testing.B) {
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
+	g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(b, ""))
 	for b.Loop() {
 		g.Convert(mapstr.M{"key": []string{"foo", "bar"}})
 	}
@@ -452,7 +566,7 @@ func BenchmarkConvertToGenericEventStringSlice(b *testing.B) {
 
 // Uses reflection to convert the string array.
 func BenchmarkConvertToGenericEventCustomStringSlice(b *testing.B) {
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
+	g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(b, ""))
 	type myString string
 	for b.Loop() {
 		g.Convert(mapstr.M{"key": []myString{"foo", "bar"}})
@@ -461,7 +575,7 @@ func BenchmarkConvertToGenericEventCustomStringSlice(b *testing.B) {
 
 // Pointers require reflection to generically dereference.
 func BenchmarkConvertToGenericEventStringPointer(b *testing.B) {
-	g := NewGenericEventConverter(false, logptest.NewTestingLogger(b, ""))
+	g := NewGenericEventConverter(false, false, logptest.NewTestingLogger(b, ""))
 	val := "foo"
 	for b.Loop() {
 		g.Convert(mapstr.M{"key": &val})

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -46,7 +46,7 @@ type processorFn struct {
 
 func newGeneralizeProcessor(keepNull bool, logger *logp.Logger) *processorFn {
 	logger = logger.Named("publisher_processing")
-	g := common.NewGenericEventConverter(keepNull, logger)
+	g := common.NewGenericEventConverter(keepNull, false, logger)
 	return newProcessor("generalizeEvent", func(event *beat.Event) (*beat.Event, error) {
 		// Filter out empty events. Empty events are still reported by ACK callbacks.
 		if len(event.Fields) == 0 {


### PR DESCRIPTION
## Overview

```mermaid
---
config:
  layout: elk
---
flowchart LR
    FS["filebeat<br/>filestream"]
    MB["metricbeat<br/>other inputs"]

    subgraph PIPE["publisher pipeline &nbsp;·&nbsp; per client"]
        direction LR
        IP["normalize<br/>in place (<b>new!</b>)"]
        CP["normalize<br/>copy (old)"]
        ENR["enrich<br/>fields · tags · meta"]

        subgraph PROCS["processors"]
            direction LR
            SNAP(["snapshot"])
            MUT["mutate"]
            SNAP --> MUT
            MUT -. "on error" .-> SNAP
        end

        IP --> ENR
        CP --> ENR
        ENR --> SNAP
    end

    Q[("queue")]
    OUT["output"]
    ES(["Elasticsearch"])

    FS -- "hands over events" --> IP
    MB -- "keeps events" --> CP
    MUT --> Q --> OUT --> ES

    classDef inplace fill:#d5f0dd,stroke:#1a7f37,stroke-width:2px,color:#0b3d1c
    classDef copy fill:#eceff1,stroke:#90a4ae,color:#37474f
    classDef undo fill:#fff4d6,stroke:#b58900,stroke-dasharray:4 3,color:#5c4400
    classDef term fill:#e3f0fb,stroke:#1f6feb,color:#0a3069

    class FS,IP inplace
    class MB,CP copy
    class SNAP undo
    class ES term
```

## Proposed commit message

```text
libbeat/common: add opt-in in-place event normalization

GenericEventConverter allocates a new map for every map that it
normalizes. Add an option that normalizes the maps of an event in place,
reducing allocations. Only a caller that exclusively owns every
reachable map can use it.

Several producers keep a reference to the maps that they hand to the
pipeline:

- The statsd server of metricbeat shares one labels map across every
  event in a batch.
- The prometheus query metricset shares result.Metric in the same way.
- The kubernetes metricsets add one cached clusterMeta map to every
  event.

In-place normalization corrupts those maps and races with the producer.

Benchmarks:

goos: linux
goarch: amd64
pkg: github.com/elastic/beats/v7/libbeat/common
cpu: Intel(R) Core(TM) Ultra 7 265U
                │    copy     │               inplace               │
                │   sec/op    │   sec/op     vs base                │
ConvertEvent-14   2.201µ ± 3%   1.886µ ± 3%  -14.29% (p=0.000 n=10)

                │    copy     │              inplace               │
                │    B/op     │    B/op     vs base                │
ConvertEvent-14   3360.0 ± 0%   616.0 ± 0%  -81.67% (p=0.000 n=10)

                │    copy     │              inplace               │
                │  allocs/op  │ allocs/op   vs base                │
ConvertEvent-14   20.000 ± 0%   3.000 ± 0%  -85.00% (p=0.000 n=10)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None.

## How to test this PR locally

```shell
go test -race ./libbeat/common/
go test -run '^$' -bench '^BenchmarkConvertEvent$' -benchmem -count 10 ./libbeat/common/
```

## Related issues

- Relates #49221

## Use cases

Callers that can prove exclusive ownership of an event field tree can normalize its maps without allocating detached copies.
