### PR TITLE
x-pack/metricbeat: fix modernize lint findings

### DIFF
--- a/x-pack/metricbeat/module/autoops_es/auto_ops_testing/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/auto_ops_testing/testing.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package auto_ops_testing
 
@@ -35,7 +34,7 @@ type GlobCallback func(t *testing.T, file string, version string, data []byte)
 type SetupServerCallback func(t *testing.T, clusterInfo []byte, data []byte, version string) (server *httptest.Server)
 
 // The config setup for the MetricSet
-type SetupConfigCallback func(server *httptest.Server) (config map[string]interface{})
+type SetupConfigCallback func(server *httptest.Server) (config map[string]any)
 
 type GetTemplateCallback func(t *testing.T, names []string, ignoreNames []string) []byte
 
@@ -47,8 +46,8 @@ func ExtractVersionFromFile(file string) (version string) {
 
 // Helper function to automatically use the server's URL and just the name as the metricset.
 func UseNamedMetricSet(name string) SetupConfigCallback {
-	return func(server *httptest.Server) map[string]interface{} {
-		return map[string]interface{}{
+	return func(server *httptest.Server) map[string]any {
+		return map[string]any{
 			"module":     "autoops_es",
 			"metricsets": []string{name},
 			"hosts":      []string{server.URL},
@@ -174,7 +173,7 @@ func CreateClusterInfo(clusterVersion string) utils.ClusterInfo {
 }
 
 // Unravel `mapstr.M.GetValue` without an error response to make it easier to assert
-func GetObjectValue(obj mapstr.M, key string) interface{} {
+func GetObjectValue(obj mapstr.M, key string) any {
 	exists, err := obj.HasKey(key)
 
 	if !exists {
@@ -208,7 +207,7 @@ func GetObjectAsString(t *testing.T, obj mapstr.M, key string) string {
 }
 
 // Unravel `mapstr.M.GetValue` and `mapstr.M.String` without an error response to make it easier to assert
-func GetObjectAsJson(obj mapstr.M, key string) interface{} {
+func GetObjectAsJson(obj mapstr.M, key string) any {
 	exists, err := obj.HasKey(key)
 
 	if err != nil {

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cache_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cache_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_shards
 

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/cat_shards_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/cat_shards_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_shards
 

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_shards
 

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/deserialize_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/deserialize_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_shards
 

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/index_shards_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/index_shards_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_shards
 

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/resolved_indices_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/resolved_indices_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_shards
 

--- a/x-pack/metricbeat/module/autoops_es/cat_shards/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_shards/testing.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_shards
 

--- a/x-pack/metricbeat/module/autoops_es/cat_template/cat_template_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_template/cat_template_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_template
 

--- a/x-pack/metricbeat/module/autoops_es/cat_template/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_template/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_template
 
@@ -92,14 +91,14 @@ func expectValidParsedDetailedTemplates(t *testing.T, data metricset.FetcherData
 
 	auto_ops_testing.CheckEventWithoutTransactionId(t, event2, data.ClusterInfo)
 
-	simpleMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "simple-response")))
+	simpleMapping, err := utils.DeserializeData[map[string]any]([]byte(getMappingObject(t, "simple-response")))
 	require.NoError(t, err)
 	simple, err := templateSchema.Apply(*simpleMapping)
 	require.NoError(t, err)
 
 	simpleTemplate := mapstr.M{"template": simple}
 
-	detailedMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "detailed-response")))
+	detailedMapping, err := utils.DeserializeData[map[string]any]([]byte(getMappingObject(t, "detailed-response")))
 	require.NoError(t, err)
 	detailed, err := templateSchema.Apply(*detailedMapping)
 	require.NoError(t, err)

--- a/x-pack/metricbeat/module/autoops_es/cat_template/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_template/testing.go
@@ -58,5 +58,6 @@ func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []st
 		added++
 	}
 
-	return []byte(mappings.String() + "}")
+	mappings.WriteString("}")
+	return []byte(mappings.String())
 }

--- a/x-pack/metricbeat/module/autoops_es/cat_template/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/cat_template/testing.go
@@ -3,13 +3,13 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cat_template
 
 import (
 	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,7 +40,8 @@ func getMappingObject(t *testing.T, templateName string) string {
 }
 
 func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []string) []byte {
-	mappings := "{"
+	var mappings strings.Builder
+	mappings.WriteString("{")
 	added := 0
 
 	for _, name := range templateNames {
@@ -49,13 +50,13 @@ func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []st
 		}
 
 		if added != 0 {
-			mappings += ","
+			mappings.WriteString(",")
 		}
 
-		mappings += `"` + name + `":` + getMappingObject(t, name)
+		mappings.WriteString(`"` + name + `":` + getMappingObject(t, name))
 
 		added++
 	}
 
-	return []byte(mappings + "}")
+	return []byte(mappings.String() + "}")
 }

--- a/x-pack/metricbeat/module/autoops_es/cluster_health/cluster_health_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_health/cluster_health_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cluster_health
 
@@ -23,7 +22,7 @@ var (
 )
 
 func TestSuccessfulFetch(t *testing.T) {
-	metricset.RunTestsForFetcherWithGlobFiles(t, "./_meta/test/cluster_health.*.json", setupSuccessfulServer, useNamedMetricSet, func(t *testing.T, data metricset.FetcherData[map[string]interface{}]) {
+	metricset.RunTestsForFetcherWithGlobFiles(t, "./_meta/test/cluster_health.*.json", setupSuccessfulServer, useNamedMetricSet, func(t *testing.T, data metricset.FetcherData[map[string]any]) {
 		require.NoError(t, data.Error)
 
 		require.Equal(t, 1, len(data.Reporter.GetEvents()))

--- a/x-pack/metricbeat/module/autoops_es/cluster_health/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_health/data.go
@@ -36,7 +36,7 @@ var (
 	}
 )
 
-func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, data *map[string]interface{}) error {
+func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, data *map[string]any) error {
 	metricSetFields, err := schema.Apply(*data)
 
 	if err != nil {

--- a/x-pack/metricbeat/module/autoops_es/cluster_health/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_health/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cluster_health
 
@@ -18,7 +17,7 @@ import (
 )
 
 // Tests that Cluster Info is consistently reported, the Cluster Name, and the dynamic status from the filename
-func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]interface{}]) {
+func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]any]) {
 	require.NoError(t, data.Error)
 	require.Equal(t, 0, len(data.Reporter.GetErrors()))
 	require.Equal(t, 1, len(data.Reporter.GetEvents()))

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/cluster_settings_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/cluster_settings_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cluster_settings
 
@@ -23,7 +22,7 @@ var (
 )
 
 func TestSuccessfulFetch(t *testing.T) {
-	metricset.RunTestsForFetcherWithGlobFiles(t, "./_meta/test/cluster_settings.*.json", setupSuccessfulServer, useNamedMetricSet, func(t *testing.T, data metricset.FetcherData[map[string]interface{}]) {
+	metricset.RunTestsForFetcherWithGlobFiles(t, "./_meta/test/cluster_settings.*.json", setupSuccessfulServer, useNamedMetricSet, func(t *testing.T, data metricset.FetcherData[map[string]any]) {
 		require.NoError(t, data.Error)
 
 		require.Equal(t, 1, len(data.Reporter.GetEvents()))

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
@@ -234,7 +234,7 @@ func flattenSettings(metricSetFields mapstr.M) mapstr.M {
 	return result
 }
 
-func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, settings *map[string]interface{}) error {
+func eventsMapping(r mb.ReporterV2, info *utils.ClusterInfo, settings *map[string]any) error {
 	metricSetFields, err := schema.Apply(*settings)
 
 	if err != nil {

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package cluster_settings
 
@@ -18,7 +17,7 @@ import (
 )
 
 // Tests that Cluster Info is consistently reported, the Cluster Name, and the dynamic status from the filename
-func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]interface{}]) {
+func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]any]) {
 	require.NoError(t, data.Error)
 	require.Equal(t, 0, len(data.Reporter.GetErrors()))
 	require.Equal(t, 1, len(data.Reporter.GetEvents()))

--- a/x-pack/metricbeat/module/autoops_es/component_template/component_template_test.go
+++ b/x-pack/metricbeat/module/autoops_es/component_template/component_template_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package component_template
 

--- a/x-pack/metricbeat/module/autoops_es/component_template/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/component_template/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package component_template
 
@@ -86,16 +85,16 @@ func expectValidParsedDetailedTemplates(t *testing.T, data metricset.FetcherData
 
 	auto_ops_testing.CheckEventWithoutTransactionId(t, event2, data.ClusterInfo)
 
-	simpleMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "simple-response")))
+	simpleMapping, err := utils.DeserializeData[map[string]any]([]byte(getMappingObject(t, "simple-response")))
 	require.NoError(t, err)
-	simple, err := templateSchema.Apply((*simpleMapping)["component_template"].(map[string]interface{}))
+	simple, err := templateSchema.Apply((*simpleMapping)["component_template"].(map[string]any))
 	require.NoError(t, err)
 
 	simpleTemplate := mapstr.M{"template": simple}
 
-	detailedMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "detailed-response")))
+	detailedMapping, err := utils.DeserializeData[map[string]any]([]byte(getMappingObject(t, "detailed-response")))
 	require.NoError(t, err)
-	detailed, err := templateSchema.Apply((*detailedMapping)["component_template"].(map[string]interface{}))
+	detailed, err := templateSchema.Apply((*detailedMapping)["component_template"].(map[string]any))
 	require.NoError(t, err)
 
 	detailedTemplate := mapstr.M{"template": detailed}

--- a/x-pack/metricbeat/module/autoops_es/component_template/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/component_template/testing.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package component_template
 
@@ -35,7 +34,8 @@ func getMappingObject(t *testing.T, templateName string) string {
 }
 
 func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []string) []byte {
-	mappings := `{"component_templates":[`
+	var mappings strings.Builder
+	mappings.WriteString(`{"component_templates":[`)
 	added := 0
 
 	for _, name := range templateNames {
@@ -44,13 +44,13 @@ func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []st
 		}
 
 		if added != 0 {
-			mappings += ","
+			mappings.WriteString(",")
 		}
 
-		mappings += getMappingObject(t, name)
+		mappings.WriteString(getMappingObject(t, name))
 
 		added++
 	}
 
-	return []byte(mappings + "]}")
+	return []byte(mappings.String() + "]}")
 }

--- a/x-pack/metricbeat/module/autoops_es/component_template/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/component_template/testing.go
@@ -52,5 +52,6 @@ func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []st
 		added++
 	}
 
-	return []byte(mappings.String() + "]}")
+	mappings.WriteString("]}")
+	return []byte(mappings.String())
 }

--- a/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
+++ b/x-pack/metricbeat/module/autoops_es/events/error_event_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package events
 

--- a/x-pack/metricbeat/module/autoops_es/events/events_test.go
+++ b/x-pack/metricbeat/module/autoops_es/events/events_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package events
 

--- a/x-pack/metricbeat/module/autoops_es/index_template/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/index_template/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package index_template
 
@@ -127,16 +126,16 @@ func expectValidParsedDetailedTemplatesCommon(t *testing.T, data metricset.Fetch
 
 	auto_ops_testing.CheckEventWithoutTransactionId(t, event2, data.ClusterInfo)
 
-	simpleMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "simple-response")))
+	simpleMapping, err := utils.DeserializeData[map[string]any]([]byte(getMappingObject(t, "simple-response")))
 	require.NoError(t, err)
-	simple, err := templateSchema.Apply((*simpleMapping)["index_template"].(map[string]interface{}))
+	simple, err := templateSchema.Apply((*simpleMapping)["index_template"].(map[string]any))
 	require.NoError(t, err)
 
 	simpleTemplate := mapstr.M{"template": simple}
 
-	detailedMapping, err := utils.DeserializeData[map[string]interface{}]([]byte(getMappingObject(t, "detailed-response")))
+	detailedMapping, err := utils.DeserializeData[map[string]any]([]byte(getMappingObject(t, "detailed-response")))
 	require.NoError(t, err)
-	detailed, err := templateSchema.Apply((*detailedMapping)["index_template"].(map[string]interface{}))
+	detailed, err := templateSchema.Apply((*detailedMapping)["index_template"].(map[string]any))
 	require.NoError(t, err)
 
 	detailedTemplate := mapstr.M{"template": detailed}
@@ -232,7 +231,7 @@ func TestGetIndexPatterns(t *testing.T) {
 			name: "should throw error when missing index_patterns",
 			template: IndexTemplate{
 				Name:          "test-index-template",
-				IndexTemplate: map[string]interface{}{},
+				IndexTemplate: map[string]any{},
 			},
 			want:        nil,
 			expectError: `index_patterns not found in template "test-index-template"`,
@@ -241,7 +240,7 @@ func TestGetIndexPatterns(t *testing.T) {
 			name: "should throw error when index_patterns is not a slice",
 			template: IndexTemplate{
 				Name: "wrongtype",
-				IndexTemplate: map[string]interface{}{
+				IndexTemplate: map[string]any{
 					"index_patterns": "not-a-slice",
 				},
 			},
@@ -252,8 +251,8 @@ func TestGetIndexPatterns(t *testing.T) {
 			name: "should throw error when index_patterns contains non-string element",
 			template: IndexTemplate{
 				Name: "nonstring",
-				IndexTemplate: map[string]interface{}{
-					"index_patterns": []interface{}{"valid", 123},
+				IndexTemplate: map[string]any{
+					"index_patterns": []any{"valid", 123},
 				},
 			},
 			want:        nil,
@@ -263,8 +262,8 @@ func TestGetIndexPatterns(t *testing.T) {
 			name: "should return a valid index_patterns",
 			template: IndexTemplate{
 				Name: "valid",
-				IndexTemplate: map[string]interface{}{
-					"index_patterns": []interface{}{"log-*", "metrics-*"},
+				IndexTemplate: map[string]any{
+					"index_patterns": []any{"log-*", "metrics-*"},
 				},
 			},
 			want:        []string{"log-*", "metrics-*"},

--- a/x-pack/metricbeat/module/autoops_es/index_template/index_template_test.go
+++ b/x-pack/metricbeat/module/autoops_es/index_template/index_template_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package index_template
 

--- a/x-pack/metricbeat/module/autoops_es/index_template/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/index_template/testing.go
@@ -52,5 +52,6 @@ func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []st
 		added++
 	}
 
-	return []byte(mappings.String() + "]}")
+	mappings.WriteString("]}")
+	return []byte(mappings.String())
 }

--- a/x-pack/metricbeat/module/autoops_es/index_template/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/index_template/testing.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package index_template
 
@@ -35,7 +34,8 @@ func getMappingObject(t *testing.T, templateName string) string {
 }
 
 func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []string) []byte {
-	mappings := `{"index_templates":[`
+	var mappings strings.Builder
+	mappings.WriteString(`{"index_templates":[`)
 	added := 0
 
 	for _, name := range templateNames {
@@ -44,13 +44,13 @@ func getTemplateResponse(t *testing.T, templateNames []string, ignoredNames []st
 		}
 
 		if added != 0 {
-			mappings += ","
+			mappings.WriteString(",")
 		}
 
-		mappings += getMappingObject(t, name)
+		mappings.WriteString(getMappingObject(t, name))
 
 		added++
 	}
 
-	return []byte(mappings + "]}")
+	return []byte(mappings.String() + "]}")
 }

--- a/x-pack/metricbeat/module/autoops_es/license/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/license/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package license
 
@@ -28,7 +27,7 @@ func TestProperlyHandlesResponseWhenNoOptionalFields(t *testing.T) {
 }
 
 // Tests that License reported with no errors
-func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]interface{}]) {
+func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]any]) {
 	require.NoError(t, data.Error)
 	require.Equal(t, 0, len(data.Reporter.GetErrors()))
 	require.Equal(t, 1, len(data.Reporter.GetEvents()))
@@ -59,7 +58,7 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]i
 }
 
 // Tests that LicenseMetricsSet reported with no errors (without optional fields)
-func expectValidParsedDataWithoutOptionalFields(t *testing.T, data metricset.FetcherData[map[string]interface{}]) {
+func expectValidParsedDataWithoutOptionalFields(t *testing.T, data metricset.FetcherData[map[string]any]) {
 	require.NoError(t, data.Error)
 	require.Equal(t, 0, len(data.Reporter.GetErrors()))
 	require.Equal(t, 1, len(data.Reporter.GetEvents()))

--- a/x-pack/metricbeat/module/autoops_es/license/license_test.go
+++ b/x-pack/metricbeat/module/autoops_es/license/license_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package license
 
@@ -23,7 +22,7 @@ var (
 )
 
 func TestSuccessfulFetch(t *testing.T) {
-	metricset.RunTestsForFetcherWithGlobFiles(t, "./_meta/test/license.valid*.json", setupSuccessfulServer, useNamedMetricSet, func(t *testing.T, data metricset.FetcherData[map[string]interface{}]) {
+	metricset.RunTestsForFetcherWithGlobFiles(t, "./_meta/test/license.valid*.json", setupSuccessfulServer, useNamedMetricSet, func(t *testing.T, data metricset.FetcherData[map[string]any]) {
 		require.NoError(t, data.Error)
 
 		require.Equal(t, 1, len(data.Reporter.GetEvents()))

--- a/x-pack/metricbeat/module/autoops_es/metricset/metricset_nested_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/metricset_nested_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package metricset
 

--- a/x-pack/metricbeat/module/autoops_es/metricset/metricset_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/metricset_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package metricset
 
@@ -23,7 +22,7 @@ import (
 )
 
 type testObjectType struct {
-	Values []map[string]interface{} `json:"items"`
+	Values []map[string]any `json:"items"`
 }
 
 const (

--- a/x-pack/metricbeat/module/autoops_es/metricset/register_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/register_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package metricset
 

--- a/x-pack/metricbeat/module/autoops_es/metricset/request_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/request_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package metricset
 
@@ -14,8 +13,10 @@ import (
 )
 
 // Helper function to get a pointer to a string.
+//
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }
 
 func TestGetCloudConnectedModeAPIURL(t *testing.T) {
@@ -26,12 +27,12 @@ func TestGetCloudConnectedModeAPIURL(t *testing.T) {
 	}{
 		{
 			name:        "env var set to custom value",
-			envVarValue: stringPtr("http://custom.api.url.from.test"),
+			envVarValue: new("http://custom.api.url.from.test"),
 			expectedURL: "http://custom.api.url.from.test",
 		},
 		{
 			name:        "env var set to empty string",
-			envVarValue: stringPtr(""),                        // Explicitly set to empty
+			envVarValue: new(""),                              // Explicitly set to empty
 			expectedURL: DEFAULT_CLOUD_CONNECTED_MODE_API_URL, // Should fall back to default
 		},
 		{

--- a/x-pack/metricbeat/module/autoops_es/metricset/request_test.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/request_test.go
@@ -12,13 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Helper function to get a pointer to a string.
-//
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}
-
 func TestGetCloudConnectedModeAPIURL(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/x-pack/metricbeat/module/autoops_es/metricset/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/metricset/testing.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package metricset
 
@@ -30,7 +29,7 @@ type FetcherData[T any] struct {
 	MetricSet mb.ReportingMetricSetV2Error
 	Reporter  *mbtest.CapturingReporterV2
 	Server    *httptest.Server
-	Config    map[string]interface{}
+	Config    map[string]any
 
 	// Data read from files
 	ClusterInfo utils.ClusterInfo
@@ -45,8 +44,8 @@ type FetcherCallback[T any] func(t *testing.T, data FetcherData[T])
 
 // Helper function to automatically use the server's URL and just the name as the metricset.
 func UseNamedMetricSet(name string) auto_ops_testing.SetupConfigCallback {
-	return func(server *httptest.Server) map[string]interface{} {
-		return map[string]interface{}{"module": "autoops_es",
+	return func(server *httptest.Server) map[string]any {
+		return map[string]any{"module": "autoops_es",
 			"metricsets": []string{name},
 			"hosts":      []string{server.URL},
 		}
@@ -165,7 +164,7 @@ func CreateClusterInfo(clusterVersion string) utils.ClusterInfo {
 }
 
 // Unravel `mapstr.M.GetValue` without an error response to make it easier to assert
-func GetObjectValue(obj mapstr.M, key string) interface{} {
+func GetObjectValue(obj mapstr.M, key string) any {
 	exists, err := obj.HasKey(key)
 
 	if err != nil {

--- a/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package node_stats
 

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data.go
@@ -223,7 +223,7 @@ type ClusterStateMasterNode struct {
 }
 
 type NodesStats struct {
-	Nodes map[string]map[string]interface{} `json:"nodes"`
+	Nodes map[string]map[string]any `json:"nodes"`
 }
 
 // Get the elected master node's ID

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package node_stats
 

--- a/x-pack/metricbeat/module/autoops_es/node_stats/node_stats_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/node_stats_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package node_stats
 

--- a/x-pack/metricbeat/module/autoops_es/node_stats/testing.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/testing.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package node_stats
 

--- a/x-pack/metricbeat/module/autoops_es/tasks_management/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/data_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package tasks_management
 

--- a/x-pack/metricbeat/module/autoops_es/tasks_management/parse_child_nodes_test.go
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/parse_child_nodes_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package tasks_management
 

--- a/x-pack/metricbeat/module/autoops_es/tasks_management/tasks_management_test.go
+++ b/x-pack/metricbeat/module/autoops_es/tasks_management/tasks_management_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package tasks_management
 

--- a/x-pack/metricbeat/module/autoops_es/utils/enrich_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/enrich_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package utils
 

--- a/x-pack/metricbeat/module/autoops_es/utils/http_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/http_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package utils
 

--- a/x-pack/metricbeat/module/autoops_es/utils/resource_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/resource_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package utils
 

--- a/x-pack/metricbeat/module/autoops_es/utils/utils.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/utils.go
@@ -43,8 +43,8 @@ func MatchesAnyPattern(value string, patterns []string) bool {
 		return false
 	}
 	for _, pattern := range patterns {
-		if strings.HasSuffix(pattern, "*") {
-			withoutStar := strings.TrimSuffix(pattern, "*")
+		if before, ok := strings.CutSuffix(pattern, "*"); ok {
+			withoutStar := before
 			if strings.HasPrefix(value, withoutStar) {
 				return true
 			}

--- a/x-pack/metricbeat/module/autoops_es/utils/utils_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/utils_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package utils
 

--- a/x-pack/metricbeat/module/autoops_es/utils/uuid_test.go
+++ b/x-pack/metricbeat/module/autoops_es/utils/uuid_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build !integration
-// +build !integration
 
 package utils
 


### PR DESCRIPTION
## Proposed commit message

```
x-pack/metricbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 46 file(s)
owned by @elastic/opex-back in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

A second commit removes the helpers the rewrites orphaned; see the review notes below.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


REDUNDANT_CONVERSION = re.compile(r"new\(\(([\w.]+)\)\(")


def drop_redundant_parens(root: Path, files: list[str]) -> int:
    """Rewrite the `new((T)(x))` the newexpr fixer emits as `new(T(x))`.

    Dropping one paren on each side keeps the call balanced, and the pattern is narrow
    enough that a textual rewrite cannot match anything else.
    """
    touched = 0
    for name in files:
        path = root / name
        before = path.read_text()
        after = REDUNDANT_CONVERSION.sub(r"new(\1(", before)
        if after != before:
            path.write_text(after)
            touched += 1
    return touched


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]
        cleaned = drop_redundant_parens(root, files)
        if cleaned:
            log(f"  dropped redundant conversion parens in {cleaned} file(s)")

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Separate commits, so the hand-written part is obvious:

1. `x-pack/metricbeat: fix modernize lint findings` is pure tool output, nothing in it was written by hand.
2. `x-pack/metricbeat: drop helper orphaned by modernize` is the part the tools could not produce:

   > `go fix` inlined the `//go:fix inline` pointer helper at every call site,
   > leaving the helper itself unused. Deleting it is the one part of this
   > branch a tool could not do, so it lives in its own commit.

- `x-pack/metricbeat/module/autoops_es/metricset/request_test.go`

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
