### PR TITLE
x-pack/filebeat,libbeat: fix modernize lint findings

### DIFF
--- a/filebeat/input/syslog/event_test.go
+++ b/filebeat/input/syslog/event_test.go
@@ -170,7 +170,7 @@ func TestIsValid(t *testing.T) {
 
 func itb(i int) []byte {
 	if i < 10 {
-		return []byte(fmt.Sprintf("0%d", i))
+		return fmt.Appendf(nil, "0%d", i)
 	}
 	return []byte(strconv.Itoa(i))
 }

--- a/filebeat/input/syslog/rfc5424_test.go
+++ b/filebeat/input/syslog/rfc5424_test.go
@@ -244,7 +244,7 @@ func TestRfc5424ParseStructuredData(t *testing.T) {
 func createVersionTestRule(v int, success bool) testRule {
 	rule := testRule{
 		title: fmt.Sprintf("versionTest v:%d", v),
-		log:   []byte(fmt.Sprintf(VersionTestTemplate, v)),
+		log:   fmt.Appendf(nil, VersionTestTemplate, v),
 		syslog: event{
 			priority:   34,
 			version:    v,
@@ -275,7 +275,7 @@ func createVersionTestRule(v int, success bool) testRule {
 func createPriorityTestRule(v int, success bool) testRule {
 	rule := testRule{
 		title: fmt.Sprintf("priorityTest v:%d", v),
-		log:   []byte(fmt.Sprintf(PriorityTestTemplate, v)),
+		log:   fmt.Appendf(nil, PriorityTestTemplate, v),
 		syslog: event{
 			priority:   v,
 			version:    1,

--- a/libbeat/processors/dns/cache.go
+++ b/libbeat/processors/dns/cache.go
@@ -223,13 +223,6 @@ func (c lookupCache) Lookup(q string, qt queryType) (*result, error) {
 	return r, nil
 }
 
-func max(a, b uint32) uint32 {
-	if a >= b {
-		return a
-	}
-	return b
-}
-
 // safeUint32 converts a float64 to a uint32, protecting against out-of-bounds
 // values. It takes the absolute value to prevent negative numbers and caps the
 // result at math.MaxUint32 to avoid integer overflows.

--- a/libbeat/processors/dns/dns_test.go
+++ b/libbeat/processors/dns/dns_test.go
@@ -174,10 +174,10 @@ func TestDNSProcessorRunInParallel(t *testing.T) {
 	// Start several goroutines.
 	g, _ := errgroup.WithContext(context.Background())
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		g.Go(func() error {
 			// Execute processor.
-			for i := 0; i < numEvents; i++ {
+			for i := range numEvents {
 				_, err := p.Run(&beat.Event{
 					Fields: mapstr.M{
 						"source.ip": "192.168.0." + strconv.Itoa(i%256),

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -259,13 +259,6 @@ func (res *miekgResolver) getOrCreateNameserverStats(ns string) *nameserverStats
 	return stats
 }
 
-func min(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func isIPv6Address(addr string) bool {
 	ip, err := netip.ParseAddr(addr)
 	if err != nil {

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -75,7 +75,7 @@ func TestMiekgResolverLookupPTR(t *testing.T) {
 
 	// Validate that our metrics exist.
 	var metricCount int
-	reg.Do(monitoring.Full, func(name string, v interface{}) {
+	reg.Do(monitoring.Full, func(name string, v any) {
 		if strings.Contains(name, "processor.dns") {
 			metricCount++
 		}
@@ -130,7 +130,7 @@ func TestMiekgResolverLookupPTRTLS(t *testing.T) {
 
 	// Validate that our metrics exist.
 	var metricCount int
-	reg.Do(monitoring.Full, func(name string, v interface{}) {
+	reg.Do(monitoring.Full, func(name string, v any) {
 		if strings.Contains(name, "processor.dns") {
 			metricCount++
 		}

--- a/libbeat/processors/syslog/syslog.go
+++ b/libbeat/processors/syslog/syslog.go
@@ -206,7 +206,7 @@ func appendStringField(m mapstr.M, field, value string) {
 		_, _ = m.Put(field, []string{t, value})
 	case []string:
 		_, _ = m.Put(field, append(t, value))
-	case []interface{}:
+	case []any:
 		_, _ = m.Put(field, append(t, value))
 	}
 }

--- a/libbeat/processors/syslog/syslog_test.go
+++ b/libbeat/processors/syslog/syslog_test.go
@@ -114,11 +114,11 @@ var syslogCases = map[string]struct {
 					"procid":   "1024",
 					"msgid":    "ID47",
 					"version":  "1",
-					"structured_data": map[string]interface{}{
-						"examplePriority@32473": map[string]interface{}{
+					"structured_data": map[string]any{
+						"examplePriority@32473": map[string]any{
 							"class": "high",
 						},
-						"exampleSDID@32473": map[string]interface{}{
+						"exampleSDID@32473": map[string]any{
 							"eventID":     "1011",
 							"eventSource": "Application",
 							"iut":         "3",
@@ -134,7 +134,6 @@ var syslogCases = map[string]struct {
 
 func TestSyslog(t *testing.T) {
 	for name, tc := range syslogCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -160,7 +159,6 @@ func TestSyslog(t *testing.T) {
 
 func BenchmarkSyslog(b *testing.B) {
 	for name, bc := range syslogCases {
-		bc := bc
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -213,18 +211,17 @@ func TestAppendStringField(t *testing.T) {
 		},
 		"interface-slice": {
 			inMap: mapstr.M{
-				"error": []interface{}{"foo", "bar"},
+				"error": []any{"foo", "bar"},
 			},
 			inField: "error",
 			inValue: "some value",
 			want: mapstr.M{
-				"error": []interface{}{"foo", "bar", "some value"},
+				"error": []any{"foo", "bar", "some value"},
 			},
 		},
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			appendStringField(tc.inMap, tc.inField, tc.inValue)

--- a/libbeat/reader/syslog/message_test.go
+++ b/libbeat/reader/syslog/message_test.go
@@ -87,7 +87,6 @@ func TestMessage_SetTimestampBSD(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -146,7 +145,6 @@ func TestMessage_SetTimestampRFC3339(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -193,7 +191,6 @@ func TestMessage_SetPriority(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			m := message{priority: -1}
@@ -235,7 +232,6 @@ func TestMessage_SetHostname(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			var m message
 
@@ -262,7 +258,6 @@ func TestMessage_SetMsg(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var m message
@@ -290,7 +285,6 @@ func TestMessage_SetTag(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			var m message
 
@@ -321,7 +315,6 @@ func TestMessage_SetAppName(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var m message
@@ -350,7 +343,6 @@ func TestMessage_SetContent(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var m message
@@ -382,7 +374,6 @@ func TestMessage_SetProcID(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var m message
@@ -410,7 +401,6 @@ func TestMessage_SetMsgID(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -441,7 +431,6 @@ func TestMessage_SetVersion(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -482,7 +471,6 @@ func TestMessage_SetRawSDValue(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -499,47 +487,47 @@ func TestMessage_SetRawSDValue(t *testing.T) {
 func TestParseStructuredData(t *testing.T) {
 	tests := map[string]struct {
 		in   string
-		want map[string]interface{}
+		want map[string]any
 	}{
 		"basic": {
 			in: `[value@1 foo="bar"]`,
-			want: map[string]interface{}{
-				"value@1": map[string]interface{}{
+			want: map[string]any{
+				"value@1": map[string]any{
 					"foo": "bar",
 				},
 			},
 		},
 		"multi-key": {
 			in: `[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`,
-			want: map[string]interface{}{
-				"exampleSDID@32473": map[string]interface{}{
+			want: map[string]any{
+				"exampleSDID@32473": map[string]any{
 					"iut":         "3",
 					"eventSource": "Application",
 					"eventID":     "1011",
 				},
-				"examplePriority@32473": map[string]interface{}{
+				"examplePriority@32473": map[string]any{
 					"class": "high",
 				},
 			},
 		},
 		"multi-key-with-escape": {
 			in: `[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011" somekey="[value\] more data"][examplePriority@32473 class="high"]`,
-			want: map[string]interface{}{
-				"exampleSDID@32473": map[string]interface{}{
+			want: map[string]any{
+				"exampleSDID@32473": map[string]any{
 					"iut":         "3",
 					"eventSource": "Application",
 					"eventID":     "1011",
 					"somekey":     "[value] more data",
 				},
-				"examplePriority@32473": map[string]interface{}{
+				"examplePriority@32473": map[string]any{
 					"class": "high",
 				},
 			},
 		},
 		"repeated-id": {
 			in: `[exampleSDID@32473 iut="3"][exampleSDID@32473 class="high"]`,
-			want: map[string]interface{}{
-				"exampleSDID@32473": map[string]interface{}{
+			want: map[string]any{
+				"exampleSDID@32473": map[string]any{
 					"iut":   "3",
 					"class": "high",
 				},
@@ -547,8 +535,8 @@ func TestParseStructuredData(t *testing.T) {
 		},
 		"repeated-id-value": {
 			in: `[exampleSDID@32473 class="low"][exampleSDID@32473 class="high"]`,
-			want: map[string]interface{}{
-				"exampleSDID@32473": map[string]interface{}{
+			want: map[string]any{
+				"exampleSDID@32473": map[string]any{
 					"class": "high",
 				},
 			},
@@ -568,7 +556,6 @@ func TestParseStructuredData(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -615,8 +602,8 @@ func TestMessage_Fields(t *testing.T) {
 						"procid":   "1024",
 						"msgid":    "msg123",
 						"version":  "1",
-						"structured_data": map[string]interface{}{
-							"a": map[string]interface{}{
+						"structured_data": map[string]any{
+							"a": map[string]any{
 								"b": "c",
 							},
 						},
@@ -699,7 +686,6 @@ func TestMessage_Fields(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/libbeat/reader/syslog/rfc3164_test.go
+++ b/libbeat/reader/syslog/rfc3164_test.go
@@ -184,7 +184,6 @@ func TestParseRFC3164(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -243,7 +242,6 @@ func BenchmarkParseRFC3164(b *testing.B) {
 	}
 
 	for name, bc := range tests {
-		bc := bc
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {

--- a/libbeat/reader/syslog/rfc5424_test.go
+++ b/libbeat/reader/syslog/rfc5424_test.go
@@ -262,7 +262,6 @@ func TestParseRFC5424(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -301,7 +300,6 @@ func BenchmarkParseRFC5424(b *testing.B) {
 	}
 
 	for name, bc := range tests {
-		bc := bc
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -331,7 +329,6 @@ func TestIsRFC5424(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -358,7 +355,6 @@ func BenchmarkIsRFC5424(b *testing.B) {
 	}
 
 	for name, bc := range tests {
-		bc := bc
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {

--- a/libbeat/reader/syslog/syslog_test.go
+++ b/libbeat/reader/syslog/syslog_test.go
@@ -100,11 +100,11 @@ func TestNewParser(t *testing.T) {
 								"procid":   "1024",
 								"msgid":    "ID47",
 								"version":  "1",
-								"structured_data": map[string]interface{}{
-									"examplePriority@32473": map[string]interface{}{
+								"structured_data": map[string]any{
+									"examplePriority@32473": map[string]any{
 										"class": "high",
 									},
-									"exampleSDID@32473": map[string]interface{}{
+									"exampleSDID@32473": map[string]any{
 										"eventID":     "1011",
 										"eventSource": "Application",
 										"iut":         "3",
@@ -148,7 +148,6 @@ func TestNewParser(t *testing.T) {
 
 	logger := logptest.NewTestingLogger(t, "")
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/libbeat/reader/syslog/util.go
+++ b/libbeat/reader/syslog/util.go
@@ -113,7 +113,7 @@ func appendStringField(m mapstr.M, field, value string) {
 		_, _ = m.Put(field, []string{t, value})
 	case []string:
 		_, _ = m.Put(field, append(t, value))
-	case []interface{}:
+	case []any:
 		_, _ = m.Put(field, append(t, value))
 	}
 }

--- a/libbeat/reader/syslog/util_test.go
+++ b/libbeat/reader/syslog/util_test.go
@@ -57,7 +57,6 @@ func TestStringToInt(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := stringToInt(tc.in)
@@ -131,7 +130,6 @@ var removeBytesCases = map[string]struct {
 
 func TestRemoveBytes(t *testing.T) {
 	for name, tc := range removeBytesCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -144,7 +142,6 @@ func TestRemoveBytes(t *testing.T) {
 
 func BenchmarkRemoveBytes(b *testing.B) {
 	for name, bc := range removeBytesCases {
-		bc := bc
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -186,7 +183,6 @@ func TestMapIndexToString(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -235,18 +231,17 @@ func TestAppendStringField(t *testing.T) {
 		},
 		"interface-slice": {
 			inMap: mapstr.M{
-				"error": []interface{}{"foo", "bar"},
+				"error": []any{"foo", "bar"},
 			},
 			inField: "error",
 			inValue: "some value",
 			want: mapstr.M{
-				"error": []interface{}{"foo", "bar", "some value"},
+				"error": []any{"foo", "bar", "some value"},
 			},
 		},
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			appendStringField(tc.inMap, tc.inField, tc.inValue)
@@ -290,7 +285,6 @@ func TestJoinStr(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/netflow/case.go
+++ b/x-pack/filebeat/input/netflow/case.go
@@ -34,7 +34,7 @@ func (c *caseConverter) memoize(nfName, converted string) string {
 }
 
 func (c *caseConverter) ToSnakeCase(orig record.Map) mapstr.M {
-	result := mapstr.M(make(map[string]interface{}, len(orig)))
+	result := mapstr.M(make(map[string]any, len(orig)))
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 

--- a/x-pack/filebeat/input/netflow/convert.go
+++ b/x-pack/filebeat/input/netflow/convert.go
@@ -385,7 +385,7 @@ func getKeyUint64(dict record.Map, key string) (value uint64, found bool) {
 }
 
 func getKeyUint64Alternatives(dict record.Map, keys ...string) (value uint64, found bool) {
-	var iface interface{}
+	var iface any
 	for _, key := range keys {
 		if iface, found = dict[key]; found {
 			if value, found = iface.(uint64); found {
@@ -416,7 +416,7 @@ func getKeyIP(dict record.Map, key string) (value net.IP, found bool) {
 
 // Replaces each net.HardwareAddr in the dictionary with its string representation
 // because HardwareAddr doesn't implement Marshaler interface.
-func fixMacAddresses(dict map[string]interface{}) {
+func fixMacAddresses(dict map[string]any) {
 	for key, value := range dict {
 		if addr, ok := value.(net.HardwareAddr); ok {
 			if len(addr) == 0 {

--- a/x-pack/filebeat/input/netflow/decoder/examples/go-netflow-example.go
+++ b/x-pack/filebeat/input/netflow/decoder/examples/go-netflow-example.go
@@ -57,7 +57,7 @@ func main() {
 		}
 
 		for _, r := range records {
-			evt, err := json.Marshal(map[string]interface{}{
+			evt, err := json.Marshal(map[string]any{
 				"@timestamp": r.Timestamp,
 				"type":       r.Type,
 				"exporter":   r.Exporter,

--- a/x-pack/filebeat/input/netflow/decoder/fields/field.go
+++ b/x-pack/filebeat/input/netflow/decoder/fields/field.go
@@ -4,7 +4,10 @@
 
 package fields
 
-import "fmt"
+import (
+	"fmt"
+	"maps"
+)
 
 var GlobalFields = FieldDict{}
 
@@ -33,7 +36,5 @@ func RegisterGlobalFields(dict FieldDict) error {
 // Merge merges the passed fields into the dictionary, overwriting existing
 // fields if duplicated.
 func (f FieldDict) Merge(otherFields FieldDict) {
-	for key, value := range otherFields {
-		f[key] = value
-	}
+	maps.Copy(f, otherFields)
 }

--- a/x-pack/filebeat/input/netflow/decoder/fields/types.go
+++ b/x-pack/filebeat/input/netflow/decoder/fields/types.go
@@ -24,7 +24,7 @@ var (
 )
 
 type Decoder interface {
-	Decode([]byte) (interface{}, error)
+	Decode([]byte) (any, error)
 	MinLength() uint16
 	MaxLength() uint16
 }
@@ -39,7 +39,7 @@ func (u UnsignedDecoder) MaxLength() uint16 {
 	return uint16(u)
 }
 
-func (u UnsignedDecoder) Decode(data []byte) (interface{}, error) {
+func (u UnsignedDecoder) Decode(data []byte) (any, error) {
 	n := len(data)
 	if n > int(u) {
 		return uint64(0), ErrOutOfBounds
@@ -57,7 +57,7 @@ func (u UnsignedDecoder) Decode(data []byte) (interface{}, error) {
 		return binary.BigEndian.Uint64(data), nil
 	default:
 		var value uint64
-		for i := 0; i < n; i++ {
+		for i := range n {
 			value = (value << 8) | uint64(data[i])
 		}
 		return value, nil
@@ -76,7 +76,7 @@ func (u SignedDecoder) MaxLength() uint16 {
 	return uint16(u)
 }
 
-func (u SignedDecoder) Decode(data []byte) (interface{}, error) {
+func (u SignedDecoder) Decode(data []byte) (any, error) {
 	n := len(data)
 	if n > int(u) {
 		return int64(0), ErrOutOfBounds
@@ -116,7 +116,7 @@ func (u FloatDecoder) MaxLength() uint16 {
 	return uint16(u)
 }
 
-func (u FloatDecoder) Decode(data []byte) (interface{}, error) {
+func (u FloatDecoder) Decode(data []byte) (any, error) {
 	n := len(data)
 	if n > int(u) {
 		return float64(0), ErrOutOfBounds
@@ -145,7 +145,7 @@ func (u BooleanDecoder) MaxLength() uint16 {
 	return 1
 }
 
-func (u BooleanDecoder) Decode(data []byte) (interface{}, error) {
+func (u BooleanDecoder) Decode(data []byte) (any, error) {
 	n := len(data)
 	switch n {
 	case 0:
@@ -181,7 +181,7 @@ func (u OctetArrayDecoder) MaxLength() uint16 {
 	return 0xffff
 }
 
-func (u OctetArrayDecoder) Decode(data []byte) (interface{}, error) {
+func (u OctetArrayDecoder) Decode(data []byte) (any, error) {
 	return data, nil
 }
 
@@ -197,7 +197,7 @@ func (u MacAddressDecoder) MaxLength() uint16 {
 	return 6
 }
 
-func (u MacAddressDecoder) Decode(data []byte) (interface{}, error) {
+func (u MacAddressDecoder) Decode(data []byte) (any, error) {
 	if len(data) != 6 {
 		return net.HardwareAddr{}, ErrOutOfBounds
 	}
@@ -216,7 +216,7 @@ func (u StringDecoder) MaxLength() uint16 {
 	return 0xffff
 }
 
-func (u StringDecoder) Decode(data []byte) (interface{}, error) {
+func (u StringDecoder) Decode(data []byte) (any, error) {
 	return strings.TrimRightFunc(string(data), func(r rune) bool {
 		return r == 0
 	}), nil
@@ -234,7 +234,7 @@ func (u DateTimeSecondsDecoder) MaxLength() uint16 {
 	return 4
 }
 
-func (u DateTimeSecondsDecoder) Decode(data []byte) (interface{}, error) {
+func (u DateTimeSecondsDecoder) Decode(data []byte) (any, error) {
 	if len(data) != 4 {
 		return time.Time{}, ErrOutOfBounds
 	}
@@ -253,7 +253,7 @@ func (u DateTimeMillisecondsDecoder) MaxLength() uint16 {
 	return 8
 }
 
-func (u DateTimeMillisecondsDecoder) Decode(data []byte) (interface{}, error) {
+func (u DateTimeMillisecondsDecoder) Decode(data []byte) (any, error) {
 	if len(data) != 8 {
 		return time.Time{}, ErrOutOfBounds
 	}
@@ -273,7 +273,7 @@ func (u NTPTimestampDecoder) MaxLength() uint16 {
 	return 8
 }
 
-func (u NTPTimestampDecoder) Decode(data []byte) (interface{}, error) {
+func (u NTPTimestampDecoder) Decode(data []byte) (any, error) {
 	if len(data) != 8 {
 		return time.Time{}, ErrOutOfBounds
 	}
@@ -294,7 +294,7 @@ func (u IPAddressDecoder) MaxLength() uint16 {
 	return uint16(u)
 }
 
-func (u IPAddressDecoder) Decode(data []byte) (interface{}, error) {
+func (u IPAddressDecoder) Decode(data []byte) (any, error) {
 	n := len(data)
 	if n != int(u) {
 		return net.IP{}, ErrOutOfBounds
@@ -317,7 +317,7 @@ func (u UnsupportedDecoder) MaxLength() uint16 {
 	return math.MaxUint16
 }
 
-func (u UnsupportedDecoder) Decode(data []byte) (interface{}, error) {
+func (u UnsupportedDecoder) Decode(data []byte) (any, error) {
 	return nil, ErrUnsupported
 }
 
@@ -335,7 +335,7 @@ func (u ACLIDDecoder) MaxLength() uint16 {
 	return aclIDLength
 }
 
-func (u ACLIDDecoder) Decode(data []byte) (interface{}, error) {
+func (u ACLIDDecoder) Decode(data []byte) (any, error) {
 	if len(data) != aclIDLength {
 		return nil, ErrOutOfBounds
 	}

--- a/x-pack/filebeat/input/netflow/decoder/fields/types_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/fields/types_test.go
@@ -41,7 +41,7 @@ func TestOctetArray(t *testing.T) {
 type testCase struct {
 	title    string
 	bytes    []byte
-	value    interface{}
+	value    any
 	err      bool
 	strValue string
 }

--- a/x-pack/filebeat/input/netflow/decoder/record/record.go
+++ b/x-pack/filebeat/input/netflow/decoder/record/record.go
@@ -43,7 +43,7 @@ const (
 //	+---------+----------------------------------------+
 //	|  Map    | nested fields found in option records. |
 //	+---------+----------------------------------------+
-type Map map[string]interface{}
+type Map map[string]any
 
 // Record represents a NetFlow record extracted from a NetFlow packet.
 type Record struct {

--- a/x-pack/filebeat/input/netflow/decoder/template/template.go
+++ b/x-pack/filebeat/input/netflow/decoder/template/template.go
@@ -84,10 +84,7 @@ func (t *Template) Apply(data *bytes.Buffer, n int) ([]record.Record, error) {
 	limit, alloc := n, n
 	if t.VariableLength {
 		limit = math.MaxInt16
-		alloc = n
-		if alloc > 16 {
-			alloc = 16
-		}
+		alloc = min(n, 16)
 	}
 	makeFn := t.makeFlow
 	if t.IsOptions {

--- a/x-pack/filebeat/input/netflow/decoder/v9/decoder.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/decoder.go
@@ -106,7 +106,7 @@ func ReadFields(d Decoder, buf *bytes.Buffer, count int) (record template.Templa
 	knownFields := d.GetFields()
 	logger := d.GetLogger()
 	record.Fields = make([]template.FieldTemplate, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		key, length, err := d.ReadFieldDefinition(buf)
 		if err != nil {
 			return template.Template{}, io.EOF

--- a/x-pack/filebeat/input/netflow/decoder/v9/session_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/session_test.go
@@ -70,10 +70,10 @@ func TestSessionMap_GetOrCreate(t *testing.T) {
 		C := make(chan *SessionState, N*Iters)
 		wg := sync.WaitGroup{}
 		wg.Add(N)
-		for i := 0; i < N; i++ {
+		for range N {
 			go func() {
 				last := sm.GetOrCreate(key)
-				for iter := 0; iter < Iters; iter++ {
+				for range Iters {
 					s := sm.GetOrCreate(key)
 					if last != s {
 						C <- last

--- a/x-pack/filebeat/input/netflow/definitions.go
+++ b/x-pack/filebeat/input/netflow/definitions.go
@@ -49,8 +49,8 @@ var logstashName2Decoder = map[string]fields.Decoder{
 
 // LoadFieldDefinitions takes a parsed YAML tree from a Logstash
 // Netflow or IPFIX custom fields format and converts it to a FieldDict.
-func LoadFieldDefinitions(yaml interface{}) (defs fields.FieldDict, err error) {
-	tree, ok := yaml.(map[interface{}]interface{})
+func LoadFieldDefinitions(yaml any) (defs fields.FieldDict, err error) {
+	tree, ok := yaml.(map[any]any)
 	if !ok {
 		return nil, fmt.Errorf("invalid custom fields definition format: expected a mapping of integer keys. Got %T", yaml)
 	}
@@ -76,7 +76,7 @@ func LoadFieldDefinitions(yaml interface{}) (defs fields.FieldDict, err error) {
 		if !fits(pem, 0, math.MaxUint32) {
 			return nil, fmt.Errorf("PEM %d out of uint32 range", pem)
 		}
-		tree, ok := fields.(map[interface{}]interface{})
+		tree, ok := fields.(map[any]any)
 		if !ok {
 			return nil, fmt.Errorf("IPFIX fields for pem=%d malformed", pem)
 		}
@@ -99,7 +99,7 @@ func LoadFieldDefinitionsFromFile(path string) (defs fields.FieldDict, err error
 	if err != nil {
 		return nil, err
 	}
-	var tree interface{}
+	var tree any
 	if err := yaml.Unmarshal(contents, &tree); err != nil {
 		return nil, fmt.Errorf("unable to parse YAML: %w", err)
 	}
@@ -117,7 +117,7 @@ func trimColon(s string) string {
 	return s
 }
 
-func toInt(value interface{}) (int64, error) {
+func toInt(value any) (int64, error) {
 	switch v := value.(type) {
 	case int64:
 		return v, nil
@@ -129,7 +129,7 @@ func toInt(value interface{}) (int64, error) {
 	return 0, fmt.Errorf("value %v cannot be converted to int", value)
 }
 
-func loadFields(def map[interface{}]interface{}, pem uint32, dest fields.FieldDict) error {
+func loadFields(def map[any]any, pem uint32, dest fields.FieldDict) error {
 	for keyI, iface := range def {
 		fieldID, err := toInt(keyI)
 		if err != nil {
@@ -138,7 +138,7 @@ func loadFields(def map[interface{}]interface{}, pem uint32, dest fields.FieldDi
 		if !fits(fieldID, 0, math.MaxUint16) {
 			return fmt.Errorf("field ID %d out of range uint16", fieldID)
 		}
-		list, ok := iface.([]interface{})
+		list, ok := iface.([]any)
 		if !ok {
 			return fmt.Errorf("field ID %d is not a list", fieldID)
 		}
@@ -187,7 +187,7 @@ func loadFields(def map[interface{}]interface{}, pem uint32, dest fields.FieldDi
 	return nil
 }
 
-func fieldsAreIPFIX(tree map[interface{}]interface{}) (bool, error) {
+func fieldsAreIPFIX(tree map[any]any) (bool, error) {
 	if len(tree) == 0 {
 		return false, errors.New("custom fields definition is empty")
 	}
@@ -195,12 +195,12 @@ func fieldsAreIPFIX(tree map[interface{}]interface{}) (bool, error) {
 	for key, value := range tree {
 		var msg string
 		switch v := value.(type) {
-		case map[interface{}]interface{}:
+		case map[any]any:
 			seenMap = true
 			if seenList {
 				msg = "expected IPFIX map of fields"
 			}
-		case []interface{}:
+		case []any:
 			seenList = true
 			if seenMap {
 				msg = "expected NetFlow single field definition"

--- a/x-pack/filebeat/input/netflow/definitions_test.go
+++ b/x-pack/filebeat/input/netflow/definitions_test.go
@@ -90,7 +90,7 @@ func TestLoadFieldDefinitions(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.title, func(t *testing.T) {
-			var tree interface{}
+			var tree any
 			if err := yaml.Unmarshal([]byte(testCase.yaml), &tree); err != nil {
 				t.Fatal(err)
 			}

--- a/x-pack/filebeat/input/netflow/input.go
+++ b/x-pack/filebeat/input/netflow/input.go
@@ -157,7 +157,7 @@ func (n *netflowInput) Run(env v2.Context, connector beat.PipelineConnector) err
 		client, err := connector.ConnectWith(beat.ClientConfig{
 			PublishMode: beat.DefaultGuarantees,
 			Processing: beat.ProcessingConfig{
-				EventNormalization: boolPtr(false),
+				EventNormalization: new(false),
 			},
 			EventListener: nil,
 		})
@@ -270,4 +270,5 @@ func (n *netflowInput) stop() {
 	n.started = false
 }
 
-func boolPtr(b bool) *bool { return &b }
+//go:fix inline
+func boolPtr(b bool) *bool { return new(b) }

--- a/x-pack/filebeat/input/netflow/input.go
+++ b/x-pack/filebeat/input/netflow/input.go
@@ -269,6 +269,3 @@ func (n *netflowInput) stop() {
 
 	n.started = false
 }
-
-//go:fix inline
-func boolPtr(b bool) *bool { return new(b) }

--- a/x-pack/filebeat/input/netflow/integration_test.go
+++ b/x-pack/filebeat/input/netflow/integration_test.go
@@ -41,14 +41,13 @@ const (
 
 func TestNetFlowIntegration(t *testing.T) {
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// make sure there is an ES instance running
 	integration.EnsureESIsRunning(t)
 	esConnectionDetails := integration.GetESURL(t, "http")
 	outputHost := fmt.Sprintf("%s://%s:%s", esConnectionDetails.Scheme, esConnectionDetails.Hostname(), esConnectionDetails.Port())
-	outputHosts := []interface{}{outputHost}
+	outputHosts := []any{outputHost}
 
 	kibanaURL, kibanaUser := integration.GetKibana(t)
 	kibanaUsername := kibanaUser.Username()
@@ -83,7 +82,7 @@ func TestNetFlowIntegration(t *testing.T) {
 				Id:   "default",
 				Type: "elasticsearch",
 				Name: "elasticsearch",
-				Source: integration.RequireNewStruct(t, map[string]interface{}{
+				Source: integration.RequireNewStruct(t, map[string]any{
 					"type":                  "elasticsearch",
 					"hosts":                 outputHosts,
 					"username":              outputUsername,
@@ -113,7 +112,7 @@ func TestNetFlowIntegration(t *testing.T) {
 				Id:   "netflow-netflow-1e8b33de-d54a-45cd-90da-23ed71c482e5",
 				Type: "netflow",
 				Name: "netflow-1",
-				Source: integration.RequireNewStruct(t, map[string]interface{}{
+				Source: integration.RequireNewStruct(t, map[string]any{
 					"use_output": "default",
 					"revision":   0,
 				}),
@@ -132,7 +131,7 @@ func TestNetFlowIntegration(t *testing.T) {
 						DataStream: &proto.DataStream{
 							Dataset: "netflow.log",
 						},
-						Source: integration.RequireNewStruct(t, map[string]interface{}{
+						Source: integration.RequireNewStruct(t, map[string]any{
 							"id":                    "netflow_integration_test",
 							"host":                  "localhost:6006",
 							"expiration_timeout":    "30m",
@@ -153,7 +152,7 @@ func TestNetFlowIntegration(t *testing.T) {
 		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
 			unitState, payload := extractStateAndPayload(observed, "input-unit-1")
 			if unitState == proto.State_HEALTHY {
-				if payload.streamStatusEquals("netflow-netflow.netflow-1e8b33de-d54a-45cd-90da-23ed71c482e2", map[string]interface{}{
+				if payload.streamStatusEquals("netflow-netflow.netflow-1e8b33de-d54a-45cd-90da-23ed71c482e2", map[string]any{
 					"status": "HEALTHY",
 					"error":  "",
 				}) {
@@ -267,19 +266,19 @@ func TestNetFlowIntegration(t *testing.T) {
 	}, waitFor, tick, fmt.Sprintf("expected netflow data stream to have %d events", expectedEventsNumbers))
 }
 
-type unitPayload map[string]interface{}
+type unitPayload map[string]any
 
-func (u unitPayload) streamStatusEquals(streamID string, expected map[string]interface{}) bool {
+func (u unitPayload) streamStatusEquals(streamID string, expected map[string]any) bool {
 	if u == nil {
 		return false
 	}
 
-	streams, ok := u["streams"].(map[string]interface{})
+	streams, ok := u["streams"].(map[string]any)
 	if !ok || streams == nil {
 		return false
 	}
 
-	streamMap, ok := streams[streamID].(map[string]interface{})
+	streamMap, ok := streams[streamID].(map[string]any)
 	if !ok || streamMap == nil {
 		return false
 	}
@@ -304,7 +303,7 @@ type DataStream struct {
 
 type DataStreamResult struct {
 	DataStreams []DataStream `json:"data_streams"`
-	Error       interface{}  `json:"error"`
+	Error       any          `json:"error"`
 }
 
 func HasDataStream(ctx context.Context, username string, password string, url string, name string) error {

--- a/x-pack/filebeat/input/netflow/netflow_test.go
+++ b/x-pack/filebeat/input/netflow/netflow_test.go
@@ -495,7 +495,7 @@ func TestReverseFlows(t *testing.T) {
 		t.Fatal()
 	}
 	for _, key := range reverseFlowsTestKeys {
-		var keys [2]interface{}
+		var keys [2]any
 		for i := range keys {
 			var err error
 			if keys[i], err = evs[i].Fields.GetValue(key); err != nil {

--- a/x-pack/filebeat/module/cisco/ios/pipeline_test.go
+++ b/x-pack/filebeat/module/cisco/ios/pipeline_test.go
@@ -41,7 +41,7 @@ type testCase struct {
 var testCases = []testCase{
 	{
 		"%SEC-6-IPACCESSLOGP: list 100 denied udp 198.51.100.1(55934) -> 198.51.100.255(15600), 1 packet",
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"cisco.ios.access_list": "100",
 			"cisco.ios.facility":    "SEC",
 			"destination.ip":        "198.51.100.255",
@@ -65,7 +65,7 @@ var testCases = []testCase{
 
 	{
 		"%SEC-6-IPACCESSLOGDP: list 100 denied icmp 198.51.100.1 -> 198.51.100.2 (3/5), 1 packet",
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"cisco.ios.access_list": "100",
 			"cisco.ios.facility":    "SEC",
 			"destination.ip":        "198.51.100.2",
@@ -89,7 +89,7 @@ var testCases = []testCase{
 
 	{
 		"%SEC-6-IPACCESSLOGRP: list 170 denied igmp 198.51.100.1 -> 224.168.168.168, 1 packet",
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"cisco.ios.access_list": "170",
 			"cisco.ios.facility":    "SEC",
 			"destination.ip":        "224.168.168.168",
@@ -111,7 +111,7 @@ var testCases = []testCase{
 
 	{
 		"%SEC-6-IPACCESSLOGSP: list INBOUND-ON-AP denied igmp 198.51.100.1 -> 224.0.0.2 (20), 1 packet",
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"cisco.ios.access_list": "INBOUND-ON-AP",
 			"cisco.ios.facility":    "SEC",
 			"destination.ip":        "224.0.0.2",
@@ -134,7 +134,7 @@ var testCases = []testCase{
 
 	{
 		"%SEC-6-IPACCESSLOGNP: list 1 permitted 0 198.51.100.1 -> 239.10.10.10, 1 packet",
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"cisco.ios.access_list": "1",
 			"cisco.ios.facility":    "SEC",
 			"destination.ip":        "239.10.10.10",
@@ -156,7 +156,7 @@ var testCases = []testCase{
 
 	{
 		"%SEC-6-IPACCESSLOGRL: access-list logging rate-limited or missed 18 packets",
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"cisco.ios.facility": "SEC",
 			"event.code":         "IPACCESSLOGRL",
 			"event.original":     isdef.IsNonEmptyString,
@@ -168,7 +168,7 @@ var testCases = []testCase{
 
 	{
 		"%IPV6-6-ACCESSLOGP: list ACL-IPv6-E0/0-IN/10 permitted tcp 2001:DB8::3(1027) -> 2001:DB8:1000::1(22), 9 packets",
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"cisco.ios.facility": "IPV6",
 			"event.code":         "ACCESSLOGP",
 			"event.original":     isdef.IsNonEmptyString,
@@ -199,7 +199,6 @@ func TestFilebeatSyslogCisco(t *testing.T) {
 
 func testInput(t *testing.T, input string, p beat.Processor) {
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s/%d", input, i), func(t *testing.T) {
 			if input == "log" {
 				tc.message = logInputHeaders[i%len(logInputHeaders)] + tc.message

--- a/x-pack/filebeat/processors/decode_cef/cef/cef.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/cef.go
@@ -33,9 +33,9 @@ var (
 
 // Field is CEF extension field value.
 type Field struct {
-	String    string      // Raw value.
-	Type      DataType    // Data type from CEF guide.
-	Interface interface{} // Converted value.
+	String    string   // Raw value.
+	Type      DataType // Data type from CEF guide.
+	Interface any      // Converted value.
 }
 
 // Event is a single CEF message.
@@ -187,7 +187,7 @@ func replaceEscapes(v string, startOffset int, escapes []escapePosition) string 
 	}
 
 	// Adjust escape offsets relative to the start offset of v.
-	for i := 0; i < len(escapes); i++ {
+	for i := range escapes {
 		escapes[i].start = escapes[i].start - startOffset
 		escapes[i].end = escapes[i].end - startOffset
 	}

--- a/x-pack/filebeat/processors/decode_cef/cef/types.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types.go
@@ -33,7 +33,7 @@ const (
 )
 
 // toType converts the given value string value to the specified data type.
-func toType(value string, typ DataType, settings *Settings) (interface{}, error) {
+func toType(value string, typ DataType, settings *Settings) (any, error) {
 	switch typ {
 	case StringType:
 		return value, nil

--- a/x-pack/filebeat/processors/decode_cef/decode_cef.go
+++ b/x-pack/filebeat/processors/decode_cef/decode_cef.go
@@ -7,6 +7,7 @@ package decode_cef
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -227,14 +228,12 @@ func appendErrorMessage(m mapstr.M, msg string) error {
 			m.Put(field, []string{v, msg})
 		}
 	case []string:
-		for _, existingTag := range v {
-			if msg == existingTag {
-				// Duplicate
-				return nil
-			}
+		if slices.Contains(v, msg) {
+			// Duplicate
+			return nil
 		}
 		m.Put(field, append(v, msg))
-	case []interface{}:
+	case []any:
 		for _, existingTag := range v {
 			if msg == existingTag {
 				// Duplicate

--- a/x-pack/filebeat/processors/decode_cef/decode_cef_test.go
+++ b/x-pack/filebeat/processors/decode_cef/decode_cef_test.go
@@ -365,7 +365,7 @@ func normalize(t testing.TB, m mapstr.M) mapstr.M {
 
 // assertEqual asserts that the two objects are deeply equal. If not it will
 // error the test and output a diff of the two objects' JSON representation.
-func assertEqual(t testing.TB, expected, actual interface{}) bool {
+func assertEqual(t testing.TB, expected, actual any) bool {
 	t.Helper()
 
 	if reflect.DeepEqual(expected, actual) {
@@ -390,7 +390,7 @@ func BenchmarkProcessorRun(b *testing.B) {
 	b.Run("short_msg", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := dec.Run(&beat.Event{
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"message": msg,
 				},
 			})
@@ -404,7 +404,7 @@ func BenchmarkProcessorRun(b *testing.B) {
 	b.Run("long_msg", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := dec.Run(&beat.Event{
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"message": longMsg,
 				},
 			})

--- a/x-pack/filebeat/processors/decode_cef/keys.ecs.go
+++ b/x-pack/filebeat/processors/decode_cef/keys.ecs.go
@@ -21,7 +21,7 @@ type mappedField struct {
 	// Translate should not mutate the input and should
 	// return an error if the input data cannot be correctly
 	// mapped to ECS-formatted data for the target field.
-	Translate func(in *cef.Field) (interface{}, error)
+	Translate func(in *cef.Field) (any, error)
 }
 
 var ecsExtensionMapping = map[string]mappedField{
@@ -62,13 +62,13 @@ var ecsExtensionMapping = map[string]mappedField{
 	"deviceAction":                 {Target: "event.action"},
 	"deviceAddress": {
 		Target: "observer.ip",
-		Translate: func(in *cef.Field) (interface{}, error) {
+		Translate: func(in *cef.Field) (any, error) {
 			return []string{in.String}, nil
 		},
 	},
 	"deviceDirection": {
 		Target: "network.direction",
-		Translate: func(in *cef.Field) (interface{}, error) {
+		Translate: func(in *cef.Field) (any, error) {
 			switch in.String {
 			case "0":
 				return "inbound", nil
@@ -105,7 +105,7 @@ var ecsExtensionMapping = map[string]mappedField{
 	"requestClientApplication": {Target: "user_agent.original"},
 	"requestContext": {
 		Target: "http.request.referrer",
-		Translate: func(in *cef.Field) (interface{}, error) {
+		Translate: func(in *cef.Field) (any, error) {
 			// Does the string look like URL?
 			if strings.HasPrefix(in.String, "http") {
 				return in.String, nil
@@ -136,13 +136,13 @@ var ecsExtensionMapping = map[string]mappedField{
 	"startTime":               {Target: "event.start"},
 	"transportProtocol": {
 		Target: "network.transport",
-		Translate: func(in *cef.Field) (interface{}, error) {
+		Translate: func(in *cef.Field) (any, error) {
 			return strings.ToLower(in.String), nil
 		},
 	},
 	"type": {Target: "event.kind"},
 }
 
-func ecsMAC(in *cef.Field) (interface{}, error) {
+func ecsMAC(in *cef.Field) (any, error) {
 	return strings.ToUpper(strings.ReplaceAll(in.String, ":", "-")), nil
 }


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat,libbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 35 file(s)
owned by @elastic/integration-experience in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

A second commit removes the helpers the rewrites orphaned; see the review notes below.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


REDUNDANT_CONVERSION = re.compile(r"new\(\(([\w.]+)\)\(")


def drop_redundant_parens(root: Path, files: list[str]) -> int:
    """Rewrite the `new((T)(x))` the newexpr fixer emits as `new(T(x))`.

    Dropping one paren on each side keeps the call balanced, and the pattern is narrow
    enough that a textual rewrite cannot match anything else.
    """
    touched = 0
    for name in files:
        path = root / name
        before = path.read_text()
        after = REDUNDANT_CONVERSION.sub(r"new(\1(", before)
        if after != before:
            path.write_text(after)
            touched += 1
    return touched


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]
        cleaned = drop_redundant_parens(root, files)
        if cleaned:
            log(f"  dropped redundant conversion parens in {cleaned} file(s)")

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Separate commits, so the hand-written part is obvious:

1. `x-pack/filebeat,libbeat: fix modernize lint findings` is pure tool output, nothing in it was written by hand.
2. `x-pack/filebeat: drop helper orphaned by modernize` is the part the tools could not produce:

   > `go fix` inlined the `//go:fix inline` pointer helper at every call site,
   > leaving the helper itself unused. Deleting it is the one part of this
   > branch a tool could not do, so it lives in its own commit.

- `x-pack/filebeat/input/netflow/input.go`

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
