### PR TITLE
add user-agent to httpjson pagination requests

### DIFF
--- a/changelog/fragments/1786038679-add-user-agent-to-httpjson-pagination-requests.yaml
+++ b/changelog/fragments/1786038679-add-user-agent-to-httpjson-pagination-requests.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: add user-agent to httpjson pagination requests
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -65,15 +65,15 @@ func newRetryLogger(log *logp.Logger) *retryLogger {
 	}
 }
 
-func (log *retryLogger) Error(msg string, keysAndValues ...interface{}) {
+func (log *retryLogger) Error(msg string, keysAndValues ...any) {
 	log.log.Errorw(msg, keysAndValues...)
 }
 
-func (log *retryLogger) Info(msg string, keysAndValues ...interface{}) {
+func (log *retryLogger) Info(msg string, keysAndValues ...any) {
 	log.log.Infow(msg, keysAndValues...)
 }
 
-func (log *retryLogger) Debug(msg string, keysAndValues ...interface{}) {
+func (log *retryLogger) Debug(msg string, keysAndValues ...any) {
 	log.log.Debugw(msg, keysAndValues...)
 }
 
@@ -98,7 +98,7 @@ type redact struct {
 func (r redact) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	v, err := private.Redact(r.value, "", r.fields)
 	if err != nil {
-		return fmt.Errorf("could not redact value: %v", err)
+		return fmt.Errorf("could not redact value: %w", err)
 	}
 	return v.MarshalLogObject(enc)
 }
@@ -156,7 +156,8 @@ func test(url *url.URL) error {
 		return "80"
 	}()
 
-	_, err := net.DialTimeout("tcp", net.JoinHostPort(url.Hostname(), port), time.Second)
+	d := &net.Dialer{Timeout: time.Second}
+	_, err := d.DialContext(context.Background(), "tcp", net.JoinHostPort(url.Hostname(), port))
 	if err != nil {
 		return fmt.Errorf("url %q is unreachable", url)
 	}
@@ -446,7 +447,8 @@ type socketDialer struct {
 }
 
 func (d socketDialer) Dial(_, _ string) (net.Conn, error) {
-	return net.Dial("unix", d.path)
+	var nd net.Dialer
+	return nd.DialContext(context.Background(), "unix", d.path)
 }
 
 func (d socketDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
@@ -470,7 +472,7 @@ func checkRedirect(config *requestConfig, log *logp.Logger) func(*http.Request, 
 		prev := via[len(via)-1] // previous request to get headers from
 
 		log.Debugf("http client: forwarding headers from previous request: %#v", prev.Header)
-		req.Header = prev.Header.Clone()
+		req.Header = prev.Header.Clone() //nolint:gosec // G119: sensitive headers are removed below for cross-origin redirects via config.RedirectSensitiveHeaders
 
 		if req.URL.Host != prev.URL.Host || (prev.URL.Scheme == "https" && req.URL.Scheme == "http") {
 			for _, k := range config.RedirectSensitiveHeaders {

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -77,7 +77,7 @@ func (log *retryLogger) Debug(msg string, keysAndValues ...any) {
 	log.log.Debugw(msg, keysAndValues...)
 }
 
-func (log *retryLogger) Warn(msg string, keysAndValues ...interface{}) {
+func (log *retryLogger) Warn(msg string, keysAndValues ...any) {
 	log.log.Warnw(msg, keysAndValues...)
 }
 
@@ -133,11 +133,11 @@ func (m mapstrM) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func tryToMapStr(v interface{}) (mapstrM, bool) {
+func tryToMapStr(v any) (mapstrM, bool) {
 	switch m := v.(type) {
 	case mapstrM:
 		return m, true
-	case map[string]interface{}:
+	case map[string]any:
 		return mapstrM(m), true
 	default:
 		return nil, false

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -234,7 +234,7 @@ func run(ctx v2.Context, cfg config, pub inputcursor.Publisher, crsr *inputcurso
 			return err
 		}
 	}
-	pagination := newPagination(cfg, client, ctx, log)
+	pagination := newPagination(cfg, client, ctx, log, ctx.Agent.UserAgent)
 	responseProcessor := newResponseProcessor(cfg, pagination, xmlDetails, metrics, ctx, log)
 	requester := newRequester(client, requestFactory, responseProcessor, metrics, ctx, log)
 

--- a/x-pack/filebeat/input/httpjson/pagination.go
+++ b/x-pack/filebeat/input/httpjson/pagination.go
@@ -28,7 +28,7 @@ type pagination struct {
 	log            *logp.Logger
 }
 
-func newPagination(config config, client *httpClient, stat status.StatusReporter, log *logp.Logger) *pagination {
+func newPagination(config config, client *httpClient, stat status.StatusReporter, log *logp.Logger, userAgent string) *pagination {
 	pagination := &pagination{client: client, status: stat, log: log}
 	if config.Response == nil {
 		return pagination
@@ -69,12 +69,13 @@ func newPagination(config config, client *httpClient, stat status.StatusReporter
 		allowedOrigins,
 		stat,
 		log,
+		userAgent,
 	)
 	pagination.requestFactory = requestFactory
 	return pagination
 }
 
-func newPaginationRequestFactory(method, encodeAs string, u url.URL, body *mapstr.M, ts []basicTransform, authConfig *authConfig, allowedOrigins []*url.URL, stat status.StatusReporter, log *logp.Logger) *requestFactory {
+func newPaginationRequestFactory(method, encodeAs string, u url.URL, body *mapstr.M, ts []basicTransform, authConfig *authConfig, allowedOrigins []*url.URL, stat status.StatusReporter, log *logp.Logger, userAgent string) *requestFactory {
 	// config validation already checked for errors here
 	rf := &requestFactory{
 		url:            u,
@@ -82,6 +83,7 @@ func newPaginationRequestFactory(method, encodeAs string, u url.URL, body *mapst
 		body:           body,
 		transforms:     ts,
 		log:            log,
+		userAgent:      userAgent,
 		encoder:        registeredEncoders[encodeAs],
 		originURL:      &u,
 		allowedOrigins: allowedOrigins,

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -60,7 +60,7 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	config := defaultConfig()
 	assert.NoError(t, cfg.Unpack(&config))
 
-	log := logp.NewLogger("")
+	log := logptest.NewTestingLogger(t, "")
 	ctx := context.Background()
 	client, err := newHTTPClient(ctx, config.Auth, config.Request, noopReporter{}, log, nil, nil)
 	assert.NoError(t, err)
@@ -78,17 +78,17 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	// first request
 	assert.NoError(t, requester.doRequest(ctx, trCtx, statelessPublisher{&beattest.FakeClient{}}))
 
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		mapstr.M{"timestamp": "2002-10-02T15:00:00Z"},
 		trCtx.cursorMap(),
 	)
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
 		trCtx.firstEvent,
 	)
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
 		trCtx.lastEvent,
@@ -143,7 +143,7 @@ func TestCtxAfterDoRequest(t *testing.T) {
 
 func Test_newRequestFactory_UsesBasicAuthInChainedRequests(t *testing.T) {
 	ctx := context.Background()
-	log := logp.NewLogger("")
+	log := logptest.NewTestingLogger(t, "")
 	cfg := defaultChainConfig()
 
 	url, _ := url.Parse("https://example.com")
@@ -213,7 +213,7 @@ func Test_newChainHTTPClient(t *testing.T) {
 	cfg := defaultChainConfig()
 	cfg.Request.URL = &urlConfig{URL: &url.URL{}}
 	ctx := context.Background()
-	log := logp.NewLogger("newChainClientTestLogger")
+	log := logptest.NewTestingLogger(t, "newChainClientTestLogger")
 
 	type args struct {
 		ctx        context.Context

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -37,21 +37,21 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	testServer := httptest.NewServer(dateCursorHandler())
 	t.Cleanup(testServer.Close)
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"interval":       1,
 		"request.method": "GET",
 		"request.url":    testServer.URL,
-		"request.transforms": []interface{}{
-			map[string]interface{}{
-				"set": map[string]interface{}{
+		"request.transforms": []any{
+			map[string]any{
+				"set": map[string]any{
 					"target":  "url.params.$filter",
 					"value":   "alertCreationTime ge [[.cursor.timestamp]]",
 					"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
 				},
 			},
 		},
-		"cursor": map[string]interface{}{
-			"timestamp": map[string]interface{}{
+		"cursor": map[string]any{
+			"timestamp": map[string]any{
 				"value": `[[index .last_response.body "@timestamp"]]`,
 			},
 		},
@@ -97,7 +97,7 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	// ignore since has dynamic date and content length values
 	// and is not relevant
 	lastResp.header = nil
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		&response{
 			page: 0,
@@ -110,19 +110,19 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	// second request
 	assert.NoError(t, requester.doRequest(ctx, trCtx, statelessPublisher{&beattest.FakeClient{}}))
 
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		mapstr.M{"timestamp": "2002-10-02T15:00:01Z"},
 		trCtx.cursorMap(),
 	)
 
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
 		trCtx.firstEvent,
 	)
 
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		&mapstr.M{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
 		trCtx.lastEvent,
@@ -130,7 +130,7 @@ func TestCtxAfterDoRequest(t *testing.T) {
 
 	lastResp = trCtx.lastResponse.clone()
 	lastResp.header = nil
-	assert.EqualValues(
+	assert.Equal(
 		t,
 		&response{
 			page: 0,
@@ -247,7 +247,7 @@ func Test_newChainHTTPClient(t *testing.T) {
 }
 
 func Test_evaluateResponse(t *testing.T) {
-	log := logp.NewLogger("newEvaluateResponseTestLogger")
+	log := logptest.NewTestingLogger(t, "newEvaluateResponseTestLogger")
 	responseTrue := bytes.NewBufferString(`{"status": "completed"}`).Bytes()
 	responseFalse := bytes.NewBufferString(`{"status": "initiated"}`).Bytes()
 
@@ -461,7 +461,7 @@ func TestPaginationRejectsCrossOriginURL(t *testing.T) {
 		url:        *base,
 		method:     "GET",
 		originURL:  base,
-		log:        logp.NewLogger("test"),
+		log:        logptest.NewTestingLogger(t, "test"),
 		encoder:    registeredEncoders[""],
 		transforms: []basicTransform{},
 	}

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	beattest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -66,7 +67,7 @@ func TestCtxAfterDoRequest(t *testing.T) {
 
 	requestFactory, err := newRequestFactory(ctx, config, noopReporter{}, log, nil, nil, "")
 	assert.NoError(t, err)
-	pagination := newPagination(config, client, noopReporter{}, log)
+	pagination := newPagination(config, client, noopReporter{}, log, "")
 	responseProcessor := newResponseProcessor(config, pagination, nil, nil, noopReporter{}, log)
 
 	requester := newRequester(client, requestFactory, responseProcessor, nil, noopReporter{}, log)
@@ -96,10 +97,11 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	// ignore since has dynamic date and content length values
 	// and is not relevant
 	lastResp.header = nil
-	assert.EqualValues(t,
+	assert.EqualValues(
+		t,
 		&response{
 			page: 0,
-			url:  *(newURL(fmt.Sprintf("%s?%s", testServer.URL, "%24filter=alertCreationTime+ge+2002-10-02T14%3A50%3A00Z"))),
+			url:  *newURL(fmt.Sprintf("%s?%s", testServer.URL, "%24filter=alertCreationTime+ge+2002-10-02T14%3A50%3A00Z")),
 			body: mapstr.M{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
 		},
 		lastResp,
@@ -128,10 +130,11 @@ func TestCtxAfterDoRequest(t *testing.T) {
 
 	lastResp = trCtx.lastResponse.clone()
 	lastResp.header = nil
-	assert.EqualValues(t,
+	assert.EqualValues(
+		t,
 		&response{
 			page: 0,
-			url:  *(newURL(fmt.Sprintf("%s?%s", testServer.URL, "%24filter=alertCreationTime+ge+2002-10-02T15%3A00%3A00Z"))),
+			url:  *newURL(fmt.Sprintf("%s?%s", testServer.URL, "%24filter=alertCreationTime+ge+2002-10-02T15%3A00%3A00Z")),
 			body: mapstr.M{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
 		},
 		lastResp,
@@ -193,7 +196,6 @@ func Test_newRequestFactory_UsesBasicAuthInChainedRequests(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			tt.args.cfg.Chain[0].Step = tt.args.step
 			tt.args.cfg.Chain[0].While = tt.args.while
 			requestFactories, err := newRequestFactory(ctx, tt.args.cfg, noopReporter{}, log, nil, nil, "")
@@ -203,7 +205,6 @@ func Test_newRequestFactory_UsesBasicAuthInChainedRequests(t *testing.T) {
 				assert.Equal(t, rf.user, user)
 				assert.Equal(t, rf.password, password)
 			}
-
 		})
 	}
 }
@@ -559,6 +560,16 @@ func TestChainStepOriginValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPaginationRequestFactorySetsUserAgent(t *testing.T) {
+	const wantUA = "Elastic-Filebeat/9.5.0 (linux; amd64)"
+	u, _ := url.Parse("https://api.example.com/v1/events")
+	rf := newPaginationRequestFactory("GET", "", *u, &mapstr.M{}, nil, nil, nil, noopReporter{}, logptest.NewTestingLogger(t, t.Name()), wantUA)
+
+	req, err := rf.newRequest(emptyTransformContext())
+	require.NoError(t, err)
+	assert.Equal(t, wantUA, req.header().Get("User-Agent"))
 }
 
 func defaultChainConfig() config {


### PR DESCRIPTION
## Proposed commit message

WHAT: newPaginationRequestFactory in x-pack/filebeat/input/httpjson/pagination.go was not populating the userAgent field of the requestFactory it returned. As a result, paginated requests (page 2 onward) were sent without a User-Agent header. Go's net/http omits headers set to the empty string entirely, so the wire-level request carried no UA.

WHY: In 9.5.0 the User-Agent began flowing through requestFactory.userAgent and being stamped onto each request in newRequest(). newRequestFactory was updated to accept and propagate a userAgent string, but newPaginationRequestFactory was not. The fix adds a userAgent string parameter to newPaginationRequestFactory (and to newPagination which calls it), then sets rf.userAgent in the factory initializer. The call site in input.go passes ctx.Agent.UserAgent, the same value used for the initial request factory. A unit test on newPaginationRequestFactory directly asserts the header is set on the produced request.

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. This restores the behavior present in 9.4.x. Users who added the delete + set transform workaround documented in issue #52483 may remove it, but it will continue to work correctly.

## How to test this PR locally

```
go test ./x-pack/filebeat/input/httpjson/... -run TestPaginationRequestFactorySetsUserAgent -v
```

## Related issues

- Closes #52483

## Use cases



## Screenshots



## Logs


