### PR TITLE
[text-auditor] Fix clear runtime typos in diskqueue, Kafka, and logv2

### DIFF
--- a/libbeat/publisher/queue/diskqueue/segments.go
+++ b/libbeat/publisher/queue/diskqueue/segments.go
@@ -549,7 +549,7 @@ func (w *segmentWriter) UpdateCount(count uint32) error {
 	// Seek to count on disk
 	_, err = w.dst.Seek(4, io.SeekStart)
 	if err != nil {
-		return fmt.Errorf("cound not seek to count position: %w", err)
+		return fmt.Errorf("could not seek to count position: %w", err)
 	}
 	// Write the count
 	err = binary.Write(w.dst, binary.LittleEndian, count)


### PR DESCRIPTION
## Proposed commit message

This PR fixes the documentation issue reported in #52480: corrects `cound not seek to count position: %w` to `could not seek to count position: %w` in `libbeat/publisher/queue/diskqueue/segments.go`.

Fixes #52480

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

## How to test this PR locally

## Related issues

-

## Use cases

## Screenshots

## Logs

Fixes #52480