### PR TITLE
libbeat/publisher: let clients opt into in-place event normalization

### DIFF
--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -146,6 +146,11 @@ type ProcessingConfig struct {
 	// is applied to events. If nil the Beat's default behavior prevails.
 	EventNormalization *bool
 
+	// NormalizeInPlace lets event normalization reuse Event.Fields maps. Set it
+	// only if the producer exclusively owns every reachable map and never
+	// accesses them after Publish.
+	NormalizeInPlace bool
+
 	// Disables the addition of input.type
 	DisableType bool
 

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -146,6 +146,11 @@ type ProcessingConfig struct {
 	// is applied to events. If nil the Beat's default behavior prevails.
 	EventNormalization *bool
 
+	// NormalizeInPlace lets event normalization reuse Event.Fields maps. Set it
+	// only if the producer exclusively owns every reachable map and never
+	// accesses them after Publish; later processors may mutate them too.
+	NormalizeInPlace bool
+
 	// Disables the addition of input.type
 	DisableType bool
 

--- a/libbeat/publisher/processing/default.go
+++ b/libbeat/publisher/processing/default.go
@@ -324,10 +324,10 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 	// setup 1: generalize/normalize output (P)
 	if cfg.EventNormalization != nil {
 		if *cfg.EventNormalization {
-			processors.add(newGeneralizeProcessor(cfg.KeepNull, b.log))
+			processors.add(newGeneralizeProcessor(cfg.KeepNull, cfg.NormalizeInPlace, b.log))
 		}
 	} else if !b.skipNormalize {
-		processors.add(newGeneralizeProcessor(cfg.KeepNull, b.log))
+		processors.add(newGeneralizeProcessor(cfg.KeepNull, cfg.NormalizeInPlace, b.log))
 	}
 
 	// setup 2: add Meta from client config (C)

--- a/libbeat/publisher/processing/default_test.go
+++ b/libbeat/publisher/processing/default_test.go
@@ -347,21 +347,29 @@ func TestEventNormalizationOverride(t *testing.T) {
 func TestNormalization(t *testing.T) {
 	cases := map[string]struct {
 		normalize bool
+		inPlace   bool
 		in        mapstr.M
 		mod       mapstr.M
 		want      mapstr.M
 	}{
 		"no sharing if normalized": {
 			normalize: true,
-			in:        mapstr.M{"a": "b"},
-			mod:       mapstr.M{"change": "x"},
-			want:      mapstr.M{"a": "b"},
+			in:        mapstr.M{"a": "b", "nested": mapstr.M{"n": "1"}},
+			mod:       mapstr.M{"change": "x", "nested": mapstr.M{"deep": "y"}},
+			want:      mapstr.M{"a": "b", "nested": mapstr.M{"n": "1"}},
 		},
 		"data sharing if not normalized": {
 			normalize: false,
 			in:        mapstr.M{"a": "b"},
 			mod:       mapstr.M{"change": "x"},
 			want:      mapstr.M{"a": "b", "change": "x"},
+		},
+		"data sharing if normalized in place": {
+			normalize: true,
+			inPlace:   true,
+			in:        mapstr.M{"a": "b", "drop": nil, "nested": mapstr.M{"n": "1", "drop": nil}},
+			mod:       mapstr.M{"change": "x", "nested": mapstr.M{"deep": "y"}},
+			want:      mapstr.M{"a": "b", "change": "x", "nested": mapstr.M{"n": "1", "deep": "y"}},
 		},
 	}
 
@@ -372,7 +380,7 @@ func TestNormalization(t *testing.T) {
 			s, err := MakeDefaultSupport(test.normalize, nil)(beat.Info{Paths: tmpPaths(t)}, logp.L(), config.NewConfig())
 			require.NoError(t, err)
 
-			prog, err := s.Create(beat.ProcessingConfig{}, false)
+			prog, err := s.Create(beat.ProcessingConfig{NormalizeInPlace: test.inPlace}, false)
 			require.NoError(t, err)
 
 			fields := test.in.Clone()

--- a/libbeat/publisher/processing/default_test.go
+++ b/libbeat/publisher/processing/default_test.go
@@ -347,21 +347,31 @@ func TestEventNormalizationOverride(t *testing.T) {
 func TestNormalization(t *testing.T) {
 	cases := map[string]struct {
 		normalize bool
+		inPlace   bool
 		in        mapstr.M
 		mod       mapstr.M
 		want      mapstr.M
 	}{
 		"no sharing if normalized": {
 			normalize: true,
-			in:        mapstr.M{"a": "b"},
-			mod:       mapstr.M{"change": "x"},
-			want:      mapstr.M{"a": "b"},
+			in:        mapstr.M{"a": "b", "nested": mapstr.M{"n": "1"}},
+			mod:       mapstr.M{"change": "x", "nested": mapstr.M{"deep": "y"}},
+			want:      mapstr.M{"a": "b", "nested": mapstr.M{"n": "1"}},
 		},
 		"data sharing if not normalized": {
 			normalize: false,
 			in:        mapstr.M{"a": "b"},
 			mod:       mapstr.M{"change": "x"},
 			want:      mapstr.M{"a": "b", "change": "x"},
+		},
+		// The dropped nil values tell normalizing in place apart from not
+		// normalizing at all, which shares data just the same.
+		"data sharing if normalized in place": {
+			normalize: true,
+			inPlace:   true,
+			in:        mapstr.M{"a": "b", "drop": nil, "nested": mapstr.M{"n": "1", "drop": nil}},
+			mod:       mapstr.M{"change": "x", "nested": mapstr.M{"deep": "y"}},
+			want:      mapstr.M{"a": "b", "change": "x", "nested": mapstr.M{"n": "1", "deep": "y"}},
 		},
 	}
 
@@ -372,7 +382,7 @@ func TestNormalization(t *testing.T) {
 			s, err := MakeDefaultSupport(test.normalize, nil)(beat.Info{Paths: tmpPaths(t)}, logp.L(), config.NewConfig())
 			require.NoError(t, err)
 
-			prog, err := s.Create(beat.ProcessingConfig{}, false)
+			prog, err := s.Create(beat.ProcessingConfig{NormalizeInPlace: test.inPlace}, false)
 			require.NoError(t, err)
 
 			fields := test.in.Clone()

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -44,9 +44,9 @@ type processorFn struct {
 	fn   func(event *beat.Event) (*beat.Event, error)
 }
 
-func newGeneralizeProcessor(keepNull bool, logger *logp.Logger) *processorFn {
+func newGeneralizeProcessor(keepNull, normalizeInPlace bool, logger *logp.Logger) *processorFn {
 	logger = logger.Named("publisher_processing")
-	g := common.NewGenericEventConverter(keepNull, false, logger)
+	g := common.NewGenericEventConverter(keepNull, normalizeInPlace, logger)
 	return newProcessor("generalizeEvent", func(event *beat.Event) (*beat.Event, error) {
 		// Filter out empty events. Empty events are still reported by ACK callbacks.
 		if len(event.Fields) == 0 {

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -44,9 +44,16 @@ type processorFn struct {
 	fn   func(event *beat.Event) (*beat.Event, error)
 }
 
-func newGeneralizeProcessor(keepNull bool, logger *logp.Logger) *processorFn {
+func newGeneralizeProcessor(keepNull, normalizeInPlace bool, logger *logp.Logger) *processorFn {
 	logger = logger.Named("publisher_processing")
-	g := common.NewGenericEventConverter(keepNull, logger)
+
+	var g *common.GenericEventConverter
+	if normalizeInPlace {
+		g = common.NewGenericEventConverterInPlace(keepNull, logger)
+	} else {
+		g = common.NewGenericEventConverter(keepNull, logger)
+	}
+
 	return newProcessor("generalizeEvent", func(event *beat.Event) (*beat.Event, error) {
 		// Filter out empty events. Empty events are still reported by ACK callbacks.
 		if len(event.Fields) == 0 {


### PR DESCRIPTION
## Proposed commit message

```text
libbeat/publisher: let clients opt into in-place event normalization

The generalize processor is the first thing that runs on a published
event, so whether it copies decides whether everything after it mutates
the producer's maps or a private copy.

Expose the choice on ProcessingConfig so a producer that hands over
ownership can avoid the copy. Defaults to copying.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None. Publisher clients retain copying normalization unless they explicitly opt in.

## How to test this PR locally

```shell
go test -race ./libbeat/common/ ./libbeat/publisher/processing/
timeout 5m script/stresstest.sh --race ./libbeat/publisher/processing '^TestNormalization$' -p 32
```

## Related issues

- Relates #49221
