### PR TITLE
libbeat,filebeat,metricbeat: fix modernize lint findings

### DIFF
--- a/filebeat/config/config_test.go
+++ b/filebeat/config/config_test.go
@@ -48,7 +48,7 @@ func TestLoadConfig2(t *testing.T) {
 }
 
 func TestEnabledInputs(t *testing.T) {
-	stdinEnabled, err := conf.NewConfigFrom(map[string]interface{}{
+	stdinEnabled, err := conf.NewConfigFrom(map[string]any{
 		"type":    "stdin",
 		"enabled": true,
 	})
@@ -56,7 +56,7 @@ func TestEnabledInputs(t *testing.T) {
 		return
 	}
 
-	udpDisabled, err := conf.NewConfigFrom(map[string]interface{}{
+	udpDisabled, err := conf.NewConfigFrom(map[string]any{
 		"type":    "udp",
 		"enabled": false,
 	})
@@ -64,7 +64,7 @@ func TestEnabledInputs(t *testing.T) {
 		return
 	}
 
-	logDisabled, err := conf.NewConfigFrom(map[string]interface{}{
+	logDisabled, err := conf.NewConfigFrom(map[string]any{
 		"type":    "log",
 		"enabled": false,
 	})

--- a/filebeat/fileset/compatibility_test.go
+++ b/filebeat/fileset/compatibility_test.go
@@ -34,17 +34,17 @@ func TestAdaptPipelineForCompatibility(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES < 6.7.0",
 			esVersion: version.MustNew("6.6.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"user_agent": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"user_agent": map[string]any{
 							"field": "foo.http_user_agent",
 						},
 					},
@@ -55,31 +55,31 @@ func TestAdaptPipelineForCompatibility(t *testing.T) {
 		{
 			name:      "ES == 6.7.0",
 			esVersion: version.MustNew("6.7.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"rename": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"rename": map[string]any{
 							"field":        "foo.src_ip",
 							"target_field": "source.ip",
 						},
 					},
-					map[string]interface{}{
-						"user_agent": map[string]interface{}{
+					map[string]any{
+						"user_agent": map[string]any{
 							"field": "foo.http_user_agent",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"rename": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"rename": map[string]any{
 							"field":        "foo.src_ip",
 							"target_field": "source.ip",
 						},
 					},
-					map[string]interface{}{
-						"user_agent": map[string]interface{}{
+					map[string]any{
+						"user_agent": map[string]any{
 							"field": "foo.http_user_agent",
 							"ecs":   true,
 						},
@@ -91,31 +91,31 @@ func TestAdaptPipelineForCompatibility(t *testing.T) {
 		{
 			name:      "ES >= 7.0.0",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"rename": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"rename": map[string]any{
 							"field":        "foo.src_ip",
 							"target_field": "source.ip",
 						},
 					},
-					map[string]interface{}{
-						"user_agent": map[string]interface{}{
+					map[string]any{
+						"user_agent": map[string]any{
 							"field": "foo.http_user_agent",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"rename": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"rename": map[string]any{
 							"field":        "foo.src_ip",
 							"target_field": "source.ip",
 						},
 					},
-					map[string]interface{}{
-						"user_agent": map[string]interface{}{
+					map[string]any{
+						"user_agent": map[string]any{
 							"field": "foo.http_user_agent",
 						},
 					},
@@ -126,7 +126,6 @@ func TestAdaptPipelineForCompatibility(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -144,17 +143,17 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES < 7.9.0",
 			esVersion: version.MustNew("7.8.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"value":              "{{panw.panos.ruleset}}",
 							"ignore_empty_value": true,
@@ -162,10 +161,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "rule.name",
 							"value": "{{panw.panos.ruleset}}",
 							"if":    "ctx?.panw?.panos?.ruleset != null",
@@ -178,10 +177,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 		{
 			name:      "ES == 7.9.0",
 			esVersion: version.MustNew("7.9.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"value":              "{{panw.panos.ruleset}}",
 							"ignore_empty_value": true,
@@ -189,10 +188,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"value":              "{{panw.panos.ruleset}}",
 							"ignore_empty_value": true,
@@ -205,10 +204,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 		{
 			name:      "ES > 7.9.0",
 			esVersion: version.MustNew("8.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"value":              "{{panw.panos.ruleset}}",
 							"ignore_empty_value": true,
@@ -216,10 +215,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"value":              "{{panw.panos.ruleset}}",
 							"ignore_empty_value": true,
@@ -232,10 +231,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 		{
 			name:      "existing if",
 			esVersion: version.MustNew("7.7.7"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"value":              "{{panw.panos.ruleset}}",
 							"ignore_empty_value": true,
@@ -244,10 +243,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "rule.name",
 							"value": "{{panw.panos.ruleset}}",
 							"if":    "ctx?.panw?.panos?.ruleset != null",
@@ -260,10 +259,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 		{
 			name:      "ignore_empty_value is false",
 			esVersion: version.MustNew("7.7.7"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"value":              "{{panw.panos.ruleset}}",
 							"ignore_empty_value": false,
@@ -272,10 +271,10 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "rule.name",
 							"value": "{{panw.panos.ruleset}}",
 							"if":    "ctx?.panw?.panos?.ruleset != null",
@@ -288,20 +287,20 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 		{
 			name:      "no value",
 			esVersion: version.MustNew("7.7.7"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":              "rule.name",
 							"ignore_empty_value": false,
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "rule.name",
 						},
 					},
@@ -312,7 +311,6 @@ func TestReplaceSetIgnoreEmptyValue(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -330,17 +328,17 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES < 7.10.0: set to true",
 			esVersion: version.MustNew("7.9.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": true,
@@ -348,10 +346,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field": "related.hosts",
 							"value": "{{host.hostname}}",
 						},
@@ -363,10 +361,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 		{
 			name:      "ES < 7.10.0: set to false",
 			esVersion: version.MustNew("7.9.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -374,10 +372,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field": "related.hosts",
 							"value": "{{host.hostname}}",
 							"if":    "ctx?.host?.hostname != null && ((ctx?.related?.hosts instanceof List && !ctx?.related?.hosts.contains(ctx?.host?.hostname)) || ctx?.related?.hosts != ctx?.host?.hostname)",
@@ -390,10 +388,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 		{
 			name:      "ES == 7.10.0",
 			esVersion: version.MustNew("7.10.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -401,10 +399,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -417,10 +415,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 		{
 			name:      "ES > 7.10.0",
 			esVersion: version.MustNew("8.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -428,10 +426,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -444,10 +442,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 		{
 			name:      "ES < 7.10.0: existing if",
 			esVersion: version.MustNew("7.7.7"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -456,10 +454,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field": "related.hosts",
 							"value": "{{host.hostname}}",
 							"if":    "ctx?.host?.hostname != null && ((ctx?.related?.hosts instanceof List && !ctx?.related?.hosts.contains(ctx?.host?.hostname)) || ctx?.related?.hosts != ctx?.host?.hostname)",
@@ -472,10 +470,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 		{
 			name:      "ES < 7.10.0: existing if with contains",
 			esVersion: version.MustNew("7.7.7"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -484,10 +482,10 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field": "related.hosts",
 							"value": "{{host.hostname}}",
 							"if":    "!ctx?.related?.hosts.contains(ctx?.host?.hostname)",
@@ -500,20 +498,20 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 		{
 			name:      "ES < 7.10.0: no value",
 			esVersion: version.MustNew("7.7.7"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"allow_duplicates": false,
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field": "related.hosts",
 						},
 					},
@@ -524,7 +522,6 @@ func TestReplaceAppendAllowDuplicates(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -542,33 +539,33 @@ func TestRemoveURIPartsProcessor(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES < 7.12.0",
 			esVersion: version.MustNew("7.11.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"uri_parts": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"uri_parts": map[string]any{
 							"field":        "test.url",
 							"target_field": "url",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -580,32 +577,32 @@ func TestRemoveURIPartsProcessor(t *testing.T) {
 		{
 			name:      "ES == 7.12.0",
 			esVersion: version.MustNew("7.12.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"uri_parts": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"uri_parts": map[string]any{
 							"field":        "test.url",
 							"target_field": "url",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"uri_parts": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"uri_parts": map[string]any{
 							"field":        "test.url",
 							"target_field": "url",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -617,32 +614,32 @@ func TestRemoveURIPartsProcessor(t *testing.T) {
 		{
 			name:      "ES > 7.12.0",
 			esVersion: version.MustNew("8.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"uri_parts": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"uri_parts": map[string]any{
 							"field":        "test.url",
 							"target_field": "url",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"uri_parts": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"uri_parts": map[string]any{
 							"field":        "test.url",
 							"target_field": "url",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -654,7 +651,6 @@ func TestRemoveURIPartsProcessor(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -672,35 +668,35 @@ func TestRemoveNetworkDirectionProcessor(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES < 7.13.0",
 			esVersion: version.MustNew("7.12.34"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"network_direction": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"network_direction": map[string]any{
 							"internal_networks": []string{
 								"loopback",
 								"private",
 							},
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -712,36 +708,36 @@ func TestRemoveNetworkDirectionProcessor(t *testing.T) {
 		{
 			name:      "ES == 7.13.0",
 			esVersion: version.MustNew("7.13.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"network_direction": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"network_direction": map[string]any{
 							"internal_networks": []string{
 								"loopback",
 								"private",
 							},
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"network_direction": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"network_direction": map[string]any{
 							"internal_networks": []string{
 								"loopback",
 								"private",
 							},
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -753,36 +749,36 @@ func TestRemoveNetworkDirectionProcessor(t *testing.T) {
 		{
 			name:      "ES > 7.13.0",
 			esVersion: version.MustNew("8.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"network_direction": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"network_direction": map[string]any{
 							"internal_networks": []string{
 								"loopback",
 								"private",
 							},
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"network_direction": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"network_direction": map[string]any{
 							"internal_networks": []string{
 								"loopback",
 								"private",
 							},
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -794,7 +790,6 @@ func TestRemoveNetworkDirectionProcessor(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -813,17 +808,17 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES >= 7.13.0: keep processor",
 			esVersion: version.MustNew("7.13.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"convert": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"convert": map[string]any{
 							"field":        "foo",
 							"target_field": "bar",
 							"type":         "ip",
@@ -831,10 +826,10 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"convert": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"convert": map[string]any{
 							"field":        "foo",
 							"target_field": "bar",
 							"type":         "ip",
@@ -847,10 +842,10 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 		{
 			name:      "ES < 7.13.0: replace with grok",
 			esVersion: version.MustNew("7.12.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"convert": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"convert": map[string]any{
 							"field":        "foo",
 							"target_field": "bar",
 							"type":         "ip",
@@ -858,10 +853,10 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"grok": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"grok": map[string]any{
 							"field": "foo",
 							"patterns": []string{
 								"^%{IP:bar}$",
@@ -875,20 +870,20 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 		{
 			name:      "implicit target",
 			esVersion: version.MustNew("7.9.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"convert": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"convert": map[string]any{
 							"field": "foo",
 							"type":  "ip",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"grok": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"grok": map[string]any{
 							"field": "foo",
 							"patterns": []string{
 								"^%{IP:foo}$",
@@ -902,10 +897,10 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 		{
 			name:      "missing field",
 			esVersion: version.MustNew("7.9.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"convert": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"convert": map[string]any{
 							"type": "ip",
 						},
 					},
@@ -916,10 +911,10 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 		{
 			name:      "keep settings in grok",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"convert": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"convert": map[string]any{
 							"field":          "foo",
 							"target_field":   "bar",
 							"type":           "ip",
@@ -928,14 +923,14 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 							"if":             "condition",
 							"ignore_failure": false,
 							"tag":            "myTag",
-							"on_failure": []interface{}{
-								map[string]interface{}{
-									"foo": map[string]interface{}{
+							"on_failure": []any{
+								map[string]any{
+									"foo": map[string]any{
 										"baz": false,
 									},
 								},
-								map[string]interface{}{
-									"bar": map[string]interface{}{
+								map[string]any{
+									"bar": map[string]any{
 										"baz": true,
 									},
 								},
@@ -944,10 +939,10 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"grok": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"grok": map[string]any{
 							"field": "foo",
 							"patterns": []string{
 								"^%{IP:bar}$",
@@ -956,14 +951,14 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 							"if":             "condition",
 							"ignore_failure": false,
 							"tag":            "myTag",
-							"on_failure": []interface{}{
-								map[string]interface{}{
-									"foo": map[string]interface{}{
+							"on_failure": []any{
+								map[string]any{
+									"foo": map[string]any{
 										"baz": false,
 									},
 								},
-								map[string]interface{}{
-									"bar": map[string]interface{}{
+								map[string]any{
+									"bar": map[string]any{
 										"baz": true,
 									},
 								},
@@ -977,7 +972,6 @@ func TestReplaceConvertIPWithGrok(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -995,32 +989,32 @@ func TestRemoveRegisteredDomainProcessor(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES < 7.13.0",
 			esVersion: version.MustNew("7.12.34"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
-					map[string]interface{}{
-						"registered_domain": map[string]interface{}{
+					map[string]any{
+						"registered_domain": map[string]any{
 							"field": "foo",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -1032,30 +1026,30 @@ func TestRemoveRegisteredDomainProcessor(t *testing.T) {
 		{
 			name:      "ES == 7.13.0",
 			esVersion: version.MustNew("7.13.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"registered_domain": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"registered_domain": map[string]any{
 							"field": "foo",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"registered_domain": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"registered_domain": map[string]any{
 							"field": "foo",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -1067,30 +1061,30 @@ func TestRemoveRegisteredDomainProcessor(t *testing.T) {
 		{
 			name:      "ES > 7.13.0",
 			esVersion: version.MustNew("8.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"registered_domain": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"registered_domain": map[string]any{
 							"field": "foo",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"registered_domain": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"registered_domain": map[string]any{
 							"field": "foo",
 						},
 					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
+					map[string]any{
+						"set": map[string]any{
 							"field": "test.field",
 							"value": "testvalue",
 						},
@@ -1102,7 +1096,6 @@ func TestRemoveRegisteredDomainProcessor(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -1120,46 +1113,46 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "Replace in on_failure section",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}(nil),
-				"on_failure": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any(nil),
+				"on_failure": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
 						},
 					},
-					map[string]interface{}{
-						"community_id": map[string]interface{}{},
+					map[string]any{
+						"community_id": map[string]any{},
 					},
-					map[string]interface{}{
-						"append": map[string]interface{}{
+					map[string]any{
+						"append": map[string]any{
 							"field": "error.message",
 							"value": "something's wrong",
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}(nil),
-				"on_failure": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any(nil),
+				"on_failure": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field": "related.hosts",
 							"value": "{{host.hostname}}",
 							"if":    "ctx?.host?.hostname != null && ((ctx?.related?.hosts instanceof List && !ctx?.related?.hosts.contains(ctx?.host?.hostname)) || ctx?.related?.hosts != ctx?.host?.hostname)",
 						},
 					},
-					map[string]interface{}{
-						"append": map[string]interface{}{
+					map[string]any{
+						"append": map[string]any{
 							"field": "error.message",
 							"value": "something's wrong",
 						},
@@ -1171,24 +1164,24 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 		{
 			name:      "Replace in processor's on_failure",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"foo": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"foo": map[string]any{
 							"bar": "baz",
-							"on_failure": []interface{}{
-								map[string]interface{}{
-									"append": map[string]interface{}{
+							"on_failure": []any{
+								map[string]any{
+									"append": map[string]any{
 										"field":            "related.hosts",
 										"value":            "{{host.hostname}}",
 										"allow_duplicates": false,
 									},
 								},
-								map[string]interface{}{
-									"community_id": map[string]interface{}{},
+								map[string]any{
+									"community_id": map[string]any{},
 								},
-								map[string]interface{}{
-									"append": map[string]interface{}{
+								map[string]any{
+									"append": map[string]any{
 										"field": "error.message",
 										"value": "something's wrong",
 									},
@@ -1198,21 +1191,21 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"foo": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"foo": map[string]any{
 							"bar": "baz",
-							"on_failure": []interface{}{
-								map[string]interface{}{
-									"append": map[string]interface{}{
+							"on_failure": []any{
+								map[string]any{
+									"append": map[string]any{
 										"field": "related.hosts",
 										"value": "{{host.hostname}}",
 										"if":    "ctx?.host?.hostname != null && ((ctx?.related?.hosts instanceof List && !ctx?.related?.hosts.contains(ctx?.host?.hostname)) || ctx?.related?.hosts != ctx?.host?.hostname)",
 									},
 								},
-								map[string]interface{}{
-									"append": map[string]interface{}{
+								map[string]any{
+									"append": map[string]any{
 										"field": "error.message",
 										"value": "something's wrong",
 									},
@@ -1227,24 +1220,24 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 		{
 			name:      "Remove empty on_failure key",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"foo": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"foo": map[string]any{
 							"bar": "baz",
-							"on_failure": []interface{}{
-								map[string]interface{}{
-									"community_id": map[string]interface{}{},
+							"on_failure": []any{
+								map[string]any{
+									"community_id": map[string]any{},
 								},
 							},
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"foo": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"foo": map[string]any{
 							"bar": "baz",
 						},
 					},
@@ -1255,10 +1248,10 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 		{
 			name:      "process foreach processor",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field":            "related.hosts",
 							"value":            "{{host.hostname}}",
 							"allow_duplicates": false,
@@ -1267,10 +1260,10 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"append": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"append": map[string]any{
 							"field": "related.hosts",
 							"value": "{{host.hostname}}",
 							"if":    "ctx?.host?.hostname != null && ((ctx?.related?.hosts instanceof List && !ctx?.related?.hosts.contains(ctx?.host?.hostname)) || ctx?.related?.hosts != ctx?.host?.hostname)",
@@ -1283,44 +1276,44 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 		{
 			name:      "Remove leftover foreach processor",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"foreach": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"foreach": map[string]any{
 							"field": "foo",
-							"processor": map[string]interface{}{
-								"community_id": map[string]interface{}{},
+							"processor": map[string]any{
+								"community_id": map[string]any{},
 							},
 						},
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}(nil),
+			expected: map[string]any{
+				"processors": []any(nil),
 			},
 			isErrExpected: false,
 		},
 		{
 			name:      "nested",
 			esVersion: version.MustNew("7.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}(nil),
-				"on_failure": []interface{}{
-					map[string]interface{}{
-						"foreach": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any(nil),
+				"on_failure": []any{
+					map[string]any{
+						"foreach": map[string]any{
 							"field": "foo",
-							"processor": map[string]interface{}{
-								"append": map[string]interface{}{
+							"processor": map[string]any{
+								"append": map[string]any{
 									"field":            "related.hosts",
 									"value":            "{{host.hostname}}",
 									"allow_duplicates": false,
 									"if":               "ctx?.host?.hostname != null",
-									"on_failure": []interface{}{
-										map[string]interface{}{
-											"community_id": map[string]interface{}{},
+									"on_failure": []any{
+										map[string]any{
+											"community_id": map[string]any{},
 										},
-										map[string]interface{}{
-											"append": map[string]interface{}{
+										map[string]any{
+											"append": map[string]any{
 												"field": "error.message",
 												"value": "panic",
 											},
@@ -1332,20 +1325,20 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}(nil),
-				"on_failure": []interface{}{
-					map[string]interface{}{
-						"foreach": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any(nil),
+				"on_failure": []any{
+					map[string]any{
+						"foreach": map[string]any{
 							"field": "foo",
-							"processor": map[string]interface{}{
-								"append": map[string]interface{}{
+							"processor": map[string]any{
+								"append": map[string]any{
 									"field": "related.hosts",
 									"value": "{{host.hostname}}",
 									"if":    "ctx?.host?.hostname != null && ((ctx?.related?.hosts instanceof List && !ctx?.related?.hosts.contains(ctx?.host?.hostname)) || ctx?.related?.hosts != ctx?.host?.hostname)",
-									"on_failure": []interface{}{
-										map[string]interface{}{
-											"append": map[string]interface{}{
+									"on_failure": []any{
+										map[string]any{
+											"append": map[string]any{
 												"field": "error.message",
 												"value": "panic",
 											},
@@ -1362,7 +1355,6 @@ func TestReplaceAlternativeFlowProcessors(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))
@@ -1380,24 +1372,24 @@ func TestRemoveDescription(t *testing.T) {
 	cases := []struct {
 		name          string
 		esVersion     *version.V
-		content       map[string]interface{}
-		expected      map[string]interface{}
+		content       map[string]any
+		expected      map[string]any
 		isErrExpected bool
 	}{
 		{
 			name:      "ES < 7.9.0",
 			esVersion: version.MustNew("7.8.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":       "rule.name",
 							"value":       "{{panw.panos.ruleset}}",
 							"description": "This is a description",
 						},
 					},
-					map[string]interface{}{
-						"script": map[string]interface{}{
+					map[string]any{
+						"script": map[string]any{
 							"source":      "abcd",
 							"lang":        "painless",
 							"description": "This is a description",
@@ -1405,16 +1397,16 @@ func TestRemoveDescription(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field": "rule.name",
 							"value": "{{panw.panos.ruleset}}",
 						},
 					},
-					map[string]interface{}{
-						"script": map[string]interface{}{
+					map[string]any{
+						"script": map[string]any{
 							"source": "abcd",
 							"lang":   "painless",
 						},
@@ -1426,10 +1418,10 @@ func TestRemoveDescription(t *testing.T) {
 		{
 			name:      "ES == 7.9.0",
 			esVersion: version.MustNew("7.9.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":       "rule.name",
 							"value":       "{{panw.panos.ruleset}}",
 							"description": "This is a description",
@@ -1437,10 +1429,10 @@ func TestRemoveDescription(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":       "rule.name",
 							"value":       "{{panw.panos.ruleset}}",
 							"description": "This is a description",
@@ -1453,10 +1445,10 @@ func TestRemoveDescription(t *testing.T) {
 		{
 			name:      "ES > 7.9.0",
 			esVersion: version.MustNew("8.0.0"),
-			content: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			content: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":       "rule.name",
 							"value":       "{{panw.panos.ruleset}}",
 							"description": "This is a description",
@@ -1464,10 +1456,10 @@ func TestRemoveDescription(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]interface{}{
-				"processors": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
+			expected: map[string]any{
+				"processors": []any{
+					map[string]any{
+						"set": map[string]any{
 							"field":       "rule.name",
 							"value":       "{{panw.panos.ruleset}}",
 							"description": "This is a description",
@@ -1480,7 +1472,6 @@ func TestRemoveDescription(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := AdaptPipelineForCompatibility(*test.esVersion, "foo-pipeline", test.content, logptest.NewTestingLogger(t, logName))

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -68,7 +68,7 @@ func TestLoadManifestNginx(t *testing.T) {
 
 	vars := manifest.Vars
 	assert.Equal(t, "paths", vars[0]["name"])
-	path := (vars[0]["default"]).([]interface{})[0].(string)
+	path := (vars[0]["default"]).([]any)[0].(string)
 	assert.Equal(t, path, "/var/log/nginx/access.log*")
 }
 
@@ -95,11 +95,11 @@ func TestEvaluateVarsNginx(t *testing.T) {
 	vars, err := fs.evaluateVars(makeTestInfo("6.6.0"))
 	require.NoError(t, err)
 
-	builtin := vars["builtin"].(map[string]interface{})
+	builtin := vars["builtin"].(map[string]any)
 	assert.IsType(t, "a-mac-with-esc-key", builtin["hostname"])
 	assert.IsType(t, "local", builtin["domain"])
 
-	assert.IsType(t, []interface{}{"/usr/local/var/log/nginx/access.log*"}, vars["paths"])
+	assert.IsType(t, []any{"/usr/local/var/log/nginx/access.log*"}, vars["paths"])
 }
 
 func TestEvaluateVarsNginxOverride(t *testing.T) {
@@ -111,7 +111,7 @@ func TestEvaluateVarsNginxOverride(t *testing.T) {
 	modulesPath, err := filepath.Abs("../module")
 	require.NoError(t, err)
 	fs, err := New(modulesPath, "access", "nginx", &FilesetConfig{
-		Var: map[string]interface{}{
+		Var: map[string]any{
 			"pipeline": "no_plugins",
 		},
 	}, logptest.NewTestingLogger(t, ""), beatPaths)
@@ -136,21 +136,21 @@ func TestEvaluateVarsMySQL(t *testing.T) {
 	vars, err := fs.evaluateVars(makeTestInfo("6.6.0"))
 	require.NoError(t, err)
 
-	builtin := vars["builtin"].(map[string]interface{})
+	builtin := vars["builtin"].(map[string]any)
 	assert.IsType(t, "a-mac-with-esc-key", builtin["hostname"])
 	assert.IsType(t, "local", builtin["domain"])
 
-	expectedPaths := []interface{}{
+	expectedPaths := []any{
 		"/var/log/mysql/mysql-slow.log*",
 		fmt.Sprintf("/var/lib/mysql/%s-slow.log", builtin["hostname"]),
 	}
 	if runtime.GOOS == "darwin" {
-		expectedPaths = []interface{}{
+		expectedPaths = []any{
 			fmt.Sprintf("/usr/local/var/mysql/%s-slow.log*", builtin["hostname"]),
 		}
 	}
 	if runtime.GOOS == "windows" {
-		expectedPaths = []interface{}{
+		expectedPaths = []any{
 			"c:/programdata/MySQL/MySQL Server*/mysql-slow.log*",
 		}
 	}
@@ -160,25 +160,25 @@ func TestEvaluateVarsMySQL(t *testing.T) {
 
 func TestResolveVariable(t *testing.T) {
 	tests := []struct {
-		Value    interface{}
-		Vars     map[string]interface{}
-		Expected interface{}
+		Value    any
+		Vars     map[string]any
+		Expected any
 	}{
 		{
 			Value: "test-{{.value}}",
-			Vars: map[string]interface{}{
+			Vars: map[string]any{
 				"value":   2,
-				"builtin": map[string]interface{}{},
+				"builtin": map[string]any{},
 			},
 			Expected: "test-2",
 		},
 		{
-			Value: []interface{}{"test-{{.value}}", "test1-{{.value}}"},
-			Vars: map[string]interface{}{
+			Value: []any{"test-{{.value}}", "test1-{{.value}}"},
+			Vars: map[string]any{
 				"value":   2,
-				"builtin": map[string]interface{}{},
+				"builtin": map[string]any{},
 			},
-			Expected: []interface{}{"test-2", "test1-2"},
+			Expected: []any{"test-2", "test1-2"},
 		},
 	}
 
@@ -209,14 +209,14 @@ func TestGetInputConfigNginxOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := map[string]struct {
-		input      map[string]interface{}
+		input      map[string]any
 		expectedFn require.ValueAssertionFunc
 	}{
 		"close_eof": {
-			map[string]interface{}{
+			map[string]any{
 				"close_eof": true,
 			},
-			func(t require.TestingT, cfg interface{}, rest ...interface{}) {
+			func(t require.TestingT, cfg any, rest ...any) {
 				c, ok := cfg.(*conf.C)
 				if !ok {
 					t.FailNow()
@@ -233,10 +233,10 @@ func TestGetInputConfigNginxOverrides(t *testing.T) {
 			},
 		},
 		"pipeline": {
-			map[string]interface{}{
+			map[string]any{
 				"pipeline": "foobar",
 			},
-			func(t require.TestingT, cfg interface{}, rest ...interface{}) {
+			func(t require.TestingT, cfg any, rest ...any) {
 				c, ok := cfg.(*conf.C)
 				if !ok {
 					t.FailNow()
@@ -299,8 +299,8 @@ func TestGetPipelineNginx(t *testing.T) {
 }
 
 func TestGetTemplateFunctions(t *testing.T) {
-	vars := map[string]interface{}{
-		"builtin": map[string]interface{}{},
+	vars := map[string]any{
+		"builtin": map[string]any{},
 	}
 	templateFunctions, err := getTemplateFunctions(vars)
 	require.NoError(t, err)

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/paths"
 )
 
-func load(t *testing.T, from interface{}) *conf.C {
+func load(t *testing.T, from any) *conf.C {
 	config, err := conf.NewConfigFrom(from)
 	if err != nil {
 		t.Fatalf("Config err: %v", err)
@@ -139,8 +139,8 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 			Module: "nginx",
 			Filesets: map[string]*FilesetConfig{
 				"access": {
-					Var: map[string]interface{}{
-						"paths": []interface{}{"/hello/test"},
+					Var: map[string]any{
+						"paths": []any{"/hello/test"},
 					},
 				},
 				"error": {
@@ -165,7 +165,7 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 
 	nginxAccess := reg.registry[0].filesets[0]
 	if assert.NotNil(t, nginxAccess) {
-		assert.Equal(t, []interface{}{"/hello/test"}, nginxAccess.vars["paths"])
+		assert.Equal(t, []any{"/hello/test"}, nginxAccess.vars["paths"])
 	}
 	for _, fileset := range reg.registry[0].filesets {
 		assert.NotEqual(t, fileset.name, "error")
@@ -209,55 +209,55 @@ func TestApplyOverrides(t *testing.T) {
 		{
 			name: "var overrides",
 			fcfg: FilesetConfig{
-				Var: map[string]interface{}{
+				Var: map[string]any{
 					"a":   "test",
 					"b.c": "test",
 				},
-				Input: map[string]interface{}{},
+				Input: map[string]any{},
 			},
 			module:  "nginx",
 			fileset: "access",
 			overrides: &ModuleOverrides{
 				"nginx": map[string]*conf.C{
-					"access": load(t, map[string]interface{}{
+					"access": load(t, map[string]any{
 						"var.a":   "test1",
 						"var.b.c": "test2",
 					}),
 				},
 			},
 			expected: FilesetConfig{
-				Var: map[string]interface{}{
+				Var: map[string]any{
 					"a": "test1",
-					"b": map[string]interface{}{"c": "test2"},
+					"b": map[string]any{"c": "test2"},
 				},
-				Input: map[string]interface{}{},
+				Input: map[string]any{},
 			},
 		},
 		{
 			name: "enable and var overrides",
 			fcfg: FilesetConfig{
 				Enabled: &falseVar,
-				Var: map[string]interface{}{
+				Var: map[string]any{
 					"paths": []string{"/var/log/nginx"},
 				},
-				Input: map[string]interface{}{},
+				Input: map[string]any{},
 			},
 			module:  "nginx",
 			fileset: "access",
 			overrides: &ModuleOverrides{
 				"nginx": map[string]*conf.C{
-					"access": load(t, map[string]interface{}{
+					"access": load(t, map[string]any{
 						"enabled":   true,
-						"var.paths": []interface{}{"/var/local/nginx/log"},
+						"var.paths": []any{"/var/local/nginx/log"},
 					}),
 				},
 			},
 			expected: FilesetConfig{
 				Enabled: &trueVar,
-				Var: map[string]interface{}{
-					"paths": []interface{}{"/var/local/nginx/log"},
+				Var: map[string]any{
+					"paths": []any{"/var/local/nginx/log"},
 				},
-				Input: map[string]interface{}{},
+				Input: map[string]any{},
 			},
 		},
 		{
@@ -267,16 +267,16 @@ func TestApplyOverrides(t *testing.T) {
 			fileset: "access",
 			overrides: &ModuleOverrides{
 				"nginx": map[string]*conf.C{
-					"access": load(t, map[string]interface{}{
+					"access": load(t, map[string]any{
 						"input.close_eof": true,
 					}),
 				},
 			},
 			expected: FilesetConfig{
-				Input: map[string]interface{}{
+				Input: map[string]any{
 					"close_eof": true,
 				},
-				Var: map[string]interface{}{},
+				Var: map[string]any{},
 			},
 		},
 	}
@@ -315,7 +315,7 @@ func TestAppendWithoutDuplicates(t *testing.T) {
 					Module: "moduleB",
 					Filesets: map[string]*FilesetConfig{
 						"fileset": {
-							Var: map[string]interface{}{
+							Var: map[string]any{
 								"paths": "test",
 							},
 						},
@@ -328,7 +328,7 @@ func TestAppendWithoutDuplicates(t *testing.T) {
 					Module: "moduleB",
 					Filesets: map[string]*FilesetConfig{
 						"fileset": {
-							Var: map[string]interface{}{
+							Var: map[string]any{
 								"paths": "test",
 							},
 						},
@@ -346,7 +346,7 @@ func TestAppendWithoutDuplicates(t *testing.T) {
 					Enabled: &falseVar,
 					Filesets: map[string]*FilesetConfig{
 						"fileset": {
-							Var: map[string]interface{}{
+							Var: map[string]any{
 								"paths": "test",
 							},
 						},
@@ -360,7 +360,7 @@ func TestAppendWithoutDuplicates(t *testing.T) {
 					Enabled: &falseVar,
 					Filesets: map[string]*FilesetConfig{
 						"fileset": {
-							Var: map[string]interface{}{
+							Var: map[string]any{
 								"paths": "test",
 							},
 						},
@@ -391,7 +391,7 @@ func TestMcfgFromConfig(t *testing.T) {
 	}{
 		{
 			name: "disable fileset",
-			config: load(t, map[string]interface{}{
+			config: load(t, map[string]any{
 				"module":        "nginx",
 				"error.enabled": false,
 			}),
@@ -408,7 +408,7 @@ func TestMcfgFromConfig(t *testing.T) {
 		},
 		{
 			name: "set variable",
-			config: load(t, map[string]interface{}{
+			config: load(t, map[string]any{
 				"module":          "nginx",
 				"access.var.test": false,
 			}),
@@ -416,7 +416,7 @@ func TestMcfgFromConfig(t *testing.T) {
 				Module: "nginx",
 				Filesets: map[string]*FilesetConfig{
 					"access": {
-						Var: map[string]interface{}{
+						Var: map[string]any{
 							"test": false,
 						},
 						Input: nil,
@@ -426,7 +426,7 @@ func TestMcfgFromConfig(t *testing.T) {
 		},
 		{
 			name: "empty fileset (nil)",
-			config: load(t, map[string]interface{}{
+			config: load(t, map[string]any{
 				"module": "nginx",
 				"error":  nil,
 			}),
@@ -457,7 +457,7 @@ func TestMissingModuleFolder(t *testing.T) {
 	p.Home = "/no/such/path"
 
 	configs := []*conf.C{
-		load(t, map[string]interface{}{"module": "nginx"}),
+		load(t, map[string]any{"module": "nginx"}),
 	}
 
 	logger := logptest.NewTestingLogger(t, "")
@@ -554,7 +554,7 @@ func TestEnableFilesetsFromOverrides(t *testing.T) {
 					Module: "foo",
 					Filesets: map[string]*FilesetConfig{
 						"bar": {
-							Var: map[string]interface{}{
+							Var: map[string]any{
 								"a": "b",
 							},
 						},
@@ -571,7 +571,7 @@ func TestEnableFilesetsFromOverrides(t *testing.T) {
 					Module: "foo",
 					Filesets: map[string]*FilesetConfig{
 						"bar": {
-							Var: map[string]interface{}{
+							Var: map[string]any{
 								"a": "b",
 							},
 						},

--- a/filebeat/fileset/pipelines_test.go
+++ b/filebeat/fileset/pipelines_test.go
@@ -58,7 +58,6 @@ func TestLoadPipelinesWithMultiPipelineFileset(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			testFilesetManifest := &manifest{
@@ -73,8 +72,8 @@ func TestLoadPipelinesWithMultiPipelineFileset(t *testing.T) {
 				name:       "fls",
 				modulePath: "./test/mod",
 				manifest:   testFilesetManifest,
-				vars: map[string]interface{}{
-					"builtin": map[string]interface{}{},
+				vars: map[string]any{
+					"builtin": map[string]any{},
 				},
 				pipelineIDs: []string{"filebeat-7.0.0-mod-fls-pipeline-plain", "filebeat-7.0.0-mod-fls-pipeline-json"},
 			}

--- a/filebeat/input/default-inputs/inputs_other.go
+++ b/filebeat/input/default-inputs/inputs_other.go
@@ -24,7 +24,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 )
 
-type osComponents interface{}
+type osComponents any
 
 func osInputs(_ beat.Info, _ osComponents) []v2.Plugin {
 	return []v2.Plugin{}

--- a/filebeat/input/file/states_test.go
+++ b/filebeat/input/file/states_test.go
@@ -81,7 +81,6 @@ var cleanupTests = []struct {
 
 func TestCleanup(t *testing.T) {
 	for _, test := range cleanupTests {
-		test := test
 		t.Run(test.title, func(t *testing.T) {
 			states := NewStates(logptest.NewTestingLogger(t, ""))
 			states.SetStates([]State{test.state})

--- a/filebeat/input/filestream/fswatch_bench_test.go
+++ b/filebeat/input/filestream/fswatch_bench_test.go
@@ -253,7 +253,7 @@ func BenchmarkGetFilesLiteralMidComponent(b *testing.B) {
 	perDir := max(benchTreeFileCount(b)/(topDirs*(1+siblingDirs)), 1)
 	writeN := func(tb testing.TB, dir, prefix string) {
 		require.NoError(tb, os.MkdirAll(dir, 0o770))
-		for k := 0; k < perDir; k++ {
+		for k := range perDir {
 			require.NoError(tb, os.WriteFile(
 				filepath.Join(dir, fmt.Sprintf("%s-%d.log", prefix, k)), []byte("x"), 0o660))
 		}
@@ -317,7 +317,7 @@ func BenchmarkGetFilesMixed(b *testing.B) {
 	perDir := max((total-structuredFiles)/(hostCount*(1+siblingDirs)), 1)
 	writeN := func(dir, prefix string) {
 		require.NoError(b, os.MkdirAll(dir, 0o770))
-		for k := 0; k < perDir; k++ {
+		for k := range perDir {
 			require.NoError(b, os.WriteFile(
 				filepath.Join(dir, fmt.Sprintf("%s-%d.log", prefix, k)), []byte("x"), 0o660))
 		}

--- a/filebeat/input/log/input_test.go
+++ b/filebeat/input/log/input_test.go
@@ -333,7 +333,7 @@ func (t TestFileInfo) Size() int64        { return 0 }
 func (t TestFileInfo) Mode() os.FileMode  { return 0 }
 func (t TestFileInfo) ModTime() time.Time { return t.time }
 func (t TestFileInfo) IsDir() bool        { return false }
-func (t TestFileInfo) Sys() interface{}   { return nil }
+func (t TestFileInfo) Sys() any           { return nil }
 
 type eventCapturer struct {
 	closed    bool

--- a/filebeat/inputsource/unix/config_test.go
+++ b/filebeat/inputsource/unix/config_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestErrorMissingPath(t *testing.T) {
-	c := conf.MustNewConfigFrom(map[string]interface{}{
+	c := conf.MustNewConfigFrom(map[string]any{
 		"timeout":          1,
 		"max_message_size": 1,
 	})
@@ -39,7 +39,7 @@ func TestErrorMissingPath(t *testing.T) {
 }
 
 func TestErrorOnEmptyLineDelimiterWhenStreamSocket(t *testing.T) {
-	c := conf.MustNewConfigFrom(map[string]interface{}{
+	c := conf.MustNewConfigFrom(map[string]any{
 		"timeout":          1,
 		"max_message_size": 1,
 		"path":             "my-path",
@@ -52,7 +52,7 @@ func TestErrorOnEmptyLineDelimiterWhenStreamSocket(t *testing.T) {
 }
 
 func TestInvalidSocketType(t *testing.T) {
-	c := conf.MustNewConfigFrom(map[string]interface{}{
+	c := conf.MustNewConfigFrom(map[string]any{
 		"timeout":          1,
 		"max_message_size": 1,
 		"path":             "my-path",

--- a/libbeat/beat/beat_test.go
+++ b/libbeat/beat/beat_test.go
@@ -150,14 +150,14 @@ func TestSetupPipelinesEnabled(t *testing.T) {
 		},
 		{
 			name: "explicitly enabled",
-			cfg: mustNewConfigFrom(t, map[string]interface{}{
+			cfg: mustNewConfigFrom(t, map[string]any{
 				"setup.pipelines.enabled": true,
 			}),
 			want: true,
 		},
 		{
 			name: "explicitly disabled",
-			cfg: mustNewConfigFrom(t, map[string]interface{}{
+			cfg: mustNewConfigFrom(t, map[string]any{
 				"setup.pipelines.enabled": false,
 			}),
 			want: false,
@@ -171,7 +171,7 @@ func TestSetupPipelinesEnabled(t *testing.T) {
 	}
 }
 
-func mustNewConfigFrom(t *testing.T, from map[string]interface{}) *config.C {
+func mustNewConfigFrom(t *testing.T, from map[string]any) *config.C {
 	t.Helper()
 	cfg, err := config.NewConfigFrom(from)
 	require.NoError(t, err, "failed to create test config")

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -571,16 +571,14 @@ func TestMultipleLoadMeta(t *testing.T) {
 	metaFile := filepath.Join(t.TempDir(), "meta.json")
 	var wg sync.WaitGroup
 	for range 64 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			testBeat, err := NewBeat("filebeat", "testidx", "0.9", false, nil)
 			require.NoError(t, err)
 			logger := logptest.NewTestingLogger(t, "")
 			testBeat.Info.Logger = logger
 			err = testBeat.LoadMeta(metaFile)
 			require.NoError(t, err)
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/libbeat/common/encoding/xml/decode_test.go
+++ b/libbeat/common/encoding/xml/decode_test.go
@@ -50,9 +50,9 @@ func TestLowercaseKeys(t *testing.T) {
 </person>
 `
 
-	expected := map[string]interface{}{
-		"person": map[string]interface{}{
-			"name": map[string]interface{}{
+	expected := map[string]any{
+		"person": map[string]any{
+			"name": map[string]any{
 				"#text": "John",
 				"id":    "123",
 			},
@@ -73,9 +73,9 @@ func TestPrependHyphenToAttr(t *testing.T) {
 </person>
 `
 
-	expected := map[string]interface{}{
-		"person": map[string]interface{}{
-			"Name": map[string]interface{}{
+	expected := map[string]any{
+		"person": map[string]any{
+			"Name": map[string]any{
 				"#text": "John",
 				"-ID":   "123",
 			},
@@ -102,17 +102,17 @@ func TestDecodeList(t *testing.T) {
 </people>
 `
 
-	expected := map[string]interface{}{
-		"people": map[string]interface{}{
-			"person": []interface{}{
-				map[string]interface{}{
-					"Name": map[string]interface{}{
+	expected := map[string]any{
+		"people": map[string]any{
+			"person": []any{
+				map[string]any{
+					"Name": map[string]any{
 						"#text": "John",
 						"ID":    "123",
 					},
 				},
-				map[string]interface{}{
-					"Name": map[string]interface{}{
+				map[string]any{
+					"Name": map[string]any{
 						"#text": "Jane",
 						"ID":    "456",
 					},
@@ -134,7 +134,7 @@ func TestEmptyElement(t *testing.T) {
 </people>
 `
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"people": "",
 	}
 
@@ -147,7 +147,7 @@ func TestEmptyElement(t *testing.T) {
 func TestDecode(t *testing.T) {
 	type testCase struct {
 		XML    string
-		Output map[string]interface{}
+		Output map[string]any
 	}
 
 	tests := []testCase{
@@ -160,9 +160,9 @@ func TestDecode(t *testing.T) {
 					<review>One of the great seminal American novels of the 20th century.</review>
 				</book>
 			</catalog>`,
-			Output: map[string]interface{}{
-				"catalog": map[string]interface{}{
-					"book": map[string]interface{}{
+			Output: map[string]any{
+				"catalog": map[string]any{
+					"book": map[string]any{
 						"author": "William H. Gaddis",
 						"review": "One of the great seminal American novels of the 20th century.",
 						"seq":    "1",
@@ -188,10 +188,10 @@ func TestDecode(t *testing.T) {
 					<description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
 				</book>
 			</catalog>`,
-			Output: map[string]interface{}{
-				"catalog": map[string]interface{}{
-					"book": []interface{}{
-						map[string]interface{}{
+			Output: map[string]any{
+				"catalog": map[string]any{
+					"book": []any{
+						map[string]any{
 							"author":       "Gambardella, Matthew",
 							"description":  "An in-depth look at creating applications with XML.",
 							"genre":        "Computer",
@@ -200,7 +200,7 @@ func TestDecode(t *testing.T) {
 							"publish_date": "2000-10-01",
 							"title":        "XML Developer's Guide",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"author":       "Ralls, Kim",
 							"description":  "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
 							"genre":        "Fantasy",
@@ -230,10 +230,10 @@ func TestDecode(t *testing.T) {
 					<description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
 				</book>
 			</catalog>`,
-			Output: map[string]interface{}{
-				"catalog": map[string]interface{}{
-					"book": []interface{}{
-						map[string]interface{}{
+			Output: map[string]any{
+				"catalog": map[string]any{
+					"book": []any{
+						map[string]any{
 							"author":       "Gambardella, Matthew",
 							"description":  "An in-depth look at creating applications with XML.",
 							"genre":        "Computer",
@@ -241,7 +241,7 @@ func TestDecode(t *testing.T) {
 							"price":        "44.95",
 							"publish_date": "2000-10-01",
 							"title":        "XML Developer's Guide"},
-						map[string]interface{}{
+						map[string]any{
 							"author":       "Ralls, Kim",
 							"description":  "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
 							"genre":        "Fantasy",
@@ -269,9 +269,9 @@ func TestDecode(t *testing.T) {
 					</paper>
 				</secondcategory>
 			</catalog>`,
-			Output: map[string]interface{}{
-				"catalog": map[string]interface{}{
-					"book": map[string]interface{}{
+			Output: map[string]any{
+				"catalog": map[string]any{
+					"book": map[string]any{
 						"author":       "Gambardella, Matthew",
 						"description":  "An in-depth look at creating applications with XML.",
 						"genre":        "Computer",
@@ -279,8 +279,8 @@ func TestDecode(t *testing.T) {
 						"price":        "44.95",
 						"publish_date": "2000-10-01",
 						"title":        "XML Developer's Guide"},
-					"secondcategory": map[string]interface{}{
-						"paper": map[string]interface{}{
+					"secondcategory": map[string]any{
+						"paper": map[string]any{
 							"description": "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
 							"id":          "bk102",
 							"test2":       "Ralls, Kim"}}}},

--- a/libbeat/common/encoding/xml/safe_reader_test.go
+++ b/libbeat/common/encoding/xml/safe_reader_test.go
@@ -31,16 +31,16 @@ func TestInvalidXMLIsSanitized(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []byte
-		want  map[string]interface{}
+		want  map[string]any
 		err   error
 	}{
 		{
 			name: "control space",
 			input: []byte(`<person><Name ID="123">John` + "\t" + `
 </Name></person>`),
-			want: map[string]interface{}{
-				"person": map[string]interface{}{
-					"Name": map[string]interface{}{
+			want: map[string]any{
+				"person": map[string]any{
+					"Name": map[string]any{
 						"#text": "John",
 						"ID":    "123",
 					},
@@ -50,9 +50,9 @@ func TestInvalidXMLIsSanitized(t *testing.T) {
 		{
 			name:  "crlf",
 			input: []byte(`<person><Name ID="123">John` + "\r\n" + `</Name></person>`),
-			want: map[string]interface{}{
-				"person": map[string]interface{}{
-					"Name": map[string]interface{}{
+			want: map[string]any{
+				"person": map[string]any{
+					"Name": map[string]any{
 						"#text": "John",
 						"ID":    "123",
 					},
@@ -62,9 +62,9 @@ func TestInvalidXMLIsSanitized(t *testing.T) {
 		{
 			name:  "single invalid",
 			input: []byte(`<person><Name ID="123">John` + "\x80" + `</Name></person>`),
-			want: map[string]interface{}{
-				"person": map[string]interface{}{
-					"Name": map[string]interface{}{
+			want: map[string]any{
+				"person": map[string]any{
+					"Name": map[string]any{
 						"#text": "John\\ufffd",
 						"ID":    "123",
 					},
@@ -74,9 +74,9 @@ func TestInvalidXMLIsSanitized(t *testing.T) {
 		{
 			name:  "double invalid",
 			input: []byte(`<person><Name ID="123">` + "\x80" + `John` + "\x80" + `</Name></person>`),
-			want: map[string]interface{}{
-				"person": map[string]interface{}{
-					"Name": map[string]interface{}{
+			want: map[string]any{
+				"person": map[string]any{
+					"Name": map[string]any{
 						"#text": "\\ufffdJohn\\ufffd",
 						"ID":    "123",
 					},
@@ -86,9 +86,9 @@ func TestInvalidXMLIsSanitized(t *testing.T) {
 		{
 			name:  "happy single invalid",
 			input: []byte(`<person><Name ID="123">😊John` + "\x80" + `</Name></person>`),
-			want: map[string]interface{}{
-				"person": map[string]interface{}{
-					"Name": map[string]interface{}{
+			want: map[string]any{
+				"person": map[string]any{
+					"Name": map[string]any{
 						"#text": "😊John\\ufffd",
 						"ID":    "123",
 					},
@@ -104,9 +104,9 @@ func TestInvalidXMLIsSanitized(t *testing.T) {
 		{
 			name:  "invalid tag value",
 			input: []byte(`<person><Name ID="` + "\x80" + `123">John</Name></person>`),
-			want: map[string]interface{}{
-				"person": map[string]interface{}{
-					"Name": map[string]interface{}{
+			want: map[string]any{
+				"person": map[string]any{
+					"Name": map[string]any{
 						"#text": "John",
 						"ID":    "\\ufffd123",
 					},
@@ -116,9 +116,9 @@ func TestInvalidXMLIsSanitized(t *testing.T) {
 		{
 			name:  "unhappy",
 			input: []byte(`<person><Name ID="123">John is` + strings.Repeat(" ", 223) + ` 😞</Name></person>`),
-			want: map[string]interface{}{
-				"person": map[string]interface{}{
-					"Name": map[string]interface{}{
+			want: map[string]any{
+				"person": map[string]any{
+					"Name": map[string]any{
 						"#text": "John is" + strings.Repeat(" ", 223) + " 😞",
 						"ID":    "123",
 					},

--- a/libbeat/esleg/eslegclient/api_mock_test.go
+++ b/libbeat/esleg/eslegclient/api_mock_test.go
@@ -55,7 +55,7 @@ func TestOneHostSuccessResp(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
-	body := map[string]interface{}{
+	body := map[string]any{
 		"user":      "test",
 		"post_date": "2009-11-15T14:12:12",
 		"message":   "trying out",
@@ -82,7 +82,7 @@ func TestOneHost500Resp(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
-	body := map[string]interface{}{
+	body := map[string]any{
 		"user":      "test",
 		"post_date": "2009-11-15T14:12:12",
 		"message":   "trying out",
@@ -116,7 +116,7 @@ func TestOneHost503Resp(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
-	body := map[string]interface{}{
+	body := map[string]any{
 		"user":      "test",
 		"post_date": "2009-11-15T14:12:12",
 		"message":   "trying out",

--- a/libbeat/esleg/eslegclient/bulkapi_mock_test.go
+++ b/libbeat/esleg/eslegclient/bulkapi_mock_test.go
@@ -41,9 +41,9 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 	expectedResp := []byte(`{"took":7,"errors":false,"items":[]}`)
 
-	ops := []map[string]interface{}{
+	ops := []map[string]any{
 		{
-			"index": map[string]interface{}{
+			"index": map[string]any{
 				"_index": index,
 				"_type":  "type1",
 				"_id":    "1",
@@ -54,7 +54,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 		},
 	}
 
-	body := make([]interface{}, 0, 10)
+	body := make([]any, 0, 10)
 	for _, op := range ops {
 		body = append(body, op)
 	}
@@ -76,9 +76,9 @@ func TestOneHost500Resp_Bulk(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
-	ops := []map[string]interface{}{
+	ops := []map[string]any{
 		{
-			"index": map[string]interface{}{
+			"index": map[string]any{
 				"_index": index,
 				"_type":  "type1",
 				"_id":    "1",
@@ -89,7 +89,7 @@ func TestOneHost500Resp_Bulk(t *testing.T) {
 		},
 	}
 
-	body := make([]interface{}, 0, 10)
+	body := make([]any, 0, 10)
 	for _, op := range ops {
 		body = append(body, op)
 	}
@@ -115,9 +115,9 @@ func TestOneHost503Resp_Bulk(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("elasticsearch"))
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
-	ops := []map[string]interface{}{
+	ops := []map[string]any{
 		{
-			"index": map[string]interface{}{
+			"index": map[string]any{
 				"_index": index,
 				"_type":  "type1",
 				"_id":    "1",
@@ -128,7 +128,7 @@ func TestOneHost503Resp_Bulk(t *testing.T) {
 		},
 	}
 
-	body := make([]interface{}, 0, 10)
+	body := make([]any, 0, 10)
 	for _, op := range ops {
 		body = append(body, op)
 	}
@@ -154,9 +154,9 @@ func TestEnforceParameters(t *testing.T) {
 	// Prepare the test bulk request.
 	index := "what"
 
-	ops := []map[string]interface{}{
+	ops := []map[string]any{
 		{
-			"index": map[string]interface{}{
+			"index": map[string]any{
 				"_index": index,
 				"_type":  "type1",
 				"_id":    "1",
@@ -167,7 +167,7 @@ func TestEnforceParameters(t *testing.T) {
 		},
 	}
 
-	body := make([]interface{}, 0, 10)
+	body := make([]any, 0, 10)
 	for _, op := range ops {
 		body = append(body, op)
 	}
@@ -255,9 +255,9 @@ func TestEnforceHeaders(t *testing.T) {
 	// Prepare the test bulk request.
 	index := "what"
 
-	ops := []map[string]interface{}{
+	ops := []map[string]any{
 		{
-			"index": map[string]interface{}{
+			"index": map[string]any{
 				"_index": index,
 				"_type":  "type1",
 				"_id":    "1",
@@ -268,7 +268,7 @@ func TestEnforceHeaders(t *testing.T) {
 		},
 	}
 
-	body := make([]interface{}, 0, 10)
+	body := make([]any, 0, 10)
 	for _, op := range ops {
 		body = append(body, op)
 	}

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -115,7 +115,6 @@ func TestConsoleOutput(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.title, func(t *testing.T) {
 			logger := logptest.NewTestingLogger(t, "")
 			batch := outest.NewBatch(test.events...)

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -403,7 +403,7 @@ func TestCollectPublishFailsNone(t *testing.T) {
 
 	event := mapstr.M{"field": 1}
 	events := make([]publisher.Event, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		events[i] = publisher.Event{Content: beat.Event{Fields: event}}
 	}
 
@@ -1058,7 +1058,6 @@ func TestBulkEncodeEvents(t *testing.T) {
 	}
 
 	for name, test := range cases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			logger := logptest.NewTestingLogger(t, "")
 			cfg := c.MustNewConfigFrom(test.config)
@@ -1179,7 +1178,7 @@ func TestBulkEncodeEventsWithOpType(t *testing.T) {
 	require.Equal(t, len(events)-1, len(encoded), "all events should have been encoded")
 	require.Equal(t, 9, len(bulkItems), "incomplete bulk")
 
-	for i := 0; i < len(cases); i++ {
+	for i := range cases {
 		bulkEventIndex, _ := cases[i]["bulkIndex"].(int)
 		if bulkEventIndex == -1 {
 			continue
@@ -1188,7 +1187,7 @@ func TestBulkEncodeEventsWithOpType(t *testing.T) {
 		caseMessage := cases[i]["message"].(string)
 		switch bulkItems[bulkEventIndex].(type) {
 		case eslegclient.BulkCreateAction:
-			validOpTypes := []interface{}{e.OpTypeCreate, nil}
+			validOpTypes := []any{e.OpTypeCreate, nil}
 			require.Contains(t, validOpTypes, caseOpType, caseMessage)
 		case eslegclient.BulkIndexAction:
 			require.Equal(t, e.OpTypeIndex, caseOpType, caseMessage)
@@ -1251,8 +1250,7 @@ func TestBulkRequestHasFilterPath(t *testing.T) {
 		return client
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	event1 := publisher.Event{Content: beat.Event{Fields: mapstr.M{"field": 1}}}
 

--- a/libbeat/outputs/kafka/partition_test.go
+++ b/libbeat/outputs/kafka/partition_test.go
@@ -40,8 +40,8 @@ import (
 type partTestScenario func(*testing.T, bool, sarama.Partitioner) error
 
 func TestPartitioners(t *testing.T) {
-	type obj map[string]interface{}
-	type arr []interface{}
+	type obj map[string]any
+	type arr []any
 
 	nonHashScenarios := []partTestScenario{
 		partTestSimple(100, false),

--- a/libbeat/outputs/logstash/async_test.go
+++ b/libbeat/outputs/logstash/async_test.go
@@ -72,7 +72,7 @@ func makeAsyncTestClient(conn *transport.Client) testClientDriver {
 
 func TestClientSendCloseDoesNotPanic(t *testing.T) {
 	require.NotPanics(t, func() {
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			testClientSendCloseDoesNotPanic(t)
 		}
 	})
@@ -112,9 +112,7 @@ func newAsyncTestDriver(client outputs.NetworkClient) *testAsyncDriver {
 		returns: nil,
 	}
 
-	driver.wg.Add(1)
-	go func() {
-		defer driver.wg.Done()
+	driver.wg.Go(func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -136,7 +134,7 @@ func newAsyncTestDriver(client outputs.NetworkClient) *testAsyncDriver {
 				driver.returns = append(driver.returns, testClientReturn{cmd.batch, err})
 			}
 		}
-	}()
+	})
 
 	return driver
 }

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -117,7 +117,7 @@ func testSimpleEvent(t *testing.T, factory clientFactory) {
 	// validate
 	events := batch.Events
 	assert.Equal(t, 1, len(events))
-	msg := events[0].(map[string]interface{})
+	msg := events[0].(map[string]any)
 	assert.Equal(t, "me", msg["name"])
 	assert.Equal(t, 10.0, msg["line"])
 }
@@ -148,7 +148,7 @@ func testSimpleEventWithTTL(t *testing.T, factory clientFactory) {
 	// validate
 	events := batch.Events
 	assert.Equal(t, 1, len(events))
-	msg := events[0].(map[string]interface{})
+	msg := events[0].(map[string]any)
 	assert.Equal(t, "me", msg["name"])
 	assert.Equal(t, 10.0, msg["line"])
 
@@ -168,7 +168,7 @@ func testSimpleEventWithTTL(t *testing.T, factory clientFactory) {
 	// validate
 	events = batch.Events
 	assert.Equal(t, 1, len(events))
-	msg = events[0].(map[string]interface{})
+	msg = events[0].(map[string]any)
 	assert.Equal(t, "me", msg["name"])
 	assert.Equal(t, 11.0, msg["line"])
 }
@@ -193,7 +193,7 @@ func testStructuredEvent(t *testing.T, factory clientFactory) {
 			"field1": 1,
 			"field2": true,
 			"field3": []int{1, 2, 3},
-			"field4": []interface{}{
+			"field4": []any{
 				1,
 				"test",
 				mapstr.M{
@@ -221,11 +221,11 @@ func testStructuredEvent(t *testing.T, factory clientFactory) {
 	assert.Equal(t, 2.0, eventGet(msg, "struct.field5.sub1"))
 }
 
-func eventGet(event interface{}, path string) interface{} {
-	doc := event.(map[string]interface{})
+func eventGet(event any, path string) any {
+	doc := event.(map[string]any)
 	elems := strings.Split(path, ".")
 	for i := 0; i < len(elems)-1; i++ {
-		doc = doc[elems[i]].(map[string]interface{})
+		doc = doc[elems[i]].(map[string]any)
 	}
 	return doc[elems[len(elems)-1]]
 }

--- a/libbeat/outputs/logstash/sync_test.go
+++ b/libbeat/outputs/logstash/sync_test.go
@@ -86,9 +86,7 @@ func newClientTestDriver(client outputs.NetworkClient) *testSyncDriver {
 		returns: nil,
 	}
 
-	driver.wg.Add(1)
-	go func() {
-		defer driver.wg.Done()
+	driver.wg.Go(func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -110,7 +108,7 @@ func newClientTestDriver(client outputs.NetworkClient) *testSyncDriver {
 				driver.returns = append(driver.returns, testClientReturn{cmd.batch, err})
 			}
 		}
-	}()
+	})
 
 	return driver
 }

--- a/libbeat/outputs/logstash/window_test.go
+++ b/libbeat/outputs/logstash/window_test.go
@@ -32,7 +32,7 @@ func TestShrinkWindowSizeNeverZero(t *testing.T) {
 	w.init(windowSize, DefaultConfig().BulkMaxSize)
 
 	w.windowSize = int32(windowSize)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		w.shrinkWindow()
 	}
 
@@ -70,7 +70,7 @@ func testGrowWindowSize(t *testing.T,
 	var w window
 	w.init(initial, windowSize)
 	w.maxOkWindowSize = maxOK
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		w.tryGrowWindow(batchSize)
 	}
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -159,7 +159,7 @@ func TestInitialization(t *testing.T) {
 }
 
 func TestNoMatch(t *testing.T) {
-	testConfig, err := config.NewConfigFrom(map[string]interface{}{
+	testConfig, err := config.NewConfigFrom(map[string]any{
 		"match_fields": []string{"foo"},
 	})
 	assert.NoError(t, err)
@@ -180,7 +180,7 @@ func TestNoMatch(t *testing.T) {
 }
 
 func TestMatchNoContainer(t *testing.T) {
-	testConfig, err := config.NewConfigFrom(map[string]interface{}{
+	testConfig, err := config.NewConfigFrom(map[string]any{
 		"match_fields": []string{"foo"},
 	})
 	assert.NoError(t, err)
@@ -201,7 +201,7 @@ func TestMatchNoContainer(t *testing.T) {
 }
 
 func TestMatchContainer(t *testing.T) {
-	testConfig, err := config.NewConfigFrom(map[string]interface{}{
+	testConfig, err := config.NewConfigFrom(map[string]any{
 		"match_fields": []string{"foo"},
 		"labels.dedot": false,
 	})
@@ -252,7 +252,7 @@ func TestMatchContainer(t *testing.T) {
 }
 
 func TestMatchContainerWithDedot(t *testing.T) {
-	testConfig, err := config.NewConfigFrom(map[string]interface{}{
+	testConfig, err := config.NewConfigFrom(map[string]any{
 		"match_fields": []string{"foo"},
 	})
 	assert.NoError(t, err)
@@ -297,7 +297,7 @@ func TestMatchContainerWithDedot(t *testing.T) {
 
 func TestMatchSource(t *testing.T) {
 	// Use defaults
-	testConfig, err := config.NewConfigFrom(map[string]interface{}{})
+	testConfig, err := config.NewConfigFrom(map[string]any{})
 	assert.NoError(t, err)
 
 	p, err := buildDockerMetadataProcessor(logp.L(), testConfig, MockWatcherFactory(
@@ -357,7 +357,7 @@ func TestMatchSource(t *testing.T) {
 
 func TestDisableSource(t *testing.T) {
 	// Use defaults
-	testConfig, err := config.NewConfigFrom(map[string]interface{}{
+	testConfig, err := config.NewConfigFrom(map[string]any{
 		"match_source": false,
 	})
 	assert.NoError(t, err)
@@ -577,7 +577,7 @@ func TestCloseBeforeCgroupCacheNoJanitorLeak(t *testing.T) {
 
 func TestWatcherError(t *testing.T) {
 	logger, observedLogs := logptest.NewTestingLoggerWithObserver(t, "")
-	testConfig, err := config.NewConfigFrom(map[string]interface{}{
+	testConfig, err := config.NewConfigFrom(map[string]any{
 		"match_fields": []string{"foo"},
 	})
 	assert.NoError(t, err)
@@ -930,7 +930,7 @@ func (m *mockWatcher) ListenStop() bus.Listener {
 }
 
 func BenchmarkAddDockerMetadata(b *testing.B) {
-	cfg, err := config.NewConfigFrom(map[string]interface{}{
+	cfg, err := config.NewConfigFrom(map[string]any{
 		"match_fields": []string{"container.id"},
 	})
 	if err != nil {

--- a/libbeat/publisher/pipeline/stress/stress_test.go
+++ b/libbeat/publisher/pipeline/stress/stress_test.go
@@ -22,7 +22,7 @@ package stress_test
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,15 +90,15 @@ func TestPipeline(t *testing.T) {
 				name = strings.Replace(name, "/", "-", -1)
 				name = strings.Replace(name, "\\", "-", -1)
 
-				dir, err := ioutil.TempDir("", "")
+				dir, err := os.MkdirTemp("", "")
 				if err != nil {
 					t.Fatal(err)
 				}
 				defer os.RemoveAll(dir)
 
 				// Merge test info into config object
-				config.Merge(map[string]interface{}{
-					"test": map[string]interface{}{
+				config.Merge(map[string]any{
+					"test": map[string]any{
 						"tmpdir": dir,
 						"name":   name,
 					},
@@ -119,7 +119,6 @@ func TestPipeline(t *testing.T) {
 
 func configTest(t *testing.T, typ string, configs []string, fn func(t *testing.T, config string)) {
 	for _, config := range configs {
-		config := config
 		t.Run(testName(typ, config), func(t *testing.T) {
 			t.Parallel()
 			fn(t, config)

--- a/libbeat/reader/readfile/line_test.go
+++ b/libbeat/reader/readfile/line_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -189,11 +190,8 @@ func TestReaderEncodings(t *testing.T) {
 				for lineTerminatorName, lineTerminator := range lineTerminators {
 					lineTerminatorIsInvalid := false
 					if invalidLineTerminatorForEncoding, ok := invalidLineTerminatorForEncoding[test.encoding]; ok {
-						for _, invalidLineTerminator := range invalidLineTerminatorForEncoding {
-							if invalidLineTerminator == lineTerminator {
-								lineTerminatorIsInvalid = true
-								break
-							}
+						if slices.Contains(invalidLineTerminatorForEncoding, lineTerminator) {
+							lineTerminatorIsInvalid = true
 						}
 					}
 					if lineTerminatorIsInvalid {
@@ -269,7 +267,7 @@ func TestReadRandomLineLengths(t *testing.T) {
 	numLines := 100
 
 	lineLengths := make([]int, numLines)
-	for i := 0; i < numLines; i++ {
+	for i := range numLines {
 		lineLengths[i] = rand.Intn(maxLength-minLength) + minLength
 	}
 
@@ -281,7 +279,7 @@ func testReadLineLengths(t *testing.T, lineLengths []int) {
 	var lines [][]byte
 	for _, lineLength := range lineLengths {
 		inputLine := make([]byte, lineLength+1)
-		for i := 0; i < lineLength; i++ {
+		for i := range lineLength {
 			char := rand.Intn('z'-'A') + 'A'
 			inputLine[i] = byte(char)
 		}
@@ -369,7 +367,7 @@ func setupTestMaxBytesLimit(lineMaxLimit, lineLen int, nl []byte) (lines []strin
 
 	var b strings.Builder
 
-	for i := 0; i < lineCount; i++ {
+	for i := range lineCount {
 		var sz int
 		// Non-empty line
 		if randomBool(rnd) {
@@ -488,7 +486,7 @@ func TestBufferSize(t *testing.T) {
 		t.Fatal("failed to initialize reader:", err)
 	}
 
-	for i := 0; i < len(lines); i++ {
+	for i := range lines {
 		b, n, err := reader.Next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -71,7 +71,7 @@ func TestNumberOfRoutingShards(t *testing.T) {
 			beatVersion := getVersion("")
 			esVersion := getVersion(test.esVersion)
 
-			indexSettings := map[string]interface{}{}
+			indexSettings := map[string]any{}
 			if test.set > 0 {
 				indexSettings[settingKey] = test.set
 			}
@@ -132,7 +132,7 @@ func (t *unitTestTemplate) Has(path string) bool {
 	return has
 }
 
-func (t *unitTestTemplate) Get(path string) interface{} {
+func (t *unitTestTemplate) Get(path string) any {
 	t.t.Helper()
 	val, err := t.data.GetValue(path)
 	if err != nil {
@@ -149,7 +149,7 @@ func (t *unitTestTemplate) AssertMissing(path string) {
 	}
 }
 
-func (t *unitTestTemplate) Assert(path string, val interface{}) {
+func (t *unitTestTemplate) Assert(path string, val any) {
 	t.t.Helper()
 	assert.Equal(t.t, val, t.Get(path))
 }

--- a/metricbeat/mb/mb_test.go
+++ b/metricbeat/mb/mb_test.go
@@ -53,18 +53,18 @@ func (m *testMetricSet) Fetch(reporter ReporterV2) {}
 func TestModuleConfig(t *testing.T) {
 	tests := []struct {
 		name string
-		in   interface{}
+		in   any
 		out  ModuleConfig
 		err  string
 	}{
 		{
 			name: "string value is not set on required field",
-			in:   map[string]interface{}{},
+			in:   map[string]any{},
 			err:  "string value is not set accessing 'module'",
 		},
 		{
 			name: "valid config",
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "example",
 				"metricsets": []string{"test"},
 			},
@@ -79,7 +79,7 @@ func TestModuleConfig(t *testing.T) {
 		},
 		{
 			name: "missing period",
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "example",
 				"metricsets": []string{"test"},
 				"period":     -1,
@@ -88,7 +88,7 @@ func TestModuleConfig(t *testing.T) {
 		},
 		{
 			name: "negative timeout",
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "example",
 				"metricsets": []string{"test"},
 				"timeout":    -1,
@@ -128,7 +128,7 @@ func TestModuleConfig(t *testing.T) {
 // Any changes to this test case are probably indicators of non-backwards
 // compatible changes affect all modules (including community modules).
 func TestModuleConfigDefaults(t *testing.T) {
-	c, err := conf.NewConfigFrom(map[string]interface{}{
+	c, err := conf.NewConfigFrom(map[string]any{
 		"module":     "mymodule",
 		"metricsets": []string{"mymetricset"},
 	})
@@ -153,7 +153,7 @@ func TestModuleConfigDefaults(t *testing.T) {
 func TestNewModuleRejectsNilPaths(t *testing.T) {
 	r := newTestRegistry(t)
 
-	c := newConfig(t, map[string]interface{}{
+	c := newConfig(t, map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{metricSetName},
 	})
@@ -167,7 +167,7 @@ func TestNewModuleRejectsNilPaths(t *testing.T) {
 func TestNewModulesDuplicateHosts(t *testing.T) {
 	r := newTestRegistry(t)
 
-	c := newConfig(t, map[string]interface{}{
+	c := newConfig(t, map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{metricSetName},
 		"hosts":      []string{"a", "b", "a"},
@@ -182,7 +182,7 @@ func TestNewModulesDuplicateHosts(t *testing.T) {
 func TestNewModulesWithDefaultMetricSet(t *testing.T) {
 	r := newTestRegistry(t, DefaultMetricSet())
 
-	c := newConfig(t, map[string]interface{}{
+	c := newConfig(t, map[string]any{
 		"module": moduleName,
 	})
 
@@ -217,7 +217,7 @@ func TestNewModulesHostParser(t *testing.T) {
 	}
 
 	t.Run("MetricSet without HostParser", func(t *testing.T) {
-		ms := newTestMetricSet(t, r, map[string]interface{}{
+		ms := newTestMetricSet(t, r, map[string]any{
 			"module":     moduleName,
 			"metricsets": []string{metricSetName},
 			"hosts":      []string{uri},
@@ -229,7 +229,7 @@ func TestNewModulesHostParser(t *testing.T) {
 	})
 
 	t.Run("MetricSet with HostParser", func(t *testing.T) {
-		ms := newTestMetricSet(t, r, map[string]interface{}{
+		ms := newTestMetricSet(t, r, map[string]any{
 			"module":     moduleName,
 			"metricsets": []string{name},
 			"hosts":      []string{uri},
@@ -278,7 +278,7 @@ func newTestRegistry(t testing.TB, metricSetOptions ...MetricSetOption) *Registe
 	return r
 }
 
-func newTestMetricSet(t testing.TB, r *Register, config map[string]interface{}) MetricSet {
+func newTestMetricSet(t testing.TB, r *Register, config map[string]any) MetricSet {
 	_, metricsets, err := NewModule(newConfig(t, config), r, beat.Info{Paths: paths.New(), Logger: logptest.NewTestingLogger(t, "")})
 	if err != nil {
 		t.Fatal(err)
@@ -290,7 +290,7 @@ func newTestMetricSet(t testing.TB, r *Register, config map[string]interface{}) 
 	return metricsets[0]
 }
 
-func newConfig(t testing.TB, moduleConfig interface{}) *conf.C {
+func newConfig(t testing.TB, moduleConfig any) *conf.C {
 	config, err := conf.NewConfigFrom(moduleConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -305,7 +305,7 @@ func TestModuleConfigQueryParams(t *testing.T) {
 		"floatKey":  11.5,
 		"boolKey":   true,
 		"nullKey":   nil,
-		"arKey":     []interface{}{1, 2},
+		"arKey":     []any{1, 2},
 	}
 
 	res := qp.String()

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -41,7 +41,7 @@ import (
 // module.
 func ExampleWrapper() {
 	// Build a configuration object.
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{reportingFetcherName},
 	})
@@ -67,9 +67,7 @@ func ExampleWrapper() {
 
 	// Process events from the output channel until it is closed.
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for event := range output {
 			event.Fields.Put("event.duration", 111)
 
@@ -78,7 +76,7 @@ func ExampleWrapper() {
 				fmt.Println(output)
 			}
 		}
-	}()
+	})
 
 	// Simulate running for a while.
 	time.Sleep(50 * time.Millisecond)
@@ -125,7 +123,7 @@ func ExampleRunner() {
 	// for demonstration purposes.
 	var b *beat.Beat
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{reportingFetcherName},
 	})
@@ -174,7 +172,7 @@ func encodeEvent(event beat.Event) (string, error) {
 	// FIX: need to parse and re-encode, so fields ordering in final json document
 	//      keeps stable.
 
-	var tmp interface{}
+	var tmp any
 	if err := stdjson.Unmarshal(output, &tmp); err != nil {
 		panic(err)
 	}

--- a/metricbeat/mb/module/runner_test.go
+++ b/metricbeat/mb/module/runner_test.go
@@ -45,7 +45,7 @@ import (
 func TestRunner(t *testing.T) {
 	pubClient, factory := newPubClientFactory()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{reportingFetcherName},
 	})
@@ -75,7 +75,7 @@ func TestRunner(t *testing.T) {
 func TestCPUDiagnostics(t *testing.T) {
 	pubClient, factory := newPubClientFactory()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"module":     "system",
 		"metricsets": []string{"cpu"},
 	})
@@ -163,7 +163,7 @@ func TestRunnerStop_ClientClosedAfterPublishGoroutine(t *testing.T) {
 		},
 	}
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{pushMetricSetName},
 		"period":     "1s",

--- a/metricbeat/mb/module/wrapper_test.go
+++ b/metricbeat/mb/module/wrapper_test.go
@@ -97,7 +97,7 @@ func newTestRegistry(t testing.TB) *mb.Register {
 	return r
 }
 
-func newConfig(t testing.TB, moduleConfig interface{}) *conf.C {
+func newConfig(t testing.TB, moduleConfig any) *conf.C {
 	config, err := conf.NewConfigFrom(moduleConfig)
 	require.NoError(t, err)
 	return config
@@ -107,7 +107,7 @@ func newConfig(t testing.TB, moduleConfig interface{}) *conf.C {
 
 func TestWrapperOfReportingFetcher(t *testing.T) {
 	hosts := []string{"alpha", "beta"}
-	c := newConfig(t, map[string]interface{}{
+	c := newConfig(t, map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{reportingFetcherName},
 		"hosts":      hosts,
@@ -138,7 +138,7 @@ func TestWrapperOfReportingFetcher(t *testing.T) {
 
 func TestWrapperOfPushMetricSet(t *testing.T) {
 	hosts := []string{"alpha"}
-	c := newConfig(t, map[string]interface{}{
+	c := newConfig(t, map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{pushMetricSetName},
 		"hosts":      hosts,
@@ -185,7 +185,7 @@ func TestPeriodIsAddedToEvent(t *testing.T) {
 	for title, c := range cases {
 		t.Run(title, func(t *testing.T) {
 			hosts := []string{"alpha"}
-			config := newConfig(t, map[string]interface{}{
+			config := newConfig(t, map[string]any{
 				"module":     moduleName,
 				"metricsets": []string{c.metricset},
 				"hosts":      hosts,
@@ -215,7 +215,7 @@ func TestPeriodIsAddedToEvent(t *testing.T) {
 
 func TestDurationIsAddedToEvent(t *testing.T) {
 	hosts := []string{"alpha"}
-	config := newConfig(t, map[string]interface{}{
+	config := newConfig(t, map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{reportingFetcherName},
 		"hosts":      hosts,
@@ -244,7 +244,7 @@ func TestDurationIsAddedToEvent(t *testing.T) {
 
 func TestNewWrapperForMetricSet(t *testing.T) {
 	hosts := []string{"alpha"}
-	c := newConfig(t, map[string]interface{}{
+	c := newConfig(t, map[string]any{
 		"module":     moduleName,
 		"metricsets": []string{reportingFetcherName},
 		"hosts":      hosts,

--- a/metricbeat/mb/testing/lightmodules_test.go
+++ b/metricbeat/mb/testing/lightmodules_test.go
@@ -55,7 +55,7 @@ func TestFetchLightModuleWithProcessors(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "test",
 		"metricsets": []string{"json"},
 		"hosts":      []string{ts.URL},
@@ -92,7 +92,7 @@ func TestDataLightModuleWithProcessors(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "test",
 		"metricsets": []string{"json"},
 		"hosts":      []string{ts.URL},

--- a/metricbeat/module/openmetrics/collector/collector_test.go
+++ b/metricbeat/module/openmetrics/collector/collector_test.go
@@ -56,12 +56,12 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 	}{
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeCounter,
 				Metric: []*p.OpenMetric{
 					{
-						Name: proto.String("http_request_duration_microseconds_total"),
+						Name: new("http_request_duration_microseconds_total"),
 						Label: []*prometheuslabels.Label{
 							{
 								Name:  "handler",
@@ -90,8 +90,8 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeGauge,
 				Metric: []*p.OpenMetric{
 					{
@@ -116,8 +116,8 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeSummary,
 				Metric: []*p.OpenMetric{
 					{
@@ -126,7 +126,7 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 							SampleSum:   proto.Float64(10),
 							Quantile: []*p.Quantile{
 								{
-									Quantile: proto.Float64(0.99),
+									Quantile: new(0.99),
 									Value:    proto.Float64(10),
 								},
 							},
@@ -160,8 +160,8 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeHistogram,
 				Metric: []*p.OpenMetric{
 					{
@@ -170,7 +170,7 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 							SampleSum:   proto.Float64(10),
 							Bucket: []*p.Bucket{
 								{
-									UpperBound:      proto.Float64(0.99),
+									UpperBound:      new(0.99),
 									CumulativeCount: proto.Float64(10),
 								},
 							},
@@ -203,8 +203,8 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeUnknown,
 				Metric: []*p.OpenMetric{
 					{
@@ -245,8 +245,8 @@ func TestGetOpenMetricsEventsFromMetricFamily(t *testing.T) {
 func TestSkipMetricFamily(t *testing.T) {
 	testFamilies := []*p.MetricFamily{
 		{
-			Name: proto.String("http_request_duration_microseconds_a_a_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_a_a_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeCounter,
 			Metric: []*p.OpenMetric{
 				{
@@ -263,8 +263,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_a_b_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_a_b_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeCounter,
 			Metric: []*p.OpenMetric{
 				{
@@ -281,8 +281,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_b_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_b_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeGauge,
 			Metric: []*p.OpenMetric{
 				{
@@ -293,8 +293,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_c_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_c_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeSummary,
 			Metric: []*p.OpenMetric{
 				{
@@ -303,7 +303,7 @@ func TestSkipMetricFamily(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Quantile: []*p.Quantile{
 							{
-								Quantile: proto.Float64(0.99),
+								Quantile: new(0.99),
 								Value:    proto.Float64(10),
 							},
 						},
@@ -312,8 +312,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_d_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_d_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeHistogram,
 			Metric: []*p.OpenMetric{
 				{
@@ -322,7 +322,7 @@ func TestSkipMetricFamily(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(10),
 							},
 						},
@@ -331,8 +331,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_e_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_e_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeUnknown,
 			Metric: []*p.OpenMetric{
 				{

--- a/metricbeat/module/traefik/health/data_test.go
+++ b/metricbeat/module/traefik/health/data_test.go
@@ -29,14 +29,14 @@ import (
 
 func TestEventMapping(t *testing.T) {
 	// Taken from actual response from a Traefik instance's health API endpoint
-	input := map[string]interface{}{
+	input := map[string]any{
 		"pid":               1,
 		"uptime":            "16h43m51.452460402s",
 		"uptime_sec":        60231.452460402,
 		"time":              "2018-06-27 20:59:57.166337808 +0000 UTC m=+60231.514060714",
 		"unixtime":          1530133197,
-		"status_code_count": map[string]interface{}{},
-		"total_status_code_count": map[string]interface{}{
+		"status_code_count": map[string]any{},
+		"total_status_code_count": map[string]any{
 			"200": 17,
 			"404": 1,
 		},

--- a/metricbeat/module/traefik/health/health_test.go
+++ b/metricbeat/module/traefik/health/health_test.go
@@ -46,7 +46,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "traefik",
 		"metricsets": []string{"health"},
 		"hosts":      []string{server.URL},

--- a/x-pack/heartbeat/hbreceiver/smoke_test.go
+++ b/x-pack/heartbeat/hbreceiver/smoke_test.go
@@ -7,6 +7,7 @@ package hbreceiver
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -77,9 +78,7 @@ func staticMonitorConfig(t *testing.T, monitors []map[string]any, extra map[stri
 	hbSection := map[string]any{
 		"monitors": monitors,
 	}
-	for k, v := range extra {
-		hbSection[k] = v
-	}
+	maps.Copy(hbSection, extra)
 	return &Config{
 		Beatconfig: map[string]any{
 			"heartbeat":               hbSection,

--- a/x-pack/libbeat/common/cloudfoundry/cache_integration_test.go
+++ b/x-pack/libbeat/common/cloudfoundry/cache_integration_test.go
@@ -69,7 +69,7 @@ func TestGetApps(t *testing.T) {
 		})
 
 		t.Run("second call, in cache, faster, same response", func(t *testing.T) {
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				startTime := time.Now()
 				testNotExists(t)
 				require.True(t, firstTimeDuration > time.Now().Sub(startTime))


### PR DESCRIPTION
## Proposed commit message

```
libbeat,filebeat,metricbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 37 file(s)
owned by @elastic/elastic-agent-data-plane in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Single commit, produced entirely by tooling. Nothing on this branch needed a hand-written follow-up.

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
