### PR TITLE
packetbeat,x-pack/auditbeat,auditbeat: fix modernize lint findings

### DIFF
--- a/auditbeat/datastore/registry_test.go
+++ b/auditbeat/datastore/registry_test.go
@@ -193,10 +193,10 @@ func TestRegistryConcurrentOpenClose(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iters; j++ {
+			for range iters {
 				b, err := OpenBucket("a", p)
 				if err != nil {
 					t.Errorf("concurrent OpenBucket: %v", err)

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -398,7 +398,7 @@ func (ms *MetricSet) setPID(retries int) (err error) {
 	}
 
 	// run the SetPID logic in a retry loop, since the startup process can be fragile.
-	for i := 0; i < retries; i++ {
+	for range retries {
 		// This call will block on send, which isn't great, but the reply can *also* time out
 		// or return something like ENOBUFS.
 		err = ms.client.SetPID(libaudit.WaitForReply)
@@ -413,7 +413,7 @@ func (ms *MetricSet) setPID(retries int) (err error) {
 			// the netlink connection is losing data. Try to drain and send again.
 			// This is technically dropping data, but auditbeat is configured as best-effort anyway, and we'll drop events under high load anyway.
 			maxRecv := 10000
-			for i := 0; i < maxRecv; i++ {
+			for range maxRecv {
 				var retryOuter bool // hack because of how switch/break statements work
 				_, err = ms.client.Netlink.Receive(true, noParse)
 				switch {

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -354,8 +354,8 @@ func assertFieldsAreDocumented(t *testing.T, events []mb.Event) {
 	}
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":              "auditd",
 		"failure_mode":        "log",
 		"socket_type":         "unicast",
@@ -371,7 +371,7 @@ func TestUnicastClient(t *testing.T) {
 
 	FailIfAuditdIsRunning(t)
 
-	c := map[string]interface{}{
+	c := map[string]any{
 		"module":      "auditd",
 		"socket_type": "unicast",
 		"audit_rules": fmt.Sprintf(`
@@ -400,7 +400,7 @@ func TestMulticastClient(t *testing.T) {
 
 	FailIfAuditdIsRunning(t)
 
-	c := map[string]interface{}{
+	c := map[string]any{
 		"module":      "auditd",
 		"socket_type": "multicast",
 		"audit_rules": fmt.Sprintf(`

--- a/auditbeat/module/auditd/config_test.go
+++ b/auditbeat/module/auditd/config_test.go
@@ -141,7 +141,6 @@ audit_rules: |
 		}
 
 		for _, tc := range tcs {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				config := defaultConfig
 				config.SocketType = tc.socketType

--- a/auditbeat/module/auditd/golden_files_test.go
+++ b/auditbeat/module/auditd/golden_files_test.go
@@ -110,8 +110,8 @@ func normalize(t testing.TB, events []mb.Event) (norm []mapstr.M) {
 	return norm
 }
 
-func configForGolden() map[string]interface{} {
-	return map[string]interface{}{
+func configForGolden() map[string]any {
+	return map[string]any{
 		"module":                  "auditd",
 		"failure_mode":            "log",
 		"socket_type":             "unicast",

--- a/auditbeat/module/file_integrity/config_test.go
+++ b/auditbeat/module/file_integrity/config_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths":             []string{"/usr/bin"},
 		"hash_types":        []string{"sha256", "sha512"},
 		"max_file_size":     "1 GiB",
@@ -61,7 +61,7 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigInvalid(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths":             []string{"/usr/bin"},
 		"hash_types":        []string{"crc32", "sha256", "hmac"},
 		"max_file_size":     "32 Hz",
@@ -92,7 +92,7 @@ func TestConfigInvalid(t *testing.T) {
 	}
 	assert.Len(t, merr.Unwrap(), 4)
 
-	config, err = conf.NewConfigFrom(map[string]interface{}{
+	config, err = conf.NewConfigFrom(map[string]any{
 		"paths":         []string{"/usr/bin"},
 		"hash_types":    []string{"crc32", "sha256", "hmac"},
 		"exclude_files": "unmatched)",
@@ -119,7 +119,7 @@ func TestConfigInvalid(t *testing.T) {
 }
 
 func TestConfigInvalidMaxFileSize(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths":         []string{"/usr/bin"},
 		"max_file_size": "0", // Value must be >= 0.
 	})
@@ -140,7 +140,7 @@ func TestConfigEvalSymlinks(t *testing.T) {
 	dir := setupTestDir(t)
 	defer os.RemoveAll(dir)
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths": []string{filepath.Join(dir, "link_to_subdir")},
 	})
 	if err != nil {
@@ -158,7 +158,7 @@ func TestConfigEvalSymlinks(t *testing.T) {
 }
 
 func TestConfigRemoveDuplicates(t *testing.T) {
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"paths": []string{"/path/a", "/path/a"},
 	})
 	if err != nil {

--- a/auditbeat/module/file_integrity/device_resolver.go
+++ b/auditbeat/module/file_integrity/device_resolver.go
@@ -172,7 +172,7 @@ func (dr *deviceResolver) buildDeviceMap() (map[string]string, error) {
 	}
 
 	// Query each drive letter
-	for i := 0; i < 26; i++ {
+	for i := range 26 {
 		if (bitmask>>i)&1 == 1 {
 			driveLetter := string(byte('A' + i))
 			drivePath := driveLetter + ":"

--- a/auditbeat/module/file_integrity/device_resolver_test.go
+++ b/auditbeat/module/file_integrity/device_resolver_test.go
@@ -143,7 +143,7 @@ func createTestDeviceMapping(count int) (map[string]string, []string) {
 	deviceMap := make(map[string]string)
 	deviceList := make([]string, 0, count)
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		device := fmt.Sprintf("\\Device\\HarddiskVolume%d", i)
 		drive := fmt.Sprintf("%c:", 'A'+i%26)
 		deviceMap[device] = drive

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"os/user"
@@ -429,9 +430,7 @@ func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {
 		}
 		file["hash"] = hashes
 	}
-	for k, v := range e.ParserResults {
-		file[k] = v
-	}
+	maps.Copy(file, e.ParserResults)
 
 	out.MetricSetFields.Put("event.kind", "event")
 	out.MetricSetFields.Put("event.category", []string{"file"})

--- a/auditbeat/module/file_integrity/event_test.go
+++ b/auditbeat/module/file_integrity/event_test.go
@@ -368,7 +368,7 @@ func BenchmarkHashFile(b *testing.B) {
 
 	zeros := make([]byte, 100)
 	const iterations = 1024 * 1024 // 100 MiB
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		if _, err = f.Write(zeros); err != nil {
 			b.Fatal(err)
 		}

--- a/auditbeat/module/file_integrity/eventreader_test.go
+++ b/auditbeat/module/file_integrity/eventreader_test.go
@@ -264,7 +264,7 @@ func TestRaces(t *testing.T) {
 	// Generate a lot of events in parallel to Start() so there is a chance of
 	// events arriving before all watched dirs are Add()-ed
 	go func() {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			for _, dir := range dirs {
 				fname := filepath.Join(dir, fmt.Sprintf("%d.dat", i))
 				require.NoError(t, os.WriteFile(fname, []byte("hello"), fileMode))
@@ -403,7 +403,7 @@ func mustRun(t *testing.T, name string, f func(t *testing.T)) {
 func rename(t *testing.T, oldPath, newPath string) {
 	const maxRetries = 100
 
-	for retries := 0; retries < maxRetries; retries++ {
+	for retries := range maxRetries {
 		err := os.Rename(oldPath, newPath)
 		if err == nil {
 			if retries > 0 {

--- a/auditbeat/module/file_integrity/exeobjparser.go
+++ b/auditbeat/module/file_integrity/exeobjparser.go
@@ -133,7 +133,6 @@ func (fields exeObjParser) Parse(dst mapstr.M, path string) (err error) {
 			// section attributes are added from another parser.
 			stats := make([]objSection, len(sections))
 			for i, s := range sections {
-				s := s
 				if all {
 					name = &s.Name
 					size = &s.Size

--- a/auditbeat/module/file_integrity/exeobjparser_test.go
+++ b/auditbeat/module/file_integrity/exeobjparser_test.go
@@ -180,15 +180,6 @@ func approxSections(tol float64) func(a, b any) bool {
 	}
 }
 
-//go:fix inline
-func strPtr(s string) *string { return new(s) }
-
-//go:fix inline
-func float64Ptr(f float64) *float64 { return new(f) }
-
-//go:fix inline
-func uint64Ptr(u uint64) *uint64 { return new(u) }
-
 func (o objSection) String() string {
 	name := "<nil>"
 	if o.Name != nil {

--- a/auditbeat/module/file_integrity/exeobjparser_test.go
+++ b/auditbeat/module/file_integrity/exeobjparser_test.go
@@ -64,11 +64,11 @@ func TestExeObjParser(t *testing.T) {
 
 				fields := []struct {
 					path string
-					cmp  func(a, b interface{}) bool
+					cmp  func(a, b any) bool
 				}{
-					{path: "import_hash", cmp: func(a, b interface{}) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
-					{path: "imphash", cmp: func(a, b interface{}) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
-					{path: "symhash", cmp: func(a, b interface{}) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
+					{path: "import_hash", cmp: func(a, b any) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
+					{path: "imphash", cmp: func(a, b any) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
+					{path: "symhash", cmp: func(a, b any) bool { return fmt.Sprint(a) == fmt.Sprint(b) }},
 					{path: "imports", cmp: approxImports(format, builder)},
 					{path: "imports_names_entropy", cmp: approxFloat64(0.1)},
 					{path: "imports_names_var_entropy", cmp: approxFloat64(0.01)},
@@ -76,7 +76,7 @@ func TestExeObjParser(t *testing.T) {
 					{path: "go_imports", cmp: approxImports(format, builder)},
 					{path: "go_imports_names_entropy", cmp: approxFloat64(0.1)},
 					{path: "go_imports_names_var_entropy", cmp: approxFloat64(0.01)},
-					{path: "go_stripped", cmp: func(a, b interface{}) bool { return a == b }},
+					{path: "go_stripped", cmp: func(a, b any) bool { return a == b }},
 					{path: "sections", cmp: approxSections(0.1)},
 				}
 
@@ -99,8 +99,8 @@ func TestExeObjParser(t *testing.T) {
 	}
 }
 
-func approxHash(format, builder string) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxHash(format, builder string) func(a, b any) bool {
+	return func(a, b any) bool {
 		as := fmt.Sprint(a)
 		bs := fmt.Sprint(b)
 		if len(as) != len(bs) {
@@ -114,8 +114,8 @@ func approxHash(format, builder string) func(a, b interface{}) bool {
 	}
 }
 
-func approxImports(format, builder string) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxImports(format, builder string) func(a, b any) bool {
+	return func(a, b any) bool {
 		as, ok := a.([]string)
 		if !ok {
 			return false
@@ -135,8 +135,8 @@ func approxImports(format, builder string) func(a, b interface{}) bool {
 	}
 }
 
-func approxFloat64(tol float64) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxFloat64(tol float64) func(a, b any) bool {
+	return func(a, b any) bool {
 		af, ok := a.(float64)
 		if !ok {
 			return false
@@ -149,8 +149,8 @@ func approxFloat64(tol float64) func(a, b interface{}) bool {
 	}
 }
 
-func approxSections(tol float64) func(a, b interface{}) bool {
-	return func(a, b interface{}) bool {
+func approxSections(tol float64) func(a, b any) bool {
+	return func(a, b any) bool {
 		aObj, ok := a.([]objSection)
 		if !ok {
 			return false
@@ -180,9 +180,14 @@ func approxSections(tol float64) func(a, b interface{}) bool {
 	}
 }
 
-func strPtr(s string) *string       { return &s }
-func float64Ptr(f float64) *float64 { return &f }
-func uint64Ptr(u uint64) *uint64    { return &u }
+//go:fix inline
+func strPtr(s string) *string { return new(s) }
+
+//go:fix inline
+func float64Ptr(f float64) *float64 { return new(f) }
+
+//go:fix inline
+func uint64Ptr(u uint64) *uint64 { return new(u) }
 
 func (o objSection) String() string {
 	name := "<nil>"
@@ -213,19 +218,19 @@ var want = map[string]mapstr.M{
 			"go_imports_names_var_entropy": 0.0014785066641319837,
 			"go_stripped":                  false,
 			"sections": []objSection{
-				{Name: strPtr(".text"), Size: uint64Ptr(0x8e400), Entropy: float64Ptr(6.17), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".rdata"), Size: uint64Ptr(0x9ea00), Entropy: float64Ptr(5.13), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".data"), Size: uint64Ptr(0x17a00), Entropy: float64Ptr(4.60), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_abbrev"), Size: uint64Ptr(0x200), Entropy: float64Ptr(4.82), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_line"), Size: uint64Ptr(0x1cc00), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_frame"), Size: uint64Ptr(0x5800), Entropy: float64Ptr(7.92), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".debug_gdb_scripts"), Size: uint64Ptr(0x200), Entropy: float64Ptr(0.84), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_info"), Size: uint64Ptr(0x32a00), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_loc"), Size: uint64Ptr(0x1ba00), Entropy: float64Ptr(7.98), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".zdebug_ranges"), Size: uint64Ptr(0x9600), Entropy: float64Ptr(7.78), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".idata"), Size: uint64Ptr(0x600), Entropy: float64Ptr(3.61), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".reloc"), Size: uint64Ptr(0x6a00), Entropy: float64Ptr(5.44), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".symtab"), Size: uint64Ptr(0x17a00), Entropy: float64Ptr(5.12), VarEntropy: float64Ptr(0.0001)},
+				{Name: new(".text"), Size: new(uint64(0x8e400)), Entropy: new(6.17), VarEntropy: new(0.0001)},
+				{Name: new(".rdata"), Size: new(uint64(0x9ea00)), Entropy: new(5.13), VarEntropy: new(0.0001)},
+				{Name: new(".data"), Size: new(uint64(0x17a00)), Entropy: new(4.60), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_abbrev"), Size: new(uint64(0x200)), Entropy: new(4.82), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_line"), Size: new(uint64(0x1cc00)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_frame"), Size: new(uint64(0x5800)), Entropy: new(7.92), VarEntropy: new(0.0001)},
+				{Name: new(".debug_gdb_scripts"), Size: new(uint64(0x200)), Entropy: new(0.84), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_info"), Size: new(uint64(0x32a00)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_loc"), Size: new(uint64(0x1ba00)), Entropy: new(7.98), VarEntropy: new(0.0001)},
+				{Name: new(".zdebug_ranges"), Size: new(uint64(0x9600)), Entropy: new(7.78), VarEntropy: new(0.0001)},
+				{Name: new(".idata"), Size: new(uint64(0x600)), Entropy: new(3.61), VarEntropy: new(0.0001)},
+				{Name: new(".reloc"), Size: new(uint64(0x6a00)), Entropy: new(5.44), VarEntropy: new(0.0001)},
+				{Name: new(".symtab"), Size: new(uint64(0x17a00)), Entropy: new(5.12), VarEntropy: new(0.0001)},
 			},
 			"import_hash": "c7269d59926fa4252270f407e4dab043",
 			"imports": []string{
@@ -284,29 +289,29 @@ var want = map[string]mapstr.M{
 			"go_imports_names_var_entropy": 0.0073028693197579415,
 			"go_stripped":                  false,
 			"sections": []objSection{
-				{Name: strPtr(""), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".text"), Size: uint64Ptr(0x7ffd6), Entropy: float64Ptr(6.17), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".rodata"), Size: uint64Ptr(0x35940), Entropy: float64Ptr(4.36), VarEntropy: float64Ptr(0.0005)},
-				{Name: strPtr(".shstrtab"), Size: uint64Ptr(0x17a), Entropy: float64Ptr(4.33), VarEntropy: float64Ptr(0.0019)},
-				{Name: strPtr(".typelink"), Size: uint64Ptr(0x4f0), Entropy: float64Ptr(3.77), VarEntropy: float64Ptr(0.0083)},
-				{Name: strPtr(".itablink"), Size: uint64Ptr(0x60), Entropy: float64Ptr(2.15), VarEntropy: float64Ptr(0.046)},
-				{Name: strPtr(".gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".gopclntab"), Size: uint64Ptr(0x5a5c8), Entropy: float64Ptr(5.49), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".go.buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.56), VarEntropy: float64Ptr(0.07)},
-				{Name: strPtr(".noptrdata"), Size: uint64Ptr(0x10720), Entropy: float64Ptr(5.61), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".data"), Size: uint64Ptr(0x7810), Entropy: float64Ptr(1.60), VarEntropy: float64Ptr(0.0004)},
-				{Name: strPtr(".bss"), Size: uint64Ptr(0x2ef48), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".noptrbss"), Size: uint64Ptr(0x5360), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0)},
-				{Name: strPtr(".zdebug_abbrev"), Size: uint64Ptr(0x1e6), Entropy: float64Ptr(4.71), VarEntropy: float64Ptr(0.007)},
-				{Name: strPtr(".zdebug_line"), Size: uint64Ptr(0x30b61), Entropy: float64Ptr(5.93), VarEntropy: float64Ptr(0.0003)},
-				{Name: strPtr(".zdebug_frame"), Size: uint64Ptr(0xee0c), Entropy: float64Ptr(3.59), VarEntropy: float64Ptr(0.0002)},
-				{Name: strPtr(".debug_gdb_scripts"), Size: uint64Ptr(0x31), Entropy: float64Ptr(4.25), VarEntropy: float64Ptr(0.016)},
-				{Name: strPtr(".zdebug_info"), Size: uint64Ptr(0x79ef9), Entropy: float64Ptr(5.80), VarEntropy: float64Ptr(0.0002)},
-				{Name: strPtr(".zdebug_loc"), Size: uint64Ptr(0x919d5), Entropy: float64Ptr(2.62), VarEntropy: float64Ptr(0.0002)},
-				{Name: strPtr(".zdebug_ranges"), Size: uint64Ptr(0x313b0), Entropy: float64Ptr(2.20), VarEntropy: float64Ptr(0.0006)},
-				{Name: strPtr(".note.go.buildid"), Size: uint64Ptr(0x64), Entropy: float64Ptr(5.29), VarEntropy: float64Ptr(0.012)},
-				{Name: strPtr(".symtab"), Size: uint64Ptr(0xc5e8), Entropy: float64Ptr(3.21), VarEntropy: float64Ptr(0.0003)},
-				{Name: strPtr(".strtab"), Size: uint64Ptr(0xb2d6), Entropy: float64Ptr(4.81), VarEntropy: float64Ptr(0.0004)},
+				{Name: new(""), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".text"), Size: new(uint64(0x7ffd6)), Entropy: new(6.17), VarEntropy: new(0.0001)},
+				{Name: new(".rodata"), Size: new(uint64(0x35940)), Entropy: new(4.36), VarEntropy: new(0.0005)},
+				{Name: new(".shstrtab"), Size: new(uint64(0x17a)), Entropy: new(4.33), VarEntropy: new(0.0019)},
+				{Name: new(".typelink"), Size: new(uint64(0x4f0)), Entropy: new(3.77), VarEntropy: new(0.0083)},
+				{Name: new(".itablink"), Size: new(uint64(0x60)), Entropy: new(2.15), VarEntropy: new(0.046)},
+				{Name: new(".gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".gopclntab"), Size: new(uint64(0x5a5c8)), Entropy: new(5.49), VarEntropy: new(0.0001)},
+				{Name: new(".go.buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.56), VarEntropy: new(0.07)},
+				{Name: new(".noptrdata"), Size: new(uint64(0x10720)), Entropy: new(5.61), VarEntropy: new(0.0001)},
+				{Name: new(".data"), Size: new(uint64(0x7810)), Entropy: new(1.60), VarEntropy: new(0.0004)},
+				{Name: new(".bss"), Size: new(uint64(0x2ef48)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".noptrbss"), Size: new(uint64(0x5360)), Entropy: new(0.0), VarEntropy: new(0.0)},
+				{Name: new(".zdebug_abbrev"), Size: new(uint64(0x1e6)), Entropy: new(4.71), VarEntropy: new(0.007)},
+				{Name: new(".zdebug_line"), Size: new(uint64(0x30b61)), Entropy: new(5.93), VarEntropy: new(0.0003)},
+				{Name: new(".zdebug_frame"), Size: new(uint64(0xee0c)), Entropy: new(3.59), VarEntropy: new(0.0002)},
+				{Name: new(".debug_gdb_scripts"), Size: new(uint64(0x31)), Entropy: new(4.25), VarEntropy: new(0.016)},
+				{Name: new(".zdebug_info"), Size: new(uint64(0x79ef9)), Entropy: new(5.80), VarEntropy: new(0.0002)},
+				{Name: new(".zdebug_loc"), Size: new(uint64(0x919d5)), Entropy: new(2.62), VarEntropy: new(0.0002)},
+				{Name: new(".zdebug_ranges"), Size: new(uint64(0x313b0)), Entropy: new(2.20), VarEntropy: new(0.0006)},
+				{Name: new(".note.go.buildid"), Size: new(uint64(0x64)), Entropy: new(5.29), VarEntropy: new(0.012)},
+				{Name: new(".symtab"), Size: new(uint64(0xc5e8)), Entropy: new(3.21), VarEntropy: new(0.0003)},
+				{Name: new(".strtab"), Size: new(uint64(0xb2d6)), Entropy: new(4.81), VarEntropy: new(0.0004)},
 			},
 			"import_hash":    "d41d8cd98f00b204e9800998ecf8427e",
 			"go_import_hash": "10bddcb4cee42080f76c88d9ff964491",
@@ -322,19 +327,19 @@ var want = map[string]mapstr.M{
 			"go_import_hash": "d41d8cd98f00b204e9800998ecf8427e",
 			"go_stripped":    true,
 			"sections": []objSection{
-				{Name: strPtr(""), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".text"), Size: uint64Ptr(0x74f85), Entropy: float64Ptr(6.18), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".rodata"), Size: uint64Ptr(0x331e4), Entropy: float64Ptr(4.25), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".shstrtab"), Size: uint64Ptr(0x94), Entropy: float64Ptr(4.27), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".typelink"), Size: uint64Ptr(0x4ec), Entropy: float64Ptr(3.69), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".itablink"), Size: uint64Ptr(0x60), Entropy: float64Ptr(2.14), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".gopclntab"), Size: uint64Ptr(0x56370), Entropy: float64Ptr(5.42), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".go.buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.56), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".noptrdata"), Size: uint64Ptr(0x10720), Entropy: float64Ptr(5.60), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".data"), Size: uint64Ptr(0x7570), Entropy: float64Ptr(1.54), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".bss"), Size: uint64Ptr(0x2ef48), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr(".noptrbss"), Size: uint64Ptr(0x5340), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
+				{Name: new(""), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new(".text"), Size: new(uint64(0x74f85)), Entropy: new(6.18), VarEntropy: new(0.0001)},
+				{Name: new(".rodata"), Size: new(uint64(0x331e4)), Entropy: new(4.25), VarEntropy: new(0.0001)},
+				{Name: new(".shstrtab"), Size: new(uint64(0x94)), Entropy: new(4.27), VarEntropy: new(0.0001)},
+				{Name: new(".typelink"), Size: new(uint64(0x4ec)), Entropy: new(3.69), VarEntropy: new(0.0001)},
+				{Name: new(".itablink"), Size: new(uint64(0x60)), Entropy: new(2.14), VarEntropy: new(0.0001)},
+				{Name: new(".gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new(".gopclntab"), Size: new(uint64(0x56370)), Entropy: new(5.42), VarEntropy: new(0.0001)},
+				{Name: new(".go.buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.56), VarEntropy: new(0.0001)},
+				{Name: new(".noptrdata"), Size: new(uint64(0x10720)), Entropy: new(5.60), VarEntropy: new(0.0001)},
+				{Name: new(".data"), Size: new(uint64(0x7570)), Entropy: new(1.54), VarEntropy: new(0.0001)},
+				{Name: new(".bss"), Size: new(uint64(0x2ef48)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new(".noptrbss"), Size: new(uint64(0x5340)), Entropy: new(0.0), VarEntropy: new(0.0001)},
 			},
 		},
 	},
@@ -391,26 +396,26 @@ var want = map[string]mapstr.M{
 				"github.com/elastic/beats/v7/auditbeat/module/file_integrity/testdata/b.hash",
 			},
 			"sections": []objSection{
-				{Name: strPtr("__text"), Size: uint64Ptr(0x8be36), Entropy: float64Ptr(6.16), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__symbol_stub1"), Size: uint64Ptr(0x102), Entropy: float64Ptr(3.62), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__rodata"), Size: uint64Ptr(0x38b4f), Entropy: float64Ptr(4.37), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__typelink"), Size: uint64Ptr(0x550), Entropy: float64Ptr(3.64), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__itablink"), Size: uint64Ptr(0x78), Entropy: float64Ptr(2.63), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gopclntab"), Size: uint64Ptr(0x614a0), Entropy: float64Ptr(5.46), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__go_buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.79), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__nl_symbol_ptr"), Size: uint64Ptr(0x158), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrdata"), Size: uint64Ptr(0x10780), Entropy: float64Ptr(5.59), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__data"), Size: uint64Ptr(0x7470), Entropy: float64Ptr(1.74), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__bss"), Size: uint64Ptr(0x2f068), Entropy: float64Ptr(6.13), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrbss"), Size: uint64Ptr(0x51c0), Entropy: float64Ptr(5.65), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_abbrev"), Size: uint64Ptr(0x117), Entropy: float64Ptr(7.16), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_line"), Size: uint64Ptr(0x1d615), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_frame"), Size: uint64Ptr(0x5b82), Entropy: float64Ptr(7.92), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__debug_gdb_scri"), Size: uint64Ptr(0x31), Entropy: float64Ptr(4.24), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_info"), Size: uint64Ptr(0x33a7b), Entropy: float64Ptr(7.99), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_loc"), Size: uint64Ptr(0x1a57f), Entropy: float64Ptr(7.98), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__zdebug_ranges"), Size: uint64Ptr(0x8371), Entropy: float64Ptr(7.89), VarEntropy: float64Ptr(0.0001)},
+				{Name: new("__text"), Size: new(uint64(0x8be36)), Entropy: new(6.16), VarEntropy: new(0.0001)},
+				{Name: new("__symbol_stub1"), Size: new(uint64(0x102)), Entropy: new(3.62), VarEntropy: new(0.0001)},
+				{Name: new("__rodata"), Size: new(uint64(0x38b4f)), Entropy: new(4.37), VarEntropy: new(0.0001)},
+				{Name: new("__typelink"), Size: new(uint64(0x550)), Entropy: new(3.64), VarEntropy: new(0.0001)},
+				{Name: new("__itablink"), Size: new(uint64(0x78)), Entropy: new(2.63), VarEntropy: new(0.0001)},
+				{Name: new("__gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__gopclntab"), Size: new(uint64(0x614a0)), Entropy: new(5.46), VarEntropy: new(0.0001)},
+				{Name: new("__go_buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.79), VarEntropy: new(0.0001)},
+				{Name: new("__nl_symbol_ptr"), Size: new(uint64(0x158)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__noptrdata"), Size: new(uint64(0x10780)), Entropy: new(5.59), VarEntropy: new(0.0001)},
+				{Name: new("__data"), Size: new(uint64(0x7470)), Entropy: new(1.74), VarEntropy: new(0.0001)},
+				{Name: new("__bss"), Size: new(uint64(0x2f068)), Entropy: new(6.13), VarEntropy: new(0.0001)},
+				{Name: new("__noptrbss"), Size: new(uint64(0x51c0)), Entropy: new(5.65), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_abbrev"), Size: new(uint64(0x117)), Entropy: new(7.16), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_line"), Size: new(uint64(0x1d615)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_frame"), Size: new(uint64(0x5b82)), Entropy: new(7.92), VarEntropy: new(0.0001)},
+				{Name: new("__debug_gdb_scri"), Size: new(uint64(0x31)), Entropy: new(4.24), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_info"), Size: new(uint64(0x33a7b)), Entropy: new(7.99), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_loc"), Size: new(uint64(0x1a57f)), Entropy: new(7.98), VarEntropy: new(0.0001)},
+				{Name: new("__zdebug_ranges"), Size: new(uint64(0x8371)), Entropy: new(7.89), VarEntropy: new(0.0001)},
 			},
 			"import_hash":                  "d3ccf195b62a9279c3c19af1080497ec",
 			"imports_names_entropy":        4.132925542571368,
@@ -424,19 +429,19 @@ var want = map[string]mapstr.M{
 	"garble_macho": {
 		"macho": mapstr.M{
 			"sections": []objSection{
-				{Name: strPtr("__text"), Size: uint64Ptr(0x80e52), Entropy: float64Ptr(6.17), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__symbol_stub1"), Size: uint64Ptr(0x102), Entropy: float64Ptr(3.62), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__rodata"), Size: uint64Ptr(0x367b3), Entropy: float64Ptr(4.28), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__typelink"), Size: uint64Ptr(0x554), Entropy: float64Ptr(3.85), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__itablink"), Size: uint64Ptr(0x78), Entropy: float64Ptr(2.61), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gosymtab"), Size: uint64Ptr(0x0), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__gopclntab"), Size: uint64Ptr(0x5cf68), Entropy: float64Ptr(5.41), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__go_buildinfo"), Size: uint64Ptr(0x20), Entropy: float64Ptr(3.85), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__nl_symbol_ptr"), Size: uint64Ptr(0x158), Entropy: float64Ptr(0.0), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrdata"), Size: uint64Ptr(0x10780), Entropy: float64Ptr(5.59), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__data"), Size: uint64Ptr(0x71f0), Entropy: float64Ptr(1.72), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__bss"), Size: uint64Ptr(0x2f088), Entropy: float64Ptr(6.13), VarEntropy: float64Ptr(0.0001)},
-				{Name: strPtr("__noptrbss"), Size: uint64Ptr(0x51a0), Entropy: float64Ptr(5.55), VarEntropy: float64Ptr(0.0001)},
+				{Name: new("__text"), Size: new(uint64(0x80e52)), Entropy: new(6.17), VarEntropy: new(0.0001)},
+				{Name: new("__symbol_stub1"), Size: new(uint64(0x102)), Entropy: new(3.62), VarEntropy: new(0.0001)},
+				{Name: new("__rodata"), Size: new(uint64(0x367b3)), Entropy: new(4.28), VarEntropy: new(0.0001)},
+				{Name: new("__typelink"), Size: new(uint64(0x554)), Entropy: new(3.85), VarEntropy: new(0.0001)},
+				{Name: new("__itablink"), Size: new(uint64(0x78)), Entropy: new(2.61), VarEntropy: new(0.0001)},
+				{Name: new("__gosymtab"), Size: new(uint64(0x0)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__gopclntab"), Size: new(uint64(0x5cf68)), Entropy: new(5.41), VarEntropy: new(0.0001)},
+				{Name: new("__go_buildinfo"), Size: new(uint64(0x20)), Entropy: new(3.85), VarEntropy: new(0.0001)},
+				{Name: new("__nl_symbol_ptr"), Size: new(uint64(0x158)), Entropy: new(0.0), VarEntropy: new(0.0001)},
+				{Name: new("__noptrdata"), Size: new(uint64(0x10780)), Entropy: new(5.59), VarEntropy: new(0.0001)},
+				{Name: new("__data"), Size: new(uint64(0x71f0)), Entropy: new(1.72), VarEntropy: new(0.0001)},
+				{Name: new("__bss"), Size: new(uint64(0x2f088)), Entropy: new(6.13), VarEntropy: new(0.0001)},
+				{Name: new("__noptrbss"), Size: new(uint64(0x51a0)), Entropy: new(5.55), VarEntropy: new(0.0001)},
 			},
 			"import_hash": "d3ccf195b62a9279c3c19af1080497ec",
 			"imports": []string{

--- a/auditbeat/module/file_integrity/file_parsers_fips_test.go
+++ b/auditbeat/module/file_integrity/file_parsers_fips_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestFileParsers(t *testing.T) {
-	cfg, err := config.NewConfigFrom(map[string]interface{}{
+	cfg, err := config.NewConfigFrom(map[string]any{
 		"paths":        []string{"/usr/bin"},
 		"file_parsers": []string{"file.elf.sections", `/\.pe\./`},
 	})

--- a/auditbeat/module/file_integrity/file_parsers_nofips_test.go
+++ b/auditbeat/module/file_integrity/file_parsers_nofips_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestFileParsers(t *testing.T) {
-	cfg, err := config.NewConfigFrom(map[string]interface{}{
+	cfg, err := config.NewConfigFrom(map[string]any{
 		"paths":        []string{"/usr/bin"},
 		"file_parsers": []string{"file.elf.sections", `/\.pe\./`},
 	})

--- a/auditbeat/module/file_integrity/fileorigin_darwin.go
+++ b/auditbeat/module/file_integrity/fileorigin_darwin.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build darwin
-// +build darwin
 
 package file_integrity
 

--- a/auditbeat/module/file_integrity/flatbuffers.go
+++ b/auditbeat/module/file_integrity/flatbuffers.go
@@ -44,7 +44,7 @@ var actionMap = map[Action]schema.Action{
 var bufferPool sync.Pool
 
 func init() {
-	bufferPool.New = func() interface{} {
+	bufferPool.New = func() any {
 		return flatbuffers.NewBuilder(1024)
 	}
 }
@@ -378,7 +378,7 @@ func fbDecodeHash(e *schema.Event) map[HashType]Digest {
 
 		if length > 0 {
 			hashValue := make([]byte, length)
-			for i := 0; i < len(hashValue); i++ {
+			for i := range hashValue {
 				hashValue[i] = byte(producer(i))
 			}
 

--- a/auditbeat/module/file_integrity/kprobes/events.go
+++ b/auditbeat/module/file_integrity/kprobes/events.go
@@ -26,7 +26,7 @@ import (
 )
 
 var probeEventPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &ProbeEvent{}
 	},
 }

--- a/auditbeat/module/file_integrity/kprobes/events_test.go
+++ b/auditbeat/module/file_integrity/kprobes/events_test.go
@@ -76,7 +76,7 @@ func BenchmarkEventAllocation(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10000; j++ {
+		for range 10000 {
 			p = &ProbeEvent{}
 			_ = p
 			p = &ProbeEvent{MaskMonitor: 1}
@@ -93,7 +93,7 @@ func BenchmarkEventPool(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10000; j++ {
+		for range 10000 {
 			p = allocProbeEvent()
 			_ = p
 			releaseProbeEvent(p.(*ProbeEvent))

--- a/auditbeat/module/file_integrity/kprobes/executor_test.go
+++ b/auditbeat/module/file_integrity/kprobes/executor_test.go
@@ -107,10 +107,8 @@ func Test_executor(t *testing.T) {
 	errChannel := make(chan error, 1)
 	wg := sync.WaitGroup{}
 	start := make(chan struct{})
-	for i := 0; i < 4; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 4 {
+		wg.Go(func() {
 			<-start
 			if runErr := exec.Run(atomicCheck); runErr != nil {
 				select {
@@ -118,7 +116,7 @@ func Test_executor(t *testing.T) {
 				default:
 				}
 			}
-		}()
+		})
 	}
 	time.Sleep(1 * time.Second)
 	close(start)

--- a/auditbeat/module/file_integrity/kprobes/monitor.go
+++ b/auditbeat/module/file_integrity/kprobes/monitor.go
@@ -71,7 +71,7 @@ type Monitor struct {
 	log         *logp.Logger
 	ctx         context.Context
 	cancelFn    context.CancelFunc
-	running     uint32
+	running     atomic.Uint32
 	isRecursive bool
 	closeErr    error
 }
@@ -120,7 +120,7 @@ func newMonitor(ctx context.Context, isRecursive bool, pChannel perfChannel, exe
 }
 
 func (w *Monitor) Add(path string) error {
-	switch atomic.LoadUint32(&w.running) {
+	switch w.running.Load() {
 	case 0:
 		return errors.New("monitor not started")
 	case 2:
@@ -131,11 +131,11 @@ func (w *Monitor) Add(path string) error {
 }
 
 func (w *Monitor) Close() error {
-	if !atomic.CompareAndSwapUint32(&w.running, 1, 2) {
-		switch atomic.LoadUint32(&w.running) {
+	if !w.running.CompareAndSwap(1, 2) {
+		switch w.running.Load() {
 		case 0:
 			// monitor hasn't started yet
-			atomic.StoreUint32(&w.running, 2)
+			w.running.Store(2)
 		default:
 			return nil
 		}
@@ -165,7 +165,7 @@ func (w *Monitor) writeErr(err error) {
 }
 
 func (w *Monitor) Start() error {
-	if !atomic.CompareAndSwapUint32(&w.running, 0, 1) {
+	if !w.running.CompareAndSwap(0, 1) {
 		return errors.New("monitor already started")
 	}
 

--- a/auditbeat/module/file_integrity/kprobes/monitor_test.go
+++ b/auditbeat/module/file_integrity/kprobes/monitor_test.go
@@ -96,7 +96,7 @@ func (p *monitorTestSuite) TestRunPerfChannelLost() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -133,7 +133,7 @@ func (p *monitorTestSuite) TestRunPerfChannelErr() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -171,7 +171,7 @@ func (p *monitorTestSuite) TestRunPathErr() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -211,7 +211,7 @@ func (p *monitorTestSuite) TestRunUnknownEventType() {
 	type Unknown struct{}
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -248,7 +248,7 @@ func (p *monitorTestSuite) TestRunPerfCloseEventChan() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -281,7 +281,7 @@ func (p *monitorTestSuite) TestDoubleStart() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -318,7 +318,7 @@ func (p *monitorTestSuite) TestAddPathNotClosed() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -343,7 +343,7 @@ func (p *monitorTestSuite) TestRunNoError() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}
@@ -412,7 +412,7 @@ func (p *monitorTestSuite) TestRunEmitError() {
 	ctx := context.Background()
 
 	perfLost := make(chan uint64)
-	perfEvent := make(chan interface{})
+	perfEvent := make(chan any)
 	perfErr := make(chan error)
 
 	mockPerfChannel := &perfChannelMock{}

--- a/auditbeat/module/file_integrity/kprobes/path_mountpoint.go
+++ b/auditbeat/module/file_integrity/kprobes/path_mountpoint.go
@@ -160,7 +160,7 @@ func parseMountInfoLine(line string) (*mount, error) {
 	}
 	mnt.Subtree = unescapeString(fields[3])
 	mnt.Path = unescapeString(fields[4])
-	for _, opt := range strings.Split(fields[5], ",") {
+	for opt := range strings.SplitSeq(fields[5], ",") {
 		if opt == "ro" {
 			mnt.ReadOnly = true
 		}

--- a/auditbeat/module/file_integrity/kprobes/path_test.go
+++ b/auditbeat/module/file_integrity/kprobes/path_test.go
@@ -324,15 +324,13 @@ func (p *pathTestSuite) TestAddTraverserContextCancel() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for {
@@ -366,15 +364,13 @@ func (p *pathTestSuite) TestAddTimeout() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	select {
 	case err = <-errChan:
@@ -450,15 +446,13 @@ func (p *pathTestSuite) TestRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {
@@ -557,15 +551,13 @@ func (p *pathTestSuite) TestNonRecursiveAdd() {
 
 	errChan := make(chan error)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		errPath := pTrav.AddPathToMonitor(ctx, tmpDir)
 		if errPath != nil {
 			errChan <- errPath
 		}
 		close(errChan)
-	}()
+	})
 
 	tries := 0
 	for idx := 0; idx < len(expectedStatQueue); {

--- a/auditbeat/module/file_integrity/kprobes/perf_channel.go
+++ b/auditbeat/module/file_integrity/kprobes/perf_channel.go
@@ -27,7 +27,7 @@ import (
 )
 
 type perfChannel interface {
-	C() <-chan interface{}
+	C() <-chan any
 	ErrC() <-chan error
 	LostC() <-chan uint64
 	Run() error

--- a/auditbeat/module/file_integrity/kprobes/perf_channel_test.go
+++ b/auditbeat/module/file_integrity/kprobes/perf_channel_test.go
@@ -25,9 +25,9 @@ type perfChannelMock struct {
 	mock.Mock
 }
 
-func (p *perfChannelMock) C() <-chan interface{} {
+func (p *perfChannelMock) C() <-chan any {
 	args := p.Called()
-	return args.Get(0).(chan interface{})
+	return args.Get(0).(chan any)
 }
 
 func (p *perfChannelMock) ErrC() <-chan error {

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -323,7 +323,7 @@ func TestErrorReporting(t *testing.T) {
 	close(done)
 	<-ready
 
-	getField := func(ev *mb.Event, field string) interface{} {
+	getField := func(ev *mb.Event, field string) any {
 		v, _ := ev.MetricSetFields.GetValue(field)
 		return v
 	}
@@ -336,7 +336,6 @@ func TestErrorReporting(t *testing.T) {
 
 	var event *mb.Event
 	for idx, ev := range events {
-		ev := ev
 		t.Log("event[", idx, "] = ", ev)
 		if match(&ev) {
 			event = &ev
@@ -361,7 +360,7 @@ func TestErrorReporting(t *testing.T) {
 	switch v := errors.(type) {
 	case string:
 		errList = []string{v}
-	case []interface{}:
+	case []any:
 		for _, val := range v {
 			str, ok := val.(string)
 			if !ok {
@@ -412,7 +411,7 @@ func (t *testReporter) Clear() {
 	t.errors = nil
 }
 
-func checkExpectedEvent(t *testing.T, ms *MetricSet, title string, input *Event, expected map[string]interface{}) {
+func checkExpectedEvent(t *testing.T, ms *MetricSet, title string, input *Event, expected map[string]any) {
 	t.Helper()
 
 	var reporter testReporter
@@ -450,7 +449,7 @@ func checkExpectedEvent(t *testing.T, ms *MetricSet, title string, input *Event,
 type expectedEvent struct {
 	title    string
 	input    Event
-	expected map[string]interface{}
+	expected map[string]any
 }
 
 func (e expectedEvent) validate(t *testing.T, ms *MetricSet) {
@@ -497,7 +496,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("11111111111111111111"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": Digest("11111111111111111111"),
@@ -519,7 +518,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -539,7 +538,7 @@ func TestEventFailedHash(t *testing.T) {
 					Action:     Updated,
 					hashFailed: true,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": nil,
@@ -561,7 +560,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("33333333333333333333"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("33333333333333333333"),
@@ -583,7 +582,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("33333333333333333333"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"attributes_modified"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("33333333333333333333"),
@@ -607,7 +606,7 @@ func TestEventFailedHash(t *testing.T) {
 					Source:     SourceFSNotify,
 					hashFailed: true,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": nil,
@@ -629,7 +628,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated", "attributes_modified"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -655,7 +654,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -671,7 +670,7 @@ func TestEventFailedHash(t *testing.T) {
 					Action:    Deleted,
 					Hashes:    nil,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"deleted"},
 					"event.type":       []string{"deletion"},
 					"file.hash.sha256": nil,
@@ -697,7 +696,7 @@ func TestEventFailedHash(t *testing.T) {
 						SHA256: []byte("22222222222222222222"),
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": Digest("22222222222222222222"),
@@ -714,7 +713,7 @@ func TestEventFailedHash(t *testing.T) {
 					Action: Moved,
 					Hashes: nil,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"moved"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": nil,
@@ -758,7 +757,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -772,7 +771,7 @@ func TestEventDelete(t *testing.T) {
 					Source:    SourceFSNotify,
 					Action:    Deleted,
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action": []string{"deleted"},
 					"event.type":   []string{"deletion"},
 				},
@@ -793,7 +792,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -823,7 +822,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -845,7 +844,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: shaNext,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"updated"},
 					"event.type":       []string{"change"},
 					"file.hash.sha256": shaNext,
@@ -890,7 +889,7 @@ func TestEventDelete(t *testing.T) {
 						SHA256: sha,
 					},
 				},
-				expected: map[string]interface{}{
+				expected: map[string]any{
 					"event.action":     []string{"created"},
 					"event.type":       []string{"creation"},
 					"file.hash.sha256": sha,
@@ -938,8 +937,8 @@ func TestEventDelete(t *testing.T) {
 	})
 }
 
-func getConfig(path ...string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(path ...string) map[string]any {
+	return map[string]any{
 		"module":        "file_integrity",
 		"paths":         path,
 		"exclude_files": []string{`(?i)\.sw[nop]$`, `[/\\]\.git([/\\]|$)`},

--- a/auditbeat/module/file_integrity/monitor/filetree.go
+++ b/auditbeat/module/file_integrity/monitor/filetree.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	path_pkg "path"
+	"slices"
 	"strings"
 )
 
@@ -60,8 +61,8 @@ func (tree FileTree) AddDir(path string) error {
 func (tree FileTree) Remove(path string) error {
 	components := strings.Split(path, PathSeparator)
 	last := -1
-	for pos := len(components) - 1; pos >= 0; pos-- {
-		if len(components[pos]) != 0 {
+	for pos, v := range slices.Backward(components) {
+		if len(v) != 0 {
 			last = pos
 			break
 		}
@@ -94,7 +95,7 @@ func (tree FileTree) At(path string) (FileTree, error) {
 func (tree FileTree) add(path string, value FileTree) error {
 	components := strings.Split(path, PathSeparator)
 	dir, last := tree, len(components)-1
-	for i := 0; i < last; i++ {
+	for i := range last {
 		if len(components[i]) == 0 {
 			continue
 		}

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -332,7 +332,7 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	// Update
 	// Repeat the write if no event is received. Under macOS often
 	// the write fails to generate a write event for non-recursive watcher
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		f, err := os.OpenFile(fpath, os.O_RDWR|os.O_APPEND, 0o640)
 		assertNoError(t, err)
 		f.WriteString(" world\n")

--- a/auditbeat/scripts/mage/config.go
+++ b/auditbeat/scripts/mage/config.go
@@ -65,7 +65,7 @@ func configFileParams(dirs ...string) (devtools.ConfigFileParams, error) {
 	p := devtools.DefaultConfigFileParams()
 	p.Templates = append(p.Templates, devtools.OSSBeatDir("_meta/config/*.tmpl"))
 	p.Templates = append(p.Templates, "build/config.modules.yml.tmpl")
-	p.ExtraVars = map[string]interface{}{
+	p.ExtraVars = map[string]any{
 		"ArchBits": archBits,
 	}
 	return p, nil

--- a/auditbeat/scripts/mage/docs.go
+++ b/auditbeat/scripts/mage/docs.go
@@ -46,7 +46,7 @@ func ModuleDocs() error {
 	}
 
 	configs := make([]string, 0, len(configFiles))
-	params := map[string]interface{}{
+	params := map[string]any{
 		"GOOS":      "linux",
 		"GOARCH":    "amd64",
 		"ArchBits":  archBits,

--- a/auditbeat/scripts/mage/package.go
+++ b/auditbeat/scripts/mage/package.go
@@ -71,7 +71,7 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 			}
 
 			// Origin rule file.
-			params := map[string]interface{}{"ArchBits": archBits}
+			params := map[string]any{"ArchBits": archBits}
 			origin := devtools.OSSBeatDir(
 				"module/auditd/_meta/audit.rules.d",
 				spec.MustExpand("sample-rules-linux-{{call .ArchBits .GOARCH}}bit.conf", params),

--- a/auditbeat/tracing/decoder.go
+++ b/auditbeat/tracing/decoder.go
@@ -37,7 +37,7 @@ const maxRawCopySize = 2048
 type Decoder interface {
 	// Decode takes a raw message and its metadata and returns a representation
 	// in a decoder-dependent type.
-	Decode(raw []byte, meta Metadata) (interface{}, error)
+	Decode(raw []byte, meta Metadata) (any, error)
 }
 
 type mapDecoder []Field
@@ -62,15 +62,15 @@ func NewMapDecoder(format ProbeFormat) Decoder {
 }
 
 // Decode implements the Decoder interface.
-func (f mapDecoder) Decode(raw []byte, meta Metadata) (mapIf interface{}, err error) {
+func (f mapDecoder) Decode(raw []byte, meta Metadata) (mapIf any, err error) {
 	n := len(raw)
-	m := make(map[string]interface{}, len(f)+1)
+	m := make(map[string]any, len(f)+1)
 	m["meta"] = meta
 	for _, field := range f {
 		if field.Offset+field.Size > n {
 			return nil, fmt.Errorf("perf event field %s overflows message of size %d", field.Name, n)
 		}
-		var value interface{}
+		var value any
 		ptr := unsafe.Pointer(&raw[field.Offset])
 		switch field.Type {
 		case FieldTypeInteger:
@@ -100,7 +100,7 @@ func (f mapDecoder) Decode(raw []byte, meta Metadata) (mapIf interface{}, err er
 // AllocateFn is the type of a function that allocates a custom struct
 // to be used with StructDecoder. This function must return a pointer to
 // a struct.
-type AllocateFn func() interface{}
+type AllocateFn func() any
 
 type fieldDecoder struct {
 	typ  FieldType
@@ -177,7 +177,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 	// Validate that allocFn() returns pointers to structs.
 	sample := allocFn()
 	tSample := reflect.TypeOf(sample)
-	if tSample.Kind() != reflect.Ptr {
+	if tSample.Kind() != reflect.Pointer {
 		return nil, errors.New("allocator function doesn't return a pointer")
 	}
 	tSample = tSample.Elem()
@@ -187,8 +187,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 
 	var inFieldsByOffset map[int]Field
 
-	for i := 0; i < tSample.NumField(); i++ {
-		outField := tSample.Field(i)
+	for outField := range tSample.Fields() {
 		values, found := outField.Tag.Lookup("kprobe")
 		if !found {
 			// Untagged field
@@ -215,7 +214,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 
 		// Special handling for metadata field
 		if name == "metadata" {
-			if outField.Type != reflect.TypeOf(Metadata{}) {
+			if outField.Type != reflect.TypeFor[Metadata]() {
 				return nil, errors.New("bad type for meta field")
 			}
 			dec.fields = append(dec.fields, fieldDecoder{
@@ -325,7 +324,7 @@ func NewStructDecoder(desc ProbeFormat, allocFn AllocateFn) (Decoder, error) {
 }
 
 // Decode implements the decoder interface.
-func (d *structDecoder) Decode(raw []byte, meta Metadata) (s interface{}, err error) {
+func (d *structDecoder) Decode(raw []byte, meta Metadata) (s any, err error) {
 	n := uintptr(len(raw))
 
 	// Allocate a new struct to fill
@@ -413,7 +412,7 @@ func NewDumpDecoder(format ProbeFormat) (Decoder, error) {
 }
 
 // Decode implements the decoder interface.
-func (d *dumpDecoder) Decode(raw []byte, _ Metadata) (interface{}, error) {
+func (d *dumpDecoder) Decode(raw []byte, _ Metadata) (any, error) {
 	if len(raw) < d.end {
 		return nil, errors.New("record too short for dump")
 	}

--- a/auditbeat/tracing/events_test.go
+++ b/auditbeat/tracing/events_test.go
@@ -90,7 +90,7 @@ func BenchmarkMapDecoder(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		m := iface.(map[string]interface{})
+		m := iface.(map[string]any)
 
 		for _, c := range m["exe"].(string) {
 			sum += int(c)
@@ -140,7 +140,7 @@ func BenchmarkStructDecoder(b *testing.B) {
 		Arg5   uint16   `kprobe:"arg5"`
 		Arg6   uint32   `kprobe:"arg6"`
 	}
-	var myAlloc AllocateFn = func() interface{} {
+	var myAlloc AllocateFn = func() any {
 		return new(myStruct)
 	}
 
@@ -243,7 +243,7 @@ func TestKProbeReal(t *testing.T) {
 			CX  int32  `kprobe:"cx"`
 			DX  uint16 `kprobe:"dx"`
 		}
-		allocFn := func() interface{} {
+		allocFn := func() any {
 			return new(myStruct)
 		}
 		if decoder, err = NewStructDecoder(desc, allocFn); err != nil {
@@ -279,7 +279,7 @@ func TestKProbeReal(t *testing.T) {
 				break
 			}
 			if true {
-				data := iface.(map[string]interface{})
+				data := iface.(map[string]any)
 				_, err = fmt.Fprintf(os.Stderr, "Got event len=%d\n", len(data))
 				if err != nil {
 					panic(err)

--- a/auditbeat/tracing/perfevent.go
+++ b/auditbeat/tracing/perfevent.go
@@ -56,7 +56,7 @@ type stream struct {
 // PerfChannel represents a channel to receive perf events.
 type PerfChannel struct {
 	done    chan struct{}
-	sampleC chan interface{}
+	sampleC chan any
 	errC    chan error
 	lostC   chan uint64
 
@@ -289,7 +289,7 @@ func (c *PerfChannel) MonitorProbe(format ProbeFormat, decoder Decoder) error {
 }
 
 // C returns the channel to read samples from.
-func (c *PerfChannel) C() <-chan interface{} {
+func (c *PerfChannel) C() <-chan any {
 	return c.sampleC
 }
 
@@ -312,7 +312,7 @@ func (c *PerfChannel) Run() error {
 	if !atomic.CompareAndSwapUintptr(&c.running, 0, 1) {
 		return ErrAlreadyRunning
 	}
-	c.sampleC = make(chan interface{}, c.sizeSampleC)
+	c.sampleC = make(chan any, c.sizeSampleC)
 	c.errC = make(chan error, c.sizeErrC)
 	c.lostC = make(chan uint64, c.sizeLostC)
 
@@ -375,7 +375,7 @@ func (ctx doneWrapperContext) Err() error {
 }
 
 // Value always returns nil.
-func (ctx doneWrapperContext) Value(key interface{}) interface{} {
+func (ctx doneWrapperContext) Value(key any) any {
 	return nil
 }
 

--- a/libbeat/reader/auditd/auditd_test.go
+++ b/libbeat/reader/auditd/auditd_test.go
@@ -62,7 +62,7 @@ func (t *testReader) Next() (reader.Message, error) {
 }
 
 // auditdLogField returns the value of a field within msg.Fields["auditd"]["log"].
-func auditdLogField(fields mapstr.M, key string) (interface{}, bool) {
+func auditdLogField(fields mapstr.M, key string) (any, bool) {
 	auditd, ok := fields["auditd"].(mapstr.M)
 	if !ok {
 		return nil, false

--- a/packetbeat/config/agent.go
+++ b/packetbeat/config/agent.go
@@ -35,10 +35,10 @@ type datastream struct {
 }
 
 type agentInput struct {
-	Type       string                   `config:"type"`
-	Datastream datastream               `config:"data_stream"`
-	Processors []mapstr.M               `config:"processors"`
-	Streams    []map[string]interface{} `config:"streams"`
+	Type       string           `config:"type"`
+	Datastream datastream       `config:"data_stream"`
+	Processors []mapstr.M       `config:"processors"`
+	Streams    []map[string]any `config:"streams"`
 }
 
 func defaultDevice() string {
@@ -92,15 +92,9 @@ func (i agentInput) addProcessorsAndIndex(cfg *conf.C) (*conf.C, error) {
 }
 
 func mergeProcsConfig(one, two procs.ProcsConfig) procs.ProcsConfig {
-	maxProcReadFreq := one.MaxProcReadFreq
-	if two.MaxProcReadFreq > maxProcReadFreq {
-		maxProcReadFreq = two.MaxProcReadFreq
-	}
+	maxProcReadFreq := max(two.MaxProcReadFreq, one.MaxProcReadFreq)
 
-	refreshPidsFreq := one.RefreshPidsFreq
-	if two.RefreshPidsFreq < refreshPidsFreq {
-		refreshPidsFreq = two.RefreshPidsFreq
-	}
+	refreshPidsFreq := min(two.RefreshPidsFreq, one.RefreshPidsFreq)
 
 	return procs.ProcsConfig{
 		Enabled:         true,

--- a/packetbeat/config/agent_test.go
+++ b/packetbeat/config/agent_test.go
@@ -93,9 +93,9 @@ streams:
 	require.Equal(t, config.Flows.Index, "logs-packet.flow-default")
 	require.Len(t, config.ProtocolsList, 2)
 
-	var protocol map[string]interface{}
+	var protocol map[string]any
 	require.NoError(t, config.ProtocolsList[0].Unpack(&protocol))
-	require.Len(t, protocol["processors"].([]interface{}), 3)
+	require.Len(t, protocol["processors"].([]any), 3)
 	require.Equal(t, "default_route", config.Interfaces[0].Device)
 	require.Equal(t, "en1", config.Interfaces[1].Device)
 	require.Equal(t, "en2", config.Interfaces[2].Device)

--- a/packetbeat/config/config_test.go
+++ b/packetbeat/config/config_test.go
@@ -64,11 +64,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -107,11 +107,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -140,11 +140,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -179,11 +179,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -221,11 +221,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -270,11 +270,11 @@ protocols:
 			},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -324,11 +324,11 @@ protocols:
 			},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -368,11 +368,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -411,11 +411,11 @@ protocols:
 			}},
 			Protocols: map[string]*config.C{},
 			ProtocolsList: []*config.C{
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"enabled": true,
 					"type":    "icmp",
 				}),
-				config.MustNewConfigFrom(map[string]interface{}{
+				config.MustNewConfigFrom(map[string]any{
 					"type": "amqp",
 					"ports": []int{
 						5672,
@@ -455,7 +455,7 @@ protocols:
 				{
 					Device:      "any",
 					Type:        "af_packet",
-					FanoutGroup: pointer(uint16(1)),
+					FanoutGroup: new(uint16(1)),
 				},
 			},
 		},
@@ -531,7 +531,7 @@ func cliOptions(file string, loop int, topSpeed, step bool, dump string) Config 
 }
 
 func configC(a, b *config.C) bool {
-	var ma, mb map[string]interface{}
+	var ma, mb map[string]any
 	err := a.Unpack(&ma)
 	if err != nil {
 		panic(err)
@@ -544,6 +544,8 @@ func configC(a, b *config.C) bool {
 }
 
 // pointer returns a pointer to val.
+//
+//go:fix inline
 func pointer[T any](val T) *T {
-	return &val
+	return new(val)
 }

--- a/packetbeat/config/config_test.go
+++ b/packetbeat/config/config_test.go
@@ -542,10 +542,3 @@ func configC(a, b *config.C) bool {
 	}
 	return cmp.Equal(ma, mb)
 }
-
-// pointer returns a pointer to val.
-//
-//go:fix inline
-func pointer[T any](val T) *T {
-	return new(val)
-}

--- a/packetbeat/decoder/decoder_test.go
+++ b/packetbeat/decoder/decoder_test.go
@@ -20,6 +20,7 @@
 package decoder
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -258,8 +259,8 @@ func TestFragment(t *testing.T) {
 		d, tcp, udp := newTestDecoder(t)
 
 		// Reverse the order of the packets.
-		for i := len(packets) - 1; i >= 0; i-- {
-			p := packets[i]
+		for _, v := range slices.Backward(packets) {
+			p := v
 			d.OnPacket(p.Data(), &p.Metadata().CaptureInfo)
 		}
 

--- a/packetbeat/flows/counters.go
+++ b/packetbeat/flows/counters.go
@@ -23,7 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-type Var interface{}
+type Var any
 
 type flagsInfo struct {
 	i    int

--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -149,10 +149,7 @@ func newFlowsWorker(
 	ticksTimeout := 1
 	ticksPeriod := -1
 	if period > 0 {
-		tick = gcd(timeout, period)
-		if tick < time.Second {
-			tick = time.Second
-		}
+		tick = max(gcd(timeout, period), time.Second)
 
 		ticksTimeout = int(timeout / tick)
 		if ticksTimeout == 0 {
@@ -551,8 +548,8 @@ func formatHardwareAddr(addr net.HardwareAddr) string {
 	return string(buf)
 }
 
-func encodeStats(stats *flowStats, ints, uints, floats []string, enableDeltaFlowReporting bool) map[string]interface{} {
-	report := make(map[string]interface{})
+func encodeStats(stats *flowStats, ints, uints, floats []string, enableDeltaFlowReporting bool) map[string]any {
+	report := make(map[string]any)
 
 	i := 0
 	for _, mask := range stats.intFlags {

--- a/packetbeat/flows/worker_test.go
+++ b/packetbeat/flows/worker_test.go
@@ -67,33 +67,33 @@ func TestCreateEvent(t *testing.T) {
 	event := createEvent(&procs.ProcessesWatcher{}, time.Now(), bif, true, nil, []string{"bytes", "packets"}, nil, false)
 
 	// Validate the contents of the event.
-	validate := lookslike.MustCompile(map[string]interface{}{
-		"source": map[string]interface{}{
+	validate := lookslike.MustCompile(map[string]any{
+		"source": map[string]any{
 			"mac":     "01-02-03-04-05-06",
 			"ip":      "203.0.113.3",
 			"port":    port1,
 			"bytes":   uint64(10),
 			"packets": uint64(1),
 		},
-		"destination": map[string]interface{}{
+		"destination": map[string]any{
 			"mac":     "06-05-04-03-02-01",
 			"ip":      "198.51.100.2",
 			"port":    port2,
 			"bytes":   uint64(460),
 			"packets": uint64(2),
 		},
-		"flow": map[string]interface{}{
+		"flow": map[string]any{
 			"id":    isdef.KeyPresent,
 			"final": true,
 			"vlan":  isdef.KeyPresent,
 		},
-		"network": map[string]interface{}{
+		"network": map[string]any{
 			"bytes":     uint64(470),
 			"packets":   uint64(3),
 			"type":      "ipv4",
 			"transport": "tcp",
 		},
-		"event": map[string]interface{}{
+		"event": map[string]any{
 			"start":    isdef.KeyPresent,
 			"end":      isdef.KeyPresent,
 			"duration": isdef.KeyPresent,

--- a/packetbeat/module/pipeline.go
+++ b/packetbeat/module/pipeline.go
@@ -42,7 +42,7 @@ var errNoFS = errors.New("no embedded file system")
 
 type pipeline struct {
 	id       string
-	contents map[string]interface{}
+	contents map[string]any
 }
 
 // UploadPipelines reads all pipelines embedded in the Packetbeat executable
@@ -148,9 +148,9 @@ func load(esClient *eslegclient.Connection, pipelines []pipeline, overwritePipel
 	return loaded, nil
 }
 
-func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]interface{}, err error) {
-	vars := map[string]interface{}{
-		"builtin": map[string]interface{}{
+func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]any, err error) {
+	vars := map[string]any{
+		"builtin": map[string]any{
 			"prefix":      prefix,
 			"module":      "",
 			"fileset":     "",
@@ -163,7 +163,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 		return nil, fmt.Errorf("failed to apply template: %w", err)
 	}
 
-	var content map[string]interface{}
+	var content map[string]any
 	switch extension := strings.ToLower(filepath.Ext(filename)); extension {
 	case ".json":
 		if err = json.Unmarshal([]byte(encodedString), &content); err != nil {
@@ -178,7 +178,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 			return nil, fmt.Errorf("failed to sanitize the YAML pipeline file: %s: %w", filename, err)
 		}
 		//nolint:errcheck // ignore
-		content = newContent.(map[string]interface{})
+		content = newContent.(map[string]any)
 	default:
 		return nil, fmt.Errorf("unsupported extension '%s' for pipeline file: %s", extension, filename)
 	}

--- a/packetbeat/pb/event.go
+++ b/packetbeat/pb/event.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -321,20 +322,16 @@ func hostBasedDirection(source, destination net.IP, ips []net.IP) string {
 		if destination.IsLoopback() || destination.IsLinkLocalUnicast() || destination.IsLinkLocalMulticast() {
 			return Ingress
 		}
-		for _, ip := range ips {
-			if destination.Equal(ip) {
-				return Ingress
-			}
+		if slices.ContainsFunc(ips, destination.Equal) {
+			return Ingress
 		}
 	}
 	if source != nil {
 		if source.IsLoopback() || source.IsLinkLocalUnicast() || source.IsLinkLocalMulticast() {
 			return Egress
 		}
-		for _, ip := range ips {
-			if source.Equal(ip) {
-				return Egress
-			}
+		if slices.ContainsFunc(ips, source.Equal) {
+			return Egress
 		}
 	}
 	return Unknown
@@ -365,7 +362,7 @@ func perimeterBasedDirection(source, destination net.IP, internalNetworks []stri
 // is a problem writing the keys to the given map (like if an intermediate key
 // exists and is not a map).
 func (f *Fields) MarshalMapStr(m mapstr.M) error {
-	typ := reflect.TypeOf(*f)
+	typ := reflect.TypeFor[Fields]()
 	val := reflect.ValueOf(*f)
 
 	for i := 0; i < typ.NumField(); i++ {
@@ -396,13 +393,13 @@ func (f *Fields) MarshalMapStr(m mapstr.M) error {
 
 // MarshalStruct marshals any struct containing ecs or packetbeat tags into the
 // given MapStr. Zero-value and nil fields are always omitted.
-func MarshalStruct(m mapstr.M, key string, val interface{}) error {
+func MarshalStruct(m mapstr.M, key string, val any) error {
 	return marshalStruct(m, key, reflect.ValueOf(val))
 }
 
 func marshalStruct(m mapstr.M, key string, val reflect.Value) error {
 	// Dereference pointers.
-	if val.Type().Kind() == reflect.Ptr {
+	if val.Type().Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return nil
 		}
@@ -417,7 +414,7 @@ func marshalStruct(m mapstr.M, key string, val reflect.Value) error {
 
 	typ := val.Type()
 	// pre-emptively handle time
-	if reflect.TypeOf(time.Time{}) == typ {
+	if reflect.TypeFor[time.Time]() == typ {
 		_, err := m.Put(key, val.Interface())
 		if err != nil {
 			return fmt.Errorf("error creating time value: %w", err)
@@ -463,7 +460,7 @@ func marshalStruct(m mapstr.M, key string, val reflect.Value) error {
 			}
 			// look for a struct or pointer to a struct
 			// that reflect.Ptr check is needed so Elem() doesn't panic
-		} else if (structField.Type.Kind() == reflect.Ptr && fieldValue.Elem().Kind() == reflect.Struct) ||
+		} else if (structField.Type.Kind() == reflect.Pointer && fieldValue.Elem().Kind() == reflect.Struct) ||
 			structField.Type.Kind() == reflect.Struct {
 			if err := marshalStruct(m, key+"."+tag, fieldValue); err != nil {
 				return err
@@ -502,7 +499,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()
 	}
 

--- a/packetbeat/processor/add_kubernetes_metadata/indexers.go
+++ b/packetbeat/processor/add_kubernetes_metadata/indexers.go
@@ -30,7 +30,7 @@ func InitializeModule() {
 	// Add IP Port Indexer as a default indexer
 	kubernetes.Indexing.AddDefaultIndexerConfig(kubernetes.IPPortIndexerName, *cfg)
 
-	formatCfg, err := conf.NewConfigFrom(map[string]interface{}{
+	formatCfg, err := conf.NewConfigFrom(map[string]any{
 		"format": "%{[ip]}:%{[port]}",
 	})
 	if err == nil {

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -19,6 +19,7 @@ package procs
 
 import (
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -188,12 +189,7 @@ func (proc *ProcessesWatcher) isLocalIP(ip net.IP) bool {
 	if ip.IsLoopback() {
 		return true
 	}
-	for _, addr := range proc.localAddrs {
-		if ip.Equal(addr) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(proc.localAddrs, ip.Equal)
 }
 
 func (proc *ProcessesWatcher) findProc(address net.IP, port uint16, transport applayer.Transport) *process {

--- a/packetbeat/procs/procs_linux.go
+++ b/packetbeat/procs/procs_linux.go
@@ -260,7 +260,7 @@ func hexToIpv6(word string) (net.IP, error) {
 	if len(word) < 32 {
 		return nil, fmt.Errorf("got ip6 address of invalid length: %d", len(word))
 	}
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		start := i * 8
 		end := (i + 1) * 8
 		part, err := strconv.ParseUint(word[start:end], 16, 32)

--- a/packetbeat/procs/procs_linux_test.go
+++ b/packetbeat/procs/procs_linux_test.go
@@ -22,6 +22,7 @@ package procs
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -139,13 +140,7 @@ func createFakeDirectoryStructure(prefix string, files []testProcFile) error {
 
 func assertUint64ArraysAreEqual(t *testing.T, expected []uint64, result []uint64) bool {
 	for _, ex := range expected {
-		found := false
-		for _, res := range result {
-			if ex == res {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(result, ex)
 		if !found {
 			t.Errorf("Expected array %v but got %v", expected, result)
 			return false

--- a/packetbeat/procs/procs_windows.go
+++ b/packetbeat/procs/procs_windows.go
@@ -115,7 +115,7 @@ func parseTable(data []byte, extractor extractor) error {
 	if lim < n*rowSize+sizeOfDWORD {
 		return errors.New("data table too small for its contents")
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ptr := unsafe.Pointer(&data[sizeOfDWORD+i*rowSize])
 		extractor.Extract(ptr)
 	}

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -92,14 +92,14 @@ func New(
 }
 
 //go:inline
-func (amqp *amqpPlugin) debugf(format string, args ...interface{}) {
+func (amqp *amqpPlugin) debugf(format string, args ...any) {
 	if amqp.isDebug {
 		amqp.amqpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (amqp *amqpPlugin) detailedf(format string, args ...interface{}) {
+func (amqp *amqpPlugin) detailedf(format string, args ...any) {
 	if amqp.isDetailed {
 		amqp.amqpDetailedLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -83,7 +83,7 @@ func New(
 }
 
 //go:inline
-func (cassandra *cassandra) debugf(format string, args ...interface{}) {
+func (cassandra *cassandra) debugf(format string, args ...any) {
 	if cassandra.isDebug {
 		cassandra.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/cassandra/internal/gocql/frame.go
+++ b/packetbeat/protos/cassandra/internal/gocql/frame.go
@@ -41,8 +41,8 @@ type frameHeader struct {
 	CustomPayload map[string][]byte
 }
 
-func (f frameHeader) ToMap() map[string]interface{} {
-	data := make(map[string]interface{})
+func (f frameHeader) ToMap() map[string]any {
+	data := make(map[string]any)
 	data["version"] = fmt.Sprintf("%d", f.Version.version())
 	data["flags"] = getHeadFlagString(f.Flags)
 	data["stream"] = f.Stream
@@ -56,7 +56,7 @@ func (f frameHeader) String() string {
 }
 
 var framerPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Framer{compres: nil, isCompressed: false, Header: nil, r: nil, decoder: nil}
 	},
 }
@@ -168,7 +168,7 @@ func (f *Framer) ReadHeader() (head *frameHeader, err error) {
 }
 
 // reads a frame form the wire into the framers buffer
-func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
+func (f *Framer) ReadFrame() (data map[string]any, err error) {
 	defer func() {
 		// The casandra plugin uses panic for flow control, panicking on
 		// errors, so return recovered errors unless they are runtime.Error.
@@ -189,7 +189,7 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	decoder.r = f.r
 	f.decoder = decoder
 
-	data = make(map[string]interface{})
+	data = make(map[string]any)
 
 	// Only QUERY, PREPARE and EXECUTE queries support tracing
 	// If a response frame has the tracing flag set, its body contains
@@ -275,18 +275,18 @@ func (f *Framer) ReadFrame() (data map[string]interface{}, err error) {
 	return data, nil
 }
 
-func (f *Framer) parseErrorFrame() (data map[string]interface{}) {
+func (f *Framer) parseErrorFrame() (data map[string]any) {
 	decoder := f.decoder
 	code := decoder.ReadInt()
 	msg := decoder.ReadString()
 
 	errT := ErrType(code)
 
-	data = make(map[string]interface{})
+	data = make(map[string]any)
 	data["code"] = code
 	data["msg"] = msg
 	data["type"] = errT.String()
-	detail := map[string]interface{}{}
+	detail := map[string]any{}
 	switch errT {
 	case errUnavailable:
 		cl := decoder.ReadConsistency()
@@ -368,15 +368,15 @@ func (f *Framer) parseErrorFrame() (data map[string]interface{}) {
 	return data
 }
 
-func (f *Framer) parseSupportedFrame() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseSupportedFrame() (data map[string]any) {
+	data = make(map[string]any)
 	data["supported"] = (f.decoder).ReadStringMultiMap()
 	return data
 }
 
-func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]interface{} {
+func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]any {
 	decoder := f.decoder
-	meta := make(map[string]interface{})
+	meta := make(map[string]any)
 	flags := decoder.ReadInt()
 	meta["flags"] = getRowFlagString(flags)
 	colCount := decoder.ReadInt()
@@ -387,7 +387,7 @@ func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]interface{} {
 		if f.proto >= protoVersion4 {
 			pkeyCount := decoder.ReadInt()
 			pkeys := make([]int, pkeyCount)
-			for i := 0; i < pkeyCount; i++ {
+			for i := range pkeyCount {
 				pkeys[i] = int(decoder.ReadShort())
 			}
 			meta["pkey_columns"] = pkeys
@@ -415,16 +415,16 @@ func (f *Framer) parseResultMetadata(getPKinfo bool) map[string]interface{} {
 	return meta
 }
 
-func (f *Framer) parseQueryFrame() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseQueryFrame() (data map[string]any) {
+	data = make(map[string]any)
 	data["query"] = (f.decoder).ReadLongString()
 	return data
 }
 
-func (f *Framer) parseResultFrame() (data map[string]interface{}) {
+func (f *Framer) parseResultFrame() (data map[string]any) {
 	kind := (f.decoder).ReadInt()
 
-	data = make(map[string]interface{})
+	data = make(map[string]any)
 	switch kind {
 	case resultKindVoid:
 		data["type"] = "void"
@@ -445,16 +445,16 @@ func (f *Framer) parseResultFrame() (data map[string]interface{}) {
 	return data
 }
 
-func (f *Framer) parseResultRows() map[string]interface{} {
-	result := make(map[string]interface{})
+func (f *Framer) parseResultRows() map[string]any {
+	result := make(map[string]any)
 	result["meta"] = f.parseResultMetadata(false)
 	result["num_rows"] = (f.decoder).ReadInt()
 
 	return result
 }
 
-func (f *Framer) parseResultPrepared() map[string]interface{} {
-	result := make(map[string]interface{})
+func (f *Framer) parseResultPrepared() map[string]any {
+	result := make(map[string]any)
 
 	uuid, err := UUIDFromBytes((f.decoder).ReadShortBytes())
 	if err != nil {
@@ -474,8 +474,8 @@ func (f *Framer) parseResultPrepared() map[string]interface{} {
 	return result
 }
 
-func (f *Framer) parseResultSchemaChange() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseResultSchemaChange() (data map[string]any) {
+	data = make(map[string]any)
 	decoder := f.decoder
 	if f.proto <= protoVersion2 {
 		change := decoder.ReadString()
@@ -512,26 +512,26 @@ func (f *Framer) parseResultSchemaChange() (data map[string]interface{}) {
 	return data
 }
 
-func (f *Framer) parseAuthenticateFrame() (data map[string]interface{}) {
-	data = make(map[string]interface{})
+func (f *Framer) parseAuthenticateFrame() (data map[string]any) {
+	data = make(map[string]any)
 	data["class"] = (f.decoder).ReadString()
 	return data
 }
 
-func (f *Framer) parseAuthSuccessFrame() (data map[string]interface{}) {
-	data = make((map[string]interface{}))
+func (f *Framer) parseAuthSuccessFrame() (data map[string]any) {
+	data = make((map[string]any))
 	data["data"] = fmt.Sprintf("%q", (f.decoder).ReadBytes())
 	return data
 }
 
-func (f *Framer) parseAuthChallengeFrame() (data map[string]interface{}) {
-	data = make((map[string]interface{}))
+func (f *Framer) parseAuthChallengeFrame() (data map[string]any) {
+	data = make((map[string]any))
 	data["data"] = fmt.Sprintf("%q", (f.decoder).ReadBytes())
 	return data
 }
 
-func (f *Framer) parseEventFrame() (data map[string]interface{}) {
-	data = make((map[string]interface{}))
+func (f *Framer) parseEventFrame() (data map[string]any) {
+	data = make((map[string]any))
 	decoder := f.decoder
 	eventType := decoder.ReadString()
 	data["type"] = eventType

--- a/packetbeat/protos/cassandra/internal/gocql/marshal.go
+++ b/packetbeat/protos/cassandra/internal/gocql/marshal.go
@@ -39,7 +39,7 @@ type TypeInfo interface {
 
 	// New creates a pointer to an empty version of whatever type
 	// is referenced by the TypeInfo receiver
-	New() interface{}
+	New() any
 }
 
 type NativeType struct {
@@ -48,7 +48,7 @@ type NativeType struct {
 	custom string // only used for TypeCustom
 }
 
-func (t NativeType) New() interface{} {
+func (t NativeType) New() any {
 	return reflect.New(goType(t)).Interface()
 }
 
@@ -82,43 +82,42 @@ type CollectionType struct {
 func goType(t TypeInfo) reflect.Type {
 	switch t.Type() {
 	case TypeVarchar, TypeASCII, TypeInet, TypeText:
-		return reflect.TypeOf(*new(string))
+		return reflect.TypeFor[string]()
 	case TypeBigInt, TypeCounter:
-		return reflect.TypeOf(*new(int64))
+		return reflect.TypeFor[int64]()
 	case TypeTimestamp:
-		return reflect.TypeOf(*new(time.Time))
+		return reflect.TypeFor[time.Time]()
 	case TypeBlob:
-		return reflect.TypeOf(*new([]byte))
+		return reflect.TypeFor[[]byte]()
 	case TypeBoolean:
-		return reflect.TypeOf(*new(bool))
+		return reflect.TypeFor[bool]()
 	case TypeFloat:
-		return reflect.TypeOf(*new(float32))
+		return reflect.TypeFor[float32]()
 	case TypeDouble:
-		return reflect.TypeOf(*new(float64))
+		return reflect.TypeFor[float64]()
 	case TypeInt:
-		return reflect.TypeOf(*new(int))
+		return reflect.TypeFor[int]()
 	case TypeDecimal:
-		return reflect.TypeOf(*new(*inf.Dec))
+		return reflect.TypeFor[*inf.Dec]()
 	case TypeUUID, TypeTimeUUID:
-		return reflect.TypeOf(*new(UUID))
+		return reflect.TypeFor[UUID]()
 	case TypeList, TypeSet:
 		return reflect.SliceOf(goType(t.(CollectionType).Elem))
 	case TypeMap:
 		return reflect.MapOf(goType(t.(CollectionType).Key), goType(t.(CollectionType).Elem))
 	case TypeVarint:
-		return reflect.TypeOf(*new(*big.Int))
+		return reflect.TypeFor[*big.Int]()
 	case TypeTuple:
 		// what can we do here? all there is to do is to make a list of interface{}
-		tuple := t.(TupleTypeInfo)
-		return reflect.TypeOf(make([]interface{}, len(tuple.Elems)))
+		return reflect.TypeFor[[]any]()
 	case TypeUDT:
-		return reflect.TypeOf(make(map[string]interface{}))
+		return reflect.TypeFor[map[string]any]()
 	default:
 		return nil
 	}
 }
 
-func (t CollectionType) New() interface{} {
+func (t CollectionType) New() any {
 	return reflect.New(goType(t)).Interface()
 }
 
@@ -140,7 +139,7 @@ type TupleTypeInfo struct {
 	Elems []TypeInfo
 }
 
-func (t TupleTypeInfo) New() interface{} {
+func (t TupleTypeInfo) New() any {
 	return reflect.New(goType(t)).Interface()
 }
 
@@ -156,7 +155,7 @@ type UDTTypeInfo struct {
 	Elements []UDTField
 }
 
-func (u UDTTypeInfo) New() interface{} {
+func (u UDTTypeInfo) New() any {
 	return reflect.New(goType(u)).Interface()
 }
 

--- a/packetbeat/protos/cassandra/parser.go
+++ b/packetbeat/protos/cassandra/parser.go
@@ -59,8 +59,8 @@ type message struct {
 	failed  bool
 	ignored bool
 
-	data   map[string]interface{}
-	header map[string]interface{}
+	data   map[string]any
+	header map[string]any
 	// list element use by 'transactions' for correlation
 	next *message
 
@@ -87,7 +87,7 @@ func (p *parser) init(
 
 }
 
-func (p *parser) debugf(format string, args ...interface{}) {
+func (p *parser) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -513,8 +513,8 @@ func addDNSToMapStr(m mapstr.M, pbf *pb.Fields, dns *mkdns.Msg, authority bool, 
 			qMapStr["etld_plus_one"] = eTLDPlusOne
 			qMapStr["registered_domain"] = eTLDPlusOne
 
-			if idx := strings.IndexByte(eTLDPlusOne, '.'); idx != -1 {
-				qMapStr["top_level_domain"] = eTLDPlusOne[idx+1:]
+			if _, after, ok := strings.Cut(eTLDPlusOne, "."); ok {
+				qMapStr["top_level_domain"] = after
 			}
 
 			subdomain := strings.TrimRight(strings.TrimSuffix(q.Name, eTLDPlusOne), ".")

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -60,8 +60,8 @@ type dnsTestMessage struct {
 	qType       string
 	qName       string
 	qEtld       string
-	qSubdomain  interface{}
-	qTLD        interface{}
+	qSubdomain  any
+	qTLD        any
 	answers     []string
 	authorities []string
 	additionals []string
@@ -107,7 +107,7 @@ func newDNS(store *eventStore, verbose bool) *dnsPlugin {
 		callback = store.publish
 	}
 
-	cfg, _ := conf.NewConfigFrom(map[string]interface{}{
+	cfg, _ := conf.NewConfigFrom(map[string]any{
 		"ports":               []int{serverPort},
 		"include_authorities": true,
 		"include_additionals": true,
@@ -144,13 +144,13 @@ func expectResult(t testing.TB, e *eventStore) mapstr.M {
 }
 
 // Retrieves a map value. The key should be the full dotted path to the element.
-func mapValue(t testing.TB, m mapstr.M, key string) interface{} {
+func mapValue(t testing.TB, m mapstr.M, key string) any {
 	t.Helper()
 	return mapValueHelper(t, m, strings.Split(key, "."))
 }
 
 // Retrieves nested MapStr values.
-func mapValueHelper(t testing.TB, m mapstr.M, keys []string) interface{} {
+func mapValueHelper(t testing.TB, m mapstr.M, keys []string) any {
 	t.Helper()
 
 	key := keys[0]
@@ -170,7 +170,7 @@ func mapValueHelper(t testing.TB, m mapstr.M, keys []string) interface{} {
 		case mapstr.M:
 			return mapValueHelper(t, typ, keys[1:])
 		case []mapstr.M:
-			var values []interface{}
+			var values []any
 			for _, m := range typ {
 				values = append(values, mapValueHelper(t, m, keys[1:]))
 			}

--- a/packetbeat/protos/dns/names.go
+++ b/packetbeat/protos/dns/names.go
@@ -99,11 +99,11 @@ func dnsHashToString(h uint8) string {
 // string representation is unknown then the numeric value will be returned
 // as a string.
 func dnsTypeBitsMapToString(t []uint16) string {
-	var s string
-	for i := 0; i < len(t); i++ {
-		s += dnsTypeToString(t[i]) + " "
+	var s strings.Builder
+	for i := range t {
+		s.WriteString(dnsTypeToString(t[i]) + " ")
 	}
-	return strings.TrimSuffix(s, " ")
+	return strings.TrimSuffix(s.String(), " ")
 }
 
 // saltToString converts a NSECX salt to uppercase and
@@ -133,7 +133,7 @@ func hexStringToString(hexString string) (string, error) {
 		default:
 			if value < 32 || value >= 127 {
 				// Unprintable characters are written as \\DDD (e.g. \\012).
-				s = append(s, []byte(fmt.Sprintf("\\%03d", int(value)))...)
+				s = append(s, fmt.Appendf(nil, "\\%03d", int(value))...)
 			} else {
 				s = append(s, value)
 			}

--- a/packetbeat/protos/http/decode.go
+++ b/packetbeat/protos/http/decode.go
@@ -86,10 +86,7 @@ func readMax(reader io.Reader, maxSize int) (result []byte, err error) {
 	const minSize = 512
 	for used := 0; ; {
 		if len(result)-used < minSize {
-			grow := len(result) >> 1
-			if grow < minSize {
-				grow = minSize
-			}
+			grow := max(len(result)>>1, minSize)
 			result = append(result, make([]byte, grow)...)
 		}
 		n, err := reader.Read(result[used:])

--- a/packetbeat/protos/http/event_test.go
+++ b/packetbeat/protos/http/event_test.go
@@ -27,8 +27,8 @@ import (
 // TestProtocolFieldsIsInSyncWithECS ensures that Packetbeat's clone of
 // ecs.Http stays in sync.
 func TestProtocolFieldsIsInSyncWithECS(t *testing.T) {
-	ecs := getFields(reflect.TypeOf(ecs.Http{}))
-	packetbeat := getFields(reflect.TypeOf(ProtocolFields{}))
+	ecs := getFields(reflect.TypeFor[ecs.Http]())
+	packetbeat := getFields(reflect.TypeFor[ProtocolFields]())
 
 	for name := range ecs {
 		_, found := packetbeat[name]
@@ -45,8 +45,7 @@ func TestProtocolFieldsIsInSyncWithECS(t *testing.T) {
 
 func getFields(typ reflect.Type) map[string]reflect.Type {
 	fields := map[string]reflect.Type{}
-	for i := 0; i < typ.NumField(); i++ {
-		structField := typ.Field(i)
+	for structField := range typ.Fields() {
 		tag := structField.Tag.Get("ecs")
 		if tag == "" {
 			continue

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -22,8 +22,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -132,14 +134,14 @@ func New(
 }
 
 //go:inline
-func (p *httpPlugin) debugf(format string, args ...interface{}) {
+func (p *httpPlugin) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.httpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (p *httpPlugin) detailedf(format string, args ...interface{}) {
+func (p *httpPlugin) detailedf(format string, args ...any) {
 	if p.isDetail {
 		p.httpDetailedLogger.Debugf(format, args...)
 	}
@@ -647,7 +649,7 @@ func (http *httpPlugin) publishTransaction(event beat.Event) {
 }
 
 func (http *httpPlugin) collectHeaders(m *message) mapstr.M {
-	hdrs := map[string]interface{}{}
+	hdrs := map[string]any{}
 
 	hdrs["content-length"] = m.contentLength
 	if len(m.contentType) > 0 {
@@ -694,8 +696,8 @@ func decodeBody(body []byte, encodings []string, maxSize int, logger *logp.Logge
 	if logger.IsDebug() {
 		logger.Debugf("decoding body with encodings=%v", encodings)
 	}
-	for idx := len(encodings) - 1; idx >= 0; idx-- {
-		format := encodings[idx]
+	for idx, v := range slices.Backward(encodings) {
+		format := v
 		body, err = decodeHTTPBody(body, format, maxSize)
 		if err != nil {
 			// Do not output a partial body unless failure occurs on the
@@ -712,8 +714,8 @@ func decodeBody(body []byte, encodings []string, maxSize int, logger *logp.Logge
 func splitCookiesHeader(headerVal string) map[string]string {
 	cookies := map[string]string{}
 
-	cstring := strings.Split(headerVal, ";")
-	for _, cval := range cstring {
+	cstring := strings.SplitSeq(headerVal, ";")
+	for cval := range cstring {
 		cookie := strings.SplitN(cval, "=", 2)
 		if len(cookie) == 2 {
 			cookies[strings.ToLower(strings.TrimSpace(cookie[0]))] = parseCookieValue(strings.TrimSpace(cookie[1]))
@@ -789,11 +791,7 @@ func (http *httpPlugin) hideHeaders(m *message) {
 
 			endOfHeader := bytes.Index(msg[authHeaderStartX:], constCRLF)
 			if endOfHeader >= 0 {
-				authHeaderEndX = authHeaderStartX + endOfHeader
-
-				if authHeaderEndX > limit {
-					authHeaderEndX = limit
-				}
+				authHeaderEndX = min(authHeaderStartX+endOfHeader, limit)
 
 				http.debugf("Redact authorization from %d to %d", authHeaderStartX, authHeaderEndX)
 
@@ -849,9 +847,7 @@ func (http *httpPlugin) extractParameters(m *message) (path string, params strin
 			return
 		}
 
-		for key, value := range http.hideSecrets(values) {
-			paramsMap[key] = value
-		}
+		maps.Copy(paramsMap, http.hideSecrets(values))
 	}
 
 	params = paramsMap.Encode()
@@ -860,12 +856,7 @@ func (http *httpPlugin) extractParameters(m *message) (path string, params strin
 }
 
 func (http *httpPlugin) isSecretParameter(key string) bool {
-	for _, keyword := range http.hideKeywords {
-		if strings.ToLower(key) == keyword {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(http.hideKeywords, strings.ToLower(key))
 }
 
 func (http *httpPlugin) Expired(tuple *common.TCPTuple, private protos.ProtocolData) {
@@ -935,10 +926,10 @@ func extractBasicAuthUser(headers map[string]common.NetString) string {
 	}
 
 	cs := string(c)
-	s := strings.IndexByte(cs, ':')
-	if s < 0 {
+	before, _, ok := strings.Cut(cs, ":")
+	if !ok {
 		return ""
 	}
 
-	return cs[:s]
+	return before
 }

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -137,14 +137,14 @@ func newParser(config *parserConfig, httpLogger, httpDetailedLogger *logp.Logger
 }
 
 //go:inline
-func (parser *parser) debugf(format string, args ...interface{}) {
+func (parser *parser) debugf(format string, args ...any) {
 	if parser.httpLogger.IsDebug() {
 		parser.httpLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (parser *parser) detailedf(format string, args ...interface{}) {
+func (parser *parser) detailedf(format string, args ...any) {
 	if parser.httpDetailedLogger.IsDebug() {
 		parser.httpDetailedLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -988,8 +988,8 @@ func TestHttpParser_RedactAuthorization_raw(t *testing.T) {
 		t.Errorf("Expecting a complete message")
 	}
 
-	rawMessageObscured := bytes.Index(msg, []byte("uthorization:*"))
-	if rawMessageObscured < 0 {
+	found := bytes.Contains(msg, []byte("uthorization:*"))
+	if !found {
 		t.Error("Obscured authorization string not found: " + string(msg[:]))
 	}
 }
@@ -1023,8 +1023,8 @@ func TestHttpParser_RedactAuthorization_Proxy_raw(t *testing.T) {
 		t.Errorf("Expecting a complete message")
 	}
 
-	rawMessageObscured := bytes.Index(msg, []byte("uthorization:*"))
-	if rawMessageObscured < 0 {
+	found := bytes.Contains(msg, []byte("uthorization:*"))
+	if !found {
 		t.Error("Failed to redact proxy-authorization header: " + string(msg[:]))
 	}
 }
@@ -2060,7 +2060,7 @@ func BenchmarkHttpLargeResponseBody(b *testing.B) {
 	const BodySize = 10 * 1024 * PacketSize
 	const numPackets = BodySize / PacketSize
 	bodyPayload := &protos.Packet{Payload: make([]byte, PacketSize)}
-	for i := 0; i < PacketSize; i++ {
+	for i := range PacketSize {
 		bodyPayload.Payload[i] = byte(0x30 + (i % 10))
 	}
 
@@ -2077,7 +2077,7 @@ func BenchmarkHttpLargeResponseBody(b *testing.B) {
 		private := protos.ProtocolData(&httpConnectionData{})
 		private = http.Parse(&headPkt, tcptuple, 0, private)
 
-		for j := 0; j < numPackets; j++ {
+		for range numPackets {
 			private = http.Parse(bodyPayload, tcptuple, 0, private)
 		}
 		http.ReceivedFin(tcptuple, 1, private)

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -156,7 +156,7 @@ func New(
 	return p, nil
 }
 
-func (mc *memcache) debugf(format string, args ...interface{}) {
+func (mc *memcache) debugf(format string, args ...any) {
 	if mc.isDebug {
 		mc.logger.Debugf(format, args...)
 	}
@@ -311,10 +311,7 @@ func mergeValueMessages(mc *memcache, prev, msg *message) (bool, error) {
 		if mc.config.maxValues < 0 {
 			delta = len(msg.values)
 		} else if len(prev.values) < mc.config.maxValues {
-			delta = mc.config.maxValues - len(prev.values)
-			if delta > len(prev.values) {
-				delta = len(prev.values)
-			}
+			delta = min(mc.config.maxValues-len(prev.values), len(prev.values))
 		}
 
 		prev.values = append(prev.values, msg.values[0:delta]...)

--- a/packetbeat/protos/memcache/parse.go
+++ b/packetbeat/protos/memcache/parse.go
@@ -77,7 +77,7 @@ func newParser(config *parserConfig, logger *logp.Logger) *parser {
 }
 
 //go:inline
-func (p *parser) debugf(format string, args ...interface{}) {
+func (p *parser) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -19,6 +19,8 @@ package mongodb
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -89,7 +91,7 @@ func New(
 }
 
 //go:inline
-func (mongodb *mongodbPlugin) debugf(format string, v ...interface{}) {
+func (mongodb *mongodbPlugin) debugf(format string, v ...any) {
 	if mongodb.isDebug {
 		mongodb.logger.Debugf(format, v...)
 	}
@@ -327,9 +329,7 @@ func newTransaction(requ, resp *mongodbMessage) *transaction {
 
 	// fill response
 	if resp != nil {
-		for k, v := range resp.event {
-			trans.event[k] = v
-		}
+		maps.Copy(trans.event, resp.event)
 
 		trans.error = resp.error
 		trans.documents = resp.documents
@@ -352,16 +352,10 @@ func (mongodb *mongodbPlugin) ReceivedFin(tcptuple *common.TCPTuple, dir uint8,
 	return private
 }
 
-func copyMapWithoutKey(d map[string]interface{}, keys ...string) map[string]interface{} {
-	res := map[string]interface{}{}
+func copyMapWithoutKey(d map[string]any, keys ...string) map[string]any {
+	res := map[string]any{}
 	for k, v := range d {
-		found := false
-		for _, excludeKey := range keys {
-			if k == excludeKey {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(keys, k)
 		if !found {
 			res[k] = v
 		}
@@ -371,7 +365,7 @@ func copyMapWithoutKey(d map[string]interface{}, keys ...string) map[string]inte
 
 func reconstructQuery(t *transaction, full bool, logger *logp.Logger) (query string) {
 	query = t.resource + "." + t.method + "("
-	var doc interface{}
+	var doc any
 
 	if len(t.params) > 0 {
 		if !full {

--- a/packetbeat/protos/mongodb/mongodb_parser.go
+++ b/packetbeat/protos/mongodb/mongodb_parser.go
@@ -164,8 +164,8 @@ func opReplyParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, boo
 
 	logger.Debugf("Prepare to read %d document from reply", m.event["numberReturned"])
 
-	documents := make([]interface{}, numberReturned)
-	for i := int32(0); i < numberReturned; i++ {
+	documents := make([]any, numberReturned)
+	for i := range numberReturned {
 		var document bson.M
 		document, err = d.readDocument(logger)
 		if err != nil {
@@ -261,7 +261,7 @@ func opInsertParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bo
 
 // Try to guess whether this key:value pair found in
 // the query represents a command.
-func isDatabaseCommand(key string, val interface{}) bool {
+func isDatabaseCommand(key string, val any) bool {
 	nameExists := false
 	for _, cmd := range databaseCommands {
 		if strings.EqualFold(cmd, key) {
@@ -423,7 +423,7 @@ func opMsgParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool)
 			logger.Errorf("An error occurred while parsing OP_MSG message: %s", err)
 			return false, false
 		}
-		m.documents = []interface{}{document}
+		m.documents = []any{document}
 
 	case msgKindDocumentSequence:
 		start := d.i
@@ -449,7 +449,7 @@ func opMsgParse(d *decoder, m *mongodbMessage, logger *logp.Logger) (bool, bool)
 			return false, false
 		}
 		m.event["message"] = cstring
-		var documents []interface{}
+		var documents []any
 		for d.i < start+int(size) {
 			document, err := d.readDocument(logger)
 			if err != nil {
@@ -576,7 +576,7 @@ func (d *decoder) readDocument(logger *logp.Logger) (bson.M, error) {
 	return documentMap, nil
 }
 
-func doc2str(documentMap interface{}) (string, error) {
+func doc2str(documentMap any) (string, error) {
 	document, err := json.Marshal(documentMap)
 	return string(document), err
 }

--- a/packetbeat/protos/mongodb/mongodb_parser_test.go
+++ b/packetbeat/protos/mongodb/mongodb_parser_test.go
@@ -148,7 +148,7 @@ func addInt32(in []byte, v int32) []byte {
 func Test_isDatabaseCommand(t *testing.T) {
 	type io struct {
 		Key   string
-		Value interface{}
+		Value any
 
 		Output bool
 	}

--- a/packetbeat/protos/mongodb/mongodb_structs.go
+++ b/packetbeat/protos/mongodb/mongodb_structs.go
@@ -53,8 +53,8 @@ type mongodbMessage struct {
 	method    string
 	error     string
 	resource  string
-	documents []interface{}
-	params    map[string]interface{}
+	documents []any
+	params    map[string]any
 
 	// Other fields vary very much depending on operation type
 	// lets just put them in a map
@@ -104,9 +104,9 @@ type transaction struct {
 	method           string
 	resource         string
 	error            string
-	params           map[string]interface{}
-	requestDocuments []interface{}
-	documents        []interface{}
+	params           map[string]any
+	requestDocuments []any
+	documents        []any
 }
 
 type msgKind byte

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -240,11 +240,11 @@ func TestReconstructQuery(t *testing.T) {
 			Input: transaction{
 				resource: "test.col",
 				method:   "find",
-				event: map[string]interface{}{
+				event: map[string]any{
 					"numberToSkip":   3,
 					"numberToReturn": 2,
 				},
-				params: map[string]interface{}{
+				params: map[string]any{
 					"me": "you",
 				},
 			},
@@ -255,7 +255,7 @@ func TestReconstructQuery(t *testing.T) {
 			Input: transaction{
 				resource: "test.col",
 				method:   "insert",
-				params: map[string]interface{}{
+				params: map[string]any{
 					"documents": "you",
 				},
 			},
@@ -266,7 +266,7 @@ func TestReconstructQuery(t *testing.T) {
 			Input: transaction{
 				resource: "test.col",
 				method:   "insert",
-				params: map[string]interface{}{
+				params: map[string]any{
 					"documents": "you",
 				},
 			},
@@ -286,7 +286,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// more docs than configured
 	trans := transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2, 3, 4, 5, 6, 7, 8,
 		},
 	}
@@ -303,7 +303,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// exactly the same number of docs
 	trans = transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2, 3,
 		},
 	}
@@ -314,7 +314,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// less docs
 	trans = transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2,
 		},
 	}
@@ -325,7 +325,7 @@ func TestMaxDocs(t *testing.T) {
 
 	// unlimited
 	trans = transaction{
-		documents: []interface{}{
+		documents: []any{
 			1, 2, 3, 4,
 		},
 	}
@@ -339,7 +339,7 @@ func TestMaxDocSize(t *testing.T) {
 
 	// more docs than configured
 	trans := transaction{
-		documents: []interface{}{
+		documents: []any{
 			"1234567",
 			"123",
 			"12",

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -895,7 +895,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 			return nil
 		}
 		// First call or rebound (1)
-		for stmtPos := 0; stmtPos < nparam; stmtPos++ {
+		for range nparam {
 			paramType = data[offset]
 			offset++
 			nparamType = append(nparamType, paramType)
@@ -919,7 +919,7 @@ func (mysql *mysqlPlugin) parseMysqlExecuteStatement(data []byte, stmtdata *mysq
 		}
 	}
 
-	for stmtPos := 0; stmtPos < nparam; stmtPos++ {
+	for stmtPos := range nparam {
 		paramType = nparamType[stmtPos]
 		// dissect parameter on paramType
 		switch paramType {

--- a/packetbeat/protos/nfs/nfs4.go
+++ b/packetbeat/protos/nfs/nfs4.go
@@ -210,7 +210,7 @@ func (nfs *nfs) eatData(op int, xdr *xdr) error {
 		if _, err := xdr.getOpaque(16); err != nil {
 			return err
 		}
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			if _, err := xdr.getUInt(); err != nil {
 				return err
 			}

--- a/packetbeat/protos/nfs/xdr.go
+++ b/packetbeat/protos/nfs/xdr.go
@@ -110,7 +110,7 @@ func (r *xdr) getUIntVector() ([]uint32, error) {
 		return nil, fmt.Errorf("xdr: vector length %d exceeds limit", l)
 	}
 	v := make([]uint32, int(l))
-	for i := 0; i < len(v); i++ {
+	for i := range v {
 		vi, err := r.getUInt()
 		if err != nil {
 			return nil, err

--- a/packetbeat/protos/nfs/xdr_test.go
+++ b/packetbeat/protos/nfs/xdr_test.go
@@ -38,7 +38,7 @@ var testMsg = []byte{
 func BytesToUint32(b []byte) []uint32 {
 	n := len(b) / 4
 	out := make([]uint32, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		out[i] = binary.BigEndian.Uint32(b[i*4:])
 	}
 	return out

--- a/packetbeat/protos/pgsql/parse.go
+++ b/packetbeat/protos/pgsql/parse.go
@@ -423,7 +423,7 @@ func (pgsql *pgsqlPlugin) parseFields(s *pgsqlStream, buf []byte) error {
 	fields := []string{}
 	fieldsFormat := []byte{}
 
-	for i := 0; i < fieldCount; i++ {
+	for range fieldCount {
 		if len(buf) <= off {
 			return errFieldBufferShort
 		}

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -201,14 +201,14 @@ func (pgsql *pgsqlPlugin) getTransaction(k common.HashableTCPTuple) []*pgsqlTran
 }
 
 //go:inline
-func (pgsql *pgsqlPlugin) debugf(format string, v ...interface{}) {
+func (pgsql *pgsqlPlugin) debugf(format string, v ...any) {
 	if pgsql.isDebug {
 		pgsql.debug.Debugf(format, v...)
 	}
 }
 
 //go:inline
-func (pgsql *pgsqlPlugin) detailf(format string, v ...interface{}) {
+func (pgsql *pgsqlPlugin) detailf(format string, v ...any) {
 	if pgsql.isDetail {
 		pgsql.detail.Debugf(format, v...)
 	}

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -20,7 +20,7 @@ package protos
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -40,7 +40,7 @@ const (
 // ProtocolData interface to represent an upper
 // protocol private data. Used with types like
 // HttpStream, MysqlStream, etc.
-type ProtocolData interface{}
+type ProtocolData any
 
 type Packet struct {
 	Ts      time.Time
@@ -298,7 +298,7 @@ func (s ProtocolsStruct) BpfFilter(withVlans bool, withICMP bool) string {
 	for proto := range s.all {
 		protos = append(protos, proto)
 	}
-	sort.Slice(protos, func(i, j int) bool { return protos[i] < protos[j] })
+	slices.Sort(protos)
 
 	var expressions []string
 	for _, proto := range protos {

--- a/packetbeat/protos/protos_test.go
+++ b/packetbeat/protos/protos_test.go
@@ -207,15 +207,15 @@ func TestGetUDP(t *testing.T) {
 func TestValidateProtocolDevice(t *testing.T) {
 	tcs := []struct {
 		testCase, device string
-		config           map[string]interface{}
+		config           map[string]any
 		expectedValid    bool
 		expectedErr      string
 	}{
 		{
 			"DeviceIsIncorrect",
 			"eth0",
-			map[string]interface{}{
-				"interface": map[string]interface{}{
+			map[string]any{
+				"interface": map[string]any{
 					"device": "eth1",
 				},
 			},
@@ -225,8 +225,8 @@ func TestValidateProtocolDevice(t *testing.T) {
 		{
 			"DeviceIsCorrect",
 			"eth1",
-			map[string]interface{}{
-				"interface": map[string]interface{}{
+			map[string]any{
+				"interface": map[string]any{
 					"device": "eth1",
 				},
 			},
@@ -236,7 +236,7 @@ func TestValidateProtocolDevice(t *testing.T) {
 		{
 			"ConfigIsInvalid",
 			"eth0",
-			map[string]interface{}{
+			map[string]any{
 				"interface": "eth1",
 			},
 			false,
@@ -245,7 +245,6 @@ func TestValidateProtocolDevice(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.testCase, func(t *testing.T) {
 			cfg := (*conf.C)(ucfg.MustNewFrom(tc.config))
 			isValid, err := validateProtocolDevice(tc.device, cfg)

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -98,7 +98,7 @@ func New(
 }
 
 //go:inline
-func (redis *redisPlugin) debugf(format string, args ...interface{}) {
+func (redis *redisPlugin) debugf(format string, args ...any) {
 	if redis.isDebug {
 		redis.logger.Debug(fmt.Sprintf(format, args...))
 	}

--- a/packetbeat/protos/sip/parser.go
+++ b/packetbeat/protos/sip/parser.go
@@ -107,14 +107,14 @@ func (pi *parsingInfo) prepareForNewMessage() {
 }
 
 //go:inline
-func (pi *parsingInfo) debugf(format string, args ...interface{}) {
+func (pi *parsingInfo) debugf(format string, args ...any) {
 	if pi.isDebug {
 		pi.sipLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (pi *parsingInfo) detailedf(format string, args ...interface{}) {
+func (pi *parsingInfo) detailedf(format string, args ...any) {
 	if pi.isDetailedDebug {
 		pi.sipDetailedLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/sip/plugin.go
+++ b/packetbeat/protos/sip/plugin.go
@@ -88,14 +88,14 @@ func New(
 }
 
 //go:inline
-func (p *plugin) debugf(format string, args ...interface{}) {
+func (p *plugin) debugf(format string, args ...any) {
 	if p.isDebug {
 		p.sipLogger.Debugf(format, args...)
 	}
 }
 
 //go:inline
-func (p *plugin) detailedf(format string, args ...interface{}) {
+func (p *plugin) detailedf(format string, args ...any) {
 	if p.isDetailed {
 		p.sipDetailedLogger.Debugf(format, args...)
 	}
@@ -589,7 +589,7 @@ func populateAuthFields(m *message, evt beat.Event, pbf *pb.Fields, fields *Prot
 	fields.AuthScheme = auth[:pos]
 
 	pos += 1
-	for _, param := range bytes.Split(auth[pos:], []byte(",")) {
+	for param := range bytes.SplitSeq(auth[pos:], []byte(",")) {
 		kv := bytes.SplitN(param, []byte("="), 2)
 		if len(kv) != 2 {
 			continue
@@ -638,7 +638,7 @@ func populateBodyFields(msg *message, pbf *pb.Fields, fields *ProtocolFields, si
 	fields.SDPBodyOriginal = msg.body
 
 	var isInMedia bool
-	for _, line := range bytes.Split(msg.body, []byte("\r\n")) {
+	for line := range bytes.SplitSeq(msg.body, []byte("\r\n")) {
 		kv := bytes.SplitN(line, []byte("="), 2)
 		if len(kv) != 2 {
 			continue
@@ -761,7 +761,7 @@ func parseFromToContact(fromTo common.NetString) (displayInfo, uri common.NetStr
 
 	// parse the header params
 	pos = endURIPos + 1
-	for _, param := range bytes.Split(fromTo[pos:], []byte(";")) {
+	for param := range bytes.SplitSeq(fromTo[pos:], []byte(";")) {
 		kv := bytes.SplitN(param, []byte("="), 2)
 		if len(kv) != 2 {
 			continue
@@ -844,7 +844,7 @@ loop:
 	}
 
 	if hasParams {
-		for _, param := range bytes.Split(uri[epos+1:], []byte(";")) {
+		for param := range bytes.SplitSeq(uri[epos+1:], []byte(";")) {
 			kv := bytes.Split(param, []byte("="))
 			if len(kv) != 2 {
 				continue

--- a/packetbeat/protos/sip/plugin_test.go
+++ b/packetbeat/protos/sip/plugin_test.go
@@ -190,7 +190,7 @@ func TestParseUDP(t *testing.T) {
 	assert.EqualValues(t, []common.NetString{common.NetString("SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0")}, getVal(fields, "sip.via.original"))
 }
 
-func getVal(f beat.Event, k string) interface{} {
+func getVal(f beat.Event, k string) any {
 	v, _ := f.GetValue(k)
 	return v
 }

--- a/packetbeat/protos/tcp/tcp.go
+++ b/packetbeat/protos/tcp/tcp.go
@@ -87,7 +87,7 @@ func NewTCP(p protos.Protocols, id, device string, idx int, logger *logp.Logger)
 }
 
 //go:inline
-func (tcp *TCP) debugf(format string, args ...interface{}) {
+func (tcp *TCP) debugf(format string, args ...any) {
 	if tcp.isDebug {
 		tcp.logger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -526,7 +526,7 @@ func (thrift *thriftPlugin) readListOrSet(data []byte) (value string, ok bool, c
 	fields := []string{}
 	offset := 5
 
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		value, ok, complete, bytesRead := funcReader(data[offset:])
 		if !ok {
 			return "", false, false, 0
@@ -590,7 +590,7 @@ func (thrift *thriftPlugin) readMap(data []byte) (value string, ok bool, complet
 	fields := []string{}
 	offset := 6
 
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		key, ok, complete, bytesRead := funcReaderKey(data[offset:])
 		if !ok {
 			return "", false, false, 0

--- a/packetbeat/protos/thrift/thrift_idl_test.go
+++ b/packetbeat/protos/thrift/thrift_idl_test.go
@@ -18,7 +18,6 @@
 package thrift
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 )
 
 func thriftIdlForTesting(t *testing.T, content string) *thriftIdl {
-	f, _ := ioutil.TempFile("", "")
+	f, _ := os.CreateTemp("", "")
 	defer os.Remove(f.Name())
 
 	f.WriteString(content)

--- a/packetbeat/protos/tls/extensions.go
+++ b/packetbeat/protos/tls/extensions.go
@@ -36,7 +36,7 @@ type Extensions struct {
 }
 
 type (
-	extensionParser func(reader bufferView, logger *logp.Logger) interface{}
+	extensionParser func(reader bufferView, logger *logp.Logger) any
 	extension       struct {
 		label   string
 		parser  extensionParser
@@ -119,7 +119,7 @@ func ParseExtensions(buffer bufferView, logger *logp.Logger) Extensions {
 	return result
 }
 
-func parseExtension(code uint16, buffer bufferView, logger *logp.Logger) (string, interface{}, bool) {
+func parseExtension(code uint16, buffer bufferView, logger *logp.Logger) (string, any, bool) {
 	if ext, ok := extensionMap[code]; ok {
 		parsed := ext.parser(buffer, logger)
 		return ext.label, parsed, ext.saveRaw
@@ -127,7 +127,7 @@ func parseExtension(code uint16, buffer bufferView, logger *logp.Logger) (string
 	return strconv.Itoa(int(code)), nil, false
 }
 
-func parseSni(buffer bufferView, logger *logp.Logger) interface{} {
+func parseSni(buffer bufferView, logger *logp.Logger) any {
 	var listLength uint16
 	if !buffer.read16Net(0, &listLength) {
 		return nil
@@ -150,7 +150,7 @@ func parseSni(buffer bufferView, logger *logp.Logger) interface{} {
 	return hosts
 }
 
-func parseMaxFragmentLen(buffer bufferView, _ *logp.Logger) interface{} {
+func parseMaxFragmentLen(buffer bufferView, _ *logp.Logger) any {
 	var val uint8
 	if buffer.length() == 1 && buffer.read8(0, &val) {
 		if val > 0 && val < 5 {
@@ -161,11 +161,11 @@ func parseMaxFragmentLen(buffer bufferView, _ *logp.Logger) interface{} {
 	return nil
 }
 
-func ignoreContent(_ bufferView, _ *logp.Logger) interface{} {
+func ignoreContent(_ bufferView, _ *logp.Logger) any {
 	return nil
 }
 
-func parseStatusReq(buffer bufferView, _ *logp.Logger) interface{} {
+func parseStatusReq(buffer bufferView, _ *logp.Logger) any {
 	if buffer.length() == 0 {
 		// Initial server response.
 		return mapstr.M{"response": true}
@@ -185,14 +185,14 @@ func parseStatusReq(buffer bufferView, _ *logp.Logger) interface{} {
 	return mapstr.M{"type": typ, "responder_id_list_length": list, "request_extensions": exts}
 }
 
-func expectEmpty(buffer bufferView, _ *logp.Logger) interface{} {
+func expectEmpty(buffer bufferView, _ *logp.Logger) any {
 	if buffer.length() != 0 {
 		return fmt.Sprintf("(expected empty: found %d bytes)", buffer.length())
 	}
 	return ""
 }
 
-func parseCertType(buffer bufferView, _ *logp.Logger) interface{} {
+func parseCertType(buffer bufferView, _ *logp.Logger) any {
 	var value uint8
 	var types []string
 	pos, limit := 0, buffer.length()
@@ -220,7 +220,7 @@ func parseCertType(buffer bufferView, _ *logp.Logger) interface{} {
 	return types
 }
 
-func parseSupportedGroups(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSupportedGroups(buffer bufferView, _ *logp.Logger) any {
 	var value uint16
 	if !buffer.read16Net(0, &value) || int(value)+2 != buffer.length() {
 		return nil
@@ -234,7 +234,7 @@ func parseSupportedGroups(buffer bufferView, _ *logp.Logger) interface{} {
 	return groups
 }
 
-func parseEcPoints(buffer bufferView, _ *logp.Logger) interface{} {
+func parseEcPoints(buffer bufferView, _ *logp.Logger) any {
 	var value, length uint8
 	if !buffer.read8(0, &length) || int(length)+1 != buffer.length() {
 		return nil
@@ -246,7 +246,7 @@ func parseEcPoints(buffer bufferView, _ *logp.Logger) interface{} {
 	return formats
 }
 
-func parseSrp(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSrp(buffer bufferView, _ *logp.Logger) any {
 	var length uint8
 	if !buffer.read8(0, &length) || int(length)+1 > buffer.length() {
 		return nil
@@ -258,7 +258,7 @@ func parseSrp(buffer bufferView, _ *logp.Logger) interface{} {
 	return user
 }
 
-func parseSignatureSchemes(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSignatureSchemes(buffer bufferView, _ *logp.Logger) any {
 	var value uint16
 	if !buffer.read16Net(0, &value) || int(value)+2 != buffer.length() {
 		return nil
@@ -270,14 +270,14 @@ func parseSignatureSchemes(buffer bufferView, _ *logp.Logger) interface{} {
 	return groups
 }
 
-func parseTicket(buffer bufferView, _ *logp.Logger) interface{} {
+func parseTicket(buffer bufferView, _ *logp.Logger) any {
 	if buffer.length() > 0 {
 		return fmt.Sprintf("(%d bytes)", buffer.length())
 	}
 	return ""
 }
 
-func parseALPN(buffer bufferView, _ *logp.Logger) interface{} {
+func parseALPN(buffer bufferView, _ *logp.Logger) any {
 	var length uint16
 	if !buffer.read16Net(0, &length) || int(length)+2 != buffer.length() {
 		return nil
@@ -295,7 +295,7 @@ func parseALPN(buffer bufferView, _ *logp.Logger) interface{} {
 	return protos
 }
 
-func parseSupportedVersions(buffer bufferView, _ *logp.Logger) interface{} {
+func parseSupportedVersions(buffer bufferView, _ *logp.Logger) any {
 	// Parsing the supported_versions extensions requires knowing whether the
 	// extension is included in a client_hello or server_hello, but a workaround
 	// can be done by looking at the extension length.
@@ -324,7 +324,7 @@ func parseSupportedVersions(buffer bufferView, _ *logp.Logger) interface{} {
 			return nil
 		}
 		list := make([]string, 0, numEntries)
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			var val uint16
 			if !buffer.read16Net(1+2*i, &val) {
 				return nil

--- a/packetbeat/protos/tls/extensions_test.go
+++ b/packetbeat/protos/tls/extensions_test.go
@@ -168,7 +168,7 @@ func TestParseSupportedVersions(t *testing.T) {
 	for _, testCase := range []struct {
 		title    string
 		data     string
-		expected interface{}
+		expected any
 	}{
 		{
 			title:    "negotiation",

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -249,7 +249,7 @@ func (hello *helloMessage) supportedCiphers() []string {
 	return ciphers
 }
 
-func (parser *parser) debugf(format string, args ...interface{}) {
+func (parser *parser) debugf(format string, args ...any) {
 	if parser.logger != nil && parser.logger.IsDebug() {
 		parser.logger.Debugf(format, args...)
 	}
@@ -605,7 +605,7 @@ func (version tlsVersion) IsZero() bool {
 	return version.major == 0 && version.minor == 0
 }
 
-func getKeySize(key interface{}) int {
+func getKeySize(key any) int {
 	if key == nil {
 		return 0
 	}
@@ -664,7 +664,7 @@ func toMap(name *pkix.Name) mapstr.M {
 	result := mapstr.M{}
 	fields := []struct {
 		name  string
-		value interface{}
+		value any
 	}{
 		{"country", name.Country},
 		{"organization", name.Organization},

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -120,7 +120,7 @@ func sBuf(t *testing.T, hexString string) *streambuf.Buffer {
 	return streambuf.New(bytes)
 }
 
-func mapGet(t *testing.T, m mapstr.M, key string) interface{} {
+func mapGet(t *testing.T, m mapstr.M, key string) any {
 	value, err := m.GetValue(key)
 	assert.NoError(t, err)
 	return value

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -102,7 +102,7 @@ func New(
 }
 
 //go:inline
-func (plugin *tlsPlugin) debugf(format string, args ...interface{}) {
+func (plugin *tlsPlugin) debugf(format string, args ...any) {
 	if plugin.isDebug {
 		plugin.tlsLogger.Debugf(format, args...)
 	}

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -217,7 +217,7 @@ func TestOCSPStatus(t *testing.T) {
 
 	for i, test := range []struct {
 		msg  string
-		want interface{}
+		want any
 	}{
 		// Packets from https://github.com/elastic/beats/issues/29962#issue-1112502582
 		//

--- a/packetbeat/route/route_bsd_test.go
+++ b/packetbeat/route/route_bsd_test.go
@@ -79,8 +79,8 @@ func defaultRoute(af int) (name string, index int, err error) {
 		if len(f) < 3 {
 			return "", -1, fmt.Errorf("unexpected netstat -I %s line: %q", name, sc.Text())
 		}
-		if strings.HasPrefix(f[2], "<Link#") {
-			idx, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(f[2], "<Link#"), ">"))
+		if after, ok := strings.CutPrefix(f[2], "<Link#"); ok {
+			idx, err := strconv.Atoi(strings.TrimSuffix(after, ">"))
 			if err != nil {
 				return "", -1, fmt.Errorf("failed to parse index from %s: %v", f[2], err)
 			}

--- a/packetbeat/route/route_test.go
+++ b/packetbeat/route/route_test.go
@@ -52,7 +52,7 @@ func TestDefault(t *testing.T) {
 				// based on the LUID.
 				b, err := run("getmac")
 				if err != nil {
-					b = []byte(fmt.Sprintf("\nunable to recover getmac information: %v", err))
+					b = fmt.Appendf(nil, "\nunable to recover getmac information: %v", err)
 				}
 				t.Logf("unexpected interface for family %d: got:%s want:%s\n%s", family, iface, wantIface, b)
 			} else {

--- a/packetbeat/route/route_windows.go
+++ b/packetbeat/route/route_windows.go
@@ -58,7 +58,7 @@ func Default(af int) (name string, index int, err error) {
 	)
 	outBufLen := uint32(workingBufferSize)
 loop:
-	for i := 0; i < maxTries; i++ {
+	for range maxTries {
 		buf := make([]byte, outBufLen)
 		addresses = (*windows.IpAdapterAddresses)(unsafe.Pointer(&buf[0]))
 		err = windows.GetAdaptersAddresses(uint32(af), 0, 0, addresses, &outBufLen)

--- a/packetbeat/scripts/mage/config.go
+++ b/packetbeat/scripts/mage/config.go
@@ -42,7 +42,7 @@ func ConfigFileParams() devtools.ConfigFileParams {
 	if SelectLogic == devtools.XPackProject {
 		p.Templates = append(p.Templates, devtools.XPackBeatDir("_meta/config/*.tmpl"))
 	}
-	p.ExtraVars = map[string]interface{}{
+	p.ExtraVars = map[string]any{
 		"device": device,
 	}
 	return p

--- a/x-pack/auditbeat/module/system/host/host_test.go
+++ b/x-pack/auditbeat/module/system/host/host_test.go
@@ -26,8 +26,8 @@ func TestData(t *testing.T) {
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":     system.ModuleName,
 		"metricsets": []string{"host"},
 	}

--- a/x-pack/auditbeat/module/system/login/login_linux_amd64_test.go
+++ b/x-pack/auditbeat/module/system/login/login_linux_amd64_test.go
@@ -260,7 +260,7 @@ func TestBtmp(t *testing.T) {
 		"Timestamp is not equal: %+v", events[3].Timestamp)
 }
 
-func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue interface{}) {
+func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue any) {
 	value, err := mapstr.GetValue(fieldName)
 	if assert.NoError(t, err) {
 		switch v := value.(type) {
@@ -272,8 +272,8 @@ func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue
 	}
 }
 
-func getBaseConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getBaseConfig() map[string]any {
+	return map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"login"},
 	}

--- a/x-pack/auditbeat/module/system/login/login_linux_arm64_test.go
+++ b/x-pack/auditbeat/module/system/login/login_linux_arm64_test.go
@@ -265,7 +265,7 @@ func TestBtmp(t *testing.T) {
 		"Timestamp is not equal: %+v", events[3].Timestamp)
 }
 
-func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue interface{}) {
+func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue any) {
 	value, err := mapstr.GetValue(fieldName)
 	if assert.NoError(t, err) {
 		switch v := value.(type) {
@@ -277,8 +277,8 @@ func checkFieldValue(t *testing.T, mapstr mapstr.M, fieldName string, fieldValue
 	}
 }
 
-func getBaseConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getBaseConfig() map[string]any {
+	return map[string]any{
 		"module":        system.ModuleName,
 		"datasets":      []string{"login"},
 		"logging.level": "debug",
@@ -288,7 +288,7 @@ func getBaseConfig() map[string]interface{} {
 // setupTestDir creates a temporary directory, copies the test files into it,
 // and returns the path.
 func setupTestDir(t *testing.T) string {
-	tmp, err := ioutil.TempDir("", "auditbeat-login-test-dir")
+	tmp, err := os.MkdirTemp("", "auditbeat-login-test-dir")
 	if err != nil {
 		t.Fatal("failed to create temp dir")
 	}

--- a/x-pack/auditbeat/module/system/package/flatbuffers.go
+++ b/x-pack/auditbeat/module/system/package/flatbuffers.go
@@ -24,7 +24,7 @@ import (
 var bufferPool sync.Pool
 
 func init() {
-	bufferPool.New = func() interface{} {
+	bufferPool.New = func() any {
 		return flatbuffers.NewBuilder(1024)
 	}
 }

--- a/x-pack/auditbeat/module/system/package/flatbuffers_test.go
+++ b/x-pack/auditbeat/module/system/package/flatbuffers_test.go
@@ -75,7 +75,7 @@ func TestFBEncodeDecode(t *testing.T) {
 	}
 
 	assert.Equal(t, len(p), len(out))
-	for i := 0; i < len(p); i++ {
+	for i := range p {
 		assert.Equal(t, p[i], out[i])
 	}
 }
@@ -87,7 +87,7 @@ func TestPoolPoison(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go poolPoison(input[i%2], t, &wg)
 	}
@@ -98,7 +98,7 @@ func poolPoison(p []*Package, t *testing.T, wg *sync.WaitGroup) {
 	builder, release := fbGetBuilder()
 	defer release()
 
-	for k := 0; k < 1000; k++ {
+	for range 1000 {
 		builder.Reset()
 
 		data := encodePackages(builder, p)
@@ -114,7 +114,7 @@ func poolPoison(p []*Package, t *testing.T, wg *sync.WaitGroup) {
 		}
 
 		assert.Equal(t, len(p), len(out))
-		for i := 0; i < len(p); i++ {
+		for i := range p {
 			assert.Equal(t, p[i], out[i])
 		}
 	}

--- a/x-pack/auditbeat/module/system/package/package_homebrew_test.go
+++ b/x-pack/auditbeat/module/system/package/package_homebrew_test.go
@@ -68,7 +68,7 @@ func TestHomebrew(t *testing.T) {
 	}
 }
 
-func checkFieldValue(t *testing.T, event beat.Event, fieldName string, fieldValue interface{}) {
+func checkFieldValue(t *testing.T, event beat.Event, fieldName string, fieldValue any) {
 	t.Helper()
 	value, err := event.GetValue(fieldName)
 	if assert.NoError(t, err, "checking field %s", fieldName) {

--- a/x-pack/auditbeat/module/system/package/package_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/package_linux_test.go
@@ -32,7 +32,7 @@ func TestRPMParallel(t *testing.T) {
 	useUID := getUser(t)
 
 	t.Logf("Starting...")
-	for i := 0; i < count; i++ {
+	for i := range count {
 		inner := i
 		go func() {
 			defer waiter.Done()

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -160,8 +160,8 @@ func TestDpkgInstalledSize(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"package"},
 	}

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -41,8 +41,8 @@ func TestData(t *testing.T) {
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"process"},
 
@@ -65,7 +65,7 @@ func TestProcessEvent(t *testing.T) {
 		assert.False(t, containsError)
 	}
 
-	expectedRootFields := map[string]interface{}{
+	expectedRootFields := map[string]any{
 		"event.kind":     "event",
 		"event.category": []string{"process"},
 		"event.type":     []string{"start"},

--- a/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
+++ b/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
@@ -351,8 +351,8 @@ func makeEventOfCmd(t *testing.T, cmd *exec.Cmd, qev quark.Event, be backend) mb
 
 // getConfigForQuark enables quark and allows hashing so we can test
 // the cached hasher.
-func getConfigForQuark(be backend) map[string]interface{} {
-	config := map[string]interface{}{
+func getConfigForQuark(be backend) map[string]any {
+	config := map[string]any{
 		"module":   system.ModuleName,
 		"datasets": []string{"process"},
 

--- a/x-pack/auditbeat/module/system/socket/dns/afpacket/afpacket.go
+++ b/x-pack/auditbeat/module/system/socket/dns/afpacket/afpacket.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux
-// +build linux
 
 package afpacket
 
@@ -68,7 +67,7 @@ func newAFPacketSniffer(base mb.BaseMetricSet, log *logp.Logger) (parent.Sniffer
 		return nil, err
 	}
 
-	opts := []interface{}{
+	opts := []any{
 		afpacket.OptFrameSize(frameSize),
 		afpacket.OptBlockSize(blockSize),
 		afpacket.OptNumBlocks(numBlocks),

--- a/x-pack/auditbeat/module/system/socket/dns/afpacket/config.go
+++ b/x-pack/auditbeat/module/system/socket/dns/afpacket/config.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build linux
-// +build linux
 
 package afpacket
 

--- a/x-pack/auditbeat/module/system/socket/events.go
+++ b/x-pack/auditbeat/module/system/socket/events.go
@@ -1114,8 +1114,8 @@ func kernErrorDesc(retval int32) string {
 }
 
 func readCString(buf []byte) string {
-	if pos := bytes.IndexByte(buf, 0); pos != -1 {
-		return string(buf[:pos])
+	if before, _, ok := bytes.Cut(buf, []byte{0}); ok {
+		return string(before)
 	}
 	return string(buf) + " ..."
 }

--- a/x-pack/auditbeat/module/system/socket/guess/creds.go
+++ b/x-pack/auditbeat/module/system/socket/guess/creds.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -119,7 +118,7 @@ func (g *guessStructCreds) Terminate() error {
 }
 
 // Extract receives the struct cred dump and discovers the offsets.
-func (g *guessStructCreds) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessStructCreds) Extract(ev any) (mapstr.M, bool) {
 	raw := ev.([]byte)
 	if len(raw) != credDumpBytes {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -86,7 +85,7 @@ func (g *guessInet6CskXmit) Probes() ([]helper.ProbeDef, error) {
 				Address:   "inet_csk_accept",
 				Fetchargs: "sock={{.RET}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(sockArgumentGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(sockArgumentGuess) }),
 		},
 		{
 			Probe: tracing.Probe{
@@ -94,7 +93,7 @@ func (g *guessInet6CskXmit) Probes() ([]helper.ProbeDef, error) {
 				Address:   "inet6_csk_xmit",
 				Fetchargs: "arg={{.P1}} dump=" + helper.MakeMemoryDump("{{.P1}}", 0, skbuffDumpSize),
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(skbuffSockGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(skbuffSockGuess) }),
 		},
 	}, nil
 }
@@ -163,7 +162,7 @@ func (g *guessInet6CskXmit) Trigger() error {
 
 // Extract receives first the sock* from inet_csk_accept, then the arguments
 // from inet6_csk_xmit.
-func (g *guessInet6CskXmit) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessInet6CskXmit) Extract(event any) (mapstr.M, bool) {
 	switch msg := event.(type) {
 	case *sockArgumentGuess:
 		g.sock = msg.Sock

--- a/x-pack/auditbeat/module/system/socket/guess/deref.go
+++ b/x-pack/auditbeat/module/system/socket/guess/deref.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -112,7 +111,7 @@ func (g *guessDeref) MaxRepeats() int {
 
 // Extract receives the memory read through a null pointer and checks if it's
 // zero or garbage.
-func (g *guessDeref) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessDeref) Extract(ev any) (mapstr.M, bool) {
 	raw := ev.([]byte)
 	if len(raw) != credDumpBytes {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/guess.go
+++ b/x-pack/auditbeat/module/system/socket/guess/guess.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -48,7 +47,7 @@ type Guesser interface {
 	// Extract receives the events generated during trigger.
 	// Done is false when it needs to be called with more events. True when
 	// the guess has completed and results is a map with the discovered values.
-	Extract(event interface{}) (result mapstr.M, done bool)
+	Extract(event any) (result mapstr.M, done bool)
 	// Terminate performs cleanup after the guess is complete.
 	Terminate() error
 }
@@ -117,7 +116,7 @@ func guessMultiple(guess RepeatGuesser, installer helper.ProbeInstaller, ctx Con
 
 func guessEventually(guess EventualGuesser, installer helper.ProbeInstaller, ctx Context) (result mapstr.M, err error) {
 	limit := guess.MaxRepeats()
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		ctx.Log.Debugf(" --- %s run #%d", guess.Name(), i)
 		if result, err = guessOnce(guess, installer, ctx); err != nil {
 			return nil, err
@@ -200,7 +199,7 @@ func guessOnce(guesser Guesser, installer helper.ProbeInstaller, ctx Context) (r
 		}
 	}()
 
-	thread.Run(func() (interface{}, error) {
+	thread.Run(func() (any, error) {
 		return nil, guesser.Trigger()
 	})
 

--- a/x-pack/auditbeat/module/system/socket/guess/helpers.go
+++ b/x-pack/auditbeat/module/system/socket/guess/helpers.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -12,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 
 	"golang.org/x/sys/unix"
 
@@ -136,11 +136,8 @@ func consolidate(partials []mapstr.M) (result mapstr.M, err error) {
 			}
 			var newList []int
 			for _, num := range baseList {
-				for _, nn := range list {
-					if num == nn {
-						newList = append(newList, num)
-						break
-					}
+				if slices.Contains(list, num) {
+					newList = append(newList, num)
 				}
 			}
 			baseList = newList

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -140,7 +139,7 @@ func (g *guessInetSockIPv4) Trigger() error {
 // Extract receives the dump of a struct inet_sock* and scans it for the
 // random local and remote IPs and ports. Will return lists of all the
 // offsets were each value was found.
-func (g *guessInetSockIPv4) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessInetSockIPv4) Extract(ev any) (mapstr.M, bool) {
 	data := ev.([]byte)
 
 	laddr := g.local.Addr[:]

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -159,7 +158,7 @@ func (g *guessInetSockIPv6) Condition(ctx Context) (bool, error) {
 
 // eventWrapper is used to wrap events from one of the probes for differentiation.
 type eventWrapper struct {
-	event interface{}
+	event any
 }
 
 // decoderWrapper takes an inner decoder and wraps it so that the returned events
@@ -169,7 +168,7 @@ type decoderWrapper struct {
 }
 
 // Decode wraps events from the inner decoder into a the wrapper type.
-func (d *decoderWrapper) Decode(raw []byte, meta tracing.Metadata) (event interface{}, err error) {
+func (d *decoderWrapper) Decode(raw []byte, meta tracing.Metadata) (event any, err error) {
 	if event, err = d.inner.Decode(raw, meta); err != nil {
 		return event, err
 	}
@@ -283,7 +282,7 @@ func (g *guessInetSockIPv6) Trigger() error {
 
 // Extract scans stores the events from the two different kprobes and then
 // looks for the result in one of them.
-func (g *guessInetSockIPv6) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessInetSockIPv6) Extract(event any) (mapstr.M, bool) {
 	if w, ok := event.(eventWrapper); ok {
 		g.ptrDump = w.event.([]byte)
 	} else {

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 

--- a/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -137,7 +136,7 @@ func (g *guessInetSockFamily) Trigger() error {
 }
 
 // Extract scans the struct inet_sock* memory for the current address family value.
-func (g *guessInetSockFamily) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessInetSockFamily) Extract(event any) (mapstr.M, bool) {
 	raw := event.([]byte)
 	var expected [2]byte
 	var hits []int

--- a/x-pack/auditbeat/module/system/socket/guess/iplocalout.go
+++ b/x-pack/auditbeat/module/system/socket/guess/iplocalout.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -111,7 +110,7 @@ func (g *guessIPLocalOut) Probes() ([]helper.ProbeDef, error) {
 				Fetchargs: "arg={{if ne .IP_LOCAL_OUT \"ip_local_out_sk\"}}{{.P2}}{{else}}{{.P1}}{{end}} dump=" +
 					helper.MakeMemoryDump("{{if ne .IP_LOCAL_OUT \"ip_local_out_sk\"}}{{.P1}}{{else}}{{.P2}}{{end}}", 0, skbuffDumpSize),
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(skbuffSockGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(skbuffSockGuess) }),
 		},
 		{
 			Probe: tracing.Probe{
@@ -119,7 +118,7 @@ func (g *guessIPLocalOut) Probes() ([]helper.ProbeDef, error) {
 				Address:   "tcp_sendmsg",
 				Fetchargs: "sock={{.TCP_SENDMSG_SOCK}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(sockArgumentGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(sockArgumentGuess) }),
 		},
 	}, nil
 }
@@ -149,7 +148,7 @@ func (g *guessIPLocalOut) Trigger() error {
 // Extract first receives and saves the sock* from tcp_sendmsg.
 // Once ip_local_out is called, it analyses the captured arguments to determine
 // their layout.
-func (g *guessIPLocalOut) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessIPLocalOut) Extract(ev any) (mapstr.M, bool) {
 	switch v := ev.(type) {
 	case *sockArgumentGuess:
 		g.sock = v.Sock

--- a/x-pack/auditbeat/module/system/socket/guess/registry.go
+++ b/x-pack/auditbeat/module/system/socket/guess/registry.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 

--- a/x-pack/auditbeat/module/system/socket/guess/skbuff.go
+++ b/x-pack/auditbeat/module/system/socket/guess/skbuff.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -126,7 +125,7 @@ func (g *guessSkBuffLen) Trigger() error {
 
 // Extract scans the sk_buff memory for any values between the expected
 // payload + [0 ... 128).
-func (g *guessSkBuffLen) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSkBuffLen) Extract(ev any) (mapstr.M, bool) {
 	skbuff := ev.([]byte)
 	if len(skbuff) != skbuffDumpSize || g.written <= 0 {
 		return nil, false
@@ -141,7 +140,7 @@ func (g *guessSkBuffLen) Extract(ev interface{}) (mapstr.M, bool) {
 	target := uint32(g.written)
 	arr := (*[n]uint32)(unsafe.Pointer(&skbuff[0]))[:]
 	var results [maxOverhead][]int
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if val := arr[i]; val >= target && val < target+maxOverhead {
 			excess := val - target
 			results[excess] = append(results[excess], i*uIntSize)
@@ -352,7 +351,7 @@ func (g *guessSkBuffProto) Trigger() error {
 
 // Extract will scan the sk_buff memory to look for all the uint16-sized memory
 // locations that contain the expected protocol value.
-func (g *guessSkBuffProto) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessSkBuffProto) Extract(event any) (mapstr.M, bool) {
 	raw := event.([]byte)
 	needle := []byte{0x08, 0x00} // ETH_P_IP
 	if g.doIPv6 {
@@ -532,7 +531,7 @@ func (g *guessSkBuffDataPtr) Probes() ([]helper.ProbeDef, error) {
 				Address:   "{{.RECV_UDP_DATAGRAM}}",
 				Fetchargs: fmt.Sprintf("ptr=%s data=%s", address, helper.MakeMemoryDump(address, 0, dataDumpBytes)),
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(dataDump) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(dataDump) }),
 		},
 		{
 			Probe: tracing.Probe{
@@ -571,7 +570,7 @@ func (g *guessSkBuffDataPtr) Prepare(ctx Context) (err error) {
 		g.dumpOffset = alignTo(g.protoOffset+2, int(sizeOfPtr))
 		g.payload = make([]byte, payloadLen)
 		banner := "HELLO!"
-		for i := 0; i < payloadLen; i++ {
+		for i := range payloadLen {
 			g.payload[i] = banner[i%len(banner)]
 		}
 	} else {
@@ -621,7 +620,7 @@ func u32At(buf []byte) uintptr {
 // (any), false : Signals that it needs another event in the current iteration.
 // nil, true : Finish the current iteration and perform a new one.
 // (non-nil), true : The guess completed.
-func (g *guessSkBuffDataPtr) Extract(event interface{}) (mapstr.M, bool) {
+func (g *guessSkBuffDataPtr) Extract(event any) (mapstr.M, bool) {
 	switch v := event.(type) {
 	case *dataDump:
 		g.data = v
@@ -693,7 +692,7 @@ func (g *guessSkBuffDataPtr) Extract(event interface{}) (mapstr.M, bool) {
 	scanFields := func(width int, ptrBase uintptr, reader func([]byte) uintptr) mapstr.M {
 		var off [3]uintptr
 		for base := g.dumpOffset - width*3; base >= limit; base -= width {
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				off[i] = reader(g.skbuff[base+i*width:]) - ptrBase
 			}
 			if off[0] == uintptr(udpHdrOff) &&

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -124,7 +123,7 @@ func (g *guessSockaddrIn) Trigger() error {
 }
 
 // Extract takes the dumped sockaddr_in and scans it for the expected values.
-func (g *guessSockaddrIn) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSockaddrIn) Extract(ev any) (mapstr.M, bool) {
 	arr := ev.([]byte)
 	if len(arr) < 8 {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -144,7 +143,7 @@ func (g *guessSockaddrIn6) Trigger() error {
 
 // Extract receives the dumped struct sockaddr_in6 and scans it for the
 // expected values.
-func (g *guessSockaddrIn6) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSockaddrIn6) Extract(ev any) (mapstr.M, bool) {
 	arr := ev.([]byte)
 	if len(arr) < 8 {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/socketsk.go
+++ b/x-pack/auditbeat/module/system/socket/guess/socketsk.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -75,7 +74,7 @@ func (g *guessSocketSock) Probes() ([]helper.ProbeDef, error) {
 				Address:   "sock_init_data",
 				Fetchargs: "sock={{.P2}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(sockEvent) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(sockEvent) }),
 		},
 
 		{
@@ -112,7 +111,7 @@ func (g *guessSocketSock) Trigger() error {
 
 // Extract first receives the sock* from sock_init_data, then uses it to
 // scan the dump from inet_release.
-func (g *guessSocketSock) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSocketSock) Extract(ev any) (mapstr.M, bool) {
 	if v, ok := ev.(*sockEvent); ok {
 		if g.initData != nil {
 			return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/syscallargs.go
+++ b/x-pack/auditbeat/module/system/socket/guess/syscallargs.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -89,7 +88,7 @@ func (g *guessSyscallArgs) Probes() ([]helper.ProbeDef, error) {
 				Address:   "{{.SYS_GETTIMEOFDAY}}",
 				Fetchargs: "p1reg={{._SYS_P1}} p2reg={{._SYS_P2}} p1pt=+0x70({{._SYS_P1}}) p2pt=+0x68({{(._SYS_P1)}})",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(syscallGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(syscallGuess) }),
 		},
 	}, nil
 }
@@ -112,7 +111,7 @@ func (g *guessSyscallArgs) Trigger() error {
 }
 
 // Extract check which set of kprobe arguments received the magic values.
-func (g *guessSyscallArgs) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessSyscallArgs) Extract(ev any) (mapstr.M, bool) {
 	args, ok := ev.(*syscallGuess)
 	if !ok {
 		return nil, false

--- a/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgargs.go
+++ b/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgargs.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -70,7 +69,7 @@ func (g *guessTCPSendMsg) Probes() ([]helper.ProbeDef, error) {
 				Address:   "tcp_sendmsg",
 				Fetchargs: "c={{.P3}} d={{.P4}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgArgCountGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgArgCountGuess) }),
 		},
 	}, nil
 }
@@ -94,7 +93,7 @@ func (g *guessTCPSendMsg) Trigger() (err error) {
 
 // Extract receives the arguments from the tcp_sendmsg call and checks
 // which one contains the number of bytes written by trigger.
-func (g *guessTCPSendMsg) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessTCPSendMsg) Extract(ev any) (mapstr.M, bool) {
 	event := ev.(*tcpSendMsgArgCountGuess)
 	if g.written <= 0 {
 		g.ctx.Log.Errorf("write failed for guess")

--- a/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgsk.go
+++ b/x-pack/auditbeat/module/system/socket/guess/tcpsendmsgsk.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -78,7 +77,7 @@ func (g *guessTcpSendmsgSock) Probes() ([]helper.ProbeDef, error) {
 				Address:   "tcp_sendmsg",
 				Fetchargs: "p1=+{{.INET_SOCK_RADDR}}({{.P1}}):u32 p2=+{{.INET_SOCK_RADDR}}({{.P2}}):u32 indirect=+{{.INET_SOCK_RADDR}}(+{{.SOCKET_SOCK}}({{.P2}})):u32",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgSockGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgSockGuess) }),
 		},
 	}, nil
 }
@@ -103,7 +102,7 @@ func (g *guessTcpSendmsgSock) Trigger() (err error) {
 
 // Extract checks which of the arguments to tcp_sendmsg contains the expected
 // value (address of destination).
-func (g *guessTcpSendmsgSock) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessTcpSendmsgSock) Extract(ev any) (mapstr.M, bool) {
 	event := ev.(*tcpSendMsgSockGuess)
 	if g.written <= 0 {
 		g.ctx.Log.Errorf("write failed for guess")

--- a/x-pack/auditbeat/module/system/socket/guess/udpsendmsg.go
+++ b/x-pack/auditbeat/module/system/socket/guess/udpsendmsg.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build (linux && 386) || (linux && amd64)
-// +build linux,386 linux,amd64
 
 package guess
 
@@ -76,7 +75,7 @@ func (g *guessUDPSendMsg) Probes() ([]helper.ProbeDef, error) {
 				Address:   "udp_sendmsg",
 				Fetchargs: "c={{.P3}} d={{.P4}}",
 			},
-			Decoder: helper.NewStructDecoder(func() interface{} { return new(udpSendMsgCountGuess) }),
+			Decoder: helper.NewStructDecoder(func() any { return new(udpSendMsgCountGuess) }),
 		},
 	}, nil
 }
@@ -90,7 +89,7 @@ func (g *guessUDPSendMsg) Terminate() error {
 	return g.cs.Cleanup()
 }
 
-func (g *guessUDPSendMsg) Extract(ev interface{}) (mapstr.M, bool) {
+func (g *guessUDPSendMsg) Extract(ev any) (mapstr.M, bool) {
 	if g.length == 0 {
 		return nil, false
 	}

--- a/x-pack/auditbeat/module/system/socket/helper/fixedthreadexecutor.go
+++ b/x-pack/auditbeat/module/system/socket/helper/fixedthreadexecutor.go
@@ -13,11 +13,11 @@ import (
 )
 
 // Task is a function that returns an arbitrary result and/or an error.
-type Task func() (interface{}, error)
+type Task func() (any, error)
 
 // TaskResult encapsulates the results of a Task.
 type TaskResult struct {
-	Data interface{}
+	Data any
 	Err  error
 }
 
@@ -66,7 +66,7 @@ func NewFixedThreadExecutor(queueSize int) FixedThreadExecutor {
 		}
 	}()
 
-	ex.Run(func() (interface{}, error) { return unix.Gettid(), nil })
+	ex.Run(func() (any, error) { return unix.Gettid(), nil })
 	res := <-ex.resultC
 	ex.TID = res.Data.(int)
 	return ex

--- a/x-pack/auditbeat/module/system/socket/helper/types.go
+++ b/x-pack/auditbeat/module/system/socket/helper/types.go
@@ -12,10 +12,10 @@ import (
 
 // Logger exposes logging functions.
 type Logger interface {
-	Errorf(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Debugf(format string, args ...interface{})
+	Errorf(format string, args ...any)
+	Warnf(format string, args ...any)
+	Infof(format string, args ...any)
+	Debugf(format string, args ...any)
 }
 
 // ProbeCondition is a function that allows to filter probes.

--- a/x-pack/auditbeat/module/system/socket/kprobes.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes.go
@@ -152,7 +152,7 @@ var sharedKProbes = []helper.ProbeDef{
 				helper.MakeMemoryDump("+{{call .POINTER_INDEX 4}}({{.SYS_P2}})", 0, maxProgArgLen),      // param4
 			),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(execveCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(execveCall) }),
 	},
 
 	{
@@ -162,7 +162,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "{{.SYS_EXECVE}}",
 			Fetchargs: "retval={{.RET}}:s32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(execveRet) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(execveRet) }),
 	},
 
 	{
@@ -170,7 +170,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Name:    "do_exit",
 			Address: "do_exit",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(doExit) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(doExit) }),
 	},
 
 	{
@@ -179,7 +179,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "commit_creds",
 			Fetchargs: "uid=+{{.STRUCT_CRED_UID}}({{.P1}}):u32 gid=+{{.STRUCT_CRED_GID}}({{.P1}}):u32 euid=+{{.STRUCT_CRED_EUID}}({{.P1}}):u32 egid=+{{.STRUCT_CRED_EGID}}({{.P1}}):u32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(commitCreds) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(commitCreds) }),
 	},
 
 	{
@@ -189,7 +189,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "{{.DO_FORK}}",
 			Fetchargs: "retval={{.RET}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(forkRet) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(forkRet) }),
 	},
 	/***************************************************************************
 	 * IPv4
@@ -201,7 +201,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "sock_init_data",
 			Fetchargs: "socket={{.P1}} sock={{.P2}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(sockInitData) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(sockInitData) }),
 	},
 
 	// IPv4/TCP/UDP socket created. Good for associating sockets with pids.
@@ -216,7 +216,7 @@ var sharedKProbes = []helper.ProbeDef{
 			// proto=0 will select the protocol by looking at socket type (STREAM|DGRAM)
 			Filter: "proto==0 || proto=={{.IPPROTO_TCP}} || proto=={{.IPPROTO_UDP}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inetCreate) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inetCreate) }),
 	},
 
 	// IPv4/TCP/UDP socket released. Good for associating sockets with pids.
@@ -226,7 +226,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "inet_release",
 			Fetchargs: "sock=+{{.SOCKET_SOCK}}({{.P1}})",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inetReleaseCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inetReleaseCall) }),
 	},
 
 	/***************************************************************************
@@ -243,7 +243,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.P1}} laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 af=+{{.SOCKADDR_IN_AF}}({{.P2}}):u16 addr=+{{.SOCKADDR_IN_ADDR}}({{.P2}}):u32 port=+{{.SOCKADDR_IN_PORT}}({{.P2}}):u16",
 			Filter:    "af=={{.AF_INET}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpIPv4ConnectCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpIPv4ConnectCall) }),
 	},
 
 	// Result of IPv4/TCP connect:
@@ -256,7 +256,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "tcp_v4_connect",
 			Fetchargs: "retval={{.RET}}:s32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpConnectResult) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpConnectResult) }),
 	},
 
 	// IPv4 packet is sent. Acceptable as a packet counter,
@@ -272,7 +272,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.IP_LOCAL_OUT_SOCK}} size=+{{.SK_BUFF_LEN}}({{.IP_LOCAL_OUT_SK_BUFF}}):u32 af=+{{.INET_SOCK_AF}}({{.IP_LOCAL_OUT_SOCK}}):u16 laddr=+{{.INET_SOCK_LADDR}}({{.IP_LOCAL_OUT_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.IP_LOCAL_OUT_SOCK}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.IP_LOCAL_OUT_SOCK}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.IP_LOCAL_OUT_SOCK}}):u16",
 			Filter:    "(af=={{.AF_INET}} || af=={{.AF_INET6}})",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(ipLocalOutCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(ipLocalOutCall) }),
 	},
 
 	// Count received IPv4/TCP packets.
@@ -284,7 +284,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "tcp_v4_do_rcv",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.P1}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.P1}}):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpV4DoRcv) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpV4DoRcv) }),
 	},
 
 	/***************************************************************************
@@ -301,7 +301,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "udp_sendmsg",
 			Fetchargs: "sock={{.UDP_SENDMSG_SOCK}} size={{.UDP_SENDMSG_LEN}} laddr=+{{.INET_SOCK_LADDR}}({{.UDP_SENDMSG_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.UDP_SENDMSG_SOCK}}):u16 raddr=+{{.SOCKADDR_IN_ADDR}}(+0({{.UDP_SENDMSG_MSG}})):u32 siptr=+0({{.UDP_SENDMSG_MSG}}) siaf=+{{.SOCKADDR_IN_AF}}(+0({{.UDP_SENDMSG_MSG}})):u16 rport=+{{.SOCKADDR_IN_PORT}}(+0({{.UDP_SENDMSG_MSG}})):u16 altraddr=+{{.INET_SOCK_RADDR}}({{.UDP_SENDMSG_SOCK}}):u32 altrport=+{{.INET_SOCK_RPORT}}({{.UDP_SENDMSG_SOCK}}):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpSendMsgCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpSendMsgCall) }),
 	},
 
 	{
@@ -310,7 +310,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Address:   "udp_queue_rcv_skb",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddr=+{{.INET_SOCK_LADDR}}({{.P1}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, skBuffDataDumpBytes),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpQueueRcvSkb) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpQueueRcvSkb) }),
 	},
 
 	/***************************************************************************
@@ -326,7 +326,7 @@ var sharedKProbes = []helper.ProbeDef{
 			Fetchargs: "magic=+0({{.SYS_P1}}):u64 timestamp=+8({{.SYS_P1}}):u64",
 			Filter:    fmt.Sprintf("magic==0x%x", clockSyncMagic),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(clockSyncCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(clockSyncCall) }),
 	},
 }
 
@@ -345,7 +345,7 @@ var ipv4OnlyKProbes = []helper.ProbeDef{
 				"family=+{{.INET_SOCK_AF}}({{.RET}}):u16",
 			Filter: "family=={{.AF_INET}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpAcceptResult4) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpAcceptResult4) }),
 	},
 
 	// Data is sent via TCP.
@@ -360,7 +360,7 @@ var ipv4OnlyKProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.TCP_SENDMSG_SOCK}} size={{.TCP_SENDMSG_LEN}} laddr=+{{.INET_SOCK_LADDR}}({{.TCP_SENDMSG_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.TCP_SENDMSG_SOCK}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.TCP_SENDMSG_SOCK}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.TCP_SENDMSG_SOCK}}):u16 " +
 				"family=+{{.INET_SOCK_AF}}({{.TCP_SENDMSG_SOCK}}):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgCall4) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgCall4) }),
 	},
 }
 
@@ -384,7 +384,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			// proto=0 will select the protocol by looking at socket type (STREAM|DGRAM)
 			Filter: "proto==0 || proto=={{.IPPROTO_TCP}} || proto=={{.IPPROTO_UDP}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inetCreate) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inetCreate) }),
 	},
 
 	/***************************************************************************
@@ -405,7 +405,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "inet6_csk_xmit",
 			Fetchargs: "sock={{.INET6_CSK_XMIT_SOCK}} size=+{{.SK_BUFF_LEN}}({{.INET6_CSK_XMIT_SKBUFF}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(inet6CskXmitCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(inet6CskXmitCall) }),
 	},
 
 	// Count received IPv6/TCP packets.
@@ -417,7 +417,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "tcp_v6_do_rcv",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.P1}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpV6DoRcv) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpV6DoRcv) }),
 	},
 
 	// An IPv6 / TCP socket connect attempt:
@@ -430,7 +430,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.P1}} laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 af=+{{.SOCKADDR_IN6_AF}}({{.P2}}):u16 addra=+{{.SOCKADDR_IN6_ADDRA}}({{.P2}}):u64 addrb=+{{.SOCKADDR_IN6_ADDRB}}({{.P2}}):u64 port=+{{.SOCKADDR_IN6_PORT}}({{.P2}}):u16",
 			Filter:    "af=={{.AF_INET6}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpIPv6ConnectCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpIPv6ConnectCall) }),
 	},
 
 	// Result of IPv6/TCP connect:
@@ -443,7 +443,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "tcp_v6_connect",
 			Fetchargs: "retval={{.RET}}:s32",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpConnectResult) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpConnectResult) }),
 	},
 
 	/***************************************************************************
@@ -463,7 +463,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "udpv6_sendmsg",
 			Fetchargs: "sock={{.UDP_SENDMSG_SOCK}} size={{.UDP_SENDMSG_LEN}} laddra={{.INET_SOCK_V6_LADDR_A}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.UDP_SENDMSG_SOCK}}):u16 raddra=+{{.SOCKADDR_IN6_ADDRA}}(+0({{.UDP_SENDMSG_MSG}})):u64 raddrb=+{{.SOCKADDR_IN6_ADDRB}}(+0({{.UDP_SENDMSG_MSG}})):u64 rport=+{{.SOCKADDR_IN6_PORT}}(+0({{.UDP_SENDMSG_MSG}})):u16 altraddra={{.INET_SOCK_V6_RADDR_A}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} altraddrb={{.INET_SOCK_V6_RADDR_B}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} altrport=+{{.INET_SOCK_RPORT}}({{.UDP_SENDMSG_SOCK}}):u16 si6ptr=+0({{.UDP_SENDMSG_MSG}}) si6af=+{{.SOCKADDR_IN6_AF}}(+0({{.UDP_SENDMSG_MSG}})):u16",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpv6SendMsgCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpv6SendMsgCall) }),
 	},
 
 	/* UDP/IPv6 receive datagram. Good for counting payload bytes and packets.*/
@@ -473,7 +473,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Address:   "udpv6_queue_rcv_skb",
 			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, skBuffDataDumpBytes),
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpv6QueueRcvSkb) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(udpv6QueueRcvSkb) }),
 	},
 
 	/***************************************************************************
@@ -492,7 +492,7 @@ var ipv6KProbes = []helper.ProbeDef{
 			Fetchargs: "sock={{.TCP_SENDMSG_SOCK}} size={{.TCP_SENDMSG_LEN}} laddr=+{{.INET_SOCK_LADDR}}({{.TCP_SENDMSG_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.TCP_SENDMSG_SOCK}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.TCP_SENDMSG_SOCK}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.TCP_SENDMSG_SOCK}}):u16 " +
 				"family=+{{.INET_SOCK_AF}}({{.TCP_SENDMSG_SOCK}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgCall) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpSendMsgCall) }),
 	},
 
 	// Return of accept(). Local side is usually zero so not fetched. Needs
@@ -508,7 +508,7 @@ var ipv6KProbes = []helper.ProbeDef{
 				"family=+{{.INET_SOCK_AF}}({{.RET}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.RET}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.RET}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.RET}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.RET}}){{.INET_SOCK_V6_TERM}}",
 			Filter: "family=={{.AF_INET}} || family=={{.AF_INET6}}",
 		},
-		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpAcceptResult) }),
+		Decoder: helper.NewStructDecoder(func() any { return new(tcpAcceptResult) }),
 	},
 }
 

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"strconv"
@@ -566,9 +567,7 @@ func (s *state) ForkProcess(parentPID, childPID uint32, ts kernelTime) error {
 			createdTime: s.kernTimestampToTime(ts),
 		}
 		child.resolvedDomains = make(map[string]string, len(parent.resolvedDomains))
-		for k, v := range parent.resolvedDomains {
-			child.resolvedDomains[k] = v
-		}
+		maps.Copy(child.resolvedDomains, parent.resolvedDomains)
 		s.log.Debugf("forking process %d with %d associated domains", childPID, len(child.resolvedDomains))
 		s.processes[childPID] = child
 	}
@@ -987,7 +986,7 @@ func (f *flow) toEvent(final bool) (ev mb.Event, err error) {
 	}
 
 	var errs []error
-	rootPut := func(key string, value interface{}) {
+	rootPut := func(key string, value any) {
 		if _, err := root.Put(key, value); err != nil {
 			errs = append(errs, err)
 		}

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -29,19 +29,19 @@ import (
 
 type logWrapper testing.T
 
-func (l *logWrapper) Errorf(format string, args ...interface{}) {
+func (l *logWrapper) Errorf(format string, args ...any) {
 	l.Logf("error: "+format, args...)
 }
 
-func (l *logWrapper) Warnf(format string, args ...interface{}) {
+func (l *logWrapper) Warnf(format string, args ...any) {
 	l.Logf("warning: "+format, args...)
 }
 
-func (l *logWrapper) Infof(format string, args ...interface{}) {
+func (l *logWrapper) Infof(format string, args ...any) {
 	l.Logf("info: "+format, args...)
 }
 
-func (l *logWrapper) Debugf(format string, args ...interface{}) {
+func (l *logWrapper) Debugf(format string, args ...any) {
 	l.Logf("debug: "+format, args...)
 }
 
@@ -216,7 +216,7 @@ func TestTCPConnWithProcess(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           localIP,
 		"source.port":         localPort,
 		"source.packets":      uint64(1),
@@ -335,7 +335,7 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow 0", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           localIP,
 		"source.port":         localPort,
 		"source.packets":      uint64(1),
@@ -378,7 +378,7 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	// we have a truncated flow with no directionality,
 	// so just report what we can
 	t.Log("read flow 1", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":         localIP,
 		"source.port":       localPort,
 		"client.ip":         localIP,
@@ -458,7 +458,7 @@ func TestUDPOutgoingSinglePacketWithProcess(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           localIP,
 		"source.port":         localPort,
 		"source.packets":      uint64(1),
@@ -525,7 +525,7 @@ func TestUDPIncomingSinglePacketWithProcess(t *testing.T) {
 	assert.Len(t, flows, 1)
 	flow := flows[0]
 	t.Log("read flow", flow)
-	for field, expected := range map[string]interface{}{
+	for field, expected := range map[string]any{
 		"source.ip":           remoteIP,
 		"source.port":         remotePort,
 		"source.packets":      uint64(1),
@@ -551,7 +551,7 @@ func TestUDPIncomingSinglePacketWithProcess(t *testing.T) {
 	}
 }
 
-func assertValue(t *testing.T, ev beat.Event, expected interface{}, field string) bool {
+func assertValue(t *testing.T, ev beat.Event, expected any, field string) bool {
 	value, err := ev.GetValue(field)
 	return assert.Nil(t, err, field) && assert.Equal(t, expected, value, field)
 }
@@ -582,11 +582,8 @@ func callExecve(meta tracing.Metadata, args []string) *execveCall {
 	ptr := &execveCall{
 		Meta: meta,
 	}
-	lim := len(args)
-	if lim > maxProgArgs {
-		lim = maxProgArgs
-	}
-	for i := 0; i < lim; i++ {
+	lim := min(len(args), maxProgArgs)
+	for i := range lim {
 		ptr.Ptrs[i] = 1
 	}
 	if lim < len(args) {

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -75,8 +75,8 @@ func testUser() *User {
 	}
 }
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":     system.ModuleName,
 		"metricsets": []string{"user"},
 

--- a/x-pack/auditbeat/module/system/user/users_linux.go
+++ b/x-pack/auditbeat/module/system/user/users_linux.go
@@ -225,7 +225,7 @@ func readShadowFile() (map[string]shadowFileEntry, error) {
 // multiRoundHash performs 10 rounds of SHA-512 hashing.
 func multiRoundHash(s string) []byte {
 	hash := sha512.Sum512([]byte(s))
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		hash = sha512.Sum512(hash[:])
 	}
 	return hash[:]

--- a/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
+++ b/x-pack/auditbeat/processors/sessionmd/add_session_metadata.go
@@ -241,7 +241,7 @@ func (p *addSessionMetadata) enrich(ev *beat.Event) (*beat.Event, error) {
 }
 
 // pidToUInt32 converts PID value to uint32
-func pidToUInt32(value interface{}) (pid uint32, err error) {
+func pidToUInt32(value any) (pid uint32, err error) {
 	switch v := value.(type) {
 	case string:
 		nr, err := strconv.Atoi(v)
@@ -267,11 +267,11 @@ func pidToUInt32(value interface{}) (pid uint32, err error) {
 	return pid, nil
 }
 
-func tryToMapStr(v interface{}) (mapstr.M, bool) {
+func tryToMapStr(v any) (mapstr.M, bool) {
 	switch m := v.(type) {
 	case mapstr.M:
 		return m, true
-	case map[string]interface{}:
+	case map[string]any:
 		return mapstr.M(m), true
 	default:
 		return nil, false

--- a/x-pack/auditbeat/processors/sessionmd/processdb/db.go
+++ b/x-pack/auditbeat/processors/sessionmd/processdb/db.go
@@ -239,13 +239,11 @@ func NewDB(ctx context.Context, metrics *monitoring.Registry, reader procfs.Read
 
 func (db *DB) calculateEntityIDv1(pid uint32, startTime time.Time) string {
 	return base64.StdEncoding.EncodeToString(
-		[]byte(
-			fmt.Sprintf("%d__%s__%d__%d",
-				pidNsInode,
-				bootID,
-				uint64(pid),
-				uint64(startTime.Unix()),
-			),
+		fmt.Appendf(nil, "%d__%s__%d__%d",
+			pidNsInode,
+			bootID,
+			uint64(pid),
+			uint64(startTime.Unix()),
 		),
 	)
 }
@@ -681,7 +679,7 @@ func (db *DB) GetProcess(pid uint32) (types.Process, error) {
 	ret := fullProcessFromDBProcess(process)
 
 	if process.PIDs.Ppid != 0 {
-		for i := 0; i < retryCount; i++ {
+		for range retryCount {
 			if parent, ok := db.processes[process.PIDs.Ppid]; ok {
 				fillParent(&ret, parent)
 				break
@@ -690,7 +688,7 @@ func (db *DB) GetProcess(pid uint32) (types.Process, error) {
 	}
 
 	if process.PIDs.Pgid != 0 {
-		for i := 0; i < retryCount; i++ {
+		for range retryCount {
 			if groupLeader, ok := db.processes[process.PIDs.Pgid]; ok {
 				fillGroupLeader(&ret, groupLeader)
 				break
@@ -699,7 +697,7 @@ func (db *DB) GetProcess(pid uint32) (types.Process, error) {
 	}
 
 	if process.PIDs.Sid != 0 {
-		for i := 0; i < retryCount; i++ {
+		for range retryCount {
 			if sessionLeader, ok := db.processes[process.PIDs.Sid]; ok {
 				fillSessionLeader(&ret, sessionLeader)
 				break

--- a/x-pack/auditbeat/processors/sessionmd/processdb/db_test.go
+++ b/x-pack/auditbeat/processors/sessionmd/processdb/db_test.go
@@ -7,7 +7,6 @@
 package processdb
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -43,8 +42,7 @@ func TestProcessOrphanResolve(t *testing.T) {
 
 	// uncomment if you want some logs
 	//_ = logp.DevelopmentSetup()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	reader := procfs.NewProcfsReader(*logger)
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), reader, logp.L(), -1, false)
 	require.NoError(t, err)
@@ -87,8 +85,7 @@ func TestProcessOrphanResolve(t *testing.T) {
 
 func TestReapExitOrphans(t *testing.T) {
 	// test to make sure that orphaned exit events are still cleaned up
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	reader := procfs.NewProcfsReader(*logger)
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), reader, logp.L(), -1, false)
 	require.NoError(t, err)
@@ -108,8 +105,7 @@ func TestReapExitOrphans(t *testing.T) {
 
 func TestReapProcesses(t *testing.T) {
 	reader := procfs.NewProcfsReader(*logger)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), reader, logp.L(), -1, true)
 	require.NoError(t, err)
 	testDB.processReapAfter = time.Duration(0)
@@ -145,8 +141,7 @@ func TestReapProcesses(t *testing.T) {
 
 func TestReapProcessesWithProcFS(t *testing.T) {
 	mockReader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), mockReader, logp.L(), -1, false)
 	require.NoError(t, err)
 	testDB.reapProcesses = true
@@ -187,8 +182,7 @@ func TestReapProcessesWithProcFS(t *testing.T) {
 func TestReapingProcessesOrphanResolvedRace(t *testing.T) {
 	// test to make sure that if we resolve a process in between mutex holds, we won't prematurely reap it
 	mockReader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	testDB, err := NewDB(ctx, monitoring.NewRegistry(), mockReader, logp.L(), -1, false)
 	require.NoError(t, err)
 	testDB.reapProcesses = true

--- a/x-pack/auditbeat/processors/sessionmd/processdb/entry_leader_test.go
+++ b/x-pack/auditbeat/processors/sessionmd/processdb/entry_leader_test.go
@@ -7,7 +7,6 @@
 package processdb
 
 import (
-	"context"
 	"path"
 	"testing"
 	"time"
@@ -193,8 +192,7 @@ func populateProcfsWithInit(reader *procfs.MockReader) {
 
 func TestSingleProcessSessionLeaderEntryTypeTerminal(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -219,8 +217,7 @@ func TestSingleProcessSessionLeaderEntryTypeTerminal(t *testing.T) {
 
 func TestSingleProcessSessionLeaderLoginProcess(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -250,8 +247,7 @@ func TestSingleProcessSessionLeaderLoginProcess(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfInit(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -282,8 +278,7 @@ func TestSingleProcessSessionLeaderChildOfInit(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfSsmSessionWorker(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -320,8 +315,7 @@ func TestSingleProcessSessionLeaderChildOfSsmSessionWorker(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfSshd(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -357,8 +351,7 @@ func TestSingleProcessSessionLeaderChildOfSshd(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfContainerdShim(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -394,8 +387,7 @@ func TestSingleProcessSessionLeaderChildOfContainerdShim(t *testing.T) {
 
 func TestSingleProcessSessionLeaderChildOfRunc(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -432,8 +424,7 @@ func TestSingleProcessSessionLeaderChildOfRunc(t *testing.T) {
 
 func TestSingleProcessEmptyProcess(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -467,8 +458,7 @@ func TestSingleProcessEmptyProcess(t *testing.T) {
 // EntryLeaderEntryMetaType
 func TestSingleProcessOverwriteOldEntryLeader(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -540,8 +530,7 @@ func TestSingleProcessOverwriteOldEntryLeader(t *testing.T) {
 func TestInitSshdBashLs(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -625,8 +614,7 @@ func TestInitSshdBashLs(t *testing.T) {
 func TestInitSshdSshdBashLs(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -719,8 +707,7 @@ func TestInitSshdSshdBashLs(t *testing.T) {
 func TestInitSshdSshdSshdBashLs(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -830,8 +817,7 @@ func TestInitSshdSshdSshdBashLs(t *testing.T) {
 func TestInitContainerdContainerdShim(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -885,8 +871,7 @@ func TestInitContainerdContainerdShim(t *testing.T) {
 func TestInitContainerdShimBashContainerdShimIsReparentedToInit(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -956,8 +941,7 @@ func TestInitContainerdShimBashContainerdShimIsReparentedToInit(t *testing.T) {
 func TestInitContainerdShimPauseContainerdShimIsReparentedToInit(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1030,8 +1014,7 @@ func TestInitContainerdShimPauseContainerdShimIsReparentedToInit(t *testing.T) {
 func TestInitSshdBashLsAndGrepGrepOnlyHasGroupLeader(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1119,8 +1102,7 @@ func TestInitSshdBashLsAndGrepGrepOnlyHasGroupLeader(t *testing.T) {
 func TestInitSshdBashLsAndGrepGrepOnlyHasSessionLeader(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1203,8 +1185,7 @@ func TestInitSshdBashLsAndGrepGrepOnlyHasSessionLeader(t *testing.T) {
 // entry meta type of "unknown" and making it an entry leader.
 func TestGrepInIsolation(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1238,8 +1219,7 @@ func TestGrepInIsolation(t *testing.T) {
 // Kernel threads should never have an entry meta type or entry leader set.
 func TestKernelThreads(t *testing.T) {
 	reader := procfs.NewMockReader()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 
@@ -1292,8 +1272,7 @@ func TestKernelThreads(t *testing.T) {
 func TestPIDReuseSameSession(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()
@@ -1399,8 +1378,7 @@ func TestPIDReuseSameSession(t *testing.T) {
 func TestPIDReuseNewSession(t *testing.T) {
 	reader := procfs.NewMockReader()
 	populateProcfsWithInit(reader)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	db, err := NewDB(ctx, monitoring.NewRegistry(), reader, logger, time.Second*30, false)
 	require.Nil(t, err)
 	db.ScrapeProcfs()

--- a/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
@@ -489,13 +489,11 @@ func setSameAsProcess(process *types.Process) {
 // This is a globally unique identifier for the process.
 func calculateEntityIDv1(pid uint32, startTime time.Time) string {
 	return base64.StdEncoding.EncodeToString(
-		[]byte(
-			fmt.Sprintf("%d__%s__%d__%d",
-				pidNsInode,
-				bootID,
-				uint64(pid),
-				uint64(startTime.Unix()), //nolint:gosec // process start times are always positive
-			),
+		fmt.Appendf(nil, "%d__%s__%d__%d",
+			pidNsInode,
+			bootID,
+			uint64(pid),
+			uint64(startTime.Unix()), //nolint:gosec // process start times are always positive
 		),
 	)
 }

--- a/x-pack/auditbeat/processors/sessionmd/provider/procfsprovider/procfsprovider.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/procfsprovider/procfsprovider.go
@@ -73,7 +73,7 @@ func (p prvdr) Sync(ev *beat.Event, pid uint32) error {
 			// possible from the event
 			pe.ProcfsLookupFail = true
 			pe.PIDs.Tgid = pid
-			var intr interface{}
+			var intr any
 			var i int
 			var ok bool
 			var parent types.Process

--- a/x-pack/packetbeat/cmd/root.go
+++ b/x-pack/packetbeat/cmd/root.go
@@ -91,14 +91,14 @@ func defaultProcessors() []mapstr.M {
 	return []mapstr.M{
 		{
 			"if.contains.tags": "forwarded",
-			"then": []interface{}{
+			"then": []any{
 				mapstr.M{
 					"drop_fields": mapstr.M{
-						"fields": []interface{}{"host"},
+						"fields": []any{"host"},
 					},
 				},
 			},
-			"else": []interface{}{
+			"else": []any{
 				mapstr.M{
 					"add_host_metadata": nil,
 				},

--- a/x-pack/packetbeat/tests/integration/otel_test.go
+++ b/x-pack/packetbeat/tests/integration/otel_test.go
@@ -73,7 +73,7 @@ func serverPort(t *testing.T, srv *httptest.Server) int {
 // sendHTTPRequests sends numRequests GET requests to url, ignoring errors.
 func sendHTTPRequests(url string, numRequests int) {
 	client := &http.Client{Timeout: 5 * time.Second}
-	for i := 0; i < numRequests; i++ {
+	for range numRequests {
 		resp, err := client.Get(url) //nolint:noctx // fine for tests
 		if err == nil {
 			resp.Body.Close()

--- a/x-pack/packetbeat/tests/system/app_run_test.go
+++ b/x-pack/packetbeat/tests/system/app_run_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build integration
-// +build integration
 
 package system
 

--- a/x-pack/packetbeat/tests/system/app_test.go
+++ b/x-pack/packetbeat/tests/system/app_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build integration
-// +build integration
 
 package system
 


### PR DESCRIPTION
## Proposed commit message

```
packetbeat,x-pack/auditbeat,auditbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 142 file(s)
owned by @elastic/sec-linux-platform in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

A second commit removes the helpers the rewrites orphaned; see the review notes below.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Two commits, so the hand-written part is obvious:

1. `packetbeat,x-pack/auditbeat,auditbeat: fix modernize lint findings` is pure tool output, nothing in it was written by hand.
2. `auditbeat,packetbeat,x-pack/auditbeat: finish the modernize cleanup` is the part the tools could not produce:

   > Two things the tooling could not do, kept out of the mechanical commit.
   > 
   > `go fix` inlined the `//go:fix inline` pointer helpers at every call site,
   > leaving the helpers themselves unused, so they are deleted here.
   > 
   > `golangci-lint --fix` refuses to write into cgo packages, so the remaining
   > `plusbuild`, `any` and `rangeint` findings under
   > x-pack/auditbeat/module/system are applied by hand.

- `auditbeat/module/file_integrity/exeobjparser_test.go`
- `packetbeat/config/config_test.go`
- `x-pack/auditbeat/module/system/socket/guess/creds.go`
- `x-pack/auditbeat/module/system/user/users_linux.go`

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
