### PR TITLE
x-pack/filebeat,packetbeat: fix modernize lint findings

### DIFF
--- a/auditbeat/datastore/registry_test.go
+++ b/auditbeat/datastore/registry_test.go
@@ -193,10 +193,10 @@ func TestRegistryConcurrentOpenClose(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iters; j++ {
+			for range iters {
 				b, err := OpenBucket("a", p)
 				if err != nil {
 					t.Errorf("concurrent OpenBucket: %v", err)

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -398,7 +398,7 @@ func (ms *MetricSet) setPID(retries int) (err error) {
 	}
 
 	// run the SetPID logic in a retry loop, since the startup process can be fragile.
-	for i := 0; i < retries; i++ {
+	for range retries {
 		// This call will block on send, which isn't great, but the reply can *also* time out
 		// or return something like ENOBUFS.
 		err = ms.client.SetPID(libaudit.WaitForReply)
@@ -413,7 +413,7 @@ func (ms *MetricSet) setPID(retries int) (err error) {
 			// the netlink connection is losing data. Try to drain and send again.
 			// This is technically dropping data, but auditbeat is configured as best-effort anyway, and we'll drop events under high load anyway.
 			maxRecv := 10000
-			for i := 0; i < maxRecv; i++ {
+			for range maxRecv {
 				var retryOuter bool // hack because of how switch/break statements work
 				_, err = ms.client.Netlink.Receive(true, noParse)
 				switch {

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -354,8 +354,8 @@ func assertFieldsAreDocumented(t *testing.T, events []mb.Event) {
 	}
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":              "auditd",
 		"failure_mode":        "log",
 		"socket_type":         "unicast",
@@ -371,7 +371,7 @@ func TestUnicastClient(t *testing.T) {
 
 	FailIfAuditdIsRunning(t)
 
-	c := map[string]interface{}{
+	c := map[string]any{
 		"module":      "auditd",
 		"socket_type": "unicast",
 		"audit_rules": fmt.Sprintf(`
@@ -400,7 +400,7 @@ func TestMulticastClient(t *testing.T) {
 
 	FailIfAuditdIsRunning(t)
 
-	c := map[string]interface{}{
+	c := map[string]any{
 		"module":      "auditd",
 		"socket_type": "multicast",
 		"audit_rules": fmt.Sprintf(`

--- a/auditbeat/module/auditd/config_test.go
+++ b/auditbeat/module/auditd/config_test.go
@@ -141,7 +141,6 @@ audit_rules: |
 		}
 
 		for _, tc := range tcs {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				config := defaultConfig
 				config.SocketType = tc.socketType

--- a/auditbeat/module/auditd/golden_files_test.go
+++ b/auditbeat/module/auditd/golden_files_test.go
@@ -110,8 +110,8 @@ func normalize(t testing.TB, events []mb.Event) (norm []mapstr.M) {
 	return norm
 }
 
-func configForGolden() map[string]interface{} {
-	return map[string]interface{}{
+func configForGolden() map[string]any {
+	return map[string]any{
 		"module":                  "auditd",
 		"failure_mode":            "log",
 		"socket_type":             "unicast",

--- a/auditbeat/module/file_integrity/config_test.go
+++ b/auditbeat/module/file_integrity/config_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths":             []string{"/usr/bin"},
 		"hash_types":        []string{"sha256", "sha512"},
 		"max_file_size":     "1 GiB",
@@ -61,7 +61,7 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigInvalid(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths":             []string{"/usr/bin"},
 		"hash_types":        []string{"crc32", "sha256", "hmac"},
 		"max_file_size":     "32 Hz",
@@ -92,7 +92,7 @@ func TestConfigInvalid(t *testing.T) {
 	}
 	assert.Len(t, merr.Unwrap(), 4)
 
-	config, err = conf.NewConfigFrom(map[string]interface{}{
+	config, err = conf.NewConfigFrom(map[string]any{
 		"paths":         []string{"/usr/bin"},
 		"hash_types":    []string{"crc32", "sha256", "hmac"},
 		"exclude_files": "unmatched)",
@@ -119,7 +119,7 @@ func TestConfigInvalid(t *testing.T) {
 }
 
 func TestConfigInvalidMaxFileSize(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths":         []string{"/usr/bin"},
 		"max_file_size": "0", // Value must be >= 0.
 	})
@@ -140,7 +140,7 @@ func TestConfigEvalSymlinks(t *testing.T) {
 	dir := setupTestDir(t)
 	defer os.RemoveAll(dir)
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths": []string{filepath.Join(dir, "link_to_subdir")},
 	})
 	if err != nil {
@@ -158,7 +158,7 @@ func TestConfigEvalSymlinks(t *testing.T) {
 }
 
 func TestConfigRemoveDuplicates(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths": []string{"/path/a", "/path/a"},
 	})
 	if err != nil {

--- a/auditbeat/module/file_integrity/device_resolver.go
+++ b/auditbeat/module/file_integrity/device_resolver.go
@@ -172,7 +172,7 @@ func (dr *deviceResolver) buildDeviceMap() (map[string]string, error) {
 	}
 
 	// Query each drive letter
-	for i := 0; i < 26; i++ {
+	for i := range 26 {
 		if (bitmask>>i)&1 == 1 {
 			driveLetter := string(byte('A' + i))
 			drivePath := driveLetter + ":"

--- a/auditbeat/module/file_integrity/device_resolver_test.go
+++ b/auditbeat/module/file_integrity/device_resolver_test.go
@@ -143,7 +143,7 @@ func createTestDeviceMapping(count int) (map[string]string, []string) {
 	deviceMap := make(map[string]string)
 	deviceList := make([]string, 0, count)
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		device := fmt.Sprintf("\\Device\\HarddiskVolume%d", i)
 		drive := fmt.Sprintf("%c:", 'A'+i%26)
 		deviceMap[device] = drive

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"os/user"
@@ -429,9 +430,7 @@ func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {
 		}
 		file["hash"] = hashes
 	}
-	for k, v := range e.ParserResults {
-		file[k] = v
-	}
+	maps.Copy(file, e.ParserResults)
 
 	out.MetricSetFields.Put("event.kind", "event")
 	out.MetricSetFields.Put("event.category", []string{"file"})

--- a/auditbeat/module/file_integrity/event_test.go
+++ b/auditbeat/module/file_integrity/event_test.go
@@ -368,7 +368,7 @@ func BenchmarkHashFile(b *testing.B) {
 
 	zeros := make([]byte, 100)
 	const iterations = 1024 * 1024 // 100 MiB
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		if _, err = f.Write(zeros); err != nil {
 			b.Fatal(err)
 		}

--- a/auditbeat/module/file_integrity/eventreader_test.go
+++ b/auditbeat/module/file_integrity/eventreader_test.go
@@ -264,7 +264,7 @@ func TestRaces(t *testing.T) {
 	// Generate a lot of events in parallel to Start() so there is a chance of
 	// events arriving before all watched dirs are Add()-ed
 	go func() {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			for _, dir := range dirs {
 				fname := filepath.Join(dir, fmt.Sprintf("%d.dat", i))
 				require.NoError(t, os.WriteFile(fname, []byte("hello"), fileMode))
@@ -403,7 +403,7 @@ func mustRun(t *testing.T, name string, f func(t *testing.T)) {
 func rename(t *testing.T, oldPath, newPath string) {
 	const maxRetries = 100
 
-	for retries := 0; retries < maxRetries; retries++ {
+	for retries := range maxRetries {
 		err := os.Rename(oldPath, newPath)
 		if err == nil {
 			if retries > 0 {

--- a/auditbeat/module/file_integrity/exeobjparser.go
+++ b/auditbeat/module/file_integrity/exeobjparser.go
@@ -133,7 +133,6 @@ func (fields exeObjParser) Parse(dst mapstr.M, path string) (err error) {
 			// section attributes are added from another parser.
 			stats := make([]objSection, len(sections))
 			for i, s := range sections {
-				s := s
 				if all {
 					name = &s.Name
 					size = &s.Size

--- a/auditbeat/module/file_integrity/exeobjparser_test.go
+++ b/auditbeat/module/file_integrity/exeobjparser_test.go
@@ -180,15 +180,6 @@ func approxSections(tol float64) func(a, b any) bool {
 	}
 }
 
-//go:fix inline
-func strPtr(s string) *string { return new(s) }
-
-//go:fix inline
-func float64Ptr(f float64) *float64 { return new(f) }
-
-//go:fix inline
-func uint64Ptr(u uint64) *uint64 { return new(u) }
-
 func (o objSection) String() string {
 	name := "<nil>"
 	if o.Name != nil {

--- a/auditbeat/module/file_integrity/exeobjparser_test.go
+++ b/auditbeat/module/file_integrity/exeobjparser_test.go
@@ -64,11 +64,11 @@ func TestExeObjParser(t *testing.T) {
 
 				fields := []struct {
 					path string
-					cmp  func(a, b interface{}) bool
+					cmp  func(a, b any) bool
 				}{
-					{path: "import_hash", cmp: func(a, b interface{}) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
-					{path: "imphash", cmp: func(a, b interface{}) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
-					{path: "symhash", cmp: func(a, b interface{}) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
+					{path: "import_hash", cmp: func(a, b any) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
+					{path: "imphash", cmp: func(a, b any) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
+					{path: "symhash", cmp: func(a, b any) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
 					{path: "imports", cmp: approxImports(format, builder)},
 					{path: "imports_names_entropy", cmp: approxFloat64(0.1)},
 					{path: "imports_names_var_entropy", cmp: approxFloat64(0.01)},
@@ -76,7 +76,7 @@ func TestExeObjParser(t *testing.T) {
 					{path: "go_imports", cmp: approxImports(format, builder)},
 					{path: "go_imports_names_entropy", cmp: approxFloat64(0.1)},
 					{path: "go_imports_names_var_entropy", cmp: approxFloat64(0.01)},
-					{path: "go_stripped", cmp: func(a, b interface{}) bool { return a == b }},
+					{path: "go_stripped", cmp: func(a, b any) bool { return a == b }},
 					{path: "sections", cmp: approxSections(0.1)},
 				}
 
@@ -99,8 +99,8 @@ func TestExeObjParser(t *testing.T) {
 	}
 }
 
-func approxHash(format, builder string) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxHash(format, builder string) func(a, b any) bool {
+	return func(a, b any) bool {
 		as := fmt.Sprint(a)
 		bs := fmt.Sprint(b)
 		if len(as) != len(bs) {
@@ -114,8 +114,8 @@ func approxHash(format, builder string) func(a, b interface{}) bool {
 	}
 }
 
-func approxImports(format, builder string) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxImports(format, builder string) func(a, b any) bool {
+	return func(a, b any) bool {
 		as, ok := a.([]string)
 		if !ok {
 			return false
@@ -135,8 +135,8 @@ func approxImports(format, builder string) func(a, b interface{}) bool {
 	}
 }
 
-func approxFloat64(tol float64) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxFloat64(tol float64) func(a, b any) bool {
+	return func(a, b any) bool {
 		af, ok := a.(float64)
 		if !ok {
 			return false
@@ -149,8 +149,8 @@ func approxFloat64(tol float64) func(a, b interface{}) bool {
 	}
 }
 
-func approxSections(tol float64) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxSections(tol float64) func(a, b any) bool {
+	return func(a, b any) bool {
 		aObj, ok := a.([]objSection)
 		if !ok {
 			return false
@@ -180,9 +180,14 @@ func approxSections(tol float64) func(a, b interface{}) bool {
 	}
 }
 
-func strPtr(s string) *string       { return &s }
-func float64Ptr(f float64) *float64 { return &f }
-func uint64Ptr(u uint64) *uint64    { return &u }
+//go:fix inline
+func strPtr(s string) *string { return new(s) }
+
+//go:fix inline
+func float64Ptr(f float64) *float64 { return new(f) }
+
+//go:fix inline
+func uint64Ptr(u uint64) *uint64 { return new(u) }
 
 func (o objSection) String() string {
 	name := "<nil>"
@@ -213,19 +218,19 @@ var want = map[string]mapstr.M{
 			"go_imports_names_var_entropy": 0.0014785066641319837,
 			"go_stripped":                  false,
 			"sections": []objSection{
-				{Name: strPtr(".text"), Size: uint64Ptr(0x8e400), Entropy: float64Ptr(6.17), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".rdata"), Size: uint64Ptr(0x9ea00), Entropy: float64Ptr(5.13), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".data"), Size: uint64Ptr(0x17a00), Entropy: float64Ptr(4.60), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_abbrev"), Size: uint64Ptr(0x200), Entropy: float64Ptr(4.82), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_line"), Size: uint64Ptr(0x1cc00), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_frame"), Size: uint64Ptr(0x5800), Entropy: float64Ptr(7.92), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".debug_gdb_scripts"), Size: uint64Ptr(0x200), Entropy: float64Ptr(0.84), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_info"), Size: uint64Ptr(0x32a00), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_loc"), Size: uint64Ptr(0x1ba00), Entropy: float64Ptr(7.98), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_ranges"), Size: uint64Ptr(0x9600), Entropy: float64Ptr(7.78), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".idata"), Size: uint64Ptr(0x600), Entropy: float64Ptr(3.61), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".reloc"), Size: uint64Ptr(0x6a00), Entropy: float64Ptr(5.44), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".symtab"), Size: uint64Ptr(0x17a00), Entropy: float64Ptr(5.12), VarEntropy: float64Ptr(0.0001)},
+				{Name: new(".text"), Size: new(uint64(0x8e400)), Entropy: new(6.17), VarEntropy: new(0.0001)},
+				{Name: new(".rdata"), Size: new(uint64(0x9ea00)), Entropy: new(5.13), VarEntropy: new(0.0001)},
+				{Name: new(".data"), Size: new(uint64(0x17a00)), Entropy: new(4.60), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_abbrev"), Size: new(uint64(0x200)), Entropy: new(4.82), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_line"), Size: new(uint64(0x1cc00)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_frame"), Size: new(uint64(0x5800)), Entropy: new(7.92), VarEntropy: new(0.0001)},
+				{Name: new(".debug_gdb_scripts"), Size: new(uint64(0x200)), Entropy: new(0.84), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_info"), Size: new(uint64(0x32a00)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_loc"), Size: new(uint64(0x1ba00)), Entropy: new(7.98), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_ranges"), Size: new(uint64(0x9600)), Entropy: new(7.78), VarEntropy: new(0.0001)},
+				{Name: new(".idata"), Size: new(uint64(0x600)), Entropy: new(3.61), VarEntropy: new(0.0001)},
+				{Name: new(".reloc"), Size: new(uint64(0x6a00)), Entropy: new(5.44), VarEntropy: new(0.0001)},
+				{Name: new(".symtab"), Size: new(uint64(0x17a00)), Entropy: new(5.12), VarEntropy: new(0.0001)},
 			},
 			"import_hash": "c7269d59926fa4252270f407e4dab043",
 			"imports": []string{
@@ -284,29 +289,29 @@ var want = map[string]mapstr.M{
 			"go_imports_names_var_entropy": 0.0073028693197579415,
 			"go_stripped":                  false,
 			"sections": []objSection{
-				{Name: strPtr(""), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".text"), Size: uint64Ptr(0x7ffd6), Entropy: float64Ptr(6.17), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".rodata"), Size: uint64Ptr(0x35940), Entropy: float64Ptr(4.36), VarEntropy: float64Ptr(0.0005)},
-				{Name: strPtr(".shstrtab"), Size: uint64Ptr(0x17a), Entropy: float64Ptr(4.33), VarEntropy: float64Ptr(0.0019)},
-				{Name: strPtr(".typelink"), Size: uint64Ptr(0x4f0), Entropy: float64Ptr(3.77), VarEntropy: float64Ptr(0.0083)},
-				{Name: strPtr(".itablink"), Size: uint64Ptr(0x60), Entropy: float64Ptr(2.15), VarEntropy: float64Ptr(0.046)},
-				{Name: strPtr(".gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".gopclntab"), Size: uint64Ptr(0x5a5c8), Entropy: float64Ptr(5.49), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".go.buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.56), VarEntropy: float64Ptr(0.07)},
-				{Name: strPtr(".noptrdata"), Size: uint64Ptr(0x10720), Entropy: float64Ptr(5.61), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".data"), Size: uint64Ptr(0x7810), Entropy: float64Ptr(1.60), VarEntropy: float64Ptr(0.0004)},
-				{Name: strPtr(".bss"), Size: uint64Ptr(0x2ef48), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".noptrbss"), Size: uint64Ptr(0x5360), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".zdebug_abbrev"), Size: uint64Ptr(0x1e6), Entropy: float64Ptr(4.71), VarEntropy: float64Ptr(0.007)},
-				{Name: strPtr(".zdebug_line"), Size: uint64Ptr(0x30b61), Entropy: float64Ptr(5.93), VarEntropy: float64Ptr(0.0003)},
-				{Name: strPtr(".zdebug_frame"), Size: uint64Ptr(0xee0c), Entropy: float64Ptr(3.59), VarEntropy: float64Ptr(0.0002)},
-				{Name: strPtr(".debug_gdb_scripts"), Size: uint64Ptr(0x31), Entropy: float64Ptr(4.25), VarEntropy: float64Ptr(0.016)},
-				{Name: strPtr(".zdebug_info"), Size: uint64Ptr(0x79ef9), Entropy: float64Ptr(5.80), VarEntropy: float64Ptr(0.0002)},
-				{Name: strPtr(".zdebug_loc"), Size: uint64Ptr(0x919d5), Entropy: float64Ptr(2.62), VarEntropy: float64Ptr(0.0002)},
-				{Name: strPtr(".zdebug_ranges"), Size: uint64Ptr(0x313b0), Entropy: float64Ptr(2.20), VarEntropy: float64Ptr(0.0006)},
-				{Name: strPtr(".note.go.buildid"), Size: uint64Ptr(0x64), Entropy: float64Ptr(5.29), VarEntropy: float64Ptr(0.012)},
-				{Name: strPtr(".symtab"), Size: uint64Ptr(0xc5e8), Entropy: float64Ptr(3.21), VarEntropy: float64Ptr(0.0003)},
-				{Name: strPtr(".strtab"), Size: uint64Ptr(0xb2d6), Entropy: float64Ptr(4.81), VarEntropy: float64Ptr(0.0004)},
+				{Name: new(""), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".text"), Size: new(uint64(0x7ffd6)), Entropy: new(6.17), VarEntropy: new(0.0001)},
+				{Name: new(".rodata"), Size: new(uint64(0x35940)), Entropy: new(4.36), VarEntropy: new(0.0005)},
+				{Name: new(".shstrtab"), Size: new(uint64(0x17a)), Entropy: new(4.33), VarEntropy: new(0.0019)},
+				{Name: new(".typelink"), Size: new(uint64(0x4f0)), Entropy: new(3.77), VarEntropy: new(0.0083)},
+				{Name: new(".itablink"), Size: new(uint64(0x60)), Entropy: new(2.15), VarEntropy: new(0.046)},
+				{Name: new(".gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".gopclntab"), Size: new(uint64(0x5a5c8)), Entropy: new(5.49), VarEntropy: new(0.0001)},
+				{Name: new(".go.buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.56), VarEntropy: new(0.07)},
+				{Name: new(".noptrdata"), Size: new(uint64(0x10720)), Entropy: new(5.61), VarEntropy: new(0.0001)},
+				{Name: new(".data"), Size: new(uint64(0x7810)), Entropy: new(1.60), VarEntropy: new(0.0004)},
+				{Name: new(".bss"), Size: new(uint64(0x2ef48)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".noptrbss"), Size: new(uint64(0x5360)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".zdebug_abbrev"), Size: new(uint64(0x1e6)), Entropy: new(4.71), VarEntropy: new(0.007)},
+				{Name: new(".zdebug_line"), Size: new(uint64(0x30b61)), Entropy: new(5.93), VarEntropy: new(0.0003)},
+				{Name: new(".zdebug_frame"), Size: new(uint64(0xee0c)), Entropy: new(3.59), VarEntropy: new(0.0002)},
+				{Name: new(".debug_gdb_scripts"), Size: new(uint64(0x31)), Entropy: new(4.25), VarEntropy: new(0.016)},
+				{Name: new(".zdebug_info"), Size: new(uint64(0x79ef9)), Entropy: new(5.80), VarEntropy: new(0.0002)},
+				{Name: new(".zdebug_loc"), Size: new(uint64(0x919d5)), Entropy: new(2.62), VarEntropy: new(0.0002)},
+				{Name: new(".zdebug_ranges"), Size: new(uint64(0x313b0)), Entropy: new(2.20), VarEntropy: new(0.0006)},
+				{Name: new(".note.go.buildid"), Size: new(uint64(0x64)), Entropy: new(5.29), VarEntropy: new(0.012)},
+				{Name: new(".symtab"), Size: new(uint64(0xc5e8)), Entropy: new(3.21), VarEntropy: new(0.0003)},
+				{Name: new(".strtab"), Size: new(uint64(0xb2d6)), Entropy: new(4.81), VarEntropy: new(0.0004)},
 			},
 			"import_hash":    "d41d8cd98f00b204e9800998ecf8427e",
 			"go_import_hash": "10bddcb4cee42080f76c88d9ff964491",
@@ -322,19 +327,19 @@ var want = map[string]mapstr.M{
 			"go_import_hash": "d41d8cd98f00b204e9800998ecf8427e",
 			"go_stripped":    true,
 			"sections": []objSection{
-				{Name: strPtr(""), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".text"), Size: uint64Ptr(0x74f85), Entropy: float64Ptr(6.18), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".rodata"), Size: uint64Ptr(0x331e4), Entropy: float64Ptr(4.25), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".shstrtab"), Size: uint64Ptr(0x94), Entropy: float64Ptr(4.27), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".typelink"), Size: uint64Ptr(0x4ec), Entropy: float64Ptr(3.69), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".itablink"), Size: uint64Ptr(0x60), Entropy: float64Ptr(2.14), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".gopclntab"), Size: uint64Ptr(0x56370), Entropy: float64Ptr(5.42), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".go.buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.56), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".noptrdata"), Size: uint64Ptr(0x10720), Entropy: float64Ptr(5.60), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".data"), Size: uint64Ptr(0x7570), Entropy: float64Ptr(1.54), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".bss"), Size: uint64Ptr(0x2ef48), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".noptrbss"), Size: uint64Ptr(0x5340), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
+				{Name: new(""), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new(".text"), Size: new(uint64(0x74f85)), Entropy: new(6.18), VarEntropy: new(0.0001)},
+				{Name: new(".rodata"), Size: new(uint64(0x331e4)), Entropy: new(4.25), VarEntropy: new(0.0001)},
+				{Name: new(".shstrtab"), Size: new(uint64(0x94)), Entropy: new(4.27), VarEntropy: new(0.0001)},
+				{Name: new(".typelink"), Size: new(uint64(0x4ec)), Entropy: new(3.69), VarEntropy: new(0.0001)},
+				{Name: new(".itablink"), Size: new(uint64(0x60)), Entropy: new(2.14), VarEntropy: new(0.0001)},
+				{Name: new(".gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new(".gopclntab"), Size: new(uint64(0x56370)), Entropy: new(5.42), VarEntropy: new(0.0001)},
+				{Name: new(".go.buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.56), VarEntropy: new(0.0001)},
+				{Name: new(".noptrdata"), Size: new(uint64(0x10720)), Entropy: new(5.60), VarEntropy: new(0.0001)},
+				{Name: new(".data"), Size: new(uint64(0x7570)), Entropy: new(1.54), VarEntropy: new(0.0001)},
+				{Name: new(".bss"), Size: new(uint64(0x2ef48)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new(".noptrbss"), Size: new(uint64(0x5340)), Entropy: new(0.0), VarEntropy: new(0.0001)},
 			},
 		},
 	},
@@ -391,26 +396,26 @@ var want = map[string]mapstr.M{
 				"github.com/elastic/beats/v7/auditbeat/module/file_integrity/testdata/b.hash",
 			},
 			"sections": []objSection{
-				{Name: strPtr("__text"), Size: uint64Ptr(0x8be36), Entropy: float64Ptr(6.16), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__symbol_stub1"), Size: uint64Ptr(0x102), Entropy: float64Ptr(3.62), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__rodata"), Size: uint64Ptr(0x38b4f), Entropy: float64Ptr(4.37), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__typelink"), Size: uint64Ptr(0x550), Entropy: float64Ptr(3.64), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__itablink"), Size: uint64Ptr(0x78), Entropy: float64Ptr(2.63), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gopclntab"), Size: uint64Ptr(0x614a0), Entropy: float64Ptr(5.46), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__go_buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.79), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__nl_symbol_ptr"), Size: uint64Ptr(0x158), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrdata"), Size: uint64Ptr(0x10780), Entropy: float64Ptr(5.59), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__data"), Size: uint64Ptr(0x7470), Entropy: float64Ptr(1.74), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__bss"), Size: uint64Ptr(0x2f068), Entropy: float64Ptr(6.13), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrbss"), Size: uint64Ptr(0x51c0), Entropy: float64Ptr(5.65), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_abbrev"), Size: uint64Ptr(0x117), Entropy: float64Ptr(7.16), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_line"), Size: uint64Ptr(0x1d615), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_frame"), Size: uint64Ptr(0x5b82), Entropy: float64Ptr(7.92), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__debug_gdb_scri"), Size: uint64Ptr(0x31), Entropy: float64Ptr(4.24), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_info"), Size: uint64Ptr(0x33a7b), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_loc"), Size: uint64Ptr(0x1a57f), Entropy: float64Ptr(7.98), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_ranges"), Size: uint64Ptr(0x8371), Entropy: float64Ptr(7.89), VarEntropy: float64Ptr(0.0001)},
+				{Name: new("__text"), Size: new(uint64(0x8be36)), Entropy: new(6.16), VarEntropy: new(0.0001)},
+				{Name: new("__symbol_stub1"), Size: new(uint64(0x102)), Entropy: new(3.62), VarEntropy: new(0.0001)},
+				{Name: new("__rodata"), Size: new(uint64(0x38b4f)), Entropy: new(4.37), VarEntropy: new(0.0001)},
+				{Name: new("__typelink"), Size: new(uint64(0x550)), Entropy: new(3.64), VarEntropy: new(0.0001)},
+				{Name: new("__itablink"), Size: new(uint64(0x78)), Entropy: new(2.63), VarEntropy: new(0.0001)},
+				{Name: new("__gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__gopclntab"), Size: new(uint64(0x614a0)), Entropy: new(5.46), VarEntropy: new(0.0001)},
+				{Name: new("__go_buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.79), VarEntropy: new(0.0001)},
+				{Name: new("__nl_symbol_ptr"), Size: new(uint64(0x158)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__noptrdata"), Size: new(uint64(0x10780)), Entropy: new(5.59), VarEntropy: new(0.0001)},
+				{Name: new("__data"), Size: new(uint64(0x7470)), Entropy: new(1.74), VarEntropy: new(0.0001)},
+				{Name: new("__bss"), Size: new(uint64(0x2f068)), Entropy: new(6.13), VarEntropy: new(0.0001)},
+				{Name: new("__noptrbss"), Size: new(uint64(0x51c0)), Entropy: new(5.65), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_abbrev"), Size: new(uint64(0x117)), Entropy: new(7.16), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_line"), Size: new(uint64(0x1d615)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_frame"), Size: new(uint64(0x5b82)), Entropy: new(7.92), VarEntropy: new(0.0001)},
+				{Name: new("__debug_gdb_scri"), Size: new(uint64(0x31)), Entropy: new(4.24), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_info"), Size: new(uint64(0x33a7b)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_loc"), Size: new(uint64(0x1a57f)), Entropy: new(7.98), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_ranges"), Size: new(uint64(0x8371)), Entropy: new(7.89), VarEntropy: new(0.0001)},
 			},
 			"import_hash":                  "d3ccf195b62a9279c3c19af1080497ec",
 			"imports_names_entropy":        4.132925542571368,
@@ -424,19 +429,19 @@ var want = map[string]mapstr.M{
 	"garble_macho": {
 		"macho": mapstr.M{
 			"sections": []objSection{
-				{Name: strPtr("__text"), Size: uint64Ptr(0x80e52), Entropy: float64Ptr(6.17), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__symbol_stub1"), Size: uint64Ptr(0x102), Entropy: float64Ptr(3.62), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__rodata"), Size: uint64Ptr(0x367b3), Entropy: float64Ptr(4.28), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__typelink"), Size: uint64Ptr(0x554), Entropy: float64Ptr(3.85), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__itablink"), Size: uint64Ptr(0x78), Entropy: float64Ptr(2.61), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gopclntab"), Size: uint64Ptr(0x5cf68), Entropy: float64Ptr(5.41), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__go_buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.85), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__nl_symbol_ptr"), Size: uint64Ptr(0x158), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrdata"), Size: uint64Ptr(0x10780), Entropy: float64Ptr(5.59), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__data"), Size: uint64Ptr(0x71f0), Entropy: float64Ptr(1.72), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__bss"), Size: uint64Ptr(0x2f088), Entropy: float64Ptr(6.13), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrbss"), Size: uint64Ptr(0x51a0), Entropy: float64Ptr(5.55), VarEntropy: float64Ptr(0.0001)},
+				{Name: new("__text"), Size: new(uint64(0x80e52)), Entropy: new(6.17), VarEntropy: new(0.0001)},
+				{Name: new("__symbol_stub1"), Size: new(uint64(0x102)), Entropy: new(3.62), VarEntropy: new(0.0001)},
+				{Name: new("__rodata"), Size: new(uint64(0x367b3)), Entropy: new(4.28), VarEntropy: new(0.0001)},
+				{Name: new("__typelink"), Size: new(uint64(0x554)), Entropy: new(3.85), VarEntropy: new(0.0001)},
+				{Name: new("__itablink"), Size: new(uint64(0x78)), Entropy: new(2.61), VarEntropy: new(0.0001)},
+				{Name: new("__gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__gopclntab"), Size: new(uint64(0x5cf68)), Entropy: new(5.41), VarEntropy: new(0.0001)},
+				{Name: new("__go_buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.85), VarEntropy: new(0.0001)},
+				{Name: new("__nl_symbol_ptr"), Size: new(uint64(0x158)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__noptrdata"), Size: new(uint64(0x10780)), Entropy: new(5.59), VarEntropy: new(0.0001)},
+				{Name: new("__data"), Size: new(uint64(0x71f0)), Entropy: new(1.72), VarEntropy: new(0.0001)},
+				{Name: new("__bss"), Size: new(uint64(0x2f088)), Entropy: new(6.13), VarEntropy: new(0.0001)},
+				{Name: new("__noptrbss"), Size: new(uint64(0x51a0)), Entropy: new(5.55), VarEntropy: new(0.0001)},
 			},
 			"import_hash": "d3ccf195b62a9279c3c19af1080497ec",
 			"imports": []string{

--- a/auditbeat/module/file_integrity/file_parsers_fips_test.go
+++ b/auditbeat/module/file_integrity/file_parsers_fips_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestFileParsers(t *testing.T) {
-	cfg, err := config.NewConfigFrom(map[string]interface{}{
+	cfg, err := config.NewConfigFrom(map[string]any{
 		"paths":        []string{"/usr/bin"},
 		"file_parsers": []string{"file.elf.sections", `/\.pe\./`},
 	})

--- a/auditbeat/module/file_integrity/file_parsers_nofips_test.go
+++ b/auditbeat/module/file_integrity/file_parsers_nofips_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestFileParsers(t *testing.T) {
-	cfg, err := config.NewConfigFrom(map[string]interface{}{
+	cfg, err := config.NewConfigFrom(map[string]any{
 		"paths":        []string{"/usr/bin"},
 		"file_parsers": []string{"file.elf.sections", `/\.pe\./`},
 	})

--- a/auditbeat/module/file_integrity/fileorigin_darwin.go
+++ b/auditbeat/module/file_integrity/fileorigin_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build darwin
-// +build darwin
 
 package file_integrity
 

--- a/auditbeat/module/file_integrity/flatbuffers.go
+++ b/auditbeat/module/file_integrity/flatbuffers.go
@@ -44,7 +44,7 @@ var actionMap = map[Action]schema.Action{
 var bufferPool sync.Pool
 
 func init() {
-	bufferPool.New = func() interface{} {
+	bufferPool.New = func() any {
 		return flatbuffers.NewBuilder(1024)
 	}
 }
@@ -378,7 +378,7 @@ func fbDecodeHash(e *schema.Event) map[HashType]Digest {
 
 		if length > 0 {
 			hashValue := make([]byte, length)
-			for i := 0; i < len(hashValue); i++ {
+			for i := range hashValue {
 				hashValue[i] = byte(producer(i))
 			}
 

--- a/auditbeat/module/file_integrity/kprobes/events.go
+++ b/auditbeat/module/file_integrity/kprobes/events.go
@@ -26,7 +26,7 @@ import (
 )
 
 var probeEventPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &ProbeEvent{}
 	},
 }

--- a/auditbeat/module/file_integrity/kprobes/events_test.go
+++ b/auditbeat/module/file_integrity/kprobes/events_test.go
@@ -76,7 +76,7 @@ func BenchmarkEventAllocation(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10000; j++ {
+		for range 10000 {
 			p = &ProbeEvent{}
 			_ = p
 			p = &ProbeEvent{MaskMonitor: 1}
@@ -93,7 +93,7 @@ func BenchmarkEventPool(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10000; j++ {
+		for range 10000 {
 			p = allocProbeEvent()
 			_ = p
 			releaseProbeEvent(p.(*ProbeEvent))

--- a/auditbeat/module/file_integrity/kprobes/executor_test.go
+++ b/auditbeat/module/file_integrity/kprobes/executor_test.go
@@ -107,10 +107,8 @@ func Test_executor(t *testing.T) {
 	errChannel := make(chan error, 1)
 	wg := sync.WaitGroup{}
 	start := make(chan struct{})
-	for i := 0; i < 4; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 4 {
+		wg.Go(func() {
 			<-start
 			if runErr := exec.Run(atomicCheck); runErr != nil {
 				select {
@@ -118,7 +116,7 @@ func Test_executor(t *testing.T) {
 				default:
 				}
 			}
-		}()
+		})
 	}
 	time.Sleep(1 * time.Second)
 	close(start)

--- a/auditbeat/module/file_integrity/kprobes/monitor.go
+++ b/auditbeat/module/file_integrity/kprobes/monitor.go
@@ -71,7 +71,7 @@ type Monitor struct {
 	log         *logp.Logger
 	ctx         context.Context
 	cancelFn    context.CancelFunc
-	running     uint32
+	running     atomic.Uint32
 	isRecursive bool
 	closeErr    error
 }
@@ -120,7 +120,7 @@ func newMonitor(ctx context.Context, isRecursive bool, pChannel perfChannel, exe
 }
 
 func (w *Monitor) Add(path string) error {
-	switch atomic.LoadUint32(&w.running) {
+	switch w.running.Load() {
 	case 0:
 		return errors.New("monitor not started")
 	case 2:
@@ -131,11 +131,11 @@ func (w *Monitor) Add(path string) error {
 }
 
 func (w *Monitor) Close() error {
-	if !atomic.CompareAndSwapUint32(&w.running, 1, 2) {
-		switch atomic.LoadUint32(&w.running) {
+	if !w.running.CompareAndSwap(1, 2) {
+		switch w.running.Load() {
 		case 0:
 			// monitor hasn't started yet
-			atomic.StoreUint32(&w.running, 2)
+			w.running.Store(2)
 		default:
 			return nil
 		}
@@ -165,7 +165,7 @@ func (w *Monitor) writeErr(err error) {
 }
 
 func (w *Monitor) Start() error {
-	if !atomic.CompareAndSwapUint32(&w.running, 0, 1) {
+	if !w.running.CompareAndSwap(0, 1) {
 		return errors.New("monitor already started")
 	}
 

--- a/auditbeat/module/file_integrity/kprobes/monitor_test.go
+++ b/auditbeat/module/file_integrity/kprobes/monitor_test.go
@@ -96,7 +96,7 @@ func (p *monitorTestSuite) TestRunPerfChannelLost() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -133,7 +133,7 @@ func (p *monitorTestSuite) TestRunPerfChannelErr() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -171,7 +171,7 @@ func (p *monitorTestSuite) TestRunPathErr() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -211,7 +211,7 @@ func (p *monitorTestSuite) TestRunUnknownEventType() {
 	type Unknown struct{}
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -248,7 +248,7 @@ func (p *monitorTestSuite) TestRunPerfCloseEventChan() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -281,7 +281,7 @@ func (p *monitorTestSuite) TestDoubleStart() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -318,7 +318,7 @@ func (p *monitorTestSuite) TestAddPathNotClosed() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -343,7 +343,7 @@ func (p *monitorTestSuite) TestRunNoError() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -412,7 +412,7 @@ func (p *monitorTestSuite) TestRunEmitError() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}

--- a/auditbeat/module/file_integrity/kprobes/path_mountpoint.go
+++ b/auditbeat/module/file_integrity/kprobes/path_mountpoint.go
@@ -160,7 +160,7 @@ func parseMountInfoLine(line string) (*mount, error) {
 	}
 	mnt.Subtree = unescapeString(fields[3])
 	mnt.Path = unescapeString(fields[4])
-	for _, opt := range strings.Split(fields[5], ",") {
+	for opt := range strings.SplitSeq(fields[5], ",") {
 		if opt == "ro" {
 			mnt.ReadOnly = true
 		}

--- a/auditbeat/module/file_integrity/kprobes/path_test.go
+++ b/auditbeat/module/file_integrity/kprobes/path_test.go
@@ -324,15 +324,13 @@ func (p *pathTestSuite) TestAddTraverserContextCancel() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for {
@@ -366,15 +364,13 @@ func (p *pathTestSuite) TestAddTimeout() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	select {
 	case err = <-errChan:
@@ -450,15 +446,13 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {
@@ -557,15 +551,13 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {

--- a/auditbeat/module/file_integrity/kprobes/perf_channel.go
+++ b/auditbeat/module/file_integrity/kprobes/perf_channel.go
@@ -27,7 +27,7 @@ import (
 )
 
 type perfChannel interface {
-	C() <-chan interface{}
+	C() <-chan any
 	ErrC() <-chan error
 	LostC() <-chan uint64
 	Run() error

--- a/auditbeat/module/file_integrity/kprobes/perf_channel_test.go
+++ b/auditbeat/module/file_integrity/kprobes/perf_channel_test.go
@@ -25,9 +25,9 @@ type perfChannelMock struct {
 	mock.Mock
 }
 
-func (p *perfChannelMock) C() <-chan interface{} {
+func (p *perfChannelMock) C() <-chan any {
 	args := p.Called()
-	return args.Get(0).(chan interface{})
+	return args.Get(0).(chan any)
 }
 
 func (p *perfChannelMock) ErrC() <-chan error {

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -323,7 +323,7 @@ func TestErrorReporting(t *testing.T) {
 	close(done)
 	<-ready
 
-	getField := func(ev *mb.Event, field string) interface{} {
+	getField := func(ev *mb.Event, field string) any {
 		v, _ := ev.MetricSetFields.GetValue(field)
 		return v
 	}
@@ -336,7 +336,6 @@ func TestErrorReporting(t *testing.T) {
 
 	var event *mb.Event
 	for idx, ev := range events {
-		ev := ev
 		t.Log("event[", idx, "] = ", ev)
 		if match(&ev) {
 			event = &ev
@@ -361,7 +360,7 @@ func TestErrorReporting(t *testing.T) {
 	switch v := errors.(type) {
 	case string:
 		errList = []string{v}
-	case []interface{}:
+	case []any:
 		for _, val := range v {
 			str, ok := val.(string)
 			if !ok {
@@ -412,7 +411,7 @@ func (t *testReporter) Clear() {
 	t.errors = nil
 }
 
-func checkExpectedEvent(t *testing.T, ms *MetricSet, title string, input *Event, expected map[string]interface{}) {
+func checkExpectedEvent(t *testing.T, ms *MetricSet, title string, input *Event, expected map[string]any) {
 	t.Helper()
 
 	var reporter testReporter
@@ -450,7 +449,7 @@ func checkExpectedEvent(t *testing.T, ms *MetricSet, title string, input *Event,
 type expectedEvent struct {
 	title    string
 	input    Event
-	expected map[string]interface{}
+	expected map[string]any
 }
 
 func (e expectedEvent) validate(t *testing.T, ms *MetricSet) {
@@ -497,7 +496,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("11111111111111111111"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": Digest("11111111111111111111"),
@@ -519,7 +518,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -539,7 +538,7 @@ func TestEventFailedHash(t *testing.T) {
 					Action:     Updated,
 					hashFailed: true,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": nil,
@@ -561,7 +560,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("33333333333333333333"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("33333333333333333333"),
@@ -583,7 +582,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("33333333333333333333"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"attributes_modified"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("33333333333333333333"),
@@ -607,7 +606,7 @@ func TestEventFailedHash(t *testing.T) {
 					Source:     SourceFSNotify,
 					hashFailed: true,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": nil,
@@ -629,7 +628,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated", "attributes_modified"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -655,7 +654,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -671,7 +670,7 @@ func TestEventFailedHash(t *testing.T) {
 					Action:    Deleted,
 					Hashes:    nil,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"deleted"},
 					"event.type":       []string{"deletion"},
 					"file.hash.sha256": nil,
@@ -697,7 +696,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -714,7 +713,7 @@ func TestEventFailedHash(t *testing.T) {
 					Action: Moved,
 					Hashes: nil,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"moved"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": nil,
@@ -758,7 +757,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -772,7 +771,7 @@ func TestEventDelete(t *testing.T) {
 					Source:    SourceFSNotify,
 					Action:    Deleted,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action": []string{"deleted"},
 					"event.type":   []string{"deletion"},
 				},
@@ -793,7 +792,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -823,7 +822,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -845,7 +844,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: shaNext,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": shaNext,
@@ -890,7 +889,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -938,8 +937,8 @@ func TestEventDelete(t *testing.T) {
 	})
 }
 
-func getConfig(path ...string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(path ...string) map[string]any {
+	return map[string]any{
 		"module":        "file_integrity",
 		"paths":         path,
 		"exclude_files": []string{`(?i)\.sw[nop]$`, `[/\\]\.git([/\\]|$)`},

--- a/auditbeat/module/file_integrity/monitor/filetree.go
+++ b/auditbeat/module/file_integrity/monitor/filetree.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	path_pkg "path"
+	"slices"
 	"strings"
 )
 
@@ -60,8 +61,8 @@ func (tree FileTree) AddDir(path string) error {
 func (tree FileTree) Remove(path string) error {
 	components := strings.Split(path, PathSeparator)
 	last := -1
-	for pos := len(components) - 1; pos >= 0; pos-- {
-		if len(components[pos]) != 0 {
+	for pos, v := range slices.Backward(components) {
+		if len(v) != 0 {
 			last = pos
 			break
 		}
@@ -94,7 +95,7 @@ func (tree FileTree) At(path string) (FileTree, error) {
 func (tree FileTree) add(path string, value FileTree) error {
 	components := strings.Split(path, PathSeparator)
 	dir, last := tree, len(components)-1
-	for i := 0; i < last; i++ {
+	for i := range last {
 		if len(components[i]) == 0 {
 			continue
 		}

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -332,7 +332,7 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	// Update
 	// Repeat the write if no event is received. Under macOS often
 	// the write fails to generate a write event for non-recursive watcher
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		f, err := os.OpenFile(fpath, os.O_RDWR|os.O_APPEND, 0o640)
 		assertNoError(t, err)
 		f.WriteString(" world\n")

--- a/auditbeat/scripts/mage/config.go
+++ b/auditbeat/scripts/mage/config.go
@@ -65,7 +65,7 @@ func configFileParams(dirs ...string) (devtools.ConfigFileParams, error) {
 	p := devtools.DefaultConfigFileParams()
 	p.Templates = append(p.Templates, devtools.OSSBeatDir("_meta/config/*.tmpl"))
 	p.Templates = append(p.Templates, "build/config.modules.yml.tmpl")
-	p.ExtraVars = map[string]interface{}{
+	p.ExtraVars = map[string]any{
 		"ArchBits": archBits,
 	}
 	return p, nil

--- a/auditbeat/scripts/mage/docs.go
+++ b/auditbeat/scripts/mage/docs.go
@@ -46,7 +46,7 @@ func ModuleDocs() error {
 	}
 
 	configs := make([]string, 0, len(configFiles))
-	params := map[string]interface{}{
+	params := map[string]any{
 		"GOOS":      "linux",
 		"GOARCH":    "amd64",
 		"ArchBits":  archBits,

--- a/auditbeat/scripts/mage/package.go
+++ b/auditbeat/scripts/mage/package.go
@@ -71,7 +71,7 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 			}
 
 			// Origin rule file.
-			params := map[string]interface{}{"ArchBits": archBits}
+			params := map[string]any{"ArchBits": archBits}
 			origin := devtools.OSSBeatDir(
 				"module/auditd/_meta/audit.rules.d",
 				spec.MustExpand("sample-rules-linux-{{call .ArchBits .GOARCH}}bit.conf", params),

--- a/auditbeat/tracing/decoder.go
+++ b/auditbeat/tracing/decoder.go
@@ -37,7 +37,7 @@ const maxRawCopySize = 2048
 type Decoder interface {
 	// Decode takes a raw message and its metadata and returns a representation
 	// in a decoder-dependent type.
-	Decode(raw []byte, meta Metadata) (interface{}, error)
+	Decode(raw []byte, meta Metadata) (any, error)
 }
 
 type mapDecoder []Field
@@ -62,15 +62,15 @@ func NewMapDecoder(format ProbeFormat) Decoder {
 }
 
 // Decode implements the Decoder interface.
-func (f mapDecoder) Decode(raw []byte, meta Metadata) (mapIf interface{}, err error) {
+func (f mapDecoder) Decode(raw []byte, meta Metadata) (mapIf any, err error) {
 	n := len(raw)
-	m := make(map[string]interface{}, len(f)+1)
+	m := make(map[string]any, len(f)+1)
 	m["meta"] = meta
 	for _, field := range f {
 		if field.Offset+field.Size > n {
 			return nil, fmt.Errorf("perf event field %s overflows message of size %d", field.Name, n)
 		}
-		var value interface{}
+		var value any
 		ptr := unsafe.Pointer(&raw[field.Offset])
 		switch field.Type {
 		case FieldTypeInteger:
@@ -100,7 +100,7 @@ func (f mapDecoder) Decode(raw []byte, meta Metadata) (mapIf interface{}, err er
 // AllocateFn is the type of a function that allocates a custom struct
 // to be used with StructDecoder. This function must return a pointer to
 // a struct.
-type AllocateFn func() interface{}
+type AllocateFn func() any
 
 type fieldDecoder struct {
 	typ  FieldType
@@ -177,7 +177,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 	// Validate that allocFn() returns pointers to structs.
 	sample := allocFn()
 	tSample := reflect.TypeOf(sample)
-	if tSample.Kind() != reflect.Ptr {
+	if tSample.Kind() != reflect.Pointer {
 		return nil, errors.New("allocator function doesn't return a pointer")
 	}
 	tSample = tSample.Elem()
@@ -187,8 +187,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 
 	var inFieldsByOffset map[int]Field
 
-	for i := 0; i < tSample.NumField(); i++ {
-		outField := tSample.Field(i)
+	for outField := range tSample.Fields() {
 		values, found := outField.Tag.Lookup("kprobe")
 		if !found {
 			// Untagged field
@@ -215,7 +214,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 
 		// Special handling for metadata field
 		if name == "metadata" {
-			if outField.Type != reflect.TypeOf(Metadata{}) {
+			if outField.Type != reflect.TypeFor[Metadata]() {
 				return nil, errors.New("bad type for meta field")
 			}
 			dec.fields = append(dec.fields, fieldDecoder{
@@ -325,7 +324,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 }
 
 // Decode implements the decoder interface.
-func (d *structDecoder) Decode(raw []byte, meta Metadata) (s interface{}, err error) {
+func (d *structDecoder) Decode(raw []byte, meta Metadata) (s any, err error) {
 	n := uintptr(len(raw))
 
 	// Allocate a new struct to fill
@@ -413,7 +412,7 @@ func NewDumpDecoder(format ProbeFormat) (Decoder, error) {
 }
 
 // Decode implements the decoder interface.
-func (d *dumpDecoder) Decode(raw []byte, _ Metadata) (interface{}, error) {
+func (d *dumpDecoder) Decode(raw []byte, _ Metadata) (any, error) {
 	if len(raw) < d.end {
 		return nil, errors.New("record too short for dump")
 	}

--- a/auditbeat/tracing/events_test.go
+++ b/auditbeat/tracing/events_test.go
@@ -90,7 +90,7 @@ func BenchmarkMapDecoder(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		m := iface.(map[string]interface{})
+		m := iface.(map[string]any)
 
 		for _, c := range m["exe"].(string) {
 			sum += int(c)
@@ -140,7 +140,7 @@ func BenchmarkStructDecoder(b *testing.B) {
 		Arg5   uint16   `kprobe:"arg5"`
 		Arg6   uint32   `kprobe:"arg6"`
 	}
-	var myAlloc AllocateFn = func() interface{} {
+	var myAlloc AllocateFn = func() any {
 		return new(myStruct)
 	}
 
@@ -243,7 +243,7 @@ func TestKProbeReal(t *testing.T) {
 			CX  int32  `kprobe:"cx"`
 			DX  uint16 `kprobe:"dx"`
 		}
-		allocFn := func() interface{} {
+		allocFn := func() any {
 			return new(myStruct)
 		}
 		if decoder, err = NewStructDecoder(desc, allocFn); err != nil {
@@ -279,7 +279,7 @@ func TestKProbeReal(t *testing.T) {
 				break
 			}
 			if true {
-				data := iface.(map[string]interface{})
+				data := iface.(map[string]any)
 				_, err = fmt.Fprintf(os.Stderr, "Got event len=%d\n", len(data))
 				if err != nil {
 					panic(err)

--- a/auditbeat/tracing/perfevent.go
+++ b/auditbeat/tracing/perfevent.go
@@ -56,7 +56,7 @@ type stream struct {
 // PerfChannel represents a channel to receive perf events.
 type PerfChannel struct {
 	done    chan struct{}
-	sampleC chan interface{}
+	sampleC chan any
 	errC    chan error
 	lostC   chan uint64
 
@@ -289,7 +289,7 @@ func (c *PerfChannel) MonitorProbe(format ProbeFormat, decoder Decoder) error {
 }
 
 // C returns the channel to read samples from.
-func (c *PerfChannel) C() <-chan interface{} {
+func (c *PerfChannel) C() <-chan any {
 	return c.sampleC
 }
 
@@ -312,7 +312,7 @@ func (c *PerfChannel) Run() error {
 	if !atomic.CompareAndSwapUintptr(&c.running, 0, 1) {
 		return ErrAlreadyRunning
 	}
-	c.sampleC = make(chan interface{}, c.sizeSampleC)
+	c.sampleC = make(chan any, c.sizeSampleC)
 	c.errC = make(chan error, c.sizeErrC)
 	c.lostC = make(chan uint64, c.sizeLostC)
 
@@ -375,7 +375,7 @@ func (ctx doneWrapperContext) Err() error {
 }
 
 // Value always returns nil.
-func (ctx doneWrapperContext) Value(key interface{}) interface{} {
+func (ctx doneWrapperContext) Value(key any) any {
 	return nil
 }
 

--- a/libbeat/processors/cache/file_store_test.go
+++ b/libbeat/processors/cache/file_store_test.go
@@ -59,7 +59,7 @@ var fileStoreTests = []struct {
 				Effort:   10,
 			},
 			Put: &putConfig{
-				TTL: ptrTo(time.Second),
+				TTL: new(time.Second),
 			},
 		},
 		want: &fileStore{path: "testdata/new_put", memStore: memStore{
@@ -140,7 +140,7 @@ var fileStoreTests = []struct {
 							Effort:   10,
 						},
 						Put: &putConfig{
-							TTL: ptrTo(time.Second),
+							TTL: new(time.Second),
 						},
 					}
 					s.add(putCfg)
@@ -186,7 +186,7 @@ var fileStoreTests = []struct {
 							Effort:   10,
 						},
 						Put: &putConfig{
-							TTL: ptrTo(time.Second),
+							TTL: new(time.Second),
 						},
 					}
 					s.add(putCfg)
@@ -381,7 +381,7 @@ var fileStoreTests = []struct {
 							Effort:   10,
 						},
 						Put: &putConfig{
-							TTL: ptrTo(time.Second),
+							TTL: new(time.Second),
 						},
 					}
 					s.add(putCfg)

--- a/libbeat/processors/cache/mem_store_test.go
+++ b/libbeat/processors/cache/mem_store_test.go
@@ -480,4 +480,5 @@ func (s *memStoreSet) has(id string) bool {
 	return ok
 }
 
-func ptrTo[T any](v T) *T { return &v }
+//go:fix inline
+func ptrTo[T any](v T) *T { return new(v) }

--- a/libbeat/processors/cache/mem_store_test.go
+++ b/libbeat/processors/cache/mem_store_test.go
@@ -47,7 +47,7 @@ var memStoreTests = []struct {
 				Effort:   10,
 			},
 			Put: &putConfig{
-				TTL: ptrTo(time.Second),
+				TTL: new(time.Second),
 			},
 		},
 		want: &memStore{
@@ -128,7 +128,7 @@ var memStoreTests = []struct {
 							Effort:   10,
 						},
 						Put: &putConfig{
-							TTL: ptrTo(time.Second),
+							TTL: new(time.Second),
 						},
 					}
 					s.add(putCfg)
@@ -174,7 +174,7 @@ var memStoreTests = []struct {
 							Effort:   10,
 						},
 						Put: &putConfig{
-							TTL: ptrTo(time.Second),
+							TTL: new(time.Second),
 						},
 					}
 					s.add(putCfg)
@@ -364,7 +364,7 @@ var memStoreTests = []struct {
 							Effort:   10,
 						},
 						Put: &putConfig{
-							TTL: ptrTo(10 * time.Minute),
+							TTL: new(10 * time.Minute),
 						},
 					}
 					s.add(putCfg)
@@ -479,6 +479,3 @@ func (s *memStoreSet) has(id string) bool {
 	s.mu.Unlock()
 	return ok
 }
-
-//go:fix inline
-func ptrTo[T any](v T) *T { return new(v) }

--- a/libbeat/processors/decode_xml/decode_xml_test.go
+++ b/libbeat/processors/decode_xml/decode_xml_test.go
@@ -60,8 +60,8 @@ func TestDecodeXML(t *testing.T) {
 			},
 			Output: mapstr.M{
 				"xml": mapstr.M{
-					"catalog": map[string]interface{}{
-						"book": map[string]interface{}{
+					"catalog": map[string]any{
+						"book": map[string]any{
 							"author": "William H. Gaddis",
 							"review": "One of the great seminal American novels of the 20th century.",
 							"seq":    "1",
@@ -95,7 +95,7 @@ func TestDecodeXML(t *testing.T) {
 			},
 			Output: mapstr.M{
 				"catalog": mapstr.M{
-					"book": map[string]interface{}{
+					"book": map[string]any{
 						"author": "William H. Gaddis",
 						"review": "One of the great seminal American novels of the 20th century.",
 						"seq":    "1",
@@ -128,8 +128,8 @@ func TestDecodeXML(t *testing.T) {
 			},
 			Output: mapstr.M{
 				"message": mapstr.M{
-					"catalog": map[string]interface{}{
-						"book": map[string]interface{}{
+					"catalog": map[string]any{
+						"book": map[string]any{
 							"author": "William H. Gaddis",
 							"review": "One of the great seminal American novels of the 20th century.",
 							"seq":    "1",
@@ -161,14 +161,14 @@ func TestDecodeXML(t *testing.T) {
 			},
 			Output: mapstr.M{
 				"message": mapstr.M{
-					"catalog": map[string]interface{}{
-						"book": []interface{}{
-							map[string]interface{}{
+					"catalog": map[string]any{
+						"book": []any{
+							map[string]any{
 								"author": "William H. Gaddis",
 								"review": "One of the great seminal American novels of the 20th century.",
 								"title":  "The Recognitions",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"author": "Ralls, Kim",
 								"review": "Some review.",
 								"title":  "Midnight Rain",
@@ -198,13 +198,13 @@ func TestDecodeXML(t *testing.T) {
 			},
 			Output: mapstr.M{
 				"message": mapstr.M{
-					"auditbase": map[string]interface{}{
-						"contextcomponents": map[string]interface{}{
-							"component": []interface{}{
-								map[string]interface{}{
+					"auditbase": map[string]any{
+						"contextcomponents": map[string]any{
+							"component": []any{
+								map[string]any{
 									"relyingparty": "N/A",
 								},
-								map[string]interface{}{
+								map[string]any{
 									"primaryauth": "N/A",
 								},
 							},
@@ -241,21 +241,21 @@ func TestDecodeXML(t *testing.T) {
 			},
 			Output: mapstr.M{
 				"message": mapstr.M{
-					"catalog": map[string]interface{}{
-						"book": []interface{}{
-							map[string]interface{}{
+					"catalog": map[string]any{
+						"book": []any{
+							map[string]any{
 								"author": "William H. Gaddis",
 								"review": "One of the great seminal American novels of the 20th century.",
 								"title":  "The Recognitions",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"author": "Ralls, Kim",
 								"review": "Some review.",
 								"title":  "Midnight Rain",
 							},
 						},
-						"secondcategory": map[string]interface{}{
-							"paper": map[string]interface{}{
+						"secondcategory": map[string]any{
+							"paper": map[string]any{
 								"description": "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
 								"id":          "bk102",
 								"test2":       "Ralls, Kim",
@@ -282,8 +282,8 @@ func TestDecodeXML(t *testing.T) {
 			},
 			Output: mapstr.M{
 				"message": mapstr.M{
-					"catalog": map[string]interface{}{
-						"book": map[string]interface{}{
+					"catalog": map[string]any{
+						"book": map[string]any{
 							"author": "William H. Gaddis",
 							"review": "One of the great seminal American novels of the 20th century.",
 							"title":  "The Recognitions",
@@ -410,7 +410,6 @@ func TestDecodeXML(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 
@@ -456,8 +455,8 @@ func TestDecodeXML(t *testing.T) {
 		}
 		expMeta := mapstr.M{
 			"xml": mapstr.M{
-				"catalog": map[string]interface{}{
-					"book": map[string]interface{}{
+				"catalog": map[string]any{
+					"book": map[string]any{
 						"author": "William H. Gaddis",
 						"review": "One of the great seminal American novels of the 20th century.",
 						"seq":    "1",
@@ -489,7 +488,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("single_object", func(b *testing.B) {
-		evt := &beat.Event{Fields: map[string]interface{}{
+		evt := &beat.Event{Fields: map[string]any{
 			"message": `<?xml version="1.0"?>
 				<catalog>
 					<book>
@@ -509,7 +508,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	})
 
 	b.Run("nested_and_array_object", func(b *testing.B) {
-		evt := &beat.Event{Fields: map[string]interface{}{
+		evt := &beat.Event{Fields: map[string]any{
 			"message": `<?xml version="1.0"?>
 				<catalog>
 					<book>
@@ -561,8 +560,8 @@ func TestXMLToDocumentID(t *testing.T) {
 
 	wantFields := mapstr.M{
 		"message": mapstr.M{
-			"catalog": map[string]interface{}{
-				"book": map[string]interface{}{
+			"catalog": map[string]any{
+				"book": map[string]any{
 					"author": "William H. Gaddis",
 					"review": "One of the great seminal American novels of the 20th century.",
 					"title":  "The Recognitions",

--- a/libbeat/processors/decode_xml_wineventlog/processor.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor.go
@@ -156,7 +156,7 @@ func fields(evt winevent.Event) (mapstr.M, mapstr.M) {
 	return win, ecs
 }
 
-func getValue(m mapstr.M, key string) interface{} {
+func getValue(m mapstr.M, key string) any {
 	v, _ := m.GetValue(key)
 	return v
 }

--- a/libbeat/processors/decode_xml_wineventlog/processor_test.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor_test.go
@@ -127,7 +127,6 @@ func TestProcessor(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 

--- a/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
+++ b/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
@@ -257,10 +257,7 @@ func handshakePayload(secLayer byte, maxSize uint32, authzid []byte) []byte {
 	var truncatedSize uint32
 	if selectedSecurity != 0 {
 		// Only 3 bytes available for max size, set to 0x00FFFFFF per RFC 4752.
-		truncatedSize = 0b00000000_11111111_11111111_11111111
-		if truncatedSize > maxSize {
-			truncatedSize = maxSize
-		}
+		truncatedSize = min(0b00000000_11111111_11111111_11111111, maxSize)
 	}
 	payload := make([]byte, 4, 4+len(authzid))
 	binary.BigEndian.PutUint32(payload, truncatedSize)

--- a/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
+++ b/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
@@ -256,7 +256,7 @@ func handshakePayload(secLayer byte, maxSize uint32, authzid []byte) []byte {
 	selectedSecurity := secLayer
 	var truncatedSize uint32
 	if selectedSecurity != 0 {
-		// Only 3 bytes available for max size, set to 0x00FFFFFF per RFC 4752.
+		// Only 3 bytes available for max size, set to 0x00FFFFFF per RFC 4752, sections 3.1 and 3.2.
 		truncatedSize = min(0x00_FF_FF_FF, maxSize)
 	}
 	payload := make([]byte, 4, 4+len(authzid))

--- a/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
+++ b/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
@@ -257,7 +257,7 @@ func handshakePayload(secLayer byte, maxSize uint32, authzid []byte) []byte {
 	var truncatedSize uint32
 	if selectedSecurity != 0 {
 		// Only 3 bytes available for max size, set to 0x00FFFFFF per RFC 4752.
-		truncatedSize = min(0b00000000_11111111_11111111_11111111, maxSize)
+		truncatedSize = min(0x00_FF_FF_FF, maxSize)
 	}
 	payload := make([]byte, 4, 4+len(authzid))
 	binary.BigEndian.PutUint32(payload, truncatedSize)

--- a/libbeat/processors/translate_sid/translatesid_test.go
+++ b/libbeat/processors/translate_sid/translatesid_test.go
@@ -66,7 +66,7 @@ func TestTranslateSID(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			evt := &beat.Event{Fields: map[string]interface{}{
+			evt := &beat.Event{Fields: map[string]any{
 				"sid": tc.SID,
 			}}
 
@@ -120,7 +120,7 @@ func TestTranslateSIDEmptyTarget(t *testing.T) {
 	c := defaultConfig()
 	c.Field = "sid"
 
-	evt := &beat.Event{Fields: map[string]interface{}{
+	evt := &beat.Event{Fields: map[string]any{
 		"sid": "S-1-5-32-544",
 	}}
 
@@ -134,7 +134,6 @@ func TestTranslateSIDEmptyTarget(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			p, err := newFromConfig(tc.Config, logger)
 			require.NoError(t, err)
@@ -162,7 +161,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	}
 
 	b.Run("builtin", func(b *testing.B) {
-		evt := &beat.Event{Fields: map[string]interface{}{
+		evt := &beat.Event{Fields: map[string]any{
 			"sid": "S-1-5-7",
 		}}
 
@@ -175,7 +174,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	})
 
 	b.Run("no_mapping", func(b *testing.B) {
-		evt := &beat.Event{Fields: map[string]interface{}{
+		evt := &beat.Event{Fields: map[string]any{
 			"sid": "S-1-5-2025429265-500",
 		}}
 
@@ -188,7 +187,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	})
 }
 
-func assertEqualIgnoreCase(t *testing.T, expected string, actual interface{}) {
+func assertEqualIgnoreCase(t *testing.T, expected string, actual any) {
 	t.Helper()
 	actualStr, ok := actual.(string)
 	if !ok {

--- a/libbeat/reader/auditd/auditd_test.go
+++ b/libbeat/reader/auditd/auditd_test.go
@@ -62,7 +62,7 @@ func (t *testReader) Next() (reader.Message, error) {
 }
 
 // auditdLogField returns the value of a field within msg.Fields["auditd"]["log"].
-func auditdLogField(fields mapstr.M, key string) (interface{}, bool) {
+func auditdLogField(fields mapstr.M, key string) (any, bool) {
 	auditd, ok := fields["auditd"].(mapstr.M)
 	if !ok {
 		return nil, false

--- a/libbeat/reader/etw/eventrenderer.go
+++ b/libbeat/reader/etw/eventrenderer.go
@@ -188,7 +188,7 @@ func renderStructArray(cache providerCache, eventInfo *cachedEventInfo, propInfo
 	}
 
 	result := make([]any, arraySize)
-	for j := 0; j < arraySize; j++ {
+	for j := range arraySize {
 		value, err := renderStruct(cache, eventInfo, propInfo, r, ptrSize, buf, bufferPools)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse struct member %d: %w", j, err)
@@ -221,7 +221,7 @@ func renderSimpleArray(cache providerCache, eventInfo *cachedEventInfo, propInfo
 	}
 
 	result := make([]any, count)
-	for i := uint32(0); i < count; i++ {
+	for i := range count {
 		// For each array element, process it as a single property
 		value, err := renderSingleProperty(cache, eventInfo, propInfo, r, ptrSize, buf, mapInfo, cachedMapInfo, bufferPools)
 		if err != nil {

--- a/libbeat/reader/etw/metadata_cache.go
+++ b/libbeat/reader/etw/metadata_cache.go
@@ -262,19 +262,19 @@ type bufferPools struct {
 func newBufferPools() *bufferPools {
 	return &bufferPools{
 		smallBufferPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, 256)
 				return &buf
 			},
 		},
 		mediumBufferPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, 1024)
 				return &buf
 			},
 		},
 		largeBufferPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, 4096)
 				return &buf
 			},

--- a/libbeat/reader/etw/session_integration_test.go
+++ b/libbeat/reader/etw/session_integration_test.go
@@ -526,7 +526,7 @@ func compareRenderedEvents(actual, expected RenderedEtwEvent, eventIndex int) []
 }
 
 // comparePropertyValues compares two property values recursively
-func comparePropertyValues(actual, expected interface{}) bool {
+func comparePropertyValues(actual, expected any) bool {
 	actualJSON, err1 := json.Marshal(actual)
 	expectedJSON, err2 := json.Marshal(expected)
 	return err1 == nil && err2 == nil && string(actualJSON) == string(expectedJSON)

--- a/libbeat/reader/etw/testingutils_test.go
+++ b/libbeat/reader/etw/testingutils_test.go
@@ -320,7 +320,7 @@ func (g *ETWEventGenerator) close() error {
 
 // generateEvents generates n random events, alternating between the two event types
 func (g *ETWEventGenerator) generateEvents(n int, wait time.Duration) error {
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i%2 == 0 {
 			if err := g.writeAllDataTypesEvent(); err != nil {
 				return err

--- a/packetbeat/config/agent.go
+++ b/packetbeat/config/agent.go
@@ -35,10 +35,10 @@ type datastream struct {
 }
 
 type agentInput struct {
-	Type       string                   `config:"type"`
-	Datastream datastream               `config:"data_stream"`
-	Processors []mapstr.M               `config:"processors"`
-	Streams    []map[string]interface{} `config:"streams"`
+	Type       string           `config:"type"`
+	Datastream datastream       `config:"data_stream"`
+	Processors []mapstr.M       `config:"processors"`
+	Streams    []map[string]any `config:"streams"`
 }
 
 func defaultDevice() string {
@@ -92,15 +92,9 @@ func (i agentInput) addProcessorsAndIndex(cfg *conf.C) (*conf.C, error) {
 }
 
 func mergeProcsConfig(one, two procs.ProcsConfig) procs.ProcsConfig {
-	maxProcReadFreq := one.MaxProcReadFreq
-	if two.MaxProcReadFreq > maxProcReadFreq {
-		maxProcReadFreq = two.MaxProcReadFreq
-	}
+	maxProcReadFreq := max(two.MaxProcReadFreq, one.MaxProcReadFreq)
 
-	refreshPidsFreq := one.RefreshPidsFreq
-	if two.RefreshPidsFreq < refreshPidsFreq {
-		refreshPidsFreq = two.RefreshPidsFreq
-	}
+	refreshPidsFreq := min(two.RefreshPidsFreq, one.RefreshPidsFreq)
 
 	return procs.ProcsConfig{
 		Enabled:         true,

--- a/packetbeat/config/agent_test.go
+++ b/packetbeat/config/agent_test.go
@@ -93,9 +93,9 @@ streams:
 	require.Equal(t, config.Flows.Index, "logs-packet.flow-default")
 	require.Len(t, config.ProtocolsList, 2)
 
-	var protocol map[string]interface{}
+	var protocol map[string]any
 	require.NoError(t, config.ProtocolsList[0].Unpack(&protocol))
-	require.Len(t, protocol["processors"].([]interface{}), 3)
+	require.Len(t, protocol["processors"].([]any), 3)
 	require.Equal(t, "default_route", config.Interfaces[0].Device)
 	require.Equal(t, "en1", config.Interfaces[1].Device)
 	require.Equal(t, "en2", config.Interfaces[2].Device)

--- a/packetbeat/config/config_test.go
+++ b/packetbeat/config/config_test.go
@@ -64,11 +64,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -107,11 +107,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -140,11 +140,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -179,11 +179,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -221,11 +221,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -270,11 +270,11 @@ protocols:
 			},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -324,11 +324,11 @@ protocols:
 			},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -368,11 +368,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -411,11 +411,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -455,7 +455,7 @@ protocols:
 				{
 					Device:      "any",
 					Type:        "af_packet",
-					FanoutGroup: pointer(uint16(1)),
+					FanoutGroup: new(uint16(1)),
 				},
 			},
 		},
@@ -531,7 +531,7 @@ func cliOptions(file string, loop int, topSpeed, step bool, dump string) Config 
 }
 
 func configC(a, b *config.C) bool {
-	var ma, mb map[string]interface{}
+	var ma, mb map[string]any
 	err := a.Unpack(&ma)
 	if err != nil {
 		panic(err)
@@ -544,6 +544,8 @@ func configC(a, b *config.C) bool {
 }
 
 // pointer returns a pointer to val.
+//
+//go:fix inline
 func pointer[T any](val T) *T {
-	return &val
+	return new(val)
 }

--- a/packetbeat/config/config_test.go
+++ b/packetbeat/config/config_test.go
@@ -542,10 +542,3 @@ func configC(a, b *config.C) bool {
 	}
 	return cmp.Equal(ma, mb)
 }
-
-// pointer returns a pointer to val.
-//
-//go:fix inline
-func pointer[T any](val T) *T {
-	return new(val)
-}

--- a/packetbeat/decoder/decoder_test.go
+++ b/packetbeat/decoder/decoder_test.go
@@ -258,9 +258,7 @@ func TestFragment(t *testing.T) {
 	t.Run("out_of_order", func(t *testing.T) {
 		d, tcp, udp := newTestDecoder(t)
 
-		// Reverse the order of the packets.
-		for _, v := range slices.Backward(packets) {
-			p := v
+		for _, p := range slices.Backward(packets) {
 			d.OnPacket(p.Data(), &p.Metadata().CaptureInfo)
 		}
 

--- a/packetbeat/decoder/decoder_test.go
+++ b/packetbeat/decoder/decoder_test.go
@@ -20,6 +20,7 @@
 package decoder
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -258,8 +259,8 @@ func TestFragment(t *testing.T) {
 		d, tcp, udp := newTestDecoder(t)
 
 		// Reverse the order of the packets.
-		for i := len(packets) - 1; i >= 0; i-- {
-			p := packets[i]
+		for _, v := range slices.Backward(packets) {
+			p := v
 			d.OnPacket(p.Data(), &p.Metadata().CaptureInfo)
 		}
 

--- a/packetbeat/flows/counters.go
+++ b/packetbeat/flows/counters.go
@@ -23,7 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-type Var interface{}
+type Var any
 
 type flagsInfo struct {
 	i    int

--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -149,10 +149,7 @@ func newFlowsWorker(
 	ticksTimeout := 1
 	ticksPeriod := -1
 	if period > 0 {
-		tick = gcd(timeout, period)
-		if tick < time.Second {
-			tick = time.Second
-		}
+		tick = max(gcd(timeout, period), time.Second)
 
 		ticksTimeout = int(timeout / tick)
 		if ticksTimeout == 0 {
@@ -551,8 +548,8 @@ func formatHardwareAddr(addr net.HardwareAddr) string {
 	return string(buf)
 }
 
-func encodeStats(stats *flowStats, ints, uints, floats []string, enableDeltaFlowReporting bool) map[string]interface{} {
-	report := make(map[string]interface{})
+func encodeStats(stats *flowStats, ints, uints, floats []string, enableDeltaFlowReporting bool) map[string]any {
+	report := make(map[string]any)
 
 	i := 0
 	for _, mask := range stats.intFlags {

--- a/packetbeat/flows/worker_test.go
+++ b/packetbeat/flows/worker_test.go
@@ -67,33 +67,33 @@ func TestCreateEvent(t *testing.T) {
 	event := createEvent(&procs.ProcessesWatcher{}, time.Now(), bif, true, nil, []string{"bytes", "packets"}, nil, false)
 
 	// Validate the contents of the event.
-	validate := lookslike.MustCompile(map[string]interface{}{
-		"source": map[string]interface{}{
+	validate := lookslike.MustCompile(map[string]any{
+		"source": map[string]any{
 			"mac":     "01-02-03-04-05-06",
 			"ip":      "203.0.113.3",
 			"port":    port1,
 			"bytes":   uint64(10),
 			"packets": uint64(1),
 		},
-		"destination": map[string]interface{}{
+		"destination": map[string]any{
 			"mac":     "06-05-04-03-02-01",
 			"ip":      "198.51.100.2",
 			"port":    port2,
 			"bytes":   uint64(460),
 			"packets": uint64(2),
 		},
-		"flow": map[string]interface{}{
+		"flow": map[string]any{
 			"id":    isdef.KeyPresent,
 			"final": true,
 			"vlan":  isdef.KeyPresent,
 		},
-		"network": map[string]interface{}{
+		"network": map[string]any{
 			"bytes":     uint64(470),
 			"packets":   uint64(3),
 			"type":      "ipv4",
 			"transport": "tcp",
 		},
-		"event": map[string]interface{}{
+		"event": map[string]any{
 			"start":    isdef.KeyPresent,
 			"end":      isdef.KeyPresent,
 			"duration": isdef.KeyPresent,

--- a/packetbeat/module/pipeline.go
+++ b/packetbeat/module/pipeline.go
@@ -42,7 +42,7 @@ var errNoFS = errors.New("no embedded file system")
 
 type pipeline struct {
 	id       string
-	contents map[string]interface{}
+	contents map[string]any
 }
 
 // UploadPipelines reads all pipelines embedded in the Packetbeat executable
@@ -148,9 +148,9 @@ func load(esClient *eslegclient.Connection, pipelines []pipeline, overwritePipel
 	return loaded, nil
 }
 
-func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]interface{}, err error) {
-	vars := map[string]interface{}{
-		"builtin": map[string]interface{}{
+func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]any, err error) {
+	vars := map[string]any{
+		"builtin": map[string]any{
 			"prefix":      prefix,
 			"module":      "",
 			"fileset":     "",
@@ -163,7 +163,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 		return nil, fmt.Errorf("failed to apply template: %w", err)
 	}
 
-	var content map[string]interface{}
+	var content map[string]any
 	switch extension := strings.ToLower(filepath.Ext(filename)); extension {
 	case ".json":
 		if err = json.Unmarshal([]byte(encodedString), &content); err != nil {
@@ -178,7 +178,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 			return nil, fmt.Errorf("failed to sanitize the YAML pipeline file: %s: %w", filename, err)
 		}
 		//nolint:errcheck // ignore
-		content = newContent.(map[string]interface{})
+		content = newContent.(map[string]any)
 	default:
 		return nil, fmt.Errorf("unsupported extension '%s' for pipeline file: %s", extension, filename)
 	}

--- a/packetbeat/pb/event.go
+++ b/packetbeat/pb/event.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -321,20 +322,16 @@ func hostBasedDirection(source, destination net.IP, ips []net.IP) string {
 		if destination.IsLoopback() || destination.IsLinkLocalUnicast() || destination.IsLinkLocalMulticast() {
 			return Ingress
 		}
-		for _, ip := range ips {
-			if destination.Equal(ip) {
-				return Ingress
-			}
+		if slices.ContainsFunc(ips, destination.Equal) {
+			return Ingress
 		}
 	}
 	if source != nil {
 		if source.IsLoopback() || source.IsLinkLocalUnicast() || source.IsLinkLocalMulticast() {
 			return Egress
 		}
-		for _, ip := range ips {
-			if source.Equal(ip) {
-				return Egress
-			}
+		if slices.ContainsFunc(ips, source.Equal) {
+			return Egress
 		}
 	}
 	return Unknown
@@ -365,7 +362,7 @@ func perimeterBasedDirection(source, destination net.IP, internalNetworks []stri
 // is a problem writing the keys to the given map (like if an intermediate key
 // exists and is not a map).
 func (f *Fields) MarshalMapStr(m mapstr.M) error {
-	typ := reflect.TypeOf(*f)
+	typ := reflect.TypeFor[Fields]()
 	val := reflect.ValueOf(*f)
 
 	for i := 0; i < typ.NumField(); i++ {
@@ -396,13 +393,13 @@ func (f *Fields) MarshalMapStr(m mapstr.M) error {
 
 // MarshalStruct marshals any struct containing ecs or packetbeat tags into the
 // given MapStr. Zero-value and nil fields are always omitted.
-func MarshalStruct(m mapstr.M, key string, val interface{}) error {
+func MarshalStruct(m mapstr.M, key string, val any) error {
 	return marshalStruct(m, key, reflect.ValueOf(val))
 }
 
 func marshalStruct(m mapstr.M, key string, val reflect.Value) error {
 	// Dereference pointers.
-	if val.Type().Kind() == reflect.Ptr {
+	if val.Type().Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return nil
 		}
@@ -417,7 +414,7 @@ func marshalStruct(m mapstr.M, key string, val reflect.Value) error {
 
 	typ := val.Type()
 	// pre-emptively handle time
-	if reflect.TypeOf(time.Time{}) == typ {
+	if reflect.TypeFor[time.Time]() == typ {
 		_, err := m.Put(key, val.Interface())
 		if err != nil {
 			return fmt.Errorf("error creating time value: %w", err)
@@ -463,7 +460,7 @@ func marshalStruct(m mapstr.M, key string, val reflect.Value) error {
 			}
 			// look for a struct or pointer to a struct
 			// that reflect.Ptr check is needed so Elem() doesn't panic
-		} else if (structField.Type.Kind() == reflect.Ptr && fieldValue.Elem().Kind() == reflect.Struct) ||
+		} else if (structField.Type.Kind() == reflect.Pointer && fieldValue.Elem().Kind() == reflect.Struct) ||
 			structField.Type.Kind() == reflect.Struct {
 			if err := marshalStruct(m, key+"."+tag, fieldValue); err != nil {
 				return err
@@ -502,7 +499,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()
 	}
 

--- a/packetbeat/processor/add_kubernetes_metadata/indexers.go
+++ b/packetbeat/processor/add_kubernetes_metadata/indexers.go
@@ -30,7 +30,7 @@ func InitializeModule() {
 	// Add IP Port Indexer as a default indexer
 	kubernetes.Indexing.AddDefaultIndexerConfig(kubernetes.IPPortIndexerName, *cfg)
 
-	formatCfg, err := conf.NewConfigFrom(map[string]interface{}{
+	formatCfg, err := conf.NewConfigFrom(map[string]any{
 		"format": "%{[ip]}:%{[port]}",
 	})
 	if err == nil {

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -19,6 +19,7 @@ package procs
 
 import (
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -188,12 +189,7 @@ func (proc *ProcessesWatcher) isLocalIP(ip net.IP) bool {
 	if ip.IsLoopback() {
 		return true
 	}
-	for _, addr := range proc.localAddrs {
-		if ip.Equal(addr) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(proc.localAddrs, ip.Equal)
 }
 
 func (proc *ProcessesWatcher) findProc(address net.IP, port uint16, transport applayer.Transport) *process {

--- a/packetbeat/procs/procs_linux.go
+++ b/packetbeat/procs/procs_linux.go
@@ -260,7 +260,7 @@ func hexToIpv6(word string) (net.IP, error) {
 	if len(word) < 32 {
 		return nil, fmt.Errorf("got ip6 address of invalid length: %d", len(word))
 	}
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		start := i * 8
 		end := (i + 1) * 8
 		part, err := strconv.ParseUint(word[start:end], 16, 32)

--- a/packetbeat/procs/procs_linux_test.go
+++ b/packetbeat/procs/procs_linux_test.go
@@ -22,6 +22,7 @@ package procs
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -139,13 +140,7 @@ func createFakeDirectoryStructure(prefix string, files []testProcFile) error {
 
 func assertUint64ArraysAreEqual(t *testing.T, expected []uint64, result []uint64) bool {
 	for _, ex := range expected {
-		found := false
-		for _, res := range result {
-			if ex == res {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(result, ex)
 		if !found {
 			t.Errorf("Expected array %v but got %v", expected, result)
 			return false

--- a/packetbeat/procs/procs_windows.go
+++ b/packetbeat/procs/procs_windows.go
@@ -115,7 +115,7 @@ func parseTable(data []byte, extractor extractor) error {
 	if lim < n*rowSize+sizeOfDWORD {
 		return errors.New("data table too small for its contents")
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ptr := unsafe.Pointer(&data[sizeOfDWORD+i*rowSize])
 		extractor.Extract(ptr)
 	}

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -92,14 +92,14 @@ func New(
 }
 
 //go:inline
-func (amqp *amqpPlugin) debugf(format string, args ...interface{}) {
+func (amqp *amqpPlugin) debugf(format string, args ...any) {
 	if amqp.isDebug {
 		amqp.amqpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (amqp *amqpPlugin) detailedf(format string, args ...interface{}) {
+func (amqp *amqpPlugin) detailedf(format string, args ...any) {
 	if amqp.isDetailed {
 		amqp.amqpDetailedLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -83,7 +83,7 @@ func New(
 }
 
 //go:inline
-func (cassandra *cassandra) debugf(format string, args ...interface{}) {
+func (cassandra *cassandra) debugf(format string, args ...any) {
 	if cassandra.isDebug {
 		cassandra.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -41,8 +41,8 @@ type frameHeader struct {
 	CustomPayload map[string][]byte
 }
 
-func (f frameHeader) ToMap() map[string]interface{} {
-	data := make(map[string]interface{})
+func (f frameHeader) ToMap() map[string]any {
+	data := make(map[string]any)
 	data["version"] = fmt.Sprintf("%d", f.Version.version())
 	data["flags"] = getHeadFlagString(f.Flags)
 	data["stream"] = f.Stream
@@ -56,7 +56,7 @@ func (f frameHeader) String() string {
 }
 
 var framerPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Framer{compres: nil, isCompressed: false, Header: nil, r: nil, decoder: nil}
 	},
 }
@@ -168,7 +168,7 @@ func (f *Framer) ReadHeader() (head *frameHeader, err error) {
 }
 
 // reads a frame form the wire into the framers buffer
-func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
+func (f *Framer) ReadFrame() (data map[string]any, err error) {
 	defer func() {
 		// The casandra plugin uses panic for flow control, panicking on
 		// errors, so return recovered errors unless they are runtime.Error.
@@ -189,7 +189,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	decoder.r = f.r
 	f.decoder = decoder
 
-	data = make(map[string]interface{})
+	data = make(map[string]any)
 
 	// Only QUERY, PREPARE and EXECUTE queries support tracing
 	// If a response frame has the tracing flag set, its body contains
@@ -275,18 +275,18 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	return data, nil
 }
 
-func (f *Framer) parseErrorFrame() (data map[string]interface{}) {
+func (f *Framer) parseErrorFrame() (data map[string]any) {
 	decoder := f.decoder
 	code := decoder.ReadInt()
 	msg := decoder.ReadString()
 
 	errT := ErrType(code)
 
-	data = make(map[string]interface{})
+	data = make(map[string]any)
 	data["code"] = code
 	data["msg"] = msg
 	data["type"] = errT.String()
-	detail := map[string]interface{}{}
+	detail := map[string]any{}
 	switch errT {
 	case errUnavailable:
 		cl := decoder.ReadConsistency()
@@ -368,15 +368,15 @@ func (f *Framer) parseErrorFrame() (data map[string]interface{}) {
 	return data
 }
 
-func (f *Framer) parseSupportedFrame() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseSupportedFrame() (data map[string]any) {
+	data = make(map[string]any)
 	data["supported"] = (f.decoder).ReadStringMultiMap()
 	return data
 }
 
-func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]interface{} {
+func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]any {
 	decoder := f.decoder
-	meta := make(map[string]interface{})
+	meta := make(map[string]any)
 	flags := decoder.ReadInt()
 	meta["flags"] = getRowFlagString(flags)
 	colCount := decoder.ReadInt()
@@ -387,7 +387,7 @@ func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]interface{} {
 		if f.proto >= protoVersion4 {
 			pkeyCount := decoder.ReadInt()
 			pkeys := make([]int, pkeyCount)
-			for i := 0; i < pkeyCount; i++ {
+			for i := range pkeyCount {
 				pkeys[i] = int(decoder.ReadShort())
 			}
 			meta["pkey_columns"] = pkeys
@@ -415,16 +415,16 @@ func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]interface{} {
 	return meta
 }
 
-func (f *Framer) parseQueryFrame() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseQueryFrame() (data map[string]any) {
+	data = make(map[string]any)
 	data["query"] = (f.decoder).ReadLongString()
 	return data
 }
 
-func (f *Framer) parseResultFrame() (data map[string]interface{}) {
+func (f *Framer) parseResultFrame() (data map[string]any) {
 	kind := (f.decoder).ReadInt()
 
-	data = make(map[string]interface{})
+	data = make(map[string]any)
 	switch kind {
 	case resultKindVoid:
 		data["type"] = "void"
@@ -445,16 +445,16 @@ func (f *Framer) parseResultFrame() (data map[string]interface{}) {
 	return data
 }
 
-func (f *Framer) parseResultRows() map[string]interface{} {
-	result := make(map[string]interface{})
+func (f *Framer) parseResultRows() map[string]any {
+	result := make(map[string]any)
 	result["meta"] = f.parseResultMetadata(false)
 	result["num_rows"] = (f.decoder).ReadInt()
 
 	return result
 }
 
-func (f *Framer) parseResultPrepared() map[string]interface{} {
-	result := make(map[string]interface{})
+func (f *Framer) parseResultPrepared() map[string]any {
+	result := make(map[string]any)
 
 	uuid, err := UUIDFromBytes((f.decoder).ReadShortBytes())
 	if err != nil {
@@ -474,8 +474,8 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 	return result
 }
 
-func (f *Framer) parseResultSchemaChange() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseResultSchemaChange() (data map[string]any) {
+	data = make(map[string]any)
 	decoder := f.decoder
 	if f.proto <= protoVersion2 {
 		change := decoder.ReadString()
@@ -512,26 +512,26 @@ func (f *Framer) parseResultSchemaChange() (data map[string]interface{}) {
 	return data
 }
 
-func (f *Framer) parseAuthenticateFrame() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseAuthenticateFrame() (data map[string]any) {
+	data = make(map[string]any)
 	data["class"] = (f.decoder).ReadString()
 	return data
 }
 
-func (f *Framer) parseAuthSuccessFrame() (data map[string]interface{}) {
-	data = make((map[string]interface{}))
+func (f *Framer) parseAuthSuccessFrame() (data map[string]any) {
+	data = make((map[string]any))
 	data["data"] = fmt.Sprintf("%q", (f.decoder).ReadBytes())
 	return data
 }
 
-func (f *Framer) parseAuthChallengeFrame() (data map[string]interface{}) {
-	data = make((map[string]interface{}))
+func (f *Framer) parseAuthChallengeFrame() (data map[string]any) {
+	data = make((map[string]any))
 	data["data"] = fmt.Sprintf("%q", (f.decoder).ReadBytes())
 	return data
 }
 
-func (f *Framer) parseEventFrame() (data map[string]interface{}) {
-	data = make((map[string]interface{}))
+func (f *Framer) parseEventFrame() (data map[string]any) {
+	data = make((map[string]any))
 	decoder := f.decoder
 	eventType := decoder.ReadString()
 	data["type"] = eventType

--- a/packetbeat/protos/cassandra/internal/gocql/marshal.go
+++ b/packetbeat/protos/cassandra/internal/gocql/marshal.go
@@ -39,7 +39,7 @@ type TypeInfo interface {
 
 	// New creates a pointer to an empty version of whatever type
 	// is referenced by the TypeInfo receiver
-	New() interface{}
+	New() any
 }
 
 type NativeType struct {
@@ -48,7 +48,7 @@ type NativeType struct {
 	custom string // only used for TypeCustom
 }
 
-func (t NativeType) New() interface{} {
+func (t NativeType) New() any {
 	return reflect.New(goType(t)).Interface()
 }
 
@@ -82,43 +82,42 @@ type CollectionType struct {
 func goType(t TypeInfo) reflect.Type {
 	switch t.Type() {
 	case TypeVarchar, TypeASCII, TypeInet, TypeText:
-		return reflect.TypeOf(*new(string))
+		return reflect.TypeFor[string]()
 	case TypeBigInt, TypeCounter:
-		return reflect.TypeOf(*new(int64))
+		return reflect.TypeFor[int64]()
 	case TypeTimestamp:
-		return reflect.TypeOf(*new(time.Time))
+		return reflect.TypeFor[time.Time]()
 	case TypeBlob:
-		return reflect.TypeOf(*new([]byte))
+		return reflect.TypeFor[[]byte]()
 	case TypeBoolean:
-		return reflect.TypeOf(*new(bool))
+		return reflect.TypeFor[bool]()
 	case TypeFloat:
-		return reflect.TypeOf(*new(float32))
+		return reflect.TypeFor[float32]()
 	case TypeDouble:
-		return reflect.TypeOf(*new(float64))
+		return reflect.TypeFor[float64]()
 	case TypeInt:
-		return reflect.TypeOf(*new(int))
+		return reflect.TypeFor[int]()
 	case TypeDecimal:
-		return reflect.TypeOf(*new(*inf.Dec))
+		return reflect.TypeFor[*inf.Dec]()
 	case TypeUUID, TypeTimeUUID:
-		return reflect.TypeOf(*new(UUID))
+		return reflect.TypeFor[UUID]()
 	case TypeList, TypeSet:
 		return reflect.SliceOf(goType(t.(CollectionType).Elem))
 	case TypeMap:
 		return reflect.MapOf(goType(t.(CollectionType).Key), goType(t.(CollectionType).Elem))
 	case TypeVarint:
-		return reflect.TypeOf(*new(*big.Int))
+		return reflect.TypeFor[*big.Int]()
 	case TypeTuple:
 		// what can we do here? all there is to do is to make a list of interface{}
-		tuple := t.(TupleTypeInfo)
-		return reflect.TypeOf(make([]interface{}, len(tuple.Elems)))
+		return reflect.TypeFor[[]any]()
 	case TypeUDT:
-		return reflect.TypeOf(make(map[string]interface{}))
+		return reflect.TypeFor[map[string]any]()
 	default:
 		return nil
 	}
 }
 
-func (t CollectionType) New() interface{} {
+func (t CollectionType) New() any {
 	return reflect.New(goType(t)).Interface()
 }
 
@@ -140,7 +139,7 @@ type TupleTypeInfo struct {
 	Elems []TypeInfo
 }
 
-func (t TupleTypeInfo) New() interface{} {
+func (t TupleTypeInfo) New() any {
 	return reflect.New(goType(t)).Interface()
 }
 
@@ -156,7 +155,7 @@ type UDTTypeInfo struct {
 	Elements []UDTField
 }
 
-func (u UDTTypeInfo) New() interface{} {
+func (u UDTTypeInfo) New() any {
 	return reflect.New(goType(u)).Interface()
 }
 

--- a/packetbeat/protos/cassandra/parser.go
+++ b/packetbeat/protos/cassandra/parser.go
@@ -59,8 +59,8 @@ type message struct {
 	failed  bool
 	ignored bool
 
-	data   map[string]interface{}
-	header map[string]interface{}
+	data   map[string]any
+	header map[string]any
 	// list element use by 'transactions' for correlation
 	next *message
 
@@ -87,7 +87,7 @@ func (p *parser) init(
 
 }
 
-func (p *parser) debugf(format string, args ...interface{}) {
+func (p *parser) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -513,8 +513,8 @@ func addDNSToMapStr(m mapstr.M, pbf *pb.Fields, dns *mkdns.Msg, authority bool, 
 			qMapStr["etld_plus_one"] = eTLDPlusOne
 			qMapStr["registered_domain"] = eTLDPlusOne
 
-			if idx := strings.IndexByte(eTLDPlusOne, '.'); idx != -1 {
-				qMapStr["top_level_domain"] = eTLDPlusOne[idx+1:]
+			if _, after, ok := strings.Cut(eTLDPlusOne, "."); ok {
+				qMapStr["top_level_domain"] = after
 			}
 
 			subdomain := strings.TrimRight(strings.TrimSuffix(q.Name, eTLDPlusOne), ".")

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -60,8 +60,8 @@ type dnsTestMessage struct {
 	qType       string
 	qName       string
 	qEtld       string
-	qSubdomain  interface{}
-	qTLD        interface{}
+	qSubdomain  any
+	qTLD        any
 	answers     []string
 	authorities []string
 	additionals []string
@@ -107,7 +107,7 @@ func newDNS(store *eventStore, verbose bool) *dnsPlugin {
 		callback = store.publish
 	}
 
-	cfg, _ := conf.NewConfigFrom(map[string]interface{}{
+	cfg, _ := conf.NewConfigFrom(map[string]any{
 		"ports":               []int{serverPort},
 		"include_authorities": true,
 		"include_additionals": true,
@@ -144,13 +144,13 @@ func expectResult(t testing.TB, e *eventStore) mapstr.M {
 }
 
 // Retrieves a map value. The key should be the full dotted path to the element.
-func mapValue(t testing.TB, m mapstr.M, key string) interface{} {
+func mapValue(t testing.TB, m mapstr.M, key string) any {
 	t.Helper()
 	return mapValueHelper(t, m, strings.Split(key, "."))
 }
 
 // Retrieves nested MapStr values.
-func mapValueHelper(t testing.TB, m mapstr.M, keys []string) interface{} {
+func mapValueHelper(t testing.TB, m mapstr.M, keys []string) any {
 	t.Helper()
 
 	key := keys[0]
@@ -170,7 +170,7 @@ func mapValueHelper(t testing.TB, m mapstr.M, keys []string) interface{} {
 		case mapstr.M:
 			return mapValueHelper(t, typ, keys[1:])
 		case []mapstr.M:
-			var values []interface{}
+			var values []any
 			for _, m := range typ {
 				values = append(values, mapValueHelper(t, m, keys[1:]))
 			}

--- a/packetbeat/protos/dns/names.go
+++ b/packetbeat/protos/dns/names.go
@@ -99,11 +99,11 @@ func dnsHashToString(h uint8) string {
 // string representation is unknown then the numeric value will be returned
 // as a string.
 func dnsTypeBitsMapToString(t []uint16) string {
-	var s string
-	for i := 0; i < len(t); i++ {
-		s += dnsTypeToString(t[i]) + " "
+	var s strings.Builder
+	for i := range t {
+		s.WriteString(dnsTypeToString(t[i]) + " ")
 	}
-	return strings.TrimSuffix(s, " ")
+	return strings.TrimSuffix(s.String(), " ")
 }
 
 // saltToString converts a NSECX salt to uppercase and
@@ -133,7 +133,7 @@ func hexStringToString(hexString string) (string, error) {
 		default:
 			if value < 32 || value >= 127 {
 				// Unprintable characters are written as \\DDD (e.g. \\012).
-				s = append(s, []byte(fmt.Sprintf("\\%03d", int(value)))...)
+				s = append(s, fmt.Appendf(nil, "\\%03d", int(value))...)
 			} else {
 				s = append(s, value)
 			}

--- a/packetbeat/protos/http/decode.go
+++ b/packetbeat/protos/http/decode.go
@@ -86,10 +86,7 @@ func readMax(reader io.Reader, maxSize int) (result []byte, err error) {
 	const minSize = 512
 	for used := 0; ; {
 		if len(result)-used < minSize {
-			grow := len(result) >> 1
-			if grow < minSize {
-				grow = minSize
-			}
+			grow := max(len(result)>>1, minSize)
 			result = append(result, make([]byte, grow)...)
 		}
 		n, err := reader.Read(result[used:])

--- a/packetbeat/protos/http/event_test.go
+++ b/packetbeat/protos/http/event_test.go
@@ -27,8 +27,8 @@ import (
 // TestProtocolFieldsIsInSyncWithECS ensures that Packetbeat's clone of
 // ecs.Http stays in sync.
 func TestProtocolFieldsIsInSyncWithECS(t *testing.T) {
-	ecs := getFields(reflect.TypeOf(ecs.Http{}))
-	packetbeat := getFields(reflect.TypeOf(ProtocolFields{}))
+	ecs := getFields(reflect.TypeFor[ecs.Http]())
+	packetbeat := getFields(reflect.TypeFor[ProtocolFields]())
 
 	for name := range ecs {
 		_, found := packetbeat[name]
@@ -45,8 +45,7 @@ func TestProtocolFieldsIsInSyncWithECS(t *testing.T) {
 
 func getFields(typ reflect.Type) map[string]reflect.Type {
 	fields := map[string]reflect.Type{}
-	for i := 0; i < typ.NumField(); i++ {
-		structField := typ.Field(i)
+	for structField := range typ.Fields() {
 		tag := structField.Tag.Get("ecs")
 		if tag == "" {
 			continue

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -22,8 +22,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -132,14 +134,14 @@ func New(
 }
 
 //go:inline
-func (p *httpPlugin) debugf(format string, args ...interface{}) {
+func (p *httpPlugin) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.httpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (p *httpPlugin) detailedf(format string, args ...interface{}) {
+func (p *httpPlugin) detailedf(format string, args ...any) {
 	if p.isDetail {
 		p.httpDetailedLogger.Debugf(format, args...)
 	}
@@ -647,7 +649,7 @@ func (http *httpPlugin) publishTransaction(event beat.Event) {
 }
 
 func (http *httpPlugin) collectHeaders(m *message) mapstr.M {
-	hdrs := map[string]interface{}{}
+	hdrs := map[string]any{}
 
 	hdrs["content-length"] = m.contentLength
 	if len(m.contentType) > 0 {
@@ -694,8 +696,8 @@ func decodeBody(body []byte, encodings []string, maxSize int, logger *logp.Logge
 	if logger.IsDebug() {
 		logger.Debugf("decoding body with encodings=%v", encodings)
 	}
-	for idx := len(encodings) - 1; idx >= 0; idx-- {
-		format := encodings[idx]
+	for idx, v := range slices.Backward(encodings) {
+		format := v
 		body, err = decodeHTTPBody(body, format, maxSize)
 		if err != nil {
 			// Do not output a partial body unless failure occurs on the
@@ -712,8 +714,8 @@ func decodeBody(body []byte, encodings []string, maxSize int, logger *logp.Logge
 func splitCookiesHeader(headerVal string) map[string]string {
 	cookies := map[string]string{}
 
-	cstring := strings.Split(headerVal, ";")
-	for _, cval := range cstring {
+	cstring := strings.SplitSeq(headerVal, ";")
+	for cval := range cstring {
 		cookie := strings.SplitN(cval, "=", 2)
 		if len(cookie) == 2 {
 			cookies[strings.ToLower(strings.TrimSpace(cookie[0]))] = parseCookieValue(strings.TrimSpace(cookie[1]))
@@ -789,11 +791,7 @@ func (http *httpPlugin) hideHeaders(m *message) {
 
 			endOfHeader := bytes.Index(msg[authHeaderStartX:], constCRLF)
 			if endOfHeader >= 0 {
-				authHeaderEndX = authHeaderStartX + endOfHeader
-
-				if authHeaderEndX > limit {
-					authHeaderEndX = limit
-				}
+				authHeaderEndX = min(authHeaderStartX+endOfHeader, limit)
 
 				http.debugf("Redact authorization from %d to %d", authHeaderStartX, authHeaderEndX)
 
@@ -849,9 +847,7 @@ func (http *httpPlugin) extractParameters(m *message) (path string, params strin
 			return
 		}
 
-		for key, value := range http.hideSecrets(values) {
-			paramsMap[key] = value
-		}
+		maps.Copy(paramsMap, http.hideSecrets(values))
 	}
 
 	params = paramsMap.Encode()
@@ -860,12 +856,7 @@ func (http *httpPlugin) extractParameters(m *message) (path string, params strin
 }
 
 func (http *httpPlugin) isSecretParameter(key string) bool {
-	for _, keyword := range http.hideKeywords {
-		if strings.ToLower(key) == keyword {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(http.hideKeywords, strings.ToLower(key))
 }
 
 func (http *httpPlugin) Expired(tuple *common.TCPTuple, private protos.ProtocolData) {
@@ -935,10 +926,10 @@ func extractBasicAuthUser(headers map[string]common.NetString) string {
 	}
 
 	cs := string(c)
-	s := strings.IndexByte(cs, ':')
-	if s < 0 {
+	before, _, ok := strings.Cut(cs, ":")
+	if !ok {
 		return ""
 	}
 
-	return cs[:s]
+	return before
 }

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -696,8 +696,7 @@ func decodeBody(body []byte, encodings []string, maxSize int, logger *logp.Logge
 	if logger.IsDebug() {
 		logger.Debugf("decoding body with encodings=%v", encodings)
 	}
-	for idx, v := range slices.Backward(encodings) {
-		format := v
+	for idx, format := range slices.Backward(encodings) {
 		body, err = decodeHTTPBody(body, format, maxSize)
 		if err != nil {
 			// Do not output a partial body unless failure occurs on the

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -137,14 +137,14 @@ func newParser(config *parserConfig, httpLogger, httpDetailedLogger *logp.Logger
 }
 
 //go:inline
-func (parser *parser) debugf(format string, args ...interface{}) {
+func (parser *parser) debugf(format string, args ...any) {
 	if parser.httpLogger.IsDebug() {
 		parser.httpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (parser *parser) detailedf(format string, args ...interface{}) {
+func (parser *parser) detailedf(format string, args ...any) {
 	if parser.httpDetailedLogger.IsDebug() {
 		parser.httpDetailedLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -988,8 +988,8 @@ func TestHttpParser_RedactAuthorization_raw(t *testing.T) {
 		t.Errorf("Expecting a complete message")
 	}
 
-	rawMessageObscured := bytes.Index(msg, []byte("uthorization:*"))
-	if rawMessageObscured < 0 {
+	found := bytes.Contains(msg, []byte("uthorization:*"))
+	if !found {
 		t.Error("Obscured authorization string not found: " + string(msg[:]))
 	}
 }
@@ -1023,8 +1023,8 @@ func TestHttpParser_RedactAuthorization_Proxy_raw(t *testing.T) {
 		t.Errorf("Expecting a complete message")
 	}
 
-	rawMessageObscured := bytes.Index(msg, []byte("uthorization:*"))
-	if rawMessageObscured < 0 {
+	found := bytes.Contains(msg, []byte("uthorization:*"))
+	if !found {
 		t.Error("Failed to redact proxy-authorization header: " + string(msg[:]))
 	}
 }
@@ -2060,7 +2060,7 @@ func BenchmarkHttpLargeResponseBody(b *testing.B) {
 	const BodySize = 10 * 1024 * PacketSize
 	const numPackets = BodySize / PacketSize
 	bodyPayload := &protos.Packet{Payload: make([]byte, PacketSize)}
-	for i := 0; i < PacketSize; i++ {
+	for i := range PacketSize {
 		bodyPayload.Payload[i] = byte(0x30 + (i % 10))
 	}
 
@@ -2077,7 +2077,7 @@ func BenchmarkHttpLargeResponseBody(b *testing.B) {
 		private := protos.ProtocolData(&httpConnectionData{})
 		private = http.Parse(&headPkt, tcptuple, 0, private)
 
-		for j := 0; j < numPackets; j++ {
+		for range numPackets {
 			private = http.Parse(bodyPayload, tcptuple, 0, private)
 		}
 		http.ReceivedFin(tcptuple, 1, private)

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -156,7 +156,7 @@ func New(
 	return p, nil
 }
 
-func (mc *memcache) debugf(format string, args ...interface{}) {
+func (mc *memcache) debugf(format string, args ...any) {
 	if mc.isDebug {
 		mc.logger.Debugf(format, args...)
 	}
@@ -311,10 +311,7 @@ func mergeValueMessages(mc *memcache, prev, msg *message) (bool, error) {
 		if mc.config.maxValues < 0 {
 			delta = len(msg.values)
 		} else if len(prev.values) < mc.config.maxValues {
-			delta = mc.config.maxValues - len(prev.values)
-			if delta > len(prev.values) {
-				delta = len(prev.values)
-			}
+			delta = min(mc.config.maxValues-len(prev.values), len(prev.values))
 		}
 
 		prev.values = append(prev.values, msg.values[0:delta]...)

--- a/packetbeat/protos/memcache/parse.go
+++ b/packetbeat/protos/memcache/parse.go
@@ -77,7 +77,7 @@ func newParser(config *parserConfig, logger *logp.Logger) *parser {
 }
 
 //go:inline
-func (p *parser) debugf(format string, args ...interface{}) {
+func (p *parser) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -19,6 +19,8 @@ package mongodb
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -89,7 +91,7 @@ func New(
 }
 
 //go:inline
-func (mongodb *mongodbPlugin) debugf(format string, v ...interface{}) {
+func (mongodb *mongodbPlugin) debugf(format string, v ...any) {
 	if mongodb.isDebug {
 		mongodb.logger.Debugf(format, v...)
 	}
@@ -327,9 +329,7 @@ func newTransaction(requ, resp *mongodbMessage) *transaction {
 
 	// fill response
 	if resp != nil {
-		for k, v := range resp.event {
-			trans.event[k] = v
-		}
+		maps.Copy(trans.event, resp.event)
 
 		trans.error = resp.error
 		trans.documents = resp.documents
@@ -352,16 +352,10 @@ func (mongodb *mongodbPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	return private
 }
 
-func copyMapWithoutKey(d map[string]interface{}, keys ...string) map[string]interface{} {
-	res := map[string]interface{}{}
+func copyMapWithoutKey(d map[string]any, keys ...string) map[string]any {
+	res := map[string]any{}
 	for k, v := range d {
-		found := false
-		for _, excludeKey := range keys {
-			if k == excludeKey {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(keys, k)
 		if !found {
 			res[k] = v
 		}
@@ -371,7 +365,7 @@ func copyMapWithoutKey(d map[string]interface{}, keys ...string) map[string]inte
 
 func reconstructQuery(t *transaction, full bool, logger *logp.Logger) (query string) {
 	query = t.resource + "." + t.method + "("
-	var doc interface{}
+	var doc any
 
 	if len(t.params) > 0 {
 		if !full {

--- a/packetbeat/protos/mongodb/mongodb_parser.go
+++ b/packetbeat/protos/mongodb/mongodb_parser.go
@@ -164,8 +164,8 @@ func opReplyParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, boo
 
 	logger.Debugf("Prepare to read %d document from reply", m.event["numberReturned"])
 
-	documents := make([]interface{}, numberReturned)
-	for i := int32(0); i < numberReturned; i++ {
+	documents := make([]any, numberReturned)
+	for i := range numberReturned {
 		var document bson.M
 		document, err = d.readDocument(logger)
 		if err != nil {
@@ -261,7 +261,7 @@ func opInsertParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bo
 
 // Try to guess whether this key:value pair found in
 // the query represents a command.
-func isDatabaseCommand(key string, val interface{}) bool {
+func isDatabaseCommand(key string, val any) bool {
 	nameExists := false
 	for _, cmd := range databaseCommands {
 		if strings.EqualFold(cmd, key) {
@@ -423,7 +423,7 @@ func opMsgParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool)
 			logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 			return false, false
 		}
-		m.documents = []interface{}{document}
+		m.documents = []any{document}
 
 	case msgKindDocumentSequence:
 		start := d.i
@@ -449,7 +449,7 @@ func opMsgParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool)
 			return false, false
 		}
 		m.event["message"] = cstring
-		var documents []interface{}
+		var documents []any
 		for d.i < start+int(size) {
 			document, err := d.readDocument(logger)
 			if err != nil {
@@ -576,7 +576,7 @@ func (d *decoder) readDocument(logger *logp.Logger) (bson.M, error) {
 	return documentMap, nil
 }
 
-func doc2str(documentMap interface{}) (string, error) {
+func doc2str(documentMap any) (string, error) {
 	document, err := json.Marshal(documentMap)
 	return string(document), err
 }

--- a/packetbeat/protos/mongodb/mongodb_parser_test.go
+++ b/packetbeat/protos/mongodb/mongodb_parser_test.go
@@ -148,7 +148,7 @@ func addInt32(in []byte, v int32) []byte {
 func Test_isDatabaseCommand(t *testing.T) {
 	type io struct {
 		Key   string
-		Value interface{}
+		Value any
 
 		Output bool
 	}

--- a/packetbeat/protos/mongodb/mongodb_structs.go
+++ b/packetbeat/protos/mongodb/mongodb_structs.go
@@ -53,8 +53,8 @@ type mongodbMessage struct {
 	method    string
 	error     string
 	resource  string
-	documents []interface{}
-	params    map[string]interface{}
+	documents []any
+	params    map[string]any
 
 	// Other fields vary very much depending on operation type
 	// lets just put them in a map
@@ -104,9 +104,9 @@ type transaction struct {
 	method           string
 	resource         string
 	error            string
-	params           map[string]interface{}
-	requestDocuments []interface{}
-	documents        []interface{}
+	params           map[string]any
+	requestDocuments []any
+	documents        []any
 }
 
 type msgKind byte

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -240,11 +240,11 @@ func TestReconstructQuery(t *testing.T) {
 			Input: transaction{
 				resource: "test.col",
 				method:   "find",
-				event: map[string]interface{}{
+				event: map[string]any{
 					"numberToSkip":   3,
 					"numberToReturn": 2,
 				},
-				params: map[string]interface{}{
+				params: map[string]any{
 					"me": "you",
 				},
 			},
@@ -255,7 +255,7 @@ func TestReconstructQuery(t *testing.T) {
 			Input: transaction{
 				resource: "test.col",
 				method:   "insert",
-				params: map[string]interface{}{
+				params: map[string]any{
 					"documents": "you",
 				},
 			},
@@ -266,7 +266,7 @@ func TestReconstructQuery(t *testing.T) {
 			Input: transaction{
 				resource: "test.col",
 				method:   "insert",
-				params: map[string]interface{}{
+				params: map[string]any{
 					"documents": "you",
 				},
 			},
@@ -286,7 +286,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// more docs than configured
 	trans := transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2, 3, 4, 5, 6, 7, 8,
 		},
 	}
@@ -303,7 +303,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// exactly the same number of docs
 	trans = transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2, 3,
 		},
 	}
@@ -314,7 +314,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// less docs
 	trans = transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2,
 		},
 	}
@@ -325,7 +325,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// unlimited
 	trans = transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2, 3, 4,
 		},
 	}
@@ -339,7 +339,7 @@ func TestMaxDocSize(t *testing.T) {
 
 	// more docs than configured
 	trans := transaction{
-		documents: []interface{}{
+		documents: []any{
 			"1234567",
 			"123",
 			"12",

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -895,7 +895,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 			return nil
 		}
 		// First call or rebound (1)
-		for stmtPos := 0; stmtPos < nparam; stmtPos++ {
+		for range nparam {
 			paramType = data[offset]
 			offset++
 			nparamType = append(nparamType, paramType)
@@ -919,7 +919,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 		}
 	}
 
-	for stmtPos := 0; stmtPos < nparam; stmtPos++ {
+	for stmtPos := range nparam {
 		paramType = nparamType[stmtPos]
 		// dissect parameter on paramType
 		switch paramType {

--- a/packetbeat/protos/nfs/nfs4.go
+++ b/packetbeat/protos/nfs/nfs4.go
@@ -210,7 +210,7 @@ func (nfs *nfs) eatData(op int, xdr *xdr) error {
 		if _, err := xdr.getOpaque(16); err != nil {
 			return err
 		}
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			if _, err := xdr.getUInt(); err != nil {
 				return err
 			}

--- a/packetbeat/protos/nfs/xdr.go
+++ b/packetbeat/protos/nfs/xdr.go
@@ -110,7 +110,7 @@ func (r *xdr) getUIntVector() ([]uint32, error) {
 		return nil, fmt.Errorf("xdr: vector length %d exceeds limit", l)
 	}
 	v := make([]uint32, int(l))
-	for i := 0; i < len(v); i++ {
+	for i := range v {
 		vi, err := r.getUInt()
 		if err != nil {
 			return nil, err

--- a/packetbeat/protos/nfs/xdr_test.go
+++ b/packetbeat/protos/nfs/xdr_test.go
@@ -38,7 +38,7 @@ var testMsg = []byte{
 func BytesToUint32(b []byte) []uint32 {
 	n := len(b) / 4
 	out := make([]uint32, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		out[i] = binary.BigEndian.Uint32(b[i*4:])
 	}
 	return out

--- a/packetbeat/protos/pgsql/parse.go
+++ b/packetbeat/protos/pgsql/parse.go
@@ -423,7 +423,7 @@ func (pgsql *pgsqlPlugin) parseFields(s *pgsqlStream, buf []byte) error {
 	fields := []string{}
 	fieldsFormat := []byte{}
 
-	for i := 0; i < fieldCount; i++ {
+	for range fieldCount {
 		if len(buf) <= off {
 			return errFieldBufferShort
 		}

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -201,14 +201,14 @@ func (pgsql *pgsqlPlugin) getTransaction(k common.HashableTCPTuple) []*pgsqlTran
 }
 
 //go:inline
-func (pgsql *pgsqlPlugin) debugf(format string, v ...interface{}) {
+func (pgsql *pgsqlPlugin) debugf(format string, v ...any) {
 	if pgsql.isDebug {
 		pgsql.debug.Debugf(format, v...)
 	}
 }
 
 //go:inline
-func (pgsql *pgsqlPlugin) detailf(format string, v ...interface{}) {
+func (pgsql *pgsqlPlugin) detailf(format string, v ...any) {
 	if pgsql.isDetail {
 		pgsql.detail.Debugf(format, v...)
 	}

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -20,7 +20,7 @@ package protos
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -40,7 +40,7 @@ const (
 // ProtocolData interface to represent an upper
 // protocol private data. Used with types like
 // HttpStream, MysqlStream, etc.
-type ProtocolData interface{}
+type ProtocolData any
 
 type Packet struct {
 	Ts      time.Time
@@ -298,7 +298,7 @@ func (s ProtocolsStruct) BpfFilter(withVlans bool, withICMP bool) string {
 	for proto := range s.all {
 		protos = append(protos, proto)
 	}
-	sort.Slice(protos, func(i, j int) bool { return protos[i] < protos[j] })
+	slices.Sort(protos)
 
 	var expressions []string
 	for _, proto := range protos {

--- a/packetbeat/protos/protos_test.go
+++ b/packetbeat/protos/protos_test.go
@@ -207,15 +207,15 @@ func TestGetUDP(t *testing.T) {
 func TestValidateProtocolDevice(t *testing.T) {
 	tcs := []struct {
 		testCase, device string
-		config           map[string]interface{}
+		config           map[string]any
 		expectedValid    bool
 		expectedErr      string
 	}{
 		{
 			"DeviceIsIncorrect",
 			"eth0",
-			map[string]interface{}{
-				"interface": map[string]interface{}{
+			map[string]any{
+				"interface": map[string]any{
 					"device": "eth1",
 				},
 			},
@@ -225,8 +225,8 @@ func TestValidateProtocolDevice(t *testing.T) {
 		{
 			"DeviceIsCorrect",
 			"eth1",
-			map[string]interface{}{
-				"interface": map[string]interface{}{
+			map[string]any{
+				"interface": map[string]any{
 					"device": "eth1",
 				},
 			},
@@ -236,7 +236,7 @@ func TestValidateProtocolDevice(t *testing.T) {
 		{
 			"ConfigIsInvalid",
 			"eth0",
-			map[string]interface{}{
+			map[string]any{
 				"interface": "eth1",
 			},
 			false,
@@ -245,7 +245,6 @@ func TestValidateProtocolDevice(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.testCase, func(t *testing.T) {
 			cfg := (*conf.C)(ucfg.MustNewFrom(tc.config))
 			isValid, err := validateProtocolDevice(tc.device, cfg)

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -98,7 +98,7 @@ func New(
 }
 
 //go:inline
-func (redis *redisPlugin) debugf(format string, args ...interface{}) {
+func (redis *redisPlugin) debugf(format string, args ...any) {
 	if redis.isDebug {
 		redis.logger.Debug(fmt.Sprintf(format, args...))
 	}

--- a/packetbeat/protos/sip/parser.go
+++ b/packetbeat/protos/sip/parser.go
@@ -107,14 +107,14 @@ func (pi *parsingInfo) prepareForNewMessage() {
 }
 
 //go:inline
-func (pi *parsingInfo) debugf(format string, args ...interface{}) {
+func (pi *parsingInfo) debugf(format string, args ...any) {
 	if pi.isDebug {
 		pi.sipLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (pi *parsingInfo) detailedf(format string, args ...interface{}) {
+func (pi *parsingInfo) detailedf(format string, args ...any) {
 	if pi.isDetailedDebug {
 		pi.sipDetailedLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/sip/plugin.go
+++ b/packetbeat/protos/sip/plugin.go
@@ -88,14 +88,14 @@ func New(
 }
 
 //go:inline
-func (p *plugin) debugf(format string, args ...interface{}) {
+func (p *plugin) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.sipLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (p *plugin) detailedf(format string, args ...interface{}) {
+func (p *plugin) detailedf(format string, args ...any) {
 	if p.isDetailed {
 		p.sipDetailedLogger.Debugf(format, args...)
 	}
@@ -589,7 +589,7 @@ func populateAuthFields(m *message, evt beat.Event, pbf *pb.Fields, fields *Prot
 	fields.AuthScheme = auth[:pos]
 
 	pos += 1
-	for _, param := range bytes.Split(auth[pos:], []byte(",")) {
+	for param := range bytes.SplitSeq(auth[pos:], []byte(",")) {
 		kv := bytes.SplitN(param, []byte("="), 2)
 		if len(kv) != 2 {
 			continue
@@ -638,7 +638,7 @@ func populateBodyFields(msg *message, pbf *pb.Fields, fields *ProtocolFields, si
 	fields.SDPBodyOriginal = msg.body
 
 	var isInMedia bool
-	for _, line := range bytes.Split(msg.body, []byte("\r\n")) {
+	for line := range bytes.SplitSeq(msg.body, []byte("\r\n")) {
 		kv := bytes.SplitN(line, []byte("="), 2)
 		if len(kv) != 2 {
 			continue
@@ -761,7 +761,7 @@ func parseFromToContact(fromTo common.NetString) (displayInfo, uri common.NetStr
 
 	// parse the header params
 	pos = endURIPos + 1
-	for _, param := range bytes.Split(fromTo[pos:], []byte(";")) {
+	for param := range bytes.SplitSeq(fromTo[pos:], []byte(";")) {
 		kv := bytes.SplitN(param, []byte("="), 2)
 		if len(kv) != 2 {
 			continue
@@ -844,7 +844,7 @@ loop:
 	}
 
 	if hasParams {
-		for _, param := range bytes.Split(uri[epos+1:], []byte(";")) {
+		for param := range bytes.SplitSeq(uri[epos+1:], []byte(";")) {
 			kv := bytes.Split(param, []byte("="))
 			if len(kv) != 2 {
 				continue

--- a/packetbeat/protos/sip/plugin_test.go
+++ b/packetbeat/protos/sip/plugin_test.go
@@ -190,7 +190,7 @@ func TestParseUDP(t *testing.T) {
 	assert.EqualValues(t, []common.NetString{common.NetString("SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0")}, getVal(fields, "sip.via.original"))
 }
 
-func getVal(f beat.Event, k string) interface{} {
+func getVal(f beat.Event, k string) any {
 	v, _ := f.GetValue(k)
 	return v
 }

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -87,7 +87,7 @@ func NewTCP(p protos.Protocols, id, device string, idx int, logger *logp.Logger)
 }
 
 //go:inline
-func (tcp *TCP) debugf(format string, args ...interface{}) {
+func (tcp *TCP) debugf(format string, args ...any) {
 	if tcp.isDebug {
 		tcp.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -526,7 +526,7 @@ func (thrift *thriftPlugin) readListOrSet(data []byte) (value string, ok bool, c
 	fields := []string{}
 	offset := 5
 
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		value, ok, complete, bytesRead := funcReader(data[offset:])
 		if !ok {
 			return "", false, false, 0
@@ -590,7 +590,7 @@ func (thrift *thriftPlugin) readMap(data []byte) (value string, ok bool, complet
 	fields := []string{}
 	offset := 6
 
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		key, ok, complete, bytesRead := funcReaderKey(data[offset:])
 		if !ok {
 			return "", false, false, 0

--- a/packetbeat/protos/thrift/thrift_idl_test.go
+++ b/packetbeat/protos/thrift/thrift_idl_test.go
@@ -18,7 +18,6 @@
 package thrift
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 )
 
 func thriftIdlForTesting(t *testing.T, content string) *thriftIdl {
-	f, _ := ioutil.TempFile("", "")
+	f, _ := os.CreateTemp("", "")
 	defer os.Remove(f.Name())
 
 	f.WriteString(content)

--- a/packetbeat/protos/tls/extensions.go
+++ b/packetbeat/protos/tls/extensions.go
@@ -36,7 +36,7 @@ type Extensions struct {
 }
 
 type (
-	extensionParser func(reader bufferView, logger *logp.Logger) interface{}
+	extensionParser func(reader bufferView, logger *logp.Logger) any
 	extension       struct {
 		label   string
 		parser  extensionParser
@@ -119,7 +119,7 @@ func ParseExtensions(buffer bufferView, logger *logp.Logger) Extensions {
 	return result
 }
 
-func parseExtension(code uint16, buffer bufferView, logger *logp.Logger) (string, interface{}, bool) {
+func parseExtension(code uint16, buffer bufferView, logger *logp.Logger) (string, any, bool) {
 	if ext, ok := extensionMap[code]; ok {
 		parsed := ext.parser(buffer, logger)
 		return ext.label, parsed, ext.saveRaw
@@ -127,7 +127,7 @@ func parseExtension(code uint16, buffer bufferView, logger *logp.Logger) (string
 	return strconv.Itoa(int(code)), nil, false
 }
 
-func parseSni(buffer bufferView, logger *logp.Logger) interface{} {
+func parseSni(buffer bufferView, logger *logp.Logger) any {
 	var listLength uint16
 	if !buffer.read16Net(0, &listLength) {
 		return nil
@@ -150,7 +150,7 @@ func parseSni(buffer bufferView, logger *logp.Logger) interface{} {
 	return hosts
 }
 
-func parseMaxFragmentLen(buffer bufferView, _ *logp.Logger) interface{} {
+func parseMaxFragmentLen(buffer bufferView, _ *logp.Logger) any {
 	var val uint8
 	if buffer.length() == 1 && buffer.read8(0, &val) {
 		if val > 0 && val < 5 {
@@ -161,11 +161,11 @@ func parseMaxFragmentLen(buffer bufferView, _ *logp.Logger) interface{} {
 	return nil
 }
 
-func ignoreContent(_ bufferView, _ *logp.Logger) interface{} {
+func ignoreContent(_ bufferView, _ *logp.Logger) any {
 	return nil
 }
 
-func parseStatusReq(buffer bufferView, _ *logp.Logger) interface{} {
+func parseStatusReq(buffer bufferView, _ *logp.Logger) any {
 	if buffer.length() == 0 {
 		// Initial server response.
 		return mapstr.M{"response": true}
@@ -185,14 +185,14 @@ func parseStatusReq(buffer bufferView, _ *logp.Logger) interface{} {
 	return mapstr.M{"type": typ, "responder_id_list_length": list, "request_extensions": exts}
 }
 
-func expectEmpty(buffer bufferView, _ *logp.Logger) interface{} {
+func expectEmpty(buffer bufferView, _ *logp.Logger) any {
 	if buffer.length() != 0 {
 		return fmt.Sprintf("(expected empty: found %d bytes)", buffer.length())
 	}
 	return ""
 }
 
-func parseCertType(buffer bufferView, _ *logp.Logger) interface{} {
+func parseCertType(buffer bufferView, _ *logp.Logger) any {
 	var value uint8
 	var types []string
 	pos, limit := 0, buffer.length()
@@ -220,7 +220,7 @@ func parseCertType(buffer bufferView, _ *logp.Logger) interface{} {
 	return types
 }
 
-func parseSupportedGroups(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSupportedGroups(buffer bufferView, _ *logp.Logger) any {
 	var value uint16
 	if !buffer.read16Net(0, &value) || int(value)+2 != buffer.length() {
 		return nil
@@ -234,7 +234,7 @@ func parseSupportedGroups(buffer bufferView, _ *logp.Logger) interface{} {
 	return groups
 }
 
-func parseEcPoints(buffer bufferView, _ *logp.Logger) interface{} {
+func parseEcPoints(buffer bufferView, _ *logp.Logger) any {
 	var value, length uint8
 	if !buffer.read8(0, &length) || int(length)+1 != buffer.length() {
 		return nil
@@ -246,7 +246,7 @@ func parseEcPoints(buffer bufferView, _ *logp.Logger) interface{} {
 	return formats
 }
 
-func parseSrp(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSrp(buffer bufferView, _ *logp.Logger) any {
 	var length uint8
 	if !buffer.read8(0, &length) || int(length)+1 > buffer.length() {
 		return nil
@@ -258,7 +258,7 @@ func parseSrp(buffer bufferView, _ *logp.Logger) interface{} {
 	return user
 }
 
-func parseSignatureSchemes(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSignatureSchemes(buffer bufferView, _ *logp.Logger) any {
 	var value uint16
 	if !buffer.read16Net(0, &value) || int(value)+2 != buffer.length() {
 		return nil
@@ -270,14 +270,14 @@ func parseSignatureSchemes(buffer bufferView, _ *logp.Logger) interface{} {
 	return groups
 }
 
-func parseTicket(buffer bufferView, _ *logp.Logger) interface{} {
+func parseTicket(buffer bufferView, _ *logp.Logger) any {
 	if buffer.length() > 0 {
 		return fmt.Sprintf("(%d bytes)", buffer.length())
 	}
 	return ""
 }
 
-func parseALPN(buffer bufferView, _ *logp.Logger) interface{} {
+func parseALPN(buffer bufferView, _ *logp.Logger) any {
 	var length uint16
 	if !buffer.read16Net(0, &length) || int(length)+2 != buffer.length() {
 		return nil
@@ -295,7 +295,7 @@ func parseALPN(buffer bufferView, _ *logp.Logger) interface{} {
 	return protos
 }
 
-func parseSupportedVersions(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSupportedVersions(buffer bufferView, _ *logp.Logger) any {
 	// Parsing the supported_versions extensions requires knowing whether the
 	// extension is included in a client_hello or server_hello, but a workaround
 	// can be done by looking at the extension length.
@@ -324,7 +324,7 @@ func parseSupportedVersions(buffer bufferView, _ *logp.Logger) interface{} {
 			return nil
 		}
 		list := make([]string, 0, numEntries)
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			var val uint16
 			if !buffer.read16Net(1+2*i, &val) {
 				return nil

--- a/packetbeat/protos/tls/extensions_test.go
+++ b/packetbeat/protos/tls/extensions_test.go
@@ -168,7 +168,7 @@ func TestParseSupportedVersions(t *testing.T) {
 	for _, testCase := range []struct {
 		title    string
 		data     string
-		expected interface{}
+		expected any
 	}{
 		{
 			title:    "negotiation",

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -249,7 +249,7 @@ func (hello *helloMessage) supportedCiphers() []string {
 	return ciphers
 }
 
-func (parser *parser) debugf(format string, args ...interface{}) {
+func (parser *parser) debugf(format string, args ...any) {
 	if parser.logger != nil && parser.logger.IsDebug() {
 		parser.logger.Debugf(format, args...)
 	}
@@ -605,7 +605,7 @@ func (version tlsVersion) IsZero() bool {
 	return version.major == 0 && version.minor == 0
 }
 
-func getKeySize(key interface{}) int {
+func getKeySize(key any) int {
 	if key == nil {
 		return 0
 	}
@@ -664,7 +664,7 @@ func toMap(name *pkix.Name) mapstr.M {
 	result := mapstr.M{}
 	fields := []struct {
 		name  string
-		value interface{}
+		value any
 	}{
 		{"country", name.Country},
 		{"organization", name.Organization},

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -120,7 +120,7 @@ func sBuf(t *testing.T, hexString string) *streambuf.Buffer {
 	return streambuf.New(bytes)
 }
 
-func mapGet(t *testing.T, m mapstr.M, key string) interface{} {
+func mapGet(t *testing.T, m mapstr.M, key string) any {
 	value, err := m.GetValue(key)
 	assert.NoError(t, err)
 	return value

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -102,7 +102,7 @@ func New(
 }
 
 //go:inline
-func (plugin *tlsPlugin) debugf(format string, args ...interface{}) {
+func (plugin *tlsPlugin) debugf(format string, args ...any) {
 	if plugin.isDebug {
 		plugin.tlsLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -217,7 +217,7 @@ func TestOCSPStatus(t *testing.T) {
 
 	for i, test := range []struct {
 		msg  string
-		want interface{}
+		want any
 	}{
 		// Packets from https://github.com/elastic/beats/issues/29962#issue-1112502582
 		//

--- a/packetbeat/route/route_bsd_test.go
+++ b/packetbeat/route/route_bsd_test.go
@@ -79,8 +79,8 @@ func defaultRoute(af int) (name string, index int, err error) {
 		if len(f) < 3 {
 			return "", -1, fmt.Errorf("unexpected netstat -I %s line: %q", name, sc.Text())
 		}
-		if strings.HasPrefix(f[2], "<Link#") {
-			idx, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(f[2], "<Link#"), ">"))
+		if after, ok := strings.CutPrefix(f[2], "<Link#"); ok {
+			idx, err := strconv.Atoi(strings.TrimSuffix(after, ">"))
 			if err != nil {
 				return "", -1, fmt.Errorf("failed to parse index from %s: %v", f[2], err)
 			}

--- a/packetbeat/route/route_test.go
+++ b/packetbeat/route/route_test.go
@@ -52,7 +52,7 @@ func TestDefault(t *testing.T) {
 				// based on the LUID.
 				b, err := run("getmac")
 				if err != nil {
-					b = []byte(fmt.Sprintf("\nunable to recover getmac information: %v", err))
+					b = fmt.Appendf(nil, "\nunable to recover getmac information: %v", err)
 				}
 				t.Logf("unexpected interface for family %d: got:%s want:%s\n%s", family, iface, wantIface, b)
 			} else {

--- a/packetbeat/route/route_windows.go
+++ b/packetbeat/route/route_windows.go
@@ -58,7 +58,7 @@ func Default(af int) (name string, index int, err error) {
 	)
 	outBufLen := uint32(workingBufferSize)
 loop:
-	for i := 0; i < maxTries; i++ {
+	for range maxTries {
 		buf := make([]byte, outBufLen)
 		addresses = (*windows.IpAdapterAddresses)(unsafe.Pointer(&buf[0]))
 		err = windows.GetAdaptersAddresses(uint32(af), 0, 0, addresses, &outBufLen)

--- a/packetbeat/scripts/mage/config.go
+++ b/packetbeat/scripts/mage/config.go
@@ -42,7 +42,7 @@ func ConfigFileParams() devtools.ConfigFileParams {
 	if SelectLogic == devtools.XPackProject {
 		p.Templates = append(p.Templates, devtools.XPackBeatDir("_meta/config/*.tmpl"))
 	}
-	p.ExtraVars = map[string]interface{}{
+	p.ExtraVars = map[string]any{
 		"device": device,
 	}
 	return p

--- a/winlogbeat/beater/acker.go
+++ b/winlogbeat/beater/acker.go
@@ -41,7 +41,7 @@ func newEventACKer(checkpoint *checkpoint.Checkpoint) *eventACKer {
 
 // ACKEvents receives callbacks from the publisher for every event that is
 // published. It persists the record number of the last event in each
-func (a *eventACKer) ACKEvents(data []interface{}) {
+func (a *eventACKer) ACKEvents(data []any) {
 	states := make(map[string]*checkpoint.EventLogState)
 
 	for _, datum := range data {

--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -118,7 +118,7 @@ func (e *eventLogger) run(
 	// Initialize per event log metrics.
 	initMetrics(api.Name())
 
-	pipeline = pipetool.WithACKer(pipeline, acker.EventPrivateReporter(func(_ int, private []interface{}) {
+	pipeline = pipetool.WithACKer(pipeline, acker.EventPrivateReporter(func(_ int, private []any) {
 		eventACKer.ACKEvents(private)
 	}))
 

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -22,7 +22,6 @@ package checkpoint
 
 import (
 	"fmt"
-
 	"maps"
 	"os"
 	"path/filepath"

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -22,7 +22,8 @@ package checkpoint
 
 import (
 	"fmt"
-	"io/ioutil"
+
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -169,9 +170,7 @@ func (c *Checkpoint) States() map[string]EventLogState {
 	defer c.lock.RUnlock()
 
 	copy := make(map[string]EventLogState)
-	for k, v := range c.states {
-		copy[k] = v
-	}
+	maps.Copy(copy, c.states)
 
 	return copy
 }
@@ -267,7 +266,7 @@ func (c *Checkpoint) read() (*PersistedState, error) {
 	c.fileLock.RLock()
 	defer c.fileLock.RUnlock()
 
-	contents, err := ioutil.ReadFile(c.file)
+	contents, err := os.ReadFile(c.file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = nil

--- a/winlogbeat/checkpoint/checkpoint_test.go
+++ b/winlogbeat/checkpoint/checkpoint_test.go
@@ -20,7 +20,6 @@
 package checkpoint
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -34,13 +33,7 @@ func eventually(t *testing.T, predicate func() (bool, error), timeout time.Durat
 	const minInterval = time.Millisecond * 5
 	const maxInterval = time.Millisecond * 500
 
-	checkInterval := timeout / 100
-	if checkInterval < minInterval {
-		checkInterval = minInterval
-	}
-	if checkInterval > maxInterval {
-		checkInterval = maxInterval
-	}
+	checkInterval := min(max(timeout/100, minInterval), maxInterval)
 	for deadline, first := time.Now().Add(timeout), true; first || time.Now().Before(deadline); first = false {
 		ok, err := predicate()
 		if err != nil {
@@ -58,7 +51,7 @@ func eventually(t *testing.T, predicate func() (bool, error), timeout time.Durat
 // Test that a write is triggered when the maximum time period since the last
 // write is reached.
 func TestWriteTimedFlush(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
+	dir, err := os.MkdirTemp("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +96,7 @@ func TestWriteTimedFlush(t *testing.T) {
 
 // Test that createDir creates the directory with 0750 permissions.
 func TestCreateDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
+	dir, err := os.MkdirTemp("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +135,7 @@ func TestCreateDir(t *testing.T) {
 // Test createDir when the directory already exists to verify that no error is
 // returned.
 func TestCreateDirAlreadyExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
+	dir, err := os.MkdirTemp("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -51,7 +51,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			WinlogbeatConfig{
 				EventLogs: []*conf.C{
-					newConfig(map[string]interface{}{
+					newConfig(map[string]any{
 						"Name": "App",
 					}),
 				},
@@ -69,7 +69,7 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
-func newConfig(from map[string]interface{}) *conf.C {
+func newConfig(from map[string]any) *conf.C {
 	cfg, err := conf.NewConfigFrom(from)
 	if err != nil {
 		panic(err)

--- a/winlogbeat/eventlog/config.go
+++ b/winlogbeat/eventlog/config.go
@@ -33,7 +33,7 @@ type validator interface {
 	Validate() error
 }
 
-func readConfig(c *conf.C, config interface{}) error {
+func readConfig(c *conf.C, config any) error {
 	if err := c.Unpack(config); err != nil {
 		return fmt.Errorf("failed unpacking config. %w", err)
 	}

--- a/winlogbeat/eventlog/metrics.go
+++ b/winlogbeat/eventlog/metrics.go
@@ -44,7 +44,7 @@ var (
 // incrementMetric increments a value in the specified expvar.Map. The key
 // should be a windows syscall.Errno or a string. Any other types will be
 // reported under the "other" key.
-func incrementMetric(v *expvar.Map, key interface{}) {
+func incrementMetric(v *expvar.Map, key any) {
 	switch t := key.(type) {
 	default:
 		v.Add("other", 1)

--- a/winlogbeat/eventlog/record_filter.go
+++ b/winlogbeat/eventlog/record_filter.go
@@ -125,7 +125,7 @@ func parseLevels(raw string) (map[uint8]struct{}, error) {
 		}
 	}
 
-	for _, expr := range strings.Split(raw, ",") {
+	for expr := range strings.SplitSeq(raw, ",") {
 		expr = strings.ToLower(strings.TrimSpace(expr))
 		switch expr {
 		case "verbose", "5":
@@ -156,7 +156,7 @@ func parseEventIDRanges(raw string) ([]eventIDRange, []eventIDRange, error) {
 	var includes []eventIDRange
 	var excludes []eventIDRange
 
-	for _, component := range strings.Split(raw, ",") {
+	for component := range strings.SplitSeq(raw, ",") {
 		component = strings.TrimSpace(component)
 		if component == "" {
 			return nil, nil, fmt.Errorf("invalid event ID query component ('%s')", component)

--- a/winlogbeat/eventlog/wineventlog_test.go
+++ b/winlogbeat/eventlog/wineventlog_test.go
@@ -172,20 +172,20 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 	// Publish large test messages.
 	const messageSize = 256 // Originally 31800, such a large value resulted in an empty eventlog under Win10.
 	const totalEvents = 1000
-	for i := 0; i < totalEvents; i++ {
+	for i := range totalEvents {
 		// #nosec G115 -- i is bounded by totalEvents and event ID is constrained to [1,1000].
 		safeWriteEvent(t, writer, uint32(i%1000)+1, strconv.Itoa(i)+" "+randomSentence(messageSize))
 	}
 
-	openLog := func(t testing.TB, config map[string]interface{}) EventLog {
+	openLog := func(t testing.TB, config map[string]any) EventLog {
 		return openLog(t, nil, config)
 	}
 
 	t.Run("has_message", func(t *testing.T) {
-		log := openLog(t, map[string]interface{}{"name": providerName, "batch_read_size": 1, "include_xml": includeXML})
+		log := openLog(t, map[string]any{"name": providerName, "batch_read_size": 1, "include_xml": includeXML})
 		defer log.Close()
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			records, err := log.Read()
 			require.NotEmpty(t, records)
 			require.NoError(t, err)
@@ -197,7 +197,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 
 	// Test reading from an event log using a custom XML query.
 	t.Run("custom_xml_query", func(t *testing.T) {
-		cfg := map[string]interface{}{
+		cfg := map[string]any{
 			"id":          "custom-xml-query",
 			"xml_query":   customXMLQuery,
 			"include_xml": includeXML,
@@ -227,7 +227,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 	t.Run("batch_read_size_config", func(t *testing.T) {
 		const batchReadSize = 2
 
-		log := openLog(t, map[string]interface{}{"name": providerName, "batch_read_size": batchReadSize, "include_xml": includeXML})
+		log := openLog(t, map[string]any{"name": providerName, "batch_read_size": batchReadSize, "include_xml": includeXML})
 		defer log.Close()
 
 		records, err := log.Read()
@@ -242,7 +242,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 	// When combined with large messages this causes EvtNext to fail with
 	// RPC_S_INVALID_BOUND error. The reader should recover from the error.
 	t.Run("large_batch_read", func(t *testing.T) {
-		log := openLog(t, map[string]interface{}{"name": providerName, "batch_read_size": 1024, "include_xml": includeXML})
+		log := openLog(t, map[string]any{"name": providerName, "batch_read_size": 1024, "include_xml": includeXML})
 		defer log.Close()
 
 		var eventCount int
@@ -270,7 +270,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 			t.Fatal(err)
 		}
 
-		log := openLog(t, map[string]interface{}{
+		log := openLog(t, map[string]any{
 			"name":           path,
 			"no_more_events": "stop",
 			"include_xml":    includeXML,
@@ -293,7 +293,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 			t.Fatal(err)
 		}
 
-		log := openLog(t, map[string]interface{}{
+		log := openLog(t, map[string]any{
 			"name":           path,
 			"no_more_events": "stop",
 			"event_id":       "3, 5",
@@ -374,7 +374,7 @@ func setLogSize(t testing.TB, provider string, sizeBytes int) {
 	}
 }
 
-func openLog(t testing.TB, state *checkpoint.EventLogState, config map[string]interface{}) EventLog {
+func openLog(t testing.TB, state *checkpoint.EventLogState, config map[string]any) EventLog {
 	cfg, err := conf.NewConfigFrom(config)
 	if err != nil {
 		t.Fatal(err)

--- a/winlogbeat/module/pipeline.go
+++ b/winlogbeat/module/pipeline.go
@@ -46,7 +46,7 @@ const logName = "pipeline"
 
 type pipeline struct {
 	id       string
-	contents map[string]interface{}
+	contents map[string]any
 }
 
 // UploadPipelines reads all pipelines embedded in the Winlogbeat executable
@@ -178,9 +178,9 @@ func load(esClient *eslegclient.Connection, pipelines []pipeline, overwritePipel
 	return loaded, nil
 }
 
-func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]interface{}, err error) {
-	vars := map[string]interface{}{
-		"builtin": map[string]interface{}{
+func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]any, err error) {
+	vars := map[string]any{
+		"builtin": map[string]any{
 			"prefix":      prefix,
 			"module":      "",
 			"fileset":     "",
@@ -193,7 +193,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 		return nil, fmt.Errorf("failed to apply template: %w", err)
 	}
 
-	var content map[string]interface{}
+	var content map[string]any
 	switch extension := strings.ToLower(filepath.Ext(filename)); extension {
 	case ".json":
 		if err = json.Unmarshal([]byte(encodedString), &content); err != nil {
@@ -208,7 +208,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 			return nil, fmt.Errorf("failed to sanitize the YAML pipeline file: %s: %w", filename, err)
 		}
 		//nolint:errcheck // ignore
-		content = newContent.(map[string]interface{})
+		content = newContent.(map[string]any)
 	default:
 		return nil, fmt.Errorf("unsupported extension '%s' for pipeline file: %s", extension, filename)
 	}

--- a/winlogbeat/scripts/mage/config.go
+++ b/winlogbeat/scripts/mage/config.go
@@ -29,7 +29,7 @@ func config() error {
 
 func configFileParams() devtools.ConfigFileParams {
 	conf := devtools.DefaultConfigFileParams()
-	conf.ExtraVars = map[string]interface{}{"GOOS": "windows"}
+	conf.ExtraVars = map[string]any{"GOOS": "windows"}
 	conf.Templates = append(conf.Templates, devtools.OSSBeatDir("_meta/config/*.tmpl"))
 	if devtools.XPackProject == SelectLogic {
 		conf.Templates = append(conf.Templates, devtools.XPackBeatDir("_meta/config/*.tmpl"))

--- a/winlogbeat/sys/bufferpool.go
+++ b/winlogbeat/sys/bufferpool.go
@@ -23,7 +23,7 @@ import (
 
 // bufferPool contains a pool of PooledByteBuffer objects.
 var bufferPool = sync.Pool{
-	New: func() interface{} { return &PooledByteBuffer{ByteBuffer: NewByteBuffer(1024)} },
+	New: func() any { return &PooledByteBuffer{ByteBuffer: NewByteBuffer(1024)} },
 }
 
 // PooledByteBuffer is an expandable buffer backed by a byte slice.

--- a/winlogbeat/sys/winevent/maputil.go
+++ b/winlogbeat/sys/winevent/maputil.go
@@ -29,7 +29,7 @@ import (
 // AddOptional adds a key and value to the given MapStr if the value is not the
 // zero value for the type of v. It is safe to call the function with a nil
 // MapStr.
-func AddOptional(m mapstr.M, key string, v interface{}) {
+func AddOptional(m mapstr.M, key string, v any) {
 	if m != nil && !isZero(v) {
 		_, _ = m.Put(key, v)
 	}
@@ -49,7 +49,7 @@ func AddPairs(m mapstr.M, key string, pairs []KeyValue) mapstr.M {
 
 	// Explicitly use the unnamed type to prevent accidental use
 	// of mapstr.M path look-up methods.
-	h := make(map[string]interface{}, len(pairs))
+	h := make(map[string]any, len(pairs))
 
 	for i, kv := range pairs {
 		// Ignore empty values.
@@ -84,7 +84,7 @@ func AddPairs(m mapstr.M, key string, pairs []KeyValue) mapstr.M {
 }
 
 // isZero return true if the given value is the zero value for its type.
-func isZero(i interface{}) bool {
+func isZero(i any) bool {
 	switch i := i.(type) {
 	case nil:
 		return true

--- a/winlogbeat/sys/wineventlog/iterator_test.go
+++ b/winlogbeat/sys/wineventlog/iterator_test.go
@@ -32,7 +32,7 @@ func TestEventIterator(t *testing.T) {
 	defer tearDown()
 
 	const eventCount = 1500
-	for i := 0; i < eventCount; i++ {
+	for i := range eventCount {
 		safeWriteEvent(t, writer, 1, "Test message "+strconv.Itoa(i+1))
 	}
 

--- a/winlogbeat/sys/wineventlog/metadata_store.go
+++ b/winlogbeat/sys/wineventlog/metadata_store.go
@@ -628,7 +628,7 @@ func (c *publisherMetadataCache) close() error {
 // --- Template Funcs
 
 // eventParam return an event data value inside a text/template.
-func eventParam(items []interface{}, paramNumber int) (interface{}, error) {
+func eventParam(items []any, paramNumber int) (any, error) {
 	// Windows parameter values start at %1 so adjust index value by -1.
 	index := paramNumber - 1
 	if index < len(items) {

--- a/winlogbeat/sys/wineventlog/publisher_metadata.go
+++ b/winlogbeat/sys/wineventlog/publisher_metadata.go
@@ -198,7 +198,7 @@ func NewMetadataKeywords(publisherMetadataHandle EvtHandle) ([]MetadataKeyword, 
 	}
 
 	var values []MetadataKeyword
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataKeyword(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get keyword at array index %v: %w", i, err)
@@ -272,7 +272,7 @@ func NewMetadataOpcodes(publisherMetadataHandle EvtHandle) ([]MetadataOpcode, er
 	}
 
 	var values []MetadataOpcode
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataOpcode(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get opcode at array index %v: %w", i, err)
@@ -349,7 +349,7 @@ func NewMetadataLevels(publisherMetadataHandle EvtHandle) ([]MetadataLevel, erro
 	}
 
 	var values []MetadataLevel
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataLevel(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get level at array index %v: %w", i, err)
@@ -423,7 +423,7 @@ func NewMetadataTasks(publisherMetadataHandle EvtHandle) ([]MetadataTask, error)
 	}
 
 	var values []MetadataTask
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataTask(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get task at array index %v: %w", i, err)
@@ -504,7 +504,7 @@ func NewMetadataChannels(publisherMetadataHandle EvtHandle) ([]MetadataChannel, 
 	}
 
 	var values []MetadataChannel
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataChannel(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get task at array index %v: %w", i, err)
@@ -613,7 +613,7 @@ func (itr *EventMetadataIterator) Err() error {
 	return itr.lastErr
 }
 
-func typeCastError(expected, got interface{}) error {
+func typeCastError(expected, got any) error {
 	return fmt.Errorf("wrong type for property. expected:%T got:%T", expected, got)
 }
 

--- a/winlogbeat/sys/wineventlog/renderer.go
+++ b/winlogbeat/sys/wineventlog/renderer.go
@@ -134,7 +134,7 @@ func (r *Renderer) renderSystem(handle EvtHandle, event *winevent.Event) error {
 	}
 	defer bb.Free()
 
-	for i := 0; i < propertyCount; i++ {
+	for i := range propertyCount {
 		property := EvtSystemPropertyID(i)
 		offset := i * int(sizeofEvtVariant)
 		evtVar := (*EvtVariant)(unsafe.Pointer(bb.PtrAt(offset)))
@@ -197,7 +197,7 @@ func (r *Renderer) renderSystem(handle EvtHandle, event *winevent.Event) error {
 // renderUser returns the event/user data values. This does not provide the
 // parameter names. It computes a fingerprint of the values types to help the
 // caller match the correct names to the returned values.
-func (r *Renderer) renderUser(mds *PublisherMetadataStore, handle EvtHandle, event *winevent.Event) (values []interface{}, fingerprint uint64, err error) {
+func (r *Renderer) renderUser(mds *PublisherMetadataStore, handle EvtHandle, event *winevent.Event) (values []any, fingerprint uint64, err error) {
 	bb, propertyCount, err := r.render(r.userContext, handle)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get user values: %w", err)
@@ -216,8 +216,8 @@ func (r *Renderer) renderUser(mds *PublisherMetadataStore, handle EvtHandle, eve
 		return nil, 0, fmt.Errorf("failed to hash property count: %w", err)
 	}
 
-	values = make([]interface{}, propertyCount)
-	for i := 0; i < propertyCount; i++ {
+	values = make([]any, propertyCount)
+	for i := range propertyCount {
 		offset := i * int(sizeofEvtVariant)
 		evtVar := (*EvtVariant)(unsafe.Pointer(bb.PtrAt(offset)))
 		binary.Write(argumentHash, binary.LittleEndian, uint32(evtVar.Type)) //nolint:errcheck // Hash writes never fail.
@@ -280,7 +280,7 @@ func (r *Renderer) render(context EvtHandle, eventHandle EvtHandle) (*sys.Pooled
 }
 
 // addEventData adds the event/user data values to the event.
-func (r *Renderer) addEventData(evtMeta *EventMetadata, values []interface{}, event *winevent.Event) {
+func (r *Renderer) addEventData(evtMeta *EventMetadata, values []any, event *winevent.Event) {
 	if len(values) == 0 {
 		return
 	}
@@ -341,7 +341,7 @@ func (r *Renderer) addEventData(evtMeta *EventMetadata, values []interface{}, ev
 
 // formatMessage adds the message to the event.
 func (r *Renderer) formatMessage(publisherMeta *PublisherMetadata,
-	eventMeta *EventMetadata, eventHandle EvtHandle, values []interface{},
+	eventMeta *EventMetadata, eventHandle EvtHandle, values []any,
 	eventID uint16) (string, error,
 ) {
 	if eventMeta != nil {
@@ -362,7 +362,7 @@ func (r *Renderer) formatMessage(publisherMeta *PublisherMetadata,
 
 // formatMessageFromTemplate creates the message by executing the stored Go
 // text/template with the event/user data values.
-func (r *Renderer) formatMessageFromTemplate(msgTmpl *template.Template, values []interface{}) (string, error) {
+func (r *Renderer) formatMessageFromTemplate(msgTmpl *template.Template, values []any) (string, error) {
 	bb := sys.NewPooledByteBuffer()
 	defer bb.Free()
 

--- a/winlogbeat/sys/wineventlog/renderer_test.go
+++ b/winlogbeat/sys/wineventlog/renderer_test.go
@@ -218,7 +218,7 @@ func TestTemplateFunc(t *testing.T) {
 		Parse(`Hello {{ eventParam $ 1 }}! Foo {{ eventParam $ 2 }}.`))
 
 	buf := new(bytes.Buffer)
-	err := tmpl.Execute(buf, []interface{}{"world"})
+	err := tmpl.Execute(buf, []any{"world"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func BenchmarkRenderer(b *testing.B) {
 
 	const totalEvents = 1000000
 	msg := strings.Repeat("Hello world! ", 21)
-	for i := 0; i < totalEvents; i++ {
+	for range totalEvents {
 		safeWriteEvent(b, writer, 10, msg)
 	}
 

--- a/winlogbeat/sys/wineventlog/stringinserts.go
+++ b/winlogbeat/sys/wineventlog/stringinserts.go
@@ -56,7 +56,7 @@ func (si *stringInserts) Slice() []EvtVariant {
 // clear clears the pointers (and unsafe pointers) so that the memory can be
 // garbage collected.
 func (si *stringInserts) clear() {
-	for i := 0; i < len(si.evtVariants); i++ {
+	for i := range len(si.evtVariants) {
 		si.evtVariants[i] = EvtVariant{}
 		si.insertStrings[i] = nil
 	}
@@ -67,7 +67,7 @@ func (si *stringInserts) clear() {
 func newTemplateStringInserts() *stringInserts {
 	si := &stringInserts{}
 
-	for i := 0; i < len(si.evtVariants); i++ {
+	for i := range len(si.evtVariants) {
 		// Use i+1 to keep our inserts numbered the same as Window's inserts.
 		templateParam := leftTemplateDelim + `eventParam $ ` + strconv.Itoa(i+1) + rightTemplateDelim
 		strSlice, err := windows.UTF16FromString(templateParam)

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -456,7 +456,7 @@ func evtVariantInt16(v uint16) int16 { return int16(v) } //nolint:gosec // prese
 func evtVariantInt32(v uint32) int32 { return int32(v) } //nolint:gosec // preserve Windows EVT_VARIANT bit pattern
 func evtVariantInt64(v uint64) int64 { return int64(v) } //nolint:gosec // preserve Windows EVT_VARIANT bit pattern
 
-func (v EvtVariant) Data(buf []byte) (interface{}, error) {
+func (v EvtVariant) Data(buf []byte) (any, error) {
 	typ := v.Type.Mask()
 	switch typ {
 	case EvtVarTypeNull:
@@ -582,7 +582,7 @@ const (
 	EvtPublisherMetadataKeywordMessageID
 )
 
-func EvtGetPublisherMetadataProperty(publisherMetadataHandle EvtHandle, propertyID EvtPublisherMetadataPropertyID) (interface{}, error) {
+func EvtGetPublisherMetadataProperty(publisherMetadataHandle EvtHandle, propertyID EvtPublisherMetadataPropertyID) (any, error) {
 	var bufferUsed uint32
 	err := _EvtGetPublisherMetadataProperty(publisherMetadataHandle, propertyID, 0, 0, nil, &bufferUsed)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // Bad linter! This is always errno or nil.
@@ -612,7 +612,7 @@ func EvtGetPublisherMetadataProperty(publisherMetadataHandle EvtHandle, property
 	}
 }
 
-func EvtGetObjectArrayProperty(arrayHandle EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, index uint32) (interface{}, error) {
+func EvtGetObjectArrayProperty(arrayHandle EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, index uint32) (any, error) {
 	var bufferUsed uint32
 	err := _EvtGetObjectArrayProperty(arrayHandle, propertyID, index, 0, 0, nil, &bufferUsed)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // Bad linter! This is always errno or nil.
@@ -647,7 +647,7 @@ func EvtGetObjectArraySize(handle EvtObjectArrayPropertyHandle) (uint32, error) 
 	return arrayLen, nil
 }
 
-func GetEventMetadataProperty(metadataHandle EvtHandle, propertyID EvtEventMetadataPropertyID) (interface{}, error) {
+func GetEventMetadataProperty(metadataHandle EvtHandle, propertyID EvtEventMetadataPropertyID) (any, error) {
 	var bufferUsed uint32
 	err := _EvtGetEventMetadataProperty(metadataHandle, 8, 0, 0, nil, &bufferUsed)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // Bad linter! This is always errno or nil.

--- a/winlogbeat/sys/wineventlog/util_test.go
+++ b/winlogbeat/sys/wineventlog/util_test.go
@@ -151,7 +151,7 @@ func mustNextHandle(t *testing.T, log EvtHandle) EvtHandle {
 	return h
 }
 
-func logAsJSON(t testing.TB, object interface{}) {
+func logAsJSON(t testing.TB, object any) {
 	data, err := json.MarshalIndent(object, "", "  ")
 	if err != nil {
 		t.Fatal(err)

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -87,10 +87,7 @@ loop:
 				switch errno {
 				case ERROR_INSUFFICIENT_BUFFER:
 					// Grow buffer.
-					newLen := 2 * len(cpBuffer)
-					if int(used) > newLen {
-						newLen = int(used)
-					}
+					newLen := max(int(used), 2*len(cpBuffer))
 					cpBuffer = make([]uint16, newLen)
 					continue
 				case ERROR_NO_MORE_ITEMS:

--- a/winlogbeat/tests/testscript/commands_windows.go
+++ b/winlogbeat/tests/testscript/commands_windows.go
@@ -516,7 +516,7 @@ func reportEvent(source string, eventType uint16, eventID uint32, sid *windows.S
 }
 
 // readNDJSON reads all *.ndjson files in dir and returns the parsed events.
-func readNDJSON(script *testscript.TestScript, dir string) []map[string]interface{} {
+func readNDJSON(script *testscript.TestScript, dir string) []map[string]any {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -525,7 +525,7 @@ func readNDJSON(script *testscript.TestScript, dir string) []map[string]interfac
 		script.Fatalf("readNDJSON: ReadDir(%q): %v", dir, err)
 	}
 
-	var events []map[string]interface{}
+	var events []map[string]any
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".ndjson") {
 			continue
@@ -534,12 +534,12 @@ func readNDJSON(script *testscript.TestScript, dir string) []map[string]interfac
 		if err != nil {
 			script.Fatalf("readNDJSON: ReadFile: %v", err)
 		}
-		for _, line := range strings.Split(string(data), "\n") {
+		for line := range strings.SplitSeq(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" {
 				continue
 			}
-			var evt map[string]interface{}
+			var evt map[string]any
 			if err := json.Unmarshal([]byte(line), &evt); err != nil {
 				script.Fatalf("readNDJSON: Unmarshal: %v\nline: %s", err, line)
 			}
@@ -550,7 +550,7 @@ func readNDJSON(script *testscript.TestScript, dir string) []map[string]interfac
 }
 
 // getField retrieves a value from a nested map using dot-separated field names.
-func getField(evt map[string]interface{}, field string) (interface{}, bool) {
+func getField(evt map[string]any, field string) (any, bool) {
 	parts := strings.SplitN(field, ".", 2)
 	val, ok := evt[parts[0]]
 	if !ok {
@@ -559,7 +559,7 @@ func getField(evt map[string]interface{}, field string) (interface{}, bool) {
 	if len(parts) == 1 {
 		return val, true
 	}
-	nested, ok := val.(map[string]interface{})
+	nested, ok := val.(map[string]any)
 	if !ok {
 		return nil, false
 	}

--- a/x-pack/auditbeat/module/system/host/host_test.go
+++ b/x-pack/auditbeat/module/system/host/host_test.go
@@ -26,8 +26,8 @@ func TestData(t *testing.T) {
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":     system.ModuleName,
 		"metricsets": []string{"host"},
 	}

--- a/x-pack/auditbeat/module/system/login/login_linux_amd64_test.go
+++ b/x-pack/auditbeat/module/system/login/login_linux_amd64_test.go
@@ -260,7 +260,7 @@ func TestBtmp(t *testing.T) {
 		"Timestamp is not equal: %+v", events[3].Timestamp)
 }
 
-func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue interface{}) {
+func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue any) {
 	value, err := mapstr.GetValue(fieldName)
 	if assert.NoError(t, err) {
 		switch v := value.(type) {
@@ -272,8 +272,8 @@ func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue
 	}
 }
 
-func getBaseConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getBaseConfig() map[string]any {
+	return map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"login"},
 	}

--- a/x-pack/auditbeat/module/system/login/login_linux_arm64_test.go
+++ b/x-pack/auditbeat/module/system/login/login_linux_arm64_test.go
@@ -265,7 +265,7 @@ func TestBtmp(t *testing.T) {
 		"Timestamp is not equal: %+v", events[3].Timestamp)
 }
 
-func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue interface{}) {
+func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue any) {
 	value, err := mapstr.GetValue(fieldName)
 	if assert.NoError(t, err) {
 		switch v := value.(type) {
@@ -277,8 +277,8 @@ func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue
 	}
 }
 
-func getBaseConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getBaseConfig() map[string]any {
+	return map[string]any{
 		"module":        system.ModuleName,
 		"datasets":      []string{"login"},
 		"logging.level": "debug",
@@ -288,7 +288,7 @@ func getBaseConfig() map[string]interface{} {
 // setupTestDir creates a temporary directory, copies the test files into it,
 // and returns the path.
 func setupTestDir(t *testing.T) string {
-	tmp, err := ioutil.TempDir("", "auditbeat-login-test-dir")
+	tmp, err := os.MkdirTemp("", "auditbeat-login-test-dir")
 	if err != nil {
 		t.Fatal("failed to create temp dir")
 	}

--- a/x-pack/auditbeat/module/system/package/flatbuffers.go
+++ b/x-pack/auditbeat/module/system/package/flatbuffers.go
@@ -24,7 +24,7 @@ import (
 var bufferPool sync.Pool
 
 func init() {
-	bufferPool.New = func() interface{} {
+	bufferPool.New = func() any {
 		return flatbuffers.NewBuilder(1024)
 	}
 }

--- a/x-pack/auditbeat/module/system/package/flatbuffers_test.go
+++ b/x-pack/auditbeat/module/system/package/flatbuffers_test.go
@@ -75,7 +75,7 @@ func TestFBEncodeDecode(t *testing.T) {
 	}
 
 	assert.Equal(t, len(p), len(out))
-	for i := 0; i < len(p); i++ {
+	for i := range p {
 		assert.Equal(t, p[i], out[i])
 	}
 }
@@ -87,7 +87,7 @@ func TestPoolPoison(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go poolPoison(input[i%2], t, &wg)
 	}
@@ -98,7 +98,7 @@ func poolPoison(p []*Package, t *testing.T, wg *sync.WaitGroup) {
 	builder, release := fbGetBuilder()
 	defer release()
 
-	for k := 0; k < 1000; k++ {
+	for range 1000 {
 		builder.Reset()
 
 		data := encodePackages(builder, p)
@@ -114,7 +114,7 @@ func poolPoison(p []*Package, t *testing.T, wg *sync.WaitGroup) {
 		}
 
 		assert.Equal(t, len(p), len(out))
-		for i := 0; i < len(p); i++ {
+		for i := range p {
 			assert.Equal(t, p[i], out[i])
 		}
 	}

--- a/x-pack/auditbeat/module/system/package/package_homebrew_test.go
+++ b/x-pack/auditbeat/module/system/package/package_homebrew_test.go
@@ -68,7 +68,7 @@ func TestHomebrew(t *testing.T) {
 	}
 }
 
-func checkFieldValue(t *testing.T, event beat.Event, fieldName string, fieldValue interface{}) {
+func checkFieldValue(t *testing.T, event beat.Event, fieldName string, fieldValue any) {
 	t.Helper()
 	value, err := event.GetValue(fieldName)
 	if assert.NoError(t, err, "checking field %s", fieldName) {

--- a/x-pack/auditbeat/module/system/package/package_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/package_linux_test.go
@@ -32,7 +32,7 @@ func TestRPMParallel(t *testing.T) {
 	useUID := getUser(t)
 
 	t.Logf("Starting...")
-	for i := 0; i < count; i++ {
+	for i := range count {
 		inner := i
 		go func() {
 			defer waiter.Done()

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -160,8 +160,8 @@ func TestDpkgInstalledSize(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"package"},
 	}

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -41,8 +41,8 @@ func TestData(t *testing.T) {
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"process"},
 
@@ -65,7 +65,7 @@ func TestProcessEvent(t *testing.T) {
 		assert.False(t, containsError)
 	}
 
-	expectedRootFields := map[string]interface{}{
+	expectedRootFields := map[string]any{
 		"event.kind":     "event",
 		"event.category": []string{"process"},
 		"event.type":     []string{"start"},

--- a/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
+++ b/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
@@ -351,8 +351,8 @@ func makeEventOfCmd(t *testing.T, cmd *exec.Cmd, qev quark.Event, be backend) mb
 
 // getConfigForQuark enables quark and allows hashing so we can test
 // the cached hasher.
-func getConfigForQuark(be backend) map[string]interface{} {
-	config := map[string]interface{}{
+func getConfigForQuark(be backend) map[string]any {
+	config := map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"process"},
 

--- a/x-pack/auditbeat/module/system/socket/dns/afpacket/afpacket.go
+++ b/x-pack/auditbeat/module/system/socket/dns/afpacket/afpacket.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux
-// +build linux
 
 package afpacket
 
@@ -68,7 +67,7 @@ func newAFPacketSniffer(base mb.BaseMetricSet, log *logp.Logger) (parent.Sniffer
 		return nil, err
 	}
 
-	opts := []interface{}{
+	opts := []any{
 		afpacket.OptFrameSize(frameSize),
 		afpacket.OptBlockSize(blockSize),
 		afpacket.OptNumBlocks(numBlocks),

--- a/x-pack/auditbeat/module/system/socket/dns/afpacket/config.go
+++ b/x-pack/auditbeat/module/system/socket/dns/afpacket/config.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux
-// +build linux
 
 package afpacket
 

--- a/x-pack/auditbeat/module/system/socket/events.go
+++ b/x-pack/auditbeat/module/system/socket/events.go
@@ -1114,8 +1114,8 @@ func kernErrorDesc(retval int32) string {
 }
 
 func readCString(buf []byte) string {
-	if pos := bytes.IndexByte(buf, 0); pos != -1 {
-		return string(buf[:pos])
+	if before, _, ok := bytes.Cut(buf, []byte{0}); ok {
+		return string(before)
 	}
 	return string(buf) + " ..."
 }

--- a/x-pack/auditbeat/module/system/socket/guess/creds.go
+++ b/x-pack/auditbeat/module/system/socket/guess/creds.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -119,7 +118,7 @@ func (g *guessStructCreds) Terminate() error {
 }
 
 // Extract receives the struct cred dump and discovers the offsets.
-func (g *guessStructCreds) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessStructCreds) Extract(ev any) (mapstr.M, bool) {
 	raw := ev.([]byte)
 	if len(raw) != credDumpBytes {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -86,7 +85,7 @@ func (g *guessInet6CskXmit) Probes() ([]helper.ProbeDef, error) {
 				Address:   "inet_csk_accept",
 				Fetchargs: "sock={{.RET}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(sockArgumentGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(sockArgumentGuess) }),
 		},
 		{
 			Probe: tracing.Probe{
@@ -94,7 +93,7 @@ func (g *guessInet6CskXmit) Probes() ([]helper.ProbeDef, error) {
 				Address:   "inet6_csk_xmit",
 				Fetchargs: "arg={{.P1}} dump=" + helper.MakeMemoryDump("{{.P1}}", 0, skbuffDumpSize),
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(skbuffSockGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(skbuffSockGuess) }),
 		},
 	}, nil
 }
@@ -163,7 +162,7 @@ func (g *guessInet6CskXmit) Trigger() error {
 
 // Extract receives first the sock* from inet_csk_accept, then the arguments
 // from inet6_csk_xmit.
-func (g *guessInet6CskXmit) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessInet6CskXmit) Extract(event any) (mapstr.M, bool) {
 	switch msg := event.(type) {
 	case *sockArgumentGuess:
 		g.sock = msg.Sock

--- a/x-pack/auditbeat/module/system/socket/guess/deref.go
+++ b/x-pack/auditbeat/module/system/socket/guess/deref.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -112,7 +111,7 @@ func (g *guessDeref) MaxRepeats() int {
 
 // Extract receives the memory read through a null pointer and checks if it's
 // zero or garbage.
-func (g *guessDeref) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessDeref) Extract(ev any) (mapstr.M, bool) {
 	raw := ev.([]byte)
 	if len(raw) != credDumpBytes {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/guess.go
+++ b/x-pack/auditbeat/module/system/socket/guess/guess.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -48,7 +47,7 @@ type Guesser interface {
 	// Extract receives the events generated during trigger.
 	// Done is false when it needs to be called with more events. True when
 	// the guess has completed and results is a map with the discovered values.
-	Extract(event interface{}) (result mapstr.M, done bool)
+	Extract(event any) (result mapstr.M, done bool)
 	// Terminate performs cleanup after the guess is complete.
 	Terminate() error
 }
@@ -117,7 +116,7 @@ func guessMultiple(guess RepeatGuesser, installer helper.ProbeInstaller, ctx Con
 
 func guessEventually(guess EventualGuesser, installer helper.ProbeInstaller, ctx Context) (result mapstr.M, err error) {
 	limit := guess.MaxRepeats()
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		ctx.Log.Debugf(" --- %s run #%d", guess.Name(), i)
 		if result, err = guessOnce(guess, installer, ctx); err != nil {
 			return nil, err
@@ -200,7 +199,7 @@ func guessOnce(guesser Guesser, installer helper.ProbeInstaller, ctx Context) (r
 		}
 	}()
 
-	thread.Run(func() (interface{}, error) {
+	thread.Run(func() (any, error) {
 		return nil, guesser.Trigger()
 	})
 

--- a/x-pack/auditbeat/module/system/socket/guess/helpers.go
+++ b/x-pack/auditbeat/module/system/socket/guess/helpers.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -12,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 
 	"golang.org/x/sys/unix"
 
@@ -136,11 +136,8 @@ func consolidate(partials []mapstr.M) (result mapstr.M, err error) {
 			}
 			var newList []int
 			for _, num := range baseList {
-				for _, nn := range list {
-					if num == nn {
-						newList = append(newList, num)
-						break
-					}
+				if slices.Contains(list, num) {
+					newList = append(newList, num)
 				}
 			}
 			baseList = newList

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -140,7 +139,7 @@ func (g *guessInetSockIPv4) Trigger() error {
 // Extract receives the dump of a struct inet_sock* and scans it for the
 // random local and remote IPs and ports. Will return lists of all the
 // offsets were each value was found.
-func (g *guessInetSockIPv4) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessInetSockIPv4) Extract(ev any) (mapstr.M, bool) {
 	data := ev.([]byte)
 
 	laddr := g.local.Addr[:]

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -159,7 +158,7 @@ func (g *guessInetSockIPv6) Condition(ctx Context) (bool, error) {
 
 // eventWrapper is used to wrap events from one of the probes for differentiation.
 type eventWrapper struct {
-	event interface{}
+	event any
 }
 
 // decoderWrapper takes an inner decoder and wraps it so that the returned events
@@ -169,7 +168,7 @@ type decoderWrapper struct {
 }
 
 // Decode wraps events from the inner decoder into a the wrapper type.
-func (d *decoderWrapper) Decode(raw []byte, meta tracing.Metadata) (event interface{}, err error) {
+func (d *decoderWrapper) Decode(raw []byte, meta tracing.Metadata) (event any, err error) {
 	if event, err = d.inner.Decode(raw, meta); err != nil {
 		return event, err
 	}
@@ -283,7 +282,7 @@ func (g *guessInetSockIPv6) Trigger() error {
 
 // Extract scans stores the events from the two different kprobes and then
 // looks for the result in one of them.
-func (g *guessInetSockIPv6) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessInetSockIPv6) Extract(event any) (mapstr.M, bool) {
 	if w, ok := event.(eventWrapper); ok {
 		g.ptrDump = w.event.([]byte)
 	} else {

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 

--- a/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -137,7 +136,7 @@ func (g *guessInetSockFamily) Trigger() error {
 }
 
 // Extract scans the struct inet_sock* memory for the current address family value.
-func (g *guessInetSockFamily) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessInetSockFamily) Extract(event any) (mapstr.M, bool) {
 	raw := event.([]byte)
 	var expected [2]byte
 	var hits []int

--- a/x-pack/auditbeat/module/system/socket/guess/iplocalout.go
+++ b/x-pack/auditbeat/module/system/socket/guess/iplocalout.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -111,7 +110,7 @@ func (g *guessIPLocalOut) Probes() ([]helper.ProbeDef, error) {
 				Fetchargs: "arg={{if ne .IP_LOCAL_OUT \"ip_local_out_sk\"}}{{.P2}}{{else}}{{.P1}}{{end}} dump=" +
 					helper.MakeMemoryDump("{{if ne .IP_LOCAL_OUT \"ip_local_out_sk\"}}{{.P1}}{{else}}{{.P2}}{{end}}", 0, skbuffDumpSize),
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(skbuffSockGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(skbuffSockGuess) }),
 		},
 		{
 			Probe: tracing.Probe{
@@ -119,7 +118,7 @@ func (g *guessIPLocalOut) Probes() ([]helper.ProbeDef, error) {
 				Address:   "tcp_sendmsg",
 				Fetchargs: "sock={{.TCP_SENDMSG_SOCK}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(sockArgumentGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(sockArgumentGuess) }),
 		},
 	}, nil
 }
@@ -149,7 +148,7 @@ func (g *guessIPLocalOut) Trigger() error {
 // Extract first receives and saves the sock* from tcp_sendmsg.
 // Once ip_local_out is called, it analyses the captured arguments to determine
 // their layout.
-func (g *guessIPLocalOut) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessIPLocalOut) Extract(ev any) (mapstr.M, bool) {
 	switch v := ev.(type) {
 	case *sockArgumentGuess:
 		g.sock = v.Sock

--- a/x-pack/auditbeat/module/system/socket/guess/registry.go
+++ b/x-pack/auditbeat/module/system/socket/guess/registry.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 

--- a/x-pack/auditbeat/module/system/socket/guess/skbuff.go
+++ b/x-pack/auditbeat/module/system/socket/guess/skbuff.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -126,7 +125,7 @@ func (g *guessSkBuffLen) Trigger() error {
 
 // Extract scans the sk_buff memory for any values between the expected
 // payload + [0 ... 128).
-func (g *guessSkBuffLen) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSkBuffLen) Extract(ev any) (mapstr.M, bool) {
 	skbuff := ev.([]byte)
 	if len(skbuff) != skbuffDumpSize || g.written <= 0 {
 		return nil, false
@@ -141,7 +140,7 @@ func (g *guessSkBuffLen) Extract(ev interface{}) (mapstr.M, bool) {
 	target := uint32(g.written)
 	arr := (*[n]uint32)(unsafe.Pointer(&skbuff[0]))[:]
 	var results [maxOverhead][]int
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if val := arr[i]; val >= target && val < target+maxOverhead {
 			excess := val - target
 			results[excess] = append(results[excess], i*uIntSize)
@@ -352,7 +351,7 @@ func (g *guessSkBuffProto) Trigger() error {
 
 // Extract will scan the sk_buff memory to look for all the uint16-sized memory
 // locations that contain the expected protocol value.
-func (g *guessSkBuffProto) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessSkBuffProto) Extract(event any) (mapstr.M, bool) {
 	raw := event.([]byte)
 	needle := []byte{0x08, 0x00} // ETH_P_IP
 	if g.doIPv6 {
@@ -532,7 +531,7 @@ func (g *guessSkBuffDataPtr) Probes() ([]helper.ProbeDef, error) {
 				Address:   "{{.RECV_UDP_DATAGRAM}}",
 				Fetchargs: fmt.Sprintf("ptr=%s data=%s", address, helper.MakeMemoryDump(address, 0, dataDumpBytes)),
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(dataDump) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(dataDump) }),
 		},
 		{
 			Probe: tracing.Probe{
@@ -571,7 +570,7 @@ func (g *guessSkBuffDataPtr) Prepare(ctx Context) (err error) {
 		g.dumpOffset = alignTo(g.protoOffset+2, int(sizeOfPtr))
 		g.payload = make([]byte, payloadLen)
 		banner := "HELLO!"
-		for i := 0; i < payloadLen; i++ {
+		for i := range payloadLen {
 			g.payload[i] = banner[i%len(banner)]
 		}
 	} else {
@@ -621,7 +620,7 @@ func u32At(buf []byte) uintptr {
 // (any), false : Signals that it needs another event in the current iteration.
 // nil, true : Finish the current iteration and perform a new one.
 // (non-nil), true : The guess completed.
-func (g *guessSkBuffDataPtr) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessSkBuffDataPtr) Extract(event any) (mapstr.M, bool) {
 	switch v := event.(type) {
 	case *dataDump:
 		g.data = v
@@ -693,7 +692,7 @@ func (g *guessSkBuffDataPtr) Extract(event interface{}) (mapstr.M, bool) {
 	scanFields := func(width int, ptrBase uintptr, reader func([]byte) uintptr) mapstr.M {
 		var off [3]uintptr
 		for base := g.dumpOffset - width*3; base >= limit; base -= width {
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				off[i] = reader(g.skbuff[base+i*width:]) - ptrBase
 			}
 			if off[0] == uintptr(udpHdrOff) &&

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -124,7 +123,7 @@ func (g *guessSockaddrIn) Trigger() error {
 }
 
 // Extract takes the dumped sockaddr_in and scans it for the expected values.
-func (g *guessSockaddrIn) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSockaddrIn) Extract(ev any) (mapstr.M, bool) {
 	arr := ev.([]byte)
 	if len(arr) < 8 {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -144,7 +143,7 @@ func (g *guessSockaddrIn6) Trigger() error {
 
 // Extract receives the dumped struct sockaddr_in6 and scans it for the
 // expected values.
-func (g *guessSockaddrIn6) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSockaddrIn6) Extract(ev any) (mapstr.M, bool) {
 	arr := ev.([]byte)
 	if len(arr) < 8 {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/socketsk.go
+++ b/x-pack/auditbeat/module/system/socket/guess/socketsk.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -75,7 +74,7 @@ func (g *guessSocketSock) Probes() ([]helper.ProbeDef, error) {
 				Address:   "sock_init_data",
 				Fetchargs: "sock={{.P2}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(sockEvent) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(sockEvent) }),
 		},
 
 		{
@@ -112,7 +111,7 @@ func (g *guessSocketSock) Trigger() error {
 
 // Extract first receives the sock* from sock_init_data, then uses it to
 // scan the dump from inet_release.
-func (g *guessSocketSock) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSocketSock) Extract(ev any) (mapstr.M, bool) {
 	if v, ok := ev.(*sockEvent); ok {
 		if g.initData != nil {
 			return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/syscallargs.go
+++ b/x-pack/auditbeat/module/system/socket/guess/syscallargs.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -89,7 +88,7 @@ func (g *guessSyscallArgs) Probes() ([]helper.ProbeDef, error) {
 				Address:   "{{.SYS_GETTIMEOFDAY}}",
 				Fetchargs: "p1reg={{._SYS_P1}} p2reg={{._SYS_P2}} p1pt=+0x70({{._SYS_P1}}) p2pt=+0x68({{(._SYS_P1)}})",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(syscallGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(syscallGuess) }),
 		},
 	}, nil
 }
@@ -112,7 +111,7 @@ func (g *guessSyscallArgs) Trigger() error {
 }
 
 // Extract check which set of kprobe arguments received the magic values.
-func (g *guessSyscallArgs) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSyscallArgs) Extract(ev any) (mapstr.M, bool) {
 	args, ok := ev.(*syscallGuess)
 	if !ok {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgargs.go
+++ b/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgargs.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -70,7 +69,7 @@ func (g *guessTCPSendMsg) Probes() ([]helper.ProbeDef, error) {
 				Address:   "tcp_sendmsg",
 				Fetchargs: "c={{.P3}} d={{.P4}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgArgCountGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgArgCountGuess) }),
 		},
 	}, nil
 }
@@ -94,7 +93,7 @@ func (g *guessTCPSendMsg) Trigger() (err error) {
 
 // Extract receives the arguments from the tcp_sendmsg call and checks
 // which one contains the number of bytes written by trigger.
-func (g *guessTCPSendMsg) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessTCPSendMsg) Extract(ev any) (mapstr.M, bool) {
 	event := ev.(*tcpSendMsgArgCountGuess)
 	if g.written <= 0 {
 		g.ctx.Log.Errorf("write failed for guess")

--- a/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgsk.go
+++ b/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgsk.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -78,7 +77,7 @@ func (g *guessTcpSendmsgSock) Probes() ([]helper.ProbeDef, error) {
 				Address:   "tcp_sendmsg",
 				Fetchargs: "p1=+{{.INET_SOCK_RADDR}}({{.P1}}):u32 p2=+{{.INET_SOCK_RADDR}}({{.P2}}):u32 indirect=+{{.INET_SOCK_RADDR}}(+{{.SOCKET_SOCK}}({{.P2}})):u32",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgSockGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgSockGuess) }),
 		},
 	}, nil
 }
@@ -103,7 +102,7 @@ func (g *guessTcpSendmsgSock) Trigger() (err error) {
 
 // Extract checks which of the arguments to tcp_sendmsg contains the expected
 // value (address of destination).
-func (g *guessTcpSendmsgSock) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessTcpSendmsgSock) Extract(ev any) (mapstr.M, bool) {
 	event := ev.(*tcpSendMsgSockGuess)
 	if g.written <= 0 {
 		g.ctx.Log.Errorf("write failed for guess")

--- a/x-pack/auditbeat/module/system/socket/guess/udpsendmsg.go
+++ b/x-pack/auditbeat/module/system/socket/guess/udpsendmsg.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -76,7 +75,7 @@ func (g *guessUDPSendMsg) Probes() ([]helper.ProbeDef, error) {
 				Address:   "udp_sendmsg",
 				Fetchargs: "c={{.P3}} d={{.P4}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(udpSendMsgCountGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(udpSendMsgCountGuess) }),
 		},
 	}, nil
 }
@@ -90,7 +89,7 @@ func (g *guessUDPSendMsg) Terminate() error {
 	return g.cs.Cleanup()
 }
 
-func (g *guessUDPSendMsg) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessUDPSendMsg) Extract(ev any) (mapstr.M, bool) {
 	if g.length == 0 {
 		return nil, false
 	}

--- a/x-pack/auditbeat/module/system/socket/helper/fixedthreadexecutor.go
+++ b/x-pack/auditbeat/module/system/socket/helper/fixedthreadexecutor.go
@@ -13,11 +13,11 @@ import (
 )
 
 // Task is a function that returns an arbitrary result and/or an error.
-type Task func() (interface{}, error)
+type Task func() (any, error)
 
 // TaskResult encapsulates the results of a Task.
 type TaskResult struct {
-	Data interface{}
+	Data any
 	Err  error
 }
 
@@ -66,7 +66,7 @@ func NewFixedThreadExecutor(queueSize int) FixedThreadExecutor {
 		}
 	}()
 
-	ex.Run(func() (interface{}, error) { return unix.Gettid(), nil })
+	ex.Run(func() (any, error) { return unix.Gettid(), nil })
 	res := <-ex.resultC
 	ex.TID = res.Data.(int)
 	return ex

--- a/x-pack/auditbeat/module/system/socket/helper/types.go
+++ b/x-pack/auditbeat/module/system/socket/helper/types.go
@@ -12,10 +12,10 @@ import (
 
 // Logger exposes logging functions.
 type Logger interface {
-	Errorf(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Debugf(format string, args ...interface{})
+	Errorf(format string, args ...any)
+	Warnf(format string, args ...any)
+	Infof(format string, args ...any)
+	Debugf(format string, args ...any)
 }
 
 // ProbeCondition is a function that allows to filter probes.

--- a/x-pack/auditbeat/module/system/socket/kprobes.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes.go
@@ -152,7 +152,7 @@ var sharedKProbes = []helper.ProbeDef{
 				helper.MakeMemoryDump("+{{call .POINTER_INDEX 4}}({{.SYS_P2}})", 0, maxProgArgLen),      // param4
 			),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(execveCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(execveCall) }),
 	},
 
 	{
@@ -162,7 +162,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "{{.SYS_EXECVE}}",
 			Fetchargs: "retval={{.RET}}:s32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(execveRet) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(execveRet) }),
 	},
 
 	{
@@ -170,7 +170,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Name:    "do_exit",
 			Address: "do_exit",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(doExit) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(doExit) }),
 	},
 
 	{
@@ -179,7 +179,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "commit_creds",
 			Fetchargs: "uid=+{{.STRUCT_CRED_UID}}({{.P1}}):u32 gid=+{{.STRUCT_CRED_GID}}({{.P1}}):u32 euid=+{{.STRUCT_CRED_EUID}}({{.P1}}):u32 egid=+{{.STRUCT_CRED_EGID}}({{.P1}}):u32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(commitCreds) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(commitCreds) }),
 	},
 
 	{
@@ -189,7 +189,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "{{.DO_FORK}}",
 			Fetchargs: "retval={{.RET}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(forkRet) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(forkRet) }),
 	},
 	/***************************************************************************
 	 * IPv4
@@ -201,7 +201,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "sock_init_data",
 			Fetchargs: "socket={{.P1}} sock={{.P2}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(sockInitData) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(sockInitData) }),
 	},
 
 	// IPv4/TCP/UDP socket created. Good for associating sockets with pids.
@@ -216,7 +216,7 @@ var sharedKProbes = []helper.ProbeDef{
 			// proto=0 will select the protocol by looking at socket type (STREAM|DGRAM)
 			Filter: "proto==0 || proto=={{.IPPROTO_TCP}} || proto=={{.IPPROTO_UDP}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inetCreate) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inetCreate) }),
 	},
 
 	// IPv4/TCP/UDP socket released. Good for associating sockets with pids.
@@ -226,7 +226,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "inet_release",
 			Fetchargs: "sock=+{{.SOCKET_SOCK}}({{.P1}})",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inetReleaseCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inetReleaseCall) }),
 	},
 
 	/***************************************************************************
@@ -243,7 +243,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.P1}} laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 af=+{{.SOCKADDR_IN_AF}}({{.P2}}):u16 addr=+{{.SOCKADDR_IN_ADDR}}({{.P2}}):u32 port=+{{.SOCKADDR_IN_PORT}}({{.P2}}):u16",
 			Filter:    "af=={{.AF_INET}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpIPv4ConnectCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpIPv4ConnectCall) }),
 	},
 
 	// Result of IPv4/TCP connect:
@@ -256,7 +256,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "tcp_v4_connect",
 			Fetchargs: "retval={{.RET}}:s32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpConnectResult) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpConnectResult) }),
 	},
 
 	// IPv4 packet is sent. Acceptable as a packet counter,
@@ -272,7 +272,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.IP_LOCAL_OUT_SOCK}} size=+{{.SK_BUFF_LEN}}({{.IP_LOCAL_OUT_SK_BUFF}}):u32 af=+{{.INET_SOCK_AF}}({{.IP_LOCAL_OUT_SOCK}}):u16 laddr=+{{.INET_SOCK_LADDR}}({{.IP_LOCAL_OUT_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.IP_LOCAL_OUT_SOCK}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.IP_LOCAL_OUT_SOCK}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.IP_LOCAL_OUT_SOCK}}):u16",
 			Filter:    "(af=={{.AF_INET}} || af=={{.AF_INET6}})",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(ipLocalOutCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(ipLocalOutCall) }),
 	},
 
 	// Count received IPv4/TCP packets.
@@ -284,7 +284,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "tcp_v4_do_rcv",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.P1}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.P1}}):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpV4DoRcv) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpV4DoRcv) }),
 	},
 
 	/***************************************************************************
@@ -301,7 +301,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "udp_sendmsg",
 			Fetchargs: "sock={{.UDP_SENDMSG_SOCK}} size={{.UDP_SENDMSG_LEN}} laddr=+{{.INET_SOCK_LADDR}}({{.UDP_SENDMSG_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.UDP_SENDMSG_SOCK}}):u16 raddr=+{{.SOCKADDR_IN_ADDR}}(+0({{.UDP_SENDMSG_MSG}})):u32 siptr=+0({{.UDP_SENDMSG_MSG}}) siaf=+{{.SOCKADDR_IN_AF}}(+0({{.UDP_SENDMSG_MSG}})):u16 rport=+{{.SOCKADDR_IN_PORT}}(+0({{.UDP_SENDMSG_MSG}})):u16 altraddr=+{{.INET_SOCK_RADDR}}({{.UDP_SENDMSG_SOCK}}):u32 altrport=+{{.INET_SOCK_RPORT}}({{.UDP_SENDMSG_SOCK}}):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpSendMsgCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpSendMsgCall) }),
 	},
 
 	{
@@ -310,7 +310,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "udp_queue_rcv_skb",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, skBuffDataDumpBytes),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpQueueRcvSkb) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpQueueRcvSkb) }),
 	},
 
 	/***************************************************************************
@@ -326,7 +326,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Fetchargs: "magic=+0({{.SYS_P1}}):u64 timestamp=+8({{.SYS_P1}}):u64",
 			Filter:    fmt.Sprintf("magic==0x%x", clockSyncMagic),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(clockSyncCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(clockSyncCall) }),
 	},
 }
 
@@ -345,7 +345,7 @@ var ipv4OnlyKProbes = []helper.ProbeDef{
 				"family=+{{.INET_SOCK_AF}}({{.RET}}):u16",
 			Filter: "family=={{.AF_INET}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpAcceptResult4) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpAcceptResult4) }),
 	},
 
 	// Data is sent via TCP.
@@ -360,7 +360,7 @@ var ipv4OnlyKProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.TCP_SENDMSG_SOCK}} size={{.TCP_SENDMSG_LEN}} laddr=+{{.INET_SOCK_LADDR}}({{.TCP_SENDMSG_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.TCP_SENDMSG_SOCK}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.TCP_SENDMSG_SOCK}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.TCP_SENDMSG_SOCK}}):u16 " +
 				"family=+{{.INET_SOCK_AF}}({{.TCP_SENDMSG_SOCK}}):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgCall4) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgCall4) }),
 	},
 }
 
@@ -384,7 +384,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			// proto=0 will select the protocol by looking at socket type (STREAM|DGRAM)
 			Filter: "proto==0 || proto=={{.IPPROTO_TCP}} || proto=={{.IPPROTO_UDP}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inetCreate) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inetCreate) }),
 	},
 
 	/***************************************************************************
@@ -405,7 +405,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "inet6_csk_xmit",
 			Fetchargs: "sock={{.INET6_CSK_XMIT_SOCK}} size=+{{.SK_BUFF_LEN}}({{.INET6_CSK_XMIT_SKBUFF}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inet6CskXmitCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inet6CskXmitCall) }),
 	},
 
 	// Count received IPv6/TCP packets.
@@ -417,7 +417,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "tcp_v6_do_rcv",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.P1}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpV6DoRcv) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpV6DoRcv) }),
 	},
 
 	// An IPv6 / TCP socket connect attempt:
@@ -430,7 +430,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.P1}} laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 af=+{{.SOCKADDR_IN6_AF}}({{.P2}}):u16 addra=+{{.SOCKADDR_IN6_ADDRA}}({{.P2}}):u64 addrb=+{{.SOCKADDR_IN6_ADDRB}}({{.P2}}):u64 port=+{{.SOCKADDR_IN6_PORT}}({{.P2}}):u16",
 			Filter:    "af=={{.AF_INET6}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpIPv6ConnectCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpIPv6ConnectCall) }),
 	},
 
 	// Result of IPv6/TCP connect:
@@ -443,7 +443,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "tcp_v6_connect",
 			Fetchargs: "retval={{.RET}}:s32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpConnectResult) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpConnectResult) }),
 	},
 
 	/***************************************************************************
@@ -463,7 +463,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "udpv6_sendmsg",
 			Fetchargs: "sock={{.UDP_SENDMSG_SOCK}} size={{.UDP_SENDMSG_LEN}} laddra={{.INET_SOCK_V6_LADDR_A}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.UDP_SENDMSG_SOCK}}):u16 raddra=+{{.SOCKADDR_IN6_ADDRA}}(+0({{.UDP_SENDMSG_MSG}})):u64 raddrb=+{{.SOCKADDR_IN6_ADDRB}}(+0({{.UDP_SENDMSG_MSG}})):u64 rport=+{{.SOCKADDR_IN6_PORT}}(+0({{.UDP_SENDMSG_MSG}})):u16 altraddra={{.INET_SOCK_V6_RADDR_A}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} altraddrb={{.INET_SOCK_V6_RADDR_B}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} altrport=+{{.INET_SOCK_RPORT}}({{.UDP_SENDMSG_SOCK}}):u16 si6ptr=+0({{.UDP_SENDMSG_MSG}}) si6af=+{{.SOCKADDR_IN6_AF}}(+0({{.UDP_SENDMSG_MSG}})):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpv6SendMsgCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpv6SendMsgCall) }),
 	},
 
 	/* UDP/IPv6 receive datagram. Good for counting payload bytes and packets.*/
@@ -473,7 +473,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "udpv6_queue_rcv_skb",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, skBuffDataDumpBytes),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpv6QueueRcvSkb) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpv6QueueRcvSkb) }),
 	},
 
 	/***************************************************************************
@@ -492,7 +492,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.TCP_SENDMSG_SOCK}} size={{.TCP_SENDMSG_LEN}} laddr=+{{.INET_SOCK_LADDR}}({{.TCP_SENDMSG_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.TCP_SENDMSG_SOCK}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.TCP_SENDMSG_SOCK}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.TCP_SENDMSG_SOCK}}):u16 " +
 				"family=+{{.INET_SOCK_AF}}({{.TCP_SENDMSG_SOCK}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgCall) }),
 	},
 
 	// Return of accept(). Local side is usually zero so not fetched. Needs
@@ -508,7 +508,7 @@ var ipv6KProbes = []helper.ProbeDef{
 				"family=+{{.INET_SOCK_AF}}({{.RET}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.RET}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.RET}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.RET}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.RET}}){{.INET_SOCK_V6_TERM}}",
 			Filter: "family=={{.AF_INET}} || family=={{.AF_INET6}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpAcceptResult) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpAcceptResult) }),
 	},
 }
 

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"strconv"
@@ -566,9 +567,7 @@ func (s *state) ForkProcess(parentPID, childPID uint32, ts kernelTime) error {
 			createdTime: s.kernTimestampToTime(ts),
 		}
 		child.resolvedDomains = make(map[string]string, len(parent.resolvedDomains))
-		for k, v := range parent.resolvedDomains {
-			child.resolvedDomains[k] = v
-		}
+		maps.Copy(child.resolvedDomains, parent.resolvedDomains)
 		s.log.Debugf("forking process %d with %d associated domains", childPID, len(child.resolvedDomains))
 		s.processes[childPID] = child
 	}
@@ -987,7 +986,7 @@ func (f *flow) toEvent(final bool) (ev mb.Event, err error) {
 	}
 
 	var errs []error
-	rootPut := func(key string, value interface{}) {
+	rootPut := func(key string, value any) {
 		if _, err := root.Put(key, value); err != nil {
 			errs = append(errs, err)
 		}

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -29,19 +29,19 @@ import (
 
 type logWrapper testing.T
 
-func (l *logWrapper) Errorf(format string, args ...interface{}) {
+func (l *logWrapper) Errorf(format string, args ...any) {
 	l.Logf("error: "+format, args...)
 }
 
-func (l *logWrapper) Warnf(format string, args ...interface{}) {
+func (l *logWrapper) Warnf(format string, args ...any) {
 	l.Logf("warning: "+format, args...)
 }
 
-func (l *logWrapper) Infof(format string, args ...interface{}) {
+func (l *logWrapper) Infof(format string, args ...any) {
 	l.Logf("info: "+format, args...)
 }
 
-func (l *logWrapper) Debugf(format string, args ...interface{}) {
+func (l *logWrapper) Debugf(format string, args ...any) {
 	l.Logf("debug: "+format, args...)
 }
 
@@ -216,7 +216,7 @@ func TestTCPConnWithProcess(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           localIP,
 		"source.port":         localPort,
 		"source.packets":      uint64(1),
@@ -335,7 +335,7 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow 0", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           localIP,
 		"source.port":         localPort,
 		"source.packets":      uint64(1),
@@ -378,7 +378,7 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	// we have a truncated flow with no directionality,
 	// so just report what we can
 	t.Log("read flow 1", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":         localIP,
 		"source.port":       localPort,
 		"client.ip":         localIP,
@@ -458,7 +458,7 @@ func TestUDPOutgoingSinglePacketWithProcess(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           localIP,
 		"source.port":         localPort,
 		"source.packets":      uint64(1),
@@ -525,7 +525,7 @@ func TestUDPIncomingSinglePacketWithProcess(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           remoteIP,
 		"source.port":         remotePort,
 		"source.packets":      uint64(1),
@@ -551,7 +551,7 @@ func TestUDPIncomingSinglePacketWithProcess(t *testing.T) {
 	}
 }
 
-func assertValue(t *testing.T, ev beat.Event, expected interface{}, field string) bool {
+func assertValue(t *testing.T, ev beat.Event, expected any, field string) bool {
 	value, err := ev.GetValue(field)
 	return assert.Nil(t, err, field) && assert.Equal(t, expected, value, field)
 }
@@ -582,11 +582,8 @@ func callExecve(meta tracing.Metadata, args []string) *execveCall {
 	ptr := &execveCall{
 		Meta: meta,
 	}
-	lim := len(args)
-	if lim > maxProgArgs {
-		lim = maxProgArgs
-	}
-	for i := 0; i < lim; i++ {
+	lim := min(len(args), maxProgArgs)
+	for i := range lim {
 		ptr.Ptrs[i] = 1
 	}
 	if lim < len(args) {

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -75,8 +75,8 @@ func testUser() *User {
 	}
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":     system.ModuleName,
 		"metricsets": []string{"user"},
 

--- a/x-pack/auditbeat/module/system/user/users_linux.go
+++ b/x-pack/auditbeat/module/system/user/users_linux.go
@@ -225,7 +225,7 @@ func readShadowFile() (map[string]shadowFileEntry, error) {
 // multiRoundHash performs 10 rounds of SHA-512 hashing.
 func multiRoundHash(s string) []byte {
 	hash := sha512.Sum512([]byte(s))
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		hash = sha512.Sum512(hash[:])
 	}
 	return hash[:]

--- a/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
+++ b/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
@@ -241,7 +241,7 @@ func (p *addSessionMetadata) enrich(ev *beat.Event) (*beat.Event, error) {
 }
 
 // pidToUInt32 converts PID value to uint32
-func pidToUInt32(value interface{}) (pid uint32, err error) {
+func pidToUInt32(value any) (pid uint32, err error) {
 	switch v := value.(type) {
 	case string:
 		nr, err := strconv.Atoi(v)
@@ -267,11 +267,11 @@ func pidToUInt32(value interface{}) (pid uint32, err error) {
 	return pid, nil
 }
 
-func tryToMapStr(v interface{}) (mapstr.M, bool) {
+func tryToMapStr(v any) (mapstr.M, bool) {
 	switch m := v.(type) {
 	case mapstr.M:
 		return m, true
-	case map[string]interface{}:
+	case map[string]any:
 		return mapstr.M(m), true
 	default:
 		return nil, false

--- a/x-pack/auditbeat/processors/sessionmd/processdb/db.go
+++ b/x-pack/auditbeat/processors/sessionmd/processdb/db.go
@@ -239,13 +239,11 @@ func NewDB(ctx context.Context, metrics *monitoring.Registry, reader procfs.Read
 
 func (db *DB) calculateEntityIDv1(pid uint32, startTime time.Time) string {
 	return base64.StdEncoding.EncodeToString(
-		[]byte(
-			fmt.Sprintf("%d__%s__%d__%d",
-				pidNsInode,
-				bootID,
-				uint64(pid),
-				uint64(startTime.Unix()),
-			),
+		fmt.Appendf(nil, "%d__%s__%d__%d",
+			pidNsInode,
+			bootID,
+			uint64(pid),
+			uint64(startTime.Unix()),
 		),
 	)
 }
@@ -681,7 +679,7 @@ func (db *DB) GetProcess(pid uint32) (types.Process, error) {
 	ret := fullProcessFromDBProcess(process)
 
 	if process.PIDs.Ppid != 0 {
-		for i := 0; i < retryCount; i++ {
+		for range retryCount {
 			if parent, ok := db.processes[process.PIDs.Ppid]; ok {
 				fillParent(&ret, parent)
 				break
@@ -690,7 +688,7 @@ func (db *DB) GetProcess(pid uint32) (types.Process, error) {
 	}
 
 	if process.PIDs.Pgid != 0 {
-		for i := 0; i < retryCount; i++ {
+		for range retryCount {
 			if groupLeader, ok := db.processes[process.PIDs.Pgid]; ok {
 				fillGroupLeader(&ret, groupLeader)
 				break
@@ -699,7 +697,7 @@ func (db *DB) GetProcess(pid uint32) (types.Process, error) {
 	}
 
 	if process.PIDs.Sid != 0 {
-		for i := 0; i < retryCount; i++ {
+		for range retryCount {
 			if sessionLeader, ok := db.processes[process.PIDs.Sid]; ok {
 				fillSessionLeader(&ret, sessionLeader)
 				break

--- a/x-pack/auditbeat/processors/sessionmd/processdb/db_test.go
+++ b/x-pack/auditbeat/processors/sessionmd/processdb/db_test.go
@@ -7,7 +7,6 @@
 package processdb
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -43,8 +42,7 @@ func TestProcessOrphanResolve(t *testing.T) {
 
 	// uncomment if you want some logs
 	//_ = logp.DevelopmentSetup()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	reader := procfs.NewProcfsReader(*logger)
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), reader, logp.L(), -1, false)
 	require.NoError(t, err)
@@ -87,8 +85,7 @@ func TestProcessOrphanResolve(t *testing.T) {
 
 func TestReapExitOrphans(t *testing.T) {
 	// test to make sure that orphaned exit events are still cleaned up
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	reader := procfs.NewProcfsReader(*logger)
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), reader, logp.L(), -1, false)
 	require.NoError(t, err)
@@ -108,8 +105,7 @@ func TestReapExitOrphans(t *testing.T) {
 
 func TestReapProcesses(t *testing.T) {
 	reader := procfs.NewProcfsReader(*logger)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), reader, logp.L(), -1, true)
 	require.NoError(t, err)
 	testDB.processReapAfter = time.Duration(0)
@@ -145,8 +141,7 @@ func TestReapProcesses(t *testing.T) {
 
 func TestReapProcessesWithProcFS(t *testing.T) {
 	mockReader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), mockReader, logp.L(), -1, false)
 	require.NoError(t, err)
 	testDB.reapProcesses = true
@@ -187,8 +182,7 @@ func TestReapProcessesWithProcFS(t *testing.T) {
 func TestReapingProcessesOrphanResolvedRace(t *testing.T) {
 	// test to make sure that if we resolve a process in between mutex holds, we won't prematurely reap it
 	mockReader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), mockReader, logp.L(), -1, false)
 	require.NoError(t, err)
 	testDB.reapProcesses = true

--- a/x-pack/auditbeat/processors/sessionmd/processdb/entry_leader_test.go
+++ b/x-pack/auditbeat/processors/sessionmd/processdb/entry_leader_test.go
@@ -7,7 +7,6 @@
 package processdb
 
 import (
-	"context"
 	"path"
 	"testing"
 	"time"
@@ -193,8 +192,7 @@ func populateProcfsWithInit(reader *procfs.MockReader) {
 
 func TestSingleProcessSessionLeaderEntryTypeTerminal(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -219,8 +217,7 @@ func TestSingleProcessSessionLeaderEntryTypeTerminal(t *testing.T) {
 
 func TestSingleProcessSessionLeaderLoginProcess(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -250,8 +247,7 @@ func TestSingleProcessSessionLeaderLoginProcess(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfInit(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -282,8 +278,7 @@ func TestSingleProcessSessionLeaderChildOfInit(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfSsmSessionWorker(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -320,8 +315,7 @@ func TestSingleProcessSessionLeaderChildOfSsmSessionWorker(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfSshd(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -357,8 +351,7 @@ func TestSingleProcessSessionLeaderChildOfSshd(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfContainerdShim(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -394,8 +387,7 @@ func TestSingleProcessSessionLeaderChildOfContainerdShim(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfRunc(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -432,8 +424,7 @@ func TestSingleProcessSessionLeaderChildOfRunc(t *testing.T) {
 
 func TestSingleProcessEmptyProcess(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -467,8 +458,7 @@ func TestSingleProcessEmptyProcess(t *testing.T) {
 // EntryLeaderEntryMetaType
 func TestSingleProcessOverwriteOldEntryLeader(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -540,8 +530,7 @@ func TestSingleProcessOverwriteOldEntryLeader(t *testing.T) {
 func TestInitSshdBashLs(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -625,8 +614,7 @@ func TestInitSshdBashLs(t *testing.T) {
 func TestInitSshdSshdBashLs(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -719,8 +707,7 @@ func TestInitSshdSshdBashLs(t *testing.T) {
 func TestInitSshdSshdSshdBashLs(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -830,8 +817,7 @@ func TestInitSshdSshdSshdBashLs(t *testing.T) {
 func TestInitContainerdContainerdShim(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -885,8 +871,7 @@ func TestInitContainerdContainerdShim(t *testing.T) {
 func TestInitContainerdShimBashContainerdShimIsReparentedToInit(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -956,8 +941,7 @@ func TestInitContainerdShimBashContainerdShimIsReparentedToInit(t *testing.T) {
 func TestInitContainerdShimPauseContainerdShimIsReparentedToInit(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1030,8 +1014,7 @@ func TestInitContainerdShimPauseContainerdShimIsReparentedToInit(t *testing.T) {
 func TestInitSshdBashLsAndGrepGrepOnlyHasGroupLeader(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1119,8 +1102,7 @@ func TestInitSshdBashLsAndGrepGrepOnlyHasGroupLeader(t *testing.T) {
 func TestInitSshdBashLsAndGrepGrepOnlyHasSessionLeader(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1203,8 +1185,7 @@ func TestInitSshdBashLsAndGrepGrepOnlyHasSessionLeader(t *testing.T) {
 // entry meta type of "unknown" and making it an entry leader.
 func TestGrepInIsolation(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1238,8 +1219,7 @@ func TestGrepInIsolation(t *testing.T) {
 // Kernel threads should never have an entry meta type or entry leader set.
 func TestKernelThreads(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 
@@ -1292,8 +1272,7 @@ func TestKernelThreads(t *testing.T) {
 func TestPIDReuseSameSession(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1399,8 +1378,7 @@ func TestPIDReuseSameSession(t *testing.T) {
 func TestPIDReuseNewSession(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()

--- a/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
@@ -489,13 +489,11 @@ func setSameAsProcess(process *types.Process) {
 // This is a globally unique identifier for the process.
 func calculateEntityIDv1(pid uint32, startTime time.Time) string {
 	return base64.StdEncoding.EncodeToString(
-		[]byte(
-			fmt.Sprintf("%d__%s__%d__%d",
-				pidNsInode,
-				bootID,
-				uint64(pid),
-				uint64(startTime.Unix()), //nolint:gosec // process start times are always positive
-			),
+		fmt.Appendf(nil, "%d__%s__%d__%d",
+			pidNsInode,
+			bootID,
+			uint64(pid),
+			uint64(startTime.Unix()), //nolint:gosec // process start times are always positive
 		),
 	)
 }

--- a/x-pack/auditbeat/processors/sessionmd/provider/procfsprovider/procfsprovider.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/procfsprovider/procfsprovider.go
@@ -73,7 +73,7 @@ func (p prvdr) Sync(ev *beat.Event, pid uint32) error {
 			// possible from the event
 			pe.ProcfsLookupFail = true
 			pe.PIDs.Tgid = pid
-			var intr interface{}
+			var intr any
 			var i int
 			var ok bool
 			var parent types.Process

--- a/x-pack/filebeat/input/azureblobstorage/auth_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/auth_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -62,14 +63,14 @@ func (t *customTransporter) Do(req *http.Request) (*http.Response, error) {
 
 			switch action {
 			case "v2.0/.well-known/openid-configuration":
-				return createJSONResponse(map[string]interface{}{
+				return createJSONResponse(map[string]any{
 					"token_endpoint":         "https://login.microsoftonline.com/" + tenant_id + "/oauth2/v2.0/token",
 					"authorization_endpoint": "https://login.microsoftonline.com/" + tenant_id + "/oauth2/v2.0/authorize",
 					"issuer":                 "https://login.microsoftonline.com/" + tenant_id + "/v2.0",
 				}, 200)
 
 			case "oauth2/v2.0/token":
-				return createJSONResponse(map[string]interface{}{
+				return createJSONResponse(map[string]any{
 					"token_type":   "Bearer",
 					"expires_in":   3600,
 					"access_token": "mock_access_token_123",
@@ -82,7 +83,7 @@ func (t *customTransporter) Do(req *http.Request) (*http.Response, error) {
 	return t.rt.RoundTrip(req)
 }
 
-func createJSONResponse(data interface{}, statusCode int) (*http.Response, error) {
+func createJSONResponse(data any, statusCode int) (*http.Response, error) {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return nil, err
@@ -164,20 +165,20 @@ func Test_ListBlobsRetriesOnTransientError(t *testing.T) {
 		failListBlobs: 3,
 	}
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"account_name": "beatsblobnew",
-		"auth.oauth2": map[string]interface{}{
+		"auth.oauth2": map[string]any{
 			"client_id":     "12345678-90ab-cdef-1234-567890abcdef",
 			"client_secret": "abcdefg1234567890!@#$%^&*()-_=+",
 			"tenant_id":     "87654321-abcd-ef90-1234-fedcba098765",
 		},
 		"max_workers": 2,
 		"poll":        false,
-		"containers": []map[string]interface{}{
+		"containers": []map[string]any{
 			{"name": beatsContainer},
 		},
 		// Keep the backoff tiny so the test stays fast.
-		"retry": map[string]interface{}{
+		"retry": map[string]any{
 			"max_retries":         10,
 			"initial_retry_delay": "1ms",
 			"max_retry_delay":     "5ms",
@@ -260,12 +261,7 @@ func (r *recordingStatusReporter) UpdateStatus(s status.Status, _ string) {
 func (r *recordingStatusReporter) has(target status.Status) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for _, s := range r.statuses {
-		if s == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.statuses, target)
 }
 
 // last returns the most recently reported status, if any.
@@ -293,15 +289,15 @@ func Test_ListBlobsNonFatalWhilePolling(t *testing.T) {
 	}))
 	t.Cleanup(serv.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"account_name":                        "beatsblobnew",
 		"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 		"max_workers":                         1,
-		"containers": []map[string]interface{}{
+		"containers": []map[string]any{
 			{"name": beatsContainer},
 		},
 		// Keep the retry backoff tiny so the failing list call returns quickly.
-		"retry": map[string]interface{}{
+		"retry": map[string]any{
 			"max_retries":         1,
 			"initial_retry_delay": "1ms",
 			"max_retry_delay":     "5ms",
@@ -377,16 +373,16 @@ func Test_ListBlobsRecoversToRunningOnEmptyPoll(t *testing.T) {
 	}))
 	t.Cleanup(serv.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"account_name":                        "beatsblobnew",
 		"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 		"max_workers":                         1,
 		"poll":                                true,
-		"containers": []map[string]interface{}{
+		"containers": []map[string]any{
 			{"name": beatsContainer},
 		},
 		// Keep the retry backoff tiny so the failing list call returns quickly.
-		"retry": map[string]interface{}{
+		"retry": map[string]any{
 			"max_retries":         1,
 			"initial_retry_delay": "1ms",
 			"max_retry_delay":     "5ms",
@@ -432,15 +428,15 @@ func Test_ListBlobsRecoversToRunningOnEmptyPoll(t *testing.T) {
 func Test_OAuth2(t *testing.T) {
 	tests := []struct {
 		name        string
-		baseConfig  map[string]interface{}
+		baseConfig  map[string]any
 		mockHandler func() http.Handler
 		expected    map[string]bool
 	}{
 		{
 			name: "OAuth2TConfig",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name": "beatsblobnew",
-				"auth.oauth2": map[string]interface{}{
+				"auth.oauth2": map[string]any{
 					"client_id":     "12345678-90ab-cdef-1234-567890abcdef",
 					"client_secret": "abcdefg1234567890!@#$%^&*()-_=+",
 					"tenant_id":     "87654321-abcd-ef90-1234-fedcba098765",
@@ -448,7 +444,7 @@ func Test_OAuth2(t *testing.T) {
 				"max_workers":   2,
 				"poll":          true,
 				"poll_interval": "30s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -520,7 +516,7 @@ func Test_OAuth2(t *testing.T) {
 					cancel()
 					return
 				case got := <-chanClient.Channel:
-					var val interface{}
+					var val any
 					var err error
 					val, err = got.Fields.GetValue("message")
 					assert.NoError(t, err)

--- a/x-pack/filebeat/input/azureblobstorage/config_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/config_test.go
@@ -17,21 +17,21 @@ import (
 
 var configTests = []struct {
 	name    string
-	config  map[string]interface{}
+	config  map[string]any
 	wantErr error
 }{
 	{
 		name: "invalid_oauth2_config",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"account_name": "beatsblobnew",
-			"auth.oauth2": map[string]interface{}{
+			"auth.oauth2": map[string]any{
 				"client_id":     "12345678-90ab-cdef-1234-567890abcdef",
 				"client_secret": "abcdefg1234567890!@#$%^&*()-_=+",
 			},
 			"max_workers":   2,
 			"poll":          true,
 			"poll_interval": "10s",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{
 					"name": beatsContainer,
 				},
@@ -41,9 +41,9 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_oauth2_config",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"account_name": "beatsblobnew",
-			"auth.oauth2": map[string]interface{}{
+			"auth.oauth2": map[string]any{
 				"client_id":     "12345678-90ab-cdef-1234-567890abcdef",
 				"client_secret": "abcdefg1234567890!@#$%^&*()-_=+",
 				"tenant_id":     "87654321-abcd-ef90-1234-fedcba098765",
@@ -51,7 +51,7 @@ var configTests = []struct {
 			"max_workers":   2,
 			"poll":          true,
 			"poll_interval": "10s",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{
 					"name": beatsContainer,
 				},
@@ -60,15 +60,15 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_retry_config",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"account_name":                        "beatsblobnew",
 			"auth.shared_credentials.account_key": "someKey",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{
 					"name": beatsContainer,
 				},
 			},
-			"retry": map[string]interface{}{
+			"retry": map[string]any{
 				"max_retries":         20,
 				"initial_retry_delay": "1s",
 				"max_retry_delay":     "30s",
@@ -77,15 +77,15 @@ var configTests = []struct {
 	},
 	{
 		name: "negative_initial_retry_delay",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"account_name":                        "beatsblobnew",
 			"auth.shared_credentials.account_key": "someKey",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{
 					"name": beatsContainer,
 				},
 			},
-			"retry": map[string]interface{}{
+			"retry": map[string]any{
 				"initial_retry_delay": "-1s",
 			},
 		},
@@ -93,15 +93,15 @@ var configTests = []struct {
 	},
 	{
 		name: "max_retry_delay_below_initial",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"account_name":                        "beatsblobnew",
 			"auth.shared_credentials.account_key": "someKey",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{
 					"name": beatsContainer,
 				},
 			},
-			"retry": map[string]interface{}{
+			"retry": map[string]any{
 				"initial_retry_delay": "30s",
 				"max_retry_delay":     "5s",
 			},
@@ -134,13 +134,13 @@ func TestConfig(t *testing.T) {
 // SDK-matching default seeded by defaultConfig (including for a partial block).
 func TestRetryConfig(t *testing.T) {
 	t.Run("explicit", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"account_name":                        "beatsblobnew",
 			"auth.shared_credentials.account_key": "someKey",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{"name": beatsContainer},
 			},
-			"retry": map[string]interface{}{
+			"retry": map[string]any{
 				"max_retries":         20,
 				"initial_retry_delay": "1s",
 				"max_retry_delay":     "30s",
@@ -160,10 +160,10 @@ func TestRetryConfig(t *testing.T) {
 	})
 
 	t.Run("defaults", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"account_name":                        "beatsblobnew",
 			"auth.shared_credentials.account_key": "someKey",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{"name": beatsContainer},
 			},
 		})
@@ -180,13 +180,13 @@ func TestRetryConfig(t *testing.T) {
 	t.Run("partial", func(t *testing.T) {
 		// A partial retry block overrides only the provided field and keeps the
 		// seeded defaults for the rest.
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"account_name":                        "beatsblobnew",
 			"auth.shared_credentials.account_key": "someKey",
-			"containers": []map[string]interface{}{
+			"containers": []map[string]any{
 				{"name": beatsContainer},
 			},
-			"retry": map[string]interface{}{
+			"retry": map[string]any{
 				"max_retries": 7,
 			},
 		})

--- a/x-pack/filebeat/input/azureblobstorage/decoding_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/decoding_test.go
@@ -256,6 +256,3 @@ func sameError(a, b error) bool {
 		return a.Error() == b.Error()
 	}
 }
-
-//go:fix inline
-func ptr[T any](v T) *T { return new(v) }

--- a/x-pack/filebeat/input/azureblobstorage/decoding_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/decoding_test.go
@@ -56,7 +56,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   ptr[decoder.Rune](' '),
+						Comma:   new((decoder.Rune)(' ')),
 					},
 				},
 			},
@@ -71,7 +71,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   ptr[decoder.Rune](' '),
+						Comma:   new((decoder.Rune)(' ')),
 					},
 				},
 			},
@@ -105,9 +105,9 @@ func TestDecoding(t *testing.T) {
 			defer f.Close()
 			p := &pub{t: t}
 			item := &azcontainer.BlobItem{
-				Name: ptr("test_blob"),
+				Name: new("test_blob"),
 				Properties: &azcontainer.BlobProperties{
-					ContentType:  ptr(tc.content),
+					ContentType:  new(tc.content),
 					LastModified: &time.Time{},
 				},
 			}
@@ -138,7 +138,7 @@ type pub struct {
 	events []beat.Event
 }
 
-func (p *pub) Publish(e beat.Event, _cursor interface{}) error {
+func (p *pub) Publish(e beat.Event, _cursor any) error {
 	p.t.Logf("%v\n", e.Fields)
 	p.events = append(p.events, e)
 	return nil
@@ -178,7 +178,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   ptr[decoder.Rune](' '),
+					Comma:   new((decoder.Rune)(' ')),
 					Comment: '#',
 				},
 			}},
@@ -209,7 +209,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   ptr[decoder.Rune]('\x00'),
+					Comma:   new((decoder.Rune)('\x00')),
 				},
 			}},
 	},
@@ -257,4 +257,5 @@ func sameError(a, b error) bool {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }

--- a/x-pack/filebeat/input/azureblobstorage/decoding_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/decoding_test.go
@@ -56,7 +56,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   new((decoder.Rune)(' ')),
+						Comma:   new(decoder.Rune(' ')),
 					},
 				},
 			},
@@ -71,7 +71,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   new((decoder.Rune)(' ')),
+						Comma:   new(decoder.Rune(' ')),
 					},
 				},
 			},
@@ -178,7 +178,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   new((decoder.Rune)(' ')),
+					Comma:   new(decoder.Rune(' ')),
 					Comment: '#',
 				},
 			}},
@@ -209,7 +209,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   new((decoder.Rune)('\x00')),
+					Comma:   new(decoder.Rune('\x00')),
 				},
 			}},
 	},

--- a/x-pack/filebeat/input/azureblobstorage/input_stateless_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/input_stateless_test.go
@@ -39,7 +39,7 @@ type statelessPublisher struct {
 	wrapped stateless.Publisher
 }
 
-func (pub statelessPublisher) Publish(event beat.Event, _ interface{}) error {
+func (pub statelessPublisher) Publish(event beat.Event, _ any) error {
 	pub.wrapped.Publish(event)
 	return nil
 }

--- a/x-pack/filebeat/input/azureblobstorage/input_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/input_test.go
@@ -46,20 +46,20 @@ const (
 func Test_StorageClient(t *testing.T) {
 	tests := []struct {
 		name          string
-		baseConfig    map[string]interface{}
+		baseConfig    map[string]any
 		mockHandler   func() http.Handler
 		expected      map[string]bool
 		expectedError error
 	}{
 		{
 			name: "SingleContainerWithPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -74,13 +74,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleContainerWithoutPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -95,13 +95,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoContainersWithPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -121,13 +121,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoContainersWithoutPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -147,13 +147,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleContainerPoll_InvalidContainerErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": "azuretest",
 					},
@@ -165,13 +165,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleContainerWithoutPoll_InvalidBucketErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": "azuretest",
 					},
@@ -183,13 +183,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoContainersWithPoll_InvalidBucketErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": "azurenew",
 					},
@@ -204,13 +204,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleBucketWithPoll_InvalidConfigValue",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         5100,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -222,13 +222,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoBucketWithPoll_InvalidConfigValue",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         5100,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -243,13 +243,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsJSONContainer,
 					},
@@ -264,13 +264,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadOctetStreamJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsMultilineJSONContainer,
 					},
@@ -284,13 +284,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadNdJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsNdJSONContainer,
 					},
@@ -304,13 +304,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadMultilineGzJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsGzJSONContainer,
 					},
@@ -324,13 +324,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadJSONWithRootAsArray",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsJSONWithArrayContainer,
 					},
@@ -346,14 +346,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByTimeStampEpoch",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"timestamp_epoch":                     1663157564,
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -367,18 +367,18 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByFileSelectorRegexSingle",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "docs/",
 					},
 				},
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -391,13 +391,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByFileSelectorRegexMulti",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                false,
 				"poll_interval":                       "10s",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "docs/",
 					},
@@ -405,7 +405,7 @@ func Test_StorageClient(t *testing.T) {
 						"regex": "data",
 					},
 				},
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -419,19 +419,19 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ExpandEventListFromField",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"expand_event_list_from_field":        "Events",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "events-array",
 					},
 				},
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsJSONContainer,
 					},
@@ -445,16 +445,16 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "MultiContainerWithMultiFileSelectors",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
-						"file_selectors": []map[string]interface{}{
+						"file_selectors": []map[string]any{
 							{
 								"regex": "docs/",
 							},
@@ -462,7 +462,7 @@ func Test_StorageClient(t *testing.T) {
 					},
 					{
 						"name": beatsContainer2,
-						"file_selectors": []map[string]interface{}{
+						"file_selectors": []map[string]any{
 							{
 								"regex": "data_3",
 							},
@@ -478,13 +478,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "CustomContentTypeUnsupported",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":                  beatsGzJSONContainer,
 						"content_type":          "application/xyz-plain",
@@ -499,13 +499,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "CustomContentTypeSupported",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":         beatsGzJSONContainer,
 						"content_type": "application/x-gzip",
@@ -523,13 +523,13 @@ func Test_StorageClient(t *testing.T) {
 			// content-type already exists and we are not overriding it.
 			// So we expect a successful run.
 			name: "CustomContentTypeIgnored",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":         beatsNdJSONContainer,
 						"content_type": "application/xyz-plain",
@@ -545,14 +545,14 @@ func Test_StorageClient(t *testing.T) {
 		{
 			// This checks if the root level content-type specifications are respected.
 			name: "CustomContentTypeAtRootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"content_type":                        "application/x-gzip",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsGzJSONContainer,
 					},
@@ -566,13 +566,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadCSVContainerLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":                       beatsCSVContainer,
 						"decoding.codec.csv.enabled": true,
@@ -588,7 +588,7 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadCSVRootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         1,
@@ -596,7 +596,7 @@ func Test_StorageClient(t *testing.T) {
 				"poll_interval":                       "10s",
 				"decoding.codec.csv.enabled":          true,
 				"decoding.codec.csv.comma":            " ",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsCSVContainer,
 					},
@@ -610,14 +610,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "BatchSizeGlobal",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"batch_size":                          3,
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -632,13 +632,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "BatchContainberLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         2,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":       beatsContainer,
 						"batch_size": 3,
@@ -654,14 +654,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByPathPrefix_NotFoundErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"path_prefix":                         "docs/",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer2,
 					},
@@ -673,14 +673,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByPathPrefix_RootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
 				"path_prefix":                         "docs/",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": beatsContainer,
 					},
@@ -693,13 +693,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByPathPrefix_ContainerLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         1,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name":        beatsContainer,
 						"path_prefix": "docs/",
@@ -776,7 +776,7 @@ func Test_StorageClient(t *testing.T) {
 					cancel()
 					return
 				case got := <-chanClient.Channel:
-					var val interface{}
+					var val any
 					var err error
 					val, err = got.Fields.GetValue("message")
 					assert.NoError(t, err)
@@ -800,13 +800,13 @@ func TestConcurrency(t *testing.T) {
 			serv := httptest.NewServer(mock.AzureConcurrencyServer())
 			t.Cleanup(serv.Close)
 
-			cfg := conf.MustNewConfigFrom(map[string]interface{}{
+			cfg := conf.MustNewConfigFrom(map[string]any{
 				"account_name":                        "beatsblobnew",
 				"auth.shared_credentials.account_key": "7pfLm1betGiRyyABEM/RFrLYlafLZHbLtGhB52LkWVeBxE7la9mIvk6YYAbQKYE/f0GdhiaOZeV8+AStsAdr/Q==",
 				"max_workers":                         workers,
 				"poll":                                true,
 				"poll_interval":                       "10s",
-				"containers": []map[string]interface{}{
+				"containers": []map[string]any{
 					{
 						"name": mock.ConcurrencyContainer,
 					},
@@ -873,14 +873,14 @@ type publisher struct {
 	stop    func([]beat.Event)
 	events  []beat.Event
 	mu      sync.Mutex
-	cursors []map[string]interface{}
+	cursors []map[string]any
 }
 
-func (p *publisher) Publish(e beat.Event, cursor interface{}) error {
+func (p *publisher) Publish(e beat.Event, cursor any) error {
 	p.mu.Lock()
 	p.events = append(p.events, e)
 	if cursor != nil {
-		var c map[string]interface{}
+		var c map[string]any
 		chkpt, ok := cursor.(*Checkpoint)
 		if !ok {
 			return fmt.Errorf("invalid cursor type for testing: %T", cursor)

--- a/x-pack/filebeat/input/azureblobstorage/mock/data_random.go
+++ b/x-pack/filebeat/input/azureblobstorage/mock/data_random.go
@@ -44,7 +44,7 @@ func generateMetadata() []byte {
 	const numDataSets = TotalRandomDataSets
 	dataSets := make([]Blob, numDataSets)
 
-	for i := 0; i < numDataSets; i++ {
+	for i := range numDataSets {
 		dataSets[i] = createRandomBlob(i)
 	}
 
@@ -92,7 +92,7 @@ func generateRandomBlob() []byte {
 	const numObjects = 10
 	dataObjects := make([]MyData, numObjects)
 
-	for i := 0; i < numObjects; i++ {
+	for i := range numObjects {
 		dataObjects[i] = createRandomData()
 	}
 

--- a/x-pack/filebeat/input/cel/config.go
+++ b/x-pack/filebeat/input/cel/config.go
@@ -50,7 +50,7 @@ type config struct {
 	// program. If it has a cursor field, that field will
 	// be overwritten by any stored cursor, but will be
 	// available if no stored cursor exists.
-	State map[string]interface{} `config:"state"`
+	State map[string]any `config:"state"`
 	// SecretState holds secret key-value pairs that are
 	// stored encrypted by Fleet (via secret: true) and
 	// placed at state.secret before CEL program execution.
@@ -108,12 +108,12 @@ func (c config) GetPackageData(key string) string {
 // to their stored string values. See
 // https://github.com/elastic/kibana/issues/267859
 type secretState struct {
-	m map[string]interface{}
+	m map[string]any
 }
 
-func (s *secretState) Unpack(v interface{}) error {
+func (s *secretState) Unpack(v any) error {
 	switch v := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		s.m = v
 		return nil
 	case string:

--- a/x-pack/filebeat/input/cel/config_okta_auth_test.go
+++ b/x-pack/filebeat/input/cel/config_okta_auth_test.go
@@ -102,7 +102,7 @@ func checkToken(t *testing.T, text string, cnf *oauth2.Config) {
 func TestOktaTokenSource_Token(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token": "mock",
 			"token_type":   "Bearer",
 			"expires_in":   3600,

--- a/x-pack/filebeat/input/cel/config_test.go
+++ b/x-pack/filebeat/input/cel/config_test.go
@@ -57,7 +57,7 @@ func TestRegexpConfig(t *testing.T) {
 func TestSecretStateUnpack(t *testing.T) {
 	t.Run("map", func(t *testing.T) {
 		var s secretState
-		err := s.Unpack(map[string]interface{}{"api_key": "secret"})
+		err := s.Unpack(map[string]any{"api_key": "secret"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -83,7 +83,7 @@ func TestSecretStateUnpack(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		headers, ok := s.m["headers"].(map[string]interface{})
+		headers, ok := s.m["headers"].(map[string]any)
 		if !ok {
 			t.Fatalf("expected map[string]interface{} for nested map, got %T", s.m["headers"])
 		}
@@ -118,8 +118,8 @@ func TestSecretStateValidation(t *testing.T) {
 
 	t.Run("state_with_secret_key_rejected", func(t *testing.T) {
 		cfg := base
-		cfg.State = map[string]interface{}{
-			"secret": map[string]interface{}{"api_key": "hidden"},
+		cfg.State = map[string]any{
+			"secret": map[string]any{"api_key": "hidden"},
 		}
 		err := cfg.Validate()
 		if err == nil {
@@ -133,7 +133,7 @@ func TestSecretStateValidation(t *testing.T) {
 
 	t.Run("state_with_secret_key_rejected_without_secret_state", func(t *testing.T) {
 		cfg := base
-		cfg.State = map[string]interface{}{
+		cfg.State = map[string]any{
 			"secret": "value",
 		}
 		err := cfg.Validate()
@@ -144,7 +144,7 @@ func TestSecretStateValidation(t *testing.T) {
 
 	t.Run("state_without_secret_key_accepted", func(t *testing.T) {
 		cfg := base
-		cfg.State = map[string]interface{}{
+		cfg.State = map[string]any{
 			"token": "not_actually_secret",
 		}
 		err := cfg.Validate()
@@ -182,7 +182,7 @@ func TestIsEnabled(t *testing.T) {
 			}
 
 			var enabled bool
-			for i := 0; i < 4; i++ {
+			for i := range 4 {
 				test.auth.take(&enabled)
 				if got := test.auth.isEnabled(); got != enabled {
 					t.Errorf("unexpected auth enabled state on iteration %d: got:%t want:%t", i, got, enabled)
@@ -265,7 +265,7 @@ func TestConfigFileAuthMutualExclusion(t *testing.T) {
 		t.Fatalf("failed to write secret file: %v", err)
 	}
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"resource.url":        "localhost",
 		"auth.file.path":      path,
 		"auth.basic.user":     "user",
@@ -287,7 +287,7 @@ func TestConfigFileAuthDisabledAllowsOther(t *testing.T) {
 		t.Fatalf("failed to write secret file: %v", err)
 	}
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"resource.url":        "localhost",
 		"auth.file.enabled":   false,
 		"auth.file.path":      path,
@@ -350,7 +350,7 @@ func TestConfigMustFailWithInvalidResource(t *testing.T) {
 		{val: "path/to/file"},
 		{val: "::invalid::", want: errors.New(`parse "::invalid::": missing protocol scheme accessing 'resource.url'`)},
 	} {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"resource.url": test.val,
 		}
 		cfg := conf.MustNewConfigFrom(m)
@@ -367,19 +367,19 @@ func TestConfigMustFailWithInvalidResource(t *testing.T) {
 var oAuth2ValidationTests = []struct {
 	name     string
 	wantErr  error
-	input    map[string]interface{}
+	input    map[string]any
 	setup    func()
 	teardown func()
 }{
 	{
 		name:    "can't_set_oauth2_and_basic_auth_together",
 		wantErr: errors.New("only one kind of auth can be enabled accessing 'auth'"),
-		input: map[string]interface{}{
+		input: map[string]any{
 			"auth.basic.user":     "user",
 			"auth.basic.password": "pass",
-			"auth.oauth2": map[string]interface{}{
+			"auth.oauth2": map[string]any{
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id":     "a_client_id",
 					"secret": "a_client_secret",
 				},
@@ -389,12 +389,12 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "can't_set_oauth2_and_digest_auth_together",
 		wantErr: errors.New("only one kind of auth can be enabled accessing 'auth'"),
-		input: map[string]interface{}{
+		input: map[string]any{
 			"auth.digest.user":     "user",
 			"auth.digest.password": "pass",
-			"auth.oauth2": map[string]interface{}{
+			"auth.oauth2": map[string]any{
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id":     "a_client_id",
 					"secret": "a_client_secret",
 				},
@@ -404,7 +404,7 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "can't_set_basic_and_digest_auth_together",
 		wantErr: errors.New("only one kind of auth can be enabled accessing 'auth'"),
-		input: map[string]interface{}{
+		input: map[string]any{
 			"auth.basic.user":      "user",
 			"auth.basic.password":  "pass",
 			"auth.digest.user":     "user",
@@ -413,13 +413,13 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "can_set_oauth2_and_basic_auth_together_if_oauth2_is_disabled",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"auth.basic.user":     "user",
 			"auth.basic.password": "pass",
-			"auth.oauth2": map[string]interface{}{
+			"auth.oauth2": map[string]any{
 				"enabled":   false,
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id":     "a_client_id",
 					"secret": "a_client_secret",
 				},
@@ -429,17 +429,17 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "token_url_and_client_credentials_must_be_set",
 		wantErr: errors.New("both token_url and client credentials must be provided accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{},
+		input: map[string]any{
+			"auth.oauth2": map[string]any{},
 		},
 	},
 	{
 		name: "client_credential_secret_may_be_empty",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"enabled":   true,
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id":     "a_client_id",
 					"secret": "",
 				},
@@ -449,11 +449,11 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "client_credential_secret_may_not_be_missing",
 		wantErr: errors.New("both token_url and client credentials must be provided accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"enabled":   true,
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id": "a_client_id",
 				},
 			},
@@ -461,12 +461,12 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "if_user_and_password_is_set_oauth2_must_use_user-password_authentication",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"user":      "a_client_user",
 				"password":  "a_client_password",
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id":     "a_client_id",
 					"secret": "a_client_secret",
 				},
@@ -476,11 +476,11 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "if_user_is_set_password_credentials_must_be_set_for_user-password_authentication",
 		wantErr: errors.New("both user and password credentials must be provided accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"user":      "a_client_user",
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id":     "a_client_id",
 					"secret": "a_client_secret",
 				},
@@ -490,11 +490,11 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "if_password_is_set_user_credentials_must_be_set_for_user-password_authentication",
 		wantErr: errors.New("both user and password credentials must be provided accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"password":  "a_client_password",
 				"token_url": "localhost",
-				"client": map[string]interface{}{
+				"client": map[string]any{
 					"id":     "a_client_id",
 					"secret": "a_client_secret",
 				},
@@ -503,8 +503,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "if_password_is_set_credentials_may_be_missing_for_user-password_authentication",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"user":      "a_client_user",
 				"password":  "a_client_password",
 				"token_url": "localhost",
@@ -514,8 +514,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "must_fail_with_an_unknown_provider",
 		wantErr: errors.New("unknown provider \"unknown\" accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "unknown",
 			},
 		},
@@ -523,8 +523,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "azure_must_have_either_tenant_id_or_token_url",
 		wantErr: errors.New("at least one of token_url or tenant_id must be provided accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "azure",
 			},
 		},
@@ -532,8 +532,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "azure_must_have_only_one_of_token_url_and_tenant_id",
 		wantErr: errors.New("only one of token_url and tenant_id can be used accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":        "azure",
 				"azure.tenant_id": "a_tenant_id",
 				"token_url":       "localhost",
@@ -543,8 +543,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "azure_must_have_client_credentials_set",
 		wantErr: errors.New("client credentials must be provided accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":        "azure",
 				"azure.tenant_id": "a_tenant_id",
 			},
@@ -552,10 +552,10 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "azure_config_is_valid",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "azure",
-				"azure": map[string]interface{}{
+				"azure": map[string]any{
 					"tenant_id": "a_tenant_id",
 				},
 				"client.id":     "a_client_id",
@@ -566,10 +566,10 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google_can't_have_token_url_or_client_credentials_set",
 		wantErr: errors.New("none of token_url and client credentials can be used, use google.credentials_file, google.jwt_file, google.credentials_json or ADC instead accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "google",
-				"azure": map[string]interface{}{
+				"azure": map[string]any{
 					"tenant_id": "a_tenant_id",
 				},
 				"client.id":     "a_client_id",
@@ -581,8 +581,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google_must_fail_if_no_ADC_available",
 		wantErr: errors.New("no authentication credentials were configured or detected (ADC) accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "google",
 			},
 		},
@@ -597,8 +597,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google_must_fail_if_credentials_file_not_found",
 		wantErr: errors.New("the file \"./wrong\" cannot be found accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":                "google",
 				"google.credentials_file": "./wrong",
 			},
@@ -607,8 +607,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google_must_fail_if_ADC_is_wrongly_set",
 		wantErr: errors.New("no authentication credentials were configured or detected (ADC) accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "google",
 			},
 		},
@@ -616,8 +616,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "google_must_work_if_ADC_is_set_up",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "google",
 			},
 		},
@@ -625,8 +625,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "google_must_work_if_credentials_file_is_correct",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":                "google",
 				"google.credentials_file": "./testdata/credentials.json",
 			},
@@ -634,8 +634,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "google_must_work_if_jwt_file_is_correct",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":        "google",
 				"google.jwt_file": "./testdata/credentials.json",
 			},
@@ -643,8 +643,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "google must work if jwt_json is correct",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "google",
 				"google.jwt_json": `{
 						"type":           "service_account",
@@ -658,8 +658,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "google_must_work_if_credentials_json_is_correct",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider": "google",
 				"google.credentials_json": `{
 						"type":           "service_account",
@@ -674,8 +674,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google_must_fail_if_credentials_json_is_not_a_valid_JSON",
 		wantErr: errors.New("the field can't be converted to valid JSON accessing 'auth.oauth2.google.credentials_json'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":                "google",
 				"google.credentials_json": `invalid`,
 			},
@@ -684,8 +684,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google must fail if jwt_json is not a valid JSON",
 		wantErr: errors.New("the field can't be converted to valid JSON accessing 'auth.oauth2.google.jwt_json'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":        "google",
 				"google.jwt_json": `invalid`,
 			},
@@ -694,8 +694,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google_must_fail_if_the_provided_credentials_file_is_not_a_valid_JSON",
 		wantErr: errors.New("the file \"./testdata/invalid_credentials.json\" does not contain valid JSON accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":                "google",
 				"google.credentials_file": "./testdata/invalid_credentials.json",
 			},
@@ -704,8 +704,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "google_must_fail_if_the_delegated_account_is_set_without_jwt_file",
 		wantErr: errors.New("google.delegated_account can only be provided with a jwt_file accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":                 "google",
 				"google.credentials_file":  "./testdata/credentials.json",
 				"google.delegated_account": "delegated@account.com",
@@ -714,8 +714,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "google_must_work_with_delegated_account_and_a_valid_jwt_file",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":                 "google",
 				"google.jwt_file":          "./testdata/credentials.json",
 				"google.delegated_account": "delegated@account.com",
@@ -725,8 +725,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "unique_okta_jwk_token",
 		wantErr: errors.New("okta validation error: one of okta.jwk_json, okta.jwk_file or okta.jwk_pem must be provided accessing 'auth.oauth2'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":  "okta",
 				"client.id": "a_client_id",
 				"token_url": "localhost",
@@ -737,8 +737,8 @@ var oAuth2ValidationTests = []struct {
 	{
 		name:    "invalid_okta_jwk_json",
 		wantErr: errors.New("the field can't be converted to valid JSON accessing 'auth.oauth2.okta.jwk_json'"),
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":      "okta",
 				"client.id":     "a_client_id",
 				"token_url":     "localhost",
@@ -749,8 +749,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "okta_successful_oauth2_validation",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":      "okta",
 				"client.id":     "a_client_id",
 				"token_url":     "localhost",
@@ -761,8 +761,8 @@ var oAuth2ValidationTests = []struct {
 	},
 	{
 		name: "okta_successful_pem_oauth2_validation",
-		input: map[string]interface{}{
-			"auth.oauth2": map[string]interface{}{
+		input: map[string]any{
+			"auth.oauth2": map[string]any{
 				"provider":  "okta",
 				"client.id": "a_client_id",
 				"token_url": "localhost",
@@ -828,32 +828,32 @@ func TestConfigOauth2Validation(t *testing.T) {
 
 var keepAliveTests = []struct {
 	name    string
-	input   map[string]interface{}
+	input   map[string]any
 	want    httpcommon.WithKeepaliveSettings
 	wantErr error
 }{
 	{
 		name:  "keep_alive_none", // Default to the old behaviour of true.
-		input: map[string]interface{}{},
+		input: map[string]any{},
 		want:  httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_true",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"resource.keep_alive.disable": true,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_false",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"resource.keep_alive.disable": false,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: false},
 	},
 	{
 		name: "keep_alive_invalid_max",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"resource.keep_alive.disable":              false,
 			"resource.keep_alive.max_idle_connections": -1,
 		},

--- a/x-pack/filebeat/input/cel/input.go
+++ b/x-pack/filebeat/input/cel/input.go
@@ -1332,8 +1332,8 @@ func getResourceAttributes(env v2.Context, cfg config) []attribute.KeyValue {
 		seen[attr.Key] = true
 	}
 
-	pairs := strings.Split(attributes, ",")
-	for _, pair := range pairs {
+	pairs := strings.SplitSeq(attributes, ",")
+	for pair := range pairs {
 		key, val, ok := strings.Cut(pair, "=")
 		if !ok || key == "" || seen[attribute.Key(key)] {
 			continue
@@ -1499,7 +1499,7 @@ func regexpsFromConfig(cfg config) (map[string]*regexp.Regexp, error) {
 
 var (
 	// mimetypes holds supported MIME type mappings.
-	mimetypes = map[string]interface{}{
+	mimetypes = map[string]any{
 		"application/gzip":         func(r io.Reader) (io.Reader, error) { return gzip.NewReader(r) },
 		"application/x-ndjson":     lib.NDJSON,
 		"application/zip":          lib.Zip,
@@ -1566,7 +1566,7 @@ func newProgram(ctx context.Context, src, root string, vars map[string]string, c
 			}
 			return m
 		}),
-		lib.Globals(map[string]interface{}{
+		lib.Globals(map[string]any{
 			"useragent":            userAgent,
 			"env":                  vars,
 			"remaining_executions": 0, // placeholder
@@ -1619,9 +1619,9 @@ func debug(log *logp.Logger, trace *httplog.LoggingRoundTripper) func(string, an
 	}
 }
 
-func evalWith(ctx context.Context, contextInjector *otel.ContextInjector, prg cel.Program, ast *cel.Ast, state map[string]interface{}, now time.Time, details bool, budget int) (map[string]interface{}, error) {
+func evalWith(ctx context.Context, contextInjector *otel.ContextInjector, prg cel.Program, ast *cel.Ast, state map[string]any, now time.Time, details bool, budget int) (map[string]any, error) {
 	contextInjector.SetContext(ctx)
-	out, det, err := prg.ContextEval(ctx, map[string]interface{}{
+	out, det, err := prg.ContextEval(ctx, map[string]any{
 		// Replace global program "now" with current time. This is necessary
 		// as the lib.Time now global is static at program instantiation time
 		// which will persist over multiple evaluations. The lib.Time behaviour
@@ -1653,7 +1653,7 @@ func evalWith(ctx context.Context, contextInjector *otel.ContextInjector, prg ce
 		return state, fmt.Errorf("failed eval: %w", err)
 	}
 
-	v, err := out.ConvertToNative(reflect.TypeOf((*structpb.Struct)(nil)))
+	v, err := out.ConvertToNative(reflect.TypeFor[*structpb.Struct]())
 	if err != nil {
 		state["events"] = errorMessage(fmt.Sprintf("failed proto conversion: %v", err))
 		clearWantMore(state)
@@ -1705,14 +1705,14 @@ func (e dumpError) writeToFile(path string) (err error) {
 // It leaves state intact if there is no "want_more" element, and sets the element to false
 // if there is. This is necessary instead of just doing delete(state, "want_more") as
 // client CEL code may expect the want_more field to be present.
-func clearWantMore(state map[string]interface{}) {
+func clearWantMore(state map[string]any) {
 	if _, ok := state["want_more"]; ok {
 		state["want_more"] = false
 	}
 }
 
-func errorMessage(msg string) map[string]interface{} {
-	return map[string]interface{}{"error": map[string]interface{}{"message": msg}}
+func errorMessage(msg string) map[string]any {
+	return map[string]any{"error": map[string]any{"message": msg}}
 }
 
 // retryLog is a shim for the retryablehttp.Client.Logger.
@@ -1722,10 +1722,10 @@ func newRetryLog(log *logp.Logger) *retryLog {
 	return &retryLog{log: log.Named("retryablehttp").WithOptions(zap.AddCallerSkip(1))}
 }
 
-func (l *retryLog) Error(msg string, kv ...interface{}) { l.log.Errorw(msg, kv...) }
-func (l *retryLog) Info(msg string, kv ...interface{})  { l.log.Infow(msg, kv...) }
-func (l *retryLog) Debug(msg string, kv ...interface{}) { l.log.Debugw(msg, kv...) }
-func (l *retryLog) Warn(msg string, kv ...interface{})  { l.log.Warnw(msg, kv...) }
+func (l *retryLog) Error(msg string, kv ...any) { l.log.Errorw(msg, kv...) }
+func (l *retryLog) Info(msg string, kv ...any)  { l.log.Infow(msg, kv...) }
+func (l *retryLog) Debug(msg string, kv ...any) { l.log.Debugw(msg, kv...) }
+func (l *retryLog) Warn(msg string, kv ...any)  { l.log.Warnw(msg, kv...) }
 
 func test(url *url.URL) error {
 	port := func() string {
@@ -1784,8 +1784,8 @@ func cloneMap(dst, src mapstr.M) {
 			d := make(mapstr.M, len(v))
 			dst[k] = d
 			cloneMap(d, v)
-		case map[string]interface{}:
-			d := make(map[string]interface{}, len(v))
+		case map[string]any:
+			d := make(map[string]any, len(v))
 			dst[k] = d
 			cloneMap(d, v)
 		case []mapstr.M:
@@ -1796,10 +1796,10 @@ func cloneMap(dst, src mapstr.M) {
 				a = append(a, d)
 			}
 			dst[k] = a
-		case []map[string]interface{}:
-			a := make([]map[string]interface{}, 0, len(v))
+		case []map[string]any:
+			a := make([]map[string]any, 0, len(v))
 			for _, m := range v {
-				d := make(map[string]interface{}, len(m))
+				d := make(map[string]any, len(m))
 				cloneMap(d, m)
 				a = append(a, d)
 			}
@@ -1825,22 +1825,22 @@ func walkMap(m mapstr.M, path string, fn func(parent mapstr.M, key string)) {
 	switch v := v.(type) {
 	case mapstr.M:
 		walkMap(v, rest, fn)
-	case map[string]interface{}:
+	case map[string]any:
 		walkMap(v, rest, fn)
 	case []mapstr.M:
 		for _, m := range v {
 			walkMap(m, rest, fn)
 		}
-	case []map[string]interface{}:
+	case []map[string]any:
 		for _, m := range v {
 			walkMap(m, rest, fn)
 		}
-	case []interface{}:
+	case []any:
 		for _, v := range v {
 			switch m := v.(type) {
 			case mapstr.M:
 				walkMap(m, rest, fn)
-			case map[string]interface{}:
+			case map[string]any:
 				walkMap(m, rest, fn)
 			}
 		}

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -48,13 +48,13 @@ var userAgent = useragent.UserAgent("Filebeat", version.GetDefaultVersion(), "",
 var inputTests = []struct {
 	name                string
 	remote              bool
-	server              func(*testing.T, http.HandlerFunc, map[string]interface{})
+	server              func(*testing.T, http.HandlerFunc, map[string]any)
 	handler             http.HandlerFunc
-	config              map[string]interface{}
+	config              map[string]any
 	time                func() time.Time
-	persistCursor       map[string]interface{}
-	want                []map[string]interface{}
-	wantCursor          []map[string]interface{}
+	persistCursor       map[string]any
+	want                []map[string]any
+	wantCursor          []map[string]any
 	wantErr             error
 	prepare             func() error
 	wantFile            string
@@ -64,99 +64,99 @@ var inputTests = []struct {
 	// Autonomous tests (no FS or net dependency).
 	{
 		name: "hello_world",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":"Hello, World!"}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "Hello, World!"},
 		},
 	},
 	{
 		name: "hello_world_sprintf",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":sprintf("Hello, %s!", ["World"])}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "Hello, World!"},
 		},
 	},
 	{
 		name: "hello_world_time",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":{"Hello, World!": now}}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
 		time: func() time.Time { return time.Date(2010, 2, 8, 0, 0, 0, 0, time.UTC) },
-		want: []map[string]interface{}{{
-			"message": map[string]interface{}{
+		want: []map[string]any{{
+			"message": map[string]any{
 				"Hello, World!": "2010-02-08T00:00:00Z",
 			},
 		}},
 	},
 	{
 		name: "hello_world_sum",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":string(sum([1,2,3,4]))}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{{
+		want: []map[string]any{{
 			"message": "10",
 		}},
 	},
 	{
 		name: "hello_world_bytes",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":string(hex_decode("68656c6c6f20776f726c64"))}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{{
+		want: []map[string]any{{
 			"message": "hello world",
 		}},
 	},
 	{
 		name: "hello_world_front_and_tail_2",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":front([1,2,3,4,5],2)}, {"message":tail([1,2,3,4,5],2)}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": []any{1.0, 2.0}},
 			{"message": []any{3.0, 4.0, 5.0}},
 		},
 	},
 	{
 		name: "bad_events_type",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":["Hello, World!"]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
@@ -164,42 +164,42 @@ var inputTests = []struct {
 	},
 	{
 		name: "hello_world_non_nil_state",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":"Hello, World!"}]}`,
-			"state":    map[string]interface{}{},
-			"resource": map[string]interface{}{
+			"state":    map[string]any{},
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "Hello, World!"},
 		},
 	},
 	{
 		name: "what_is_next",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":"Hello, World!"}],"cursor":[{"todo":"What's next?"}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "Hello, World!"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"todo": "What's next?"},
 		},
 	},
 	{
 		name: "bad_cursor_type",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":"Hello, World!"}],"cursor":["What's next?"]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
@@ -207,37 +207,37 @@ var inputTests = []struct {
 	},
 	{
 		name: "show_state",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[state]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"url": ""},
 		},
 	},
 	{
 		name: "show_provided_state",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[state]}`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"we":   "can",
 				"put":  []string{"a", "bunch"},
 				"of":   "stuff",
 				"here": "!",
 			},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"we":   "can",
-				"put":  []interface{}{"a", "bunch"}, // We lose typing.
+				"put":  []any{"a", "bunch"}, // We lose typing.
 				"of":   "stuff",
 				"here": "!",
 				"url":  "",
@@ -246,7 +246,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "iterative_state",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	{
@@ -259,20 +259,20 @@ var inputTests = []struct {
 		"data": state.data, // Make sure we have this for the next iteration.
 	}
 	`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"data":   []string{"first", "second", "third"},
 				"cursor": map[string]int{"next": 0},
 			},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "first"},
 			{"message": "second"},
 			{"message": "third"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			// The serialisation of numbers is to float when under 1<<53 (strings above).
 			// This is not visible within CEL, but presents in Go testing.
 			{"next": 1.0},
@@ -282,7 +282,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "iterative_state_implicit_initial_cursor",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	int(has(state.cursor) && has(state.cursor.next) ? state.cursor.next : 0).as(index, {
@@ -295,19 +295,19 @@ var inputTests = []struct {
 		"data": state.data, // Make sure we have this for the next iteration.
 	})
 	`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"data": []string{"first", "second", "third"},
 			},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "first"},
 			{"message": "second"},
 			{"message": "third"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			// The serialisation of numbers is to float when under 1<<53 (strings above).
 			// This is not visible within CEL, but presents in Go testing.
 			{"next": 1.0},
@@ -317,7 +317,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "iterative_state_provided_stored_cursor",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	{
@@ -330,22 +330,22 @@ var inputTests = []struct {
 		"data": state.data, // Make sure we have this for the next iteration.
 	}
 	`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"data":   []string{"first", "second", "third"},
 				"cursor": map[string]int{"next": 0},
 			},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		persistCursor: map[string]interface{}{
+		persistCursor: map[string]any{
 			"next": 1,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "second"},
 			{"message": "third"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			// The serialisation of numbers is to float when under 1<<53 (strings above).
 			// This is not visible within CEL, but presents in Go testing.
 			{"next": 2.0},
@@ -354,7 +354,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "iterative_state_implicit_initial_cursor_provided_stored_cursor",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	int(has(state.cursor) && has(state.cursor.next) ? state.cursor.next : 0).as(index, {
@@ -367,21 +367,21 @@ var inputTests = []struct {
 		"data": state.data, // Make sure we have this for the next iteration.
 	})
 	`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"data": []string{"first", "second", "third"},
 			},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		persistCursor: map[string]interface{}{
+		persistCursor: map[string]any{
 			"next": 1,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "second"},
 			{"message": "third"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			// The serialisation of numbers is to float when under 1<<53 (strings above).
 			// This is not visible within CEL, but presents in Go testing.
 			{"next": 2.0},
@@ -390,7 +390,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "strings_split",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	{
@@ -401,14 +401,14 @@ var inputTests = []struct {
 		)
 	}
 	`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"data": "first:second:third",
 			},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "first"},
 			{"message": "second"},
 			{"message": "third"},
@@ -416,7 +416,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "optional_types",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			// Program returns a compilation error if optional types are not enabled.
 			"program": `{"events":[
@@ -426,17 +426,17 @@ var inputTests = []struct {
 					{"message":"Hello, Void!"}
 			]}`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "Hello, Void!"},
 		},
 	},
 	{
 		name: "env_var_static",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"allowed_environment": []string{
 				"CELTESTENVVAR",
@@ -448,11 +448,11 @@ var inputTests = []struct {
 				{"message":env.?DISALLOWEDCELTESTENVVAR.orValue("not present")},
 			]}`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "TESTVALUE"},
 			{"message": "not present"},
 			{"message": "not present"},
@@ -460,7 +460,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "env_var_dynamic",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"allowed_environment": []string{
 				"CELTESTENVVAR",
@@ -470,11 +470,11 @@ var inputTests = []struct {
 				{"message":env[?k].orValue("not present")}
 			)}`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "TESTVALUE"},
 			{"message": "not present"},
 			{"message": "not present"},
@@ -483,7 +483,7 @@ var inputTests = []struct {
 	{
 		// This test exists purely to demonstrate that the lib is available.
 		name: "aws_signing_static",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `{"events": [{
 				"message": post_request("http://www.example.com/", "text/plain", "request data").sign_aws_from_static(
@@ -499,73 +499,73 @@ var inputTests = []struct {
 				).Header.Authorization[?0].orValue("nope")
 			}]}`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "AWS4-HMAC-SHA256 Credential=id/20091110/region/service/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token, Signature=ad27046c0009e06c6626e6009ba2af96027f4893b7a190ab67aaec85becb25cd"},
 		},
 	},
 	{
 		// This test exists purely to demonstrate that the lib is available.
 		name: "optional_types_v2",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `{"events": [{
 				"message": optional.unwrap([optional.of(42), optional.none()]).encode_json(),
 			}]}`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "[42]"},
 		},
 	},
 	{
 		// This test exists purely to demonstrate that the lib is available.
 		name: "two_var_comprehension_v2",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `{"events": [{
 				"message": {'hello': 'world'}.transformMap(k, v, v + '!').encode_json(),
 			}]}`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": `{"hello":"world!"}`},
 		},
 	},
 	{
 		name: "timestamp_round",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":timestamp("2009-11-10T23:00:00Z").round(duration("24h"))}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{{
+		want: []map[string]any{{
 			"message": "2009-11-11T00:00:00Z",
 		}},
 	},
 	{
 		name: "timestamp_truncate",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":timestamp("2009-11-10T23:00:00Z").truncate(duration("24h"))}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{{
+		want: []map[string]any{{
 			"message": "2009-11-10T00:00:00Z",
 		}},
 	},
@@ -573,34 +573,34 @@ var inputTests = []struct {
 	// Emit tests.
 	{
 		name: "emit_no_cursor",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[], "emit_result": [{"message":"hello"},{"message":"world"}].emit(e, e)}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "hello"},
 			{"message": "world"},
 		},
 	},
 	{
 		name: "emit_with_cursor",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[], "emit_result": [{"message":"hello","id":1},{"message":"world","id":2}].emit(e, {"message":e.message}, {"id":e.id})}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"message": "hello"},
 			{"message": "world"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"id": int64(1)},
 			{"id": int64(2)},
 		},
@@ -609,7 +609,7 @@ var inputTests = []struct {
 	// Emit error-handling pattern (mirrors the documented example).
 	{
 		name: "emit_error_handling_success",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	[{"msg":"a"},{"msg":"b"}].emit(e, e, {"id": e.msg}).as(r,
@@ -620,16 +620,16 @@ var inputTests = []struct {
 	)
 	`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"msg": "a"},
 			{"msg": "b"},
-			{"published": float64(2), "cursor": map[string]interface{}{"id": "b"}},
+			{"published": float64(2), "cursor": map[string]any{"id": "b"}},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"id": "a"},
 			{"id": "b"},
 			{"id": "b"},
@@ -637,7 +637,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "emit_error_handling_failure",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	[{"msg":"a"}, "bad"].emit(e, e, {"id": "x"}).as(r,
@@ -648,15 +648,15 @@ var inputTests = []struct {
 	)
 	`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"msg": "a"},
 			{"error": "emit: event must be a map, got string"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"id": "x"},
 		},
 	},
@@ -664,7 +664,7 @@ var inputTests = []struct {
 	// Stream decode tests.
 	{
 		name: "decode_csv_stream_lazy_gzip",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	base64_decode(
@@ -680,18 +680,18 @@ var inputTests = []struct {
 	)
 	`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"name": "Alice", "age": "30", "city": "New York"},
 			{"name": "Bob", "age": "25", "city": "London"},
 		},
 	},
 	{
 		name: "decode_csv_stream_lazy_no_header_gzip",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	base64_decode(
@@ -706,18 +706,18 @@ var inputTests = []struct {
 	)
 	`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
-			{"fields": []interface{}{"Alice", "30", "New York"}},
-			{"fields": []interface{}{"Bob", "25", "London"}},
+		want: []map[string]any{
+			{"fields": []any{"Alice", "30", "New York"}},
+			{"fields": []any{"Bob", "25", "London"}},
 		},
 	},
 	{
 		name: "decode_lines_gzip",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	base64_decode(
@@ -733,11 +733,11 @@ var inputTests = []struct {
 	)
 	`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"line": "hello world"},
 			{"line": "foo bar"},
 			{"line": "baz qux"},
@@ -745,7 +745,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "emit_with_decode_lines_gzip",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	base64_decode(
@@ -764,11 +764,11 @@ var inputTests = []struct {
 	)
 	`,
 			"state": nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"line": "hello world"},
 			{"line": "foo bar"},
 			{"line": "baz qux"},
@@ -778,42 +778,42 @@ var inputTests = []struct {
 	// FS-based tests.
 	{
 		name: "ndjson_log_file_simple",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events": try(file(state.url, "application/x-ndjson").map(e, try(e, "error.message")), "file.error")}`,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "testdata/log-1.ndjson",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"level": "info", "message": "something happened"},
 			{"level": "error", "message": "something bad happened"},
 		},
 	},
 	{
 		name: "ndjson_log_file_simple_file_scheme",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events": try(file(state.url, "application/x-ndjson").map(e, try(e, "error.message")), "file.error")}`,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": fileSchemePath("testdata/log-1.ndjson"),
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"level": "info", "message": "something happened"},
 			{"level": "error", "message": "something bad happened"},
 		},
 	},
 	{
 		name: "ndjson_log_file_corrupted",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events": try(file(state.url, "application/x-ndjson").map(e, try(e, "error.message")), "file.error")}`,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "testdata/corrupted-log-1.ndjson",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"level": "info", "message": "something happened"},
 			{"error.message": `unexpected end of JSON input: {"message":"Dave, stop. Stop, will you? Stop, Dave. Will you stop, Dave? Stop, Dave."`},
 			{"level": "error", "message": "something bad happened"},
@@ -821,14 +821,14 @@ var inputTests = []struct {
 	},
 	{
 		name: "missing_file",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events": try(file(state.url, "application/x-ndjson").map(e, try(e, "error.message")), "file.error")}`,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "testdata/absent.ndjson",
 			},
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"file.error": "file: " + missingFileError("testdata/absent.ndjson")},
 		},
 	},
@@ -836,7 +836,7 @@ var inputTests = []struct {
 	// Decoder tests.
 	{
 		name: "decode_xml",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				const text = `<?xml version="1.0" encoding="UTF-8"?>
 <order orderid="56733" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="sales.xsd">
@@ -865,7 +865,7 @@ var inputTests = []struct {
 			config["resource.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(get(state.url).Body).as(body, {
@@ -910,18 +910,18 @@ var inputTests = []struct {
 			},
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"order": map[string]interface{}{
-					"address": map[string]interface{}{
+				"order": map[string]any{
+					"address": map[string]any{
 						"address": "Beekplantsoen 594, 2 hoog, 6849 IG",
 						"city":    "Boekend",
 						"company": "Sydøstlige Gruppe",
 						"country": "Netherlands",
 						"name":    "Joord Lennart",
 					},
-					"item": []interface{}{
-						map[string]interface{}{
+					"item": []any{
+						map[string]any{
 							"cost":   99.95,
 							"name":   "Egil's Saga",
 							"note":   "Free Sample",
@@ -942,7 +942,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_request",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(get(state.url).Body).as(body, {
@@ -951,15 +951,15 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -971,7 +971,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_request_check_user_agent_default",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).Body.as(body, {
@@ -993,15 +993,15 @@ var inputTests = []struct {
 
 			w.Write([]byte(msg))
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1013,7 +1013,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_request_check_user_agent_user_defined",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get_request(state.url).with({
@@ -1041,15 +1041,15 @@ var inputTests = []struct {
 
 			w.Write([]byte(msg))
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1061,7 +1061,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_headers",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":         1,
 			"resource.headers": http.Header{"foo": {"bar"}},
 			"program": `
@@ -1074,7 +1074,7 @@ var inputTests = []struct {
 			enc := json.NewEncoder(w)
 			enc.Encode(map[string][]any{"events": {r.Header.Get("foo")}})
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"events": []any{"bar"},
 			},
@@ -1083,7 +1083,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_max_body_size_ok",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":               1,
 			"resource.max_body_size": int64(6),
 			"program": `
@@ -1095,7 +1095,7 @@ var inputTests = []struct {
 		handler: func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("hello"))
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"message": "hello",
 			},
@@ -1104,7 +1104,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_max_body_size_too_big",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":               1,
 			"resource.max_body_size": int64(4),
 			"program": `
@@ -1116,7 +1116,7 @@ var inputTests = []struct {
 		handler: func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("hello"))
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"error": map[string]any{
 					"message": `failed eval: ERROR: <input>:2:5: response body too big
@@ -1129,7 +1129,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_request_check_user_agent_none",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get_request(state.url).with({
@@ -1155,15 +1155,15 @@ var inputTests = []struct {
 
 			w.Write([]byte(msg))
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1175,7 +1175,7 @@ var inputTests = []struct {
 	{
 		name:   "GET_request_TLS",
 		server: newTestServer(httptest.NewTLSServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                       1,
 			"resource.ssl.verification_mode": "none",
 			"program": `
@@ -1185,15 +1185,15 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1205,7 +1205,7 @@ var inputTests = []struct {
 	{
 		name:   "retry_after_request",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).as(resp, {
@@ -1217,14 +1217,14 @@ var inputTests = []struct {
 	`,
 		},
 		handler: retryAfterHandler("1"),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"hello": "world"},
 		},
 	},
 	{
 		name:   "retry_after_request_time",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).as(resp, {
@@ -1236,14 +1236,14 @@ var inputTests = []struct {
 	`,
 		},
 		handler: retryAfterHandler(time.Now().Add(time.Second).UTC().Format(http.TimeFormat)),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"hello": "world"},
 		},
 	},
 	{
 		name:   "rate_limit_request_0",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).as(resp, {
@@ -1256,14 +1256,14 @@ var inputTests = []struct {
 	`,
 		},
 		handler: rateLimitHandler("0", 100*time.Millisecond),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"hello": "world"},
 		},
 	},
 	{
 		name:   "rate_limit_request_10",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).as(resp, {
@@ -1276,14 +1276,14 @@ var inputTests = []struct {
 	`,
 		},
 		handler: rateLimitHandler("10", 100*time.Millisecond),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"hello": "world"},
 		},
 	},
 	{
 		name:   "rate_limit_request_10_too_slow",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).as(resp, {
@@ -1296,12 +1296,12 @@ var inputTests = []struct {
 	`,
 		},
 		handler: rateLimitHandler("10", 10*time.Second),
-		want:    []map[string]interface{}{},
+		want:    []map[string]any{},
 	},
 	{
 		name:   "retry_failure",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).as(resp, {
@@ -1313,17 +1313,17 @@ var inputTests = []struct {
 	`,
 		},
 		handler: retryHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"hello": "world"},
 		},
 	},
 	{
 		name:   "retry_failure_no_success",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
-			"resource": map[string]interface{}{
-				"retry": map[string]interface{}{
+			"resource": map[string]any{
+				"retry": map[string]any{
 					"max_attempts": 2,
 				},
 			},
@@ -1343,7 +1343,7 @@ var inputTests = []struct {
 			//nolint:errcheck // No point checking errors in test server.
 			w.Write([]byte(`{"error":"we were too slow"}`))
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"error": "we were too slow"},
 			{"status": float64(504)}, // Float because of JSON.
 		},
@@ -1352,7 +1352,7 @@ var inputTests = []struct {
 	{
 		name:   "POST_request",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(post(state.url, "application/json", '{"test":"abc"}').Body).as(body, {
@@ -1362,15 +1362,15 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodPost, `{"test":"abc"}`),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1382,7 +1382,7 @@ var inputTests = []struct {
 	{
 		name:   "repeated_POST_request",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": "100ms",
 			"program": `
 	bytes(post(state.url, "application/json", '{"test":"abc"}').Body).as(body, {
@@ -1392,15 +1392,15 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodPost, `{"test":"abc"}`),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1408,13 +1408,13 @@ var inputTests = []struct {
 				},
 			},
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1426,7 +1426,7 @@ var inputTests = []struct {
 	{
 		name:   "split_events",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(get(state.url).Body).as(body, {
@@ -1435,13 +1435,13 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"world": "moon",
 			},
 			{
-				"space": []interface{}{
-					map[string]interface{}{
+				"space": []any{
+					map[string]any{
 						"cake": "pumpkin",
 					},
 				},
@@ -1451,7 +1451,7 @@ var inputTests = []struct {
 	{
 		name:   "split_events_keep_parent",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(get(state.url).Body).as(body, {
@@ -1463,16 +1463,16 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": map[string]interface{}{
+				"hello": map[string]any{
 					"world": "moon",
 				},
 			},
 			{
-				"hello": map[string]interface{}{
-					"space": []interface{}{
-						map[string]interface{}{
+				"hello": map[string]any{
+					"space": []any{
+						map[string]any{
 							"cake": "pumpkin",
 						},
 					},
@@ -1483,7 +1483,7 @@ var inputTests = []struct {
 	{
 		name:   "nested_split_events",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(get(state.url).Body).decode_json().as(e0, {
@@ -1498,12 +1498,12 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"world": "moon",
 			},
 			{
-				"space": map[string]interface{}{
+				"space": map[string]any{
 					"cake": "pumpkin",
 				},
 			},
@@ -1512,7 +1512,7 @@ var inputTests = []struct {
 	{
 		name:   "absent_split",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(get(state.url).Body).decode_json().as(e, {
@@ -1527,16 +1527,16 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want:    []map[string]interface{}(nil),
+		want:    []map[string]any(nil),
 	},
 
 	// Cursor/pagination tests.
 	{
 		name:   "date_cursor",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"fake_now": "2002-10-02T15:00:00Z",
 			},
 			"program": `
@@ -1561,12 +1561,12 @@ var inputTests = []struct {
 	`,
 		},
 		handler: dateCursorHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:02Z", "foo": "bar"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"timestamp": "2002-10-02T15:00:00Z"},
 			{"timestamp": "2002-10-02T15:00:01Z"},
 			{"timestamp": "2002-10-02T15:00:02Z"},
@@ -1574,15 +1574,15 @@ var inputTests = []struct {
 	},
 	{
 		name: "tracer_filename_sanitization",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["resource.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                 1,
 			"resource.tracer.filename": "cel/logs/http-request-trace-*.ndjson",
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"fake_now": "2002-10-02T15:00:00Z",
 			},
 			"program": `
@@ -1607,12 +1607,12 @@ var inputTests = []struct {
 	`,
 		},
 		handler: dateCursorHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:02Z", "foo": "bar"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"timestamp": "2002-10-02T15:00:00Z"},
 			{"timestamp": "2002-10-02T15:00:01Z"},
 			{"timestamp": "2002-10-02T15:00:02Z"},
@@ -1621,16 +1621,16 @@ var inputTests = []struct {
 	},
 	{
 		name: "tracer_filename_sanitization_enabled",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["resource.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                 1,
 			"resource.tracer.enabled":  true,
 			"resource.tracer.filename": "cel/logs/http-request-trace-*.ndjson",
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"fake_now": "2002-10-02T15:00:00Z",
 			},
 			"program": `
@@ -1655,12 +1655,12 @@ var inputTests = []struct {
 	`,
 		},
 		handler: dateCursorHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:02Z", "foo": "bar"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"timestamp": "2002-10-02T15:00:00Z"},
 			{"timestamp": "2002-10-02T15:00:01Z"},
 			{"timestamp": "2002-10-02T15:00:02Z"},
@@ -1669,16 +1669,16 @@ var inputTests = []struct {
 	},
 	{
 		name: "tracer_filename_sanitization_disabled",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["resource.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                 1,
 			"resource.tracer.enabled":  false,
 			"resource.tracer.filename": "cel/logs/http-request-trace-*.ndjson",
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"fake_now": "2002-10-02T15:00:00Z",
 			},
 			"program": `
@@ -1703,12 +1703,12 @@ var inputTests = []struct {
 	`,
 		},
 		handler: dateCursorHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"@timestamp": "2002-10-02T15:00:00Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:01Z", "foo": "bar"},
 			{"@timestamp": "2002-10-02T15:00:02Z", "foo": "bar"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"timestamp": "2002-10-02T15:00:00Z"},
 			{"timestamp": "2002-10-02T15:00:01Z"},
 			{"timestamp": "2002-10-02T15:00:02Z"},
@@ -1723,7 +1723,7 @@ var inputTests = []struct {
 	{
 		name:   "tracer_disabled_escaping_logs",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                 1,
 			"resource.tracer.enabled":  false,
 			"resource.tracer.filename": "/var/log/http-request-trace-*.ndjson",
@@ -1735,7 +1735,7 @@ var inputTests = []struct {
 	{
 		name:   "pagination_cursor_object",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	(!is_error(state.cursor.page) ?
@@ -1752,11 +1752,11 @@ var inputTests = []struct {
 	`,
 		},
 		handler: paginationHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"foo": "a"},
 			{"foo": "b"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"page": "bar"},
 			{"page": ""},
 		},
@@ -1764,7 +1764,7 @@ var inputTests = []struct {
 	{
 		name:   "pagination_cursor_array",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	(!is_error(state.cursor.page) ?
@@ -1785,11 +1785,11 @@ var inputTests = []struct {
 	`,
 		},
 		handler: paginationHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"foo": "a"},
 			{"foo": "b"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"page": "bar"},
 			{"page": ""},
 		},
@@ -1801,7 +1801,7 @@ var inputTests = []struct {
 		// retaining identity in "first" doesn't follow a logic that I understand.
 		name:   "first_event_cursor",
 		server: newTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	(!is_error(state.cursor.page) ?
@@ -1823,13 +1823,13 @@ var inputTests = []struct {
 	`,
 		},
 		handler: paginationHandler(),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"first": "none", "foo": "a"},
 			{"first": "a", "foo": "b"},
 			{"first": "b", "foo": "c"},
 			{"first": "c", "foo": "d"},
 		},
-		wantCursor: []map[string]interface{}{
+		wantCursor: []map[string]any{
 			{"first": "a", "page": "bar"},
 			{"first": "b", "page": ""},
 			{"first": "c", "page": ""},
@@ -1840,12 +1840,12 @@ var inputTests = []struct {
 	// Authenticated access tests.
 	{
 		name: "basic_accept",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":            1,
 			"auth.basic.user":     "test_client",
 			"auth.basic.password": "secret_password",
@@ -1859,15 +1859,15 @@ var inputTests = []struct {
 			fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("test_client:secret_password"))),
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1878,12 +1878,12 @@ var inputTests = []struct {
 	},
 	{
 		name: "basic_reject",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":            1,
 			"auth.basic.user":     "test_client",
 			"auth.basic.password": "pleeassssee",
@@ -1897,7 +1897,7 @@ var inputTests = []struct {
 			fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("test_client:secret_password"))),
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"error": "not authorized",
 			},
@@ -1905,12 +1905,12 @@ var inputTests = []struct {
 	},
 	{
 		name: "token_accept",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":         1,
 			"auth.token.type":  "Token",
 			"auth.token.value": "sssh_super_secret_token",
@@ -1924,15 +1924,15 @@ var inputTests = []struct {
 			"Token sssh_super_secret_token",
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -1943,12 +1943,12 @@ var inputTests = []struct {
 	},
 	{
 		name: "token_reject",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":         1,
 			"auth.token.type":  "Token",
 			"auth.token.value": "leaked_but_rolled_over_token_found_on_github",
@@ -1962,7 +1962,7 @@ var inputTests = []struct {
 			"Token sssh_super_secret_token",
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"error": "not authorized",
 			},
@@ -1970,7 +1970,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "file_auth_default_header",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			dir := t.TempDir()
 			secret := "file-secret"
 			path := filepath.Join(dir, "auth_token")
@@ -1982,7 +1982,7 @@ var inputTests = []struct {
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                   1,
 			"auth.file.prefix":           "Bearer ",
 			"auth.file.refresh_interval": "100ms",
@@ -1996,15 +1996,15 @@ var inputTests = []struct {
 			"Bearer file-secret",
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2015,7 +2015,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "file_auth_custom_header",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			dir := t.TempDir()
 			tokenPath := filepath.Join(dir, "api_token")
 			if err := os.WriteFile(tokenPath, []byte("secret-api-token\n"), 0o600); err != nil {
@@ -2028,7 +2028,7 @@ var inputTests = []struct {
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	bytes(get(state.url).Body).as(body, {
@@ -2041,15 +2041,15 @@ var inputTests = []struct {
 			"X-API-Key",
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2060,12 +2060,12 @@ var inputTests = []struct {
 	},
 	{
 		name: "digest_accept",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":             1,
 			"auth.digest.user":     "test_client",
 			"auth.digest.password": "secret_password",
@@ -2082,15 +2082,15 @@ var inputTests = []struct {
 			"random_string",
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2101,12 +2101,12 @@ var inputTests = []struct {
 	},
 	{
 		name: "digest_reject",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":             1,
 			"auth.digest.user":     "test_client",
 			"auth.digest.password": "wrong_secret_password",
@@ -2123,7 +2123,7 @@ var inputTests = []struct {
 			"random_string",
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"error": "not authorized",
 			},
@@ -2133,8 +2133,8 @@ var inputTests = []struct {
 		// Test case modelled on `curl --digest -u test_user:secret_password https://httpbin.org/digest-auth/auth/test_user/secret_password/md5`.
 		name:   "digest_remote",
 		remote: true,
-		server: func(_ *testing.T, _ http.HandlerFunc, _ map[string]interface{}) {},
-		config: map[string]interface{}{
+		server: func(_ *testing.T, _ http.HandlerFunc, _ map[string]any) {},
+		config: map[string]any{
 			"resource.url":         "https://httpbin.org/digest-auth/auth/test_user/secret_password/md5",
 			"interval":             1,
 			"auth.digest.user":     "test_user",
@@ -2145,7 +2145,7 @@ var inputTests = []struct {
 	})
 	`,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
 				"authenticated": true,
 				"user":          "test_user",
@@ -2154,17 +2154,17 @@ var inputTests = []struct {
 	},
 	{
 		name: "OAuth2",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			config["auth.oauth2.token_url"] = s.URL + "/token"
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                  1,
 			"auth.oauth2.client.id":     "a_client_id",
 			"auth.oauth2.client.secret": "a_client_secret",
-			"auth.oauth2.endpoint_params": map[string]interface{}{
+			"auth.oauth2.endpoint_params": map[string]any{
 				"param1": "v1",
 			},
 			"auth.oauth2.scopes": []string{"scope1", "scope2"},
@@ -2177,24 +2177,24 @@ var inputTests = []struct {
 		handler: func(w http.ResponseWriter, r *http.Request) {
 			if r.UserAgent() != userAgent {
 				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(fmt.Sprintf("unexpected UA: %s", r.UserAgent())))
+				w.Write(fmt.Appendf(nil, "unexpected UA: %s", r.UserAgent()))
 				return
 			}
 			oauth2Handler(w, r)
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"hello": "world"},
 		},
 	},
 
 	{
 		name: "Auth AWS V4 Signer",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                   1,
 			"auth.aws.access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 			"auth.aws.secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -2207,15 +2207,15 @@ var inputTests = []struct {
 	`,
 		},
 		handler: awsAuthHandler("AKIAIOSFODNN7EXAMPLE", defaultHandler(http.MethodGet, "")),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2228,12 +2228,12 @@ var inputTests = []struct {
 	// Auth header sanitization in trace logs.
 	{
 		name: "trace_sanitize_basic_auth",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                 1,
 			"auth.basic.user":          "test_client",
 			"auth.basic.password":      "secret_password",
@@ -2249,15 +2249,15 @@ var inputTests = []struct {
 			fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("test_client:secret_password"))),
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2270,12 +2270,12 @@ var inputTests = []struct {
 	},
 	{
 		name: "trace_sanitize_token_auth",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                 1,
 			"auth.token.type":          "Token",
 			"auth.token.value":         "sssh_super_secret_token",
@@ -2291,15 +2291,15 @@ var inputTests = []struct {
 			"Token sssh_super_secret_token",
 			defaultHandler(http.MethodGet, ""),
 		),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2312,17 +2312,17 @@ var inputTests = []struct {
 	},
 	{
 		name: "trace_sanitize_oauth2",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["resource.url"] = s.URL
 			config["auth.oauth2.token_url"] = s.URL + "/token"
 			t.Cleanup(s.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":                  1,
 			"auth.oauth2.client.id":     "a_client_id",
 			"auth.oauth2.client.secret": "a_client_secret",
-			"auth.oauth2.endpoint_params": map[string]interface{}{
+			"auth.oauth2.endpoint_params": map[string]any{
 				"param1": "v1",
 			},
 			"auth.oauth2.scopes":       []string{"scope1", "scope2"},
@@ -2337,12 +2337,12 @@ var inputTests = []struct {
 		handler: func(w http.ResponseWriter, r *http.Request) {
 			if r.UserAgent() != userAgent {
 				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte(fmt.Sprintf("unexpected UA: %s", r.UserAgent())))
+				w.Write(fmt.Appendf(nil, "unexpected UA: %s", r.UserAgent()))
 				return
 			}
 			oauth2Handler(w, r)
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"hello": "world"},
 		},
 		wantFile:            filepath.Join("cel", "logs", "http-request-trace-test_id_trace_sanitize_oauth2.ndjson"),
@@ -2353,7 +2353,7 @@ var inputTests = []struct {
 	{
 		name:   "simple_multistep_GET_request",
 		server: newChainTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	// Get the record IDs.
@@ -2365,15 +2365,15 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2384,7 +2384,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "three_step_GET_request",
-		server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -2399,7 +2399,7 @@ var inputTests = []struct {
 			config["resource.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	// Get the record IDs.
@@ -2413,15 +2413,15 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"hello": []interface{}{
-					map[string]interface{}{
+				"hello": []any{
+					map[string]any{
 						"world": "moon",
 					},
-					map[string]interface{}{
-						"space": []interface{}{
-							map[string]interface{}{
+					map[string]any{
+						"space": []any{
+							map[string]any{
 								"cake": "pumpkin",
 							},
 						},
@@ -2435,7 +2435,7 @@ var inputTests = []struct {
 	{
 		name:   "type_error_message_compile_time",
 		server: newChainTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).Body.decode_json().records.map(r,
@@ -2453,7 +2453,7 @@ var inputTests = []struct {
 	{
 		name:   "type_error_message_run_time",
 		server: newChainTestServer(httptest.NewServer),
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `
 	get(state.url).Body.decode_json().records.map(r,
@@ -2464,9 +2464,9 @@ var inputTests = []struct {
 	`,
 		},
 		handler: defaultHandler(http.MethodGet, ""),
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"error": map[string]interface{}{
+				"error": map[string]any{
 					"message": `failed eval: ERROR: <input>:3:20: no such overload
  |   get(state.url+'/'+r.id).Body.decode_json()).as(events, {
  | ...................^`,
@@ -2477,79 +2477,79 @@ var inputTests = []struct {
 
 	{
 		name: "debug",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":{"value": 1+debug("partial sum", 2+3)}}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
 		time: func() time.Time { return time.Date(2010, 2, 8, 0, 0, 0, 0, time.UTC) },
-		want: []map[string]interface{}{{
-			"message": map[string]interface{}{
+		want: []map[string]any{{
+			"message": map[string]any{
 				"value": 6.0, // float64 due to json encoding.
 			},
 		}},
 	},
 	{
 		name: "debug_error",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":{"value": try(debug("divide by zero", 0/0))}}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
 		time: func() time.Time { return time.Date(2010, 2, 8, 0, 0, 0, 0, time.UTC) },
-		want: []map[string]interface{}{{
-			"message": map[string]interface{}{
+		want: []map[string]any{{
+			"message": map[string]any{
 				"value": "division by zero",
 			},
 		}},
 	},
 	{
 		name: "dump_no_error",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":{"value": try(debug("divide by zero", 0/0))}}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
-			"failure_dump": map[string]interface{}{
+			"failure_dump": map[string]any{
 				"enabled":  true,
 				"filename": "failure_dumps/dump.json",
 			},
 		},
 		time:       func() time.Time { return time.Date(2010, 2, 8, 0, 0, 0, 0, time.UTC) },
 		wantNoFile: filepath.Join("cel", "failure_dumps", "dump-2010-02-08T00-00-00.000.json"),
-		want: []map[string]interface{}{{
-			"message": map[string]interface{}{
+		want: []map[string]any{{
+			"message": map[string]any{
 				"value": "division by zero",
 			},
 		}},
 	},
 	{
 		name: "dump_error",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":{"value": debug("divide by zero", 0/0)}}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
-			"failure_dump": map[string]interface{}{
+			"failure_dump": map[string]any{
 				"enabled":  true,
 				"filename": "failure_dumps/dump.json",
 			},
 		},
 		time:     func() time.Time { return time.Date(2010, 2, 9, 0, 0, 0, 0, time.UTC) },
 		wantFile: filepath.Join("cel", "failure_dumps", "dump-2010-02-09T00-00-00.000.json"), // One day after the no dump case.
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"error": map[string]interface{}{
+				"error": map[string]any{
 					"message": `failed eval: ERROR: <input>:1:58: division by zero
  | {"events":[{"message":{"value": debug("divide by zero", 0/0)}}]}
  | .........................................................^`,
@@ -2559,14 +2559,14 @@ var inputTests = []struct {
 	},
 	{
 		name: "dump_error_delete",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program":  `{"events":[{"message":{"value": debug("divide by zero", 0/0)}}]}`,
 			"state":    nil,
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
-			"failure_dump": map[string]interface{}{
+			"failure_dump": map[string]any{
 				"enabled":  false, // We have a name but are disabled, so delete.
 				"filename": "failure_dumps/dump.json",
 			},
@@ -2581,9 +2581,9 @@ var inputTests = []struct {
 			return os.WriteFile(filepath.Join("cel", "failure_dumps", "dump-2010-02-09T00-00-00.000.json"), nil, 0o600)
 		},
 		wantNoFile: filepath.Join("cel", "failure_dumps", "dump-2010-02-09T00-00-00.000.json"), // One day after the no dump case.
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"error": map[string]interface{}{
+				"error": map[string]any{
 					"message": `failed eval: ERROR: <input>:1:58: division by zero
  | {"events":[{"message":{"value": debug("divide by zero", 0/0)}}]}
  | .........................................................^`,
@@ -2594,7 +2594,7 @@ var inputTests = []struct {
 
 	{
 		name: "max_executions_with_remaining_executions",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval":       1,
 			"max_executions": 5,
 			"program": `debug("STATE", int(state.n).as(n, {
@@ -2603,12 +2603,12 @@ var inputTests = []struct {
 							"want_more":  remaining_executions != 0,
 						}))`,
 			"state": map[string]any{"n": 0},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
 		time: func() time.Time { return time.Date(2010, 2, 9, 0, 0, 0, 0, time.UTC) },
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{"n": float64(1), "remaining_executions": float64(4)},
 			{"n": float64(2), "remaining_executions": float64(3)},
 			{"n": float64(3), "remaining_executions": float64(2)},
@@ -2622,7 +2622,7 @@ var inputTests = []struct {
 	// Coverage
 	{
 		name: "coverage",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"interval": 1,
 			"program": `int(state.n).as(n, {
 							"events": [{"n": n+1}],
@@ -2639,7 +2639,7 @@ var inputTests = []struct {
 						})`,
 			"record_coverage": true,
 			"state":           map[string]any{"n": 0},
-			"resource": map[string]interface{}{
+			"resource": map[string]any{
 				"url": "",
 			},
 		},
@@ -2649,7 +2649,7 @@ var inputTests = []struct {
 		// the test construction that asks that we get at least as many
 		// results from the input as there are elements in the want slice
 		// and then stop.
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			// First periodic run.
 			{"n": float64(1)},
 			{"n": float64(2)},
@@ -2842,14 +2842,14 @@ type publisher struct {
 	done      func()
 	mu        sync.Mutex
 	published []beat.Event
-	cursors   []map[string]interface{}
+	cursors   []map[string]any
 }
 
-func (p *publisher) Publish(e beat.Event, cursor interface{}) error {
+func (p *publisher) Publish(e beat.Event, cursor any) error {
 	p.mu.Lock()
 	p.published = append(p.published, e)
 	if cursor != nil {
-		c, ok := cursor.(map[string]interface{})
+		c, ok := cursor.(map[string]any)
 		if !ok {
 			return fmt.Errorf("invalid cursor type for testing: %T", cursor)
 		}
@@ -2878,16 +2878,16 @@ func missingFileError(path string) string {
 	return fmt.Sprint(err)
 }
 
-func newTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, http.HandlerFunc, map[string]interface{}) {
-	return func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+func newTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, http.HandlerFunc, map[string]any) {
+	return func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 		server := serve(h)
 		config["resource.url"] = server.URL
 		t.Cleanup(server.Close)
 	}
 }
 
-func newChainTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, http.HandlerFunc, map[string]interface{}) {
-	return func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+func newChainTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, http.HandlerFunc, map[string]any) {
+	return func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 		r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/":

--- a/x-pack/filebeat/input/cel/input_trace_test.go
+++ b/x-pack/filebeat/input/cel/input_trace_test.go
@@ -262,7 +262,7 @@ type traceTestPublisher struct {
 	done func(n int)
 }
 
-func (p *traceTestPublisher) Publish(_ beat.Event, _ any) error {
+func (p *traceTestPublisher) Publish(beat.Event, any) error {
 	p.mu.Lock()
 	p.n++
 	n := p.n

--- a/x-pack/filebeat/input/cel/input_trace_test.go
+++ b/x-pack/filebeat/input/cel/input_trace_test.go
@@ -35,7 +35,7 @@ func TestTraceSpans_SingleExecution(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	defer tp.Shutdown(context.Background())
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"interval":     "1m",
 		"resource.url": server.URL,
 		"program": `
@@ -122,7 +122,7 @@ func TestTraceSpans_WantMore(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	defer tp.Shutdown(context.Background())
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"interval":     "1m",
 		"resource.url": server.URL,
 		"program": `
@@ -198,7 +198,7 @@ func TestTraceSpans_EvalError(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	defer tp.Shutdown(context.Background())
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"interval":     1,
 		"resource.url": server.URL,
 		"program": `
@@ -262,7 +262,7 @@ type traceTestPublisher struct {
 	done func(n int)
 }
 
-func (p *traceTestPublisher) Publish(_ beat.Event, _ interface{}) error {
+func (p *traceTestPublisher) Publish(_ beat.Event, _ any) error {
 	p.mu.Lock()
 	p.n++
 	n := p.n

--- a/x-pack/filebeat/input/cel/integration_test.go
+++ b/x-pack/filebeat/input/cel/integration_test.go
@@ -33,7 +33,7 @@ func TestCheckinV2(t *testing.T) {
 	// make sure there is an ES instance running
 	integration.EnsureESIsRunning(t)
 	esConnectionDetails := integration.GetESURL(t, "http")
-	outputHosts := []interface{}{fmt.Sprintf("%s://%s:%s", esConnectionDetails.Scheme, esConnectionDetails.Hostname(), esConnectionDetails.Port())}
+	outputHosts := []any{fmt.Sprintf("%s://%s:%s", esConnectionDetails.Scheme, esConnectionDetails.Hostname(), esConnectionDetails.Port())}
 	outputUsername := esConnectionDetails.User.Username()
 	outputPassword, _ := esConnectionDetails.User.Password()
 	outputProtocol := esConnectionDetails.Scheme
@@ -68,7 +68,7 @@ func TestCheckinV2(t *testing.T) {
 				Id:   "default",
 				Type: "elasticsearch",
 				Name: "elasticsearch",
-				Source: integration.RequireNewStruct(t, map[string]interface{}{
+				Source: integration.RequireNewStruct(t, map[string]any{
 					"type":                  "elasticsearch",
 					"hosts":                 outputHosts,
 					"username":              outputUsername,
@@ -89,7 +89,7 @@ func TestCheckinV2(t *testing.T) {
 				Id:   "cel-cel-1e8b33de-d54a-45cd-90da-23ed71c482e5",
 				Type: "cel",
 				Name: "cel-1",
-				Source: integration.RequireNewStruct(t, map[string]interface{}{
+				Source: integration.RequireNewStruct(t, map[string]any{
 					"use_output": "default",
 					"revision":   0,
 				}),
@@ -108,7 +108,7 @@ func TestCheckinV2(t *testing.T) {
 						DataStream: &proto.DataStream{
 							Dataset: "cel.cel",
 						},
-						Source: integration.RequireNewStruct(t, map[string]interface{}{
+						Source: integration.RequireNewStruct(t, map[string]any{
 							"interval":                        "10s",
 							"program":                         `bytes(get(state.url).Body).as(body,{"events":[body.decode_json()]})`,
 							"redact.delete":                   false,
@@ -122,7 +122,7 @@ func TestCheckinV2(t *testing.T) {
 						DataStream: &proto.DataStream{
 							Dataset: "cel.cel",
 						},
-						Source: integration.RequireNewStruct(t, map[string]interface{}{
+						Source: integration.RequireNewStruct(t, map[string]any{
 							"interval":                        "10s",
 							"program":                         `bytes(get(state.url).Body).as(body,{"events":[body.decode_json()]})`,
 							"redact.delete":                   false,
@@ -150,7 +150,7 @@ func TestCheckinV2(t *testing.T) {
 				Id:   "default",
 				Type: "elasticsearch",
 				Name: "elasticsearch",
-				Source: integration.RequireNewStruct(t, map[string]interface{}{
+				Source: integration.RequireNewStruct(t, map[string]any{
 					"type":                  "elasticsearch",
 					"hosts":                 outputHosts,
 					"username":              outputUsername,
@@ -171,7 +171,7 @@ func TestCheckinV2(t *testing.T) {
 				Id:   "cel-cel-1e8b33de-d54a-45cd-90da-23ed71c482e5",
 				Type: "cel",
 				Name: "cel-1",
-				Source: integration.RequireNewStruct(t, map[string]interface{}{
+				Source: integration.RequireNewStruct(t, map[string]any{
 					"use_output": "default",
 					"revision":   0,
 				}),
@@ -190,7 +190,7 @@ func TestCheckinV2(t *testing.T) {
 						DataStream: &proto.DataStream{
 							Dataset: "cel.cel",
 						},
-						Source: integration.RequireNewStruct(t, map[string]interface{}{
+						Source: integration.RequireNewStruct(t, map[string]any{
 							"interval":                        "10s",
 							"program":                         `bytes(get(state.url).Body).as(body,{"events":[body.decode_json()]})`,
 							"redact.delete":                   false,
@@ -216,7 +216,7 @@ func TestCheckinV2(t *testing.T) {
 				Id:   "default",
 				Type: "elasticsearch",
 				Name: "elasticsearch",
-				Source: integration.RequireNewStruct(t, map[string]interface{}{
+				Source: integration.RequireNewStruct(t, map[string]any{
 					"type":                  "elasticsearch",
 					"hosts":                 outputHosts,
 					"username":              outputUsername,
@@ -284,13 +284,13 @@ func TestCheckinV2(t *testing.T) {
 				return false, allStreams
 			}
 
-			if !reflect.DeepEqual(map[string]interface{}{
-				"streams": map[string]interface{}{
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]interface{}{
+			if !reflect.DeepEqual(map[string]any{
+				"streams": map[string]any{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]interface{}{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
@@ -310,13 +310,13 @@ func TestCheckinV2(t *testing.T) {
 				return false, allStreams
 			}
 
-			if !reflect.DeepEqual(map[string]interface{}{
-				"streams": map[string]interface{}{
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]interface{}{
+			if !reflect.DeepEqual(map[string]any{
+				"streams": map[string]any{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]any{
 						"status": "DEGRADED",
 						"error":  "failed evaluation: failed eval: ERROR: <input>:1:63: failed to unmarshal JSON message: invalid character 'i' looking for beginning of value\n | bytes(get(state.url).Body).as(body,{\"events\":[body.decode_json()]})\n | ..............................................................^",
 					},
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]interface{}{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
@@ -335,13 +335,13 @@ func TestCheckinV2(t *testing.T) {
 				return false, allStreams
 			}
 
-			if !reflect.DeepEqual(map[string]interface{}{
-				"streams": map[string]interface{}{
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]interface{}{
+			if !reflect.DeepEqual(map[string]any{
+				"streams": map[string]any{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]any{
 						"status": "DEGRADED",
 						"error":  "failed evaluation: failed eval: ERROR: <input>:1:63: failed to unmarshal JSON message: invalid character 'i' looking for beginning of value\n | bytes(get(state.url).Body).as(body,{\"events\":[body.decode_json()]})\n | ..............................................................^",
 					},
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]interface{}{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]any{
 						"status": "DEGRADED",
 						"error":  "failed evaluation: failed eval: ERROR: <input>:1:63: failed to unmarshal JSON message: invalid character 'i' looking for beginning of value\n | bytes(get(state.url).Body).as(body,{\"events\":[body.decode_json()]})\n | ..............................................................^",
 					},
@@ -361,13 +361,13 @@ func TestCheckinV2(t *testing.T) {
 				return false, allStreams
 			}
 
-			if !reflect.DeepEqual(map[string]interface{}{
-				"streams": map[string]interface{}{
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]interface{}{
+			if !reflect.DeepEqual(map[string]any{
+				"streams": map[string]any{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]interface{}{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
@@ -386,13 +386,13 @@ func TestCheckinV2(t *testing.T) {
 				return false, allStreams
 			}
 
-			if !reflect.DeepEqual(map[string]interface{}{
-				"streams": map[string]interface{}{
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]interface{}{
+			if !reflect.DeepEqual(map[string]any{
+				"streams": map[string]any{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]interface{}{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]any{
 						"status": "DEGRADED",
 						"error":  "failed evaluation: failed eval: ERROR: <input>:1:63: failed to unmarshal JSON message: invalid character 'i' looking for beginning of value\n | bytes(get(state.url).Body).as(body,{\"events\":[body.decode_json()]})\n | ..............................................................^",
 					},
@@ -410,9 +410,9 @@ func TestCheckinV2(t *testing.T) {
 				return false, oneStream
 			}
 
-			if !reflect.DeepEqual(map[string]interface{}{
-				"streams": map[string]interface{}{
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]interface{}{
+			if !reflect.DeepEqual(map[string]any{
+				"streams": map[string]any{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
@@ -442,13 +442,13 @@ func TestCheckinV2(t *testing.T) {
 				return false, allStreams
 			}
 
-			if !reflect.DeepEqual(map[string]interface{}{
-				"streams": map[string]interface{}{
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]interface{}{
+			if !reflect.DeepEqual(map[string]any{
+				"streams": map[string]any{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-23ed71c482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
-					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]interface{}{
+					"cel-cel.cel-1e8b33de-d54a-45cd-90da-ffffffc482e2": map[string]any{
 						"status": "HEALTHY",
 						"error":  "",
 					},
@@ -496,7 +496,7 @@ func TestCheckinV2(t *testing.T) {
 	}
 }
 
-func extractStateAndPayload(observed *proto.CheckinObserved, inputID string) (proto.State, map[string]interface{}) {
+func extractStateAndPayload(observed *proto.CheckinObserved, inputID string) (proto.State, map[string]any) {
 	for _, unit := range observed.GetUnits() {
 		if unit.Id == inputID {
 			return unit.GetState(), unit.Payload.AsMap()

--- a/x-pack/filebeat/input/entityanalytics/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/conf_test.go
@@ -49,7 +49,6 @@ func TestConf_Validate(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/entityanalytics/integration_ad_test.go
+++ b/x-pack/filebeat/input/entityanalytics/integration_ad_test.go
@@ -315,7 +315,7 @@ func startADIntegLDAPServer(t *testing.T, fix *adFixture) string {
 	ln.Close()
 
 	go func() { _ = s.Run(addr) }()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		if s.Ready() {
 			break
 		}

--- a/x-pack/filebeat/input/entityanalytics/internal/collections/uuid_set_test.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/collections/uuid_set_test.go
@@ -57,7 +57,6 @@ func TestNewUUIDSet(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -82,29 +81,28 @@ func TestUUIDSet_UnmarshalJSON(t *testing.T) {
 			Want: NewUUIDSet(),
 		},
 		"ok-testUUID1-elem": {
-			In:   []byte(fmt.Sprintf(`["%s"]`, testUUID1Str)),
+			In:   fmt.Appendf(nil, `["%s"]`, testUUID1Str),
 			Want: NewUUIDSet(testUUID1),
 		},
 		"ok-testUUID3-elem": {
-			In:   []byte(fmt.Sprintf(`["%s", "%s", "%s"]`, testUUID1Str, testUUID2Str, testUUID3Str)),
+			In:   fmt.Appendf(nil, `["%s", "%s", "%s"]`, testUUID1Str, testUUID2Str, testUUID3Str),
 			Want: NewUUIDSet(testUUID1, testUUID2, testUUID3),
 		},
 		"ok-dup-elem": {
-			In:   []byte(fmt.Sprintf(`["%s","%s","%s"]`, testUUID1Str, testUUID2Str, testUUID2Str)),
+			In:   fmt.Appendf(nil, `["%s","%s","%s"]`, testUUID1Str, testUUID2Str, testUUID2Str),
 			Want: NewUUIDSet(testUUID1, testUUID2),
 		},
 		"err-mixed-types": {
-			In:      []byte(fmt.Sprintf(`["%s",0]`, testUUID1Str)),
+			In:      fmt.Appendf(nil, `["%s",0]`, testUUID1Str),
 			WantErr: "json: cannot unmarshal number into Go value of type uuid.UUID",
 		},
 		"err-not-list-str": {
-			In:      []byte(fmt.Sprintf(`"%s"`, testUUID1Str)),
+			In:      fmt.Appendf(nil, `"%s"`, testUUID1Str),
 			WantErr: "json: cannot unmarshal string into Go value of type []uuid.UUID",
 		},
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -134,16 +132,15 @@ func TestUUIDSet_MarshalJSON(t *testing.T) {
 		},
 		"ok-testUUID1-elem": {
 			In:   NewUUIDSet(testUUID1),
-			Want: []byte(fmt.Sprintf(`["%s"]`, testUUID1Str)),
+			Want: fmt.Appendf(nil, `["%s"]`, testUUID1Str),
 		},
 		"ok-testUUID3-elem": {
 			In:   NewUUIDSet(testUUID1, testUUID2, testUUID3),
-			Want: []byte(fmt.Sprintf(`["%s","%s","%s"]`, testUUID1Str, testUUID2Str, testUUID3Str)),
+			Want: fmt.Appendf(nil, `["%s","%s","%s"]`, testUUID1Str, testUUID2Str, testUUID3Str),
 		},
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -175,7 +172,6 @@ func TestUUIDSet_Len(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -201,7 +197,6 @@ func TestUUIDSet_Values(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -240,7 +235,6 @@ func TestUUIDSet_Add(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -280,7 +274,6 @@ func TestUUIDSet_Remove(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -314,7 +307,6 @@ func TestUUIDSet_Contains(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/entityanalytics/internal/collections/uuid_tree_test.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/collections/uuid_tree_test.go
@@ -20,7 +20,7 @@ func TestUUIDTree_UnmarshalJSON(t *testing.T) {
 		WantErr string
 	}{
 		"ok": {
-			In: []byte(fmt.Sprintf(`{"%s":["%s","%s"],"%s":["%s"]}`, testUUID1Str, testUUID2Str, testUUID3Str, testUUID4Str, testUUID5Str)),
+			In: fmt.Appendf(nil, `{"%s":["%s","%s"],"%s":["%s"]}`, testUUID1Str, testUUID2Str, testUUID3Str, testUUID4Str, testUUID5Str),
 			Want: UUIDTree{edges: map[uuid.UUID]*UUIDSet{
 				testUUID1: {m: map[uuid.UUID]struct{}{testUUID2: {}, testUUID3: {}}},
 				testUUID4: {m: map[uuid.UUID]struct{}{testUUID5: {}}},
@@ -35,17 +35,16 @@ func TestUUIDTree_UnmarshalJSON(t *testing.T) {
 			Want: UUIDTree{edges: map[uuid.UUID]*UUIDSet{}},
 		},
 		"err-bad-uuid-key": {
-			In:      []byte(fmt.Sprintf(`{"1":["%s"]}`, testUUID1)),
+			In:      fmt.Appendf(nil, `{"1":["%s"]}`, testUUID1),
 			WantErr: "uuid: incorrect UUID length 1 in string \"1\"",
 		},
 		"err-bad-uuid-set": {
-			In:      []byte(fmt.Sprintf(`{"%s":[1]}`, testUUID1)),
+			In:      fmt.Appendf(nil, `{"%s":[1]}`, testUUID1),
 			WantErr: "json: cannot unmarshal number into Go value of type uuid.UUID",
 		},
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -78,12 +77,11 @@ func TestUUIDTree_MarshalJSON(t *testing.T) {
 				testUUID1: {m: map[uuid.UUID]struct{}{testUUID2: {}, testUUID3: {}}},
 				testUUID4: {m: map[uuid.UUID]struct{}{testUUID5: {}}},
 			}},
-			Want: []byte(fmt.Sprintf(`{"%s":["%s","%s"],"%s":["%s"]}`, testUUID1Str, testUUID2Str, testUUID3Str, testUUID4Str, testUUID5Str)),
+			Want: fmt.Appendf(nil, `{"%s":["%s","%s"],"%s":["%s"]}`, testUUID1Str, testUUID2Str, testUUID3Str, testUUID4Str, testUUID5Str),
 		},
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -124,7 +122,6 @@ func TestUUIDTree_RemoveVertex(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -165,7 +162,6 @@ func TestUUIDTree_ContainsVertex(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -214,7 +210,6 @@ func TestUUIDTree_AddEdge(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -259,7 +254,6 @@ func TestUUIDTree_RemoveEdge(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -294,7 +288,6 @@ func TestUUIDTree_ContainsEdge(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -328,7 +321,6 @@ func TestUUIDTree_Expand(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -362,7 +354,6 @@ func TestUUIDTree_ExpandFromSet(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
@@ -174,7 +174,7 @@ func (s *testBackendStore) Has(key string) (bool, error) {
 	return ok, nil
 }
 
-func (s *testBackendStore) Get(key string, value interface{}) error {
+func (s *testBackendStore) Get(key string, value any) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	raw, ok := s.data[key]
@@ -184,7 +184,7 @@ func (s *testBackendStore) Get(key string, value interface{}) error {
 	return json.Unmarshal(raw, value)
 }
 
-func (s *testBackendStore) Set(key string, value interface{}) error {
+func (s *testBackendStore) Set(key string, value any) error {
 	raw, err := json.Marshal(value)
 	if err != nil {
 		return err
@@ -224,7 +224,7 @@ type jsonDecoder struct {
 	raw []byte
 }
 
-func (d *jsonDecoder) Decode(to interface{}) error {
+func (d *jsonDecoder) Decode(to any) error {
 	return json.Unmarshal(d.raw, to)
 }
 

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/tracker.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/tracker.go
@@ -58,7 +58,7 @@ func NewTxTracker(ctx context.Context) *TxTracker {
 // NewTxACKHandler creates a new beat.EventListener. As events are ACK-ed and if the event
 // contains a TxTracker, Ack will be called on the TxTracker.
 func NewTxACKHandler() beat.EventListener {
-	return acker.ConnectionOnly(acker.EventPrivateReporter(func(acked int, privates []interface{}) {
+	return acker.ConnectionOnly(acker.EventPrivateReporter(func(acked int, privates []any) {
 		for _, private := range privates {
 			if t, ok := private.(*TxTracker); ok {
 				t.Ack()

--- a/x-pack/filebeat/input/entityanalytics/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/minimal_test.go
@@ -122,8 +122,7 @@ func TestMinimalInput_RunSync_FullCycle(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ackClient := &ackingClient{inner: client}
 	s := &bboltSyncer{store: store, bucketName: bucketName}

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/minimal_test.go
@@ -27,7 +27,7 @@ import (
 //     least the duration fields are wired through end-to-end.
 func TestMinimalConfigRoundTrip(t *testing.T) {
 	const wantFields = 15 // includes TLS which is json:"-" but still a struct field
-	if got := reflect.TypeOf(ecad.Config{}).NumField(); got != wantFields {
+	if got := reflect.TypeFor[ecad.Config]().NumField(); got != wantFields {
 		t.Fatalf("ecad.Config has %d exported fields, want %d; "+
 			"update localConf inside minimalProvider and this test", got, wantFields)
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/statestore_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/statestore_test.go
@@ -361,9 +361,6 @@ func TestErrIsItemFound(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func ptr[T any](v T) *T { return new(v) }
-
 func testSetupStore(t *testing.T, path string) *kvstore.Store {
 	t.Helper()
 

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/statestore_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/statestore_test.go
@@ -361,7 +361,8 @@ func TestErrIsItemFound(t *testing.T) {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }
 
 func testSetupStore(t *testing.T, path string) *kvstore.Store {
 	t.Helper()

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/conf_test.go
@@ -70,7 +70,6 @@ func TestConf_Validate(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device.go
@@ -5,6 +5,8 @@
 package fetcher
 
 import (
+	"maps"
+
 	"github.com/gofrs/uuid/v5"
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/internal/collections"
@@ -43,9 +45,7 @@ func (d *Device) Merge(other *Device) {
 	if d.ID != other.ID {
 		return
 	}
-	for k, v := range other.Fields {
-		d.Fields[k] = v
-	}
+	maps.Copy(d.Fields, other.Fields)
 	other.MemberOf.ForEach(func(elem uuid.UUID) {
 		d.MemberOf.Add(elem)
 	})

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device_test.go
@@ -27,7 +27,7 @@ func TestDevice_Merge(t *testing.T) {
 		"ok": {
 			In: &Device{
 				ID: uuid.Must(uuid.FromString("187f924c-e867-477e-8d74-dd762d6379dd")),
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"a": "alpha",
 				},
 				MemberOf:           collections.NewUUIDSet(uuid.Must(uuid.FromString("fcda226a-c920-4d99-81bc-d2d691a6c212"))),
@@ -40,7 +40,7 @@ func TestDevice_Merge(t *testing.T) {
 			},
 			InOther: &Device{
 				ID: uuid.Must(uuid.FromString("187f924c-e867-477e-8d74-dd762d6379dd")),
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"b": "beta",
 				},
 				MemberOf:           collections.NewUUIDSet(uuid.Must(uuid.FromString("a77e8cbb-27a5-49d3-9d5e-801997621f87"))),
@@ -53,7 +53,7 @@ func TestDevice_Merge(t *testing.T) {
 			},
 			Want: &Device{
 				ID: uuid.Must(uuid.FromString("187f924c-e867-477e-8d74-dd762d6379dd")),
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"a": "alpha",
 					"b": "beta",
 				},
@@ -79,7 +79,6 @@ func TestDevice_Merge(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph_test.go
@@ -78,15 +78,15 @@ var devicesResponse1 = apiDeviceResponse{
 			"displayName":            "DESKTOP-LK3PESR",
 			"operatingSystem":        "Windows",
 			"operatingSystemVersion": "10.0.19043.1237",
-			"physicalIds":            []interface{}{},
-			"extensionAttributes": map[string]interface{}{
+			"physicalIds":            []any{},
+			"extensionAttributes": map[string]any{
 				"extensionAttribute1": "BYOD-Device",
 				"extensionAttribute2": nil,
 				"extensionAttribute3": nil,
 				"extensionAttribute4": nil,
 			},
-			"alternativeSecurityIds": []interface{}{
-				map[string]interface{}{
+			"alternativeSecurityIds": []any{
+				map[string]any{
 					"type":             "2", // Rendered as string to avoid in-flight conversion to float.
 					"identityProvider": nil,
 					"key":              "WAA1ADAAOQA6AD...QBnAD0A",
@@ -105,15 +105,15 @@ var devicesResponse2 = apiDeviceResponse{
 			"displayName":            "DESKTOP-LETW452G",
 			"operatingSystem":        "Windows",
 			"operatingSystemVersion": "10.0.19043.1337",
-			"physicalIds":            []interface{}{},
-			"extensionAttributes": map[string]interface{}{
+			"physicalIds":            []any{},
+			"extensionAttributes": map[string]any{
 				"extensionAttribute1": "BYOD-Device",
 				"extensionAttribute2": nil,
 				"extensionAttribute3": nil,
 				"extensionAttribute4": nil,
 			},
-			"alternativeSecurityIds": []interface{}{
-				map[string]interface{}{
+			"alternativeSecurityIds": []any{
+				map[string]any{
 					"type":             "2", // Rendered as string to avoid in-flight conversion to float.
 					"identityProvider": nil,
 					"key":              "DGFSGHSGGTH345A...35DSFH0A",
@@ -455,7 +455,7 @@ func TestGraph_Users(t *testing.T) {
 	wantUsers := []*fetcher.User{
 		{
 			ID: uuid.Must(uuid.FromString("5ebc6a0f-05b7-4f42-9c8a-682bbc75d0fc")),
-			Fields: map[string]interface{}{
+			Fields: map[string]any{
 				"userPrincipalName": "user.one@example.com",
 				"mail":              "user.one@example.com",
 				"displayName":       "User One",
@@ -470,7 +470,7 @@ func TestGraph_Users(t *testing.T) {
 		},
 		{
 			ID: uuid.Must(uuid.FromString("d897d560-3d17-4dae-81b3-c898fe82bf84")),
-			Fields: map[string]interface{}{
+			Fields: map[string]any{
 				"userPrincipalName": "user.two@example.com",
 				"mail":              "user.two@example.com",
 				"displayName":       "User Two",
@@ -519,21 +519,21 @@ func TestGraph_Devices(t *testing.T) {
 	wantDevices := []*fetcher.Device{
 		{
 			ID: uuid.Must(uuid.FromString("6a59ea83-02bd-468f-a40b-f2c3d1821983")),
-			Fields: map[string]interface{}{
+			Fields: map[string]any{
 				"accountEnabled":         true,
 				"deviceId":               "eab73519-780d-4d43-be6d-a4a89af2a348",
 				"displayName":            "DESKTOP-LK3PESR",
 				"operatingSystem":        "Windows",
 				"operatingSystemVersion": "10.0.19043.1237",
-				"physicalIds":            []interface{}{},
-				"extensionAttributes": map[string]interface{}{
+				"physicalIds":            []any{},
+				"extensionAttributes": map[string]any{
 					"extensionAttribute1": "BYOD-Device",
 					"extensionAttribute2": nil,
 					"extensionAttribute3": nil,
 					"extensionAttribute4": nil,
 				},
-				"alternativeSecurityIds": []interface{}{
-					map[string]interface{}{
+				"alternativeSecurityIds": []any{
+					map[string]any{
 						"type":             "2", // Rendered as string to avoid in-flight conversion to float.
 						"identityProvider": nil,
 						"key":              "WAA1ADAAOQA6AD...QBnAD0A",
@@ -550,21 +550,21 @@ func TestGraph_Devices(t *testing.T) {
 		},
 		{
 			ID: uuid.Must(uuid.FromString("adbbe40a-0627-4328-89f1-88cac84dbc7f")),
-			Fields: map[string]interface{}{
+			Fields: map[string]any{
 				"accountEnabled":         true,
 				"deviceId":               "2fbbb8f9-ff67-4a21-b867-a344d18a4198",
 				"displayName":            "DESKTOP-LETW452G",
 				"operatingSystem":        "Windows",
 				"operatingSystemVersion": "10.0.19043.1337",
-				"physicalIds":            []interface{}{},
-				"extensionAttributes": map[string]interface{}{
+				"physicalIds":            []any{},
+				"extensionAttributes": map[string]any{
 					"extensionAttribute1": "BYOD-Device",
 					"extensionAttribute2": nil,
 					"extensionAttribute3": nil,
 					"extensionAttribute4": nil,
 				},
-				"alternativeSecurityIds": []interface{}{
-					map[string]interface{}{
+				"alternativeSecurityIds": []any{
+					map[string]any{
 						"type":             "2", // Rendered as string to avoid in-flight conversion to float.
 						"identityProvider": nil,
 						"key":              "DGFSGHSGGTH345A...35DSFH0A",
@@ -619,7 +619,7 @@ func TestGraph_Devices(t *testing.T) {
 			// Using go-cmp because testify is too weak for this comparison.
 			// reflect.DeepEqual works, but won't show a reasonable diff.
 			exporter := cmp.Exporter(func(t reflect.Type) bool {
-				return t == reflect.TypeOf(collections.UUIDSet{})
+				return t == reflect.TypeFor[collections.UUIDSet]()
 			})
 			if !cmp.Equal(wantDevices, gotDevices, exporter) {
 				t.Errorf("unexpected result:\n--- got\n--- want\n%s", cmp.Diff(wantDevices, gotDevices, exporter))

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/mock/mock.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/mock/mock.go
@@ -110,7 +110,7 @@ var GroupResponse = []*fetcher.Group{
 var UserResponse = []*fetcher.User{
 	{
 		ID: uuid.Must(uuid.FromString("5ebc6a0f-05b7-4f42-9c8a-682bbc75d0fc")),
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"userPrincipalName": "user.one@example.com",
 			"mail":              "user.one@example.com",
 			"displayName":       "User One",
@@ -123,7 +123,7 @@ var UserResponse = []*fetcher.User{
 	},
 	{
 		ID: uuid.Must(uuid.FromString("d897d560-3d17-4dae-81b3-c898fe82bf84")),
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"userPrincipalName": "user.two@example.com",
 			"mail":              "user.two@example.com",
 			"displayName":       "User Two",
@@ -139,21 +139,21 @@ var UserResponse = []*fetcher.User{
 var DeviceResponse = []*fetcher.Device{
 	{
 		ID: uuid.Must(uuid.FromString("6a59ea83-02bd-468f-a40b-f2c3d1821983")),
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"accountEnabled":         true,
 			"deviceId":               "eab73519-780d-4d43-be6d-a4a89af2a348",
 			"displayName":            "DESKTOP-LK3PESR",
 			"operatingSystem":        "Windows",
 			"operatingSystemVersion": "10.0.19043.1237",
-			"physicalIds":            []interface{}{},
-			"extensionAttributes": map[string]interface{}{
+			"physicalIds":            []any{},
+			"extensionAttributes": map[string]any{
 				"extensionAttribute1": "BYOD-Device",
 				"extensionAttribute2": nil,
 				"extensionAttribute3": nil,
 				"extensionAttribute4": nil,
 			},
-			"alternativeSecurityIds": []interface{}{
-				map[string]interface{}{
+			"alternativeSecurityIds": []any{
+				map[string]any{
 					"type":             "2", // Rendered as string to avoid in-flight conversion to float.
 					"identityProvider": nil,
 					"key":              "WAA1ADAAOQA6AD...QBnAD0A",
@@ -163,21 +163,21 @@ var DeviceResponse = []*fetcher.Device{
 	},
 	{
 		ID: uuid.Must(uuid.FromString("adbbe40a-0627-4328-89f1-88cac84dbc7f")),
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"accountEnabled":         true,
 			"deviceId":               "2fbbb8f9-ff67-4a21-b867-a344d18a4198",
 			"displayName":            "DESKTOP-LETW452G",
 			"operatingSystem":        "Windows",
 			"operatingSystemVersion": "10.0.19043.1337",
-			"physicalIds":            []interface{}{},
-			"extensionAttributes": map[string]interface{}{
+			"physicalIds":            []any{},
+			"extensionAttributes": map[string]any{
 				"extensionAttribute1": "BYOD-Device",
 				"extensionAttribute2": nil,
 				"extensionAttribute3": nil,
 				"extensionAttribute4": nil,
 			},
-			"alternativeSecurityIds": []interface{}{
-				map[string]interface{}{
+			"alternativeSecurityIds": []any{
+				map[string]any{
 					"type":             "2", // Rendered as string to avoid in-flight conversion to float.
 					"identityProvider": nil,
 					"key":              "DGFSGHSGGTH345A...35DSFH0A",

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/user.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/user.go
@@ -5,6 +5,8 @@
 package fetcher
 
 import (
+	"maps"
+
 	"github.com/gofrs/uuid/v5"
 
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/internal/collections"
@@ -76,9 +78,7 @@ func (u *User) Merge(other *User) {
 	if u.ID != other.ID {
 		return
 	}
-	for k, v := range other.Fields {
-		u.Fields[k] = v
-	}
+	maps.Copy(u.Fields, other.Fields)
 	other.MemberOf.ForEach(func(elem uuid.UUID) {
 		u.MemberOf.Add(elem)
 	})

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/user_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/user_test.go
@@ -27,7 +27,7 @@ func TestUser_Merge(t *testing.T) {
 		"ok": {
 			In: &User{
 				ID: uuid.Must(uuid.FromString("187f924c-e867-477e-8d74-dd762d6379dd")),
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"a": "alpha",
 				},
 				MemberOf:           collections.NewUUIDSet(uuid.Must(uuid.FromString("fcda226a-c920-4d99-81bc-d2d691a6c212"))),
@@ -35,7 +35,7 @@ func TestUser_Merge(t *testing.T) {
 			},
 			InOther: &User{
 				ID: uuid.Must(uuid.FromString("187f924c-e867-477e-8d74-dd762d6379dd")),
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"b": "beta",
 				},
 				MemberOf:           collections.NewUUIDSet(uuid.Must(uuid.FromString("a77e8cbb-27a5-49d3-9d5e-801997621f87"))),
@@ -43,7 +43,7 @@ func TestUser_Merge(t *testing.T) {
 			},
 			Want: &User{
 				ID: uuid.Must(uuid.FromString("187f924c-e867-477e-8d74-dd762d6379dd")),
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"a": "alpha",
 					"b": "beta",
 				},
@@ -60,7 +60,6 @@ func TestUser_Merge(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/minimal_test.go
@@ -25,7 +25,7 @@ import (
 //     at least the duration fields are wired through end-to-end.
 func TestMinimalConfigRoundTrip(t *testing.T) {
 	const wantFields = 14
-	if got := reflect.TypeOf(ecentraid.Config{}).NumField(); got != wantFields {
+	if got := reflect.TypeFor[ecentraid.Config]().NumField(); got != wantFields {
 		t.Fatalf("ecentraid.Config has %d exported fields, want %d; "+
 			"update localConf inside minimalProvider and this test", got, wantFields)
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/statestore_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/statestore_test.go
@@ -124,7 +124,7 @@ func TestStateStore_Close(t *testing.T) {
 	ss.users = map[uuid.UUID]*fetcher.User{
 		user1ID: {
 			ID: user1ID,
-			Fields: map[string]interface{}{
+			Fields: map[string]any{
 				"userPrincipalName": "user.one@example.com",
 				"mail":              "user.one@example.com",
 				"displayName":       "User One",
@@ -143,18 +143,18 @@ func TestStateStore_Close(t *testing.T) {
 	ss.devices = map[uuid.UUID]*fetcher.Device{
 		device1ID: {
 			ID: device1ID,
-			Fields: map[string]interface{}{
+			Fields: map[string]any{
 				"accountEnabled":         true,
 				"deviceId":               "2fbbb8f9-ff67-4a21-b867-a344d18a4198",
 				"displayName":            "DESKTOP-LETW452G",
 				"operatingSystem":        "Windows",
 				"operatingSystemVersion": "10.0.19043.1337",
-				"physicalIds":            []interface{}{},
-				"extensionAttributes": map[string]interface{}{
+				"physicalIds":            []any{},
+				"extensionAttributes": map[string]any{
 					"extensionAttribute1": "BYOD-Device",
 				},
-				"alternativeSecurityIds": []interface{}{
-					map[string]interface{}{
+				"alternativeSecurityIds": []any{
+					map[string]any{
 						"type":             "2",
 						"identityProvider": nil,
 						"key":              "DGFSGHSGGTH345A...35DSFH0A",
@@ -307,7 +307,6 @@ func TestErrIsItemFound(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/conf_test.go
@@ -54,7 +54,7 @@ var validateTests = []struct {
 		cfg: conf{
 			SyncInterval: 24 * time.Hour, UpdateInterval: 15 * time.Minute,
 			Tracer: &tracerConfig{
-				Enabled: ptrTo(false),
+				Enabled: new(false),
 				Logger:  lumberjack.Logger{Filename: "/var/logs/path.log"},
 			},
 		},
@@ -65,7 +65,7 @@ var validateTests = []struct {
 		cfg: conf{
 			SyncInterval: 24 * time.Hour, UpdateInterval: 15 * time.Minute,
 			Tracer: &tracerConfig{
-				Enabled: ptrTo(true),
+				Enabled: new(true),
 				Logger:  lumberjack.Logger{Filename: "jamf/logs/path.log"},
 			},
 		},
@@ -75,14 +75,15 @@ var validateTests = []struct {
 		cfg: conf{
 			SyncInterval: 24 * time.Hour, UpdateInterval: 15 * time.Minute,
 			Tracer: &tracerConfig{
-				Enabled: ptrTo(true),
+				Enabled: new(true),
 				Logger:  lumberjack.Logger{Filename: "/var/logs/path.log"},
 			},
 		},
 	},
 }
 
-func ptrTo[T any](v T) *T { return &v }
+//go:fix inline
+func ptrTo[T any](v T) *T { return new(v) }
 
 func TestConfValidate(t *testing.T) {
 	for _, test := range validateTests {
@@ -108,32 +109,32 @@ func sameError(a, b error) bool {
 
 var keepAliveTests = []struct {
 	name    string
-	input   map[string]interface{}
+	input   map[string]any
 	want    httpcommon.WithKeepaliveSettings
 	wantErr error
 }{
 	{
 		name:  "keep_alive_none", // Default to the old behaviour of true.
-		input: map[string]interface{}{},
+		input: map[string]any{},
 		want:  httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_true",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable": true,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_false",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable": false,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: false},
 	},
 	{
 		name: "keep_alive_invalid_max",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable":              false,
 			"request.keep_alive.max_idle_connections": -1,
 		},

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/conf_test.go
@@ -82,9 +82,6 @@ var validateTests = []struct {
 	},
 }
 
-//go:fix inline
-func ptrTo[T any](v T) *T { return new(v) }
-
 func TestConfValidate(t *testing.T) {
 	for _, test := range validateTests {
 		t.Run(test.name, func(t *testing.T) {

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
@@ -273,10 +273,10 @@ func newRetryLog(log *logp.Logger) *retryLog {
 	return &retryLog{log: log.Named("retryablehttp").WithOptions(zap.AddCallerSkip(1))}
 }
 
-func (l *retryLog) Error(msg string, kv ...interface{}) { l.log.Errorw(msg, kv...) }
-func (l *retryLog) Info(msg string, kv ...interface{})  { l.log.Infow(msg, kv...) }
-func (l *retryLog) Debug(msg string, kv ...interface{}) { l.log.Debugw(msg, kv...) }
-func (l *retryLog) Warn(msg string, kv ...interface{})  { l.log.Warnw(msg, kv...) }
+func (l *retryLog) Error(msg string, kv ...any) { l.log.Errorw(msg, kv...) }
+func (l *retryLog) Info(msg string, kv ...any)  { l.log.Infow(msg, kv...) }
+func (l *retryLog) Debug(msg string, kv ...any) { l.log.Debugw(msg, kv...) }
+func (l *retryLog) Warn(msg string, kv ...any)  { l.log.Warnw(msg, kv...) }
 
 // runFullSync performs a full synchronization. It will fetch user and group
 // identities from Azure Active Directory, enrich users with group memberships,

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/minimal_test.go
@@ -24,7 +24,7 @@ import (
 //     least the duration fields are wired through end-to-end.
 func TestMinimalConfigRoundTrip(t *testing.T) {
 	const wantFields = 8
-	if got := reflect.TypeOf(ecjamf.Config{}).NumField(); got != wantFields {
+	if got := reflect.TypeFor[ecjamf.Config]().NumField(); got != wantFields {
 		t.Fatalf("ecjamf.Config has %d exported fields, want %d; "+
 			"update localConf inside minimalProvider and this test", got, wantFields)
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
@@ -164,14 +164,14 @@ func (o *oAuth2Config) Validate() error {
 		if o.OktaJWKJSON != nil {
 			// Validate JWK format by attempting to parse it
 			var jwkData struct {
-				N    interface{} `json:"n"`
-				E    interface{} `json:"e"`
-				D    interface{} `json:"d"`
-				P    interface{} `json:"p"`
-				Q    interface{} `json:"q"`
-				Dp   interface{} `json:"dp"`
-				Dq   interface{} `json:"dq"`
-				Qinv interface{} `json:"qi"`
+				N    any `json:"n"`
+				E    any `json:"e"`
+				D    any `json:"d"`
+				P    any `json:"p"`
+				Q    any `json:"q"`
+				Dp   any `json:"dp"`
+				Dq   any `json:"dq"`
+				Qinv any `json:"qi"`
 			}
 			if err := json.Unmarshal(o.OktaJWKJSON, &jwkData); err != nil {
 				return fmt.Errorf("oauth2 validation error: invalid JWK JSON format: %w", err)

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf_test.go
@@ -102,9 +102,6 @@ var validateTests = []struct {
 	},
 }
 
-//go:fix inline
-func ptrTo[T any](v T) *T { return new(v) }
-
 func TestConfValidate(t *testing.T) {
 	for _, test := range validateTests {
 		t.Run(test.name, func(t *testing.T) {

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf_test.go
@@ -67,7 +67,7 @@ var validateTests = []struct {
 			cfg.OktaDomain = "test.okta.com"
 			cfg.OktaToken = "test-token"
 			cfg.Tracer = &tracerConfig{
-				Enabled: ptrTo(false),
+				Enabled: new(false),
 				Logger:  lumberjack.Logger{Filename: "/var/logs/path.log"},
 			}
 			return cfg
@@ -81,7 +81,7 @@ var validateTests = []struct {
 			cfg.OktaDomain = "test.okta.com"
 			cfg.OktaToken = "test-token"
 			cfg.Tracer = &tracerConfig{
-				Enabled: ptrTo(true),
+				Enabled: new(true),
 				Logger:  lumberjack.Logger{Filename: "okta/logs/path.log"},
 			}
 			return cfg
@@ -94,7 +94,7 @@ var validateTests = []struct {
 			cfg.OktaDomain = "test.okta.com"
 			cfg.OktaToken = "test-token"
 			cfg.Tracer = &tracerConfig{
-				Enabled: ptrTo(true),
+				Enabled: new(true),
 				Logger:  lumberjack.Logger{Filename: "/var/logs/path.log"},
 			}
 			return cfg
@@ -102,7 +102,8 @@ var validateTests = []struct {
 	},
 }
 
-func ptrTo[T any](v T) *T { return &v }
+//go:fix inline
+func ptrTo[T any](v T) *T { return new(v) }
 
 func TestConfValidate(t *testing.T) {
 	for _, test := range validateTests {
@@ -128,32 +129,32 @@ func sameError(a, b error) bool {
 
 var keepAliveTests = []struct {
 	name    string
-	input   map[string]interface{}
+	input   map[string]any
 	want    httpcommon.WithKeepaliveSettings
 	wantErr error
 }{
 	{
 		name:  "keep_alive_none", // Default to the old behaviour of true.
-		input: map[string]interface{}{},
+		input: map[string]any{},
 		want:  httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_true",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable": true,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_false",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable": false,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: false},
 	},
 	{
 		name: "keep_alive_invalid_max",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable":              false,
 			"request.keep_alive.max_idle_connections": -1,
 		},

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/minimal_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/minimal_test.go
@@ -24,7 +24,7 @@ import (
 //     least the duration fields are wired through end-to-end.
 func TestMinimalConfigRoundTrip(t *testing.T) {
 	const wantFields = 12
-	if got := reflect.TypeOf(ecokta.Config{}).NumField(); got != wantFields {
+	if got := reflect.TypeFor[ecokta.Config]().NumField(); got != wantFields {
 		t.Fatalf("ecokta.Config has %d exported fields, want %d; "+
 			"update localConf inside minimalProvider and this test", got, wantFields)
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
@@ -28,7 +28,7 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 		{
 			name: "valid oauth2 config with jwk_json",
 			config: &oAuth2Config{
-				Enabled:  boolPtr(true),
+				Enabled:  new(true),
 				ClientID: "test-client",
 				Scopes:   []string{"okta.users.read"},
 				TokenURL: "https://test.okta.com/oauth2/v1/token",
@@ -49,7 +49,7 @@ func TestOAuth2ConfigValidation(t *testing.T) {
 		{
 			name: "valid oauth2 config with jwk_pem",
 			config: &oAuth2Config{
-				Enabled:  boolPtr(true),
+				Enabled:  new(true),
 				ClientID: "test-client",
 				Scopes:   []string{"okta.users.read"},
 				TokenURL: "https://test.okta.com/oauth2/v1/token",
@@ -89,7 +89,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 		{
 			name: "invalid - bad jwk_pem data",
 			config: &oAuth2Config{
-				Enabled:    boolPtr(true),
+				Enabled:    new(true),
 				ClientID:   "test-client",
 				Scopes:     []string{"okta.users.read"},
 				TokenURL:   "https://test.okta.com/oauth2/v1/token",
@@ -100,7 +100,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 		{
 			name: "valid oauth2 config with client secret",
 			config: &oAuth2Config{
-				Enabled:      boolPtr(true),
+				Enabled:      new(true),
 				ClientID:     "test-client",
 				ClientSecret: "test-secret",
 				Scopes:       []string{"okta.users.read"},
@@ -111,7 +111,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 		{
 			name: "invalid - missing client.id",
 			config: &oAuth2Config{
-				Enabled:     boolPtr(true),
+				Enabled:     new(true),
 				Scopes:      []string{"okta.users.read"},
 				TokenURL:    "https://test.okta.com/oauth2/v1/token",
 				OktaJWKJSON: common.JSONBlob(`{"kty": "RSA"}`),
@@ -121,7 +121,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 		{
 			name: "invalid - missing scopes",
 			config: &oAuth2Config{
-				Enabled:     boolPtr(true),
+				Enabled:     new(true),
 				ClientID:    "test-client",
 				TokenURL:    "https://test.okta.com/oauth2/v1/token",
 				OktaJWKJSON: common.JSONBlob(`{"kty": "RSA"}`),
@@ -131,7 +131,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 		{
 			name: "invalid - missing token_url",
 			config: &oAuth2Config{
-				Enabled:     boolPtr(true),
+				Enabled:     new(true),
 				ClientID:    "test-client",
 				Scopes:      []string{"okta.users.read"},
 				OktaJWKJSON: common.JSONBlob(`{"kty": "RSA"}`),
@@ -141,7 +141,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 		{
 			name: "invalid - mixing client secret and JWT keys",
 			config: &oAuth2Config{
-				Enabled:      boolPtr(true),
+				Enabled:      new(true),
 				ClientID:     "test-client",
 				ClientSecret: "test-secret",
 				Scopes:       []string{"okta.users.read"},
@@ -153,7 +153,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 		{
 			name: "invalid - no authentication method provided",
 			config: &oAuth2Config{
-				Enabled:  boolPtr(true),
+				Enabled:  new(true),
 				ClientID: "test-client",
 				Scopes:   []string{"okta.users.read"},
 				TokenURL: "https://test.okta.com/oauth2/v1/token",
@@ -188,14 +188,14 @@ func TestOAuth2ConfigIsEnabled(t *testing.T) {
 		{
 			name: "enabled explicitly",
 			config: &oAuth2Config{
-				Enabled: boolPtr(true),
+				Enabled: new(true),
 			},
 			want: true,
 		},
 		{
 			name: "disabled explicitly",
 			config: &oAuth2Config{
-				Enabled: boolPtr(false),
+				Enabled: new(false),
 			},
 			want: false,
 		},
@@ -227,7 +227,7 @@ func TestConfValidationWithOAuth2(t *testing.T) {
 			config: conf{
 				OktaDomain: "test.okta.com",
 				OAuth2: &oAuth2Config{
-					Enabled:  boolPtr(true),
+					Enabled:  new(true),
 					ClientID: "test-client",
 					Scopes:   []string{"okta.users.read"},
 					TokenURL: "https://test.okta.com/oauth2/v1/token",
@@ -276,7 +276,7 @@ func TestConfValidationWithOAuth2(t *testing.T) {
 				OktaDomain: "test.okta.com",
 				OktaToken:  "test-token",
 				OAuth2: &oAuth2Config{
-					Enabled:  boolPtr(true),
+					Enabled:  new(true),
 					ClientID: "test-client",
 					Scopes:   []string{"okta.users.read"},
 					TokenURL: "https://test.okta.com/oauth2/v1/token",
@@ -324,7 +324,7 @@ func TestGetAuthToken(t *testing.T) {
 			name: "oauth2 enabled",
 			config: conf{
 				OAuth2: &oAuth2Config{
-					Enabled: boolPtr(true),
+					Enabled: new(true),
 				},
 			},
 			expected: "",
@@ -334,7 +334,7 @@ func TestGetAuthToken(t *testing.T) {
 			config: conf{
 				OktaToken: "test-token",
 				OAuth2: &oAuth2Config{
-					Enabled: boolPtr(false),
+					Enabled: new(false),
 				},
 			},
 			expected: "test-token",
@@ -357,8 +357,9 @@ func TestGetAuthToken(t *testing.T) {
 	}
 }
 
+//go:fix inline
 func boolPtr(b bool) *bool {
-	return &b
+	return new(b)
 }
 
 // testOktaJWKJSON is a JWK JSON obtained from the Okta integration.
@@ -399,7 +400,7 @@ LNV/bIgMHOMoxiGrwyjAhg==
 func TestOktaTokenSource_Token(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token": "mock",
 			"token_type":   "Bearer",
 			"expires_in":   3600,

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go
@@ -357,11 +357,6 @@ func TestGetAuthToken(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func boolPtr(b bool) *bool {
-	return new(b)
-}
-
 // testOktaJWKJSON is a JWK JSON obtained from the Okta integration.
 const testOktaJWKJSON = `{ "d": "Cmhokw2MnZfX6da36nnsnQ7IPX9vE6se8_D1NgyL9j9rarYpexhlp45hswcAIFNgWA03NV848Gc0e84AW6wMbyD2E8LPI0Bd8lhdmzRE6L4or2Rxqqjk2Pr2aqGnqs4A0uTijAA7MfPF1zFFdR3EOVx499fEeTiMcLjO83IJCoNiOySDoQgt3KofX5bCbaDy2eiB83rzf0fEcWrWfTY65_Hc2c5lek-1uuF7NpELVzX80p5H-b9MOfLn0BdOGe-mJ2j5bXi-UCQ45Wxj2jdkoA_Qwb4MEtXZjp5LjcM75SrlGfVd99acML2wGZgYLGweJ0sAPDlKzGvj4ve-JT8nNw", "p": "8-UBb4psN0wRPktkh3S48L3ng4T5zR08t7nwXDYNajROrS2j7oq60dtlGY4IwgwcC0c9GDQP7NiN2IpU2uahYkGQ7lDyM_h7UfQWL5fMrsYiKgn2pUgSy5TTT8smkSLbJAD35nAH6PknsQ2PuvOlb4laiC0MXw1Rw4vT9HAEB9M", "q": "0DJkPEN0bECG_6lorlNJgIfoNahVevGKK-Yti1YZ5K-nQCuffPCwPG0oZZo_55y5LODe9W7psxnAt7wxkpAY4lK2hpHTWJSkPjqXWFYIP8trn4RZDShnJXli0i1XqPOqkiVzBZGx5nLtj2bUtmXfIU7-kneHGvLQ5EXcyQW1ISM", "dp": "Ye1PWEPSE5ndSo_m-2RoZXE6pdocmrjkijiEQ-IIHN6HwI0Ux1C4lk5rF4mqBo_qKrUd2Lv-sPB6c7mHPKVhoxwEX0vtE-TvTwacadufeYVgblS1zcNUmJ1XAzDkeV3vc1NYNhRBeM-hmjuBvGTbxh72VLsRvpCQhd186yaW17U", "dq": "jvSK7vZCUrJb_-CLCGgX6DFpuK5FQ43mmg4K58nPLb-Oz_kkId4CpPsu6dToXFi4raAad9wYi-n68i4-u6xF6eFxgyVOQVyPCkug7_7i2ysKUxXFL8u2R3z55edMca4eSQt91y0bQmlXxUeOd0-rzms3UcrQ8igYVyXBXCaXIJE", "qi": "iIY1Y4bzMYIFG7XH7gNP7C-mWi6QH4l9aGRTzPB_gPaFThvc0XKW0S0l82bfp_PPPWg4D4QpDCp7rZ6KhEA8BlNi86Vt3V6F3Hz5XiDa4ikgQNsAXiXLqf83R-y1-cwHjW70PP3U89hmalCRRFfVXcLHV77AVHqbrp9rAIo-X-I", "kty": "RSA", "e": "AQAB", "kid": "koeFQjkyiav_3Qwr3aRinCqCD2LaEHOjFnje7XlkbdI", "n": "xloTY8bAuI5AEo8JursCd7w0LmELCae7JOFaVo9njGrG8tRNqgIdjPyoGY_ABwKkmjcCMLGMA29llFDbry8rB4LTWai-h_jX4_uUUnl52mLX-lO6merL5HEPZF438Ql9Hrxs5yGzT8n865-E_3uwYSBrhTjvlZJeXYUeVHfKo8pJSSsw3RZEjBW4Tt0eFmCZnFErtTyk3oUPaYVP-8YLLAenhUDV4Lm1dC4dxqUj0Oh6XrWgIb-eYHGolMY9g9xbgyd4ir39RodA_1DOjzHWpNfCM-J5ZOtfpuKCAe5__u7L8FT0m56XOxcDoVVsz1J1VNrACWAGbhDWNjyHfL5E2Q" }`
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -289,10 +289,10 @@ func newRetryLog(log *logp.Logger) *retryLog {
 	return &retryLog{log: log.Named("retryablehttp").WithOptions(zap.AddCallerSkip(1))}
 }
 
-func (l *retryLog) Error(msg string, kv ...interface{}) { l.log.Errorw(msg, kv...) }
-func (l *retryLog) Info(msg string, kv ...interface{})  { l.log.Infow(msg, kv...) }
-func (l *retryLog) Debug(msg string, kv ...interface{}) { l.log.Debugw(msg, kv...) }
-func (l *retryLog) Warn(msg string, kv ...interface{})  { l.log.Warnw(msg, kv...) }
+func (l *retryLog) Error(msg string, kv ...any) { l.log.Errorw(msg, kv...) }
+func (l *retryLog) Info(msg string, kv ...any)  { l.log.Infow(msg, kv...) }
+func (l *retryLog) Debug(msg string, kv ...any) { l.log.Debugw(msg, kv...) }
+func (l *retryLog) Warn(msg string, kv ...any)  { l.log.Warnw(msg, kv...) }
 
 // runFullSync performs a full synchronization. It will fetch user and group
 // identities from Azure Active Directory, enrich users with group memberships,

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/statestore_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/statestore_test.go
@@ -287,9 +287,6 @@ func TestErrIsItemFound(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func ptr[T any](v T) *T { return new(v) }
-
 func testSetupStore(t *testing.T, path string) *kvstore.Store {
 	t.Helper()
 

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/statestore_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/statestore_test.go
@@ -97,14 +97,14 @@ func TestStateStore(t *testing.T) {
 					ID:              "userid",
 					Status:          "STATUS",
 					Created:         time.Now(),
-					StatusChanged:   ptr(time.Now()),
-					LastLogin:       ptr(time.Now()),
+					StatusChanged:   new(time.Now()),
+					LastLogin:       new(time.Now()),
 					LastUpdated:     time.Now(),
-					PasswordChanged: ptr(time.Now()),
-					Type: map[string]interface{}{
+					PasswordChanged: new(time.Now()),
+					Type: map[string]any{
 						"id": "typeid",
 					},
-					Profile: map[string]interface{}{
+					Profile: map[string]any{
 						"login":     "name.surname@example.com",
 						"email":     "name.surname@example.com",
 						"firstName": "name",
@@ -115,11 +115,11 @@ func TestStateStore(t *testing.T) {
 						RecoveryQuestion: &struct{}{}, // Had a question: not retained.
 						Provider: okta.Provider{
 							Type: "OKTA",
-							Name: ptr("OKTA"),
+							Name: new("OKTA"),
 						},
 					},
 					Links: okta.HAL{
-						"self": map[string]interface{}{
+						"self": map[string]any{
 							"href": "https://localhost/api/v1/users/userid",
 						},
 					},
@@ -135,7 +135,7 @@ func TestStateStore(t *testing.T) {
 					Created:     time.Now(),
 					LastUpdated: time.Now(),
 					Links: okta.HAL{
-						"self": map[string]interface{}{
+						"self": map[string]any{
 							"href": "https://localhost/api/v1/devices/deviceid",
 						},
 					},
@@ -287,7 +287,8 @@ func TestErrIsItemFound(t *testing.T) {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }
 
 func testSetupStore(t *testing.T, path string) *kvstore.Store {
 	t.Helper()

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -219,8 +219,7 @@ func Test_RunEtwInput_StartConsumerError(t *testing.T) {
 	}
 
 	// Setup cancellation
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
+	ctx := t.Context()
 
 	// Setup input
 	inputCtx := input.Context{

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -395,8 +395,3 @@ func (t userAgentDecorator) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 	return t.Transport.RoundTrip(r)
 }
-
-// boolPtr returns a pointer to b.
-//
-//go:fix inline
-func boolPtr(b bool) *bool { return new(b) }

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -66,7 +66,7 @@ func configID(config *conf.C) (string, error) {
 		return tmp.ID, nil
 	}
 
-	var h map[string]interface{}
+	var h map[string]any
 	_ = config.Unpack(&h)
 	id, err := hashstructure.Hash(h, nil)
 	if err != nil {
@@ -153,7 +153,7 @@ func NewInput(cfg *conf.C, connector channel.Connector, inputContext input.Conte
 	// Build outlet for events.
 	in.outlet, err = connector.ConnectWith(cfg, beat.ClientConfig{
 		EventListener: acker.ConnectionOnly(
-			acker.EventPrivateReporter(func(_ int, privates []interface{}) {
+			acker.EventPrivateReporter(func(_ int, privates []any) {
 				for _, priv := range privates {
 					if msg, ok := priv.(*pubsub.Message); ok {
 						msg.Ack()
@@ -171,7 +171,7 @@ func NewInput(cfg *conf.C, connector channel.Connector, inputContext input.Conte
 		Processing: beat.ProcessingConfig{
 			// This input only produces events with basic types so normalization
 			// is not required.
-			EventNormalization: boolPtr(false),
+			EventNormalization: new(false),
 		},
 	})
 	if err != nil {
@@ -397,4 +397,6 @@ func (t userAgentDecorator) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 // boolPtr returns a pointer to b.
-func boolPtr(b bool) *bool { return &b }
+//
+//go:fix inline
+func boolPtr(b bool) *bool { return new(b) }

--- a/x-pack/filebeat/input/gcppubsub/pubsub_test.go
+++ b/x-pack/filebeat/input/gcppubsub/pubsub_test.go
@@ -45,10 +45,10 @@ func ifNotDone(ctx context.Context, f func()) func() {
 }
 
 func defaultTestConfig() *conf.C {
-	return conf.MustNewConfigFrom(map[string]interface{}{
+	return conf.MustNewConfigFrom(map[string]any{
 		"project_id": emulatorProjectID,
 		"topic":      emulatorTopic,
-		"subscription": map[string]interface{}{
+		"subscription": map[string]any{
 			"name":   emulatorSubscription,
 			"create": true,
 		},
@@ -147,10 +147,7 @@ func (o *stubOutleter) waitForEvents(numEvents int) ([]beat.Event, bool) {
 		o.cond.Wait()
 	}
 
-	size := numEvents
-	if size >= len(o.Events) {
-		size = len(o.Events)
-	}
+	size := min(numEvents, len(o.Events))
 
 	out := make([]beat.Event, size)
 	copy(out, o.Events)

--- a/x-pack/filebeat/input/gcppubsub/testutil/testutil.go
+++ b/x-pack/filebeat/input/gcppubsub/testutil/testutil.go
@@ -125,7 +125,7 @@ func PublishMessages(t *testing.T, client *pubsub.Client, numMsgs int) []string 
 	defer topic.Stop()
 
 	messageIDs := make([]string, numMsgs)
-	for i := 0; i < numMsgs; i++ {
+	for i := range numMsgs {
 		result := topic.Publish(ctx, &pubsub.Message{
 			Data: []byte(time.Now().UTC().Format(time.RFC3339Nano) + ": hello world " + strconv.Itoa(i)),
 		})

--- a/x-pack/filebeat/input/gcs/decoding_test.go
+++ b/x-pack/filebeat/input/gcs/decoding_test.go
@@ -53,7 +53,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   ptr[decoder.Rune](' '),
+						Comma:   new((decoder.Rune)(' ')),
 					},
 				},
 			},
@@ -67,7 +67,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   ptr[decoder.Rune](' '),
+						Comma:   new((decoder.Rune)(' ')),
 					},
 				},
 			},
@@ -113,7 +113,7 @@ type pub struct {
 	events []beat.Event
 }
 
-func (p *pub) Publish(e beat.Event, _cursor interface{}) error {
+func (p *pub) Publish(e beat.Event, _cursor any) error {
 	p.t.Logf("%v\n", e.Fields)
 	p.events = append(p.events, e)
 	return nil
@@ -153,7 +153,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   ptr[decoder.Rune](' '),
+					Comma:   new((decoder.Rune)(' ')),
 					Comment: '#',
 				},
 			}},
@@ -184,7 +184,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   ptr[decoder.Rune]('\x00'),
+					Comma:   new((decoder.Rune)('\x00')),
 				},
 			}},
 	},
@@ -232,4 +232,5 @@ func sameError(a, b error) bool {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }

--- a/x-pack/filebeat/input/gcs/decoding_test.go
+++ b/x-pack/filebeat/input/gcs/decoding_test.go
@@ -231,6 +231,3 @@ func sameError(a, b error) bool {
 		return a.Error() == b.Error()
 	}
 }
-
-//go:fix inline
-func ptr[T any](v T) *T { return new(v) }

--- a/x-pack/filebeat/input/gcs/decoding_test.go
+++ b/x-pack/filebeat/input/gcs/decoding_test.go
@@ -53,7 +53,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   new((decoder.Rune)(' ')),
+						Comma:   new(decoder.Rune(' ')),
 					},
 				},
 			},
@@ -67,7 +67,7 @@ func TestDecoding(t *testing.T) {
 				Codec: &decoder.CodecConfig{
 					CSV: &decoder.CSVCodecConfig{
 						Enabled: true,
-						Comma:   new((decoder.Rune)(' ')),
+						Comma:   new(decoder.Rune(' ')),
 					},
 				},
 			},
@@ -153,7 +153,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   new((decoder.Rune)(' ')),
+					Comma:   new(decoder.Rune(' ')),
 					Comment: '#',
 				},
 			}},
@@ -184,7 +184,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   new((decoder.Rune)('\x00')),
+					Comma:   new(decoder.Rune('\x00')),
 				},
 			}},
 	},

--- a/x-pack/filebeat/input/gcs/helper.go
+++ b/x-pack/filebeat/input/gcs/helper.go
@@ -38,14 +38,14 @@ func decodeJSON(body io.Reader) ([]mapstr.M, error) {
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", decoder.InputOffset(), err)
 		}
 
-		var obj interface{}
+		var obj any
 		if err := newJSONDecoder(bytes.NewReader(raw)).Decode(&obj); err != nil {
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", decoder.InputOffset(), err)
 		}
 		switch v := obj.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			objs = append(objs, v)
-		case []interface{}:
+		case []any:
 			nobjs, err := decodeJSONArray(bytes.NewReader(raw), decoder.InputOffset())
 			if err != nil {
 				return nil, fmt.Errorf("recursive error %d: %w", decoder.InputOffset(), err)
@@ -84,12 +84,12 @@ func decodeJSONArray(raw *bytes.Reader, parentOffset int64) ([]mapstr.M, error) 
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", parentOffset+dec.InputOffset(), err)
 		}
 
-		var obj interface{}
+		var obj any
 		if err := newJSONDecoder(bytes.NewReader(raw)).Decode(&obj); err != nil {
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", parentOffset+dec.InputOffset(), err)
 		}
 
-		m, ok := obj.(map[string]interface{})
+		m, ok := obj.(map[string]any)
 		if ok {
 			objs = append(objs, m)
 		}

--- a/x-pack/filebeat/input/gcs/input_stateless_test.go
+++ b/x-pack/filebeat/input/gcs/input_stateless_test.go
@@ -41,7 +41,7 @@ type statelessPublisher struct {
 	wrapped stateless.Publisher
 }
 
-func (pub statelessPublisher) Publish(event beat.Event, _ interface{}) error {
+func (pub statelessPublisher) Publish(event beat.Event, _ any) error {
 	pub.wrapped.Publish(event)
 	return nil
 }

--- a/x-pack/filebeat/input/gcs/input_test.go
+++ b/x-pack/filebeat/input/gcs/input_test.go
@@ -43,7 +43,7 @@ const (
 func Test_StorageClient(t *testing.T) {
 	tests := []struct {
 		name        string
-		baseConfig  map[string]interface{}
+		baseConfig  map[string]any
 		mockHandler func() http.Handler
 		expected    map[string]bool
 		checkJSON   bool
@@ -51,13 +51,13 @@ func Test_StorageClient(t *testing.T) {
 	}{
 		{
 			name: "SingleBucketWithPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test-new",
 					},
@@ -72,13 +72,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleBucketWithoutPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       false,
 				"poll_interval":              "10s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
 					},
@@ -93,13 +93,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoBucketsWithPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
 					},
@@ -119,13 +119,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoBucketsWithoutPoll_NoErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       false,
 				"poll_interval":              "10s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
 					},
@@ -145,13 +145,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleBucketWithPoll_InvalidBucketErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test",
 					},
@@ -163,13 +163,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleBucketWithoutPoll_InvalidBucketErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       false,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test",
 					},
@@ -181,13 +181,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoBucketsWithPoll_InvalidBucketErr",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test",
 					},
@@ -202,13 +202,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleBucketWithPoll_InvalidConfigValue",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                5100,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test",
 					},
@@ -220,13 +220,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "TwoBucketWithPoll_InvalidConfigValue",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                5100,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test",
 					},
@@ -241,14 +241,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "SingleBucketWithPoll_parseJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
 				"parse_json":                 true,
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestLatest,
 					},
@@ -263,13 +263,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsJSONBucket,
 					},
@@ -284,13 +284,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadOctetStreamJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsMultilineJSONBucket,
 					},
@@ -304,13 +304,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadNDJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsNdJSONBucket,
 					},
@@ -324,13 +324,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadMultilineGzJSON",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsGzJSONBucket,
 					},
@@ -344,13 +344,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadJSONWithRootAsArray",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsJSONWithArrayBucket,
 					},
@@ -366,14 +366,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByTimeStampEpoch",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
 				"timestamp_epoch":            1661385600,
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
 					},
@@ -387,18 +387,18 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByFileSelectorRegexSingle",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "docs/",
 					},
 				},
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
 					},
@@ -411,13 +411,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByFileSelectorRegexMulti",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "docs/",
 					},
@@ -425,7 +425,7 @@ func Test_StorageClient(t *testing.T) {
 						"regex": "data",
 					},
 				},
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
 					},
@@ -439,19 +439,19 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ExpandEventListFromField",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                   "elastic-sa",
 				"auth.credentials_file.path":   "testdata/gcs_creds.json",
 				"max_workers":                  1,
 				"poll":                         true,
 				"poll_interval":                "5s",
 				"expand_event_list_from_field": "Events",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "events-array",
 					},
 				},
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsJSONBucket,
 					},
@@ -465,16 +465,16 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "MultiContainerWithMultiFileSelectors",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
-						"file_selectors": []map[string]interface{}{
+						"file_selectors": []map[string]any{
 							{
 								"regex": "docs/",
 							},
@@ -482,7 +482,7 @@ func Test_StorageClient(t *testing.T) {
 					},
 					{
 						"name": bucketGcsTestLatest,
-						"file_selectors": []map[string]interface{}{
+						"file_selectors": []map[string]any{
 							{
 								"regex": "data_3",
 							},
@@ -498,18 +498,18 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "FilterByFileSelectorEmptyRegex",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"file_selectors": []map[string]interface{}{
+				"file_selectors": []map[string]any{
 					{
 						"regex": "",
 					},
 				},
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": bucketGcsTestNew,
 					},
@@ -524,13 +524,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "RetryWithDefaultValues",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "1m",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test-new",
 					},
@@ -545,19 +545,19 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "RetryWithCustomValues",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "10s",
-				"retry": map[string]interface{}{
+				"retry": map[string]any{
 					"max_attempts":             5,
 					"initial_backoff_duration": "1s",
 					"max_backoff_duration":     "3s",
 					"backoff_multiplier":       1.4,
 				},
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test-new",
 					},
@@ -572,19 +572,19 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "RetryMinimumValueCheck",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "10s",
-				"retry": map[string]interface{}{
+				"retry": map[string]any{
 					"max_attempts":             5,
 					"initial_backoff_duration": "1s",
 					"max_backoff_duration":     "3s",
 					"backoff_multiplier":       1,
 				},
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test-new",
 					},
@@ -596,14 +596,14 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "BatchSizeGlobal",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"batch_size":                 3,
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": "gcs-test-new",
 					},
@@ -618,13 +618,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "BatchSizeBucketLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "5s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name":       "gcs-test-new",
 						"batch_size": 3,
@@ -640,7 +640,7 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadCSVRootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
@@ -648,7 +648,7 @@ func Test_StorageClient(t *testing.T) {
 				"poll_interval":              "10s",
 				"decoding.codec.csv.enabled": true,
 				"decoding.codec.csv.comma":   " ",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsCSVBucket,
 					},
@@ -662,13 +662,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "ReadCSVBucketLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                1,
 				"poll":                       true,
 				"poll_interval":              "10s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name":                       beatsCSVBucket,
 						"decoding.codec.csv.enabled": true,
@@ -684,13 +684,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "CustomContentTypeUnsupported",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "10s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name":                  beatsGzJSONBucket,
 						"content_type":          "application/xyz-plain",
@@ -705,13 +705,13 @@ func Test_StorageClient(t *testing.T) {
 		},
 		{
 			name: "CustomContentTypeSupported",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "10s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name":         beatsGzJSONBucket,
 						"content_type": "application/x-gzip",
@@ -729,13 +729,13 @@ func Test_StorageClient(t *testing.T) {
 			// content-type already exists and we are not overriding it.
 			// So we expect a successful run.
 			name: "CustomContentTypeIgnored",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "10s",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name":         beatsNdJSONBucket,
 						"content_type": "application/xyz-plain",
@@ -751,14 +751,14 @@ func Test_StorageClient(t *testing.T) {
 		{
 			// This checks if the root level content-type specifications are respected.
 			name: "CustomContentTypeAtRootLevel",
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"project_id":                 "elastic-sa",
 				"auth.credentials_file.path": "testdata/gcs_creds.json",
 				"max_workers":                2,
 				"poll":                       true,
 				"poll_interval":              "10s",
 				"content_type":               "application/x-gzip",
-				"buckets": []map[string]interface{}{
+				"buckets": []map[string]any{
 					{
 						"name": beatsGzJSONBucket,
 					},
@@ -835,7 +835,7 @@ func Test_StorageClient(t *testing.T) {
 					cancel()
 					return
 				case got := <-chanClient.Channel:
-					var val interface{}
+					var val any
 					var err error
 					if !tt.checkJSON {
 						val, err = got.Fields.GetValue("message")

--- a/x-pack/filebeat/input/http_endpoint/ack.go
+++ b/x-pack/filebeat/input/http_endpoint/ack.go
@@ -17,7 +17,7 @@ import (
 // to decrement the number of pending ACKs.
 func newEventACKHandler() beat.EventListener {
 	return acker.ConnectionOnly(
-		acker.EventPrivateReporter(func(_ int, privates []interface{}) {
+		acker.EventPrivateReporter(func(_ int, privates []any) {
 			for _, private := range privates {
 				if ack, ok := private.(*batchACKTracker); ok {
 					ack.ACK()

--- a/x-pack/filebeat/input/http_endpoint/config_test.go
+++ b/x-pack/filebeat/input/http_endpoint/config_test.go
@@ -93,9 +93,6 @@ func sameError(a, b error) bool {
 	}
 }
 
-//go:fix inline
-func ptrTo[T any](v T) *T { return new(v) }
-
 func TestApplyInFlightDefaults(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/x-pack/filebeat/input/http_endpoint/config_test.go
+++ b/x-pack/filebeat/input/http_endpoint/config_test.go
@@ -55,7 +55,7 @@ func Test_validateConfig(t *testing.T) {
 				URL:          "/",
 				ResponseBody: `{"message": "success"}`,
 				Method:       http.MethodPost,
-				Tracer:       &tracerConfig{Enabled: ptrTo(true), Logger: lumberjack.Logger{Filename: "http_endpoint/log"}},
+				Tracer:       &tracerConfig{Enabled: new(true), Logger: lumberjack.Logger{Filename: "http_endpoint/log"}},
 			},
 		},
 		{
@@ -64,7 +64,7 @@ func Test_validateConfig(t *testing.T) {
 				URL:          "/",
 				ResponseBody: `{"message": "success"}`,
 				Method:       http.MethodPost,
-				Tracer:       &tracerConfig{Enabled: ptrTo(true), Logger: lumberjack.Logger{Filename: "/var/log"}},
+				Tracer:       &tracerConfig{Enabled: new(true), Logger: lumberjack.Logger{Filename: "/var/log"}},
 			},
 		},
 	}
@@ -93,7 +93,8 @@ func sameError(a, b error) bool {
 	}
 }
 
-func ptrTo[T any](v T) *T { return &v }
+//go:fix inline
+func ptrTo[T any](v T) *T { return new(v) }
 
 func TestApplyInFlightDefaults(t *testing.T) {
 	tests := []struct {

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -74,7 +74,7 @@ func validateZoomCRC(crc *crcValidator, obj mapstr.M) (status int, resp string, 
 		return 0, "", errNotCRC
 	}
 
-	payload, ok := obj["payload"].(map[string]interface{})
+	payload, ok := obj["payload"].(map[string]any)
 	if !ok {
 		return 0, "", errNotCRC
 	}

--- a/x-pack/filebeat/input/http_endpoint/crc_test.go
+++ b/x-pack/filebeat/input/http_endpoint/crc_test.go
@@ -27,7 +27,7 @@ func Test_validateZoomCRC(t *testing.T) {
 			name: "valid request",
 			crc:  newCRC("Zoom", "secretValueTest"),
 			inputJSON: mapstr.M{
-				"payload": map[string]interface{}{
+				"payload": map[string]any{
 					"plainToken": "qgg8vlvZRS6UYooatFL8Aw",
 				},
 				"event_ts": int64(1654503849680),
@@ -51,7 +51,7 @@ func Test_validateZoomCRC(t *testing.T) {
 			name: "empty challenge value",
 			crc:  newCRC("Zoom", "secretValueTest"),
 			inputJSON: mapstr.M{
-				"payload": map[string]interface{}{
+				"payload": map[string]any{
 					"plainToken": "",
 				},
 				"event_ts": int64(1654503849680),

--- a/x-pack/filebeat/input/http_endpoint/gzip.go
+++ b/x-pack/filebeat/input/http_endpoint/gzip.go
@@ -12,7 +12,7 @@ import (
 )
 
 var gzipDecoderPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(gzip.Reader)
 	},
 }

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -224,7 +224,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var headers map[string]interface{}
+	var headers map[string]any
 	if len(h.includeHeaders) != 0 {
 		headers = getIncludedHeaders(r, h.includeHeaders)
 	}
@@ -349,7 +349,7 @@ func (h *handler) sendAPIErrorResponse(txID string, w http.ResponseWriter, r *ht
 	}
 	enc := json.NewEncoder(mw)
 	enc.SetEscapeHTML(false)
-	err := enc.Encode(map[string]interface{}{"message": apiError.Error()})
+	err := enc.Encode(map[string]any{"message": apiError.Error()})
 	if err != nil {
 		log.Debugw("Failed to write HTTP response.", "error", err, "client.address", r.RemoteAddr)
 	}
@@ -460,7 +460,7 @@ func decodeJSON(body io.Reader, prg *program) (objs []mapstr.M, err error) {
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", decoder.InputOffset(), err)
 		}
 
-		var obj interface{}
+		var obj any
 		if err = newJSONDecoder(bytes.NewReader(raw)).Decode(&obj); err != nil {
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", decoder.InputOffset(), err)
 		}
@@ -470,7 +470,7 @@ func decodeJSON(body io.Reader, prg *program) (objs []mapstr.M, err error) {
 			if err != nil {
 				return nil, err
 			}
-			if _, ok := obj.([]interface{}); ok {
+			if _, ok := obj.([]any); ok {
 				// Re-marshal to ensure the raw bytes agree with the constructed object.
 				// This is only necessary when the program constructs an array return.
 				raw, err = json.Marshal(obj)
@@ -481,9 +481,9 @@ func decodeJSON(body io.Reader, prg *program) (objs []mapstr.M, err error) {
 		}
 
 		switch v := obj.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			objs = append(objs, v)
-		case []interface{}:
+		case []any:
 			nobjs, err := decodeJSONArray(bytes.NewReader(raw))
 			if err != nil {
 				return nil, fmt.Errorf("recursive error %d: %w", decoder.InputOffset(), err)
@@ -592,14 +592,14 @@ func (a *numberAdapter) NativeToValue(value any) ref.Val {
 	return a.fallback.NativeToValue(value)
 }
 
-func (p *program) eval(obj interface{}) (interface{}, error) {
-	out, _, err := p.prg.Eval(map[string]interface{}{"obj": obj})
+func (p *program) eval(obj any) (any, error) {
+	out, _, err := p.prg.Eval(map[string]any{"obj": obj})
 	if err != nil {
 		err = lib.DecoratedError{AST: p.ast, Err: err}
 		return nil, fmt.Errorf("failed eval: %w", err)
 	}
 
-	v, err := out.ConvertToNative(reflect.TypeOf((*structpb.Value)(nil)))
+	v, err := out.ConvertToNative(reflect.TypeFor[*structpb.Value]())
 	if err != nil {
 		return nil, fmt.Errorf("failed proto conversion: %w", err)
 	}
@@ -634,12 +634,12 @@ func decodeJSONArray(raw *bytes.Reader) (objs []mapstr.M, err error) {
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", dec.InputOffset(), err)
 		}
 
-		var obj interface{}
+		var obj any
 		if err := newJSONDecoder(bytes.NewReader(raw)).Decode(&obj); err != nil {
 			return nil, fmt.Errorf("malformed JSON object at stream position %d: %w", dec.InputOffset(), err)
 		}
 
-		m, ok := obj.(map[string]interface{})
+		m, ok := obj.(map[string]any)
 		if ok {
 			objs = append(objs, m)
 		}

--- a/x-pack/filebeat/input/http_endpoint/handler_test.go
+++ b/x-pack/filebeat/input/http_endpoint/handler_test.go
@@ -858,15 +858,13 @@ func TestConcurrentRequestsExceedHighWater(t *testing.T) {
 	var wg sync.WaitGroup
 	var slowReqStatus, fastReqStatus int
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		req := httptest.NewRequest(http.MethodPost, "/", slowBody)
 		req.Header.Set("Content-Type", "application/json")
 		respRec := httptest.NewRecorder()
 		h.ServeHTTP(respRec, req)
 		slowReqStatus = respRec.Code
-	}()
+	})
 
 	// Wait until the slow request has accumulated enough in-flight bytes
 	// to cross the high-water mark before sending the second request.
@@ -876,15 +874,13 @@ func TestConcurrentRequestsExceedHighWater(t *testing.T) {
 
 	// Send a fast request while the slow one is still reading.
 	// This should be rejected because in-flight is above high water mark (30).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"id":1}`))
 		req.Header.Set("Content-Type", "application/json")
 		respRec := httptest.NewRecorder()
 		h.ServeHTTP(respRec, req)
 		fastReqStatus = respRec.Code
-	}()
+	})
 
 	wg.Wait()
 

--- a/x-pack/filebeat/input/http_endpoint/input_test.go
+++ b/x-pack/filebeat/input/http_endpoint/input_test.go
@@ -453,10 +453,7 @@ func TestServerPool(t *testing.T) {
 			metrics := newInputMetrics(monitoring.NewRegistry(), logp.NewNopLogger())
 			var wg sync.WaitGroup
 			for _, cfg := range cfgs {
-				cfg := cfg
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					err := servers.serve(ctx, cfg, pub.Publish, metrics)
 					if err != http.ErrServerClosed {
 						select {
@@ -464,7 +461,7 @@ func TestServerPool(t *testing.T) {
 						default:
 						}
 					}
-				}()
+				})
 			}
 			if wantErr == nil {
 				addrCount := make(map[string]int)
@@ -525,15 +522,12 @@ func TestServerPool(t *testing.T) {
 			// Try to re-register the same addresses.
 			ctx, cancel = newCtx("server_pool_test", test.name)
 			for _, cfg := range cfgs {
-				cfg := cfg
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					err := servers.serve(ctx, cfg, pub.Publish, metrics)
 					if err != nil && err != http.ErrServerClosed && wantErr == nil { //nolint:errorlint // http.ErrServerClosed is a documented sentinel, never wrapped.
 						t.Errorf("failed to re-register %v: %v", cfg.addr, err)
 					}
-				}()
+				})
 			}
 			cancel()
 			wg.Wait()
@@ -648,14 +642,12 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 
 	metrics := newInputMetrics(monitoring.NewRegistry(), logp.NewNopLogger())
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := servers.serve(ctx, cfg, delayedPublish, metrics)
 		if err != nil && err != http.ErrServerClosed {
 			t.Errorf("unexpected serve error: %v", err)
 		}
-	}()
+	})
 	waitForServer(t, addr, 5*time.Second)
 
 	var reqWg sync.WaitGroup
@@ -663,9 +655,7 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 	// Send first request with wait_for_completion_timeout.
 	// This will hold bytes in-flight until ACK (which we delay).
 	var firstStatus int
-	reqWg.Add(1)
-	go func() {
-		defer reqWg.Done()
+	reqWg.Go(func() {
 		resp, err := doRequest(http.MethodPost,
 			"http://"+addr+"/?wait_for_completion_timeout=5s",
 			"application/json",
@@ -676,16 +666,14 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 		}
 		firstStatus = resp.StatusCode
 		resp.Body.Close()
-	}()
+	})
 
 	// Wait a bit for first request to be processing (reading body, waiting for ACK).
 	time.Sleep(200 * time.Millisecond)
 
 	// Send second request while first is holding bytes.
 	var secondStatus int
-	reqWg.Add(1)
-	go func() {
-		defer reqWg.Done()
+	reqWg.Go(func() {
 		resp, err := doRequest(http.MethodPost,
 			"http://"+addr+"/?wait_for_completion_timeout=5s",
 			"application/json",
@@ -696,7 +684,7 @@ func TestConcurrentExceedMaxInFlight(t *testing.T) {
 		}
 		secondStatus = resp.StatusCode
 		resp.Body.Close()
-	}()
+	})
 
 	// Wait for second request to complete (should be rejected quickly).
 	time.Sleep(200 * time.Millisecond)
@@ -1137,11 +1125,9 @@ func TestPatternReregistration(t *testing.T) {
 	ctx1, cancel1 := newCtx("test", "input-1")
 	var wg sync.WaitGroup
 	err1 := make(chan error, 1)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err1 <- servers.serve(ctx1, cfg, pub.Publish, metrics)
-	}()
+	})
 	waitForServer(t, "127.0.0.1:9023", 5*time.Second)
 
 	resp, err := doRequest("", "http://127.0.0.1:9023/a/", "application/json", strings.NewReader(`{"x":1}`))
@@ -1168,11 +1154,9 @@ func TestPatternReregistration(t *testing.T) {
 	// Re-register same pattern on a new server.
 	ctx2, cancel2 := newCtx("test", "input-2")
 	err2 := make(chan error, 1)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err2 <- servers.serve(ctx2, cfg, pub.Publish, metrics)
-	}()
+	})
 	waitForServer(t, "127.0.0.1:9023", 5*time.Second)
 
 	resp, err = doRequest("", "http://127.0.0.1:9023/a/", "application/json", strings.NewReader(`{"x":2}`))

--- a/x-pack/filebeat/input/httpjson/config_okta_auth_test.go
+++ b/x-pack/filebeat/input/httpjson/config_okta_auth_test.go
@@ -102,7 +102,7 @@ func checkToken(t *testing.T, text string, cnf *oauth2.Config) {
 func TestOktaTokenSource_Token(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token": "mock_access_token",
 			"token_type":   "Bearer",
 			"expires_in":   3600,

--- a/x-pack/filebeat/input/httpjson/config_test.go
+++ b/x-pack/filebeat/input/httpjson/config_test.go
@@ -149,7 +149,7 @@ func TestGetEndpointParamsWithAzure(t *testing.T) {
 }
 
 func TestConfigFailsWithInvalidMethod(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"request.method": "DELETE",
 	}
 	cfg := conf.MustNewConfigFrom(m)
@@ -160,7 +160,7 @@ func TestConfigFailsWithInvalidMethod(t *testing.T) {
 }
 
 func TestConfigMustFailWithInvalidURL(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"request.url": "::invalid::",
 	}
 	cfg := conf.MustNewConfigFrom(m)
@@ -170,7 +170,7 @@ func TestConfigMustFailWithInvalidURL(t *testing.T) {
 }
 
 func TestConfigMustFailWithSchemelessURL(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"request.url": "host.name/path/to/endpoint",
 	}
 	cfg := conf.MustNewConfigFrom(m)
@@ -183,19 +183,19 @@ func TestConfigOauth2Validation(t *testing.T) {
 	cases := []struct {
 		name        string
 		expectedErr string
-		input       map[string]interface{}
+		input       map[string]any
 		setup       func()
 		teardown    func()
 	}{
 		{
 			name:        "can't set oauth2 and basic auth together",
 			expectedErr: "only one kind of auth can be enabled accessing 'auth'",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"auth.basic.user":     "user",
 				"auth.basic.password": "pass",
-				"auth.oauth2": map[string]interface{}{
+				"auth.oauth2": map[string]any{
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "a_client_secret",
 					},
@@ -205,7 +205,7 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "can't set file and basic auth together",
 			expectedErr: "only one kind of auth can be enabled accessing 'auth'",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"auth.basic.user":     "user",
 				"auth.basic.password": "pass",
 				"auth.file.path":      "./token",
@@ -213,7 +213,7 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "can set file and basic auth together if file auth disabled",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"auth.basic.user":     "user",
 				"auth.basic.password": "pass",
 				"auth.file.enabled":   false,
@@ -223,11 +223,11 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "can't set file and oauth2 auth together",
 			expectedErr: "only one kind of auth can be enabled accessing 'auth'",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"auth.file.path": "./token",
-				"auth.oauth2": map[string]interface{}{
+				"auth.oauth2": map[string]any{
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "a_client_secret",
 					},
@@ -236,12 +236,12 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "can set file and oauth2 auth together if file auth disabled",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"auth.file.enabled": false,
 				"auth.file.path":    "./token",
-				"auth.oauth2": map[string]interface{}{
+				"auth.oauth2": map[string]any{
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "a_client_secret",
 					},
@@ -250,13 +250,13 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "can set oauth2 and basic auth together if oauth2 is disabled",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"auth.basic.user":     "user",
 				"auth.basic.password": "pass",
-				"auth.oauth2": map[string]interface{}{
+				"auth.oauth2": map[string]any{
 					"enabled":   false,
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "a_client_secret",
 					},
@@ -266,17 +266,17 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "token_url and client credentials must be set",
 			expectedErr: "both token_url and client credentials must be provided accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{},
+			input: map[string]any{
+				"auth.oauth2": map[string]any{},
 			},
 		},
 		{
 			name: "client credential secret may be empty",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"enabled":   true,
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "",
 					},
@@ -286,11 +286,11 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "client credential secret may not be missing",
 			expectedErr: "both token_url and client credentials must be provided accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"enabled":   true,
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id": "a_client_id",
 					},
 				},
@@ -298,12 +298,12 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "if user and password is set oauth2 must use user-password authentication",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"user":      "a_client_user",
 					"password":  "a_client_password",
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "a_client_secret",
 					},
@@ -313,11 +313,11 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "if user is set password credentials must be set for user-password authentication",
 			expectedErr: "both user and password credentials must be provided accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"user":      "a_client_user",
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "a_client_secret",
 					},
@@ -327,11 +327,11 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "if password is set user credentials must be set for user-password authentication",
 			expectedErr: "both user and password credentials must be provided accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"password":  "a_client_password",
 					"token_url": "localhost",
-					"client": map[string]interface{}{
+					"client": map[string]any{
 						"id":     "a_client_id",
 						"secret": "a_client_secret",
 					},
@@ -340,8 +340,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "if password is set credentials may be missing for user-password authentication",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"user":      "a_client_user",
 					"password":  "a_client_password",
 					"token_url": "localhost",
@@ -351,8 +351,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "must fail with an unknown provider",
 			expectedErr: "unknown provider \"unknown\" accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "unknown",
 				},
 			},
@@ -360,8 +360,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "azure must have either tenant_id or token_url",
 			expectedErr: "at least one of token_url or tenant_id must be provided accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "azure",
 				},
 			},
@@ -369,8 +369,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "azure must have only one of token_url and tenant_id",
 			expectedErr: "only one of token_url and tenant_id can be used accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":        "azure",
 					"azure.tenant_id": "a_tenant_id",
 					"token_url":       "localhost",
@@ -380,8 +380,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "azure must have client credentials set",
 			expectedErr: "client credentials must be provided accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":        "azure",
 					"azure.tenant_id": "a_tenant_id",
 				},
@@ -389,10 +389,10 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "azure config is valid",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "azure",
-					"azure": map[string]interface{}{
+					"azure": map[string]any{
 						"tenant_id": "a_tenant_id",
 					},
 					"client.id":     "a_client_id",
@@ -403,10 +403,10 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google can't have token_url or client credentials set",
 			expectedErr: "none of token_url and client credentials can be used, use google.credentials_file, google.jwt_file, google.credentials_json or ADC instead accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "google",
-					"azure": map[string]interface{}{
+					"azure": map[string]any{
 						"tenant_id": "a_tenant_id",
 					},
 					"client.id":     "a_client_id",
@@ -418,8 +418,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google must fail if no ADC available",
 			expectedErr: "no authentication credentials were configured or detected (ADC) accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "google",
 				},
 			},
@@ -433,8 +433,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must send scopes and delegated_account if ADC available",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                 "google",
 					"google.delegated_account": "delegated@account.com",
 					"scopes":                   []string{"foo"},
@@ -453,8 +453,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google must fail if credentials file not found",
 			expectedErr: "the file \"./wrong\" cannot be found accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                "google",
 					"google.credentials_file": "./wrong",
 				},
@@ -463,8 +463,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google must fail if ADC is wrongly set",
 			expectedErr: "no authentication credentials were configured or detected (ADC) accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "google",
 				},
 			},
@@ -472,8 +472,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must work if ADC is set up",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "google",
 				},
 			},
@@ -481,8 +481,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must work if credentials_file is correct",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                "google",
 					"google.credentials_file": "./testdata/credentials.json",
 				},
@@ -490,8 +490,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must work if jwt_file is correct",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":        "google",
 					"google.jwt_file": "./testdata/credentials.json",
 				},
@@ -499,8 +499,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must work if jwt_json is correct",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "google",
 					"google.jwt_json": `{
 						"type":           "service_account",
@@ -514,8 +514,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must work if credentials_json is correct",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider": "google",
 					"google.credentials_json": `{
 						"type":           "service_account",
@@ -530,8 +530,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google must fail if credentials_json is not a valid JSON",
 			expectedErr: "the field can't be converted to valid JSON accessing 'auth.oauth2.google.credentials_json'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                "google",
 					"google.credentials_json": `invalid`,
 				},
@@ -540,8 +540,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google must fail if jwt_json is not a valid JSON",
 			expectedErr: "the field can't be converted to valid JSON accessing 'auth.oauth2.google.jwt_json'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":        "google",
 					"google.jwt_json": `invalid`,
 				},
@@ -550,8 +550,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google must fail if the provided credentials file is not a valid JSON",
 			expectedErr: "the file \"./testdata/invalid_credentials.json\" does not contain valid JSON accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                "google",
 					"google.credentials_file": "./testdata/invalid_credentials.json",
 				},
@@ -560,8 +560,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "google must fail if the delegated_account is set without jwt_file",
 			expectedErr: "google.delegated_account can only be provided with a jwt_file accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                 "google",
 					"google.credentials_file":  "./testdata/credentials.json",
 					"google.delegated_account": "delegated@account.com",
@@ -570,8 +570,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must work with delegated_account and a valid jwt_file",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                 "google",
 					"google.jwt_file":          "./testdata/credentials.json",
 					"google.delegated_account": "delegated@account.com",
@@ -580,8 +580,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "google must work with delegated_account and ADC set up",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":                 "google",
 					"google.delegated_account": "delegated@account.com",
 				},
@@ -591,8 +591,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "okta requires token_url, client_id, scopes and at least one of okta.jwk_json or okta.jwk_file to be provided",
 			expectedErr: "okta validation error: one of okta.jwk_json, okta.jwk_file or okta.jwk_pem must be provided accessing 'auth.oauth2'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":  "okta",
 					"client.id": "a_client_id",
 					"token_url": "localhost",
@@ -603,8 +603,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		{
 			name:        "okta oauth2 validation fails if jwk_json is not a valid JSON",
 			expectedErr: "the field can't be converted to valid JSON accessing 'auth.oauth2.okta.jwk_json'",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":      "okta",
 					"client.id":     "a_client_id",
 					"token_url":     "localhost",
@@ -615,8 +615,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "okta successful oauth2 validation",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":      "okta",
 					"client.id":     "a_client_id",
 					"token_url":     "localhost",
@@ -627,8 +627,8 @@ func TestConfigOauth2Validation(t *testing.T) {
 		},
 		{
 			name: "okta successful pem oauth2 validation",
-			input: map[string]interface{}{
-				"auth.oauth2": map[string]interface{}{
+			input: map[string]any{
+				"auth.oauth2": map[string]any{
 					"provider":  "okta",
 					"client.id": "a_client_id",
 					"token_url": "localhost",
@@ -669,7 +669,6 @@ LNV/bIgMHOMoxiGrwyjAhg==
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			if c.setup != nil {
 				c.setup()
@@ -702,27 +701,27 @@ LNV/bIgMHOMoxiGrwyjAhg==
 func TestPaginationAllowedHostsValidation(t *testing.T) {
 	tests := []struct {
 		name    string
-		hosts   []interface{}
+		hosts   []any
 		wantErr string
 	}{
 		{
 			name:  "valid_entries",
-			hosts: []interface{}{"https://cdn.example.com", "https://api.other.com:8443"},
+			hosts: []any{"https://cdn.example.com", "https://api.other.com:8443"},
 		},
 		{
 			name:    "missing_scheme",
-			hosts:   []interface{}{"cdn.example.com"},
+			hosts:   []any{"cdn.example.com"},
 			wantErr: `pagination_allowed_hosts entry "cdn.example.com" must have both a scheme and a host`,
 		},
 		{
 			name:    "missing_host",
-			hosts:   []interface{}{"https://"},
+			hosts:   []any{"https://"},
 			wantErr: `pagination_allowed_hosts entry "https://" must have both a scheme and a host`,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := map[string]interface{}{
+			m := map[string]any{
 				"request.url":                       "https://localhost",
 				"response.pagination_allowed_hosts": test.hosts,
 			}
@@ -746,17 +745,17 @@ func TestPaginationAllowedHostsValidation(t *testing.T) {
 }
 
 func TestCursorEntryConfig(t *testing.T) {
-	in := map[string]interface{}{
-		"entry1": map[string]interface{}{
+	in := map[string]any{
+		"entry1": map[string]any{
 			"ignore_empty_value": true,
 		},
-		"entry2": map[string]interface{}{
+		"entry2": map[string]any{
 			"ignore_empty_value": false,
 		},
-		"entry3": map[string]interface{}{
+		"entry3": map[string]any{
 			"ignore_empty_value": nil,
 		},
-		"entry4": map[string]interface{}{},
+		"entry4": map[string]any{},
 	}
 	cfg := conf.MustNewConfigFrom(in)
 	conf := cursorConfig{}
@@ -769,32 +768,32 @@ func TestCursorEntryConfig(t *testing.T) {
 
 var keepAliveTests = []struct {
 	name    string
-	input   map[string]interface{}
+	input   map[string]any
 	want    httpcommon.WithKeepaliveSettings
 	wantErr error
 }{
 	{
 		name:  "keep_alive_none", // Default to the old behaviour of true.
-		input: map[string]interface{}{},
+		input: map[string]any{},
 		want:  httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_true",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable": true,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: true},
 	},
 	{
 		name: "keep_alive_false",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable": false,
 		},
 		want: httpcommon.WithKeepaliveSettings{Disable: false},
 	},
 	{
 		name: "keep_alive_invalid_max",
-		input: map[string]interface{}{
+		input: map[string]any{
 			"request.keep_alive.disable":              false,
 			"request.keep_alive.max_idle_connections": -1,
 		},

--- a/x-pack/filebeat/input/httpjson/cursor_test.go
+++ b/x-pack/filebeat/input/httpjson/cursor_test.go
@@ -22,7 +22,7 @@ import (
 func TestCursorUpdate(t *testing.T) {
 	testCases := []struct {
 		name          string
-		baseConfig    map[string]interface{}
+		baseConfig    map[string]any
 		trCtx         *transformContext
 		initialState  mapstr.M
 		expectedState mapstr.M
@@ -30,8 +30,8 @@ func TestCursorUpdate(t *testing.T) {
 	}{
 		{
 			name: "update an unexisting value",
-			baseConfig: map[string]interface{}{
-				"entry1": map[string]interface{}{
+			baseConfig: map[string]any{
+				"entry1": map[string]any{
 					"value": "v1",
 				},
 			},
@@ -44,8 +44,8 @@ func TestCursorUpdate(t *testing.T) {
 		},
 		{
 			name: "update an existing value with a template",
-			baseConfig: map[string]interface{}{
-				"entry1": map[string]interface{}{
+			baseConfig: map[string]any{
+				"entry1": map[string]any{
 					"value": "[[ .last_response.body.foo ]]",
 				},
 			},
@@ -66,30 +66,30 @@ func TestCursorUpdate(t *testing.T) {
 		},
 		{
 			name: "don't update an existing value if template result is empty",
-			baseConfig: map[string]interface{}{
-				"entry1": map[string]interface{}{
+			baseConfig: map[string]any{
+				"entry1": map[string]any{
 					"value":              ``,
 					"do_not_log_failure": true,
 				},
-				"entry2": map[string]interface{}{
+				"entry2": map[string]any{
 					"value":              ``,
 					"ignore_empty_value": true,
 				},
-				"entry3": map[string]interface{}{
+				"entry3": map[string]any{
 					"value":              ``,
 					"ignore_empty_value": nil,
 				},
-				"entry4": map[string]interface{}{
+				"entry4": map[string]any{
 					"value":              ``,
 					"ignore_empty_value": false,
 					"do_not_log_failure": true,
 				},
-				"entry5": map[string]interface{}{
+				"entry5": map[string]any{
 					"value":              ``,
 					"ignore_empty_value": false,
 					"do_not_log_failure": false,
 				},
-				"entry6": map[string]interface{}{
+				"entry6": map[string]any{
 					"value":              ``,
 					"ignore_empty_value": false,
 				},
@@ -117,8 +117,8 @@ func TestCursorUpdate(t *testing.T) {
 		},
 		{
 			name: "update an existing value if template result is empty and ignore_empty_value is false",
-			baseConfig: map[string]interface{}{
-				"entry1": map[string]interface{}{
+			baseConfig: map[string]any{
+				"entry1": map[string]any{
 					"value":              ``,
 					"ignore_empty_value": false,
 					"do_not_log_failure": true,
@@ -161,9 +161,9 @@ func TestCursorUpdate(t *testing.T) {
 func BenchmarkCursorUpdate(b *testing.B) {
 	for _, nItems := range []int{100, 1000, 5000} {
 		b.Run(fmt.Sprintf("response_%d_items", nItems), func(b *testing.B) {
-			items := make([]interface{}, nItems)
+			items := make([]any, nItems)
 			for i := range items {
-				items[i] = map[string]interface{}{
+				items[i] = map[string]any{
 					"id":    i,
 					"name":  fmt.Sprintf("item-%d", i),
 					"value": strings.Repeat("x", 100),
@@ -175,13 +175,13 @@ func BenchmarkCursorUpdate(b *testing.B) {
 			}
 
 			lastEvent := mapstr.M{
-				"id":        map[string]interface{}{"time": "2025-01-01T00:00:00Z"},
+				"id":        map[string]any{"time": "2025-01-01T00:00:00Z"},
 				"name":      "some-event",
 				"important": "data",
 			}
 
-			cursorCfg := conf.MustNewConfigFrom(map[string]interface{}{
-				"updated": map[string]interface{}{
+			cursorCfg := conf.MustNewConfigFrom(map[string]any{
+				"updated": map[string]any{
 					"value": "[[ .last_event.id.time ]]",
 				},
 			})

--- a/x-pack/filebeat/input/httpjson/encoding.go
+++ b/x-pack/filebeat/input/httpjson/encoding.go
@@ -99,10 +99,10 @@ func encodeAsForm(trReq transformable) ([]byte, error) {
 // decodeAsNdjson decodes the message in p as a JSON object stream
 // It is more relaxed than NDJSON.
 func decodeAsNdjson(p []byte, dst *response) error {
-	var results []interface{}
+	var results []any
 	dec := json.NewDecoder(bytes.NewReader(p))
 	for dec.More() {
-		var o interface{}
+		var o any
 		if err := dec.Decode(&o); err != nil {
 			return textContextError{error: err, body: p}
 		}
@@ -114,7 +114,7 @@ func decodeAsNdjson(p []byte, dst *response) error {
 
 // decodeAsCSV decodes p as a headed CSV document into dst.
 func decodeAsCSV(p []byte, dst *response) error {
-	var results []interface{}
+	var results []any
 
 	r := csv.NewReader(bytes.NewReader(p))
 
@@ -130,7 +130,7 @@ func decodeAsCSV(p []byte, dst *response) error {
 
 	event, err := r.Read()
 	for ; err == nil; event, err = r.Read() {
-		o := make(map[string]interface{}, len(header))
+		o := make(map[string]any, len(header))
 		if len(header) != len(event) {
 			// sanity check, csv.Reader should fail on this scenario
 			// and this code path should be unreachable
@@ -155,7 +155,7 @@ func decodeAsCSV(p []byte, dst *response) error {
 
 // decodeAsZip decodes p as a ZIP archive into dst.
 func decodeAsZip(p []byte, dst *response) error {
-	var results []interface{}
+	var results []any
 	r, err := zip.NewReader(bytes.NewReader(p), int64(len(p)))
 	if err != nil {
 		return err
@@ -171,7 +171,7 @@ func decodeAsZip(p []byte, dst *response) error {
 
 		dec := json.NewDecoder(rc)
 		for dec.More() {
-			var o interface{}
+			var o any
 			if err := dec.Decode(&o); err != nil {
 				rc.Close()
 				return textContextError{error: err, body: p}

--- a/x-pack/filebeat/input/httpjson/input_stateless.go
+++ b/x-pack/filebeat/input/httpjson/input_stateless.go
@@ -39,7 +39,7 @@ type statelessPublisher struct {
 	wrapped stateless.Publisher
 }
 
-func (pub statelessPublisher) Publish(event beat.Event, _ interface{}) error {
+func (pub statelessPublisher) Publish(event beat.Event, _ any) error {
 	pub.wrapped.Publish(event)
 	return nil
 }

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -33,8 +33,8 @@ import (
 
 var testCases = []struct {
 	name                    string
-	setupServer             func(testing.TB, http.HandlerFunc, map[string]interface{})
-	baseConfig              map[string]interface{}
+	setupServer             func(testing.TB, http.HandlerFunc, map[string]any)
+	baseConfig              map[string]any
 	handler                 http.HandlerFunc
 	expected                []string
 	expectedFile            string
@@ -47,7 +47,7 @@ var testCases = []struct {
 	{
 		name:        "simple_GET_request",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
 		},
@@ -57,7 +57,7 @@ var testCases = []struct {
 	{
 		name:        "simple_HTTPS_GET_request",
 		setupServer: newTestServer(httptest.NewTLSServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                      1,
 			"request.method":                http.MethodGet,
 			"request.ssl.verification_mode": "none",
@@ -68,7 +68,7 @@ var testCases = []struct {
 	{
 		name:        "simple_GET_request_returns_an_array_of_strings_no_events",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
 		},
@@ -78,7 +78,7 @@ var testCases = []struct {
 	{
 		name:        "request_honors_rate_limit",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                     1,
 			"http_method":                  http.MethodGet,
 			"request.rate_limit.limit":     `[[.last_response.header.Get "X-Rate-Limit-Limit"]]`,
@@ -91,7 +91,7 @@ var testCases = []struct {
 	{
 		name:        "request_retries_when_failed",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
 		},
@@ -101,10 +101,10 @@ var testCases = []struct {
 	{
 		name:        "POST_request_with_body",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodPost,
-			"request.body": map[string]interface{}{
+			"request.body": map[string]any{
 				"test": "abc",
 			},
 		},
@@ -114,10 +114,10 @@ var testCases = []struct {
 	{
 		name:        "POST_request_with_empty_object_body",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodPost,
-			"request.body":   map[string]interface{}{},
+			"request.body":   map[string]any{},
 		},
 		handler:  defaultHandler(http.MethodPost, `{}`, ""),
 		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
@@ -125,7 +125,7 @@ var testCases = []struct {
 	{
 		name:        "repeated_POST_requests",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       "100ms",
 			"request.method": http.MethodPost,
 		},
@@ -138,10 +138,10 @@ var testCases = []struct {
 	{
 		name:        "split_by_json_objects_array",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.hello",
 			},
 		},
@@ -151,10 +151,10 @@ var testCases = []struct {
 	{
 		name:        "split_by_json_objects_array_with_keep_parent",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target":      "body.hello",
 				"keep_parent": true,
 			},
@@ -168,10 +168,10 @@ var testCases = []struct {
 	{
 		name:        "split_on_empty_array_without_ignore_empty_value",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.response.empty",
 			},
 		},
@@ -181,10 +181,10 @@ var testCases = []struct {
 	{
 		name:        "split_on_empty_array_with_ignore_empty_value",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target":             "body.response.empty",
 				"ignore_empty_value": true,
 			},
@@ -195,10 +195,10 @@ var testCases = []struct {
 	{
 		name:        "split_on_null_field_with_ignore_empty_value_keeping_parent",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target":             "body.response.empty",
 				"ignore_empty_value": true,
 				"keep_parent":        true,
@@ -210,10 +210,10 @@ var testCases = []struct {
 	{
 		name:        "split_on_empty_array_with_ignore_empty_value_keeping_parent",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target":             "body.response.empty",
 				"ignore_empty_value": true,
 				"keep_parent":        true,
@@ -225,10 +225,10 @@ var testCases = []struct {
 	{
 		name:        "split_on_null_field_at_root_with_ignore_empty_value_keeping_parent",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target":             "body.response",
 				"ignore_empty_value": true,
 				"keep_parent":        true,
@@ -240,10 +240,10 @@ var testCases = []struct {
 	{
 		name:        "split_on_empty_array_at_root_with_ignore_empty_value_keeping_parent",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target":             "body.response",
 				"ignore_empty_value": true,
 				"keep_parent":        true,
@@ -255,12 +255,12 @@ var testCases = []struct {
 	{
 		name:        "nested_split",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.hello",
-				"split": map[string]interface{}{
+				"split": map[string]any{
 					"target":      "body.space",
 					"keep_parent": true,
 				},
@@ -275,10 +275,10 @@ var testCases = []struct {
 	{
 		name:        "split_events_by_not_found",
 		setupServer: newTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.unknown",
 			},
 		},
@@ -287,7 +287,7 @@ var testCases = []struct {
 	},
 	{
 		name: "date_cursor",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			// mock timeNow func to return a fixed value
 			timeNow = func() time.Time {
 				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
@@ -299,20 +299,20 @@ var testCases = []struct {
 			t.Cleanup(server.Close)
 			t.Cleanup(func() { timeNow = time.Now })
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"request.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":  "url.params.$filter",
 						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
 						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"timestamp": map[string]interface{}{
+			"cursor": map[string]any{
+				"timestamp": map[string]any{
 					"value": `[[index .last_response.body "@timestamp"]]`,
 				},
 			},
@@ -326,7 +326,7 @@ var testCases = []struct {
 	},
 	{
 		name: "tracer_filename_sanitization",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			// mock timeNow func to return a fixed value
 			timeNow = func() time.Time {
 				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
@@ -338,20 +338,20 @@ var testCases = []struct {
 			t.Cleanup(server.Close)
 			t.Cleanup(func() { timeNow = time.Now })
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"request.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":  "url.params.$filter",
 						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
 						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"timestamp": map[string]interface{}{
+			"cursor": map[string]any{
+				"timestamp": map[string]any{
 					"value": `[[index .last_response.body "@timestamp"]]`,
 				},
 			},
@@ -367,7 +367,7 @@ var testCases = []struct {
 	},
 	{
 		name: "tracer_filename_sanitization_enabled",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			// mock timeNow func to return a fixed value
 			timeNow = func() time.Time {
 				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
@@ -379,20 +379,20 @@ var testCases = []struct {
 			t.Cleanup(server.Close)
 			t.Cleanup(func() { timeNow = time.Now })
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"request.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":  "url.params.$filter",
 						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
 						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"timestamp": map[string]interface{}{
+			"cursor": map[string]any{
+				"timestamp": map[string]any{
 					"value": `[[index .last_response.body "@timestamp"]]`,
 				},
 			},
@@ -409,7 +409,7 @@ var testCases = []struct {
 	},
 	{
 		name: "tracer_filename_sanitization_disabled",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			// mock timeNow func to return a fixed value
 			timeNow = func() time.Time {
 				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
@@ -421,20 +421,20 @@ var testCases = []struct {
 			t.Cleanup(server.Close)
 			t.Cleanup(func() { timeNow = time.Now })
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"request.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":  "url.params.$filter",
 						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
 						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"timestamp": map[string]interface{}{
+			"cursor": map[string]any{
+				"timestamp": map[string]any{
 					"value": `[[index .last_response.body "@timestamp"]]`,
 				},
 			},
@@ -456,12 +456,12 @@ var testCases = []struct {
 	// case can exercise an out-of-tree path at the input level.
 	{
 		name: "tracer_disabled_escaping_logs",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                1,
 			"request.method":          http.MethodGet,
 			"request.tracer.enabled":  false,
@@ -472,28 +472,28 @@ var testCases = []struct {
 	},
 	{
 		name: "pagination",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       time.Millisecond,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.items",
-				"transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+				"transforms": []any{
+					map[string]any{
+						"set": map[string]any{
 							"target": "body.page",
 							"value":  "[[.last_response.page]]",
 						},
 					},
 				},
 			},
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.params.page",
 						"value":                  "[[.last_response.body.nextPageToken]]",
 						"fail_on_template_error": true,
@@ -509,28 +509,28 @@ var testCases = []struct {
 	},
 	{
 		name: "pagination_not_log_fail",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       time.Millisecond,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.items",
-				"transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+				"transforms": []any{
+					map[string]any{
+						"set": map[string]any{
 							"target": "body.page",
 							"value":  "[[.last_response.page]]",
 						},
 					},
 				},
 			},
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.params.page",
 						"value":                  "[[.last_response.body.nextPageToken]]",
 						"fail_on_template_error": true,
@@ -547,19 +547,19 @@ var testCases = []struct {
 	},
 	{
 		name: "first_event",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.items",
-				"transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+				"transforms": []any{
+					map[string]any{
+						"set": map[string]any{
 							"target":  "body.first",
 							"value":   "[[.cursor.first]]",
 							"default": "none",
@@ -567,17 +567,17 @@ var testCases = []struct {
 					},
 				},
 			},
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.params.page",
 						"value":                  "[[.last_response.body.nextPageToken]]",
 						"fail_on_template_error": true,
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"first": map[string]interface{}{
+			"cursor": map[string]any{
+				"first": map[string]any{
 					"value": "[[.first_event.foo]]",
 				},
 			},
@@ -587,17 +587,17 @@ var testCases = []struct {
 	},
 	{
 		name: "pagination_with_array_response",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target": "url.params.page",
 						"value":  `[[index (index .last_response.body 0) "nextPageToken"]]`,
 					},
@@ -609,18 +609,18 @@ var testCases = []struct {
 	},
 	{
 		name: "oauth2",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			config["auth.oauth2.token_url"] = server.URL + "/token"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                  1,
 			"request.method":            http.MethodPost,
 			"auth.oauth2.client.id":     "a_client_id",
 			"auth.oauth2.client.secret": "a_client_secret",
-			"auth.oauth2.endpoint_params": map[string]interface{}{
+			"auth.oauth2.endpoint_params": map[string]any{
 				"param1": "v1",
 			},
 			"auth.oauth2.scopes": []string{"scope1", "scope2"},
@@ -630,12 +630,12 @@ var testCases = []struct {
 	},
 	{
 		name: "aws auth",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                   1,
 			"request.method":             http.MethodGet,
 			"auth.aws.access_key_id":     "AKIAIOSFODNN7EXAMPLE",
@@ -648,7 +648,7 @@ var testCases = []struct {
 	},
 	{
 		name: "file_auth_default_header",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			dir := t.TempDir()
 			secret := "file-secret"
 			path := filepath.Join(dir, "auth_token")
@@ -662,7 +662,7 @@ var testCases = []struct {
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
 		},
@@ -671,7 +671,7 @@ var testCases = []struct {
 	},
 	{
 		name: "file_auth_custom_header",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			dir := t.TempDir()
 			tokenPath := filepath.Join(dir, "api_token")
 			if err := os.WriteFile(tokenPath, []byte("secret-api-token\n"), 0o600); err != nil {
@@ -684,7 +684,7 @@ var testCases = []struct {
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
 		},
@@ -695,12 +695,12 @@ var testCases = []struct {
 	// Auth header sanitization in trace logs.
 	{
 		name: "trace_sanitize_basic_auth",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                1,
 			"request.method":          http.MethodGet,
 			"auth.basic.user":         "test_user",
@@ -715,18 +715,18 @@ var testCases = []struct {
 	},
 	{
 		name: "trace_sanitize_oauth2",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			config["auth.oauth2.token_url"] = server.URL + "/token"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                  1,
 			"request.method":            http.MethodPost,
 			"auth.oauth2.client.id":     "a_client_id",
 			"auth.oauth2.client.secret": "a_client_secret",
-			"auth.oauth2.endpoint_params": map[string]interface{}{
+			"auth.oauth2.endpoint_params": map[string]any{
 				"param1": "v1",
 			},
 			"auth.oauth2.scopes":      []string{"scope1", "scope2"},
@@ -740,12 +740,12 @@ var testCases = []struct {
 	},
 	{
 		name: "trace_sanitize_aws_auth",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                   1,
 			"request.method":             http.MethodGet,
 			"auth.aws.access_key_id":     "AKIAIOSFODNN7EXAMPLE",
@@ -762,7 +762,7 @@ var testCases = []struct {
 	},
 	{
 		name: "trace_sanitize_file_auth",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			dir := t.TempDir()
 			secret := "file-secret"
 			path := filepath.Join(dir, "auth_token")
@@ -776,7 +776,7 @@ var testCases = []struct {
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                1,
 			"request.method":          http.MethodGet,
 			"request.tracer.enabled":  true,
@@ -789,29 +789,29 @@ var testCases = []struct {
 	},
 	{
 		name: "request_transforms_can_access_state_from_previous_transforms",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL + "/test-path"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodPost,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"request.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target": "header.X-Foo",
 						"value":  "foo",
 					},
 				},
-				map[string]interface{}{
-					"set": map[string]interface{}{
+				map[string]any{
+					"set": map[string]any{
 						"target": "body.bar",
 						"value":  `[[.header.Get "X-Foo"]]`,
 					},
 				},
-				map[string]interface{}{
-					"set": map[string]interface{}{
+				map[string]any{
+					"set": map[string]any{
 						"target": "body.url.path",
 						"value":  `[[.url.Path]]`,
 					},
@@ -823,25 +823,25 @@ var testCases = []struct {
 	},
 	{
 		name: "response_transforms_can't_access_request_state_from_previous_transforms",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			server := httptest.NewServer(h)
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       10,
 			"request.method": http.MethodGet,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"request.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target": "header.X-Foo",
 						"value":  "foo",
 					},
 				},
 			},
-			"response.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target": "body.bar",
 						"value":  `[[.header.Get "X-Foo"]]`,
 					},
@@ -854,12 +854,12 @@ var testCases = []struct {
 	{
 		name:        "simple_Chain_GET_request",
 		setupServer: newChainTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       10,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
 					},
@@ -872,12 +872,12 @@ var testCases = []struct {
 	{
 		name:        "simple_naked_Chain_GET_request",
 		setupServer: newNakedChainTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       10,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.url":    "placeholder:$.records[:]",
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:]",
@@ -890,7 +890,7 @@ var testCases = []struct {
 	},
 	{
 		name: "multiple_Chain_GET_request",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -907,18 +907,18 @@ var testCases = []struct {
 			config["chain.1.step.request.url"] = server.URL + "/$.file_name"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       10,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
 					},
 				},
-				map[string]interface{}{
-					"step": map[string]interface{}{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.file_name",
 					},
@@ -930,7 +930,7 @@ var testCases = []struct {
 	},
 	{
 		name: "date_cursor_while_using_chain",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			// mock timeNow func to return a fixed value
 			timeNow = func() time.Time {
 				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
@@ -951,28 +951,28 @@ var testCases = []struct {
 			t.Cleanup(server.Close)
 			t.Cleanup(func() { timeNow = time.Now })
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"request.transforms": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"request.transforms": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":  "url.params.$filter",
 						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
 						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
 					},
 				},
 			},
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"timestamp": map[string]interface{}{
+			"cursor": map[string]any{
+				"timestamp": map[string]any{
 					"value": `[[index .last_response.body "@timestamp"]]`,
 				},
 			},
@@ -983,15 +983,15 @@ var testCases = []struct {
 	{
 		name:        "split_by_json_objects_array_in_chain",
 		setupServer: newChainTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
-						"response.split": map[string]interface{}{
+						"response.split": map[string]any{
 							"target": "body.hello",
 						},
 					},
@@ -1004,15 +1004,15 @@ var testCases = []struct {
 	{
 		name:        "split_by_json_objects_array_with_keep_parent_in_chain",
 		setupServer: newChainTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
-						"response.split": map[string]interface{}{
+						"response.split": map[string]any{
 							"target":      "body.hello",
 							"keep_parent": true,
 						},
@@ -1029,20 +1029,20 @@ var testCases = []struct {
 	{
 		name:        "nested_split_in_chain",
 		setupServer: newChainTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target": "body.hello",
 			},
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
-						"response.split": map[string]interface{}{
+						"response.split": map[string]any{
 							"target": "body.hello",
-							"split": map[string]interface{}{
+							"split": map[string]any{
 								"target":      "body.space",
 								"keep_parent": true,
 							},
@@ -1060,21 +1060,21 @@ var testCases = []struct {
 	{
 		name:        "pagination_when_used_with_chaining",
 		setupServer: newChainPaginationTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.value",
 						"value":                  "[[.last_response.body.nextLink]]",
 						"fail_on_template_error": true,
 					},
 				},
 			},
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
 					},
@@ -1090,12 +1090,12 @@ var testCases = []struct {
 	{
 		name:        "pagination_when_used_with_chaining_not_log_fail",
 		setupServer: newChainPaginationTestServer(httptest.NewServer),
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.value",
 						"value":                  "[[.last_response.body.nextLink]]",
 						"fail_on_template_error": true,
@@ -1103,9 +1103,9 @@ var testCases = []struct {
 					},
 				},
 			},
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.records[:].id",
 					},
@@ -1120,7 +1120,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_with_clause_and_first_response_object",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1139,19 +1139,19 @@ var testCases = []struct {
 			config["chain.1.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                     1,
 			"request.method":               http.MethodGet,
 			"response.save_first_response": true,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.exportId",
 					},
 				},
-				map[string]interface{}{
-					"step": map[string]interface{}{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,.first_response.body.exportId",
@@ -1166,7 +1166,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_with_clause_with_values_from_string_array",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1182,12 +1182,12 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.text[:]"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.text[:]",
 						"replace_with":   "$.exportId,2212",
@@ -1202,7 +1202,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_clause_with_string_from_string_array",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1218,12 +1218,12 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$[:]"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$[:]",
 						"replace_with":   "$.exportId,2212",
@@ -1238,7 +1238,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_clause_with_int_from_int_array",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1254,12 +1254,12 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$[:]"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$[:]",
 						"replace_with":   "$.exportId,2212",
@@ -1274,7 +1274,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_with_clause_with_hardcoded_value_1",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1290,12 +1290,12 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,2212",
@@ -1310,7 +1310,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_with_clause_with_hardcoded_value_(no_dot_prefix)",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1326,13 +1326,13 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                     1,
 			"request.method":               http.MethodGet,
 			"response.save_first_response": true,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,first_response.body.id",
@@ -1347,7 +1347,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_with_clause_with_hardcoded_value_(more_than_one_dot_prefix)",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1363,13 +1363,13 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                     1,
 			"request.method":               http.MethodGet,
 			"response.save_first_response": true,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,..first_response.body.id",
@@ -1384,7 +1384,7 @@ var testCases = []struct {
 	},
 	{
 		name: "replace_with_clause_with_hardcoded_value_containing_'.'_(dots)",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/":
@@ -1400,12 +1400,12 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodGet,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,.xyz.2212.abc.",
@@ -1420,7 +1420,7 @@ var testCases = []struct {
 	},
 	{
 		name: "global_transform_context_separation_with_parent_last_response_object",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			var serverURL string
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -1444,28 +1444,28 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                            1,
 			"request.method":                      http.MethodPost,
 			"response.request_body_on_pagination": true,
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.value",
 						"value":                  "[[.last_response.body.nextLink]]",
 						"fail_on_template_error": true,
 					},
 				},
 			},
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodPost,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,.parent_last_response.body.exportId",
-						"request.transforms": []interface{}{
-							map[string]interface{}{
-								"set": map[string]interface{}{
+						"request.transforms": []any{
+							map[string]any{
+								"set": map[string]any{
 									"target": "body.exportId",
 									"value":  "[[ .parent_last_response.body.exportId ]]",
 								},
@@ -1484,7 +1484,7 @@ var testCases = []struct {
 	},
 	{
 		name: "cursor_value_is_updated_for_root_response_with_chaining_&_pagination",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			var serverURL string
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -1509,34 +1509,34 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                            1,
 			"request.method":                      http.MethodPost,
 			"response.request_body_on_pagination": true,
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.value",
 						"value":                  "[[.last_response.body.nextLink]]",
 						"fail_on_template_error": true,
 					},
 				},
 			},
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodPost,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,.parent_last_response.body.exportId",
-						"request.transforms": []interface{}{
-							map[string]interface{}{
-								"set": map[string]interface{}{
+						"request.transforms": []any{
+							map[string]any{
+								"set": map[string]any{
 									"target": "body.exportId",
 									"value":  "[[ .parent_last_response.body.exportId ]]",
 								},
 							},
-							map[string]interface{}{
-								"set": map[string]interface{}{
+							map[string]any{
+								"set": map[string]any{
 									"target": "body.createdAt",
 									"value":  "[[ .cursor.last_published_login ]]",
 								},
@@ -1545,8 +1545,8 @@ var testCases = []struct {
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"last_published_login": map[string]interface{}{
+			"cursor": map[string]any{
+				"last_published_login": map[string]any{
 					"value": "[[ .last_event.createdAt ]]",
 				},
 			},
@@ -1560,7 +1560,7 @@ var testCases = []struct {
 	},
 	{
 		name: "cursor_value_is_updated_for_root_response_with_chaining_&_pagination_along_with_split_operator",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			var serverURL string
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -1585,39 +1585,39 @@ var testCases = []struct {
 			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":                            1,
 			"request.method":                      http.MethodPost,
 			"response.request_body_on_pagination": true,
-			"response.pagination": []interface{}{
-				map[string]interface{}{
-					"set": map[string]interface{}{
+			"response.pagination": []any{
+				map[string]any{
+					"set": map[string]any{
 						"target":                 "url.value",
 						"value":                  "[[.last_response.body.nextLink]]",
 						"fail_on_template_error": true,
 					},
 				},
 			},
-			"response.split": map[string]interface{}{
+			"response.split": map[string]any{
 				"target":      "body.time",
 				"type":        "array",
 				"keep_parent": true,
 			},
-			"chain": []interface{}{
-				map[string]interface{}{
-					"step": map[string]interface{}{
+			"chain": []any{
+				map[string]any{
+					"step": map[string]any{
 						"request.method": http.MethodPost,
 						"replace":        "$.files[:].id",
 						"replace_with":   "$.exportId,.parent_last_response.body.exportId",
-						"request.transforms": []interface{}{
-							map[string]interface{}{
-								"set": map[string]interface{}{
+						"request.transforms": []any{
+							map[string]any{
+								"set": map[string]any{
 									"target": "body.exportId",
 									"value":  "[[ .parent_last_response.body.exportId ]]",
 								},
 							},
-							map[string]interface{}{
-								"set": map[string]interface{}{
+							map[string]any{
+								"set": map[string]any{
 									"target": "body.createdAt",
 									"value":  "[[ .cursor.last_published_login ]]",
 								},
@@ -1626,8 +1626,8 @@ var testCases = []struct {
 					},
 				},
 			},
-			"cursor": map[string]interface{}{
-				"last_published_login": map[string]interface{}{
+			"cursor": map[string]any{
+				"last_published_login": map[string]any{
 					"value": "[[ .last_event.time.timeStamp ]]",
 				},
 			},
@@ -1641,7 +1641,7 @@ var testCases = []struct {
 	},
 	{
 		name: "Test simple XML decode",
-		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				const text = `<?xml version="1.0" encoding="UTF-8"?>
 <order orderid="56733" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="sales.xsd">
@@ -1670,7 +1670,7 @@ var testCases = []struct {
 			config["request.url"] = server.URL
 			t.Cleanup(server.Close)
 		},
-		baseConfig: map[string]interface{}{
+		baseConfig: map[string]any{
 			"interval":       1,
 			"request.method": http.MethodGet,
 			"response.xsd": `<?xml version="1.0" encoding="UTF-8" ?>
@@ -1710,16 +1710,16 @@ var testCases = []struct {
 		},
 		handler: defaultHandler(http.MethodGet, "", ""),
 		expected: []string{mapstr.M{
-			"order": map[string]interface{}{
-				"address": map[string]interface{}{
+			"order": map[string]any{
+				"address": map[string]any{
 					"address": "Beekplantsoen 594, 2 hoog, 6849 IG",
 					"city":    "Boekend",
 					"company": "Sydøstlige Gruppe",
 					"country": "Netherlands",
 					"name":    "Joord Lennart",
 				},
-				"item": []interface{}{
-					map[string]interface{}{
+				"item": []any{
+					map[string]any{
 						"cost":   99.95,
 						"name":   "Egil's Saga",
 						"note":   "Free Sample",
@@ -1928,8 +1928,8 @@ func BenchmarkInput(b *testing.B) {
 
 func newTestServer(
 	newServer func(http.Handler) *httptest.Server,
-) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
-	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+) func(testing.TB, http.HandlerFunc, map[string]any) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 		server := newServer(h)
 		config["request.url"] = server.URL
 		t.Cleanup(server.Close)
@@ -1938,8 +1938,8 @@ func newTestServer(
 
 func newChainTestServer(
 	newServer func(http.Handler) *httptest.Server,
-) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
-	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+) func(testing.TB, http.HandlerFunc, map[string]any) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 		r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/":
@@ -1957,8 +1957,8 @@ func newChainTestServer(
 
 func newNakedChainTestServer(
 	newServer func(http.Handler) *httptest.Server,
-) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
-	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+) func(testing.TB, http.HandlerFunc, map[string]any) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 		var server *httptest.Server
 		r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
@@ -1976,8 +1976,8 @@ func newNakedChainTestServer(
 
 func newChainPaginationTestServer(
 	newServer func(http.Handler) *httptest.Server,
-) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
-	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+) func(testing.TB, http.HandlerFunc, map[string]any) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 		var serverURL string
 		r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {

--- a/x-pack/filebeat/input/httpjson/metrics_test.go
+++ b/x-pack/filebeat/input/httpjson/metrics_test.go
@@ -25,8 +25,8 @@ import (
 func TestMetrics(t *testing.T) {
 	testCases := []struct {
 		name           string
-		setupServer    func(*testing.T, http.HandlerFunc, map[string]interface{})
-		baseConfig     map[string]interface{}
+		setupServer    func(*testing.T, http.HandlerFunc, map[string]any)
+		baseConfig     map[string]any
 		handler        http.HandlerFunc
 		expectedEvents []string
 		assertMetrics  func(reg *monitoring.Registry) error
@@ -37,31 +37,31 @@ func TestMetrics(t *testing.T) {
 			skipReason: "windows:flakey test on windows - see https://github.com/elastic/beats/issues/39676",
 
 			name: "Test pagination metrics",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 				server := httptest.NewServer(h)
 				config["request.url"] = server.URL
 				t.Cleanup(server.Close)
 			},
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"interval":       time.Millisecond,
 				"request.method": http.MethodPost,
-				"request.body": map[string]interface{}{
+				"request.body": map[string]any{
 					"field": "value",
 				},
-				"response.split": map[string]interface{}{
+				"response.split": map[string]any{
 					"target": "body.items",
-					"transforms": []interface{}{
-						map[string]interface{}{
-							"set": map[string]interface{}{
+					"transforms": []any{
+						map[string]any{
+							"set": map[string]any{
 								"target": "body.page",
 								"value":  "[[.last_response.page]]",
 							},
 						},
 					},
 				},
-				"response.pagination": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+				"response.pagination": []any{
+					map[string]any{
+						"set": map[string]any{
 							"target":                 "url.params.page",
 							"value":                  "[[.last_response.body.nextPageToken]]",
 							"fail_on_template_error": true,
@@ -75,12 +75,12 @@ func TestMetrics(t *testing.T) {
 				`{"foo":"a","page":"0"}`, `{"foo":"b","page":"1"}`, `{"foo":"c","page":"0"}`, `{"foo":"d","page":"0"}`,
 			},
 			assertMetrics: func(reg *monitoring.Registry) error {
-				checkHasValue := func(v interface{}) bool {
+				checkHasValue := func(v any) bool {
 					switch t := v.(type) {
 					case int64:
 						return t > 0
-					case map[string]interface{}:
-						h := t["histogram"].(map[string]interface{})
+					case map[string]any:
+						h := t["histogram"].(map[string]any)
 						return h["count"].(int64) > 0 && h["max"].(int64) > 0
 					}
 					return false

--- a/x-pack/filebeat/input/httpjson/redirect.go
+++ b/x-pack/filebeat/input/httpjson/redirect.go
@@ -65,7 +65,7 @@ func (m InputManager) migrateCursor(src, dst *conf.C) {
 	defer store.Close()
 
 	key := cursorKey("httpjson", id, u.String())
-	var entry map[string]interface{}
+	var entry map[string]any
 	if err := store.Get(key, &entry); err != nil {
 		return
 	}

--- a/x-pack/filebeat/input/httpjson/redirect_test.go
+++ b/x-pack/filebeat/input/httpjson/redirect_test.go
@@ -33,13 +33,13 @@ func TestRedirect_EndToEnd(t *testing.T) {
 	loader, err := v2.NewLoader(log, []v2.Plugin{httpjsonPlugin, celPlugin}, "type", "")
 	require.NoError(t, err)
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"type":        "httpjson",
 		"interval":    "60s",
 		"run_as_cel":  true,
 		"request.url": "https://api.example.com/events",
 		"cel.program": `{"events":[{"message":"Hello, World!"}]}`,
-		"cel.state":   map[string]interface{}{},
+		"cel.state":   map[string]any{},
 	})
 
 	input, err := loader.Configure(cfg)
@@ -61,7 +61,7 @@ func TestRedirect_NoRedirectWhenFlagAbsent(t *testing.T) {
 	loader, err := v2.NewLoader(log, []v2.Plugin{httpjsonPlugin}, "type", "")
 	require.NoError(t, err)
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"type":        "httpjson",
 		"interval":    "60s",
 		"request.url": "https://api.example.com/events",
@@ -85,7 +85,7 @@ func TestRedirect_ErrorWithoutProgram(t *testing.T) {
 	loader, err := v2.NewLoader(log, []v2.Plugin{httpjsonPlugin}, "type", "")
 	require.NoError(t, err)
 
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
 		"type":        "httpjson",
 		"interval":    "60s",
 		"request.url": "https://api.example.com/events",
@@ -98,7 +98,7 @@ func TestRedirect_ErrorWithoutProgram(t *testing.T) {
 
 func TestConvertHttpjsonToCel(t *testing.T) {
 	t.Run("minimal", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"interval":    "60s",
 			"request.url": "https://api.example.com/events",
@@ -126,7 +126,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("passthrough_id", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"id":          "my-input",
 			"interval":    "60s",
@@ -143,7 +143,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("auth_block", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":                "httpjson",
 			"interval":            "60s",
 			"request.url":         "https://api.example.com/events",
@@ -165,7 +165,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("retry_block", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":                       "httpjson",
 			"interval":                   "60s",
 			"request.url":                "https://api.example.com/events",
@@ -191,7 +191,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("redirect_block", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":                             "httpjson",
 			"interval":                         "60s",
 			"request.url":                      "https://api.example.com/events",
@@ -216,7 +216,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("keep_alive_block", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"interval":    "60s",
 			"request.url": "https://api.example.com/events",
@@ -242,7 +242,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("tracer_block", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":                    "httpjson",
 			"interval":                "60s",
 			"request.url":             "https://api.example.com/events",
@@ -263,7 +263,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("transport_ssl", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":                          "httpjson",
 			"interval":                      "60s",
 			"request.url":                   "https://api.example.com/events",
@@ -284,7 +284,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("transport_timeout", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":            "httpjson",
 			"interval":        "60s",
 			"request.url":     "https://api.example.com/events",
@@ -301,7 +301,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("transport_proxy", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":                  "httpjson",
 			"interval":              "60s",
 			"request.url":           "https://api.example.com/events",
@@ -323,7 +323,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("cel_max_executions", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":               "httpjson",
 			"interval":           "60s",
 			"request.url":        "https://api.example.com/events",
@@ -340,12 +340,12 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("cel_state", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"interval":    "60s",
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.state":   map[string]interface{}{"cursor": map[string]interface{}{"ts": "2024-01-01T00:00:00Z"}},
+			"cel.state":   map[string]any{"cursor": map[string]any{"ts": "2024-01-01T00:00:00Z"}},
 		})
 
 		out, err := convertHttpjsonToCel(cfg)
@@ -361,12 +361,12 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("cel_regexp", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"interval":    "60s",
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.regexp":  map[string]interface{}{"link_next": `<([^>]+)>;\s*rel="next"`},
+			"cel.regexp":  map[string]any{"link_next": `<([^>]+)>;\s*rel="next"`},
 		})
 
 		out, err := convertHttpjsonToCel(cfg)
@@ -378,12 +378,12 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("cel_xsd", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"interval":    "60s",
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.xsd":     map[string]interface{}{"evt": "<xs:schema/>"},
+			"cel.xsd":     map[string]any{"evt": "<xs:schema/>"},
 		})
 
 		out, err := convertHttpjsonToCel(cfg)
@@ -395,12 +395,12 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("cel_redact", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"interval":    "60s",
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.redact":  map[string]interface{}{"fields": []string{"auth_token"}, "delete": true},
+			"cel.redact":  map[string]any{"fields": []string{"auth_token"}, "delete": true},
 		})
 
 		out, err := convertHttpjsonToCel(cfg)
@@ -416,7 +416,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("httpjson_only_fields_excluded", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":           "httpjson",
 			"interval":       "60s",
 			"request.url":    "https://api.example.com/events",
@@ -437,7 +437,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("realistic_full_config", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"id":          "okta-system-log",
 			"interval":    "120s",
@@ -473,9 +473,9 @@ state.url.with({
     })
 ))`,
 			"cel.max_executions": 100,
-			"cel.state":          map[string]interface{}{"cursor": map[string]interface{}{"after": ""}},
-			"cel.regexp":         map[string]interface{}{"link": `<([^>]+)>;\s*rel="next"`},
-			"cel.redact":         map[string]interface{}{"fields": []string{"auth.oauth2.client.secret"}},
+			"cel.state":          map[string]any{"cursor": map[string]any{"after": ""}},
+			"cel.regexp":         map[string]any{"link": `<([^>]+)>;\s*rel="next"`},
+			"cel.redact":         map[string]any{"fields": []string{"auth.oauth2.client.secret"}},
 		})
 
 		out, err := convertHttpjsonToCel(cfg)
@@ -574,23 +574,23 @@ func TestMigrateCursor(t *testing.T) {
 		store := newTestStore()
 		s, err := store.StoreFor("httpjson")
 		require.NoError(t, err)
-		err = s.Set("httpjson::my-input::https://api.example.com/events", map[string]interface{}{
+		err = s.Set("httpjson::my-input::https://api.example.com/events", map[string]any{
 			"ttl":     0,
 			"updated": time.Now(),
-			"cursor":  map[string]interface{}{"timestamp": "2025-06-15T10:30:00Z"},
+			"cursor":  map[string]any{"timestamp": "2025-06-15T10:30:00Z"},
 		})
 		require.NoError(t, err)
 		s.Close()
 
 		mgr := NewInputManager(logp.NewNopLogger(), store)
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"id":          "my-input",
 			"interval":    "60s",
 			"run_as_cel":  true,
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.state":   map[string]interface{}{"cursor": map[string]interface{}{"timestamp": ""}},
+			"cel.state":   map[string]any{"cursor": map[string]any{"timestamp": ""}},
 		})
 
 		_, newCfg, err := mgr.Redirect(cfg)
@@ -604,14 +604,14 @@ func TestMigrateCursor(t *testing.T) {
 	t.Run("no_entry", func(t *testing.T) {
 		store := newTestStore()
 		mgr := NewInputManager(logp.NewNopLogger(), store)
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"id":          "my-input",
 			"interval":    "60s",
 			"run_as_cel":  true,
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.state":   map[string]interface{}{"cursor": map[string]interface{}{"timestamp": "default"}},
+			"cel.state":   map[string]any{"cursor": map[string]any{"timestamp": "default"}},
 		})
 
 		_, newCfg, err := mgr.Redirect(cfg)
@@ -626,22 +626,22 @@ func TestMigrateCursor(t *testing.T) {
 		store := newTestStore()
 		s, err := store.StoreFor("httpjson")
 		require.NoError(t, err)
-		err = s.Set("httpjson::https://api.example.com/events", map[string]interface{}{
+		err = s.Set("httpjson::https://api.example.com/events", map[string]any{
 			"ttl":     0,
 			"updated": time.Now(),
-			"cursor":  map[string]interface{}{"page": "42"},
+			"cursor":  map[string]any{"page": "42"},
 		})
 		require.NoError(t, err)
 		s.Close()
 
 		mgr := NewInputManager(logp.NewNopLogger(), store)
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"interval":    "60s",
 			"run_as_cel":  true,
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.state":   map[string]interface{}{},
+			"cel.state":   map[string]any{},
 		})
 
 		_, newCfg, err := mgr.Redirect(cfg)
@@ -656,16 +656,16 @@ func TestMigrateCursor(t *testing.T) {
 		store := newTestStore()
 		s, err := store.StoreFor("httpjson")
 		require.NoError(t, err)
-		err = s.Set("httpjson::no-state::https://api.example.com/events", map[string]interface{}{
+		err = s.Set("httpjson::no-state::https://api.example.com/events", map[string]any{
 			"ttl":     0,
 			"updated": time.Now(),
-			"cursor":  map[string]interface{}{"offset": "100"},
+			"cursor":  map[string]any{"offset": "100"},
 		})
 		require.NoError(t, err)
 		s.Close()
 
 		mgr := NewInputManager(logp.NewNopLogger(), store)
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"id":          "no-state",
 			"interval":    "60s",
@@ -686,23 +686,23 @@ func TestMigrateCursor(t *testing.T) {
 		store := newTestStore()
 		s, err := store.StoreFor("httpjson")
 		require.NoError(t, err)
-		err = s.Set("httpjson::idem::https://api.example.com/events", map[string]interface{}{
+		err = s.Set("httpjson::idem::https://api.example.com/events", map[string]any{
 			"ttl":     0,
 			"updated": time.Now(),
-			"cursor":  map[string]interface{}{"seq": "99"},
+			"cursor":  map[string]any{"seq": "99"},
 		})
 		require.NoError(t, err)
 		s.Close()
 
 		mgr := NewInputManager(logp.NewNopLogger(), store)
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
 			"id":          "idem",
 			"interval":    "60s",
 			"run_as_cel":  true,
 			"request.url": "https://api.example.com/events",
 			"cel.program": `true`,
-			"cel.state":   map[string]interface{}{},
+			"cel.state":   map[string]any{},
 		})
 
 		_, first, err := mgr.Redirect(cfg)

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -79,7 +79,7 @@ func (r *requester) doRequest(ctx context.Context, trCtx *transformContext, publ
 
 			if rf.saveFirstResponse {
 				// store first response in transform context
-				var bodyMap map[string]interface{}
+				var bodyMap map[string]any
 				body, err := io.ReadAll(httpResp.Body)
 				if err != nil {
 					err = fmt.Errorf("failed to read http response body: %w", err)
@@ -628,7 +628,7 @@ func (r *requester) getIdsFromResponses(intermediateResps []*http.Response, repl
 		}
 
 		// get replace values from collected json
-		var v interface{}
+		var v any
 		if err := json.Unmarshal(b, &v); err != nil {
 			return nil, fmt.Errorf("cannot unmarshal data: %w", textContextError{error: err, body: b})
 		}
@@ -638,7 +638,7 @@ func (r *requester) getIdsFromResponses(intermediateResps []*http.Response, repl
 		}
 
 		switch tresp := values.(type) {
-		case []interface{}:
+		case []any:
 			for _, v := range tresp {
 				switch v.(type) {
 				case float64, string:
@@ -950,7 +950,7 @@ const (
 )
 
 func fetchValueFromContext(trCtx *transformContext, expression string) (string, bool, error) {
-	var val interface{}
+	var val any
 
 	switch keys := processExpression(expression); keys[0] {
 	case lastResponse:
@@ -1013,7 +1013,7 @@ func responseToMap(r *response) (mapstr.M, error) {
 	if r.body == nil {
 		return nil, fmt.Errorf("response body is empty for request url: %s", &r.url)
 	}
-	respMap := map[string]interface{}{
+	respMap := map[string]any{
 		"header": make(mapstr.M),
 		"body":   r.body,
 	}
@@ -1025,7 +1025,7 @@ func responseToMap(r *response) (mapstr.M, error) {
 	return respMap, nil
 }
 
-func iterateRecursive(m mapstr.M, keys []string, depth int) (interface{}, error) {
+func iterateRecursive(m mapstr.M, keys []string, depth int) (any, error) {
 	val := m[keys[depth]]
 
 	if val == nil {
@@ -1044,7 +1044,7 @@ func iterateRecursive(m mapstr.M, keys []string, depth int) (interface{}, error)
 	case reflect.String:
 		return v.String(), nil
 	case reflect.Map:
-		nextMap, ok := v.Interface().(map[string]interface{})
+		nextMap, ok := v.Interface().(map[string]any)
 		if !ok {
 			return nil, errors.New("unable to parse the value of the given expression")
 		}

--- a/x-pack/filebeat/input/httpjson/response.go
+++ b/x-pack/filebeat/input/httpjson/response.go
@@ -24,7 +24,7 @@ type response struct {
 	url        url.URL
 	header     http.Header
 	xmlDetails map[string]xml.Detail
-	body       interface{}
+	body       any
 }
 
 func (resp *response) clone() *response {
@@ -35,13 +35,13 @@ func (resp *response) clone() *response {
 	}
 
 	switch t := resp.body.(type) {
-	case []interface{}:
-		c := make([]interface{}, len(t))
+	case []any:
+		c := make([]any, len(t))
 		copy(c, t)
 		clone.body = c
 	case mapstr.M:
 		clone.body = t.Clone()
-	case map[string]interface{}:
+	case map[string]any:
 		clone.body = mapstr.M(t).Clone()
 	}
 
@@ -51,7 +51,7 @@ func (resp *response) clone() *response {
 func (resp *response) asTransformables(stat status.StatusReporter, log *logp.Logger, allowStringArray bool) []transformable {
 	var ts []transformable
 
-	convertAndAppend := func(m map[string]interface{}) {
+	convertAndAppend := func(m map[string]any) {
 		tr := transformable{}
 		tr.setHeader(resp.header.Clone())
 		tr.setURL(resp.url)
@@ -60,13 +60,13 @@ func (resp *response) asTransformables(stat status.StatusReporter, log *logp.Log
 	}
 
 	switch tresp := resp.body.(type) {
-	case []interface{}:
+	case []any:
 		var scalars int
 		for _, v := range tresp {
 			switch v := v.(type) {
 			case string, float64:
 				scalars++
-			case map[string]interface{}:
+			case map[string]any:
 				convertAndAppend(v)
 			default:
 				msg := fmt.Sprintf("events must be JSON objects, but got %T: skipping", v)
@@ -79,7 +79,7 @@ func (resp *response) asTransformables(stat status.StatusReporter, log *logp.Log
 			log.Debug(msg)
 			stat.UpdateStatus(status.Degraded, msg)
 		}
-	case map[string]interface{}:
+	case map[string]any:
 		convertAndAppend(tresp)
 	default:
 		stat.UpdateStatus(status.Degraded, "response is not a valid JSON")
@@ -94,7 +94,7 @@ func (resp *response) templateValues() mapstr.M {
 		return mapstr.M{}
 	}
 	body := resp.body
-	if m, ok := body.(map[string]interface{}); ok {
+	if m, ok := body.(map[string]any); ok {
 		body = mapstr.M(m)
 	}
 	return mapstr.M{

--- a/x-pack/filebeat/input/httpjson/response_test.go
+++ b/x-pack/filebeat/input/httpjson/response_test.go
@@ -53,7 +53,7 @@ func TestTemplateValuesBodyType(t *testing.T) {
 	// that the String method produces valid JSON for use in templates
 	// with value_type: json. See elastic/beats#50384.
 	resp := &response{
-		body: map[string]interface{}{
+		body: map[string]any{
 			"key": "value",
 		},
 	}
@@ -161,7 +161,7 @@ var asTransformablesTests = []struct {
 func TestAsTransformables(t *testing.T) {
 	for _, test := range asTransformablesTests {
 		t.Run(test.name, func(t *testing.T) {
-			var data interface{}
+			var data any
 			err := json.Unmarshal([]byte(test.message), &data)
 			if err != nil {
 				t.Fatalf("error unmarshalling json: %s", err)

--- a/x-pack/filebeat/input/httpjson/split.go
+++ b/x-pack/filebeat/input/httpjson/split.go
@@ -135,7 +135,7 @@ func (s *split) split(ctx context.Context, trCtx *transformContext, root mapstr.
 
 	switch s.kind {
 	case "", splitTypeArr:
-		varr, ok := v.([]interface{})
+		varr, ok := v.([]any)
 		if !ok {
 			return errExpectedSplitArr
 		}
@@ -215,7 +215,7 @@ func (s *split) split(ctx context.Context, trCtx *transformContext, root mapstr.
 			h.handleEvent(ctx, root)
 			return errEmptyField
 		}
-		for _, substr := range strings.Split(vstr, s.delimiter) {
+		for substr := range strings.SplitSeq(vstr, s.delimiter) {
 			if err := s.processMessageSplitString(ctx, trCtx, root, substr, h); err != nil {
 				s.log.Debug(err)
 			}
@@ -229,7 +229,7 @@ func (s *split) split(ctx context.Context, trCtx *transformContext, root mapstr.
 
 // processMessage processes an array or map split result value, v, via h after performing
 // any necessary transformations. If key is "", the value is an element of an array.
-func (s *split) processMessage(ctx context.Context, trCtx *transformContext, root mapstr.M, key string, v interface{}, h handler) error {
+func (s *split) processMessage(ctx context.Context, trCtx *transformContext, root mapstr.M, key string, v any, h handler) error {
 	obj, ok := toMapStr(v, s.targetInfo.Name)
 	if !ok {
 		return errExpectedSplitObj
@@ -266,16 +266,16 @@ func (s *split) processMessage(ctx context.Context, trCtx *transformContext, roo
 	return nil
 }
 
-func toMapStr(v interface{}, key string) (mapstr.M, bool) {
+func toMapStr(v any, key string) (mapstr.M, bool) {
 	if v == nil {
 		return mapstr.M{}, false
 	}
 	switch t := v.(type) {
 	case mapstr.M:
 		return t, true
-	case map[string]interface{}:
+	case map[string]any:
 		return mapstr.M(t), true
-	case string, []bool, []int, []string, []interface{}:
+	case string, []bool, []int, []string, []any:
 		return mapstr.M{key: t}, true
 	}
 	return mapstr.M{}, false

--- a/x-pack/filebeat/input/httpjson/split_test.go
+++ b/x-pack/filebeat/input/httpjson/split_test.go
@@ -40,25 +40,25 @@ func TestSplit(t *testing.T) {
 			resp: transformable{
 				"body": mapstr.M{
 					"this": "is kept",
-					"alerts": []interface{}{
-						map[string]interface{}{
+					"alerts": []any{
+						map[string]any{
 							"this_is": "also kept",
-							"entities": []interface{}{
-								map[string]interface{}{
+							"entities": []any{
+								map[string]any{
 									"something": "something",
 								},
-								map[string]interface{}{
+								map[string]any{
 									"else": "else",
 								},
 							},
 						},
-						map[string]interface{}{
+						map[string]any{
 							"this_is": "also kept 2",
-							"entities": []interface{}{
-								map[string]interface{}{
+							"entities": []any{
+								map[string]any{
 									"something": "something 2",
 								},
-								map[string]interface{}{
+								map[string]any{
 									"else": "else 2",
 								},
 							},
@@ -107,19 +107,19 @@ func TestSplit(t *testing.T) {
 			resp: transformable{
 				"body": mapstr.M{
 					"this": "is not kept",
-					"alerts": []interface{}{
-						map[string]interface{}{
+					"alerts": []any{
+						map[string]any{
 							"this_is": "kept",
-							"entities": map[string]interface{}{
-								"id1": map[string]interface{}{
+							"entities": map[string]any{
+								"id1": map[string]any{
 									"something": "else",
 								},
 							},
 						},
-						map[string]interface{}{
+						map[string]any{
 							"this_is": "also kept",
-							"entities": map[string]interface{}{
-								"id2": map[string]interface{}{
+							"entities": map[string]any{
+								"id2": map[string]any{
 									"something": "else 2",
 								},
 							},
@@ -150,8 +150,8 @@ func TestSplit(t *testing.T) {
 					Target: "body.entities",
 					Type:   "map",
 					Transforms: transformsConfig{
-						conf.MustNewConfigFrom(map[string]interface{}{
-							"set": map[string]interface{}{
+						conf.MustNewConfigFrom(map[string]any{
+							"set": map[string]any{
 								"target": "body.foo",
 								"value":  "set for each",
 							},
@@ -163,19 +163,19 @@ func TestSplit(t *testing.T) {
 			resp: transformable{
 				"body": mapstr.M{
 					"this": "is not kept",
-					"alerts": []interface{}{
-						map[string]interface{}{
+					"alerts": []any{
+						map[string]any{
 							"this_is": "kept",
-							"entities": map[string]interface{}{
-								"id1": map[string]interface{}{
+							"entities": map[string]any{
+								"id1": map[string]any{
 									"something": "else",
 								},
 							},
 						},
-						map[string]interface{}{
+						map[string]any{
 							"this_is": "also not kept",
-							"entities": map[string]interface{}{
-								"id2": map[string]interface{}{
+							"entities": map[string]any{
+								"id2": map[string]any{
 									"something": "else 2",
 								},
 							},
@@ -208,15 +208,15 @@ func TestSplit(t *testing.T) {
 			ctx: emptyTransformContext(),
 			resp: transformable{
 				"body": mapstr.M{
-					"response": []interface{}{
-						map[string]interface{}{
-							"Event": map[string]interface{}{
+					"response": []any{
+						map[string]any{
+							"Event": map[string]any{
 								"timestamp": "1606324417",
-								"Attributes": []interface{}{
-									map[string]interface{}{
+								"Attributes": []any{
+									map[string]any{
 										"key": "value",
 									},
-									map[string]interface{}{
+									map[string]any{
 										"key2": "value2",
 									},
 								},
@@ -258,9 +258,9 @@ func TestSplit(t *testing.T) {
 			ctx: emptyTransformContext(),
 			resp: transformable{
 				"body": mapstr.M{
-					"response": []interface{}{
-						map[string]interface{}{
-							"Event": map[string]interface{}{
+					"response": []any{
+						map[string]any{
+							"Event": map[string]any{
 								"timestamp": "1606324417",
 							},
 						},
@@ -289,12 +289,12 @@ func TestSplit(t *testing.T) {
 			ctx: emptyTransformContext(),
 			resp: transformable{
 				"body": mapstr.M{
-					"response": []interface{}{},
+					"response": []any{},
 				},
 			},
 			expectedMessages: []mapstr.M{
 				{
-					"response": []interface{}{},
+					"response": []any{},
 				},
 			},
 			expectedErr: errEmptyRootField,
@@ -315,12 +315,12 @@ func TestSplit(t *testing.T) {
 				"body": mapstr.M{
 					"@timestamp":    "1234567890",
 					"nextPageToken": "tok",
-					"items": []interface{}{
+					"items": []any{
 						mapstr.M{"foo": "bar"},
 						mapstr.M{
 							"baz": "buzz",
 							"splitHere": mapstr.M{
-								"splitMore": []interface{}{
+								"splitMore": []any{
 									mapstr.M{
 										"deepest1": "data",
 									},
@@ -377,16 +377,16 @@ func TestSplit(t *testing.T) {
 			ctx: emptyTransformContext(),
 			resp: transformable{
 				"body": mapstr.M{
-					"response": []interface{}{
-						map[string]interface{}{
-							"Event": map[string]interface{}{
+					"response": []any{
+						map[string]any{
+							"Event": map[string]any{
 								"timestamp":  "1606324417",
-								"Attributes": []interface{}{},
-								"OtherAttributes": []interface{}{
-									map[string]interface{}{
+								"Attributes": []any{},
+								"OtherAttributes": []any{
+									map[string]any{
 										"key": "value",
 									},
-									map[string]interface{}{
+									map[string]any{
 										"key2": "value2",
 									},
 								},
@@ -399,7 +399,7 @@ func TestSplit(t *testing.T) {
 				{
 					"Event": mapstr.M{
 						"timestamp":  "1606324417",
-						"Attributes": []interface{}{},
+						"Attributes": []any{},
 						"OtherAttributes": mapstr.M{
 							"key": "value",
 						},
@@ -408,7 +408,7 @@ func TestSplit(t *testing.T) {
 				{
 					"Event": mapstr.M{
 						"timestamp":  "1606324417",
-						"Attributes": []interface{}{},
+						"Attributes": []any{},
 						"OtherAttributes": mapstr.M{
 							"key2": "value2",
 						},
@@ -435,15 +435,15 @@ func TestSplit(t *testing.T) {
 			ctx: emptyTransformContext(),
 			resp: transformable{
 				"body": mapstr.M{
-					"response": []interface{}{
-						map[string]interface{}{
-							"Event": map[string]interface{}{
+					"response": []any{
+						map[string]any{
+							"Event": map[string]any{
 								"timestamp": "1606324417",
-								"OtherAttributes": []interface{}{
-									map[string]interface{}{
+								"OtherAttributes": []any{
+									map[string]any{
 										"key": "value",
 									},
-									map[string]interface{}{
+									map[string]any{
 										"key2": "value2",
 									},
 								},
@@ -492,15 +492,15 @@ func TestSplit(t *testing.T) {
 			ctx: emptyTransformContext(),
 			resp: transformable{
 				"body": mapstr.M{
-					"response": []interface{}{
-						map[string]interface{}{
-							"Event": map[string]interface{}{
+					"response": []any{
+						map[string]any{
+							"Event": map[string]any{
 								"timestamp":  "1606324417",
-								"Attributes": map[string]interface{}{},
-								"OtherAttributes": map[string]interface{}{
+								"Attributes": map[string]any{},
+								"OtherAttributes": map[string]any{
 									// Only include a single item here to avoid
 									// map iteration order flakes.
-									"1": map[string]interface{}{
+									"1": map[string]any{
 										"key": "value",
 									},
 								},
@@ -542,14 +542,14 @@ func TestSplit(t *testing.T) {
 			ctx: emptyTransformContext(),
 			resp: transformable{
 				"body": mapstr.M{
-					"response": []interface{}{
-						map[string]interface{}{
-							"Event": map[string]interface{}{
+					"response": []any{
+						map[string]any{
+							"Event": map[string]any{
 								"timestamp": "1606324417",
-								"OtherAttributes": map[string]interface{}{
+								"OtherAttributes": map[string]any{
 									// Only include a single item here to avoid
 									// map iteration order flakes.
-									"1": map[string]interface{}{
+									"1": map[string]any{
 										"key": "value",
 									},
 								},
@@ -634,7 +634,7 @@ func TestSplit(t *testing.T) {
 			resp: transformable{
 				"body": mapstr.M{
 					"this": "is kept",
-					"alerts": []interface{}{
+					"alerts": []any{
 						"test1",
 						"test2",
 						"test3",
@@ -668,8 +668,8 @@ func TestSplit(t *testing.T) {
 			resp: transformable{
 				"body": mapstr.M{
 					"this": "is kept",
-					"alerts": []interface{}{
-						[]interface{}{"test1-1", "test1-2"},
+					"alerts": []any{
+						[]any{"test1-1", "test1-2"},
 						[]string{"test2-1", "test2-2"},
 						[]int{1, 2},
 					},
@@ -678,7 +678,7 @@ func TestSplit(t *testing.T) {
 			expectedMessages: []mapstr.M{
 				{
 					"this": "is kept",
-					"alerts": []interface{}{
+					"alerts": []any{
 						"test1-1",
 						"test1-2",
 					},

--- a/x-pack/filebeat/input/httpjson/transform.go
+++ b/x-pack/filebeat/input/httpjson/transform.go
@@ -95,11 +95,11 @@ func (tr transformable) access() mapstr.M {
 	return mapstr.M(tr)
 }
 
-func (tr transformable) Put(k string, v interface{}) {
+func (tr transformable) Put(k string, v any) {
 	_, _ = tr.access().Put(k, v)
 }
 
-func (tr transformable) GetValue(k string) (interface{}, error) {
+func (tr transformable) GetValue(k string) (any, error) {
 	return tr.access().GetValue(k)
 }
 
@@ -247,14 +247,14 @@ func newValueType(s string) (valueType, error) {
 	}
 }
 
-func (vt valueType) convertToType(v string) (interface{}, error) {
+func (vt valueType) convertToType(v string) (any, error) {
 	switch vt {
 	case valueTypeString:
 		return v, nil
 	case valueTypeInt:
 		return strconv.ParseInt(v, 10, 64)
 	case valueTypeJSON:
-		var o interface{}
+		var o any
 		if err := json.Unmarshal([]byte(v), &o); err != nil {
 			return nil, err
 		}

--- a/x-pack/filebeat/input/httpjson/transform_append.go
+++ b/x-pack/filebeat/input/httpjson/transform_append.go
@@ -32,7 +32,7 @@ type appendt struct {
 	doNotLogFailure     bool
 	valueType           valueType
 
-	runFunc func(ctx *transformContext, transformable transformable, key string, val interface{}) error
+	runFunc func(ctx *transformContext, transformable transformable, key string, val any) error
 
 	status status.StatusReporter
 	log    *logp.Logger
@@ -149,8 +149,8 @@ func (append *appendt) run(ctx *transformContext, tr transformable) (transformab
 	return tr, nil
 }
 
-func appendToCommonMap(m mapstr.M, key string, val interface{}) error {
-	var value interface{}
+func appendToCommonMap(m mapstr.M, key string, val any) error {
+	var value any
 	strVal, isString := val.(string)
 	if found, _ := m.HasKey(key); found {
 		prev, _ := m.GetValue(key)
@@ -160,14 +160,14 @@ func appendToCommonMap(m mapstr.M, key string, val interface{}) error {
 				return fmt.Errorf("can't append a %T value to a string list", val)
 			}
 			value = append(t, strVal)
-		case []interface{}:
+		case []any:
 			value = append(t, val)
 		default:
-			value = []interface{}{prev, val}
+			value = []any{prev, val}
 		}
 
 	} else {
-		value = []interface{}{val}
+		value = []any{val}
 	}
 	if _, err := m.Put(key, value); err != nil {
 		return err
@@ -175,11 +175,11 @@ func appendToCommonMap(m mapstr.M, key string, val interface{}) error {
 	return nil
 }
 
-func appendBody(ctx *transformContext, transformable transformable, key string, value interface{}) error {
+func appendBody(ctx *transformContext, transformable transformable, key string, value any) error {
 	return appendToCommonMap(transformable.body(), key, value)
 }
 
-func appendHeader(ctx *transformContext, transformable transformable, key string, value interface{}) error {
+func appendHeader(ctx *transformContext, transformable transformable, key string, value any) error {
 	v, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("headers can only contain string values, but got: %T", value)
@@ -188,7 +188,7 @@ func appendHeader(ctx *transformContext, transformable transformable, key string
 	return nil
 }
 
-func appendURLParams(ctx *transformContext, transformable transformable, key string, value interface{}) error {
+func appendURLParams(ctx *transformContext, transformable transformable, key string, value any) error {
 	v, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("URL params can only contain string values, but got: %T", value)

--- a/x-pack/filebeat/input/httpjson/transform_append_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_append_test.go
@@ -22,14 +22,14 @@ func TestNewAppend(t *testing.T) {
 	cases := []struct {
 		name           string
 		constructor    constructor
-		config         map[string]interface{}
+		config         map[string]any
 		expectedTarget targetInfo
 		expectedErr    string
 	}{
 		{
 			name:        "newAppendResponse targets body",
 			constructor: newAppendResponse,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -37,7 +37,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendResponse targets something else",
 			constructor: newAppendResponse,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -45,7 +45,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendRequest targets body",
 			constructor: newAppendRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -53,7 +53,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendRequest targets header",
 			constructor: newAppendRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "header.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "header"},
@@ -61,7 +61,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendRequest targets url param",
 			constructor: newAppendRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.params.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "url.params"},
@@ -69,7 +69,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendRequest targets something else",
 			constructor: newAppendRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -77,7 +77,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendPagination targets body",
 			constructor: newAppendPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -85,7 +85,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendPagination targets header",
 			constructor: newAppendPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "header.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "header"},
@@ -93,7 +93,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendPagination targets url param",
 			constructor: newAppendPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.params.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "url.params"},
@@ -101,7 +101,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendPagination targets url value",
 			constructor: newAppendPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.value",
 			},
 			expectedErr: "invalid target type: url.value",
@@ -109,7 +109,7 @@ func TestNewAppend(t *testing.T) {
 		{
 			name:        "newAppendPagination targets something else",
 			constructor: newAppendPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -117,7 +117,6 @@ func TestNewAppend(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := conf.MustNewConfigFrom(tc.config)
 			gotAppend, gotErr := tc.constructor(cfg, noopReporter{}, nil)
@@ -134,7 +133,7 @@ func TestNewAppend(t *testing.T) {
 func TestAppendFunctions(t *testing.T) {
 	cases := []struct {
 		name        string
-		tfunc       func(ctx *transformContext, transformable transformable, key string, val interface{}) error
+		tfunc       func(ctx *transformContext, transformable transformable, key string, val any) error
 		paramCtx    *transformContext
 		paramTr     transformable
 		paramKey    string
@@ -149,7 +148,7 @@ func TestAppendFunctions(t *testing.T) {
 			paramTr:     transformable{"body": mapstr.M{"a_key": "a_value"}},
 			paramKey:    "a_key",
 			paramVal:    "another_value",
-			expectedTr:  transformable{"body": mapstr.M{"a_key": []interface{}{"a_value", "another_value"}}},
+			expectedTr:  transformable{"body": mapstr.M{"a_key": []any{"a_value", "another_value"}}},
 			expectedErr: nil,
 		},
 		{
@@ -159,7 +158,7 @@ func TestAppendFunctions(t *testing.T) {
 			paramTr:     transformable{"body": mapstr.M{}},
 			paramKey:    "a_key",
 			paramVal:    "a_value",
-			expectedTr:  transformable{"body": mapstr.M{"a_key": []interface{}{"a_value"}}},
+			expectedTr:  transformable{"body": mapstr.M{"a_key": []any{"a_value"}}},
 			expectedErr: nil,
 		},
 		{
@@ -187,7 +186,6 @@ func TestAppendFunctions(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
 			gotErr := tcase.tfunc(tcase.paramCtx, tcase.paramTr, tcase.paramKey, tcase.paramVal)
 			if tcase.expectedErr == nil {
@@ -304,7 +302,7 @@ func TestAppendTemplate(t *testing.T) {
 }
 
 func TestDifferentAppendValueTypes(t *testing.T) {
-	c1 := map[string]interface{}{
+	c1 := map[string]any{
 		"target":     "body.p1",
 		"value":      `{"param":"value"}`,
 		"value_type": "json",
@@ -325,8 +323,8 @@ func TestDifferentAppendValueTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	exp := mapstr.M{
-		"p1": []interface{}{
-			map[string]interface{}{
+		"p1": []any{
+			map[string]any{
 				"param": "value",
 			},
 		},
@@ -334,7 +332,7 @@ func TestDifferentAppendValueTypes(t *testing.T) {
 
 	assert.EqualValues(t, exp, tr.body())
 
-	c2 := map[string]interface{}{
+	c2 := map[string]any{
 		"target":     "body.p1",
 		"value":      "1",
 		"value_type": "int",
@@ -354,7 +352,7 @@ func TestDifferentAppendValueTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	exp = mapstr.M{
-		"p1": []interface{}{int64(1)},
+		"p1": []any{int64(1)},
 	}
 
 	assert.EqualValues(t, exp, tr.body())
@@ -375,7 +373,7 @@ func TestDifferentAppendValueTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	exp = mapstr.M{
-		"p1": []interface{}{"1"},
+		"p1": []any{"1"},
 	}
 
 	assert.EqualValues(t, exp, tr.body())

--- a/x-pack/filebeat/input/httpjson/transform_delete_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_delete_test.go
@@ -18,14 +18,14 @@ func TestNewDelete(t *testing.T) {
 	cases := []struct {
 		name           string
 		constructor    constructor
-		config         map[string]interface{}
+		config         map[string]any
 		expectedTarget targetInfo
 		expectedErr    string
 	}{
 		{
 			name:        "newDeleteResponse targets body",
 			constructor: newDeleteResponse,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -33,7 +33,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeleteResponse targets something else",
 			constructor: newDeleteResponse,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -41,7 +41,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeleteRequest targets body",
 			constructor: newDeleteRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -49,7 +49,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeleteRequest targets header",
 			constructor: newDeleteRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "header.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "header"},
@@ -57,7 +57,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeleteRequest targets url param",
 			constructor: newDeleteRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.params.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "url.params"},
@@ -65,7 +65,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeleteRequest targets something else",
 			constructor: newDeleteRequest,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -73,7 +73,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeletePagination targets body",
 			constructor: newDeletePagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -81,7 +81,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeletePagination targets header",
 			constructor: newDeletePagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "header.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "header"},
@@ -89,7 +89,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeletePagination targets url param",
 			constructor: newDeletePagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.params.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "url.params"},
@@ -97,7 +97,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeletePagination targets url value",
 			constructor: newDeletePagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.value",
 			},
 			expectedErr: "invalid target type: url.value",
@@ -105,7 +105,7 @@ func TestNewDelete(t *testing.T) {
 		{
 			name:        "newDeletePagination targets something else",
 			constructor: newDeletePagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -113,7 +113,6 @@ func TestNewDelete(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := conf.MustNewConfigFrom(tc.config)
 			gotDelete, gotErr := tc.constructor(cfg, noopReporter{}, nil)
@@ -169,7 +168,6 @@ func TestDeleteFunctions(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
 			gotErr := tcase.tfunc(tcase.paramCtx, tcase.paramTr, tcase.paramKey)
 			if tcase.expectedErr == nil {

--- a/x-pack/filebeat/input/httpjson/transform_registry.go
+++ b/x-pack/filebeat/input/httpjson/transform_registry.go
@@ -48,14 +48,14 @@ func (reg registry) String() string {
 		return "(empty registry)"
 	}
 
-	var str string
+	var str strings.Builder
 	for namespace, m := range reg {
 		names := make([]string, 0, len(m))
 		for k := range m {
 			names = append(names, k)
 		}
-		str += fmt.Sprintf("%s: (%s)\n", namespace, strings.Join(names, ", "))
+		str.WriteString(fmt.Sprintf("%s: (%s)\n", namespace, strings.Join(names, ", ")))
 	}
 
-	return str
+	return str.String()
 }

--- a/x-pack/filebeat/input/httpjson/transform_set.go
+++ b/x-pack/filebeat/input/httpjson/transform_set.go
@@ -36,7 +36,7 @@ type set struct {
 	doNotLogFailure     bool
 	valueType           valueType
 
-	runFunc func(ctx *transformContext, transformable transformable, key string, val interface{}) error
+	runFunc func(ctx *transformContext, transformable transformable, key string, val any) error
 
 	status status.StatusReporter
 	log    *logp.Logger
@@ -135,18 +135,18 @@ func (set *set) run(ctx *transformContext, tr transformable) (transformable, err
 	return tr, nil
 }
 
-func setToCommonMap(m mapstr.M, key string, val interface{}) error {
+func setToCommonMap(m mapstr.M, key string, val any) error {
 	if _, err := m.Put(key, val); err != nil {
 		return err
 	}
 	return nil
 }
 
-func setBody(ctx *transformContext, transformable transformable, key string, value interface{}) error {
+func setBody(ctx *transformContext, transformable transformable, key string, value any) error {
 	return setToCommonMap(transformable.body(), key, value)
 }
 
-func setHeader(ctx *transformContext, transformable transformable, key string, value interface{}) error {
+func setHeader(ctx *transformContext, transformable transformable, key string, value any) error {
 	v, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("headers can only contain string values, but got: %T", value)
@@ -155,7 +155,7 @@ func setHeader(ctx *transformContext, transformable transformable, key string, v
 	return nil
 }
 
-func setURLParams(ctx *transformContext, transformable transformable, key string, value interface{}) error {
+func setURLParams(ctx *transformContext, transformable transformable, key string, value any) error {
 	v, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("URL params can only contain string values, but got: %T", value)
@@ -168,7 +168,7 @@ func setURLParams(ctx *transformContext, transformable transformable, key string
 	return nil
 }
 
-func setURLValue(ctx *transformContext, transformable transformable, _ string, value interface{}) error {
+func setURLValue(ctx *transformContext, transformable transformable, _ string, value any) error {
 	v, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("URL value can only contain string values, but got: %T", value)

--- a/x-pack/filebeat/input/httpjson/transform_set_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_set_test.go
@@ -24,14 +24,14 @@ func TestNewSet(t *testing.T) {
 	cases := []struct {
 		name           string
 		constructor    constructor
-		config         map[string]interface{}
+		config         map[string]any
 		expectedTarget targetInfo
 		expectedErr    string
 	}{
 		{
 			name:        "newSetResponse targets body",
 			constructor: newSetResponse,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -39,7 +39,7 @@ func TestNewSet(t *testing.T) {
 		{
 			name:        "newSetResponse targets something else",
 			constructor: newSetResponse,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -47,7 +47,7 @@ func TestNewSet(t *testing.T) {
 		{
 			name:        "newSetRequestPagination targets body",
 			constructor: newSetRequestPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
@@ -55,7 +55,7 @@ func TestNewSet(t *testing.T) {
 		{
 			name:        "newSetRequestPagination targets header",
 			constructor: newSetRequestPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "header.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "header"},
@@ -63,7 +63,7 @@ func TestNewSet(t *testing.T) {
 		{
 			name:        "newSetRequestPagination targets url param",
 			constructor: newSetRequestPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.params.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "url.params"},
@@ -71,7 +71,7 @@ func TestNewSet(t *testing.T) {
 		{
 			name:        "newSetRequestPagination targets url value",
 			constructor: newSetRequestPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "url.value",
 			},
 			expectedTarget: targetInfo{Type: "url.value"},
@@ -79,7 +79,7 @@ func TestNewSet(t *testing.T) {
 		{
 			name:        "newSetRequestPagination targets something else",
 			constructor: newSetRequestPagination,
-			config: map[string]interface{}{
+			config: map[string]any{
 				"target": "cursor.foo",
 			},
 			expectedErr: "invalid target: cursor.foo",
@@ -87,7 +87,6 @@ func TestNewSet(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := conf.MustNewConfigFrom(tc.config)
 			gotSet, gotErr := tc.constructor(cfg, noopReporter{}, nil)
@@ -104,7 +103,7 @@ func TestNewSet(t *testing.T) {
 func TestSetFunctions(t *testing.T) {
 	cases := []struct {
 		name        string
-		tfunc       func(ctx *transformContext, transformable transformable, key string, val interface{}) error
+		tfunc       func(ctx *transformContext, transformable transformable, key string, val any) error
 		paramCtx    *transformContext
 		paramTr     transformable
 		paramKey    string
@@ -154,7 +153,6 @@ func TestSetFunctions(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
 			gotErr := tcase.tfunc(tcase.paramCtx, tcase.paramTr, tcase.paramKey, tcase.paramVal)
 			if tcase.expectedErr == nil {
@@ -271,7 +269,7 @@ func TestSetTemplate(t *testing.T) {
 }
 
 func TestDifferentSetValueTypes(t *testing.T) {
-	c1 := map[string]interface{}{
+	c1 := map[string]any{
 		"target":     "body.p1",
 		"value":      `{"param":"value"}`,
 		"value_type": "json",
@@ -292,14 +290,14 @@ func TestDifferentSetValueTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	exp := mapstr.M{
-		"p1": map[string]interface{}{
+		"p1": map[string]any{
 			"param": "value",
 		},
 	}
 
 	assert.EqualValues(t, exp, tr.body())
 
-	c2 := map[string]interface{}{
+	c2 := map[string]any{
 		"target":     "body.p1",
 		"value":      "1",
 		"value_type": "int",

--- a/x-pack/filebeat/input/httpjson/transform_target_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_target_test.go
@@ -60,7 +60,6 @@ func TestGetTargetInfo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := getTargetInfo(tc.param)
 			if tc.expectedErr == "" {

--- a/x-pack/filebeat/input/httpjson/transform_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_test.go
@@ -57,14 +57,14 @@ func TestNewTransformsFromConfig(t *testing.T) {
 
 	cases := []struct {
 		name               string
-		paramCfg           map[string]interface{}
+		paramCfg           map[string]any
 		paramNamespace     string
 		expectedTransforms transforms
 		expectedErr        string
 	}{
 		{
 			name: "fails if config has more than one action",
-			paramCfg: map[string]interface{}{
+			paramCfg: map[string]any{
 				"set":  nil,
 				"set2": nil,
 			},
@@ -72,7 +72,7 @@ func TestNewTransformsFromConfig(t *testing.T) {
 		},
 		{
 			name: "fails if not found in namespace",
-			paramCfg: map[string]interface{}{
+			paramCfg: map[string]any{
 				"set": nil,
 			},
 			paramNamespace: "empty",
@@ -80,8 +80,8 @@ func TestNewTransformsFromConfig(t *testing.T) {
 		},
 		{
 			name: "fails if constructor fails",
-			paramCfg: map[string]interface{}{
-				"set": map[string]interface{}{
+			paramCfg: map[string]any{
+				"set": map[string]any{
 					"target": "invalid",
 				},
 			},
@@ -90,8 +90,8 @@ func TestNewTransformsFromConfig(t *testing.T) {
 		},
 		{
 			name: "transform is correct",
-			paramCfg: map[string]interface{}{
-				"set": map[string]interface{}{
+			paramCfg: map[string]any{
+				"set": map[string]any{
 					"target": "body.foo",
 				},
 			},
@@ -107,7 +107,6 @@ func TestNewTransformsFromConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := conf.MustNewConfigFrom(tc.paramCfg)
 			gotTransforms, gotErr := newTransformsFromConfig(registeredTransforms, transformsConfig{cfg}, tc.paramNamespace, noopReporter{}, nil)
@@ -140,14 +139,14 @@ func TestNewBasicTransformsFromConfig(t *testing.T) {
 
 	cases := []struct {
 		name           string
-		paramCfg       map[string]interface{}
+		paramCfg       map[string]any
 		paramNamespace string
 		expectedErr    string
 	}{
 		{
 			name: "succeeds if transform is basicTransform",
-			paramCfg: map[string]interface{}{
-				"set": map[string]interface{}{
+			paramCfg: map[string]any{
+				"set": map[string]any{
 					"target": "body.foo",
 				},
 			},
@@ -155,7 +154,7 @@ func TestNewBasicTransformsFromConfig(t *testing.T) {
 		},
 		{
 			name: "fails if transform is not a basicTransform",
-			paramCfg: map[string]interface{}{
+			paramCfg: map[string]any{
 				"fake": nil,
 			},
 			paramNamespace: "test",
@@ -164,7 +163,6 @@ func TestNewBasicTransformsFromConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := conf.MustNewConfigFrom(tc.paramCfg)
 			_, gotErr := newBasicTransformsFromConfig(registeredTransforms, transformsConfig{cfg}, tc.paramNamespace, noopReporter{}, nil)

--- a/x-pack/filebeat/input/httpjson/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl.go
@@ -343,7 +343,7 @@ func getRFC5988Link(rel string, links []string) string {
 	return getMatchLink(rel, links)
 }
 
-func toInt(v interface{}) int64 {
+func toInt(v any) int64 {
 	vv := reflect.ValueOf(v)
 	switch vv.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -376,7 +376,7 @@ func div(a, b int64) int64 {
 	return a / b
 }
 
-func min(arg1, arg2 reflect.Value) (interface{}, error) {
+func min(arg1, arg2 reflect.Value) (any, error) {
 	lessThan, err := lt(arg1, arg2)
 	if err != nil {
 		return nil, err
@@ -389,7 +389,7 @@ func min(arg1, arg2 reflect.Value) (interface{}, error) {
 	return arg2.Interface(), nil
 }
 
-func max(arg1, arg2 reflect.Value) (interface{}, error) {
+func max(arg1, arg2 reflect.Value) (any, error) {
 	lessThan, err := lt(arg1, arg2)
 	if err != nil {
 		return nil, err
@@ -519,7 +519,7 @@ func uuidString() string {
 // join concatenates the elements of its first argument to create a single string. The separator
 // string sep is placed between elements in the resulting string. If the first argument is not of
 // type string or []string, its elements will be stringified.
-func join(v interface{}, sep string) string {
+func join(v any, sep string) string {
 	// check for []string or string to avoid using reflect
 	switch t := v.(type) {
 	case []string:
@@ -577,7 +577,7 @@ func replaceAll(old, new, s string) string {
 }
 
 // toJSON converts the given structure into a JSON string.
-func toJSON(i interface{}) (string, error) {
+func toJSON(i any) (string, error) {
 	result, err := json.Marshal(i)
 	if err != nil {
 		return "", fmt.Errorf("toJSON failed: %w", err)

--- a/x-pack/filebeat/input/httpjson/value_tpl_test.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl_test.go
@@ -582,7 +582,7 @@ func TestValueTpl(t *testing.T) {
 							"foo",
 							"bar",
 						},
-						"iarr": []interface{}{
+						"iarr": []any{
 							"foo",
 							2,
 						},
@@ -789,7 +789,7 @@ func TestValueTpl(t *testing.T) {
 			name:  "func toJSON",
 			value: "[[ toJSON .first_event.events ]]",
 			paramCtx: &transformContext{
-				firstEvent:   &mapstr.M{"events": []interface{}{map[string]interface{}{"id": 1234}}},
+				firstEvent:   &mapstr.M{"events": []any{map[string]any{"id": 1234}}},
 				lastEvent:    &mapstr.M{},
 				lastResponse: newTestResponse(nil, nil, ""),
 			},
@@ -799,7 +799,6 @@ func TestValueTpl(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.setup != nil {
 				tc.setup(t)

--- a/x-pack/filebeat/input/internal/private/private_test.go
+++ b/x-pack/filebeat/input/internal/private/private_test.go
@@ -363,7 +363,7 @@ var redactTests = []redactTest{
 			return m
 		}(),
 		want:    map[string]any(nil),
-		wantErr: cycle{reflect.TypeOf(map[string]any(nil))},
+		wantErr: cycle{reflect.TypeFor[map[string]any]()},
 	},
 	func() redactTest {
 		type s struct {
@@ -467,7 +467,7 @@ var redactTests = []redactTest{
 			in:      v,
 			tag:     "",
 			want:    s{},
-			wantErr: cycle{reflect.TypeOf(&s{})},
+			wantErr: cycle{reflect.TypeFor[*s]()},
 		}
 	}(),
 	func() redactTest {
@@ -586,7 +586,7 @@ var redactTests = []redactTest{
 			in:      v,
 			tag:     "json",
 			want:    s{},
-			wantErr: cycle{reflect.TypeOf(&s{})},
+			wantErr: cycle{reflect.TypeFor[*s]()},
 		}
 	}(),
 	{

--- a/x-pack/filebeat/input/lumberjack/ack.go
+++ b/x-pack/filebeat/input/lumberjack/ack.go
@@ -67,7 +67,7 @@ func (t *batchACKTracker) ACK() {
 // to decrement the number of pending ACKs.
 func newEventACKHandler() beat.EventListener {
 	return acker.ConnectionOnly(
-		acker.EventPrivateReporter(func(_ int, privates []interface{}) {
+		acker.EventPrivateReporter(func(_ int, privates []any) {
 			for _, private := range privates {
 				if ack, ok := private.(*batchACKTracker); ok {
 					ack.ACK()

--- a/x-pack/filebeat/input/lumberjack/config_test.go
+++ b/x-pack/filebeat/input/lumberjack/config_test.go
@@ -15,13 +15,13 @@ import (
 func TestConfig(t *testing.T) {
 	testCases := []struct {
 		name        string
-		userConfig  map[string]interface{}
+		userConfig  map[string]any
 		expected    *config
 		expectedErr string
 	}{
 		{
 			"defaults",
-			map[string]interface{}{},
+			map[string]any{},
 			&config{
 				ListenAddress: "localhost:5044",
 				Versions:      []string{"v1", "v2"},
@@ -30,7 +30,7 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			"validate version",
-			map[string]interface{}{
+			map[string]any{
 				"versions": []string{"v3"},
 			},
 			nil,
@@ -38,7 +38,7 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			"validate keepalive",
-			map[string]interface{}{
+			map[string]any{
 				"keepalive": "-1s",
 			},
 			nil,
@@ -46,7 +46,7 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			"validate max_connections",
-			map[string]interface{}{
+			map[string]any{
 				"max_connections": -1,
 			},
 			nil,
@@ -55,7 +55,6 @@ func TestConfig(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			c := conf.MustNewConfigFrom(tc.userConfig)
 

--- a/x-pack/filebeat/input/lumberjack/logger.go
+++ b/x-pack/filebeat/input/lumberjack/logger.go
@@ -27,14 +27,14 @@ type goLumberLogger struct {
 	parent *logp.Logger
 }
 
-func (l *goLumberLogger) Printf(s string, i ...interface{}) {
+func (l *goLumberLogger) Printf(s string, i ...any) {
 	l.parent.Debugf(s, i...)
 }
 
-func (l *goLumberLogger) Println(i ...interface{}) {
+func (l *goLumberLogger) Println(i ...any) {
 	l.parent.Debug(i...)
 }
 
-func (l *goLumberLogger) Print(i ...interface{}) {
+func (l *goLumberLogger) Print(i ...any) {
 	l.parent.Debug(i...)
 }

--- a/x-pack/filebeat/input/lumberjack/server.go
+++ b/x-pack/filebeat/input/lumberjack/server.go
@@ -118,11 +118,11 @@ func (s *server) processBatch(batch *lj.Batch) {
 	acker.Ready()
 }
 
-func makeEvent(remoteAddr string, tlsState *tls.ConnectionState, lumberjackEvent interface{}, acker *batchACKTracker) beat.Event {
+func makeEvent(remoteAddr string, tlsState *tls.ConnectionState, lumberjackEvent any, acker *batchACKTracker) beat.Event {
 	event := beat.Event{
 		Timestamp: time.Now().UTC(),
-		Fields: map[string]interface{}{
-			"source": map[string]interface{}{
+		Fields: map[string]any{
+			"source": map[string]any{
 				"address": remoteAddr,
 			},
 			"lumberjack": lumberjackEvent,
@@ -131,8 +131,8 @@ func makeEvent(remoteAddr string, tlsState *tls.ConnectionState, lumberjackEvent
 	}
 
 	if tlsState != nil && len(tlsState.PeerCertificates) > 0 {
-		event.Fields["tls"] = map[string]interface{}{
-			"client": map[string]interface{}{
+		event.Fields["tls"] = map[string]any{
+			"client": map[string]any{
 				"subject": tlsState.PeerCertificates[0].Subject.CommonName,
 			},
 		}

--- a/x-pack/filebeat/input/lumberjack/server_test.go
+++ b/x-pack/filebeat/input/lumberjack/server_test.go
@@ -128,9 +128,9 @@ func sendData(ctx context.Context, t testing.TB, bindAddress string, numberOfEve
 	}()
 	t.Log("Lumberjack client connected.")
 
-	events := make([]interface{}, 0, numberOfEvents)
-	for i := 0; i < numberOfEvents; i++ {
-		events = append(events, map[string]interface{}{
+	events := make([]any, 0, numberOfEvents)
+	for i := range numberOfEvents {
+		events = append(events, map[string]any{
 			"message": "hello world!",
 			"index":   i,
 		})

--- a/x-pack/filebeat/input/o365audit/config.go
+++ b/x-pack/filebeat/input/o365audit/config.go
@@ -164,13 +164,13 @@ func (c *Config) Validate() (err error) {
 type stringList []string
 
 // Unpack populates the stringList with either a single string value or an array.
-func (s *stringList) Unpack(value interface{}) error {
+func (s *stringList) Unpack(value any) error {
 	switch v := value.(type) {
 	case string:
 		*s = []string{v}
 	case []string:
 		*s = v
-	case []interface{}:
+	case []any:
 		*s = make([]string, len(v))
 		for idx, ival := range v {
 			str, ok := ival.(string)

--- a/x-pack/filebeat/input/o365audit/contentblob_test.go
+++ b/x-pack/filebeat/input/o365audit/contentblob_test.go
@@ -30,7 +30,7 @@ func (n noopReporter) UpdateStatus(status status.Status, msg string) {}
 
 var errStopped = errors.New("stopped")
 
-func (s *contentStore) onEvent(b beat.Event, checkpointUpdate interface{}) error {
+func (s *contentStore) onEvent(b beat.Event, checkpointUpdate any) error {
 	b.Private = checkpointUpdate
 	s.events = append(s.events, b)
 	if s.stopped {

--- a/x-pack/filebeat/input/o365audit/input.go
+++ b/x-pack/filebeat/input/o365audit/input.go
@@ -233,14 +233,14 @@ type apiEnvironment struct {
 	tenantID    string
 	contentType string
 	config      APIConfig
-	callback    func(event beat.Event, cursor interface{}) error
+	callback    func(event beat.Event, cursor any) error
 	status      status.StatusReporter
 	logger      *logp.Logger
 	clock       func() time.Time
 }
 
 // Report returns an action that produces a beat.Event from the given object.
-func (env apiEnvironment) Report(raw json.RawMessage, doc mapstr.M, private interface{}) poll.Action {
+func (env apiEnvironment) Report(raw json.RawMessage, doc mapstr.M, private any) poll.Action {
 	return func(poll.Enqueuer) error {
 		err := env.callback(env.toBeatEvent(raw, doc), private)
 		switch err {

--- a/x-pack/filebeat/input/o365audit/listblobs.go
+++ b/x-pack/filebeat/input/o365audit/listblobs.go
@@ -88,7 +88,7 @@ func (l listBlob) RequestDecorators() []autorest.PrepareDecorator {
 		autorest.WithPath(l.env.tenantID),
 		autorest.WithPath("activity/feed/subscriptions/content"),
 		autorest.WithQueryParameters(
-			map[string]interface{}{
+			map[string]any{
 				"contentType": l.env.contentType,
 				"startTime":   l.startTime.Format(apiDateFormat),
 				"endTime":     l.endTime.Format(apiDateFormat),
@@ -274,7 +274,7 @@ func (l listBlob) handleError(response *http.Response) (actions []poll.Action) {
 	return append(actions, poll.Fetch(l))
 }
 
-func readJSONBody(response *http.Response, dest interface{}) error {
+func readJSONBody(response *http.Response, dest any) error {
 	defer autorest.Respond(response,
 		autorest.ByDiscardingBody(),
 		autorest.ByClosing())

--- a/x-pack/filebeat/input/o365audit/listblobs_test.go
+++ b/x-pack/filebeat/input/o365audit/listblobs_test.go
@@ -100,7 +100,7 @@ func (f *fakePoll) PagedSearchQuery(t testing.TB, lb poll.Transaction, db []blob
 	return f.deliverResult(t, lb, result, nextUrl)
 }
 
-func (f *fakePoll) deliverResult(t testing.TB, pl poll.Transaction, msg interface{}, nextUrl string) (urls []string, next poll.Transaction) {
+func (f *fakePoll) deliverResult(t testing.TB, pl poll.Transaction, msg any, nextUrl string) (urls []string, next poll.Transaction) {
 	js, err := json.Marshal(msg)
 	if !assert.NoError(t, err) {
 		t.Fatal(err)

--- a/x-pack/filebeat/input/o365audit/subscribe.go
+++ b/x-pack/filebeat/input/o365audit/subscribe.go
@@ -33,7 +33,7 @@ func (s subscribe) RequestDecorators() []autorest.PrepareDecorator {
 		autorest.WithPath(s.tenantID),
 		autorest.WithPath("activity/feed/subscriptions/start"),
 		autorest.WithQueryParameters(
-			map[string]interface{}{
+			map[string]any{
 				"contentType": s.contentType,
 			}),
 	}

--- a/x-pack/filebeat/input/streaming/cel.go
+++ b/x-pack/filebeat/input/streaming/cel.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	// mimetypes holds supported MIME type mappings.
-	mimetypes = map[string]interface{}{
+	mimetypes = map[string]any{
 		"application/gzip":         func(r io.Reader) (io.Reader, error) { return gzip.NewReader(r) },
 		"application/x-ndjson":     lib.NDJSON,
 		"application/zip":          lib.Zip,
@@ -67,7 +67,7 @@ func newProgram(ctx context.Context, src, root string, patterns map[string]*rege
 		lib.Try(),
 		lib.Debug(debug(log)),
 		lib.MIME(mimetypes),
-		lib.Globals(map[string]interface{}{
+		lib.Globals(map[string]any{
 			"useragent": userAgent,
 		}),
 	}
@@ -228,16 +228,16 @@ func parseURL(arg ref.Val) ref.Val {
 	if err != nil {
 		return types.NewErr("%s", err)
 	}
-	var user interface{}
+	var user any
 	if u.User != nil {
 		password, passwordSet := u.User.Password()
-		user = map[string]interface{}{
+		user = map[string]any{
 			"Username":    u.User.Username(),
 			"Password":    password,
 			"PasswordSet": passwordSet,
 		}
 	}
-	return types.NewStringInterfaceMap(types.DefaultTypeAdapter, map[string]interface{}{
+	return types.NewStringInterfaceMap(types.DefaultTypeAdapter, map[string]any{
 		"Scheme":      u.Scheme,
 		"Opaque":      u.Opaque,
 		"User":        user,
@@ -260,7 +260,7 @@ func formatURL(arg ref.Val) ref.Val {
 	if err != nil {
 		return types.NewErr("no such overload for format_url: %v", err)
 	}
-	m, ok := v.(map[string]interface{})
+	m, ok := v.(map[string]any)
 	if !ok {
 		// This should never happen.
 		return types.NewErr("unexpected type for url map: %T", v)
@@ -313,7 +313,7 @@ func formatURL(arg ref.Val) ref.Val {
 
 // maybeStringLookup returns a string from m[key] if it is present and the
 // empty string if not. It panics is m[key] is not a string.
-func maybeStringLookup(m map[string]interface{}, key string) string {
+func maybeStringLookup(m map[string]any, key string) string {
 	v, ok := m[key]
 	if !ok {
 		return ""
@@ -323,7 +323,7 @@ func maybeStringLookup(m map[string]interface{}, key string) string {
 
 // maybeBoolLookup returns a bool from m[key] if it is present and false if
 // not. It panics is m[key] is not a bool.
-func maybeBoolLookup(m map[string]interface{}, key string) bool {
+func maybeBoolLookup(m map[string]any, key string) bool {
 	v, ok := m[key]
 	if !ok {
 		return false

--- a/x-pack/filebeat/input/streaming/config_test.go
+++ b/x-pack/filebeat/input/streaming/config_test.go
@@ -16,12 +16,12 @@ import (
 
 var configTests = []struct {
 	name    string
-	config  map[string]interface{}
+	config  map[string]any
 	wantErr error
 }{
 	{
 		name: "invalid_url_scheme",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					bytes(state.response).decode_json().as(inner_body,{
 					"events": [inner_body],
@@ -32,7 +32,7 @@ var configTests = []struct {
 	},
 	{
 		name: "missing_url",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					bytes(state.response).decode_json().as(inner_body,{
 					"events": [inner_body],
@@ -42,7 +42,7 @@ var configTests = []struct {
 	},
 	{
 		name: "invalid_program",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					bytes(state.response).decode_json().as(inner_body,{
 					"events": has(state.cursor) && inner_body.ts > state.cursor.last_updated ? 
@@ -56,8 +56,8 @@ var configTests = []struct {
 	},
 	{
 		name: "invalid_regexps",
-		config: map[string]interface{}{
-			"regexp": map[string]interface{}{
+		config: map[string]any{
+			"regexp": map[string]any{
 				"products":  "(?i)(xq>)d+)",
 				"solutions": "(?i)(Search|Observability|Security)",
 			},
@@ -67,8 +67,8 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_regexps",
-		config: map[string]interface{}{
-			"regexp": map[string]interface{}{
+		config: map[string]any{
+			"regexp": map[string]any{
 				"products":  "(?i)(Elasticsearch|Beats|Logstash|Kibana)",
 				"solutions": "(?i)(Search|Observability|Security)",
 			},
@@ -77,17 +77,17 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_config",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					bytes(state.response).decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
 			"url": "wss://localhost:443/v1/stream",
-			"regexp": map[string]interface{}{
+			"regexp": map[string]any{
 				"products":  "(?i)(Elasticsearch|Beats|Logstash|Kibana)",
 				"solutions": "(?i)(Search|Observability|Security)",
 			},
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"cursor": map[string]int{
 					"last_updated": 1502908200,
 				},
@@ -96,8 +96,8 @@ var configTests = []struct {
 	},
 	{
 		name: "invalid_retry_wait_min_greater_than_wait_max",
-		config: map[string]interface{}{
-			"retry": map[string]interface{}{
+		config: map[string]any{
+			"retry": map[string]any{
 				"max_attempts": 3,
 				"wait_min":     "3s",
 				"wait_max":     "2s",
@@ -108,8 +108,8 @@ var configTests = []struct {
 	},
 	{
 		name: "invalid_retry_max_attempts_eq_zero",
-		config: map[string]interface{}{
-			"retry": map[string]interface{}{
+		config: map[string]any{
+			"retry": map[string]any{
 				"max_attempts": 0,
 				"wait_min":     "1s",
 				"wait_max":     "2s",
@@ -120,8 +120,8 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_retry",
-		config: map[string]interface{}{
-			"retry": map[string]interface{}{
+		config: map[string]any{
+			"retry": map[string]any{
 				"max_attempts": 3,
 				"wait_min":     "2s",
 				"wait_max":     "5s",
@@ -131,8 +131,8 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_retry_with_infinite",
-		config: map[string]interface{}{
-			"retry": map[string]interface{}{
+		config: map[string]any{
+			"retry": map[string]any{
 				"infinite_retries": true,
 				"max_attempts":     0,
 				"wait_min":         "1s",
@@ -143,8 +143,8 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_authStyle_default",
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"client_id":     "a_client_id",
 				"client_secret": "a_client_secret",
 				"token_url":     "https://localhost:443/token",
@@ -154,8 +154,8 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_authStyle_in_params",
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"auth_style":    "in_params",
 				"client_id":     "a_client_id",
 				"client_secret": "a_client_secret",
@@ -166,8 +166,8 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_authStyle_in_header",
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"auth_style":    "in_header",
 				"client_id":     "a_client_id",
 				"client_secret": "a_client_secret",
@@ -178,8 +178,8 @@ var configTests = []struct {
 	},
 	{
 		name: "invalid_authStyle",
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"auth_style":    "in_query",
 				"client_id":     "a_client_id",
 				"client_secret": "a_client_secret",
@@ -191,8 +191,8 @@ var configTests = []struct {
 	},
 	{
 		name: "valid_tokenExpiryBuffer",
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"client_id":           "a_client_id",
 				"client_secret":       "a_client_secret",
 				"token_url":           "https://localhost:443/token",
@@ -203,8 +203,8 @@ var configTests = []struct {
 	},
 	{
 		name: "invalid_tokenExpiryBuffer",
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"client_id":           "a_client_id",
 				"client_secret":       "a_client_secret",
 				"token_url":           "https://localhost:443/token",

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -927,8 +927,7 @@ func TestFollowSessionRejectsCrossOriginResourceURLs(t *testing.T) {
 				ID:              "origin_test",
 				MetricsRegistry: monitoring.NewRegistry(),
 			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			s, err := NewFalconHoseFollower(ctx, env, cfg, nil, &testPublisher{log}, nil, log, time.Now)
 			if err != nil {

--- a/x-pack/filebeat/input/streaming/input.go
+++ b/x-pack/filebeat/input/streaming/input.go
@@ -78,7 +78,7 @@ func (input) Test(src inputcursor.Source, _ v2.TestContext) error {
 // context cancellation or type invalidity errors, any other error will be retried.
 func (input) Run(env v2.Context, src inputcursor.Source, crsr inputcursor.Cursor, pub inputcursor.Publisher) error {
 	env.UpdateStatus(status.Starting, "")
-	var cursor map[string]interface{}
+	var cursor map[string]any
 	if !crsr.IsNew() { // Allow the user to bootstrap the program if needed.
 		env.UpdateStatus(status.Configuring, "")
 		err := crsr.Unpack(&cursor)
@@ -145,12 +145,12 @@ func getURL(ctx context.Context, name, src, url string, state map[string]any, re
 	return url, nil
 }
 
-func evalURLWith(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[string]interface{}, now time.Time) (string, error) {
+func evalURLWith(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[string]any, now time.Time) (string, error) {
 	out, err := evalRefVal(ctx, prg, ast, state, now)
 	if err != nil {
 		return "", fmt.Errorf("failed eval: %w", err)
 	}
-	v, err := out.ConvertToNative(reflect.TypeOf(""))
+	v, err := out.ConvertToNative(reflect.TypeFor[string]())
 	if err != nil {
 		return "", fmt.Errorf("failed type conversion: %w", err)
 	}
@@ -325,7 +325,7 @@ func (p processor) process(ctx context.Context, state, cursor map[string]any, st
 	return goodCursor, err
 }
 
-func evalWith(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[string]interface{}, now time.Time) (map[string]interface{}, error) {
+func evalWith(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[string]any, now time.Time) (map[string]any, error) {
 	out, err := evalRefVal(ctx, prg, ast, state, now)
 	if err != nil {
 		state["events"] = errorMessage(fmt.Sprintf("failed eval: %v", err))
@@ -333,7 +333,7 @@ func evalWith(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[stri
 		return state, fmt.Errorf("failed eval: %w", err)
 	}
 
-	v, err := out.ConvertToNative(reflect.TypeOf((*structpb.Struct)(nil)))
+	v, err := out.ConvertToNative(reflect.TypeFor[*structpb.Struct]())
 	if err != nil {
 		state["events"] = errorMessage(fmt.Sprintf("failed proto conversion: %v", err))
 		clearWantMore(state)
@@ -351,8 +351,8 @@ func evalWith(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[stri
 	}
 }
 
-func evalRefVal(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[string]interface{}, now time.Time) (ref.Val, error) {
-	out, _, err := prg.ContextEval(ctx, map[string]interface{}{
+func evalRefVal(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[string]any, now time.Time) (ref.Val, error) {
+	out, _, err := prg.ContextEval(ctx, map[string]any{
 		// Replace global program "now" with current time. This is necessary
 		// as the lib.Time now global is static at program instantiation time
 		// which will persist over multiple evaluations. The lib.Time behaviour
@@ -378,14 +378,14 @@ func evalRefVal(ctx context.Context, prg cel.Program, ast *cel.Ast, state map[st
 // It leaves state intact if there is no "want_more" element, and sets the element to false
 // if there is. This is necessary instead of just doing delete(state, "want_more") as
 // client CEL code may expect the want_more field to be present.
-func clearWantMore(state map[string]interface{}) {
+func clearWantMore(state map[string]any) {
 	if _, ok := state["want_more"]; ok {
 		state["want_more"] = false
 	}
 }
 
-func errorMessage(msg string) map[string]interface{} {
-	return map[string]interface{}{"error": map[string]interface{}{"message": msg}}
+func errorMessage(msg string) map[string]any {
+	return map[string]any{"error": map[string]any{"message": msg}}
 }
 
 func formHeader(cfg config) map[string][]string {

--- a/x-pack/filebeat/input/streaming/input_test.go
+++ b/x-pack/filebeat/input/streaming/input_test.go
@@ -44,23 +44,23 @@ type WebSocketHandler func(*testing.T, *websocket.Conn, []string)
 
 var inputTests = []struct {
 	name          string
-	server        func(*testing.T, WebSocketHandler, map[string]interface{}, []string)
-	proxyServer   func(*testing.T, WebSocketHandler, map[string]interface{}, []string) *httptest.Server
-	oauth2Server  func(*testing.T, http.HandlerFunc, map[string]interface{})
+	server        func(*testing.T, WebSocketHandler, map[string]any, []string)
+	proxyServer   func(*testing.T, WebSocketHandler, map[string]any, []string) *httptest.Server
+	oauth2Server  func(*testing.T, http.HandlerFunc, map[string]any)
 	handler       WebSocketHandler
 	oauth2Handler http.HandlerFunc
-	config        map[string]interface{}
+	config        map[string]any
 	response      []string
 	time          func() time.Time
-	persistCursor map[string]interface{}
-	want          []map[string]interface{}
+	persistCursor map[string]any
+	want          []map[string]any
 	wantErr       error
 }{
 	{
 		name:    "single_event",
 		server:  newWebSocketTestServer(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
@@ -92,23 +92,23 @@ var inputTests = []struct {
 				},
 				"id": "ZeYGULpZmL5N0151HN1OyA"
 		   }`},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
 				"ts":   "2017-08-17T14:54:12.949180-07:00",
 				"data": "2017-08-17T14:54:12.949180-07:00 example sendmail[30641]:v7HLqYbx029423: to=/dev/null, ctladdr=<user1@example.com> (8/0),delay=00:00:00, xdelay=00:00:00, mailer=*file*, tls_verify=NONE, pri=35342,dsn=2.0.0, stat=Sent",
-				"sm": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"sm": map[string]any{
+					"tls": map[string]any{
 						"verify": "NONE",
 					},
 					"stat":   "Sent",
 					"qid":    "v7HLqYbx029423",
 					"dsn":    "2.0.0",
 					"mailer": "*file*",
-					"to": []interface{}{
+					"to": []any{
 						"/dev/null",
 					},
 					"ctladdr": "<user1@example.com> (8/0)",
@@ -124,7 +124,7 @@ var inputTests = []struct {
 		name:    "multiple_events",
 		server:  newWebSocketTestServer(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
@@ -183,23 +183,23 @@ var inputTests = []struct {
 				"id": "ZeYGULpZmL5N0151HN1OyX"
 	   }`,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
 				"ts":   "2017-08-17T14:54:12.949180-07:00",
 				"data": "2017-08-17T14:54:12.949180-07:00 example sendmail[30641]:v7HLqYbx029423: to=/dev/null, ctladdr=<user1@example.com> (8/0),delay=00:00:00, xdelay=00:00:00, mailer=*file*, tls_verify=NONE, pri=35342,dsn=2.0.0, stat=Sent",
-				"sm": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"sm": map[string]any{
+					"tls": map[string]any{
 						"verify": "NONE",
 					},
 					"stat":   "Sent",
 					"qid":    "v7HLqYbx029423",
 					"dsn":    "2.0.0",
 					"mailer": "*file*",
-					"to": []interface{}{
+					"to": []any{
 						"/dev/null",
 					},
 					"ctladdr": "<user1@example.com> (8/0)",
@@ -210,21 +210,21 @@ var inputTests = []struct {
 				"id": "ZeYGULpZmL5N0151HN1OyA",
 			},
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
 				"ts":   "2017-08-17T14:54:12.949180-07:00",
 				"data": "2017-08-17T14:54:12.949180-07:00 example sendmail[30641]:v7HLqYbx029423: to=/dev/null, ctladdr=<user1@example.com> (8/0),delay=00:00:00, xdelay=00:00:00, mailer=*file*, tls_verify=NONE, pri=35342,dsn=2.0.0, stat=Sent",
-				"sm": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"sm": map[string]any{
+					"tls": map[string]any{
 						"verify": "NONE",
 					},
 					"stat":   "Sent",
 					"qid":    "v7HLqYbx029423",
 					"dsn":    "2.0.0",
 					"mailer": "*file*",
-					"to": []interface{}{
+					"to": []any{
 						"/dev/null",
 					},
 					"ctladdr": "<user1@example.com> (8/0)",
@@ -240,7 +240,7 @@ var inputTests = []struct {
 		name:    "bad_cursor",
 		server:  newWebSocketTestServer(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
@@ -260,7 +260,7 @@ var inputTests = []struct {
 		name:    "invalid_url_scheme",
 		server:  invalidWebSocketTestServer(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
@@ -272,12 +272,12 @@ var inputTests = []struct {
 		name:    "cursor_condition_check",
 		server:  newWebSocketTestServer(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 	              state.response.decode_json().as(inner_body,{
 					"events": has(state.cursor) && inner_body.ts > state.cursor.last_updated ?  [inner_body] : [],
 	          })`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"cursor": map[string]int{
 					"last_updated": 1502908200,
 				},
@@ -300,9 +300,9 @@ var inputTests = []struct {
 	          "ts": 1503081000
 	      }`,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint-1.com",
 					"cid":   "mmeng_vxciml",
 				},
@@ -314,12 +314,12 @@ var inputTests = []struct {
 		name:    "auth_basic_token",
 		server:  webSocketTestServerWithAuth(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
-			"auth": map[string]interface{}{
+			"auth": map[string]any{
 				"basic_token": basicToken,
 			},
 		},
@@ -333,9 +333,9 @@ var inputTests = []struct {
 	          "ts": 1502908200
 	      }`,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
@@ -347,12 +347,12 @@ var inputTests = []struct {
 		name:    "auth_bearer_token",
 		server:  webSocketTestServerWithAuth(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
-			"auth": map[string]interface{}{
+			"auth": map[string]any{
 				"bearer_token": bearerToken,
 			},
 		},
@@ -366,9 +366,9 @@ var inputTests = []struct {
 	          "ts": 1502908200
 	      }`,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
@@ -380,13 +380,13 @@ var inputTests = []struct {
 		name:    "auth_custom",
 		server:  webSocketTestServerWithAuth(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
-			"auth": map[string]interface{}{
-				"custom": map[string]interface{}{
+			"auth": map[string]any{
+				"custom": map[string]any{
 					"header": customHeader,
 					"value":  customValue,
 				},
@@ -402,9 +402,9 @@ var inputTests = []struct {
 	          "ts": 1502908200
 	      }`,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
@@ -416,12 +416,12 @@ var inputTests = []struct {
 		name:    "test_retry_success",
 		server:  webSocketServerWithRetry(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
-			"retry": map[string]interface{}{
+			"retry": map[string]any{
 				"max_attempts": 3,
 				"wait_min":     "1s",
 				"wait_max":     "2s",
@@ -437,9 +437,9 @@ var inputTests = []struct {
 	          "ts": 1502908200
 	      }`,
 		},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
@@ -451,12 +451,12 @@ var inputTests = []struct {
 		name:    "test_retry_failure",
 		server:  webSocketServerWithRetry(httptest.NewServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
-			"retry": map[string]interface{}{
+			"retry": map[string]any{
 				"max_attempts": 2,
 				"wait_min":     "1s",
 				"wait_max":     "2s",
@@ -468,12 +468,12 @@ var inputTests = []struct {
 		name:    "single_event_tls",
 		server:  webSocketServerWithTLS(httptest.NewUnstartedServer),
 		handler: defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
 				})`,
-			"ssl": map[string]interface{}{
+			"ssl": map[string]any{
 				"enabled":                 true,
 				"certificate_authorities": []string{"testdata/certs/ca.crt"},
 				"certificate":             "testdata/certs/cert.pem",
@@ -506,23 +506,23 @@ var inputTests = []struct {
 				},
 				"id": "ZeYGULpZmL5N0151HN1OyA"
 		   }`},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
 				"ts":   "2017-08-17T14:54:12.949180-07:00",
 				"data": "2017-08-17T14:54:12.949180-07:00 example sendmail[30641]:v7HLqYbx029423: to=/dev/null, ctladdr=<user1@example.com> (8/0),delay=00:00:00, xdelay=00:00:00, mailer=*file*, tls_verify=NONE, pri=35342,dsn=2.0.0, stat=Sent",
-				"sm": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"sm": map[string]any{
+					"tls": map[string]any{
 						"verify": "NONE",
 					},
 					"stat":   "Sent",
 					"qid":    "v7HLqYbx029423",
 					"dsn":    "2.0.0",
 					"mailer": "*file*",
-					"to": []interface{}{
+					"to": []any{
 						"/dev/null",
 					},
 					"ctladdr": "<user1@example.com> (8/0)",
@@ -538,7 +538,7 @@ var inputTests = []struct {
 		name:        "basic_proxy_forwarding",
 		proxyServer: newWebSocketProxyTestServer,
 		handler:     defaultHandler,
-		config: map[string]interface{}{
+		config: map[string]any{
 			"program": `
 					state.response.decode_json().as(inner_body,{
 					"events": [inner_body],
@@ -570,23 +570,23 @@ var inputTests = []struct {
 				},
 				"id": "ZeYGULpZmL5N0151HN1OyA"
 			 }`},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
 				"ts":   "2017-08-17T14:54:12.949180-07:00",
 				"data": "2017-08-17T14:54:12.949180-07:00 example sendmail[30641]:v7HLqYbx029423: to=/dev/null, ctladdr=<user1@example.com> (8/0),delay=00:00:00, xdelay=00:00:00, mailer=*file*, tls_verify=NONE, pri=35342,dsn=2.0.0, stat=Sent",
-				"sm": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"sm": map[string]any{
+					"tls": map[string]any{
 						"verify": "NONE",
 					},
 					"stat":   "Sent",
 					"qid":    "v7HLqYbx029423",
 					"dsn":    "2.0.0",
 					"mailer": "*file*",
-					"to": []interface{}{
+					"to": []any{
 						"/dev/null",
 					},
 					"ctladdr": "<user1@example.com> (8/0)",
@@ -600,7 +600,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "oauth2_blank_auth_style",
-		oauth2Server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		oauth2Server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["auth.token_url"] = s.URL + "/token"
 			config["url"] = "ws://placeholder"
@@ -609,8 +609,8 @@ var inputTests = []struct {
 		oauth2Handler: oauth2TokenHandler,
 		server:        webSocketTestServerWithAuth(httptest.NewServer),
 		handler:       defaultHandler,
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"client_id":     "a_client_id",
 				"client_secret": "a_client_secret",
 				"scopes": []string{
@@ -652,23 +652,23 @@ var inputTests = []struct {
 				},
 				"id": "ZeYGULpZmL5N0151HN1OyA"
 			 }`},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
 				"ts":   "2017-08-17T14:54:12.949180-07:00",
 				"data": "2017-08-17T14:54:12.949180-07:00 example sendmail[30641]:v7HLqYbx029423: to=/dev/null, ctladdr=<user1@example.com> (8/0),delay=00:00:00, xdelay=00:00:00, mailer=*file*, tls_verify=NONE, pri=35342,dsn=2.0.0, stat=Sent",
-				"sm": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"sm": map[string]any{
+					"tls": map[string]any{
 						"verify": "NONE",
 					},
 					"stat":   "Sent",
 					"qid":    "v7HLqYbx029423",
 					"dsn":    "2.0.0",
 					"mailer": "*file*",
-					"to": []interface{}{
+					"to": []any{
 						"/dev/null",
 					},
 					"ctladdr": "<user1@example.com> (8/0)",
@@ -682,7 +682,7 @@ var inputTests = []struct {
 	},
 	{
 		name: "oauth2_in_params_auth_style",
-		oauth2Server: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+		oauth2Server: func(t *testing.T, h http.HandlerFunc, config map[string]any) {
 			s := httptest.NewServer(h)
 			config["auth.token_url"] = s.URL + "/token"
 			config["url"] = "ws://placeholder"
@@ -691,8 +691,8 @@ var inputTests = []struct {
 		oauth2Handler: oauth2TokenHandler,
 		server:        webSocketTestServerWithAuth(httptest.NewServer),
 		handler:       defaultHandler,
-		config: map[string]interface{}{
-			"auth": map[string]interface{}{
+		config: map[string]any{
+			"auth": map[string]any{
 				"auth_style":    "in_params",
 				"client_id":     "a_client_id",
 				"client_secret": "a_client_secret",
@@ -735,23 +735,23 @@ var inputTests = []struct {
 				},
 				"id": "ZeYGULpZmL5N0151HN1OyA"
 			 }`},
-		want: []map[string]interface{}{
+		want: []map[string]any{
 			{
-				"pps": map[string]interface{}{
+				"pps": map[string]any{
 					"agent": "example.proofpoint.com",
 					"cid":   "mmeng_uivm071",
 				},
 				"ts":   "2017-08-17T14:54:12.949180-07:00",
 				"data": "2017-08-17T14:54:12.949180-07:00 example sendmail[30641]:v7HLqYbx029423: to=/dev/null, ctladdr=<user1@example.com> (8/0),delay=00:00:00, xdelay=00:00:00, mailer=*file*, tls_verify=NONE, pri=35342,dsn=2.0.0, stat=Sent",
-				"sm": map[string]interface{}{
-					"tls": map[string]interface{}{
+				"sm": map[string]any{
+					"tls": map[string]any{
 						"verify": "NONE",
 					},
 					"stat":   "Sent",
 					"qid":    "v7HLqYbx029423",
 					"dsn":    "2.0.0",
 					"mailer": "*file*",
-					"to": []interface{}{
+					"to": []any{
 						"/dev/null",
 					},
 					"ctladdr": "<user1@example.com> (8/0)",
@@ -767,17 +767,17 @@ var inputTests = []struct {
 
 var urlEvalTests = []struct {
 	name   string
-	config map[string]interface{}
+	config map[string]any
 	time   func() time.Time
 	want   string
 }{
 	{
 		name: "cursor based url modification",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"url":         "ws://testapi/getresults",
 			"url_program": `has(state.cursor) && has(state.cursor.since) ? state.url+"?since="+ state.cursor.since : state.url`,
-			"state": map[string]interface{}{
-				"cursor": map[string]interface{}{
+			"state": map[string]any{
+				"cursor": map[string]any{
 					"since": "2017-08-17T14:54:12",
 				},
 			},
@@ -786,11 +786,11 @@ var urlEvalTests = []struct {
 	},
 	{
 		name: "cursor based url modification using simplified query",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"url":         "ws://testapi/getresults",
 			"url_program": `state.url + "?since=" + state.?cursor.since.orValue(state.url)`,
-			"state": map[string]interface{}{
-				"cursor": map[string]interface{}{
+			"state": map[string]any{
+				"cursor": map[string]any{
 					"since": "2017-08-17T14:54:12",
 				},
 			},
@@ -799,10 +799,10 @@ var urlEvalTests = []struct {
 	},
 	{
 		name: "url modification with no cursor",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"url":         "ws://testapi/getresults",
 			"url_program": `has(state.cursor) && has(state.cursor.since) ? state.url+"?since="+ state.cursor.since: state.url+"?since="+ state.initial_start_time`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"initial_start_time": "2022-01-01T00:00:00Z",
 			},
 		},
@@ -810,10 +810,10 @@ var urlEvalTests = []struct {
 	},
 	{
 		name: "url modification with no cursor, using simplified query",
-		config: map[string]interface{}{
+		config: map[string]any{
 			"url":         "ws://testapi/getresults",
 			"url_program": `state.url + "?since=" + state.?cursor.since.orValue(state.initial_start_time)`,
-			"state": map[string]interface{}{
+			"state": map[string]any{
 				"initial_start_time": "2022-01-01T00:00:00Z",
 			},
 		},
@@ -841,9 +841,9 @@ func TestURLEval(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			var state map[string]interface{}
+			var state map[string]any
 			if conf.State == nil {
-				state = make(map[string]interface{})
+				state = make(map[string]any)
 			} else {
 				state = conf.State
 			}
@@ -945,13 +945,13 @@ func TestInput(t *testing.T) {
 // cloneConfig returns a deep copy of m via a JSON round-trip. This prevents
 // server factories from mutating the package-level inputTests table, which
 // would otherwise cause stale URLs and state when tests are run with -count >1.
-func cloneConfig(t *testing.T, m map[string]interface{}) map[string]interface{} {
+func cloneConfig(t *testing.T, m map[string]any) map[string]any {
 	t.Helper()
 	b, err := json.Marshal(m)
 	if err != nil {
 		t.Fatalf("failed to marshal config for deep copy: %v", err)
 	}
-	var clone map[string]interface{}
+	var clone map[string]any
 	if err := json.Unmarshal(b, &clone); err != nil {
 		t.Fatalf("failed to unmarshal config for deep copy: %v", err)
 	}
@@ -1006,7 +1006,7 @@ func TestURLProgramReconnect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"url":         "ws" + server.URL[4:] + "/v1/stream",
 		"url_program": `has(state.?cursor.last_timestamp) ? state.url + "?sinceTime=" + state.cursor.last_timestamp : state.url`,
 		"program": `
@@ -1014,7 +1014,7 @@ func TestURLProgramReconnect(t *testing.T) {
 				"cursor": {"last_timestamp": body.ts},
 				"events": [body],
 			})`,
-		"retry": map[string]interface{}{
+		"retry": map[string]any{
 			"blanket_retries": true,
 			"wait_min":        "10ms",
 			"wait_max":        "50ms",
@@ -1109,7 +1109,7 @@ func TestURLProgramReconnectZeroEvents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"url":         "ws" + server.URL[4:] + "/v1/stream",
 		"url_program": `has(state.?cursor.last_timestamp) ? state.url + "?sinceTime=" + state.cursor.last_timestamp : state.url`,
 		"program": `
@@ -1119,7 +1119,7 @@ func TestURLProgramReconnectZeroEvents(t *testing.T) {
 				:
 					{"events": []}
 			)`,
-		"retry": map[string]interface{}{
+		"retry": map[string]any{
 			"blanket_retries": true,
 			"wait_min":        "10ms",
 			"wait_max":        "50ms",
@@ -1176,14 +1176,14 @@ type publisher struct {
 	done      func()
 	mu        sync.Mutex
 	published []beat.Event
-	cursors   []map[string]interface{}
+	cursors   []map[string]any
 }
 
-func (p *publisher) Publish(e beat.Event, cursor interface{}) error {
+func (p *publisher) Publish(e beat.Event, cursor any) error {
 	p.mu.Lock()
 	p.published = append(p.published, e)
 	if cursor != nil {
-		c, ok := cursor.(map[string]interface{})
+		c, ok := cursor.(map[string]any)
 		if !ok {
 			return fmt.Errorf("invalid cursor type for testing: %T", cursor)
 		}
@@ -1194,8 +1194,8 @@ func (p *publisher) Publish(e beat.Event, cursor interface{}) error {
 	return nil
 }
 
-func newWebSocketTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]interface{}, []string) {
-	return func(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) {
+func newWebSocketTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]any, []string) {
+	return func(t *testing.T, handler WebSocketHandler, config map[string]any, response []string) {
 		server := serve(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			upgrader := websocket.Upgrader{
 				CheckOrigin: func(r *http.Request) bool {
@@ -1220,8 +1220,8 @@ func newWebSocketTestServer(serve func(http.Handler) *httptest.Server) func(*tes
 }
 
 // invalidWebSocketTestServer returns a function that creates a WebSocket server with an invalid URL scheme.
-func invalidWebSocketTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]interface{}, []string) {
-	return func(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) {
+func invalidWebSocketTestServer(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]any, []string) {
+	return func(t *testing.T, handler WebSocketHandler, config map[string]any, response []string) {
 		server := serve(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			upgrader := websocket.Upgrader{
 				CheckOrigin: func(r *http.Request) bool {
@@ -1243,8 +1243,8 @@ func invalidWebSocketTestServer(serve func(http.Handler) *httptest.Server) func(
 }
 
 // webSocketTestServerWithAuth returns a function that creates a WebSocket server with authentication. This does not however simulate a TLS connection.
-func webSocketTestServerWithAuth(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]interface{}, []string) {
-	return func(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) {
+func webSocketTestServerWithAuth(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]any, []string) {
+	return func(t *testing.T, handler WebSocketHandler, config map[string]any, response []string) {
 		server := serve(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			upgrader := websocket.Upgrader{
 				CheckOrigin: func(r *http.Request) bool {
@@ -1288,8 +1288,8 @@ func webSocketTestServerWithAuth(serve func(http.Handler) *httptest.Server) func
 }
 
 // webSocketServerWithRetry returns a function that creates a WebSocket server that rejects the first two connection attempts and accepts the third.
-func webSocketServerWithRetry(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]interface{}, []string) {
-	return func(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) {
+func webSocketServerWithRetry(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]any, []string) {
+	return func(t *testing.T, handler WebSocketHandler, config map[string]any, response []string) {
 		var attempt int
 		server := serve(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			attempt++
@@ -1321,8 +1321,8 @@ func webSocketServerWithRetry(serve func(http.Handler) *httptest.Server) func(*t
 }
 
 // webSocketServerWithTLS simulates a WebSocket server with TLS based authentication.
-func webSocketServerWithTLS(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]interface{}, []string) {
-	return func(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) {
+func webSocketServerWithTLS(serve func(http.Handler) *httptest.Server) func(*testing.T, WebSocketHandler, map[string]any, []string) {
+	return func(t *testing.T, handler WebSocketHandler, config map[string]any, response []string) {
 		server := serve(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			upgrader := websocket.Upgrader{
 				CheckOrigin: func(r *http.Request) bool {
@@ -1433,7 +1433,7 @@ func webSocketProxyHandler(targetURL string) http.HandlerFunc {
 }
 
 // newWebSocketProxyTestServer creates a proxy server forwarding WebSocket traffic.
-func newWebSocketProxyTestServer(t *testing.T, handler WebSocketHandler, config map[string]interface{}, response []string) *httptest.Server {
+func newWebSocketProxyTestServer(t *testing.T, handler WebSocketHandler, config map[string]any, response []string) *httptest.Server {
 	backendServer := webSocketTestServer(t, handler, response)
 	t.Cleanup(backendServer.Close)
 	config["url"] = "ws" + backendServer.URL[4:]

--- a/x-pack/filebeat/input/streaming/redact.go
+++ b/x-pack/filebeat/input/streaming/redact.go
@@ -47,8 +47,8 @@ func cloneMap(dst, src mapstr.M) {
 			d := make(mapstr.M, len(v))
 			dst[k] = d
 			cloneMap(d, v)
-		case map[string]interface{}:
-			d := make(map[string]interface{}, len(v))
+		case map[string]any:
+			d := make(map[string]any, len(v))
 			dst[k] = d
 			cloneMap(d, v)
 		case []mapstr.M:
@@ -59,10 +59,10 @@ func cloneMap(dst, src mapstr.M) {
 				a = append(a, d)
 			}
 			dst[k] = a
-		case []map[string]interface{}:
-			a := make([]map[string]interface{}, 0, len(v))
+		case []map[string]any:
+			a := make([]map[string]any, 0, len(v))
 			for _, m := range v {
-				d := make(map[string]interface{}, len(m))
+				d := make(map[string]any, len(m))
 				cloneMap(d, m)
 				a = append(a, d)
 			}
@@ -88,22 +88,22 @@ func walkMap(m mapstr.M, path string, fn func(parent mapstr.M, key string)) {
 	switch v := v.(type) {
 	case mapstr.M:
 		walkMap(v, rest, fn)
-	case map[string]interface{}:
+	case map[string]any:
 		walkMap(v, rest, fn)
 	case []mapstr.M:
 		for _, m := range v {
 			walkMap(m, rest, fn)
 		}
-	case []map[string]interface{}:
+	case []map[string]any:
 		for _, m := range v {
 			walkMap(m, rest, fn)
 		}
-	case []interface{}:
+	case []any:
 		for _, v := range v {
 			switch m := v.(type) {
 			case mapstr.M:
 				walkMap(m, rest, fn)
-			case map[string]interface{}:
+			case map[string]any:
 				walkMap(m, rest, fn)
 			}
 		}

--- a/x-pack/filebeat/input/streaming/websocket.go
+++ b/x-pack/filebeat/input/streaming/websocket.go
@@ -558,11 +558,9 @@ func connectWebSocket(ctx context.Context, cfg config, url string, stat status.S
 // calculateWaitTime calculates the wait time for the next attempt based on the exponential backoff algorithm.
 func calculateWaitTime(waitMin, waitMax time.Duration, attempt, maxAttempts int) time.Duration {
 	// calculate exponential backoff
-	waitTime := wait(waitMin, waitMax, attempt, maxAttempts, spread)
-	// caps the wait time to the maximum wait time
-	if waitTime > waitMax {
-		waitTime = waitMax
-	}
+	waitTime := min(
+		// caps the wait time to the maximum wait time
+		wait(waitMin, waitMax, attempt, maxAttempts, spread), waitMax)
 
 	return waitTime
 }

--- a/x-pack/filebeat/input/streaming/websocket_test.go
+++ b/x-pack/filebeat/input/streaming/websocket_test.go
@@ -45,7 +45,7 @@ func TestFollowStreamReturnsOnCancelWithStalledServer(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"url": "ws" + server.URL[4:] + "/stall",
 		"program": `
 			state.response.decode_json().as(body, {

--- a/x-pack/libbeat/reader/parquet/parquet_benchmark_test.go
+++ b/x-pack/libbeat/reader/parquet/parquet_benchmark_test.go
@@ -217,11 +217,9 @@ func BenchmarkReadParquet(b *testing.B) {
 					for _, f := range filePtrArr {
 						f.Seek(0, 0)
 						cf := f
-						wg.Add(1)
-						go func() {
-							defer wg.Done()
+						wg.Go(func() {
 							tc.invocation(b, cfg, cf)
-						}()
+						})
 					}
 					wg.Wait()
 				}

--- a/x-pack/libbeat/reader/parquet/parquet_test.go
+++ b/x-pack/libbeat/reader/parquet/parquet_test.go
@@ -114,7 +114,7 @@ func createRandomParquet(t testing.TB, fname string, numCols int, numRows int) m
 	data := make(map[string]bool)
 	// creates a new Arrow schema
 	fields := make([]arrow.Field, 0, numCols)
-	for i := 0; i < numCols; i++ {
+	for i := range numCols {
 		fieldType := arrow.PrimitiveTypes.Int32
 		field := arrow.Field{Name: fmt.Sprintf("col%d", i), Type: fieldType, Nullable: true}
 		fields = append(fields, field)
@@ -142,7 +142,7 @@ func createRandomParquet(t testing.TB, fname string, numCols int, numRows int) m
 	for rowIdx := int64(0); rowIdx < int64(numRows); rowIdx++ {
 		// creates an Arrow record with random data
 		var recordColumns []arrow.Array
-		for colIdx := 0; colIdx < numCols; colIdx++ {
+		for range numCols {
 			randData := []int32{r.Int31()}
 			builder := array.NewInt32Builder(memoryPool)
 			builder.AppendValues(randData, nil)

--- a/x-pack/osquerybeat/beater/action_handler.go
+++ b/x-pack/osquerybeat/beater/action_handler.go
@@ -22,11 +22,11 @@ var (
 )
 
 type actionResultPublisher interface {
-	PublishActionResult(req map[string]interface{}, res map[string]interface{})
+	PublishActionResult(req map[string]any, res map[string]any)
 }
 
 type queryResultPublisher interface {
-	Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{})
+	Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any)
 }
 
 type scheduledResponsePublisher interface {
@@ -34,11 +34,11 @@ type scheduledResponsePublisher interface {
 }
 
 type queryProfilePublisher interface {
-	PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{})
+	PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any)
 }
 
 type liveProfileRecorder interface {
-	RecordLiveProfile(query string, profile map[string]interface{})
+	RecordLiveProfile(query string, profile map[string]any)
 }
 
 type scheduledQueryPublisher interface {
@@ -53,7 +53,7 @@ type actionQueryPublisher interface {
 }
 
 type queryExecutor interface {
-	Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]interface{}, error)
+	Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]any, error)
 }
 
 type namespaceProvider interface {
@@ -91,13 +91,13 @@ func (a *actionHandler) Name() string {
 }
 
 // Execute handles the action request.
-func (a *actionHandler) Execute(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (a *actionHandler) Execute(ctx context.Context, req map[string]any) (map[string]any, error) {
 
 	start := time.Now().UTC()
 	count, err := a.execute(ctx, req)
 	end := time.Now().UTC()
 
-	res := map[string]interface{}{
+	res := map[string]any{
 		"started_at":   start.Format(time.RFC3339Nano),
 		"completed_at": end.Format(time.RFC3339Nano),
 	}
@@ -110,7 +110,7 @@ func (a *actionHandler) Execute(ctx context.Context, req map[string]interface{})
 	return res, nil
 }
 
-func (a *actionHandler) execute(ctx context.Context, req map[string]interface{}) (int, error) {
+func (a *actionHandler) execute(ctx context.Context, req map[string]any) (int, error) {
 	ac, err := action.FromMap(req)
 	if err != nil {
 		return 0, fmt.Errorf("%w: %w", err, ErrQueryExecution)
@@ -132,7 +132,7 @@ func (a *actionHandler) namespace() string {
 	return config.DefaultNamespace
 }
 
-func (a *actionHandler) executeQuery(ctx context.Context, index string, ac action.Action, responseID string, req map[string]interface{}) (int, error) {
+func (a *actionHandler) executeQuery(ctx context.Context, index string, ac action.Action, responseID string, req map[string]any) (int, error) {
 
 	if a.queryExec == nil {
 		return 0, ErrNoQueryExecutor

--- a/x-pack/osquerybeat/beater/action_handler_test.go
+++ b/x-pack/osquerybeat/beater/action_handler_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 type mockExecutor struct {
-	result []map[string]interface{}
+	result []map[string]any
 	err    error
 
 	receivedSql string
 }
 
-func (e *mockExecutor) Query(ctx context.Context, sql string, to time.Duration) ([]map[string]interface{}, error) {
+func (e *mockExecutor) Query(ctx context.Context, sql string, to time.Duration) ([]map[string]any, error) {
 	e.receivedSql = sql
 
 	return e.result, e.err
@@ -40,14 +40,14 @@ type mockPublisher struct {
 	packID     string
 	packName   string
 	queryName  string
-	meta       map[string]interface{}
-	hits       []map[string]interface{}
+	meta       map[string]any
+	hits       []map[string]any
 	ecsm       ecs.Mapping
-	reqData    interface{}
-	profile    map[string]interface{}
+	reqData    any
+	profile    map[string]any
 }
 
-func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
+func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any) {
 	p.index = index
 	p.idValue = idValue
 	p.idFieldKey = idFieldKey
@@ -62,7 +62,7 @@ func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID,
 	p.reqData = reqData
 }
 
-func (p *mockPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{}) {
+func (p *mockPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
 	p.profile = profile
 }
 
@@ -78,9 +78,9 @@ func TestActionHandlerExecute(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		nonMatchingPlatform = "linux"
 	}
-	request := map[string]interface{}{
+	request := map[string]any{
 		"id": actionID,
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"query": actionSQL,
 		},
 	}
@@ -90,7 +90,7 @@ func TestActionHandlerExecute(t *testing.T) {
 		QueryExecutor queryExecutor
 		Publisher     actionQueryPublisher
 
-		Request map[string]interface{}
+		Request map[string]any
 		Err     error
 		Skipped bool
 	}{
@@ -115,9 +115,9 @@ func TestActionHandlerExecute(t *testing.T) {
 			Name:          "skips non matching platform",
 			QueryExecutor: &mockExecutor{},
 			Publisher:     &mockPublisher{},
-			Request: map[string]interface{}{
+			Request: map[string]any{
 				"id": actionID,
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":    actionSQL,
 					"platform": nonMatchingPlatform,
 				},

--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -26,7 +26,7 @@ const (
 
 // nativeOsqueryOptionDefaults are applied to the options map when building the
 // config for osqueryd, only when each key is not already set in the native config.
-var nativeOsqueryOptionDefaults = map[string]interface{}{
+var nativeOsqueryOptionDefaults = map[string]any{
 	"schedule_splay_percent": 10,
 	"schedule_max_drift":     60,
 }
@@ -234,7 +234,7 @@ func newOsqueryConfig(osqueryConfig *config.OsqueryConfig) *config.OsqueryConfig
 		osqueryConfig = &config.OsqueryConfig{}
 	}
 	if osqueryConfig.Options == nil {
-		osqueryConfig.Options = make(map[string]interface{})
+		osqueryConfig.Options = make(map[string]any)
 	}
 	// Apply native osquery option defaults only when not already set in config
 	for k, v := range nativeOsqueryOptionDefaults {
@@ -416,7 +416,7 @@ func getPackQueryName(packName, queryName string) string {
 // Due to current configuration passing between the agent and beats the keys that contain dots (".")
 // are split into the nested tree-like structure.
 // This converts this dynamic map[string]interface{} tree into strongly typed flat map.
-func flattenECSMapping(m map[string]interface{}) (ecs.Mapping, error) {
+func flattenECSMapping(m map[string]any) (ecs.Mapping, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -433,7 +433,7 @@ func flattenECSMapping(m map[string]interface{}) (ecs.Mapping, error) {
 	return ecsm, nil
 }
 
-func traverseTree(depth int, ecsm ecs.Mapping, path []string, v interface{}) error {
+func traverseTree(depth int, ecsm ecs.Mapping, path []string, v any) error {
 
 	if path[len(path)-1] == keyField {
 		if s, ok := v.(string); ok {
@@ -462,7 +462,7 @@ func traverseTree(depth int, ecsm ecs.Mapping, path []string, v interface{}) err
 			Value: v,
 		}
 		return nil
-	} else if m, ok := v.(map[string]interface{}); ok {
+	} else if m, ok := v.(map[string]any); ok {
 		if depth < maxECSMappingDepth {
 			for k, v := range m {
 				if strings.TrimSpace(k) == "" {

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -96,7 +96,7 @@ func TestConfigPluginNew(t *testing.T) {
 
 func TestFlattenECSMapping(t *testing.T) {
 	const mapping = `{"user":{"custom":{"shoeSize":{"value":45}},"id":{"field":"uid"},"name":{"field":"username"}}}`
-	var m map[string]interface{}
+	var m map[string]any
 	err := json.Unmarshal([]byte(mapping), &m)
 	if err != nil {
 		t.Fatal(err)
@@ -122,13 +122,13 @@ func TestFlattenECSMapping(t *testing.T) {
 	}
 }
 
-func generateTestMapping(depth int, k string, v interface{}) map[string]interface{} {
-	m := make(map[string]interface{})
+func generateTestMapping(depth int, k string, v any) map[string]any {
+	m := make(map[string]any)
 	res := m
 	key := 'a'
 
-	for i := 0; i < depth; i++ {
-		newmap := make(map[string]interface{})
+	for range depth {
+		newmap := make(map[string]any)
 		m[string(key)] = newmap
 		m = newmap
 		key += 1
@@ -176,41 +176,41 @@ func TestFlattenECSMappingMoreEdges(t *testing.T) {
 	}
 
 	values := map[string]struct {
-		m   interface{}
+		m   any
 		err error
 	}{
 		"empty field": {
-			map[string]interface{}{
+			map[string]any{
 				"field": "",
 			},
 			ErrECSMappingIsInvalid,
 		},
 		"empty field with whitespaces": {
-			map[string]interface{}{
+			map[string]any{
 				"field": "   ",
 			},
 			ErrECSMappingIsInvalid,
 		},
 		"nil field": {
-			map[string]interface{}{
+			map[string]any{
 				"field": nil,
 			},
 			ErrECSMappingIsInvalid,
 		},
 		"empty string value": {
-			map[string]interface{}{
+			map[string]any{
 				"value": "",
 			},
 			nil,
 		},
 		"empty string value with whitespaces": {
-			map[string]interface{}{
+			map[string]any{
 				"value": "   ",
 			},
 			nil,
 		},
 		"nil value": {
-			map[string]interface{}{
+			map[string]any{
 				"value": nil,
 			},
 			nil,
@@ -265,17 +265,17 @@ func TestSet(t *testing.T) {
 					ID:       "users",
 					Query:    "select * from users limit 2",
 					Interval: 60,
-					ECSMapping: map[string]interface{}{
-						"user": map[string]interface{}{
-							"custom": map[string]interface{}{
-								"shoeSize": map[string]interface{}{
+					ECSMapping: map[string]any{
+						"user": map[string]any{
+							"custom": map[string]any{
+								"shoeSize": map[string]any{
 									"value": 45,
 								},
 							},
-							"id": map[string]interface{}{
+							"id": map[string]any{
 								"field": "uid",
 							},
-							"name": map[string]interface{}{
+							"name": map[string]any{
 								"field": "username",
 							},
 						},

--- a/x-pack/osquerybeat/beater/live_profile_store.go
+++ b/x-pack/osquerybeat/beater/live_profile_store.go
@@ -63,7 +63,7 @@ func newLiveProfileStore(log *logp.Logger, dir string, maxProfiles int) (*livePr
 	return store, nil
 }
 
-func (s *liveProfileStore) Record(query string, profile map[string]interface{}) {
+func (s *liveProfileStore) Record(query string, profile map[string]any) {
 	if s == nil || query == "" {
 		return
 	}
@@ -91,11 +91,11 @@ func (s *liveProfileStore) Record(query string, profile map[string]interface{}) 
 	s.mx.Unlock()
 }
 
-func (s *liveProfileStore) RecordLiveProfile(query string, profile map[string]interface{}) {
+func (s *liveProfileStore) RecordLiveProfile(query string, profile map[string]any) {
 	s.Record(query, profile)
 }
 
-func (s *liveProfileStore) List() []map[string]interface{} {
+func (s *liveProfileStore) List() []map[string]any {
 	if s == nil {
 		return nil
 	}
@@ -110,7 +110,7 @@ func (s *liveProfileStore) List() []map[string]interface{} {
 
 	type profileEntry struct {
 		modTime int64
-		data    map[string]interface{}
+		data    map[string]any
 	}
 
 	var results []profileEntry
@@ -130,7 +130,7 @@ func (s *liveProfileStore) List() []map[string]interface{} {
 			}
 			continue
 		}
-		var payload map[string]interface{}
+		var payload map[string]any
 		if err := json.Unmarshal(bytes, &payload); err != nil {
 			if s.log != nil {
 				s.log.Debugw("failed to unmarshal live query profile", "file", path, "error", err)
@@ -154,7 +154,7 @@ func (s *liveProfileStore) List() []map[string]interface{} {
 		return results[i].modTime > results[j].modTime
 	})
 
-	profiles := make([]map[string]interface{}, 0, len(results))
+	profiles := make([]map[string]any, 0, len(results))
 	for _, item := range results {
 		profiles = append(profiles, item.data)
 	}

--- a/x-pack/osquerybeat/beater/live_profile_store_test.go
+++ b/x-pack/osquerybeat/beater/live_profile_store_test.go
@@ -22,13 +22,13 @@ func TestLiveProfileStoreEvictsAndDeletesFiles(t *testing.T) {
 	query1 := "select * from uptime"
 	query2 := "select * from osquery_info"
 
-	store.Record(query1, map[string]interface{}{"source": "live", "query": query1})
+	store.Record(query1, map[string]any{"source": "live", "query": query1})
 	file1 := filepath.Join(dir, liveProfileFilename(liveProfileKey(query1)))
 	if _, err := os.Stat(file1); err != nil {
 		t.Fatalf("expected profile file for query1, got error: %v", err)
 	}
 
-	store.Record(query2, map[string]interface{}{"source": "live", "query": query2})
+	store.Record(query2, map[string]any{"source": "live", "query": query2})
 	file2 := filepath.Join(dir, liveProfileFilename(liveProfileKey(query2)))
 	if _, err := os.Stat(file2); err != nil {
 		t.Fatalf("expected profile file for query2, got error: %v", err)

--- a/x-pack/osquerybeat/beater/osquery_runner_test.go
+++ b/x-pack/osquerybeat/beater/osquery_runner_test.go
@@ -144,7 +144,7 @@ func TestOsqueryRunnerRestart(t *testing.T) {
 	inputConfigs := []config.InputConfig{
 		{
 			Osquery: &config.OsqueryConfig{
-				Options: map[string]interface{}{
+				Options: map[string]any{
 					"foo": "bar",
 				},
 			},

--- a/x-pack/osquerybeat/beater/osquerybeat_extensions_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_extensions_test.go
@@ -47,7 +47,7 @@ func TestExtensionsDiagnosticsPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loaded := []map[string]interface{}{
+	loaded := []map[string]any{
 		{"name": "valid_ext", "version": "1.0", "path": validExt},
 	}
 
@@ -74,7 +74,7 @@ func TestExtensionsDiagnosticsPayload(t *testing.T) {
 		t.Fatalf("expected extensions_require [valid_ext], got %v", payload["extensions_require"])
 	}
 
-	entries, ok := payload["configured_entries"].([]map[string]interface{})
+	entries, ok := payload["configured_entries"].([]map[string]any)
 	if !ok || len(entries) != 2 {
 		t.Fatalf("unexpected configured_entries: %v", payload["configured_entries"])
 	}
@@ -84,7 +84,7 @@ func TestExtensionsDiagnosticsPayload(t *testing.T) {
 	if loadedPaths, ok := entries[0]["loaded"].([]string); !ok || len(loadedPaths) != 1 || loadedPaths[0] != validExt {
 		t.Fatalf("expected %q loaded, got %v", validExt, entries[0]["loaded"])
 	}
-	if skipped, ok := entries[0]["skipped"].([]map[string]interface{}); !ok || len(skipped) != 1 || skipped[0]["path"] != skippedExt {
+	if skipped, ok := entries[0]["skipped"].([]map[string]any); !ok || len(skipped) != 1 || skipped[0]["path"] != skippedExt {
 		t.Fatalf("expected %q skipped, got %v", skippedExt, entries[0]["skipped"])
 	}
 	if entries[1]["status"] != "error" || entries[1]["reason"] == nil {

--- a/x-pack/osquerybeat/beater/osquerybeat_publisher_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_publisher_test.go
@@ -21,16 +21,16 @@ type mockBeatPublisher struct {
 var _ osquerybeatPublisher = (*mockBeatPublisher)(nil)
 var _ scheduledQueryPublisher = (*mockBeatPublisher)(nil)
 
-func (m *mockBeatPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
+func (m *mockBeatPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any) {
 }
 
-func (m *mockBeatPublisher) PublishActionResult(req map[string]interface{}, res map[string]interface{}) {
+func (m *mockBeatPublisher) PublishActionResult(req map[string]any, res map[string]any) {
 }
 
 func (m *mockBeatPublisher) PublishScheduledResponse(scheduleID, packID, packName, queryName, spaceID, responseID string, startedAt, completedAt, plannedScheduleTime time.Time, resultCount int, scheduleExecutionCount int64) {
 }
 
-func (m *mockBeatPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{}) {
+func (m *mockBeatPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
 }
 
 func (m *mockBeatPublisher) Configure(inputs []config.InputConfig) error {

--- a/x-pack/osquerybeat/beater/osquerybeat_status_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_status_test.go
@@ -74,11 +74,11 @@ type testManager struct {
 }
 
 type diagnosticsQueryExecutor struct {
-	rows []map[string]interface{}
+	rows []map[string]any
 	err  error
 }
 
-func (e *diagnosticsQueryExecutor) Query(context.Context, string, time.Duration) ([]map[string]interface{}, error) {
+func (e *diagnosticsQueryExecutor) Query(context.Context, string, time.Duration) ([]map[string]any, error) {
 	return e.rows, e.err
 }
 
@@ -378,7 +378,7 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 		qp: newQueryProfiler(logp.NewLogger("test")),
 	}
 	ob.setDiagnosticsQueryExecutor(&diagnosticsQueryExecutor{
-		rows: []map[string]interface{}{
+		rows: []map[string]any{
 			{
 				"name":              "pack_test_query",
 				"query":             "select * from users limit 1",
@@ -402,7 +402,7 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 	hook, ok := mgr.diagHook["scheduled_query_profiles"]
 	require.True(t, ok, "expected scheduled profiles diagnostics hook")
 
-	var payload map[string]interface{}
+	var payload map[string]any
 	err := json.Unmarshal(hook(), &payload)
 	require.NoError(t, err)
 
@@ -411,11 +411,11 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 	//nolint:testifylint // We're comparing integers from a JSON
 	assert.Equal(t, float64(1), count)
 
-	profiles, ok := payload["osquery_schedule"].([]interface{})
+	profiles, ok := payload["osquery_schedule"].([]any)
 	require.True(t, ok)
 	require.Len(t, profiles, 1)
 
-	p0, ok := profiles[0].(map[string]interface{})
+	p0, ok := profiles[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "select * from users limit 1", p0["query"])
 
@@ -424,7 +424,7 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 	//nolint:testifylint // We're comparing integers from a JSON
 	assert.Equal(t, float64(0), liveCount)
 
-	liveProfiles, ok := payload["live_query_profiles"].([]interface{})
+	liveProfiles, ok := payload["live_query_profiles"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, liveProfiles)
 }

--- a/x-pack/osquerybeat/beater/query_profiler.go
+++ b/x-pack/osquerybeat/beater/query_profiler.go
@@ -52,7 +52,7 @@ func newQueryProfiler(log *logp.Logger) *queryProfiler {
 	}
 }
 
-func (p *queryProfiler) profileScheduledQuery(ctx context.Context, qe queryExecutor, queryName string) (map[string]interface{}, error) {
+func (p *queryProfiler) profileScheduledQuery(ctx context.Context, qe queryExecutor, queryName string) (map[string]any, error) {
 	escapedName := strings.ReplaceAll(queryName, "'", "''")
 	query := osqueryScheduleProfileQueryPrefix + escapedName + osqueryScheduleProfileQuerySuffix
 	rows, err := qe.Query(ctx, query, 10*time.Second)
@@ -74,7 +74,7 @@ func (p *queryProfiler) profileScheduledQuery(ctx context.Context, qe queryExecu
 	lastMemory := toInt64(row["last_memory"])
 
 	cpuMS := userMS + systemMS
-	profile := map[string]interface{}{
+	profile := map[string]any{
 		"source":                 "scheduled",
 		"query_name":             queryName,
 		"utilization":            utilizationFromMillis(cpuMS, wallMS),
@@ -113,7 +113,7 @@ func (p *queryProfiler) scheduledProfilesDiagnostics(ctx context.Context, qe que
 	return data
 }
 
-func (p *queryProfiler) scheduledProfilesDiagnosticsPayload(ctx context.Context, qe queryExecutor) (map[string]interface{}, error) {
+func (p *queryProfiler) scheduledProfilesDiagnosticsPayload(ctx context.Context, qe queryExecutor) (map[string]any, error) {
 	if qe == nil {
 		return nil, fmt.Errorf("osquery client is not connected")
 	}
@@ -123,14 +123,14 @@ func (p *queryProfiler) scheduledProfilesDiagnosticsPayload(ctx context.Context,
 		return nil, fmt.Errorf("failed to query osquery_schedule: %w", err)
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"osquery_schedule": rows,
 		"count":            len(rows),
 	}, nil
 }
 
 func diagnosticsErrorJSON(message string) []byte {
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"error": message,
 	}
 	data, err := json.MarshalIndent(payload, "", "  ")
@@ -172,34 +172,25 @@ LIMIT 1`, 5*time.Second)
 	return snap, nil
 }
 
-func buildLiveQueryProfile(query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]interface{} {
+func buildLiveQueryProfile(query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]any {
 	return buildRuntimeQueryProfile("live", query, before, after, duration, queryErr)
 }
 
 // buildRuntimeQueryProfile builds a profile from osquery process metrics before and after a query.
 // source distinguishes collection contexts (for example "live" vs "rrule") for downstream consumers.
 // See the comment above collectRuntimeSnapshot for how concurrent osquery work affects these metrics.
-func buildRuntimeQueryProfile(source, query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]interface{} {
-	userDelta := after.userTimeMS - before.userTimeMS
-	if userDelta < 0 {
-		userDelta = 0
-	}
-	systemDelta := after.systemTimeMS - before.systemTimeMS
-	if systemDelta < 0 {
-		systemDelta = 0
-	}
+func buildRuntimeQueryProfile(source, query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]any {
+	userDelta := max(after.userTimeMS-before.userTimeMS, 0)
+	systemDelta := max(after.systemTimeMS-before.systemTimeMS, 0)
 	cpuMS := userDelta + systemDelta
-	wallMS := duration.Milliseconds()
-	if wallMS < 0 {
-		wallMS = 0
-	}
+	wallMS := max(duration.Milliseconds(), 0)
 
 	exitCode := int64(0)
 	if queryErr != nil {
 		exitCode = 1
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"source":      source,
 		"query":       query,
 		"utilization": utilizationFromMillis(cpuMS, wallMS),
@@ -219,7 +210,7 @@ func utilizationFromMillis(cpuMS, wallMS int64) float64 {
 	return float64(cpuMS) / float64(wallMS) * 100.0
 }
 
-func toInt64(v interface{}) int64 {
+func toInt64(v any) int64 {
 	switch n := v.(type) {
 	case int:
 		return int64(n)
@@ -246,7 +237,7 @@ func toInt64(v interface{}) int64 {
 	return 0
 }
 
-func toString(v interface{}) string {
+func toString(v any) string {
 	switch s := v.(type) {
 	case string:
 		return s

--- a/x-pack/osquerybeat/beater/query_profiler_test.go
+++ b/x-pack/osquerybeat/beater/query_profiler_test.go
@@ -16,7 +16,7 @@ import (
 func TestToInt64(t *testing.T) {
 	tests := []struct {
 		name string
-		in   interface{}
+		in   any
 		want int64
 	}{
 		{"int", 42, 42},
@@ -40,7 +40,7 @@ func TestToInt64(t *testing.T) {
 func TestToString(t *testing.T) {
 	tests := []struct {
 		name string
-		in   interface{}
+		in   any
 		want string
 	}{
 		{"string", "hello", "hello"},
@@ -111,7 +111,7 @@ func TestBuildLiveQueryProfile(t *testing.T) {
 
 func TestDiagnosticsErrorJSON(t *testing.T) {
 	data := diagnosticsErrorJSON("something failed")
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
 		t.Fatal(err)
 	}
@@ -128,18 +128,18 @@ func TestNewQueryProfiler(t *testing.T) {
 }
 
 type mockProfileQueryExecutor struct {
-	rows []map[string]interface{}
+	rows []map[string]any
 	err  error
 }
 
-func (m *mockProfileQueryExecutor) Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]interface{}, error) {
+func (m *mockProfileQueryExecutor) Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]any, error) {
 	return m.rows, m.err
 }
 
 func TestProfileScheduledQuery_FirstRun(t *testing.T) {
 	ctx := context.Background()
 	qe := &mockProfileQueryExecutor{
-		rows: []map[string]interface{}{
+		rows: []map[string]any{
 			{
 				"name":              "q1",
 				"query":             "SELECT * FROM osquery_info",
@@ -179,7 +179,7 @@ func TestScheduledProfilesDiagnosticsWithResolver_NilExecutor(t *testing.T) {
 	ctx := context.Background()
 	p := newQueryProfiler(logp.NewLogger("test"))
 	data := p.scheduledProfilesDiagnostics(ctx, nil)
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/osquerybeat/beater/recurrence_query_handler.go
+++ b/x-pack/osquerybeat/beater/recurrence_query_handler.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"runtime"
 	"strings"
 	"sync"
@@ -51,7 +52,7 @@ type recurrenceQueryHandler struct {
 	osqueryVer   string
 
 	mx              sync.Mutex
-	previousResults map[string]map[string]map[string]interface{}
+	previousResults map[string]map[string]map[string]any
 }
 
 // newRecurrenceQueryHandler creates a new RRULE query handler.
@@ -65,7 +66,7 @@ func newRecurrenceQueryHandler(log *logp.Logger, cli *osqdcli.Client, configPlug
 		publisher:       pub,
 		profiles:        profiles,
 		osqueryVer:      osqueryVersion,
-		previousResults: make(map[string]map[string]map[string]interface{}),
+		previousResults: make(map[string]map[string]map[string]any),
 	}
 
 	h.scheduler = scheduler.New(log, h.executeQuery)
@@ -191,7 +192,7 @@ func platformMatches(selector, goos string) bool {
 	if selector == "" || selector == "all" {
 		return true
 	}
-	for _, platform := range strings.Split(selector, ",") {
+	for platform := range strings.SplitSeq(selector, ",") {
 		switch strings.TrimSpace(strings.ToLower(platform)) {
 		case "all":
 			return true
@@ -332,7 +333,7 @@ func (h *recurrenceQueryHandler) executeQuery(ctx context.Context, scheduledQuer
 
 	scheduleID := scheduledQuery.ScheduleID()
 
-	baseMeta := map[string]interface{}{
+	baseMeta := map[string]any{
 		"unix_time":                completedAt.Unix(),
 		"planned_schedule_time":    plannedScheduleTime.Format(time.RFC3339Nano),
 		"rrule_query":              true,
@@ -341,7 +342,7 @@ func (h *recurrenceQueryHandler) executeQuery(ctx context.Context, scheduledQuer
 	}
 
 	totalHits := 0
-	publish := func(typ, action string, rows []map[string]interface{}) {
+	publish := func(typ, action string, rows []map[string]any) {
 		if len(rows) == 0 {
 			return
 		}
@@ -369,15 +370,13 @@ func (h *recurrenceQueryHandler) executeQuery(ctx context.Context, scheduledQuer
 	return nil
 }
 
-func cloneRRuleMeta(meta map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(meta)+2)
-	for k, v := range meta {
-		out[k] = v
-	}
+func cloneRRuleMeta(meta map[string]any) map[string]any {
+	out := make(map[string]any, len(meta)+2)
+	maps.Copy(out, meta)
 	return out
 }
 
-func (h *recurrenceQueryHandler) diffResults(name string, hits []map[string]interface{}, includeRemoved bool) ([]map[string]interface{}, []map[string]interface{}) {
+func (h *recurrenceQueryHandler) diffResults(name string, hits []map[string]any, includeRemoved bool) ([]map[string]any, []map[string]any) {
 	current := rowsByKey(hits)
 
 	h.mx.Lock()
@@ -389,8 +388,8 @@ func (h *recurrenceQueryHandler) diffResults(name string, hits []map[string]inte
 	return added, removed
 }
 
-func diffRows(previous, current map[string]map[string]interface{}, includeRemoved bool) ([]map[string]interface{}, []map[string]interface{}) {
-	var added []map[string]interface{}
+func diffRows(previous, current map[string]map[string]any, includeRemoved bool) ([]map[string]any, []map[string]any) {
+	var added []map[string]any
 	for key, row := range current {
 		if _, ok := previous[key]; !ok {
 			added = append(added, row)
@@ -399,7 +398,7 @@ func diffRows(previous, current map[string]map[string]interface{}, includeRemove
 	if !includeRemoved {
 		return added, nil
 	}
-	var removed []map[string]interface{}
+	var removed []map[string]any
 	for key, row := range previous {
 		if _, ok := current[key]; !ok {
 			removed = append(removed, row)
@@ -408,15 +407,15 @@ func diffRows(previous, current map[string]map[string]interface{}, includeRemove
 	return added, removed
 }
 
-func rowsByKey(rows []map[string]interface{}) map[string]map[string]interface{} {
-	out := make(map[string]map[string]interface{}, len(rows))
+func rowsByKey(rows []map[string]any) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(rows))
 	for _, row := range rows {
 		out[rowKey(row)] = row
 	}
 	return out
 }
 
-func rowKey(row map[string]interface{}) string {
+func rowKey(row map[string]any) string {
 	raw, err := json.Marshal(row)
 	if err != nil {
 		return fmt.Sprintf("%v", row)

--- a/x-pack/osquerybeat/beater/recurrence_query_handler_test.go
+++ b/x-pack/osquerybeat/beater/recurrence_query_handler_test.go
@@ -70,21 +70,21 @@ func TestRecurrenceQueryHandlerCreateScheduledQuerySkipsIneligibleQueries(t *tes
 }
 
 func TestRRuleDiffRows(t *testing.T) {
-	previous := rowsByKey([]map[string]interface{}{
+	previous := rowsByKey([]map[string]any{
 		{"id": int64(1), "name": "old"},
 		{"id": int64(2), "name": "same"},
 	})
-	current := rowsByKey([]map[string]interface{}{
+	current := rowsByKey([]map[string]any{
 		{"id": int64(2), "name": "same"},
 		{"id": int64(3), "name": "new"},
 	})
 
 	added, removed := diffRows(previous, current, true)
-	assert.ElementsMatch(t, []map[string]interface{}{{"id": int64(3), "name": "new"}}, added)
-	assert.ElementsMatch(t, []map[string]interface{}{{"id": int64(1), "name": "old"}}, removed)
+	assert.ElementsMatch(t, []map[string]any{{"id": int64(3), "name": "new"}}, added)
+	assert.ElementsMatch(t, []map[string]any{{"id": int64(1), "name": "old"}}, removed)
 
 	added, removed = diffRows(previous, current, false)
-	assert.ElementsMatch(t, []map[string]interface{}{{"id": int64(3), "name": "new"}}, added)
+	assert.ElementsMatch(t, []map[string]any{{"id": int64(3), "name": "new"}}, added)
 	assert.Empty(t, removed)
 }
 

--- a/x-pack/osquerybeat/beater/resetable_action_handler.go
+++ b/x-pack/osquerybeat/beater/resetable_action_handler.go
@@ -63,7 +63,7 @@ func resetableActionHandlerWithTimeout(timeout time.Duration) optionFunc {
 	}
 }
 
-func (a *resetableActionHandler) Execute(ctx context.Context, req map[string]interface{}) (res map[string]interface{}, err error) {
+func (a *resetableActionHandler) Execute(ctx context.Context, req map[string]any) (res map[string]any, err error) {
 	a.log.Debug(formatLogMessage("execute"))
 
 	// Normalize error on exit, always return nil as error and encode it into result as per current contract
@@ -120,14 +120,14 @@ func (a *resetableActionHandler) Execute(ctx context.Context, req map[string]int
 	return res, nil
 }
 
-func formatLogMessage(format string, args ...interface{}) string {
+func formatLogMessage(format string, args ...any) string {
 	return "resetable action handler: " + fmt.Sprintf(format, args...)
 }
 
-func renderResult(res map[string]interface{}, err error) map[string]interface{} {
+func renderResult(res map[string]any, err error) map[string]any {
 	if res == nil {
 		now := time.Now().UTC()
-		res = map[string]interface{}{
+		res = map[string]any{
 			"started_at":   now.Format(time.RFC3339Nano),
 			"completed_at": now.Format(time.RFC3339Nano),
 		}
@@ -138,7 +138,7 @@ func renderResult(res map[string]interface{}, err error) map[string]interface{} 
 	return res
 }
 
-func (a *resetableActionHandler) execute(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (a *resetableActionHandler) execute(ctx context.Context, req map[string]any) (map[string]any, error) {
 	a.mx.Lock()
 	defer a.mx.Unlock()
 

--- a/x-pack/osquerybeat/beater/resetable_action_handler_test.go
+++ b/x-pack/osquerybeat/beater/resetable_action_handler_test.go
@@ -22,9 +22,9 @@ type mockActionHandler struct {
 	err error
 }
 
-func (a *mockActionHandler) Execute(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (a *mockActionHandler) Execute(ctx context.Context, req map[string]any) (map[string]any, error) {
 	now := time.Now().UTC()
-	res := map[string]interface{}{
+	res := map[string]any{
 		"started_at":   now.Format(time.RFC3339Nano),
 		"completed_at": now.Format(time.RFC3339Nano),
 	}
@@ -41,17 +41,16 @@ func (a *mockActionHandler) Name() string {
 }
 
 type mockActionResultPublisher struct {
-	req, res map[string]interface{}
+	req, res map[string]any
 }
 
-func (p *mockActionResultPublisher) PublishActionResult(req map[string]interface{}, res map[string]interface{}) {
+func (p *mockActionResultPublisher) PublishActionResult(req map[string]any, res map[string]any) {
 	p.req = req
 	p.res = res
 }
 
 func TestResetableActionHandler(t *testing.T) {
-	ctx, cn := context.WithCancel(context.Background())
-	defer cn()
+	ctx := t.Context()
 
 	log := logp.NewLogger("resetable_action_handler_test")
 

--- a/x-pack/osquerybeat/cmd/root.go
+++ b/x-pack/osquerybeat/cmd/root.go
@@ -149,7 +149,7 @@ func osquerybeatCfgFromStreams(rawIn *proto.UnitExpectedConfig, agentInfo *clien
 			streamList[iter]["type"] = rawIn.Type
 		}
 		if v, ok := streamList[iter]["data_stream"]; ok {
-			if m, ok := v.(map[string]interface{}); ok {
+			if m, ok := v.(map[string]any); ok {
 				if _, ok := m["namespace"]; !ok {
 					m["namespace"] = ns
 				}

--- a/x-pack/osquerybeat/cmd/root_test.go
+++ b/x-pack/osquerybeat/cmd/root_test.go
@@ -72,7 +72,7 @@ func readRawIn(filename string, rawIn *proto.UnitExpectedConfig) error {
 	return err
 }
 
-func readOut(filename string) (cfg []map[string]interface{}, err error) {
+func readOut(filename string) (cfg []map[string]any, err error) {
 	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -84,15 +84,15 @@ func readOut(filename string) (cfg []map[string]interface{}, err error) {
 	return cfg, err
 }
 
-func cfgToArrMap(cfg []*reload.ConfigWithMeta) ([]map[string]interface{}, error) {
-	res := make([]map[string]interface{}, 0, len(cfg))
+func cfgToArrMap(cfg []*reload.ConfigWithMeta) ([]map[string]any, error) {
+	res := make([]map[string]any, 0, len(cfg))
 	for _, c := range cfg {
 		var m mapstr.M
 		err := c.Config.Unpack(&m)
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, map[string]interface{}(m))
+		res = append(res, map[string]any(m))
 	}
 	return res, nil
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/state_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/state_test.go
@@ -130,13 +130,11 @@ func TestGetAmcacheState(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			got := GetAmcacheState()
 			assert.NotNil(t, got, "Expected GetAmcacheState to return a non-nil value")
 			assert.Equal(t, got, instance, "Expected GetAmcacheState to return the same instance")
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/tables.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/tables.go
@@ -158,7 +158,7 @@ func fillInEntryFromKey(e Entry, key *regparser.CM_KEY_NODE, log *logger.Logger)
 			}
 		case reflect.Struct:
 			switch field.Type() {
-			case reflect.TypeOf(time.Time{}):
+			case reflect.TypeFor[time.Time]():
 				timeString := strings.TrimRight(value.ValueData().String, "\x00")
 				timestamp, err := time.Parse("01/02/2006 15:04:05", timeString)
 				if err != nil {

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/safari.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/safari.go
@@ -42,8 +42,8 @@ func newSafariParser(ctx context.Context, location searchLocation, log *logger.L
 
 func inferSafariBrowserName(path string) string {
 	normalized := filepath.ToSlash(path)
-	segments := strings.Split(normalized, "/")
-	for _, segment := range segments {
+	segments := strings.SplitSeq(normalized, "/")
+	for segment := range segments {
 		segment = strings.TrimSpace(segment)
 		if segment == "" {
 			continue

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/users.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/users.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
@@ -54,13 +55,7 @@ func discoverUsers(log *logger.Logger) []string {
 					continue
 				}
 
-				found := false
-				for _, existing := range userDirs {
-					if existing == match { // Compare full paths, not just usernames
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(userDirs, match)
 				if !found {
 					log.Infof("discovered user: %s, fullPath: %s", username, match)
 					userDirs = append(userDirs, match) // Store full path instead of just username

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding.go
@@ -6,6 +6,7 @@ package encoding
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -46,7 +47,7 @@ func MarshalToMapWithFlags(in any, flags EncodingFlag) (map[string]string, error
 	v := reflect.ValueOf(in)
 	t := reflect.TypeOf(in)
 
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil, fmt.Errorf("input pointer is nil")
 		}
@@ -91,7 +92,7 @@ func MarshalToMapWithFlags(in any, flags EncodingFlag) (map[string]string, error
 		// and the tag will be empty.  We need to recurse into the embedded struct and merge the results.
 		if fieldType.Anonymous && tag == "" {
 			// Handle pointer to struct if necessary
-			if fieldValue.Kind() == reflect.Ptr {
+			if fieldValue.Kind() == reflect.Pointer {
 				if fieldValue.IsNil() {
 					continue
 				}
@@ -105,9 +106,7 @@ func MarshalToMapWithFlags(in any, flags EncodingFlag) (map[string]string, error
 					return nil, err
 				}
 				// Merge the embedded results into the current map
-				for k, v := range embeddedMap {
-					result[k] = v
-				}
+				maps.Copy(result, embeddedMap)
 				continue // Skip the rest of the loop for this field
 			}
 		}
@@ -141,7 +140,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 	var columns []table.ColumnDefinition
 
 	// Handle pointer types by unwrapping to get the underlying type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -149,8 +148,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		return nil, fmt.Errorf("unsupported type: %s, must be a struct or pointer to struct", t.Kind())
 	}
 
-	for i := 0; i < t.NumField(); i++ {
-		fieldType := t.Field(i)
+	for fieldType := range t.Fields() {
 
 		if !fieldType.IsExported() {
 			continue
@@ -165,7 +163,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		if fieldType.Anonymous && key == "" {
 			// Get the embedded struct type, handling pointer to struct if necessary
 			embeddedType := fieldType.Type
-			if embeddedType.Kind() == reflect.Ptr {
+			if embeddedType.Kind() == reflect.Pointer {
 				embeddedType = embeddedType.Elem()
 			}
 
@@ -196,7 +194,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		fieldKind := fieldType.Type.Kind()
 
 		// Handle pointer types by unwrapping to get the underlying type
-		if fieldKind == reflect.Ptr {
+		if fieldKind == reflect.Pointer {
 			fieldKind = fieldType.Type.Elem().Kind()
 		}
 
@@ -220,7 +218,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		case reflect.Struct:
 			// Handle time.Time type
 			switch fieldType.Type {
-			case reflect.TypeOf(time.Time{}):
+			case reflect.TypeFor[time.Time]():
 				if timeFormat, ok := tag.Lookup("format"); ok {
 					switch strings.ToLower(timeFormat) {
 					case "unix", "unixnano", "unixmilli", "unixmicro":
@@ -248,7 +246,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 // It also handles the EncodingFlagUseNumbersZeroValues flag and the tag format and tz attributes.
 func convertValueToStringWithTag(fieldValue reflect.Value, flag EncodingFlag, tag *reflect.StructTag) (string, error) {
 	// Handle pointers first
-	if fieldValue.Kind() == reflect.Ptr {
+	if fieldValue.Kind() == reflect.Pointer {
 		if fieldValue.IsNil() {
 			return "", nil
 		}
@@ -298,7 +296,7 @@ func convertValueToStringWithTag(fieldValue reflect.Value, flag EncodingFlag, ta
 	case reflect.Struct:
 		// Handle time.Time type
 		switch fieldValue.Type() {
-		case reflect.TypeOf(time.Time{}):
+		case reflect.TypeFor[time.Time]():
 			return formatTimeWithTagFormat(fieldValue, flag, tag)
 		default:
 			return "", fmt.Errorf("unsupported struct type: %s", fieldValue.Type())

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/application_id.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/application_id.go
@@ -32,9 +32,9 @@ func newApplicationID(id string) *jumpliststypes.ApplicationID {
 // It is used to create a new ApplicationId object from the file name.
 func getAppIdFromFileName(filePath string) *jumpliststypes.ApplicationID {
 	fileName := filepath.Base(filePath)
-	dotIndex := strings.Index(fileName, ".")
-	if dotIndex != -1 {
-		return newApplicationID(fileName[:dotIndex])
+	before, _, ok := strings.Cut(fileName, ".")
+	if ok {
+		return newApplicationID(before)
 	}
 	return newApplicationID("")
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate/scrape_app_ids.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate/scrape_app_ids.go
@@ -33,8 +33,8 @@ func scrapeJumplistAppIDs(opts generatorOptions, log *logger.Logger) (map[string
 		return nil, err
 	}
 
-	lines := strings.Split(bodyString, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(bodyString, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue // Skip empty lines

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog.go
@@ -158,7 +158,7 @@ func (l *Logger) Info(msg string) {
 }
 
 // Infof logs a formatted informational message (only if verbose is enabled)
-func (l *Logger) Infof(format string, args ...interface{}) {
+func (l *Logger) Infof(format string, args ...any) {
 	l.log(LevelInfo, fmt.Sprintf(format, args...))
 }
 
@@ -168,7 +168,7 @@ func (l *Logger) Warning(msg string) {
 }
 
 // Warningf logs a formatted warning message
-func (l *Logger) Warningf(format string, args ...interface{}) {
+func (l *Logger) Warningf(format string, args ...any) {
 	l.log(LevelWarning, fmt.Sprintf(format, args...))
 }
 
@@ -178,7 +178,7 @@ func (l *Logger) Error(msg string) {
 }
 
 // Errorf logs a formatted error message
-func (l *Logger) Errorf(format string, args ...interface{}) {
+func (l *Logger) Errorf(format string, args ...any) {
 	l.log(LevelError, fmt.Sprintf(format, args...))
 }
 
@@ -189,7 +189,7 @@ func (l *Logger) Fatal(msg string) {
 }
 
 // Fatalf logs a formatted error message and exits
-func (l *Logger) Fatalf(format string, args ...interface{}) {
+func (l *Logger) Fatalf(format string, args ...any) {
 	l.log(LevelError, fmt.Sprintf(format, args...))
 	osExit(1)
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog_test.go
@@ -366,7 +366,7 @@ func TestConcurrentLogging(t *testing.T) {
 
 	// Run concurrent logging operations
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(id int) {
 			log.Infof("concurrent message %d", id)
 			log.Warningf("concurrent warning %d", id)
@@ -376,7 +376,7 @@ func TestConcurrentLogging(t *testing.T) {
 	}
 
 	// Wait for all goroutines to complete
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
@@ -41,8 +41,8 @@ func ReadIOFS(fsys fs.FS, pid string) (procio ProcIO, err error) {
 		return
 	}
 
-	lines := bytes.Split(b, []byte{'\n'})
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte{'\n'})
+	for line := range lines {
 		detail := bytes.SplitN(line, []byte{':'}, 2)
 		if len(detail) != 2 {
 			continue

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
@@ -85,8 +85,8 @@ func ReadStatFS(sysfs fs.FS, pid string) (stat ProcStat, err error) {
 		return
 	}
 
-	lines := bytes.Split(b, []byte{'\n'})
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte{'\n'})
+	for line := range lines {
 		detail := bytes.SplitN(line, []byte{':'}, 2)
 		if len(detail) != 2 {
 			continue

--- a/x-pack/osquerybeat/internal/action/action.go
+++ b/x-pack/osquerybeat/internal/action/action.go
@@ -31,7 +31,7 @@ type Action struct {
 	Profile *bool
 }
 
-func FromMap(m map[string]interface{}) (a Action, err error) {
+func FromMap(m map[string]any) (a Action, err error) {
 	if len(m) == 0 {
 		return a, ErrActionRequest
 	}
@@ -52,8 +52,8 @@ func FromMap(m map[string]interface{}) (a Action, err error) {
 		profile   *bool
 	)
 	if v, ok := m["data"]; ok {
-		var data map[string]interface{}
-		if data, ok = v.(map[string]interface{}); !ok {
+		var data map[string]any
+		if data, ok = v.(map[string]any); !ok {
 			return a, fmt.Errorf("invalid data: %w", ErrActionRequest)
 		}
 
@@ -71,7 +71,7 @@ func FromMap(m map[string]interface{}) (a Action, err error) {
 		}
 		// Parse optional ECS Mapping
 		if v, ok := data["ecs_mapping"]; ok && v != nil {
-			m, ok := v.(map[string]interface{})
+			m, ok := v.(map[string]any)
 			if !ok {
 				return a, fmt.Errorf("invalid ECS mapping: %w", ErrActionRequest)
 			}
@@ -167,20 +167,20 @@ func platformMatches(goos string, platforms []string) bool {
 	return false
 }
 
-func parseECSMapping(m map[string]interface{}) (ecsm ecs.Mapping, err error) {
+func parseECSMapping(m map[string]any) (ecsm ecs.Mapping, err error) {
 	ecsm = make(ecs.Mapping)
 	for k, v := range m {
 		k = strings.TrimSpace(k)
 		if k == "" {
 			return ecsm, ErrActionRequest
 		}
-		valmap, ok := v.(map[string]interface{})
+		valmap, ok := v.(map[string]any)
 		if !ok {
 			return ecsm, ErrActionRequest
 		}
 
 		var (
-			val   interface{}
+			val   any
 			field string
 		)
 
@@ -210,7 +210,7 @@ func parseECSMapping(m map[string]interface{}) (ecsm ecs.Mapping, err error) {
 	return ecsm, err
 }
 
-func convertToInt64(i interface{}) (int64, error) {
+func convertToInt64(i any) (int64, error) {
 	switch v := i.(type) {
 	case int8:
 		return int64(v), nil

--- a/x-pack/osquerybeat/internal/action/action_test.go
+++ b/x-pack/osquerybeat/internal/action/action_test.go
@@ -17,7 +17,7 @@ func TestActionFromMap(t *testing.T) {
 
 	tests := []struct {
 		Name string
-		Map  map[string]interface{}
+		Map  map[string]any
 		Err  error
 	}{
 		{
@@ -27,19 +27,19 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "empty",
-			Map:  map[string]interface{}{},
+			Map:  map[string]any{},
 			Err:  ErrActionRequest,
 		},
 		{
 			Name: "invalid id",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": 123,
 			},
 			Err: ErrActionRequest,
 		},
 		{
 			Name: "invalid data",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id":   "123456789",
 				"data": "foo",
 			},
@@ -47,9 +47,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "invalid query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": 123221231,
 				},
 			},
@@ -57,18 +57,18 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "valid string for query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from foo",
 				},
 			},
 		},
 		{
 			Name: "valid profile flag",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":   "select * from foo",
 					"profile": true,
 				},
@@ -76,9 +76,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "valid platform",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":    "select * from foo",
 					"platform": " linux , windows ",
 				},
@@ -86,9 +86,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "invalid platform type",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":    "select * from foo",
 					"platform": []string{"linux"},
 				},
@@ -97,9 +97,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "invalid profile flag type",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":   "select * from foo",
 					"profile": "true",
 				},
@@ -108,9 +108,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "empty id",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from foo",
 				},
 			},
@@ -118,9 +118,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "space empty id",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "    ",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from foo",
 				},
 			},
@@ -128,9 +128,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "empty query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "",
 				},
 			},
@@ -138,9 +138,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "space empty query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "   ",
 				},
 			},
@@ -214,15 +214,15 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 
 	tests := []struct {
 		Name   string
-		Map    map[string]interface{}
+		Map    map[string]any
 		Action Action
 		Err    error
 	}{
 		{
 			Name: "valid",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
 				},
 			},
@@ -233,9 +233,9 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping nil",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":       "select * from users limit 2",
 					"ecs_mapping": nil,
 				},
@@ -247,9 +247,9 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping empty string",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":       "select * from users limit 2",
 					"ecs_mapping": "",
 				},
@@ -258,11 +258,11 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping empty",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":       "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{},
+					"ecs_mapping": map[string]any{},
 				},
 			},
 			Action: Action{
@@ -273,11 +273,11 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
+					"ecs_mapping": map[string]any{
 						"foo": "bar",
 					},
 				},
@@ -286,12 +286,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, field spaces string",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"field": "      ",
 						},
 					},
@@ -301,12 +301,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, key empty",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"": map[string]any{
 							"field": "uid",
 						},
 					},
@@ -316,12 +316,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, key spaces",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"  ": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"  ": map[string]any{
 							"field": "uid",
 						},
 					},
@@ -331,12 +331,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, field non-string",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"field": 123,
 						},
 					},
@@ -346,12 +346,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, both field and value defined",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"value": 48,
 							"field": "uid",
 						},
@@ -362,15 +362,15 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping valid",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"value": 48,
 						},
-						"user.id": map[string]interface{}{
+						"user.id": map[string]any{
 							"field": "uid",
 						},
 					},

--- a/x-pack/osquerybeat/internal/config/config_test.go
+++ b/x-pack/osquerybeat/internal/config/config_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
-//go:fix inline
-func boolPtr(v bool) *bool { return new(v) }
-
 func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/x-pack/osquerybeat/internal/config/config_test.go
+++ b/x-pack/osquerybeat/internal/config/config_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
-func boolPtr(v bool) *bool { return &v }
+//go:fix inline
+func boolPtr(v bool) *bool { return new(v) }
 
 func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 	tests := []struct {
@@ -77,7 +78,7 @@ func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 					AMD64: &InstallArtifactConfig{
 						ArtifactURL:      "http://example.com/osquery.tar.gz",
 						SHA256:           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-						AllowInsecureURL: boolPtr(true),
+						AllowInsecureURL: new(true),
 					},
 				},
 			},
@@ -89,7 +90,7 @@ func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 					AMD64: &InstallArtifactConfig{
 						ArtifactURL:      "http://example.com/osquery.tar.gz",
 						SHA256:           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-						AllowInsecureURL: boolPtr(false),
+						AllowInsecureURL: new(false),
 					},
 				},
 				AllowInsecureURL: true,
@@ -272,7 +273,7 @@ func TestInstallConfigPlatformOverrides(t *testing.T) {
 			AMD64: &InstallArtifactConfig{
 				ArtifactURL:      "https://example.org/osquery-linux.tar.gz",
 				SHA256:           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				AllowInsecureURL: boolPtr(true),
+				AllowInsecureURL: new(true),
 			},
 		},
 	}
@@ -304,7 +305,7 @@ func TestInstallConfigOverridePrecedence(t *testing.T) {
 			AMD64: &InstallArtifactConfig{
 				ArtifactURL:      "https://example.org/osquery-linux-amd64.tar.gz",
 				SHA256:           "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				AllowInsecureURL: boolPtr(true),
+				AllowInsecureURL: new(true),
 				SSL:              archSSL,
 			},
 		},
@@ -422,12 +423,12 @@ func TestGetOsqueryExtensions(t *testing.T) {
 	})
 
 	t.Run("unpacks config tags from yaml", func(t *testing.T) {
-		c, err := conf.NewConfigFrom(map[string]interface{}{
-			"inputs": []map[string]interface{}{
+		c, err := conf.NewConfigFrom(map[string]any{
+			"inputs": []map[string]any{
 				{
-					"osquery": map[string]interface{}{
-						"elastic_options": map[string]interface{}{
-							"extensions": map[string]interface{}{
+					"osquery": map[string]any{
+						"elastic_options": map[string]any{
+							"extensions": map[string]any{
 								"paths":   []string{"/opt/ext"},
 								"timeout": 15,
 								"require": []string{"my_extension"},

--- a/x-pack/osquerybeat/internal/config/osquery.go
+++ b/x-pack/osquerybeat/internal/config/osquery.go
@@ -232,7 +232,7 @@ type Query struct {
 	Description int    `config:"description" json:"description,omitempty"`
 
 	// Optional ECS mapping for the query, not rendered into osqueryd configuration
-	ECSMapping map[string]interface{} `config:"ecs_mapping" json:"-"`
+	ECSMapping map[string]any `config:"ecs_mapping" json:"-"`
 
 	// A boolean to set 'snapshot' mode, default true
 	// This is different from the default osquery behavior where the missing value defaults to false
@@ -313,16 +313,16 @@ type Events struct {
 }
 
 type OsqueryConfig struct {
-	Options               map[string]interface{} `config:"options" json:"options,omitempty"`
-	ElasticOptions        *ElasticOptions        `config:"elastic_options" json:"-"`
-	Schedule              map[string]Query       `config:"schedule" json:"schedule,omitempty"`
-	Packs                 map[string]Pack        `config:"packs" json:"packs,omitempty"`
-	Filepaths             map[string][]string    `config:"file_paths" json:"file_paths,omitempty"`
-	Views                 map[string]string      `config:"views" json:"views,omitempty"`
-	Events                *Events                `config:"events" json:"events,omitempty"`
-	Yara                  map[string]interface{} `config:"yara" json:"yara,omitempty"`
-	PrometheusTargets     map[string]interface{} `config:"prometheus_targets" json:"prometheus_targets,omitempty"`
-	AutoTableConstruction map[string]interface{} `config:"auto_table_construction" json:"auto_table_construction,omitempty"`
+	Options               map[string]any      `config:"options" json:"options,omitempty"`
+	ElasticOptions        *ElasticOptions     `config:"elastic_options" json:"-"`
+	Schedule              map[string]Query    `config:"schedule" json:"schedule,omitempty"`
+	Packs                 map[string]Pack     `config:"packs" json:"packs,omitempty"`
+	Filepaths             map[string][]string `config:"file_paths" json:"file_paths,omitempty"`
+	Views                 map[string]string   `config:"views" json:"views,omitempty"`
+	Events                *Events             `config:"events" json:"events,omitempty"`
+	Yara                  map[string]any      `config:"yara" json:"yara,omitempty"`
+	PrometheusTargets     map[string]any      `config:"prometheus_targets" json:"prometheus_targets,omitempty"`
+	AutoTableConstruction map[string]any      `config:"auto_table_construction" json:"auto_table_construction,omitempty"`
 }
 
 // forOsqueryd returns a copy of c without queries that osquerybeat runs via RRULE (they would

--- a/x-pack/osquerybeat/internal/config/osquery_test.go
+++ b/x-pack/osquerybeat/internal/config/osquery_test.go
@@ -37,19 +37,19 @@ func TestOsqueryConfig_Render_OmitsRRULEQueries(t *testing.T) {
 	}
 	out, err := cfg.Render()
 	require.NoError(t, err)
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(out, &decoded))
-	sched, ok := decoded["schedule"].(map[string]interface{})
+	sched, ok := decoded["schedule"].(map[string]any)
 	require.True(t, ok, "schedule present")
 	_, hasRRule := sched["rrule"]
 	assert.False(t, hasRRule, "RRULE-only top-level query must not appear in osqueryd config")
 	_, hasNative := sched["native"]
 	assert.True(t, hasNative)
-	packs, ok := decoded["packs"].(map[string]interface{})
+	packs, ok := decoded["packs"].(map[string]any)
 	require.True(t, ok)
-	mixed, ok := packs["mixed"].(map[string]interface{})
+	mixed, ok := packs["mixed"].(map[string]any)
 	require.True(t, ok)
-	mq, ok := mixed["queries"].(map[string]interface{})
+	mq, ok := mixed["queries"].(map[string]any)
 	require.True(t, ok)
 	_, hasB := mq["b"]
 	assert.False(t, hasB, "RRULE pack query must be omitted")
@@ -63,16 +63,16 @@ func TestOsqueryConfig_Render_Options(t *testing.T) {
 	// Native osquery options (e.g. schedule_splay_percent, schedule_max_drift) are
 	// passed through in Options; defaults are applied when building config for osqueryd (beater).
 	rendered, err := OsqueryConfig{
-		Options: map[string]interface{}{
+		Options: map[string]any{
 			"schedule_splay_percent": 10,
 			"schedule_max_drift":     60,
 		},
 	}.Render()
 	require.NoError(t, err)
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(rendered, &result)
 	require.NoError(t, err)
-	options, ok := result["options"].(map[string]interface{})
+	options, ok := result["options"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(10), options["schedule_splay_percent"])
 	assert.Equal(t, float64(60), options["schedule_max_drift"])
@@ -228,6 +228,7 @@ func TestRRuleScheduleConfig_ParseDates(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func intPtr(i int) *int {
-	return &i
+	return new(i)
 }

--- a/x-pack/osquerybeat/internal/config/osquery_test.go
+++ b/x-pack/osquerybeat/internal/config/osquery_test.go
@@ -227,8 +227,3 @@ func TestRRuleScheduleConfig_ParseDates(t *testing.T) {
 		assert.Nil(t, parsed)
 	})
 }
-
-//go:fix inline
-func intPtr(i int) *int {
-	return new(i)
-}

--- a/x-pack/osquerybeat/internal/config/watcher.go
+++ b/x-pack/osquerybeat/internal/config/watcher.go
@@ -23,7 +23,7 @@ func (r *reloader) debugLogConfig(cfg *reload.ConfigWithMeta) {
 		return
 	}
 
-	var m map[string]interface{}
+	var m map[string]any
 	err := cfg.Config.Unpack(&m)
 	if err != nil {
 		r.log.Debugf("Failed to unpack the config for debug logging: %v", err)

--- a/x-pack/osquerybeat/internal/ecs/mapping.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping.go
@@ -8,11 +8,11 @@ import "strings"
 
 const keySeparator = "."
 
-type Doc map[string]interface{}
+type Doc map[string]any
 
 type MappingInfo struct {
-	Field string      `json:"field,omitempty" config:"field,omitempty"`
-	Value interface{} `json:"value,omitempty" config:"value,omitempty"`
+	Field string `json:"field,omitempty" config:"field,omitempty"`
+	Value any    `json:"value,omitempty" config:"value,omitempty"`
 }
 
 // Mapping is ECS mapping definition where the key is the dotted ECS field name
@@ -20,7 +20,7 @@ type Mapping map[string]MappingInfo
 
 // Map creates the copy of the values from the doc[src] key to the doc[dst] key where the dst can be nested '.' delimited key
 // Source is expected to be a simple key name, the destination could be nested child node
-func (m Mapping) Map(doc map[string]interface{}) map[string]interface{} {
+func (m Mapping) Map(doc map[string]any) map[string]any {
 	res := make(Doc)
 	for dst, mi := range m {
 		if mi.Value != nil {
@@ -36,7 +36,7 @@ func (m Mapping) Map(doc map[string]interface{}) map[string]interface{} {
 	return res
 }
 
-func (d Doc) Get(key string) (val interface{}, ok bool) {
+func (d Doc) Get(key string) (val any, ok bool) {
 	keys := getKeys(key)
 	node := d
 
@@ -46,7 +46,7 @@ func (d Doc) Get(key string) (val interface{}, ok bool) {
 		}
 		val, ok = node[keys[i]]
 		if ok {
-			node, ok = val.(map[string]interface{})
+			node, ok = val.(map[string]any)
 			if ok {
 				continue
 			} else {
@@ -63,9 +63,9 @@ func (d Doc) Get(key string) (val interface{}, ok bool) {
 	return val, ok
 }
 
-func (d Doc) Set(key string, val interface{}) {
+func (d Doc) Set(key string, val any) {
 	keys := getKeys(key)
-	node := map[string]interface{}(d)
+	node := map[string]any(d)
 
 	// Create nested keys if needed
 	for i := 0; i < len(keys)-1; i++ {
@@ -75,7 +75,7 @@ func (d Doc) Set(key string, val interface{}) {
 
 		inode, ok := node[keys[i]]
 		if ok {
-			node, ok = inode.(map[string]interface{})
+			node, ok = inode.(map[string]any)
 			// Should never happen, internal implementation
 			if !ok {
 				return
@@ -85,7 +85,7 @@ func (d Doc) Set(key string, val interface{}) {
 			// otherwise the large numbers are serialized into scientific notation in bulk json
 			// which breaks values like unix timestamp in seconds
 			// Fixes the issue https://github.com/elastic/security-team/issues/1950
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 			node[keys[i]] = m
 			node = m
 		}

--- a/x-pack/osquerybeat/internal/ecs/mapping_test.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping_test.go
@@ -70,8 +70,8 @@ func TestMapValue(t *testing.T) {
 		"value.empty":  {Value: ""},
 		"value.zero":   {Value: 0},
 		"value.number": {Value: 42},
-		"value.map":    {Value: map[string]interface{}{"foo": "bar"}},
-		"value.array":  {Value: []interface{}{"1234", "test", 42}},
+		"value.map":    {Value: map[string]any{"foo": "bar"}},
+		"value.array":  {Value: []any{"1234", "test", 42}},
 	}
 
 	doc := Doc(mapping.Map(testOsqueryResult))

--- a/x-pack/osquerybeat/internal/install/artifact/artifact_test.go
+++ b/x-pack/osquerybeat/internal/install/artifact/artifact_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
+
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/config"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/distro"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -370,7 +371,7 @@ func TestEnsureConcurrentCallsUseSingleInstallFlow(t *testing.T) {
 	results := make(chan Result, 2)
 
 	wg.Add(2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 			res, err := Ensure(context.Background(), cfg, installDir, log)

--- a/x-pack/osquerybeat/internal/osqd/args.go
+++ b/x-pack/osquerybeat/internal/osqd/args.go
@@ -6,6 +6,7 @@ package osqd
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 )
@@ -21,7 +22,7 @@ const (
 )
 
 type Args []string
-type Flags map[string]interface{}
+type Flags map[string]any
 
 func (f Flags) GetString(key string) string {
 	if f == nil {
@@ -108,9 +109,7 @@ var protectedFlags = Flags{
 func init() {
 	// Append platform specific flags
 	plArgs := platformArgs()
-	for k, v := range plArgs {
-		protectedFlags[k] = v
-	}
+	maps.Copy(protectedFlags, plArgs)
 }
 
 func convertToArgs(flags Flags) Args {

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -368,13 +369,7 @@ func TestArgsExtensionsRequire(t *testing.T) {
 
 	args := osq.args(nil)
 	want := "--extensions_require=ext_one,ext_two"
-	found := false
-	for _, a := range args {
-		if a == want {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(args, want)
 	if !found {
 		t.Fatalf("expected %q in osqueryd args, got: %v", want, args)
 	}

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
@@ -44,7 +44,7 @@ func SocketPath(dir string) string {
 	return filepath.Join(dir, "osquery.sock")
 }
 
-func platformArgs() map[string]interface{} {
+func platformArgs() map[string]any {
 	return nil
 }
 

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
@@ -27,7 +27,7 @@ func SocketPath(dir string) string {
 	return `\\.\pipe\elastic\osquery\` + uuid.Must(uuid.NewV4()).String()
 }
 
-func platformArgs() map[string]interface{} {
+func platformArgs() map[string]any {
 	return nil
 }
 

--- a/x-pack/osquerybeat/internal/osqdcli/client_test.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client_test.go
@@ -18,11 +18,11 @@ func TestResolveHitTypes(t *testing.T) {
 	tests := []struct {
 		name          string
 		hit, colTypes map[string]string
-		res           map[string]interface{}
+		res           map[string]any
 	}{
 		{
 			name: "empty",
-			res:  map[string]interface{}{},
+			res:  map[string]any{},
 		},
 		{
 			name: "resolvable",
@@ -39,7 +39,7 @@ func TestResolveHitTypes(t *testing.T) {
 				"pid_uint": "UNSIGNED_BIGINT",
 				"pid_text": "TEXT",
 			},
-			res: map[string]interface{}{
+			res: map[string]any{
 				"pid":      int64(5551),
 				"pid_int":  int64(5552),
 				"pid_uint": uint64(5553),
@@ -55,7 +55,7 @@ func TestResolveHitTypes(t *testing.T) {
 				"foo":  "bar",
 			},
 			colTypes: map[string]string{"data": "BIGINT"},
-			res: map[string]interface{}{
+			res: map[string]any{
 				"data": "0,22,137,138,29754,49154,49155",
 				"foo":  "bar",
 			},

--- a/x-pack/osquerybeat/internal/osqdcli/retry.go
+++ b/x-pack/osquerybeat/internal/osqdcli/retry.go
@@ -21,7 +21,7 @@ type tryFunc func(ctx context.Context) error
 
 func (r *retry) Run(ctx context.Context, fn tryFunc) (err error) {
 	maxAttempts := r.maxRetry + 1
-	for i := 0; i < maxAttempts; i++ {
+	for i := range maxAttempts {
 		attempt := i + 1
 		if r.log != nil {
 			r.log.Debugf("attempt %v out of %v", attempt, maxAttempts)

--- a/x-pack/osquerybeat/internal/pub/publisher.go
+++ b/x-pack/osquerybeat/internal/pub/publisher.go
@@ -153,7 +153,7 @@ func (p *Publisher) Configure(inputs []config.InputConfig) error {
 	return nil
 }
 
-func (p *Publisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
+func (p *Publisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
 
@@ -182,7 +182,7 @@ func (p *Publisher) Close() {
 	}
 }
 
-func (p *Publisher) PublishActionResult(req map[string]interface{}, res map[string]interface{}) {
+func (p *Publisher) PublishActionResult(req map[string]any, res map[string]any) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
 
@@ -210,7 +210,7 @@ func (p *Publisher) PublishScheduledResponse(scheduleID, packID, packName, query
 		return
 	}
 
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"schedule_id":              scheduleID,
 		"response_id":              responseID,
 		"action_input_type":        "osquery_scheduled",
@@ -218,8 +218,8 @@ func (p *Publisher) PublishScheduledResponse(scheduleID, packID, packName, query
 		"completed_at":             completedAt.Format(time.RFC3339Nano),
 		"planned_schedule_time":    plannedScheduleTime.Format(time.RFC3339Nano),
 		"schedule_execution_count": scheduleExecutionCount,
-		"action_response": map[string]interface{}{
-			"osquery": map[string]interface{}{
+		"action_response": map[string]any{
+			"osquery": map[string]any{
 				"count": resultCount,
 			},
 		},
@@ -241,7 +241,7 @@ func (p *Publisher) PublishScheduledResponse(scheduleID, packID, packName, query
 	p.publishActionResponseEvent(fields, completedAt)
 }
 
-func (p *Publisher) publishActionResponseEvent(fields map[string]interface{}, timestamp time.Time) {
+func (p *Publisher) publishActionResponseEvent(fields map[string]any, timestamp time.Time) {
 	event := beat.Event{
 		Timestamp: timestamp,
 		Fields:    fields,
@@ -249,7 +249,7 @@ func (p *Publisher) publishActionResponseEvent(fields map[string]interface{}, ti
 	p.actionResponsesClient.Publish(event)
 }
 
-func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{}) {
+func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
 
@@ -263,13 +263,13 @@ func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID s
 
 	fields := mapstr.M{
 		"type": "osquery_profile",
-		"event": map[string]interface{}{
+		"event": map[string]any{
 			"module": eventModule,
 		},
 		"osquery_profile": profile,
 	}
 	if queryName != "" {
-		fields["query"] = map[string]interface{}{
+		fields["query"] = map[string]any{
 			"name": queryName,
 		}
 	}
@@ -296,10 +296,10 @@ func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID s
 	p.queryProfileClient.Publish(event)
 }
 
-func actionResultToEvent(req, res map[string]interface{}) map[string]interface{} {
-	m := make(map[string]interface{}, 9)
+func actionResultToEvent(req, res map[string]any) map[string]any {
+	m := make(map[string]any, 9)
 
-	copyKey := func(key string, src, dst map[string]interface{}) {
+	copyKey := func(key string, src, dst map[string]any) {
 		if v, ok := src[key]; ok {
 			dst[key] = v
 		}
@@ -310,8 +310,8 @@ func actionResultToEvent(req, res map[string]interface{}) map[string]interface{}
 	copyKey("error", res, m)
 
 	if v, ok := res["count"]; ok {
-		m["action_response"] = map[string]interface{}{
-			"osquery": map[string]interface{}{
+		m["action_response"] = map[string]any{
+			"osquery": map[string]any{
 				"count": v,
 			},
 		}
@@ -371,7 +371,7 @@ func (p *Publisher) processorsForInputConfig(inCfg config.InputConfig, defaultDa
 	return procs, nil
 }
 
-func hitToEvent(index, eventType, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta, hit map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) beat.Event {
+func hitToEvent(index, eventType, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta, hit map[string]any, ecsm ecs.Mapping, reqData any) beat.Event {
 	var fields mapstr.M
 
 	if len(ecsm) > 0 {
@@ -383,13 +383,13 @@ func hitToEvent(index, eventType, idValue, idFieldKey, responseID, spaceID, pack
 
 	// Add event.module for ECS
 	// There could be already "event" properties set, preserve them and set the "event.module"
-	var evf map[string]interface{}
+	var evf map[string]any
 	ievf, ok := fields["event"]
 	if ok {
-		evf, ok = ievf.(map[string]interface{})
+		evf, ok = ievf.(map[string]any)
 	}
 	if !ok {
-		evf = make(map[string]interface{})
+		evf = make(map[string]any)
 	}
 	evf["module"] = eventModule
 	fields["event"] = evf

--- a/x-pack/osquerybeat/internal/pub/publisher_test.go
+++ b/x-pack/osquerybeat/internal/pub/publisher_test.go
@@ -22,10 +22,10 @@ func TestHitToEvent(t *testing.T) {
 
 	type params struct {
 		index, eventType, idValue, idFieldKey, responseID string
-		meta                                              map[string]interface{}
-		hit                                               map[string]interface{}
+		meta                                              map[string]any
+		hit                                               map[string]any
 		ecsm                                              ecs.Mapping
-		reqData                                           interface{}
+		reqData                                           any
 	}
 
 	genParams := func(mask int) (p params) {
@@ -43,7 +43,7 @@ func TestHitToEvent(t *testing.T) {
 			p.responseID = uuid.Must(uuid.NewV4()).String()
 		}
 		if mask>>2&1 > 0 {
-			p.hit = map[string]interface{}{
+			p.hit = map[string]any{
 				"foo": "bar",
 			}
 		}
@@ -55,14 +55,14 @@ func TestHitToEvent(t *testing.T) {
 			}
 		}
 		if mask&1 > 0 {
-			p.reqData = map[string]interface{}{
+			p.reqData = map[string]any{
 				"query": "select * from uptime",
 			}
 		}
 		return p
 	}
 
-	for i := 0; i < maxMask; i++ {
+	for i := range maxMask {
 		p := genParams(i)
 		ev := hitToEvent(p.index, p.eventType, p.idValue, p.idFieldKey, p.responseID, "", "", "", "", p.meta, p.hit, p.ecsm, p.reqData)
 
@@ -123,8 +123,8 @@ func TestActionResultToEvent(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		req, res map[string]interface{}
-		want     map[string]interface{}
+		req, res map[string]any
+		want     map[string]any
 	}{
 		{
 			name: "successful",
@@ -246,7 +246,7 @@ func TestHitToEvent_SpaceID(t *testing.T) {
 		"",
 		"",
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -269,7 +269,7 @@ func TestHitToEvent_PackID(t *testing.T) {
 		"",
 		"",
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -293,7 +293,7 @@ func TestHitToEvent_PackNameAndQueryName(t *testing.T) {
 		packName,
 		queryName,
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -318,7 +318,7 @@ func TestHitToEvent_NoPackNameOrQueryName(t *testing.T) {
 		"",
 		"",
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -331,8 +331,8 @@ func TestHitToEvent_NoPackNameOrQueryName(t *testing.T) {
 	}
 }
 
-func toMap(t *testing.T, s string) map[string]interface{} {
-	var m map[string]interface{}
+func toMap(t *testing.T, s string) map[string]any {
+	var m map[string]any
 	err := json.Unmarshal([]byte(s), &m)
 	if err != nil {
 		t.Fatal(err)

--- a/x-pack/osquerybeat/internal/scheduler/schedule.go
+++ b/x-pack/osquerybeat/internal/scheduler/schedule.go
@@ -96,7 +96,7 @@ func (s *RecurrenceSchedule) minimumInterval() (time.Duration, bool) {
 	found := false
 
 	// Sample a bounded number of upcoming occurrences to keep this validation cheap.
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		next := s.rule.After(current, false)
 		if next.IsZero() {
 			break
@@ -243,7 +243,7 @@ func (s *RecurrenceSchedule) String() string {
 }
 
 // Unpack implements the config unpacker interface
-func (s *RecurrenceSchedule) Unpack(cfg map[string]interface{}) error {
+func (s *RecurrenceSchedule) Unpack(cfg map[string]any) error {
 	if v, ok := cfg["rrule"].(string); ok {
 		s.RRule = v
 	}

--- a/x-pack/osquerybeat/internal/scheduler/schedule_test.go
+++ b/x-pack/osquerybeat/internal/scheduler/schedule_test.go
@@ -335,9 +335,6 @@ func TestRecurrenceSchedule_ExecutionIndex_Weekly(t *testing.T) {
 	assert.Equal(t, 4, n)
 }
 
-//go:fix inline
-func ptr(t time.Time) *time.Time { return new(t) }
-
 func TestRecurrenceSchedule_WeeklyPattern(t *testing.T) {
 	// Every Monday and Wednesday
 	s := &RecurrenceSchedule{RRule: "FREQ=WEEKLY;BYDAY=MO,WE"}

--- a/x-pack/osquerybeat/internal/scheduler/schedule_test.go
+++ b/x-pack/osquerybeat/internal/scheduler/schedule_test.go
@@ -325,7 +325,7 @@ func TestRecurrenceSchedule_ExecutionIndex_Weekly(t *testing.T) {
 	// Every Monday and Wednesday, starting Monday Jan 15, 2024
 	s := &RecurrenceSchedule{
 		RRule:     "FREQ=WEEKLY;BYDAY=MO,WE",
-		StartDate: ptr(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)),
+		StartDate: new(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)),
 	}
 	require.NoError(t, s.Parse())
 
@@ -335,7 +335,8 @@ func TestRecurrenceSchedule_ExecutionIndex_Weekly(t *testing.T) {
 	assert.Equal(t, 4, n)
 }
 
-func ptr(t time.Time) *time.Time { return &t }
+//go:fix inline
+func ptr(t time.Time) *time.Time { return new(t) }
 
 func TestRecurrenceSchedule_WeeklyPattern(t *testing.T) {
 	// Every Monday and Wednesday
@@ -475,7 +476,7 @@ func TestRecurrenceSchedule_ValidateSplay(t *testing.T) {
 }
 
 func TestRecurrenceSchedule_Unpack(t *testing.T) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"rrule":      "FREQ=DAILY",
 		"start_date": "2024-01-15T09:00:00Z",
 		"end_date":   "2024-12-31T23:59:59Z",
@@ -494,7 +495,7 @@ func TestRecurrenceSchedule_Unpack(t *testing.T) {
 }
 
 func TestRecurrenceSchedule_UnpackNormalizesDatesToUTC(t *testing.T) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"rrule":      "FREQ=DAILY",
 		"start_date": "2024-01-15T11:00:00+02:00",
 		"end_date":   "2025-01-01T01:59:59+02:00",
@@ -511,7 +512,7 @@ func TestRecurrenceSchedule_UnpackNormalizesDatesToUTC(t *testing.T) {
 }
 
 func TestRecurrenceSchedule_UnpackDefaults(t *testing.T) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"rrule": "FREQ=DAILY",
 	}
 
@@ -524,12 +525,12 @@ func TestRecurrenceSchedule_UnpackDefaults(t *testing.T) {
 func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 	tests := []struct {
 		name    string
-		cfg     map[string]interface{}
+		cfg     map[string]any
 		wantErr bool
 	}{
 		{
 			name: "invalid splay format",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "not a duration",
@@ -538,7 +539,7 @@ func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 		},
 		{
 			name: "negative splay",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "-5m",
@@ -547,7 +548,7 @@ func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 		},
 		{
 			name: "splay exceeds max",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "13h",
@@ -556,7 +557,7 @@ func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 		},
 		{
 			name: "splay exceeds max",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "13h",

--- a/x-pack/osquerybeat/internal/scheduler/scheduler.go
+++ b/x-pack/osquerybeat/internal/scheduler/scheduler.go
@@ -274,10 +274,7 @@ func (s *Scheduler) runJob(ctx context.Context, job *scheduledJob) {
 
 		scheduledTime := nextRun.Add(splayDuration)
 
-		waitDuration := time.Until(scheduledTime)
-		if waitDuration < 0 {
-			waitDuration = 0
-		}
+		waitDuration := max(time.Until(scheduledTime), 0)
 
 		s.log.Debugf("Query '%s' scheduled for %v (splay: %v)", sq.Name, scheduledTime, splayDuration)
 

--- a/x-pack/osquerybeat/scripts/mage/config.go
+++ b/x-pack/osquerybeat/scripts/mage/config.go
@@ -12,7 +12,7 @@ import (
 func XPackConfigFileParams() devtools.ConfigFileParams {
 	p := devtools.DefaultConfigFileParams()
 	p.Templates = append(p.Templates, "_meta/config/*.tmpl")
-	p.ExtraVars = map[string]interface{}{
+	p.ExtraVars = map[string]any{
 		"ExcludeConsole":             false,
 		"ExcludeFileOutput":          true,
 		"ExcludeKafka":               true,

--- a/x-pack/osquerybeat/scripts/mage/update.go
+++ b/x-pack/osquerybeat/scripts/mage/update.go
@@ -14,7 +14,7 @@ import (
 type Update mg.Namespace
 
 // Aliases stores aliases for the targets.
-var Aliases = map[string]interface{}{
+var Aliases = map[string]any{
 	"update": Update.All,
 }
 

--- a/x-pack/packetbeat/cmd/root.go
+++ b/x-pack/packetbeat/cmd/root.go
@@ -91,14 +91,14 @@ func defaultProcessors() []mapstr.M {
 	return []mapstr.M{
 		{
 			"if.contains.tags": "forwarded",
-			"then": []interface{}{
+			"then": []any{
 				mapstr.M{
 					"drop_fields": mapstr.M{
-						"fields": []interface{}{"host"},
+						"fields": []any{"host"},
 					},
 				},
 			},
-			"else": []interface{}{
+			"else": []any{
 				mapstr.M{
 					"add_host_metadata": nil,
 				},

--- a/x-pack/packetbeat/tests/integration/otel_test.go
+++ b/x-pack/packetbeat/tests/integration/otel_test.go
@@ -73,7 +73,7 @@ func serverPort(t *testing.T, srv *httptest.Server) int {
 // sendHTTPRequests sends numRequests GET requests to url, ignoring errors.
 func sendHTTPRequests(url string, numRequests int) {
 	client := &http.Client{Timeout: 5 * time.Second}
-	for i := 0; i < numRequests; i++ {
+	for range numRequests {
 		resp, err := client.Get(url) //nolint:noctx // fine for tests
 		if err == nil {
 			resp.Body.Close()

--- a/x-pack/packetbeat/tests/system/app_run_test.go
+++ b/x-pack/packetbeat/tests/system/app_run_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build integration
-// +build integration
 
 package system
 

--- a/x-pack/packetbeat/tests/system/app_test.go
+++ b/x-pack/packetbeat/tests/system/app_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build integration
-// +build integration
 
 package system
 

--- a/x-pack/winlogbeat/cmd/export.go
+++ b/x-pack/winlogbeat/cmd/export.go
@@ -53,7 +53,7 @@ func GenExportPipelineCmd(settings instance.Settings) *cobra.Command {
 	return genExportPipelineCmd
 }
 
-func fatalf(msg string, vs ...interface{}) {
+func fatalf(msg string, vs ...any) {
 	fmt.Fprintf(os.Stderr, msg, vs...)
 	fmt.Fprintln(os.Stderr)
 	os.Exit(1)

--- a/x-pack/winlogbeat/module/wintest/docker.go
+++ b/x-pack/winlogbeat/module/wintest/docker.go
@@ -135,7 +135,7 @@ func dockerCompose(env map[string]string, verbose bool) error {
 	}
 	var err error
 	const retries = 2
-	for n := 0; n < retries; n++ {
+	for range retries {
 		_, err = sh.Exec(
 			env,
 			out,

--- a/x-pack/winlogbeat/module/wintest/simulate.go
+++ b/x-pack/winlogbeat/module/wintest/simulate.go
@@ -195,8 +195,8 @@ func newError(body []byte) error {
 				Type     string `json:"type"`
 				Reason   string `json:"reason"`
 				CausedBy struct {
-					Type   string      `json:"type"`
-					Reason interface{} `json:"reason"`
+					Type   string `json:"type"`
+					Reason any    `json:"reason"`
 				} `json:"caused_by,omitempty"`
 			} `json:"caused_by,omitempty"`
 			Suppressed []struct {
@@ -223,12 +223,12 @@ func newError(body []byte) error {
 // marshalNormalizedJSON marshals test results ensuring that field
 // order remains consistent independent of field order returned by
 // ES to minimize diff noise during changes.
-func marshalNormalizedJSON(v interface{}) ([]byte, error) {
+func marshalNormalizedJSON(v any) ([]byte, error) {
 	msg, err := json.Marshal(v)
 	if err != nil {
 		return msg, err
 	}
-	var obj interface{}
+	var obj any
 	err = jsonUnmarshalUsingNumber(msg, &obj)
 	if err != nil {
 		return msg, err
@@ -240,7 +240,7 @@ func marshalNormalizedJSON(v interface{}) ([]byte, error) {
 // does not default to unmarshaling numeric values to float64 in order to
 // prevent low bit truncation of values greater than 1<<53.
 // See https://golang.org/cl/6202068 for details.
-func jsonUnmarshalUsingNumber(data []byte, v interface{}) error {
+func jsonUnmarshalUsingNumber(data []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	err := dec.Decode(v)
@@ -263,7 +263,7 @@ func jsonUnmarshalUsingNumber(data []byte, v interface{}) error {
 func ErrorMessage(msg json.RawMessage) error {
 	var event struct {
 		Error struct {
-			Message interface{}
+			Message any
 		}
 	}
 	err := json.Unmarshal(msg, &event)


### PR DESCRIPTION
## Proposed commit message

```
x-pack/filebeat,packetbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 332 file(s)
owned by @elastic/security-service-integrations in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

A second commit removes the helpers the rewrites orphaned; see the review notes below.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


REDUNDANT_CONVERSION = re.compile(r"new\(\(([\w.]+)\)\(")


def drop_redundant_parens(root: Path, files: list[str]) -> int:
    """Rewrite the `new((T)(x))` the newexpr fixer emits as `new(T(x))`.

    Dropping one paren on each side keeps the call balanced, and the pattern is narrow
    enough that a textual rewrite cannot match anything else.
    """
    touched = 0
    for name in files:
        path = root / name
        before = path.read_text()
        after = REDUNDANT_CONVERSION.sub(r"new(\1(", before)
        if after != before:
            path.write_text(after)
            touched += 1
    return touched


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]
        cleaned = drop_redundant_parens(root, files)
        if cleaned:
            log(f"  dropped redundant conversion parens in {cleaned} file(s)")

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Separate commits, so the hand-written part is obvious:

1. `x-pack/filebeat,packetbeat: fix modernize lint findings` is pure tool output, nothing in it was written by hand.
2. `libbeat,x-pack/filebeat,x-pack/auditbeat: finish the modernize cleanup` is the part the tools could not produce:

   > Two things the tooling could not do, kept out of the mechanical commit.
   > 
   > `go fix` inlined the `//go:fix inline` pointer helpers at every call site,
   > leaving the helpers themselves unused, so they are deleted here. It declined to
   > inline `ptrTo` in libbeat/processors/cache, whose arguments are all typed
   > constants; those call sites are rewritten to `new(expr)` by hand so that helper
   > can go as well.
   > 
   > `golangci-lint --fix` refuses to write into cgo packages, so the remaining
   > `plusbuild`, `any` and `rangeint` findings under
   > x-pack/auditbeat/module/system are applied by hand.

- `auditbeat/module/file_integrity/exeobjparser_test.go`
- `libbeat/processors/cache/file_store_test.go`
- `libbeat/processors/cache/mem_store_test.go`
- `packetbeat/config/config_test.go`
- `x-pack/auditbeat/module/system/socket/guess/creds.go`
- `x-pack/auditbeat/module/system/user/users_linux.go`
- `x-pack/filebeat/input/azureblobstorage/decoding_test.go`
- `x-pack/filebeat/input/entityanalytics/provider/activedirectory/statestore_test.go`
- `x-pack/filebeat/input/entityanalytics/provider/jamf/conf_test.go`
- `x-pack/filebeat/input/entityanalytics/provider/okta/conf_test.go`
- `x-pack/filebeat/input/entityanalytics/provider/okta/oauth2_test.go`
- `x-pack/filebeat/input/entityanalytics/provider/okta/statestore_test.go`
- `x-pack/filebeat/input/gcppubsub/input.go`
- `x-pack/filebeat/input/gcs/decoding_test.go`
- `x-pack/filebeat/input/http_endpoint/config_test.go`
- `x-pack/osquerybeat/internal/config/config_test.go`
- `x-pack/osquerybeat/internal/config/osquery_test.go`
- `x-pack/osquerybeat/internal/scheduler/schedule_test.go`

Plus `Address feedback`, addressing review comments.

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
