### PR TITLE
filestream: rename "Enhanced Fingerprint" to "growing fingerprint"

### DIFF
--- a/changelog/fragments/1786106224-filestream-growing-fingerprint-rename.yaml
+++ b/changelog/fragments/1786106224-filestream-growing-fingerprint-rename.yaml
@@ -1,0 +1,47 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: other
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: The filestream "Enhanced Fingerprint" feature is now called "growing fingerprint".
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  Only the name changes. The `file_identity.fingerprint.growing` setting, its
+  default, and the behavior it controls are unchanged.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/docs/reference/filebeat/file-identity.md
+++ b/docs/reference/filebeat/file-identity.md
@@ -58,7 +58,7 @@ Here is the brief high-level comparison of all currently available options:
 | path | Files are never moved or renamed, file names are never re-used. | Simple and fast. | The most unstable option, requires to maintain immutable file paths. |
 | native (default in Filebeat < 9.0) | Stable file systems, files < 64 bytes in size, ingestion without delays. | Low CPU / memory overhead. | Might cause data duplication or data loss if the file system provides unstable `inode` or `device ID` values. No support for network shares, containers or VMs.
 | inode_marker | Same as `native` but `device ID` is changing. | Same as `native` + no dependency on `device ID`. | Can still cause data duplication or data loss due to unstable `inode` values provided by the file system. Also, no support for network shares, containers or VMs. |
-| fingerprint (default in Filebeat >= 9.0) | Log files with unique content.<br><br>{applies_to}`stack: ga 9.5+` Log files of any size (enhanced fingerprint).<br><br>{applies_to}`stack: ga 9.0-9.4` Log files larger than the fingerprint size (1 KB by default). | The most stable. Support for any OS, any file system, network shares, containers and VMs.<br><br>{applies_to}`stack: ga 9.5+` Ingests files smaller than the fingerprint size without delay. | Slightly higher CPU / memory usage.<br><br>{applies_to}`stack: ga 9.0-9.4` Doesn't ingest files until they reach the fingerprint size (1 KB by default). |
+| fingerprint (default in Filebeat >= 9.0) | Log files with unique content.<br><br>{applies_to}`stack: ga 9.5+` Log files of any size (growing fingerprint).<br><br>{applies_to}`stack: ga 9.0-9.4` Log files larger than the fingerprint size (1 KB by default). | The most stable. Support for any OS, any file system, network shares, containers and VMs.<br><br>{applies_to}`stack: ga 9.5+` Ingests files smaller than the fingerprint size without delay. | Slightly higher CPU / memory usage.<br><br>{applies_to}`stack: ga 9.0-9.4` Doesn't ingest files until they reach the fingerprint size (1 KB by default). |
 
 ### `path`
 
@@ -186,15 +186,15 @@ file_identity.fingerprint: ~
 
 {applies_to}`stack: ga 9.0-9.4` If a new log file appears, the filestream input doesn’t register it until it grows to 1056 bytes (`offset`+`length`). Files that don't grow to that size are not ingested.
 
-{applies_to}`stack: ga 9.5+` This limitation is removed by default. Refer to [Enhanced fingerprint](#file-identity-fingerprint-growing) for details.
+{applies_to}`stack: ga 9.5+` This limitation is removed by default. Refer to [growing fingerprint](#file-identity-fingerprint-growing) for details.
 
-#### Enhanced fingerprint [file-identity-fingerprint-growing]
+#### Growing fingerprint [file-identity-fingerprint-growing]
 
 ```{applies_to}
 stack: ga 9.5.0+
 ```
 
-Enhanced fingerprint, controlled by `file_identity.fingerprint.growing`, is enabled by default and lets the filestream input track files that are smaller than the fingerprint size (`offset`+`length`) instead of skipping them until they grow large enough.
+Growing fingerprint, controlled by `file_identity.fingerprint.growing`, is enabled by default and lets the filestream input track files that are smaller than the fingerprint size (`offset`+`length`) instead of skipping them until they grow large enough.
 
 While a file is smaller than `offset`+`length`, it is tracked using the raw bytes available from `offset` to the end of the file, and its identity follows the content as the file grows. Once the file reaches `offset`+`length`, its identity becomes the regular SHA-256 fingerprint — byte-for-byte identical to the value the static fingerprint produces for the same bytes — and its registry entry is migrated automatically. No data is re-ingested and no duplicate registry entries are created.
 
@@ -214,7 +214,7 @@ Earlier Filebeat versions do not understand the tracking information used for th
 Files that had already reached the fingerprint size before rollback are not affected.
 ::::
 
-You don't need to configure `rotation.external.strategy: copytruncate` when using the `fingerprint` file identity. Because the fingerprint follows the file content, the input detects copytruncate rotation on its own: after the active file is copied to its rotated name and then truncated, the rotated file keeps its identity and offset, while the truncated active file is picked up as a new file. If you do set `rotation.external.strategy: copytruncate` with the `fingerprint` file identity, it is ignored, and enhanced fingerprint remains enabled.
+You don't need to configure `rotation.external.strategy: copytruncate` when using the `fingerprint` file identity. Because the fingerprint follows the file content, the input detects copytruncate rotation on its own: after the active file is copied to its rotated name and then truncated, the rotated file keeps its identity and offset, while the truncated active file is picked up as a new file. If you do set `rotation.external.strategy: copytruncate` with the `fingerprint` file identity, it is ignored, and growing fingerprint remains enabled.
 
 To opt out and restore the pre-9.5 behavior, where files smaller than `offset`+`length` are not ingested until they reach that size, set `growing` to `false`:
 

--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -208,7 +208,7 @@ Any unsupported change in `file_identity` methods between runs may result in dup
 
 `fingerprint` is the recommended file identity and the default in 9.0 and later. It does not rely on the file system or operating system. Instead, it generates a hash from part of the file (the first 1024 bytes by default) and uses that hash to identify the file. This works well with log rotation strategies that move or rename files and on Windows, where file identifiers might be more volatile.
 
-{applies_to}`stack: ga 9.5+` The [Enhanced fingerprint](/reference/filebeat/file-identity.md#file-identity-fingerprint-growing) behavior (`file_identity.fingerprint.growing`, enabled by default) tracks files smaller than the fingerprint size, so they are ingested without delay. In earlier versions, Filebeat waits until the file reaches 1024 bytes before ingesting it.
+{applies_to}`stack: ga 9.5+` The [growing fingerprint](/reference/filebeat/file-identity.md#file-identity-fingerprint-growing) behavior (`file_identity.fingerprint.growing`, enabled by default) tracks files smaller than the fingerprint size, so they are ingested without delay. In earlier versions, Filebeat waits until the file reaches 1024 bytes before ingesting it.
 
 ::::{warning}
 Once this file identity is enabled, changing the fingerprint configuration (offset, length, etc) will lead to a global re-ingestion of all files that match the paths configuration of the input.
@@ -445,7 +445,7 @@ $$$filebeat-input-filestream-file-identity-fingerprint$$$
     ```
 
     `growing` {applies_to}`stack: ga 9.5.0+`
-  :   When `true` (default), files smaller than the fingerprint size (`offset` + `length`) are tracked using the bytes available so far, instead of being skipped until they grow large enough. Once a file reaches the fingerprint size, it's automatically migrated to the regular SHA-256 fingerprint, with no data duplication. Refer to [Enhanced fingerprint](/reference/filebeat/file-identity.md#file-identity-fingerprint-growing) for details.
+  :   When `true` (default), files smaller than the fingerprint size (`offset` + `length`) are tracked using the bytes available so far, instead of being skipped until they grow large enough. Once a file reaches the fingerprint size, it's automatically migrated to the regular SHA-256 fingerprint, with no data duplication. Refer to [growing fingerprint](/reference/filebeat/file-identity.md#file-identity-fingerprint-growing) for details.
 
       Set to `false` to restore the pre-9.5 behavior.
 
@@ -1220,7 +1220,7 @@ Following are some scenarios where this can happen:
 ::::{warning}
 {applies_to}`stack: ga 9.0-9.4` Enabling fingerprint mode delays ingesting new files until they grow to at least `offset`+`length` bytes in size. Until then, these files are ignored.
 
-{applies_to}`stack: ga 9.5+` Enhanced fingerprint tracks smaller files by default. The ingestion delay applies only when `file_identity.fingerprint.growing` is set to `false`.
+{applies_to}`stack: ga 9.5+` Growing fingerprint tracks smaller files by default. The ingestion delay applies only when `file_identity.fingerprint.growing` is set to `false`.
 ::::
 
 Normally, log lines contain timestamps and other unique fields that make the default fingerprint range suitable. Inspect your logs to determine appropriate `offset` and `length` values. The default `offset` is `0`, and the default `length` is `1024` bytes. `length` cannot be less than `64` bytes.

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -448,7 +448,7 @@ filebeat.inputs:
   # if the fingerprints match, then the files are considered equal.
   #file_identity.fingerprint: ~
 
-  # Enhanced Fingerprint behavior. When enabled (the default since 9.5),
+  # Growing fingerprint behavior. When enabled (the default since 9.5),
   # files smaller than the configured fingerprint size (prospector.scanner
   # .fingerprint.offset + length) are tracked using the raw bytes available
   # so far, instead of being skipped until they grow large enough. Once a

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -867,7 +867,7 @@ filebeat.inputs:
   # if the fingerprints match, then the files are considered equal.
   #file_identity.fingerprint: ~
 
-  # Enhanced Fingerprint behavior. When enabled (the default since 9.5),
+  # Growing fingerprint behavior. When enabled (the default since 9.5),
   # files smaller than the configured fingerprint size (prospector.scanner
   # .fingerprint.offset + length) are tracked using the raw bytes available
   # so far, instead of being skipped until they grow large enough. Once a

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -84,11 +84,10 @@ type fingerprintConfig struct {
 	Enabled bool  `config:"enabled"`
 	Offset  int64 `config:"offset"`
 	Length  int64 `config:"length"`
-	// Growing enables Enhanced Fingerprint behaviour: files smaller than
-	// Offset+Length are tracked using the raw bytes from Offset to the file's
-	// end (hex-encoded). When a file reaches the threshold, its registry key
-	// migrates to the same SHA-256 hex the static fingerprint produces, so
-	// existing static-fingerprint state is preserved.
+	// Growing tracks files smaller than Offset+Length using the raw bytes
+	// from Offset to the file's end (hex-encoded). When a file reaches the
+	// threshold, its registry key migrates to the same SHA-256 hex the static
+	// fingerprint produces, so existing static-fingerprint state is preserved.
 	//
 	// Not user-configurable here: the YAML key under prospector.scanner.fingerprint
 	// is silently ignored. The user-facing knob is file_identity.fingerprint.growing;

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -277,8 +277,8 @@ func (w *fileWatcher) watch(
 	//   1. Exact-FileID rename match — works for every identity including
 	//      static fingerprint. Catches a plain rename where the file's
 	//      content (and so its fingerprint) is unchanged.
-	//   2. Prefix-match rename detection (Enhanced Fingerprint / growing
-	//      mode only) — catches rename + content growth in the same scan.
+	//   2. Prefix-match rename detection (growing fingerprint only) —
+	//      catches rename + content growth in the same scan.
 	//   3. Postpone deletes for entries under an unobservable prefix. Runs
 	//      AFTER both rename passes so a file renamed out of a directory that
 	//      became unobservable this scan is still detected as a rename, instead

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -2997,7 +2997,7 @@ func TestToFileDescriptor_TooSmallFile_NoFileOpen(t *testing.T) {
 		"expected errFileTooSmall, it probably tried to open the file")
 }
 
-// TestToFileDescriptor_GrowingLifecycle tests the Enhanced Fingerprint
+// TestToFileDescriptor_GrowingLifecycle tests the growing fingerprint
 // lifecycle through the scanner:
 //
 //  1. small file (below offset+length) under growing mode → raw-hex

--- a/filebeat/input/filestream/identifier_fingerprint.go
+++ b/filebeat/input/filestream/identifier_fingerprint.go
@@ -27,10 +27,10 @@ import (
 // fingerprint file identity. The fields are propagated to the scanner's
 // fingerprint config via normalizeConfig before the prospector is created.
 type fingerprintIdentityConfig struct {
-	// Growing opts into the Enhanced Fingerprint behavior: files smaller
-	// than the configured fingerprint size (prospector.scanner.fingerprint.
-	// offset + prospector.scanner.fingerprint.length) are tracked using the
-	// raw bytes available so far, instead of being skipped as too small.
+	// Growing tracks files smaller than the configured fingerprint size
+	// (prospector.scanner.fingerprint.offset +
+	// prospector.scanner.fingerprint.length) using the raw bytes available
+	// so far, instead of skipping them as too small.
 	// Once such a file grows past the threshold it is automatically rekeyed
 	// to the same SHA-256 hex the static fingerprint produces, so existing
 	// static-fingerprint state is reused with no data duplication.

--- a/filebeat/input/filestream/prospector_creator_test.go
+++ b/filebeat/input/filestream/prospector_creator_test.go
@@ -122,12 +122,12 @@ prospector.scanner.fingerprint.enabled: false
 			wantCopyTruncate bool
 		}{
 			{
-				name:             "Enhanced Fingerprint ignores copytruncate and uses the standard prospector",
+				name:             "growing fingerprint ignores copytruncate and uses the standard prospector",
 				fileIdentity:     "file_identity.fingerprint: ~",
 				wantCopyTruncate: false,
 			},
 			{
-				name:             "opting out of Enhanced Fingerprint keeps the copytruncate prospector",
+				name:             "opting out of growing fingerprint keeps the copytruncate prospector",
 				fileIdentity:     "file_identity.fingerprint.growing: false",
 				wantCopyTruncate: true,
 			},
@@ -161,7 +161,7 @@ rotation.external.strategy.copytruncate:
 				fp, ok := p.(*fileProspector)
 				require.True(t, ok, "expected the standard file prospector, got %T", p)
 				assert.True(t, fp.growingFingerprint,
-					"Enhanced Fingerprint must stay enabled when copytruncate is ignored")
+					"growing fingerprint must stay enabled when copytruncate is ignored")
 			})
 		}
 	})

--- a/filebeat/tests/integration/filestream_fingerprint_test.go
+++ b/filebeat/tests/integration/filestream_fingerprint_test.go
@@ -43,7 +43,7 @@ const (
 	fingerprintCfgBase = `
 filebeat.inputs:
   - type: filestream
-    id: test-enhanced-fingerprint
+    id: test-growing-fingerprint
     enabled: true
     compression: auto
     paths:
@@ -67,17 +67,17 @@ logging:
   metrics:
     enabled: false
 `
-	fingerprintEnhanced            = "file_identity.fingerprint: ~"
-	fingerprintStatic              = "file_identity.fingerprint:\n      growing: false"
-	fingerprintEnhancedKeepRemoved = fingerprintEnhanced + "\n    clean_removed: false"
+	fingerprintGrowing            = "file_identity.fingerprint: ~"
+	fingerprintStatic             = "file_identity.fingerprint:\n      growing: false"
+	fingerprintGrowingKeepRemoved = fingerprintGrowing + "\n    clean_removed: false"
 )
 
 func fingerprintCfg(logDir, checkInterval, fingerprintBlock, pathHome string) string {
 	return fmt.Sprintf(fingerprintCfgBase, logDir, checkInterval, fingerprintBlock, pathHome)
 }
 
-func enhancedFingerprintCfg(logDir, checkInterval, pathHome string) string {
-	return fingerprintCfg(logDir, checkInterval, fingerprintEnhanced, pathHome)
+func growingFingerprintCfg(logDir, checkInterval, pathHome string) string {
+	return fingerprintCfg(logDir, checkInterval, fingerprintGrowing, pathHome)
 }
 
 func staticFingerprintCfg(logDir, checkInterval, pathHome string) string {
@@ -223,7 +223,7 @@ func TestFilestreamGrowingFingerprint(t *testing.T) {
 	file4 := filepath.Join(logDir, "file4.log.gz")
 	file5 := filepath.Join(logDir, "file5.log.gz")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -364,7 +364,7 @@ func TestFilestreamGrowingFingerprint_update_while_stopped(t *testing.T) {
 	file2 := filepath.Join(logDir, "file2.log")
 	file3 := filepath.Join(logDir, "file3.log")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -462,7 +462,7 @@ func TestFilestreamGrowingFingerprint_supersetFileNotConflated(t *testing.T) {
 	// 4 lines, well below the 1024-byte threshold => tracked in the growing phase.
 	shared := generateLines("shared line", 4)
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 	filebeat.WaitLogsContains("Input 'filestream' starting",
 		10*time.Second, "filestream did not start")
@@ -516,7 +516,7 @@ func TestFilestreamGrowingFingerprintTruncation(t *testing.T) {
 
 	logFile := filepath.Join(logDir, "truncate.log")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -780,7 +780,7 @@ func TestFilestreamGrowingFingerprint_rename_and_grow(t *testing.T) {
 	appLog := filepath.Join(logDir, "app.log")
 	appLogRenamed := filepath.Join(logDir, "app.log.1")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -841,7 +841,7 @@ func TestFilestreamGrowingFingerprint_rename_and_grow(t *testing.T) {
 	filebeat.Stop()
 }
 
-// TestFilestreamEnhancedFingerprint_ThresholdTransition verifies the SHA-256
+// TestFilestreamGrowingFingerprint_ThresholdTransition verifies the SHA-256
 // transition at the configured offset+length threshold. A file is created
 // with content below the threshold,
 // then grown past the threshold in the same Filebeat run. The prospector
@@ -854,13 +854,13 @@ func TestFilestreamGrowingFingerprint_rename_and_grow(t *testing.T) {
 //	Phase 2: + 25 lines ≈ +1250 bytes, total ≈ 1500 bytes (above threshold)
 //
 // Expected: 30 events total (5 + 25), one migration log, no duplicates.
-func TestFilestreamEnhancedFingerprint_ThresholdTransition(t *testing.T) {
+func TestFilestreamGrowingFingerprint_ThresholdTransition(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
 	logFile := filepath.Join(logDir, "app.log")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -894,10 +894,10 @@ func TestFilestreamEnhancedFingerprint_ThresholdTransition(t *testing.T) {
 	assertFingerprintMigratedToSHA256(t, tempDir, logFile)
 }
 
-// TestFilestreamEnhancedFingerprint_NoDuplicationOnUpgrade is the no-data-
+// TestFilestreamGrowingFingerprint_NoDuplicationOnUpgrade is the no-data-
 // duplication guarantee end-to-end. A user running with the default
 // (static) fingerprint identity already has files at or above threshold
-// indexed in the registry. When they run with the enhanced fingerprint enabled,
+// indexed in the registry. When they run with the growing fingerprint enabled,
 // no re-ingestion of files already at threshold should happen.
 //
 // The test:
@@ -909,7 +909,7 @@ func TestFilestreamEnhancedFingerprint_ThresholdTransition(t *testing.T) {
 //  6. Verifies no additional events are published.
 //
 // The promise: opting in to growing is contained to small files.
-func TestFilestreamEnhancedFingerprint_NoDuplicationOnUpgrade(t *testing.T) {
+func TestFilestreamGrowingFingerprint_NoDuplicationOnUpgrade(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
@@ -946,7 +946,7 @@ func TestFilestreamEnhancedFingerprint_NoDuplicationOnUpgrade(t *testing.T) {
 	//   2. smallFile is now eligible (growing tracks below-threshold files)
 	//      → its 5 lines are ingested for the first time.
 	// Expected post-upgrade total: 30 (large, unchanged) + 5 (small, new) = 35.
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 	filebeat.WaitLogsContains("Input 'filestream' starting",
 		10*time.Second, "filestream did not restart under growing config")
@@ -973,8 +973,8 @@ func TestFilestreamEnhancedFingerprint_NoDuplicationOnUpgrade(t *testing.T) {
 	assertGrowingRegistryEntry(t, tempDir, smallFile)
 }
 
-// TestFilestreamEnhancedFingerprint_DisableGrowingAfterEnabling exercises the
-// opt-out (revert) path: a deployment runs with Enhanced Fingerprint enabled
+// TestFilestreamGrowingFingerprint_DisableGrowingAfterEnabling exercises the
+// opt-out (revert) path: a deployment runs with growing fingerprint enabled
 // (the 9.5 default), then falls back to the legacy static behavior with
 // `file_identity.fingerprint.growing: false`.
 //
@@ -987,7 +987,7 @@ func TestFilestreamEnhancedFingerprint_NoDuplicationOnUpgrade(t *testing.T) {
 //     orphaned and the file is held back until it reaches offset+length; when it
 //     does, it is picked up under a fresh SHA-256 key from offset 0, re-ingesting
 //     the bytes already read during the growing phase.
-func TestFilestreamEnhancedFingerprint_DisableGrowingAfterEnabling(t *testing.T) {
+func TestFilestreamGrowingFingerprint_DisableGrowingAfterEnabling(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
@@ -996,7 +996,7 @@ func TestFilestreamEnhancedFingerprint_DisableGrowingAfterEnabling(t *testing.T)
 
 	// Phase 1 (growing enabled): large file (~1500 bytes) above threshold,
 	// small file (~250 bytes) below it. Both are ingested (30 + 5 = 35 events).
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	appendToFile(t, largeFile, generateLines("large", 30))
 	appendToFile(t, smallFile, generateLines("small", 5))
 
@@ -1120,7 +1120,7 @@ func seedLegacyFingerprintRegistry(t *testing.T, tempDir, inputID, filePath stri
 		"failed to write registry meta.json")
 }
 
-// TestFilestreamEnhancedFingerprint_ReadsLegacyStaticRegistry is the
+// TestFilestreamGrowingFingerprint_ReadsLegacyStaticRegistry is the
 // cross-version backwards-compatibility guarantee: a registry written by a
 // Filebeat from BEFORE growing fingerprint existed is read correctly by the new
 // growing-fingerprint-by-default Filebeat. It covers both kinds of pre-existing
@@ -1137,7 +1137,7 @@ func seedLegacyFingerprintRegistry(t *testing.T, tempDir, inputID, filePath stri
 // binary in static mode), this seeds the registry from raw bytes in the exact
 // legacy on-disk format, so it pins on-disk format compatibility itself,
 // independent of what the new binary writes.
-func TestFilestreamEnhancedFingerprint_ReadsLegacyStaticRegistry(t *testing.T) {
+func TestFilestreamGrowingFingerprint_ReadsLegacyStaticRegistry(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
@@ -1152,7 +1152,7 @@ func TestFilestreamEnhancedFingerprint_ReadsLegacyStaticRegistry(t *testing.T) {
 	// length) — identical to what static fingerprinting computed.
 	sum := sha256.Sum256([]byte(largeOld)[:1024])
 	largeSHA := hex.EncodeToString(sum[:])
-	seedLegacyFingerprintRegistry(t, tempDir, "test-enhanced-fingerprint", largeFile, largeInfo.Size(), largeSHA)
+	seedLegacyFingerprintRegistry(t, tempDir, "test-growing-fingerprint", largeFile, largeInfo.Size(), largeSHA)
 
 	// Case 1: a file below the threshold. The old (static) Filebeat dropped it,
 	// so it has NO registry entry; growing mode ingests it now.
@@ -1161,7 +1161,7 @@ func TestFilestreamEnhancedFingerprint_ReadsLegacyStaticRegistry(t *testing.T) {
 	writeTruncatingFile(t, smallFile, smallOld)
 
 	// Start the new Filebeat with growing enabled by default, over the legacy registry.
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 	filebeat.WaitLogsContains("Input 'filestream' starting",
 		10*time.Second, "filestream did not start")
@@ -1207,22 +1207,22 @@ func TestFilestreamEnhancedFingerprint_ReadsLegacyStaticRegistry(t *testing.T) {
 	// original fingerprint (the appends stayed above threshold; no new key).
 	assertSingleSHA256RegistryEntry(t, tempDir, largeFile)
 	state := readFingerprintRegistry(t, tempDir)
-	wantKey := fmt.Sprintf("filestream::test-enhanced-fingerprint::fingerprint::%s", largeSHA)
+	wantKey := fmt.Sprintf("filestream::test-growing-fingerprint::fingerprint::%s", largeSHA)
 	e, ok := state[wantKey]
 	require.True(t, ok, "the original legacy key %q must still be present", wantKey)
 	assert.False(t, e.removed, "the original legacy key must remain active (not removed/migrated)")
 }
 
-// TestFilestreamEnhancedFingerprint_NoDuplicationConfigReload is
+// TestFilestreamGrowingFingerprint_NoDuplicationConfigReload is
 // the same no-data-duplication guarantee as
-// TestFilestreamEnhancedFingerprint_NoDuplicationOnUpgrade but exercises
+// TestFilestreamGrowingFingerprint_NoDuplicationOnUpgrade but exercises
 // Filebeat's live config-reload path (filebeat.config.inputs with
 // reload.enabled). The input is restarted, when the inputs.d/*.yml
 // file is edited. On both configs, the inputs have the same id, so the registry
 // state is preserved across the reload — the new growing-enabled prospector
 // must reuse the existing SHA-256 entry and produce no new events for a file
 // that was already at threshold.
-func TestFilestreamEnhancedFingerprint_NoDuplicationConfigReload(t *testing.T) {
+func TestFilestreamGrowingFingerprint_NoDuplicationConfigReload(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 	inputsDir := filepath.Join(tempDir, "inputs.d")
@@ -1258,7 +1258,7 @@ logging:
 	// Initial input config: static fingerprint.
 	staticInputCfg := `
 - type: filestream
-  id: test-enhanced-fingerprint
+  id: test-growing-fingerprint
   enabled: true
   paths:
     - %s/*.log
@@ -1271,7 +1271,7 @@ logging:
 	// Post-reload input config: growing enabled.
 	growingInputCfg := `
 - type: filestream
-  id: test-enhanced-fingerprint
+  id: test-growing-fingerprint
   enabled: true
   paths:
     - %s/*.log
@@ -1343,7 +1343,7 @@ logging:
 	assertGrowingRegistryEntry(t, tempDir, smallFile)
 }
 
-// TestFilestreamEnhancedFingerprint_ThresholdTransitionAcrossRestart covers
+// TestFilestreamGrowingFingerprint_ThresholdTransitionAcrossRestart covers
 // the case where a file crosses the threshold while Filebeat is stopped.
 // On restart, the scanner sees a file at/above threshold whose registry
 // entry is still a raw-hex (growing) key. On the watch loop's first scan the
@@ -1352,13 +1352,13 @@ logging:
 // against the raw-hex registry entry and migrates the key to the final
 // SHA-256, resuming from the stored offset without re-ingesting content
 // already harvested before the stop.
-func TestFilestreamEnhancedFingerprint_ThresholdTransitionAcrossRestart(t *testing.T) {
+func TestFilestreamGrowingFingerprint_ThresholdTransitionAcrossRestart(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
 	logFile := filepath.Join(logDir, "app.log")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 
 	// Phase 1: small file (~250 bytes), tracked with raw-hex (growing).
 	appendToFile(t, logFile, generateLines("before-restart", 5))
@@ -1398,7 +1398,7 @@ func TestFilestreamEnhancedFingerprint_ThresholdTransitionAcrossRestart(t *testi
 	assertFingerprintMigratedToSHA256(t, tempDir, logFile)
 }
 
-// TestFilestreamEnhancedFingerprint_RenameAndThresholdCrossing verifies the
+// TestFilestreamGrowingFingerprint_RenameAndThresholdCrossing verifies the
 // rename + threshold-crossing case while filebeat is running: a
 // file is renamed AND grown past the configured threshold within a single
 // scan interval. The fileWatcher's prefix-match phase
@@ -1413,7 +1413,7 @@ func TestFilestreamEnhancedFingerprint_ThresholdTransitionAcrossRestart(t *testi
 // Expected: 30 events total, no duplicates, monotonic offsets. Registry
 // ends up with one active SHA-256 entry for app.log.1 and the raw-hex
 // entry from before the rename is removed.
-func TestFilestreamEnhancedFingerprint_RenameAndThresholdCrossing(t *testing.T) {
+func TestFilestreamGrowingFingerprint_RenameAndThresholdCrossing(t *testing.T) {
 	t.Parallel()
 	filebeat, homeDir, logDir := newFingerprintFilebeat(t)
 
@@ -1426,7 +1426,7 @@ func TestFilestreamEnhancedFingerprint_RenameAndThresholdCrossing(t *testing.T) 
 	// test window. (With a longer interval the harvester may finish reading
 	// via the still-open fd before the scanner re-scans, leaving the
 	// registry under the original raw-hex key.)
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", homeDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", homeDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -1481,11 +1481,11 @@ func TestFilestreamEnhancedFingerprint_RenameAndThresholdCrossing(t *testing.T) 
 	assertFingerprintMigratedToSHA256(t, homeDir, appLogRenamed)
 }
 
-// TestFilestreamEnhancedFingerprint_RenameAndThresholdAcrossRestart is the
+// TestFilestreamGrowingFingerprint_RenameAndThresholdAcrossRestart is the
 // hardest of the threshold scenarios: BOTH rename and threshold-crossing
 // happen while Filebeat is stopped.
 // Requires `clean_removed: false`.
-func TestFilestreamEnhancedFingerprint_RenameAndThresholdAcrossRestart(t *testing.T) {
+func TestFilestreamGrowingFingerprint_RenameAndThresholdAcrossRestart(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
@@ -1495,7 +1495,7 @@ func TestFilestreamEnhancedFingerprint_RenameAndThresholdAcrossRestart(t *testin
 	// clean_removed disabled so the stopped-rename entry survives startup and the prospector can
 	// migrate it.
 	filebeat.WriteConfigFile(
-		fingerprintCfg(logDir, "1s", fingerprintEnhancedKeepRemoved, tempDir))
+		fingerprintCfg(logDir, "1s", fingerprintGrowingKeepRemoved, tempDir))
 
 	// Phase 1: small file (~250 bytes) — below threshold, raw-hex registry key.
 	appendToFile(t, appLog, generateLines("before-restart line", 5))
@@ -1540,7 +1540,7 @@ func TestFilestreamEnhancedFingerprint_RenameAndThresholdAcrossRestart(t *testin
 	assertFingerprintMigratedToSHA256(t, tempDir, appLogRenamed)
 }
 
-// TestFilestreamEnhancedFingerprint_RenameBelowThresholdAcrossRestartKeepRemoved
+// TestFilestreamGrowingFingerprint_RenameBelowThresholdAcrossRestartKeepRemoved
 // documents the deliberate behaviour for a file that is renamed AND appended
 // while Filebeat is stopped, staying below the fingerprint threshold, with
 // clean_removed:false (so the pre-rename entry is not cleaned by path at
@@ -1561,8 +1561,8 @@ func TestFilestreamEnhancedFingerprint_RenameAndThresholdAcrossRestart(t *testin
 // The full-size fingerprint path is unaffected: once above the threshold the
 // identity is a hash over the whole fingerprint window and a moved+appended
 // file resumes from its cursor as before (see
-// TestFilestreamEnhancedFingerprint_RenameAndThresholdAcrossRestart).
-func TestFilestreamEnhancedFingerprint_RenameBelowThresholdAcrossRestartKeepRemoved(t *testing.T) {
+// TestFilestreamGrowingFingerprint_RenameAndThresholdAcrossRestart).
+func TestFilestreamGrowingFingerprint_RenameBelowThresholdAcrossRestartKeepRemoved(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
@@ -1572,7 +1572,7 @@ func TestFilestreamEnhancedFingerprint_RenameBelowThresholdAcrossRestartKeepRemo
 	// clean_removed disabled so the pre-rename entry (source app.log) survives
 	// startup and can be recovered by the prospector's prefix-match fallback.
 	filebeat.WriteConfigFile(
-		fingerprintCfg(logDir, "1s", fingerprintEnhancedKeepRemoved, tempDir))
+		fingerprintCfg(logDir, "1s", fingerprintGrowingKeepRemoved, tempDir))
 
 	// Phase 1: small file (one line, ~50 bytes) — below threshold, raw-hex key.
 	appendToFile(t, appLog, generateLines("app original line", 1))
@@ -1625,7 +1625,7 @@ func TestFilestreamEnhancedFingerprint_RenameBelowThresholdAcrossRestartKeepRemo
 	assertGrowingRegistryEntry(t, tempDir, appLogRenamed)
 }
 
-// TestFilestreamEnhancedFingerprint_Gzip covers Enhanced Fingerprint on
+// TestFilestreamGrowingFingerprint_Gzip covers growing fingerprint on
 // GZIP-compressed files. The fingerprint is computed on DECOMPRESSED content,
 // so the threshold check is against the decompressed size, not the on-disk
 // gzip-file size.
@@ -1636,7 +1636,7 @@ func TestFilestreamEnhancedFingerprint_RenameBelowThresholdAcrossRestartKeepRemo
 //   - largeGz: decompressed ~1500 bytes → above threshold → SHA-256 tracking.
 //
 // Both must be ingested completely under growing mode.
-func TestFilestreamEnhancedFingerprint_Gzip(t *testing.T) {
+func TestFilestreamGrowingFingerprint_Gzip(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
@@ -1654,7 +1654,7 @@ func TestFilestreamEnhancedFingerprint_Gzip(t *testing.T) {
 	require.NoError(t, os.WriteFile(largeGzFile, largeGzBytes, 0o644),
 		"failed to write large gzip file")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -1685,7 +1685,7 @@ func TestFilestreamEnhancedFingerprint_Gzip(t *testing.T) {
 	assertSingleSHA256RegistryEntry(t, tempDir, largeGzFile)
 }
 
-// TestFilestreamEnhancedFingerprint_TruncationAboveToBelowThreshold covers
+// TestFilestreamGrowingFingerprint_TruncationAboveToBelowThreshold covers
 // the edge case where a file already at threshold (SHA-256 key) is truncated
 // to below threshold with different content. The new content has a different
 // fingerprint identity (raw-hex of the new bytes), so the file is treated as
@@ -1693,14 +1693,14 @@ func TestFilestreamEnhancedFingerprint_Gzip(t *testing.T) {
 //
 // The existing TestFilestreamGrowingFingerprintTruncation covers the
 // below→below case (raw-hex → different raw-hex). This test covers the
-// above→below case (SHA-256 → raw-hex), specific to Enhanced Fingerprint.
-func TestFilestreamEnhancedFingerprint_TruncationAboveToBelowThreshold(t *testing.T) {
+// above→below case (SHA-256 → raw-hex), specific to growing fingerprint.
+func TestFilestreamGrowingFingerprint_TruncationAboveToBelowThreshold(t *testing.T) {
 	t.Parallel()
 	filebeat, tempDir, logDir := newFingerprintFilebeat(t)
 
 	logFile := filepath.Join(logDir, "app.log")
 
-	filebeat.WriteConfigFile(enhancedFingerprintCfg(logDir, "1s", tempDir))
+	filebeat.WriteConfigFile(growingFingerprintCfg(logDir, "1s", tempDir))
 	filebeat.Start()
 
 	filebeat.WaitLogsContains("Input 'filestream' starting",
@@ -1761,7 +1761,7 @@ func TestFilestreamEnhancedFingerprint_TruncationAboveToBelowThreshold(t *testin
 }
 
 // fingerprintRegistryEntry holds the parts of a fingerprint registry entry
-// the Enhanced Fingerprint tests care about.
+// the growing fingerprint tests care about.
 type fingerprintRegistryEntry struct {
 	key         string // full registry key: filestream::<inputID>::fingerprint::<keypart>
 	fingerprint string // the key part after ::fingerprint:: (a SHA-256 for final, a bounded hash for growing)

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2567,7 +2567,7 @@ filebeat.inputs:
   # if the fingerprints match, then the files are considered equal.
   #file_identity.fingerprint: ~
 
-  # Enhanced Fingerprint behavior. When enabled (the default since 9.5),
+  # Growing fingerprint behavior. When enabled (the default since 9.5),
   # files smaller than the configured fingerprint size (prospector.scanner
   # .fingerprint.offset + length) are tracked using the raw bytes available
   # so far, instead of being skipped until they grow large enough. Once a


### PR DESCRIPTION
## Proposed commit message

```
filestream: rename "Enhanced Fingerprint" to "growing fingerprint"

Rename "Enhanced Fingerprint" to "growing fingerprint". The new name
matches `file_identity.fingerprint.growing` and "static fingerprint".
The setting, default, and behavior do not change.

The old name remains in changelog/9.5.0.yaml and
docs/release-notes/_snippets/9.5.0/index.md.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~ No behavior change. Existing tests are renamed, not added.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.
