### PR TITLE
metricbeat,x-pack/metricbeat: fix modernize lint findings

### DIFF
--- a/metricbeat/helper/sql/sql.go
+++ b/metricbeat/helper/sql/sql.go
@@ -37,7 +37,7 @@ type DbClient struct {
 }
 
 type sqlRow interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 	Next() bool
 	Columns() ([]string, error)
 	Err() error
@@ -76,7 +76,7 @@ func (d *DbClient) FetchTableMode(ctx context.Context, query string) ([]mapstr.M
 // FetchTableModeWithParams executes a parameterized query and returns results in table format.
 // This is similar to FetchTableMode but accepts query parameters for safe parameter substitution.
 // Use this for cursor-based queries where the cursor value is passed as a parameter.
-func (d *DbClient) FetchTableModeWithParams(ctx context.Context, query string, args ...interface{}) ([]mapstr.M, error) {
+func (d *DbClient) FetchTableModeWithParams(ctx context.Context, query string, args ...any) ([]mapstr.M, error) {
 	rows, err := d.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("parameterized query failed: %w", err)
@@ -98,9 +98,9 @@ func (d *DbClient) fetchTableMode(rows sqlRow) ([]mapstr.M, error) {
 		cols[k] = strings.ToLower(v)
 	}
 
-	vals := make([]interface{}, len(cols))
-	for i := 0; i < len(cols); i++ {
-		vals[i] = new(interface{})
+	vals := make([]any, len(cols))
+	for i := range cols {
+		vals[i] = new(any)
 	}
 
 	rr := make([]mapstr.M, 0)
@@ -114,7 +114,7 @@ func (d *DbClient) fetchTableMode(rows sqlRow) ([]mapstr.M, error) {
 		r := mapstr.M{}
 
 		for i, c := range cols {
-			value := getValue(vals[i].(*interface{})) //nolint:errcheck // getValue does not return an error. Each element is guaranteed to be *interface{}.
+			value := getValue(vals[i].(*any)) //nolint:errcheck // getValue does not return an error. Each element is guaranteed to be *interface{}.
 			r.Put(c, value)
 		}
 
@@ -144,7 +144,7 @@ func (d *DbClient) fetchVariableMode(rows sqlRow) (mapstr.M, error) {
 
 	for rows.Next() {
 		var key string
-		var val interface{}
+		var val any
 		err := rows.Scan(&key, &val)
 		if err != nil {
 			d.logger.Debug(fmt.Errorf("error trying to scan rows: %w", err))
@@ -162,7 +162,6 @@ func (d *DbClient) fetchVariableMode(rows sqlRow) (mapstr.M, error) {
 	r := mapstr.M{}
 
 	for key, value := range data {
-		value := value
 		value = getValue(&value)
 		r.Put(key, value)
 	}
@@ -181,13 +180,13 @@ func ReplaceUnderscores(ms mapstr.M) mapstr.M {
 	return dotMap
 }
 
-func getValue(pval *interface{}) interface{} {
+func getValue(pval *any) any {
 	if pval == nil {
 		return nil
 	}
 
 	switch v := (*pval).(type) {
-	case nil, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, string, []interface{}:
+	case nil, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, string, []any:
 		return v
 	case []byte:
 		return string(v)

--- a/metricbeat/helper/sql/sql_test.go
+++ b/metricbeat/helper/sql/sql_test.go
@@ -36,7 +36,7 @@ import (
 
 type kv struct {
 	k string
-	v interface{}
+	v any
 }
 
 type mockVariableMode struct {
@@ -44,11 +44,11 @@ type mockVariableMode struct {
 	results []kv
 }
 
-func (m *mockVariableMode) Scan(dest ...interface{}) error {
+func (m *mockVariableMode) Scan(dest ...any) error {
 	d1 := dest[0].(*string) //nolint:errcheck // false positive
 	*d1 = m.results[m.index].k
 
-	d2 := dest[1].(*interface{}) //nolint:errcheck // false positive
+	d2 := dest[1].(*any) //nolint:errcheck // false positive
 	*d2 = m.results[m.index].v
 
 	m.index++
@@ -73,9 +73,9 @@ type mockTableMode struct {
 	totalResults int
 }
 
-func (m *mockTableMode) Scan(dest ...interface{}) error {
+func (m *mockTableMode) Scan(dest ...any) error {
 	for i, d := range dest {
-		d1 := d.(*interface{}) //nolint:errcheck // false positive
+		d1 := d.(*any) //nolint:errcheck // false positive
 		*d1 = m.results[i].v
 	}
 
@@ -111,7 +111,7 @@ var results = []kv{
 	{k: "float32", v: float32(13.2)},
 	{k: "null", v: nil},
 	{k: "boolean", v: true},
-	{k: "array", v: []interface{}{0, 1, 2}},
+	{k: "array", v: []any{0, 1, 2}},
 	{k: "byte_array", v: []byte("byte_array")},
 	{k: "time", v: time.Now()},
 }
@@ -157,8 +157,8 @@ func checkValue(t *testing.T, res kv, ms mapstr.M) {
 		if actual != nil {
 			t.Errorf("key %q: expected nil, got %v (%T)", res.k, actual, actual)
 		}
-	case []interface{}:
-		actualSlice := actual.([]interface{}) //nolint:errcheck // slice expected
+	case []any:
+		actualSlice := actual.([]any) //nolint:errcheck // slice expected
 		if len(v) != len(actualSlice) {
 			t.Errorf("key %q: slice length mismatch: expected %d, got %d", res.k, len(v), len(actualSlice))
 			return

--- a/metricbeat/module/aerospike/aerospike.go
+++ b/metricbeat/module/aerospike/aerospike.go
@@ -98,10 +98,10 @@ func ParseHost(host string) (*as.Host, error) {
 	return as.NewHost(pieces[0], port), nil
 }
 
-func ParseInfo(info string) map[string]interface{} {
-	result := make(map[string]interface{})
+func ParseInfo(info string) map[string]any {
+	result := make(map[string]any)
 
-	for _, keyValueStr := range strings.Split(info, ";") {
+	for keyValueStr := range strings.SplitSeq(info, ";") {
 		KeyValArr := strings.Split(keyValueStr, "=")
 		if len(KeyValArr) == 2 {
 			result[KeyValArr[0]] = KeyValArr[1]

--- a/metricbeat/module/aerospike/aerospike_test.go
+++ b/metricbeat/module/aerospike/aerospike_test.go
@@ -101,11 +101,6 @@ func TestParseInfo(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func pointer[T any](d T) *T {
-	return new(d)
-}
-
 func TestParseClientPolicy(t *testing.T) {
 	sampleClusterName := "TestCluster"
 	sampleUser := "TestUser"

--- a/metricbeat/module/aerospike/aerospike_test.go
+++ b/metricbeat/module/aerospike/aerospike_test.go
@@ -73,12 +73,12 @@ func TestParseInfo(t *testing.T) {
 	tests := []struct {
 		Name     string
 		info     string
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			Name: "with kv",
 			info: "key1=value1;key2=value2",
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"key1": "value1",
 				"key2": "value2",
 			},
@@ -86,12 +86,12 @@ func TestParseInfo(t *testing.T) {
 		{
 			Name:     "without kv",
 			info:     "wrong result",
-			expected: map[string]interface{}{},
+			expected: map[string]any{},
 		},
 		{
 			Name:     "mixed",
 			info:     "wrong result;key=value",
-			expected: map[string]interface{}{"key": "value"},
+			expected: map[string]any{"key": "value"},
 		},
 	}
 
@@ -101,8 +101,9 @@ func TestParseInfo(t *testing.T) {
 	}
 }
 
+//go:fix inline
 func pointer[T any](d T) *T {
-	return &d
+	return new(d)
 }
 
 func TestParseClientPolicy(t *testing.T) {
@@ -111,7 +112,7 @@ func TestParseClientPolicy(t *testing.T) {
 	samplePassword := "MySecretPassword"
 
 	TLSPolicy := as.NewClientPolicy()
-	tlsconfig, _ := tlscommon.LoadTLSConfig(&tlscommon.Config{Enabled: pointer(true)}, logptest.NewTestingLogger(t, ""))
+	tlsconfig, _ := tlscommon.LoadTLSConfig(&tlscommon.Config{Enabled: new(true)}, logptest.NewTestingLogger(t, ""))
 	TLSPolicy.TlsConfig = tlsconfig.ToConfig()
 
 	ClusterNamePolicy := as.NewClientPolicy()
@@ -151,7 +152,7 @@ func TestParseClientPolicy(t *testing.T) {
 			Name: "TLS Declaration",
 			Config: Config{
 				TLS: &tlscommon.Config{
-					Enabled: pointer(true),
+					Enabled: new(true),
 				},
 			},
 			expectedClientPolicy: TLSPolicy,
@@ -194,7 +195,7 @@ func TestParseClientPolicy(t *testing.T) {
 			Name: "TLS and Basic Auth",
 			Config: Config{
 				TLS: &tlscommon.Config{
-					Enabled: pointer(true),
+					Enabled: new(true),
 				},
 				User:     sampleUser,
 				Password: samplePassword,

--- a/metricbeat/module/aerospike/namespace/namespace.go
+++ b/metricbeat/module/aerospike/namespace/namespace.go
@@ -90,7 +90,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 			continue
 		}
 
-		for _, namespace := range strings.Split(info["namespaces"], ";") {
+		for namespace := range strings.SplitSeq(info["namespaces"], ";") {
 			info, err := node.RequestInfo(m.infoPolicy, "namespace/"+namespace)
 			if err != nil {
 				m.Logger().Errorf("Failed to retrieve metrics for namespace %s from node %s", namespace, node.GetName())

--- a/metricbeat/module/aerospike/namespace/namespace_integration_test.go
+++ b/metricbeat/module/aerospike/namespace/namespace_integration_test.go
@@ -51,8 +51,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event)
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "aerospike",
 		"metricsets": []string{"namespace"},
 		"hosts":      []string{host},

--- a/metricbeat/module/apache/status/data.go
+++ b/metricbeat/module/apache/status/data.go
@@ -99,7 +99,7 @@ var (
 	}
 )
 
-func applySchema(event mapstr.M, fullEvent map[string]interface{}) error {
+func applySchema(event mapstr.M, fullEvent map[string]any) error {
 	applicableSchema := schema
 	if _, found := fullEvent["ServerUptimeSeconds"]; !found {
 		applicableSchema = schemaOld
@@ -125,7 +125,7 @@ func eventMapping(scanner *bufio.Scanner, hostname string, logger *logp.Logger) 
 		totalAll        int
 	)
 
-	fullEvent := map[string]interface{}{}
+	fullEvent := map[string]any{}
 
 	// Iterate through all events to gather data
 	for scanner.Scan() {

--- a/metricbeat/module/apache/status/status_integration_test.go
+++ b/metricbeat/module/apache/status/status_integration_test.go
@@ -79,8 +79,8 @@ func TestFetchFleetMode(t *testing.T) {
 	assert.Equal(t, mapstr.ErrKeyNotFound, err, "apache.status.hostname shouldn't be present in the fleet mode")
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "apache",
 		"metricsets": []string{"status"},
 		"hosts":      []string{host},

--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -83,7 +83,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "apache",
 		"metricsets": []string{"status"},
 		"hosts":      []string{server.URL},
@@ -161,7 +161,7 @@ func TestFetchTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "apache",
 		"metricsets": []string{"status"},
 		"hosts":      []string{server.URL},
@@ -212,7 +212,7 @@ func TestMultipleFetches(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "apache",
 		"metricsets": []string{"status"},
 		"hosts":      []string{server.URL},
@@ -220,7 +220,7 @@ func TestMultipleFetches(t *testing.T) {
 
 	f := mbtest.NewReportingMetricSetV2Error(t, config)
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		_, errs := mbtest.ReportingFetchV2Error(f)
 		if len(errs) > 0 {
 			t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
@@ -250,7 +250,7 @@ func TestHostParser(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		hostData, err := hostParser(mbtest.NewTestModule(t, map[string]interface{}{}), test.host)
+		hostData, err := hostParser(mbtest.NewTestModule(t, map[string]any{}), test.host)
 		if err != nil && test.err != "" {
 			assert.Contains(t, err.Error(), test.err)
 		} else if assert.NoError(t, err, "unexpected error") {

--- a/metricbeat/module/ceph/cluster_disk/cluster_disk_integration_test.go
+++ b/metricbeat/module/ceph/cluster_disk/cluster_disk_integration_test.go
@@ -41,8 +41,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"cluster_disk"},
 		"hosts":      []string{host},

--- a/metricbeat/module/ceph/cluster_disk/cluster_disk_test.go
+++ b/metricbeat/module/ceph/cluster_disk/cluster_disk_test.go
@@ -18,7 +18,8 @@
 package cluster_disk
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -34,7 +35,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/df_sample_response.json")
+	response, err := os.ReadFile(absPath + "/df_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +45,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"cluster_disk"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/ceph/cluster_health/cluster_health_integration_test.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health_integration_test.go
@@ -41,8 +41,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"cluster_health"},
 		"hosts":      []string{host},

--- a/metricbeat/module/ceph/cluster_health/cluster_health_test.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health_test.go
@@ -18,7 +18,8 @@
 package cluster_health
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -34,7 +35,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/sample_response.json")
+	response, err := os.ReadFile(absPath + "/sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +45,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"cluster_health"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/ceph/cluster_status/cluster_status_integration_test.go
+++ b/metricbeat/module/ceph/cluster_status/cluster_status_integration_test.go
@@ -41,8 +41,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"cluster_status"},
 		"hosts":      []string{host},

--- a/metricbeat/module/ceph/cluster_status/cluster_status_test.go
+++ b/metricbeat/module/ceph/cluster_status/cluster_status_test.go
@@ -18,7 +18,8 @@
 package cluster_status
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -34,7 +35,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/status_sample_response.json")
+	response, err := os.ReadFile(absPath + "/status_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +45,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"cluster_status"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/ceph/mgr/event_mapping.go
+++ b/metricbeat/module/ceph/mgr/event_mapping.go
@@ -39,7 +39,7 @@ type Result struct {
 }
 
 // UnmarshalResponse method unmarshals the content to the given response object.
-func UnmarshalResponse(content []byte, response interface{}) error {
+func UnmarshalResponse(content []byte, response any) error {
 	var request Request
 	err := json.Unmarshal(content, &request)
 	if err != nil {

--- a/metricbeat/module/ceph/mgr/metricset.go
+++ b/metricbeat/module/ceph/mgr/metricset.go
@@ -47,6 +47,6 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 }
 
 func (m *MetricSet) WithPrefix(prefix string) *MetricSet {
-	m.HTTP.SetBody([]byte(fmt.Sprintf(`{"prefix": "%s", "format": "json"}`, prefix)))
+	m.HTTP.SetBody(fmt.Appendf(nil, `{"prefix": "%s", "format": "json"}`, prefix))
 	return m
 }

--- a/metricbeat/module/ceph/mgr_cluster_disk/mgr_cluster_disk_integration_test.go
+++ b/metricbeat/module/ceph/mgr_cluster_disk/mgr_cluster_disk_integration_test.go
@@ -40,8 +40,8 @@ func TestData(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func getConfig(host, password string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host, password string) map[string]any {
+	return map[string]any{
 		"module":                "ceph",
 		"metricsets":            []string{"mgr_cluster_disk"},
 		"hosts":                 []string{host},

--- a/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health.go
+++ b/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health.go
@@ -65,13 +65,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
-	m.HTTP.SetBody([]byte(fmt.Sprintf(`{"prefix": "%s", "format": "json"}`, cephStatusPrefix)))
+	m.HTTP.SetBody(fmt.Appendf(nil, `{"prefix": "%s", "format": "json"}`, cephStatusPrefix))
 	statusContent, err := m.HTTP.FetchContent()
 	if err != nil {
 		return err
 	}
 
-	m.HTTP.SetBody([]byte(fmt.Sprintf(`{"prefix": "%s", "format": "json"}`, cephTimeSyncStatusPrefix)))
+	m.HTTP.SetBody(fmt.Appendf(nil, `{"prefix": "%s", "format": "json"}`, cephTimeSyncStatusPrefix))
 	timeStatusContent, err := m.HTTP.FetchContent()
 	if err != nil {
 		return err

--- a/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health_integration_test.go
+++ b/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health_integration_test.go
@@ -39,8 +39,8 @@ func TestData(t *testing.T) {
 	err := mbtest.WriteEventsReporterV2Error(f, t, "")
 	require.NoError(t, err)
 }
-func getConfig(host, password string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host, password string) map[string]any {
+	return map[string]any{
 		"module":                "ceph",
 		"metricsets":            []string{"mgr_cluster_health"},
 		"hosts":                 []string{host},

--- a/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health_test.go
+++ b/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health_test.go
@@ -19,9 +19,9 @@ package mgr_cluster_health
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -41,9 +41,9 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("./_meta/testdata/")
 	assert.NoError(t, err)
 
-	statusResponse, err := ioutil.ReadFile(absPath + "/status.json")
+	statusResponse, err := os.ReadFile(absPath + "/status.json")
 	assert.NoError(t, err)
-	timeSyncStatusResponse, err := ioutil.ReadFile(absPath + "/time_sync_status.json")
+	timeSyncStatusResponse, err := os.ReadFile(absPath + "/time_sync_status.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -63,7 +63,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"mgr_cluster_health"},
 		"hosts":      []string{server.URL},
@@ -93,7 +93,7 @@ func TestFetchEventContents_Failed(t *testing.T) {
 	absPath, err := filepath.Abs("./_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/failed.json")
+	response, err := os.ReadFile(absPath + "/failed.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -103,7 +103,7 @@ func TestFetchEventContents_Failed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"mgr_cluster_health"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/ceph/mgr_osd_perf/mgr_osd_perf_integration_test.go
+++ b/metricbeat/module/ceph/mgr_osd_perf/mgr_osd_perf_integration_test.go
@@ -40,8 +40,8 @@ func TestData(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func getConfig(host, password string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host, password string) map[string]any {
+	return map[string]any{
 		"module":                "ceph",
 		"metricsets":            []string{"mgr_osd_perf"},
 		"hosts":                 []string{host},

--- a/metricbeat/module/ceph/mgr_osd_pool_stats/mgr_osd_pool_stats_integration_test.go
+++ b/metricbeat/module/ceph/mgr_osd_pool_stats/mgr_osd_pool_stats_integration_test.go
@@ -40,8 +40,8 @@ func TestData(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func getConfig(host, password string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host, password string) map[string]any {
+	return map[string]any{
 		"module":                "ceph",
 		"metricsets":            []string{"mgr_osd_pool_stats"},
 		"hosts":                 []string{host},

--- a/metricbeat/module/ceph/mgr_osd_tree/mgr_osd_tree_integration_test.go
+++ b/metricbeat/module/ceph/mgr_osd_tree/mgr_osd_tree_integration_test.go
@@ -40,8 +40,8 @@ func TestData(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func getConfig(host, password string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host, password string) map[string]any {
+	return map[string]any{
 		"module":                "ceph",
 		"metricsets":            []string{"mgr_osd_tree"},
 		"hosts":                 []string{host},

--- a/metricbeat/module/ceph/mgr_pool_disk/mgr_pool_disk_integration_test.go
+++ b/metricbeat/module/ceph/mgr_pool_disk/mgr_pool_disk_integration_test.go
@@ -40,8 +40,8 @@ func TestData(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func getConfig(host, password string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host, password string) map[string]any {
+	return map[string]any{
 		"module":                "ceph",
 		"metricsets":            []string{"mgr_pool_disk"},
 		"hosts":                 []string{host},

--- a/metricbeat/module/ceph/monitor_health/monitor_health_test.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health_test.go
@@ -18,7 +18,8 @@
 package monitor_health
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -36,7 +37,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/sample_response.json")
+	response, err := os.ReadFile(absPath + "/sample_response.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -44,7 +45,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"monitor_health"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/ceph/osd_df/osd_df_integration_test.go
+++ b/metricbeat/module/ceph/osd_df/osd_df_integration_test.go
@@ -36,8 +36,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"osd_df"},
 		"hosts":      []string{host},

--- a/metricbeat/module/ceph/osd_df/osd_df_test.go
+++ b/metricbeat/module/ceph/osd_df/osd_df_test.go
@@ -18,7 +18,8 @@
 package osd_df
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -33,7 +34,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/osd_df_sample_response.json")
+	response, err := os.ReadFile(absPath + "/osd_df_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +44,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"osd_df"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/ceph/osd_tree/osd_tree_integration_test.go
+++ b/metricbeat/module/ceph/osd_tree/osd_tree_integration_test.go
@@ -36,8 +36,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"osd_tree"},
 		"hosts":      []string{host},

--- a/metricbeat/module/ceph/osd_tree/osd_tree_test.go
+++ b/metricbeat/module/ceph/osd_tree/osd_tree_test.go
@@ -18,7 +18,8 @@
 package osd_tree
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -33,7 +34,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/osd_tree_sample_response.json")
+	response, err := os.ReadFile(absPath + "/osd_tree_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +44,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"osd_tree"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/ceph/pool_disk/pool_disk_integration_test.go
+++ b/metricbeat/module/ceph/pool_disk/pool_disk_integration_test.go
@@ -36,8 +36,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"pool_disk"},
 		"hosts":      []string{host},

--- a/metricbeat/module/ceph/pool_disk/pool_disk_test.go
+++ b/metricbeat/module/ceph/pool_disk/pool_disk_test.go
@@ -18,7 +18,8 @@
 package pool_disk
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -34,7 +35,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/df_sample_response.json")
+	response, err := os.ReadFile(absPath + "/df_sample_response.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -42,7 +43,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "ceph",
 		"metricsets": []string{"pool_disk"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/couchbase/bucket/bucket_integration_test.go
+++ b/metricbeat/module/couchbase/bucket/bucket_integration_test.go
@@ -57,8 +57,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "couchbase",
 		"metricsets": []string{"bucket"},
 		"hosts":      []string{couchbase.GetDSN(host)},

--- a/metricbeat/module/couchbase/bucket/bucket_test.go
+++ b/metricbeat/module/couchbase/bucket/bucket_test.go
@@ -20,7 +20,8 @@
 package bucket
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -37,7 +38,7 @@ func TestFetchEventContents(t *testing.T) {
 	assert.NoError(t, err)
 
 	// response is a raw response from a couchbase
-	response, err := ioutil.ReadFile(absPath + "/sample_response.json")
+	response, err := os.ReadFile(absPath + "/sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +48,7 @@ func TestFetchEventContents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "couchbase",
 		"metricsets": []string{"bucket"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/couchbase/cluster/cluster_integration_test.go
+++ b/metricbeat/module/couchbase/cluster/cluster_integration_test.go
@@ -42,8 +42,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "couchbase",
 		"metricsets": []string{"cluster"},
 		"hosts":      []string{couchbase.GetDSN(host)},

--- a/metricbeat/module/couchbase/node/node_integration_test.go
+++ b/metricbeat/module/couchbase/node/node_integration_test.go
@@ -42,8 +42,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "couchbase",
 		"metricsets": []string{"node"},
 		"hosts":      []string{couchbase.GetDSN(host)},

--- a/metricbeat/module/couchdb/server/server_integration_test.go
+++ b/metricbeat/module/couchdb/server/server_integration_test.go
@@ -51,14 +51,14 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
+func getConfig(host string) map[string]any {
 	h := os.Getenv("COUCHDB_HOST")
 
 	if h != "" {
 		host = h
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "couchdb",
 		"metricsets": []string{"server"},
 		"hosts":      []string{host},

--- a/metricbeat/module/etcd/leader/leader.go
+++ b/metricbeat/module/etcd/leader/leader.go
@@ -103,7 +103,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 
 	// Errors might be reported as {"message":"<error message>"}
 	// let's look for that structure
-	var jsonResponse map[string]interface{}
+	var jsonResponse map[string]any
 	if err = json.Unmarshal(content, &jsonResponse); err == nil {
 		if retMessage := jsonResponse[msgElement]; retMessage != "" {
 			// there is an error message element, let's use it

--- a/metricbeat/module/etcd/leader/leader_integration_test.go
+++ b/metricbeat/module/etcd/leader/leader_integration_test.go
@@ -55,8 +55,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "etcd",
 		"metricsets": []string{"leader"},
 		"hosts":      []string{host},

--- a/metricbeat/module/etcd/leader/leader_test.go
+++ b/metricbeat/module/etcd/leader/leader_test.go
@@ -19,9 +19,9 @@ package leader
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -33,7 +33,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("../_meta/test/leaderstats.json")
+	content, err := os.ReadFile("../_meta/test/leaderstats.json")
 	assert.NoError(t, err)
 
 	var data Leader
@@ -109,7 +109,7 @@ func TestFetchEventContent(t *testing.T) {
 			absPath, err := filepath.Abs(mockedFetchLocation + tc.mockedFetchFile)
 			assert.NoError(t, err)
 
-			response, err := ioutil.ReadFile(absPath)
+			response, err := os.ReadFile(absPath)
 			assert.NoError(t, err)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -119,7 +119,7 @@ func TestFetchEventContent(t *testing.T) {
 			}))
 			defer server.Close()
 
-			config := map[string]interface{}{
+			config := map[string]any{
 				"module":     module,
 				"metricsets": []string{metricset},
 				"hosts":      []string{server.URL},

--- a/metricbeat/module/etcd/metrics/metrics_integration_test.go
+++ b/metricbeat/module/etcd/metrics/metrics_integration_test.go
@@ -48,8 +48,8 @@ func TestIntegrationData(t *testing.T) {
 	m.WriteEvents(t, "")
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "etcd",
 		"metricsets": []string{"metrics"},
 		"hosts":      []string{host},

--- a/metricbeat/module/etcd/self/self_integration_test.go
+++ b/metricbeat/module/etcd/self/self_integration_test.go
@@ -56,8 +56,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "etcd",
 		"metricsets": []string{"self"},
 		"hosts":      []string{host},

--- a/metricbeat/module/etcd/self/self_test.go
+++ b/metricbeat/module/etcd/self/self_test.go
@@ -18,9 +18,9 @@
 package self
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("../_meta/test/selfstats.json")
+	content, err := os.ReadFile("../_meta/test/selfstats.json")
 	assert.NoError(t, err)
 
 	event := eventMapping(content)
@@ -43,7 +43,7 @@ func TestFetchEventContent(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/test/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/selfstats.json")
+	response, err := os.ReadFile(absPath + "/selfstats.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -51,7 +51,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "etcd",
 		"metricsets": []string{"self"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/etcd/store/data.go
+++ b/metricbeat/module/etcd/store/data.go
@@ -63,7 +63,7 @@ var (
 )
 
 func eventMapping(content []byte) mapstr.M {
-	var data map[string]interface{}
+	var data map[string]any
 	json.Unmarshal(content, &data)
 	event, _ := schema.Apply(data)
 	return event

--- a/metricbeat/module/etcd/store/store_integration_test.go
+++ b/metricbeat/module/etcd/store/store_integration_test.go
@@ -46,8 +46,8 @@ func TestData(t *testing.T) {
 	f.WriteEvents(t, "")
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "etcd",
 		"metricsets": []string{"store"},
 		"hosts":      []string{host},

--- a/metricbeat/module/etcd/store/store_test.go
+++ b/metricbeat/module/etcd/store/store_test.go
@@ -18,9 +18,9 @@
 package store
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +32,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("../_meta/test/storestats.json")
+	content, err := os.ReadFile("../_meta/test/storestats.json")
 	assert.NoError(t, err)
 
 	event := eventMapping(content)
@@ -44,7 +44,7 @@ func TestFetchEventContent(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/test/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/storestats.json")
+	response, err := os.ReadFile(absPath + "/storestats.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +54,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "etcd",
 		"metricsets": []string{"store"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/golang/expvar/expvar_integration_test.go
+++ b/metricbeat/module/golang/expvar/expvar_integration_test.go
@@ -54,8 +54,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":           "golang",
 		"metricsets":       []string{"expvar"},
 		"expvar.namespace": "metricbeat",

--- a/metricbeat/module/golang/heap/data.go
+++ b/metricbeat/module/golang/heap/data.go
@@ -27,7 +27,7 @@ import (
 // Stats contains the memory info that we get from the fetch request
 type Stats struct {
 	MemStats runtime.MemStats
-	Cmdline  []interface{}
+	Cmdline  []any
 }
 
 func eventMapping(stats Stats, m *MetricSet) mapstr.M {

--- a/metricbeat/module/golang/heap/heap_integration_test.go
+++ b/metricbeat/module/golang/heap/heap_integration_test.go
@@ -54,8 +54,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "golang",
 		"metricsets": []string{"heap"},
 		"hosts":      []string{host},

--- a/metricbeat/module/golang/util.go
+++ b/metricbeat/module/golang/util.go
@@ -25,11 +25,11 @@ import (
 )
 
 // GetCmdStr Convert cmd array to cmd line
-func GetCmdStr(v interface{}, logger *logp.Logger) interface{} {
+func GetCmdStr(v any, logger *logp.Logger) any {
 	switch t := v.(type) {
-	case []interface{}:
+	case []any:
 		var buffer bytes.Buffer
-		strs := v.([]interface{})
+		strs := v.([]any)
 		for _, v := range strs {
 			buffer.WriteString(v.(string))
 			buffer.WriteString(" ")

--- a/metricbeat/module/haproxy/haproxy.go
+++ b/metricbeat/module/haproxy/haproxy.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+
 	"net"
 	"net/url"
 	"strings"
@@ -260,11 +260,11 @@ func (c *Client) GetInfo() (*Info, error) {
 		return nil, err
 	}
 
-	if b, err := ioutil.ReadAll(res); err == nil {
+	if b, err := io.ReadAll(res); err == nil {
 
-		resultMap := map[string]interface{}{}
+		resultMap := map[string]any{}
 
-		for _, ln := range strings.Split(string(b), "\n") {
+		for ln := range strings.SplitSeq(string(b), "\n") {
 
 			ln := strings.TrimSpace(ln)
 			if ln == "" {

--- a/metricbeat/module/haproxy/haproxy_test.go
+++ b/metricbeat/module/haproxy/haproxy_test.go
@@ -35,7 +35,7 @@ func TestHostParser(t *testing.T) {
 		{"unix:///var/lib/haproxy/stats", "unix:///var/lib/haproxy/stats"},
 	}
 
-	m := mbtest.NewTestModule(t, map[string]interface{}{})
+	m := mbtest.NewTestModule(t, map[string]any{})
 
 	for _, test := range tests {
 		hi, err := HostParser(m, test.host)

--- a/metricbeat/module/haproxy/info/data.go
+++ b/metricbeat/module/haproxy/info/data.go
@@ -165,7 +165,7 @@ func eventMapping(info *haproxy.Info, r mb.ReporterV2) (mb.Event, error) {
 
 	st := reflect.ValueOf(info).Elem()
 	typeOfT := st.Type()
-	source := map[string]interface{}{}
+	source := map[string]any{}
 
 	for i := 0; i < st.NumField(); i++ {
 		f := st.Field(i)

--- a/metricbeat/module/haproxy/info/info_integration_test.go
+++ b/metricbeat/module/haproxy/info/info_integration_test.go
@@ -56,8 +56,8 @@ func TestData(t *testing.T) {
 
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "haproxy",
 		"metricsets": []string{"info"},
 		"hosts":      []string{"tcp://" + host},

--- a/metricbeat/module/haproxy/stat/data.go
+++ b/metricbeat/module/haproxy/stat/data.go
@@ -178,7 +178,7 @@ func eventMapping(info []*haproxy.Stat, r mb.ReporterV2) {
 	for _, evt := range info {
 		st := reflect.ValueOf(evt).Elem()
 		typeOfT := st.Type()
-		source := map[string]interface{}{}
+		source := map[string]any{}
 
 		for i := 0; i < st.NumField(); i++ {
 			f := st.Field(i)

--- a/metricbeat/module/haproxy/stat/stat_integration_test.go
+++ b/metricbeat/module/haproxy/stat/stat_integration_test.go
@@ -56,8 +56,8 @@ func TestData(t *testing.T) {
 
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "haproxy",
 		"metricsets": []string{"stat"},
 		"hosts":      []string{"tcp://" + host},

--- a/metricbeat/module/http/json/data.go
+++ b/metricbeat/module/http/json/data.go
@@ -27,7 +27,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-func (m *MetricSet) processBody(response *http.Response, jsonBody interface{}) mb.Event {
+func (m *MetricSet) processBody(response *http.Response, jsonBody any) mb.Event {
 	var event mapstr.M
 
 	if m.deDotEnabled {

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -20,7 +20,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -128,7 +128,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		}
 	}()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/metricbeat/module/http/json/json_integration_test.go
+++ b/metricbeat/module/http/json/json_integration_test.go
@@ -62,7 +62,7 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string, jsonType string) map[string]interface{} {
+func getConfig(host string, jsonType string) map[string]any {
 	var path string
 	var responseIsArray bool
 	switch jsonType {
@@ -74,7 +74,7 @@ func getConfig(host string, jsonType string) map[string]interface{} {
 		responseIsArray = true
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":        "http",
 		"metricsets":    []string{"json"},
 		"hosts":         []string{host},

--- a/metricbeat/module/jolokia/jmx/config.go
+++ b/metricbeat/module/jolokia/jmx/config.go
@@ -75,11 +75,11 @@ type Target struct {
 //
 // ]
 type RequestBlock struct {
-	Type      string                 `json:"type"`
-	MBean     string                 `json:"mbean"`
-	Attribute []string               `json:"attribute"`
-	Config    map[string]interface{} `json:"config"`
-	Target    *TargetBlock           `json:"target,omitempty"`
+	Type      string         `json:"type"`
+	MBean     string         `json:"mbean"`
+	Attribute []string       `json:"attribute"`
+	Config    map[string]any `json:"config"`
+	Target    *TargetBlock   `json:"target,omitempty"`
 }
 
 // TargetBlock is used to build the target blocks of the following format into RequestBlock.
@@ -424,7 +424,7 @@ func (pc *JolokiaHTTPPostFetcher) buildRequestBodyAndMapping(mappings []JMXMappi
 	// So use canonicalized names everywhere.
 	// If Jolokia returns non-canonicalized MBean names, then we'll need to canonicalize
 	// them or change our approach to mappings.
-	config := map[string]interface{}{
+	config := map[string]any{
 		"ignoreErrors":    true,
 		"canonicalNaming": true,
 	}

--- a/metricbeat/module/jolokia/jmx/data.go
+++ b/metricbeat/module/jolokia/jmx/data.go
@@ -33,10 +33,10 @@ const (
 
 type Entry struct {
 	Request struct {
-		Mbean     string      `json:"mbean"`
-		Attribute interface{} `json:"attribute"`
+		Mbean     string `json:"mbean"`
+		Attribute any    `json:"attribute"`
 	}
-	Value interface{}
+	Value any
 }
 
 // Map responseBody to mapstr.M
@@ -134,11 +134,11 @@ func eventMapping(entries []Entry, mapping AttributeMapping, logger *logp.Logger
 				if err != nil {
 					errs = append(errs, err)
 				}
-			case map[string]interface{}:
+			case map[string]any:
 				errs = constructEvents(entryValues, v, mbeanEvents, mapping, errs, logger)
 			}
-		case []interface{}:
-			entryValues, ok := v.Value.(map[string]interface{})
+		case []any:
+			entryValues, ok := v.Value.(map[string]any)
 			if ok {
 				errs = constructEvents(entryValues, v, mbeanEvents, mapping, errs, logger)
 			}
@@ -153,7 +153,7 @@ func eventMapping(entries []Entry, mapping AttributeMapping, logger *logp.Logger
 	return events, errors.Join(errs...)
 }
 
-func constructEvents(entryValues map[string]interface{}, v Entry, mbeanEvents map[eventKey]mapstr.M, mapping AttributeMapping, errs []error, logger *logp.Logger) []error {
+func constructEvents(entryValues map[string]any, v Entry, mbeanEvents map[eventKey]mapstr.M, mapping AttributeMapping, errs []error, logger *logp.Logger) []error {
 	hasWildcard := strings.Contains(v.Request.Mbean, "*")
 	for attribute, value := range entryValues {
 		if !hasWildcard {
@@ -167,7 +167,7 @@ func constructEvents(entryValues map[string]interface{}, v Entry, mbeanEvents ma
 		// If there was a wildcard, we are going to have an additional
 		// nesting level in response values, and attribute here is going
 		// to be actually the matching mbean name
-		values, ok := value.(map[string]interface{})
+		values, ok := value.(map[string]any)
 		if !ok {
 			errs = append(errs, fmt.Errorf("expected map of values for %s", v.Request.Mbean))
 			continue
@@ -200,7 +200,7 @@ func parseResponseEntry(
 	requestMbeanName string,
 	responseMbeanName string,
 	attributeName string,
-	attributeValue interface{},
+	attributeValue any,
 	events map[eventKey]mapstr.M,
 	mapping AttributeMapping,
 	logger *logp.Logger,
@@ -223,8 +223,8 @@ func parseResponseEntry(
 	// In case the attributeValue is a map the keys are dedotted
 	data := attributeValue
 	switch aValue := attributeValue.(type) {
-	case map[string]interface{}:
-		newData := map[string]interface{}{}
+	case map[string]any:
+		newData := map[string]any{}
 		for k, v := range aValue {
 			newData[common.DeDot(k)] = v
 		}

--- a/metricbeat/module/jolokia/jmx/data_test.go
+++ b/metricbeat/module/jolokia/jmx/data_test.go
@@ -18,7 +18,7 @@
 package jmx
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +34,7 @@ func TestEventMapper(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response.json")
 
 	require.NoError(t, err)
 
@@ -71,20 +71,20 @@ func TestEventMapper(t *testing.T) {
 				"cms_collection_count": float64(1),
 			},
 			"memory": mapstr.M{
-				"heap_usage": map[string]interface{}{
+				"heap_usage": map[string]any{
 					"init":      float64(1073741824),
 					"committed": float64(1037959168),
 					"max":       float64(1037959168),
 					"used":      float64(227420472),
 				},
-				"non_heap_usage": map[string]interface{}{
+				"non_heap_usage": map[string]any{
 					"init":      float64(2555904),
 					"committed": float64(53477376),
 					"max":       float64(-1),
 					"used":      float64(50519768),
 				},
 			},
-			"metrics": map[string]interface{}{
+			"metrics": map[string]any{
 				"atomikos_nbTransactions": float64(0),
 				"classes":                 float64(18857),
 				"classes_loaded":          float64(19127),
@@ -105,7 +105,7 @@ func TestEventGroupingMapper(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response.json")
 
 	require.NoError(t, err)
 
@@ -137,7 +137,7 @@ func TestEventGroupingMapper(t *testing.T) {
 	expected := []mapstr.M{
 		{
 			"uptime": float64(47283),
-			"metrics": map[string]interface{}{
+			"metrics": map[string]any{
 				"atomikos_nbTransactions": float64(0),
 				"classes":                 float64(18857),
 				"classes_loaded":          float64(19127),
@@ -153,13 +153,13 @@ func TestEventGroupingMapper(t *testing.T) {
 		},
 		{
 			"memory": mapstr.M{
-				"heap_usage": map[string]interface{}{
+				"heap_usage": map[string]any{
 					"init":      float64(1073741824),
 					"committed": float64(1037959168),
 					"max":       float64(1037959168),
 					"used":      float64(227420472),
 				},
-				"non_heap_usage": map[string]interface{}{
+				"non_heap_usage": map[string]any{
 					"init":      float64(2555904),
 					"committed": float64(53477376),
 					"max":       float64(-1),
@@ -182,7 +182,7 @@ func TestEventGroupingMapperGetRequest(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_get_response.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_get_response.json")
 
 	require.NoError(t, err)
 
@@ -204,13 +204,13 @@ func TestEventGroupingMapperGetRequest(t *testing.T) {
 	expected := []mapstr.M{
 		{
 			"memory": mapstr.M{
-				"heap_usage": map[string]interface{}{
+				"heap_usage": map[string]any{
 					"init":      float64(1073741824),
 					"committed": float64(1037959168),
 					"max":       float64(1037959168),
 					"used":      float64(227420472),
 				},
-				"non_heap_usage": map[string]interface{}{
+				"non_heap_usage": map[string]any{
 					"init":      float64(2555904),
 					"committed": float64(53477376),
 					"max":       float64(-1),
@@ -231,7 +231,7 @@ func TestEventGroupingMapperGetRequestUptime(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_get_response_uptime.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_get_response_uptime.json")
 
 	require.NoError(t, err)
 
@@ -265,7 +265,7 @@ func TestEventMapperWithWildcard(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response_wildcard.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response_wildcard.json")
 
 	require.NoError(t, err)
 
@@ -306,7 +306,7 @@ func TestEventGroupingMapperWithWildcard(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response_wildcard.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response_wildcard.json")
 
 	require.NoError(t, err)
 

--- a/metricbeat/module/jolokia/jmx/jmx_integration_test.go
+++ b/metricbeat/module/jolokia/jmx/jmx_integration_test.go
@@ -55,14 +55,14 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfigs(host string) []map[string]interface{} {
-	return []map[string]interface{}{
+func getConfigs(host string) []map[string]any {
+	return []map[string]any{
 		{
 			"module":     "jolokia",
 			"metricsets": []string{"jmx"},
 			"hosts":      []string{host},
 			"namespace":  "testnamespace",
-			"jmx.mappings": []map[string]interface{}{
+			"jmx.mappings": []map[string]any{
 				{
 					"mbean": "java.lang:type=Runtime",
 					"attributes": []map[string]string{
@@ -105,7 +105,7 @@ func getConfigs(host string) []map[string]interface{} {
 			"metricsets": []string{"jmx"},
 			"hosts":      []string{host},
 			"namespace":  "testnamespace",
-			"jmx.mappings": []map[string]interface{}{
+			"jmx.mappings": []map[string]any{
 				{
 					"mbean": "Catalina:name=*,type=ThreadPool",
 					"attributes": []map[string]string{
@@ -155,7 +155,7 @@ func getConfigs(host string) []map[string]interface{} {
 			"hosts":       []string{host},
 			"namespace":   "testnamespace",
 			"http_method": "GET",
-			"jmx.mappings": []map[string]interface{}{
+			"jmx.mappings": []map[string]any{
 				{
 					"mbean": "java.lang:type=GarbageCollector,name=ConcurrentMarkSweep",
 					"attributes": []map[string]string{

--- a/metricbeat/module/kafka/broker.go
+++ b/metricbeat/module/kafka/broker.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -562,10 +563,8 @@ func fromSaramaGroupMemberDescription(memberDescr *sarama.GroupMemberDescription
 
 func anyIPsMatch(as, bs []net.IP) bool {
 	for _, a := range as {
-		for _, b := range bs {
-			if a.Equal(b) {
-				return true
-			}
+		if slices.ContainsFunc(bs, a.Equal) {
+			return true
 		}
 	}
 	return false

--- a/metricbeat/module/kafka/broker/broker_integration_test.go
+++ b/metricbeat/module/kafka/broker/broker_integration_test.go
@@ -58,8 +58,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", m.Module().Name(), m.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "kafka",
 		"metricsets": []string{"broker"},
 		"hosts":      []string{host},

--- a/metricbeat/module/kafka/consumer/consumer_integration_test.go
+++ b/metricbeat/module/kafka/consumer/consumer_integration_test.go
@@ -58,8 +58,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", m.Module().Name(), m.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "kafka",
 		"metricsets": []string{"consumer"},
 		"hosts":      []string{host},

--- a/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
+++ b/metricbeat/module/kafka/consumergroup/consumergroup_integration_test.go
@@ -53,7 +53,7 @@ func TestData(t *testing.T) {
 	defer c.Close()
 
 	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(host))
-	for retries := 0; retries < 3; retries++ {
+	for range 3 {
 		err = mbtest.WriteEventsReporterV2Error(ms, t, "")
 		if err == nil {
 			return
@@ -79,7 +79,7 @@ func TestFetch(t *testing.T) {
 
 	var data []mb.Event
 	var errors []error
-	for retries := 0; retries < 3; retries++ {
+	for range 3 {
 		data, errors = mbtest.ReportingFetchV2Error(f)
 		if len(data) > 0 {
 			continue
@@ -115,8 +115,8 @@ func startConsumer(t *testing.T, host string, groupID string) (io.Closer, error)
 	return consumerGroup, nil
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "kafka",
 		"metricsets": []string{"consumergroup"},
 		"hosts":      []string{host},

--- a/metricbeat/module/kafka/consumergroup/query_test.go
+++ b/metricbeat/module/kafka/consumergroup/query_test.go
@@ -20,6 +20,7 @@ package consumergroup
 import (
 	"fmt"
 	"io"
+	"maps"
 	"reflect"
 	"testing"
 
@@ -280,9 +281,7 @@ func testEvent(
 	}
 
 	for _, extra := range fields {
-		for k, v := range extra {
-			event[k] = v
-		}
+		maps.Copy(event, extra)
 	}
 	return event
 }

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -20,6 +20,7 @@ package partition
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -204,10 +205,5 @@ func queryOffsetRange(
 }
 
 func hasID(id int32, lst []int32) bool {
-	for _, other := range lst {
-		if id == other {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(lst, id)
 }

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -166,13 +166,13 @@ func generateKafkaData(t *testing.T, host string, topic string) {
 	}
 }
 
-func getConfig(host string, topic string) map[string]interface{} {
+func getConfig(host string, topic string) map[string]any {
 	var topics []string
 	if topic != "" {
 		topics = []string{topic}
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "kafka",
 		"metricsets": []string{"partition"},
 		"hosts":      []string{host},

--- a/metricbeat/module/kafka/producer/producer_integration_test.go
+++ b/metricbeat/module/kafka/producer/producer_integration_test.go
@@ -58,8 +58,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", m.Module().Name(), m.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "kafka",
 		"metricsets": []string{"producer"},
 		"hosts":      []string{host},

--- a/metricbeat/module/memcached/stats/stats.go
+++ b/metricbeat/module/memcached/stats/stats.go
@@ -69,7 +69,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 
 	scanner := bufio.NewScanner(conn)
 
-	data := map[string]interface{}{}
+	data := map[string]any{}
 
 	for scanner.Scan() {
 		text := scanner.Text()

--- a/metricbeat/module/memcached/stats/stats_integration_test.go
+++ b/metricbeat/module/memcached/stats/stats_integration_test.go
@@ -57,8 +57,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event)
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "memcached",
 		"metricsets": []string{"stats"},
 		"hosts":      []string{host},

--- a/metricbeat/module/mongodb/collstats/collstats.go
+++ b/metricbeat/module/mongodb/collstats/collstats.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -53,7 +54,7 @@ type CollStatsOptions struct {
 type CollectionInfo struct {
 	Database   string
 	Collection string
-	TopInfo    map[string]interface{} // Optional info from top command (mongod only)
+	TopInfo    map[string]any // Optional info from top command (mongod only)
 }
 
 // Metricset type defines all fields of the Metricset
@@ -128,7 +129,6 @@ func (m *Metricset) Fetch(reporter mb.ReporterV2) error {
 	collStatsErrGroup.SetLimit(10) // limit number of goroutines running at the same time
 
 	for _, collInfo := range collections {
-		collInfo := collInfo // make sure it works properly on older Go versions
 
 		collStatsErrGroup.Go(func() error {
 			database, collection := collInfo.Database, collInfo.Collection
@@ -146,7 +146,7 @@ func (m *Metricset) Fetch(reporter mb.ReporterV2) error {
 			}
 
 			// Create infoMap structure similar to what top command provides
-			infoMap := map[string]interface{}{
+			infoMap := map[string]any{
 				"stats": collStats,
 			}
 
@@ -211,7 +211,7 @@ func (m *Metricset) cacheMongoVersion(client *mongo.Client) {
 }
 
 // fetchCollStatsWithVersion selects the appropriate method based on MongoDB version
-func (m *Metricset) fetchCollStatsWithVersion(client *mongo.Client, dbName, collectionName string) (map[string]interface{}, error) {
+func (m *Metricset) fetchCollStatsWithVersion(client *mongo.Client, dbName, collectionName string) (map[string]any, error) {
 	// For MongoDB 6.2+, try aggregation first with fallback to command
 	if isVersionAtLeast(m.mongoVersion, "6.2.0") {
 		m.Logger().Debugf("collstats: using $collStats aggregation for %s.%s (scale=%d)", dbName, collectionName, m.options.Scale)
@@ -232,7 +232,7 @@ func (m *Metricset) fetchCollStatsWithVersion(client *mongo.Client, dbName, coll
 }
 
 // fetchCollStatsAggregation uses the $collStats aggregation stage (MongoDB 6.2+)
-func (m *Metricset) fetchCollStatsAggregation(client *mongo.Client, dbName, collectionName string) (map[string]interface{}, error) {
+func (m *Metricset) fetchCollStatsAggregation(client *mongo.Client, dbName, collectionName string) (map[string]any, error) {
 	collection := client.Database(dbName).Collection(collectionName)
 	ctx := context.Background()
 
@@ -258,7 +258,7 @@ func (m *Metricset) fetchCollStatsAggregation(client *mongo.Client, dbName, coll
 	}
 	defer cursor.Close(ctx)
 
-	var results []map[string]interface{}
+	var results []map[string]any
 	if err := cursor.All(ctx, &results); err != nil {
 		return nil, fmt.Errorf("could not decode aggregation results: %w", err)
 	}
@@ -289,7 +289,7 @@ func (m *Metricset) fetchCollStatsAggregation(client *mongo.Client, dbName, coll
 }
 
 // fetchCollStatsCommand uses the legacy collStats command (pre-6.2 and fallback)
-func (m *Metricset) fetchCollStatsCommand(client *mongo.Client, dbName, collectionName string) (map[string]interface{}, error) {
+func (m *Metricset) fetchCollStatsCommand(client *mongo.Client, dbName, collectionName string) (map[string]any, error) {
 	db := client.Database(dbName)
 
 	// Build command with options.
@@ -311,7 +311,7 @@ func (m *Metricset) fetchCollStatsCommand(client *mongo.Client, dbName, collecti
 	if err := collStats.Err(); err != nil {
 		return nil, fmt.Errorf("collStats command failed: %w", err)
 	}
-	var statsRes map[string]interface{}
+	var statsRes map[string]any
 	if err := collStats.Decode(&statsRes); err != nil {
 		return nil, fmt.Errorf("could not decode mongo response for database=%s, collection=%s: %w", dbName, collectionName, err)
 	}
@@ -320,7 +320,7 @@ func (m *Metricset) fetchCollStatsCommand(client *mongo.Client, dbName, collecti
 }
 
 // applyOptionsToStats applies post-processing options to collected statistics
-func (m *Metricset) applyOptionsToStats(stats map[string]interface{}) (map[string]interface{}, error) {
+func (m *Metricset) applyOptionsToStats(stats map[string]any) (map[string]any, error) {
 	if stats == nil {
 		return stats, nil
 	}
@@ -340,16 +340,14 @@ func (m *Metricset) applyOptionsToStats(stats map[string]interface{}) (map[strin
 }
 
 // mergeShardedCollStats merges collection statistics from multiple shards
-func mergeShardedCollStats(shardResults []map[string]interface{}) (map[string]interface{}, error) {
+func mergeShardedCollStats(shardResults []map[string]any) (map[string]any, error) {
 	if len(shardResults) == 0 {
 		return nil, fmt.Errorf("no shard results to merge")
 	}
 
 	// Start with the first shard's result as the base
-	merged := make(map[string]interface{})
-	for key, value := range shardResults[0] {
-		merged[key] = value
-	}
+	merged := make(map[string]any)
+	maps.Copy(merged, shardResults[0])
 
 	// Fields that should be summed across shards
 	sumFields := []string{
@@ -479,7 +477,7 @@ func mergeShardedCollStats(shardResults []map[string]interface{}) (map[string]in
 // includes it (the hostname of the serving node), even on a standalone mongod or
 // a replica set. Treating "host" as shard metadata would force every standalone
 // result through the sharded-merge path and emit a spurious shardCount=1.
-func hasShardMetadata(result map[string]interface{}) bool {
+func hasShardMetadata(result map[string]any) bool {
 	if result == nil {
 		return false
 	}
@@ -488,7 +486,7 @@ func hasShardMetadata(result map[string]interface{}) bool {
 }
 
 // convertToFloat64 safely converts various numeric types to float64
-func convertToFloat64(value interface{}) (float64, bool) {
+func convertToFloat64(value any) (float64, bool) {
 	switch v := value.(type) {
 	case float64:
 		return v, true
@@ -521,7 +519,7 @@ func convertToFloat64(value interface{}) (float64, bool) {
 
 // flattenAggregationResult flattens the $collStats aggregation output (storageStats sub-document)
 // to resemble the legacy collStats command result expected by existing mapping logic.
-func flattenAggregationResult(result map[string]interface{}) map[string]interface{} {
+func flattenAggregationResult(result map[string]any) map[string]any {
 	if result == nil {
 		return result
 	}
@@ -531,7 +529,7 @@ func flattenAggregationResult(result map[string]interface{}) map[string]interfac
 		return result // already flat (legacy or unexpected format)
 	}
 
-	storageStats, ok := storageStatsRaw.(map[string]interface{})
+	storageStats, ok := storageStatsRaw.(map[string]any)
 	if !ok {
 		return result
 	}
@@ -581,7 +579,7 @@ func getMongoDBVersion(client *mongo.Client) (string, error) {
 		return "", fmt.Errorf("buildInfo command failed: %w", err)
 	}
 
-	var buildInfo map[string]interface{}
+	var buildInfo map[string]any
 	if err := result.Decode(&buildInfo); err != nil {
 		return "", fmt.Errorf("could not decode buildInfo: %w", err)
 	}
@@ -672,7 +670,7 @@ func (m *Metricset) getCollectionsFromTop(client *mongo.Client) ([]CollectionInf
 		return nil, fmt.Errorf("'top' command failed: %w", err)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := res.Decode(&result); err != nil {
 		return nil, fmt.Errorf("could not decode mongo response: %w", err)
 	}
@@ -681,7 +679,7 @@ func (m *Metricset) getCollectionsFromTop(client *mongo.Client) ([]CollectionInf
 		return nil, errors.New("collection 'totals' key not found in mongodb response")
 	}
 
-	totals, ok := result["totals"].(map[string]interface{})
+	totals, ok := result["totals"].(map[string]any)
 	if !ok {
 		return nil, errors.New("collection 'totals' is not a map")
 	}
@@ -693,7 +691,7 @@ func (m *Metricset) getCollectionsFromTop(client *mongo.Client) ([]CollectionInf
 			continue
 		}
 
-		infoMap, ok := info.(map[string]interface{})
+		infoMap, ok := info.(map[string]any)
 		if !ok {
 			m.Logger().Debugf("unexpected data returned by mongodb for group %s", group)
 			continue

--- a/metricbeat/module/mongodb/collstats/collstats_integration_test.go
+++ b/metricbeat/module/mongodb/collstats/collstats_integration_test.go
@@ -73,15 +73,15 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "mongodb",
 		"metricsets": []string{"collstats"},
 		"hosts":      []string{host},
 	}
 }
 
-func getConfigWithScale(host string, scale int) map[string]interface{} {
+func getConfigWithScale(host string, scale int) map[string]any {
 	cfg := getConfig(host)
 	cfg["scale"] = scale
 	return cfg
@@ -121,7 +121,6 @@ func TestFetchStandaloneVersions(t *testing.T) {
 	require.NoError(t, err, "resolve working directory")
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run("mongo_"+strings.ReplaceAll(tc.version, ".", "_"), func(t *testing.T) {
 			logIfVerbose(t, "Starting test for MongoDB %s on port %s", tc.version, tc.port)
 
@@ -166,7 +165,7 @@ func TestFetchStandaloneVersions(t *testing.T) {
 			// Wait for container to be healthy
 			logIfVerbose(t, "Waiting for MongoDB to be healthy...")
 			var containerReady bool
-			for i := 0; i < 30; i++ {
+			for range 30 {
 				healthCtx, healthCancel := context.WithTimeout(context.Background(), 10*time.Second)
 				healthCmd := exec.CommandContext(healthCtx, "docker", "ps", "--filter", fmt.Sprintf("name=%s", projectName), "--filter", "health=healthy", "--format", "{{.Names}}") //nolint:gosec // safe integration test
 				output, _ := healthCmd.CombinedOutput()
@@ -313,7 +312,6 @@ func TestFetchShardedMongos(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run("mongo_"+strings.ReplaceAll(tc.version, ".", "_"), func(t *testing.T) {
 			projectName := fmt.Sprintf("mbcollstatssharded%s", strings.ReplaceAll(tc.version, ".", ""))
 			cleanupEnv := buildComposeEnv(projectName, tc.version, "")
@@ -432,21 +430,21 @@ func verifyStandaloneEvents(t *testing.T, events []mb.Event, expectExtendedStats
 	}
 }
 
-func assertPositiveNumber(t *testing.T, value interface{}, msg string) {
+func assertPositiveNumber(t *testing.T, value any, msg string) {
 	t.Helper()
 	number, ok := normalizeNumeric(value)
 	require.Truef(t, ok, "%s must be numeric (got %T)", msg, value)
 	require.Greaterf(t, number, float64(0), "%s must be > 0 (got %v)", msg, value)
 }
 
-func assertNonNegativeNumber(t *testing.T, value interface{}, msg string) {
+func assertNonNegativeNumber(t *testing.T, value any, msg string) {
 	t.Helper()
 	number, ok := normalizeNumeric(value)
 	require.Truef(t, ok, "%s must be numeric (got %T)", msg, value)
 	require.GreaterOrEqualf(t, number, float64(0), "%s must be >= 0 (got %v)", msg, value)
 }
 
-func assertExactNumber(t *testing.T, value interface{}, expected float64, msg string) {
+func assertExactNumber(t *testing.T, value any, expected float64, msg string) {
 	t.Helper()
 	number, ok := normalizeNumeric(value)
 	require.Truef(t, ok, "%s must be numeric (got %T)", msg, value)
@@ -475,7 +473,7 @@ func assertExtendedStatsFields(t *testing.T, stats mapstr.M) {
 	}
 }
 
-func normalizeNumeric(value interface{}) (float64, bool) {
+func normalizeNumeric(value any) (float64, bool) {
 	switch v := value.(type) {
 	case int:
 		return float64(v), true
@@ -719,7 +717,7 @@ func runSeedScript(scriptPath, dir string, env []string) error {
 	return nil
 }
 
-func logIfVerbose(t *testing.T, format string, args ...interface{}) {
+func logIfVerbose(t *testing.T, format string, args ...any) {
 	if !shouldLogVerbose() {
 		return
 	}

--- a/metricbeat/module/mongodb/collstats/collstats_test.go
+++ b/metricbeat/module/mongodb/collstats/collstats_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestFlattenAggregationResult_NoStorageStats(t *testing.T) {
-	input := map[string]interface{}{
+	input := map[string]any{
 		"size": float64(10),
 	}
 	out := flattenAggregationResult(input)
@@ -39,8 +39,8 @@ func TestFlattenAggregationResult_NoStorageStats(t *testing.T) {
 }
 
 func TestFlattenAggregationResult_WithStorageStats(t *testing.T) {
-	input := map[string]interface{}{
-		"storageStats": map[string]interface{}{
+	input := map[string]any{
+		"storageStats": map[string]any{
 			"size":            float64(1000),
 			"count":           int64(50),
 			"avgObjSize":      float64(20),
@@ -82,9 +82,9 @@ func TestFlattenAggregationResult_WithStorageStats(t *testing.T) {
 }
 
 func TestFlattenAggregationResult_DoesNotOverrideExisting(t *testing.T) {
-	input := map[string]interface{}{
+	input := map[string]any{
 		"count": int64(999), // pre-existing value should not be overridden
-		"storageStats": map[string]interface{}{
+		"storageStats": map[string]any{
 			"count": int64(50),
 		},
 	}
@@ -98,7 +98,7 @@ func TestFlattenAggregationResult_DoesNotOverrideExisting(t *testing.T) {
 func TestApplyOptionsToStats_NoClientRescale(t *testing.T) {
 	metricset := &Metricset{options: CollStatsOptions{Scale: 1024}}
 	// Simulate server already applied scale (so values are post-scale). We expect applyOptionsToStats to leave them untouched.
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"size":           float64(2048), // Already scaled KB value
 		"storageSize":    float64(4096),
 		"totalIndexSize": float64(1024),
@@ -116,7 +116,7 @@ func TestApplyOptionsToStats_NoClientRescale(t *testing.T) {
 
 func TestApplyOptionsToStats_NoShardRescale(t *testing.T) {
 	metricset := &Metricset{options: CollStatsOptions{Scale: 1024}}
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"size": float64(3000), // Already scaled total (KB)
 		// shards.* breakdown not collected
 	}
@@ -142,14 +142,14 @@ func TestApplyOptionsToStats_NilStats(t *testing.T) {
 func TestMergeShardedCollStats(t *testing.T) {
 	tests := []struct {
 		name          string
-		shardResults  []map[string]interface{}
+		shardResults  []map[string]any
 		expectedCount int64
 		expectedSize  float64
 		expectedErr   bool
 	}{
 		{
 			name: "single shard",
-			shardResults: []map[string]interface{}{
+			shardResults: []map[string]any{
 				{
 					"ns":          "test.collection",
 					"shard":       "shard01",
@@ -166,7 +166,7 @@ func TestMergeShardedCollStats(t *testing.T) {
 		},
 		{
 			name: "multiple shards with summable fields",
-			shardResults: []map[string]interface{}{
+			shardResults: []map[string]any{
 				{
 					"ns":          "test.collection",
 					"shard":       "shard01",
@@ -192,7 +192,7 @@ func TestMergeShardedCollStats(t *testing.T) {
 		},
 		{
 			name: "shards with index sizes (ignored)",
-			shardResults: []map[string]interface{}{
+			shardResults: []map[string]any{
 				{
 					"ns":    "test.collection",
 					"shard": "shard01",
@@ -216,7 +216,7 @@ func TestMergeShardedCollStats(t *testing.T) {
 		},
 		{
 			name:          "empty shard results",
-			shardResults:  []map[string]interface{}{},
+			shardResults:  []map[string]any{},
 			expectedCount: 0,
 			expectedSize:  0,
 			expectedErr:   true,
@@ -266,7 +266,7 @@ func TestMergeShardedCollStats(t *testing.T) {
 func TestConvertToFloat64(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected float64
 		success  bool
 	}{
@@ -368,7 +368,7 @@ func TestConvertToFloat64(t *testing.T) {
 }
 
 func TestMergeShardedCollStats_WeightedAverages(t *testing.T) {
-	shardResults := []map[string]interface{}{
+	shardResults := []map[string]any{
 		{
 			"shard":      "shard01",
 			"count":      int64(1000),
@@ -392,7 +392,7 @@ func TestMergeShardedCollStats_WeightedAverages(t *testing.T) {
 }
 
 func TestMergeShardedCollStats_SumsFreeStorageSize(t *testing.T) {
-	shardResults := []map[string]interface{}{
+	shardResults := []map[string]any{
 		{
 			"shard":           "shard01",
 			"count":           int64(10),
@@ -413,7 +413,7 @@ func TestMergeShardedCollStats_SumsFreeStorageSize(t *testing.T) {
 func TestMergeShardedCollStats_ZeroDocsSetsAvgObjSizeZero(t *testing.T) {
 	// When no documents exist across shards, avgObjSize must be 0 (mongosh parity)
 	// even if a shard reports a stale avgObjSize.
-	shardResults := []map[string]interface{}{
+	shardResults := []map[string]any{
 		{"shard": "shard01", "count": int64(0), "avgObjSize": float64(50)},
 		{"shard": "shard02", "count": int64(0), "avgObjSize": float64(75)},
 	}
@@ -425,7 +425,7 @@ func TestMergeShardedCollStats_ZeroDocsSetsAvgObjSizeZero(t *testing.T) {
 
 func TestMergeShardedCollStats_WeightedAvgSkipsShardsMissingCount(t *testing.T) {
 	// A shard missing count must not contribute to the weighted avgObjSize.
-	shardResults := []map[string]interface{}{
+	shardResults := []map[string]any{
 		{"shard": "shard01", "count": int64(100), "avgObjSize": float64(40)},
 		// no count -> excluded from weighting AND from totalDocCount
 		{"shard": "shard02", "avgObjSize": float64(1000)},
@@ -438,7 +438,7 @@ func TestMergeShardedCollStats_WeightedAvgSkipsShardsMissingCount(t *testing.T) 
 }
 
 func TestMergeShardedCollStats_MaxFieldsTakeMaximum(t *testing.T) {
-	shardResults := []map[string]interface{}{
+	shardResults := []map[string]any{
 		{"shard": "shard01", "count": int64(1), "max": int64(100), "maxSize": float64(2048)},
 		{"shard": "shard02", "count": int64(1), "max": int64(500), "maxSize": float64(1024)},
 	}
@@ -450,7 +450,7 @@ func TestMergeShardedCollStats_MaxFieldsTakeMaximum(t *testing.T) {
 }
 
 func TestMergeShardedCollStats_RemovesLocalTimeMetadata(t *testing.T) {
-	shardResults := []map[string]interface{}{
+	shardResults := []map[string]any{
 		{"shard": "shard01", "host": "h1", "localTime": "t1", "count": int64(5)},
 	}
 
@@ -462,7 +462,7 @@ func TestMergeShardedCollStats_RemovesLocalTimeMetadata(t *testing.T) {
 
 func TestMergeShardedCollStats_IgnoresNonNumericSummableFields(t *testing.T) {
 	// A non-numeric value for a summable field must be skipped, not crash or coerce.
-	shardResults := []map[string]interface{}{
+	shardResults := []map[string]any{
 		{"shard": "shard01", "count": "not-a-number", "size": float64(10)},
 		{"shard": "shard02", "count": int64(7), "size": float64(20)},
 	}
@@ -477,16 +477,16 @@ func TestMergeShardedCollStats_IgnoresNonNumericSummableFields(t *testing.T) {
 func TestHasShardMetadata(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    map[string]interface{}
+		input    map[string]any
 		expected bool
 	}{
 		{name: "nil", input: nil, expected: false},
-		{name: "no metadata", input: map[string]interface{}{"count": int64(1)}, expected: false},
-		{name: "has shard", input: map[string]interface{}{"shard": "s1"}, expected: true},
+		{name: "no metadata", input: map[string]any{"count": int64(1)}, expected: false},
+		{name: "has shard", input: map[string]any{"shard": "s1"}, expected: true},
 		// "host" alone is NOT a sharding signal: $collStats always emits a
 		// top-level host (the serving node), including on standalone/replica set.
-		{name: "host only (standalone $collStats)", input: map[string]interface{}{"host": "h1"}, expected: false},
-		{name: "has both", input: map[string]interface{}{"shard": "s1", "host": "h1"}, expected: true},
+		{name: "host only (standalone $collStats)", input: map[string]any{"host": "h1"}, expected: false},
+		{name: "has both", input: map[string]any{"shard": "s1", "host": "h1"}, expected: true},
 	}
 
 	for _, tt := range tests {
@@ -502,7 +502,7 @@ func TestFlattenAggregationResult_NilInput(t *testing.T) {
 
 func TestFlattenAggregationResult_StorageStatsWrongType(t *testing.T) {
 	// storageStats present but not a map must be returned unchanged (no panic).
-	input := map[string]interface{}{
+	input := map[string]any{
 		"storageStats": "unexpected-string",
 		"size":         float64(5),
 	}
@@ -516,8 +516,8 @@ func TestFlattenAggregationResult_StorageStatsWrongType(t *testing.T) {
 
 func TestFlattenAggregationResult_DefaultsScaleFactorWhenAbsent(t *testing.T) {
 	// storageStats present without scaleFactor -> default to 1.
-	input := map[string]interface{}{
-		"storageStats": map[string]interface{}{
+	input := map[string]any{
+		"storageStats": map[string]any{
 			"size": float64(100),
 		},
 	}
@@ -740,7 +740,7 @@ func TestCacheMongoVersion_PermanentFailureUsesLegacyPath(t *testing.T) {
 		},
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		ms.cacheMongoVersion(nil)
 		assert.Empty(t, ms.mongoVersion, "version must remain uncached after failure #%d", i+1)
 		assert.False(t, isVersionAtLeast(ms.mongoVersion, "6.2.0"), "must use legacy path when version unknown")

--- a/metricbeat/module/mongodb/collstats/data.go
+++ b/metricbeat/module/mongodb/collstats/data.go
@@ -134,7 +134,7 @@ func eventMapping(key string, data mapstr.M) (mapstr.M, error) {
 	return event, nil
 }
 
-func mustGetMapStrValue(m mapstr.M, key string) interface{} {
+func mustGetMapStrValue(m mapstr.M, key string) any {
 	v, _ := m.GetValue(key)
 	return v
 }

--- a/metricbeat/module/mongodb/collstats/data_test.go
+++ b/metricbeat/module/mongodb/collstats/data_test.go
@@ -125,7 +125,7 @@ func TestEventMappingPreservesCollectionWithDots(t *testing.T) {
 }
 
 func TestMergeShardedCollStats_WeightedAndIndexMerge(t *testing.T) {
-	shard1 := map[string]interface{}{
+	shard1 := map[string]any{
 		"count":       int64(10),
 		"size":        float64(1000),
 		"storageSize": float64(2000),
@@ -133,7 +133,7 @@ func TestMergeShardedCollStats_WeightedAndIndexMerge(t *testing.T) {
 		"shard":       "shard1",
 		"host":        "host1",
 	}
-	shard2 := map[string]interface{}{
+	shard2 := map[string]any{
 		"count":       int64(20),
 		"size":        float64(3000),
 		"storageSize": float64(4000),
@@ -141,7 +141,7 @@ func TestMergeShardedCollStats_WeightedAndIndexMerge(t *testing.T) {
 		"shard":       "shard2",
 		"host":        "host2",
 	}
-	merged, err := mergeShardedCollStats([]map[string]interface{}{shard1, shard2})
+	merged, err := mergeShardedCollStats([]map[string]any{shard1, shard2})
 	assert.NoError(t, err)
 	// Summed fields
 	assert.Equal(t, int64(30), merged["count"].(int64))           //nolint:errcheck // safe
@@ -158,8 +158,8 @@ func TestMergeShardedCollStats_WeightedAndIndexMerge(t *testing.T) {
 }
 
 func TestFlattenAggregationResult(t *testing.T) {
-	input := map[string]interface{}{
-		"storageStats": map[string]interface{}{
+	input := map[string]any{
+		"storageStats": map[string]any{
 			"size":           1000,
 			"count":          5,
 			"avgObjSize":     200,

--- a/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
+++ b/metricbeat/module/mongodb/dbstats/dbstats_integration_test.go
@@ -87,8 +87,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "mongodb",
 		"metricsets": []string{"dbstats"},
 		"hosts":      []string{host},

--- a/metricbeat/module/mongodb/metrics/metrics.go
+++ b/metricbeat/module/mongodb/metrics/metrics.go
@@ -73,7 +73,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 
 	db := client.Database("admin")
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 	res := db.RunCommand(context.Background(), bson.D{bson.E{Key: "serverStatus", Value: 1}})
 	if err = res.Err(); err != nil {
 		return fmt.Errorf("failed to retrieve data from 'serverStatus' command: %w", err)

--- a/metricbeat/module/mongodb/metrics/metrics_intergration_test.go
+++ b/metricbeat/module/mongodb/metrics/metrics_intergration_test.go
@@ -58,8 +58,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "mongodb",
 		"metricsets": []string{"metrics"},
 		"hosts":      []string{host},

--- a/metricbeat/module/mongodb/mongodb_test.go
+++ b/metricbeat/module/mongodb/mongodb_test.go
@@ -110,7 +110,7 @@ func TestParseMongoURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mod := mbtest.NewTestModule(t, map[string]interface{}{
+		mod := mbtest.NewTestModule(t, map[string]any{
 			"username": test.Username,
 			"password": test.Password,
 		})

--- a/metricbeat/module/mongodb/replstatus/replstatus_integration_test.go
+++ b/metricbeat/module/mongodb/replstatus/replstatus_integration_test.go
@@ -96,8 +96,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "mongodb",
 		"metricsets": []string{"replstatus"},
 		"hosts":      []string{host},

--- a/metricbeat/module/mongodb/status/status.go
+++ b/metricbeat/module/mongodb/status/status.go
@@ -80,7 +80,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return fmt.Errorf("failed to retrieve 'serverStatus': %w", err)
 	}
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 	if err = res.Decode(&result); err != nil {
 		return fmt.Errorf("could not decode 'serverStatus' response: %w", err)
 	}

--- a/metricbeat/module/mongodb/status/status_integration_test.go
+++ b/metricbeat/module/mongodb/status/status_integration_test.go
@@ -66,8 +66,8 @@ func TestData(t *testing.T) {
 
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "mongodb",
 		"metricsets": []string{"status"},
 		"hosts":      []string{host},

--- a/metricbeat/module/mysql/galera_status/data.go
+++ b/metricbeat/module/mysql/galera_status/data.go
@@ -95,7 +95,7 @@ var (
 // Map data to MapStr of server stats variables: http://galeracluster.com/documentation-webpages/galerastatusvariables.html
 // queryMode specifies, which subset of the available Variables is used.
 func eventMapping(status map[string]string) mapstr.M {
-	source := map[string]interface{}{}
+	source := map[string]any{}
 	for key, val := range status {
 		source[key] = val
 	}

--- a/metricbeat/module/mysql/mysql_test.go
+++ b/metricbeat/module/mysql/mysql_test.go
@@ -46,7 +46,7 @@ func TestParseDSN(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c := map[string]interface{}{
+		c := map[string]any{
 			"username": test.username,
 			"password": test.password,
 		}

--- a/metricbeat/module/mysql/status/data.go
+++ b/metricbeat/module/mysql/status/data.go
@@ -162,7 +162,7 @@ var (
 // Map data to MapStr of server stats variables: http://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html
 // This is only a subset of the available values
 func eventMapping(status map[string]string) mapstr.M {
-	source := map[string]interface{}{}
+	source := map[string]any{}
 	for key, val := range status {
 		source[key] = val
 	}

--- a/metricbeat/module/mysql/status/status_integration_test.go
+++ b/metricbeat/module/mysql/status/status_integration_test.go
@@ -93,8 +93,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string, raw bool) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string, raw bool) map[string]any {
+	return map[string]any{
 		"module":     "mysql",
 		"metricsets": []string{"status"},
 		"hosts":      []string{mysql.GetMySQLEnvDSN(host)},

--- a/metricbeat/module/mysql/status/status_test.go
+++ b/metricbeat/module/mysql/status/status_test.go
@@ -35,12 +35,12 @@ import (
 // validated when the MetricSet is created.
 func TestConfigValidation(t *testing.T) {
 	tests := []struct {
-		in  interface{}
+		in  any
 		err string
 	}{
 		{
 			// Missing 'hosts'
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "mysql",
 				"metricsets": []string{"status"},
 			},
@@ -48,7 +48,7 @@ func TestConfigValidation(t *testing.T) {
 		},
 		{
 			// Invalid DSN
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "mysql",
 				"metricsets": []string{"status"},
 				"hosts":      []string{"127.0.0.1"},
@@ -57,7 +57,7 @@ func TestConfigValidation(t *testing.T) {
 		},
 		{
 			// Local unix socket
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "mysql",
 				"metricsets": []string{"status"},
 				"hosts":      []string{"user@unix(/path/to/socket)/"},
@@ -65,7 +65,7 @@ func TestConfigValidation(t *testing.T) {
 		},
 		{
 			// TCP on a remote host, e.g. Amazon RDS:
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "mysql",
 				"metricsets": []string{"status"},
 				"hosts":      []string{"id:password@tcp(your-amazonaws-uri.com:3306)/}"},
@@ -73,7 +73,7 @@ func TestConfigValidation(t *testing.T) {
 		},
 		{
 			// TCP on a remote host with user/pass specified separately
-			in: map[string]interface{}{
+			in: map[string]any{
 				"module":     "mysql",
 				"metricsets": []string{"status"},
 				"hosts":      []string{"tcp(your-amazonaws-uri.com:3306)/}"},

--- a/metricbeat/module/nats/connection/connection_integration_test.go
+++ b/metricbeat/module/nats/connection/connection_integration_test.go
@@ -52,8 +52,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"connection"},
 		"hosts":      []string{host},

--- a/metricbeat/module/nats/connection/connection_test.go
+++ b/metricbeat/module/nats/connection/connection_test.go
@@ -18,9 +18,9 @@
 package connection
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/connectionsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/connectionsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, content)
@@ -40,7 +40,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/connectionsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/connectionsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -48,7 +48,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"connection"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/nats/connection/data.go
+++ b/metricbeat/module/nats/connection/data.go
@@ -62,13 +62,13 @@ var (
 
 // Connections stores connections related information
 type Connections struct {
-	Now         time.Time                `json:"now"`
-	ServerID    string                   `json:"server_id"`
-	Connections []map[string]interface{} `json:"connections,omitempty"`
+	Now         time.Time        `json:"now"`
+	ServerID    string           `json:"server_id"`
+	Connections []map[string]any `json:"connections,omitempty"`
 }
 
 // eventMapping maps a connection to a Metricbeat event using connectionsSchema
-func eventMapping(content map[string]interface{}, fieldsSchema s.Schema) (mb.Event, error) {
+func eventMapping(content map[string]any, fieldsSchema s.Schema) (mb.Event, error) {
 	fields, err := fieldsSchema.Apply(content)
 	if err != nil {
 		return mb.Event{}, fmt.Errorf("error applying connection schema: %w", err)

--- a/metricbeat/module/nats/connections/connections_integration_test.go
+++ b/metricbeat/module/nats/connections/connections_integration_test.go
@@ -45,8 +45,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"connections"},
 		"hosts":      []string{host},

--- a/metricbeat/module/nats/connections/connections_test.go
+++ b/metricbeat/module/nats/connections/connections_test.go
@@ -18,9 +18,9 @@
 package connections
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/connectionsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/connectionsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/connectionsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/connectionsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -51,7 +51,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"connections"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/nats/connections/data.go
+++ b/metricbeat/module/nats/connections/data.go
@@ -40,7 +40,7 @@ var (
 )
 
 func eventMapping(r mb.ReporterV2, content []byte) error {
-	var inInterface map[string]interface{}
+	var inInterface map[string]any
 
 	err := json.Unmarshal(content, &inInterface)
 	if err != nil {

--- a/metricbeat/module/nats/jetstream/data.go
+++ b/metricbeat/module/nats/jetstream/data.go
@@ -111,7 +111,7 @@ var (
 				"max_msg_size":         c.Int("config_max_msg_size"),
 				"subjects": s.Conv{
 					Key: "config_subjects",
-					Func: func(key string, data map[string]interface{}) (interface{}, error) {
+					Func: func(key string, data map[string]any) (any, error) {
 						emptyIface, err := mapstr.M(data).GetValue(key)
 						if err != nil {
 							return []string{}, s.NewKeyNotFoundError(key)
@@ -362,7 +362,7 @@ func statsMapping(r mb.ReporterV2, response JetstreamResponse) error {
 		return fmt.Errorf("failure applying module schema: %w", err)
 	}
 
-	metricSetFields, err := jetstreamStatsSchema.Apply(map[string]interface{}{
+	metricSetFields, err := jetstreamStatsSchema.Apply(map[string]any{
 		"category":         statsCategory,
 		"max_memory":       response.Config.MaxMemory,
 		"max_storage":      response.Config.MaxStorage,
@@ -426,7 +426,7 @@ func accountMapping(r mb.ReporterV2, account JetstreamAccountDetails, response J
 		return fmt.Errorf("failure applying module schema: %w", err)
 	}
 
-	metricSetFields, err := jetstreamAccountSchema.Apply(map[string]interface{}{
+	metricSetFields, err := jetstreamAccountSchema.Apply(map[string]any{
 		"category":         accountCategory,
 		"id":               account.Id,
 		"name":             account.Name,
@@ -465,7 +465,7 @@ func streamMapping(r mb.ReporterV2, stream JetstreamStreamDetail, account Jetstr
 		return fmt.Errorf("failure applying module schema: %w", err)
 	}
 
-	metricSetFields, err := jetstreamStreamSchema.Apply(map[string]interface{}{
+	metricSetFields, err := jetstreamStreamSchema.Apply(map[string]any{
 		"category":                    streamCategory,
 		"name":                        stream.Name,
 		"created":                     stream.Created,
@@ -519,7 +519,7 @@ func consumerMapping(r mb.ReporterV2, consumer JetstreamConsumerDetail, stream J
 		return fmt.Errorf("failure applying module schema: %w", err)
 	}
 
-	metricSetFields, err := jetstreamConsumerSchema.Apply(map[string]interface{}{
+	metricSetFields, err := jetstreamConsumerSchema.Apply(map[string]any{
 		"category":               consumerCategory,
 		"stream_name":            stream.Name,
 		"name":                   consumer.Name,
@@ -569,7 +569,7 @@ func consumerMapping(r mb.ReporterV2, consumer JetstreamConsumerDetail, stream J
 }
 
 func getSharedEventDetails(response JetstreamResponse) (mapstr.M, time.Time, error) {
-	moduleFields, err := moduleSchema.Apply(map[string]interface{}{
+	moduleFields, err := moduleSchema.Apply(map[string]any{
 		"server_id": response.ServerID,
 		"now":       response.Now,
 	})

--- a/metricbeat/module/nats/jetstream/jetstream_integration_test.go
+++ b/metricbeat/module/nats/jetstream/jetstream_integration_test.go
@@ -50,22 +50,22 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"jetstream"},
 		"hosts":      []string{host},
-		"jetstream": map[string]interface{}{
-			"stats": map[string]interface{}{
+		"jetstream": map[string]any{
+			"stats": map[string]any{
 				"enabled": true,
 			},
-			"account": map[string]interface{}{
+			"account": map[string]any{
 				"enabled": true,
 			},
-			"stream": map[string]interface{}{
+			"stream": map[string]any{
 				"enabled": true,
 			},
-			"consumer": map[string]interface{}{
+			"consumer": map[string]any{
 				"enabled": true,
 			},
 		},

--- a/metricbeat/module/nats/jetstream/jetstream_test.go
+++ b/metricbeat/module/nats/jetstream/jetstream_test.go
@@ -65,9 +65,9 @@ func TestFetchEventContentForStats(t *testing.T) {
 		WritePath: "_meta/testdata/expected",
 		// Not sure why this field isn't being recognized as documented. It does exist.
 		OmitDocumentedFieldsCheck: []string{"nats.jetstream.category"},
-		Module: map[string]interface{}{
-			"jetstream": map[string]interface{}{
-				"stats": map[string]interface{}{
+		Module: map[string]any{
+			"jetstream": map[string]any{
+				"stats": map[string]any{
 					"enabled": true,
 				},
 			},
@@ -86,9 +86,9 @@ func TestFetchEventContentForAccount(t *testing.T) {
 		WritePath: "_meta/testdata/expected",
 		// Not sure why this field isn't being recognized as documented. It does exist.
 		OmitDocumentedFieldsCheck: []string{"nats.jetstream.account.accounts"},
-		Module: map[string]interface{}{
-			"jetstream": map[string]interface{}{
-				"account": map[string]interface{}{
+		Module: map[string]any{
+			"jetstream": map[string]any{
+				"account": map[string]any{
 					"enabled": true,
 				},
 			},
@@ -107,9 +107,9 @@ func TestFetchEventContentForStreams(t *testing.T) {
 		WritePath: "_meta/testdata/expected",
 		// Not sure why this field isn't being recognized as documented. It does exist.
 		OmitDocumentedFieldsCheck: []string{"nats.jetstream.category"},
-		Module: map[string]interface{}{
-			"jetstream": map[string]interface{}{
-				"stream": map[string]interface{}{
+		Module: map[string]any{
+			"jetstream": map[string]any{
+				"stream": map[string]any{
 					"enabled": true,
 				},
 			},
@@ -128,9 +128,9 @@ func TestFetchEventContentForConsumers(t *testing.T) {
 		WritePath: "_meta/testdata/expected",
 		// Not sure why this field isn't being recognized as documented. It does exist.
 		OmitDocumentedFieldsCheck: []string{"nats.jetstream.category"},
-		Module: map[string]interface{}{
-			"jetstream": map[string]interface{}{
-				"consumer": map[string]interface{}{
+		Module: map[string]any{
+			"jetstream": map[string]any{
+				"consumer": map[string]any{
 					"enabled": true,
 				},
 			},
@@ -149,18 +149,18 @@ func TestFetchEventContentForAll(t *testing.T) {
 		WritePath: "_meta/testdata/expected",
 		// Not sure why this field isn't being recognized as documented. It does exist.
 		OmitDocumentedFieldsCheck: []string{"nats.jetstream.category", "nats.jetstream.account.accounts"},
-		Module: map[string]interface{}{
-			"jetstream": map[string]interface{}{
-				"stats": map[string]interface{}{
+		Module: map[string]any{
+			"jetstream": map[string]any{
+				"stats": map[string]any{
 					"enabled": true,
 				},
-				"account": map[string]interface{}{
+				"account": map[string]any{
 					"enabled": true,
 				},
-				"stream": map[string]interface{}{
+				"stream": map[string]any{
 					"enabled": true,
 				},
-				"consumer": map[string]interface{}{
+				"consumer": map[string]any{
 					"enabled": true,
 				},
 			},
@@ -179,18 +179,18 @@ func TestFetchEventContentForAllWithNothingEnabled(t *testing.T) {
 		WritePath: "_meta/testdata/expected",
 		// Not sure why this field isn't being recognized as documented. It does exist.
 		OmitDocumentedFieldsCheck: []string{},
-		Module: map[string]interface{}{
-			"jetstream": map[string]interface{}{
-				"stats": map[string]interface{}{
+		Module: map[string]any{
+			"jetstream": map[string]any{
+				"stats": map[string]any{
 					"enabled": false,
 				},
-				"account": map[string]interface{}{
+				"account": map[string]any{
 					"enabled": false,
 				},
-				"stream": map[string]interface{}{
+				"stream": map[string]any{
 					"enabled": false,
 				},
-				"consumer": map[string]interface{}{
+				"consumer": map[string]any{
 					"enabled": false,
 				},
 			},
@@ -209,20 +209,20 @@ func TestFetchEventContentForAllWithFilters(t *testing.T) {
 		WritePath: "_meta/testdata/expected",
 		// Not sure why this field isn't being recognized as documented. It does exist.
 		OmitDocumentedFieldsCheck: []string{"nats.jetstream.category", "nats.jetstream.account.accounts"},
-		Module: map[string]interface{}{
-			"jetstream": map[string]interface{}{
-				"stats": map[string]interface{}{
+		Module: map[string]any{
+			"jetstream": map[string]any{
+				"stats": map[string]any{
 					"enabled": true,
 				},
-				"account": map[string]interface{}{
+				"account": map[string]any{
 					"enabled": true,
 					"names":   []string{"account-2"},
 				},
-				"stream": map[string]interface{}{
+				"stream": map[string]any{
 					"enabled": true,
 					"names":   []string{"test-stream-2"},
 				},
-				"consumer": map[string]interface{}{
+				"consumer": map[string]any{
 					"enabled": true,
 					"names":   []string{"test-stream-2-consumer-2"},
 				},

--- a/metricbeat/module/nats/route/data.go
+++ b/metricbeat/module/nats/route/data.go
@@ -52,13 +52,13 @@ var (
 
 // Routes stores routes related information
 type Routes struct {
-	Now      time.Time                `json:"now"`
-	ServerID string                   `json:"server_id"`
-	Routes   []map[string]interface{} `json:"routes,omitempty"`
+	Now      time.Time        `json:"now"`
+	ServerID string           `json:"server_id"`
+	Routes   []map[string]any `json:"routes,omitempty"`
 }
 
 // eventMapping maps a route to a Metricbeat event using routesSchema
-func eventMapping(content map[string]interface{}, fieldsSchema s.Schema) (mb.Event, error) {
+func eventMapping(content map[string]any, fieldsSchema s.Schema) (mb.Event, error) {
 	fields, err := fieldsSchema.Apply(content)
 	if err != nil {
 		return mb.Event{}, fmt.Errorf("error applying routes schema: %w", err)

--- a/metricbeat/module/nats/route/route_integration_test.go
+++ b/metricbeat/module/nats/route/route_integration_test.go
@@ -47,8 +47,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"route"},
 		"hosts":      []string{host},

--- a/metricbeat/module/nats/route/route_test.go
+++ b/metricbeat/module/nats/route/route_test.go
@@ -18,9 +18,9 @@
 package route
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/routesmetrics.json")
+	content, err := os.ReadFile("./_meta/test/routesmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, content)
@@ -40,7 +40,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/routesmetrics.json")
+	response, _ := os.ReadFile(absPath + "/routesmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -48,7 +48,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"route"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/nats/routes/data.go
+++ b/metricbeat/module/nats/routes/data.go
@@ -40,7 +40,7 @@ var (
 )
 
 func eventMapping(r mb.ReporterV2, content []byte) error {
-	var inInterface map[string]interface{}
+	var inInterface map[string]any
 
 	err := json.Unmarshal(content, &inInterface)
 	if err != nil {

--- a/metricbeat/module/nats/routes/routes_integration_test.go
+++ b/metricbeat/module/nats/routes/routes_integration_test.go
@@ -45,8 +45,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"routes"},
 		"hosts":      []string{host},

--- a/metricbeat/module/nats/routes/routes_test.go
+++ b/metricbeat/module/nats/routes/routes_test.go
@@ -18,9 +18,9 @@
 package routes
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/routesmetrics.json")
+	content, err := os.ReadFile("./_meta/test/routesmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/routesmetrics.json")
+	response, _ := os.ReadFile(absPath + "/routesmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -51,7 +51,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"routes"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/nats/stats/data.go
+++ b/metricbeat/module/nats/stats/data.go
@@ -74,7 +74,7 @@ var (
 
 func eventMapping(r mb.ReporterV2, content []byte) error {
 	var metricsetMetrics mapstr.M
-	var inInterface map[string]interface{}
+	var inInterface map[string]any
 
 	err := json.Unmarshal(content, &inInterface)
 	if err != nil {

--- a/metricbeat/module/nats/stats/stats_integration_test.go
+++ b/metricbeat/module/nats/stats/stats_integration_test.go
@@ -45,8 +45,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"stats"},
 		"hosts":      []string{host},

--- a/metricbeat/module/nats/stats/stats_test.go
+++ b/metricbeat/module/nats/stats/stats_test.go
@@ -18,9 +18,9 @@
 package stats
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/statsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/statsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test/")
 
-	response, _ := ioutil.ReadFile(absPath + "/statsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/statsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -51,7 +51,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"stats"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/nats/subscriptions/data.go
+++ b/metricbeat/module/nats/subscriptions/data.go
@@ -45,7 +45,7 @@ var (
 
 func eventMapping(r mb.ReporterV2, content []byte) error {
 	var event mb.Event
-	var inInterface map[string]interface{}
+	var inInterface map[string]any
 
 	err := json.Unmarshal(content, &inInterface)
 	if err != nil {

--- a/metricbeat/module/nats/subscriptions/subscriptions_integration_test.go
+++ b/metricbeat/module/nats/subscriptions/subscriptions_integration_test.go
@@ -45,8 +45,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"subscriptions"},
 		"hosts":      []string{host},

--- a/metricbeat/module/nats/subscriptions/subscriptions_test.go
+++ b/metricbeat/module/nats/subscriptions/subscriptions_test.go
@@ -18,9 +18,9 @@
 package subscriptions
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/subscriptionsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/subscriptionsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test/")
 
-	response, _ := ioutil.ReadFile(absPath + "/subscriptionsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/subscriptionsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")
@@ -51,7 +51,7 @@ func TestFetchEventContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "nats",
 		"metricsets": []string{"subscriptions"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
@@ -56,8 +56,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "nginx",
 		"metricsets": []string{"stubstatus"},
 		"hosts":      []string{host},

--- a/metricbeat/module/php_fpm/pool/pool.go
+++ b/metricbeat/module/php_fpm/pool/pool.go
@@ -59,7 +59,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	if err != nil {
 		return fmt.Errorf("error in http fetch: %w", err)
 	}
-	var stats map[string]interface{}
+	var stats map[string]any
 	err = json.Unmarshal(content, &stats)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling json: %w", err)

--- a/metricbeat/module/php_fpm/pool/pool_integration_test.go
+++ b/metricbeat/module/php_fpm/pool/pool_integration_test.go
@@ -44,8 +44,8 @@ func TestFetch(t *testing.T) {
 
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "php_fpm",
 		"metricsets": []string{"pool"},
 		"hosts":      []string{host},

--- a/metricbeat/module/php_fpm/process/process_integration_test.go
+++ b/metricbeat/module/php_fpm/process/process_integration_test.go
@@ -44,8 +44,8 @@ func TestFetch(t *testing.T) {
 
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "php_fpm",
 		"metricsets": []string{"process"},
 		"hosts":      []string{host},

--- a/metricbeat/module/postgresql/activity/activity_integration_test.go
+++ b/metricbeat/module/postgresql/activity/activity_integration_test.go
@@ -77,8 +77,8 @@ func TestData(t *testing.T) {
 	})
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "postgresql",
 		"metricsets": []string{"activity"},
 		"hosts":      []string{postgresql.GetDSN(host)},

--- a/metricbeat/module/postgresql/bgwriter/bgwriter_integration_test.go
+++ b/metricbeat/module/postgresql/bgwriter/bgwriter_integration_test.go
@@ -70,8 +70,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "postgresql",
 		"metricsets": []string{"bgwriter"},
 		"hosts":      []string{postgresql.GetDSN(host)},

--- a/metricbeat/module/postgresql/database/database_integration_test.go
+++ b/metricbeat/module/postgresql/database/database_integration_test.go
@@ -86,8 +86,8 @@ func TestData(t *testing.T) {
 	})
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "postgresql",
 		"metricsets": []string{"database"},
 		"hosts":      []string{postgresql.GetDSN(host)},

--- a/metricbeat/module/postgresql/metricset.go
+++ b/metricbeat/module/postgresql/metricset.go
@@ -54,7 +54,7 @@ func (ms *MetricSet) DB(ctx context.Context) (*sql.Conn, error) {
 }
 
 // QueryStats makes the database call for a given metric
-func (ms *MetricSet) QueryStats(ctx context.Context, query string) ([]map[string]interface{}, error) {
+func (ms *MetricSet) QueryStats(ctx context.Context, query string) ([]map[string]any, error) {
 	db, err := ms.DB(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain a connection with the database: %w", err)
@@ -71,12 +71,12 @@ func (ms *MetricSet) QueryStats(ctx context.Context, query string) ([]map[string
 		return nil, fmt.Errorf("scanning columns: %w", err)
 	}
 	vals := make([][]byte, len(columns))
-	valPointers := make([]interface{}, len(columns))
+	valPointers := make([]any, len(columns))
 	for i := range vals {
 		valPointers[i] = &vals[i]
 	}
 
-	results := []map[string]interface{}{}
+	results := []map[string]any{}
 
 	for rows.Next() {
 		err = rows.Scan(valPointers...)
@@ -84,7 +84,7 @@ func (ms *MetricSet) QueryStats(ctx context.Context, query string) ([]map[string
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 
-		result := map[string]interface{}{}
+		result := map[string]any{}
 		for i, col := range columns {
 			result[col] = string(vals[i])
 		}

--- a/metricbeat/module/postgresql/postgresql_test.go
+++ b/metricbeat/module/postgresql/postgresql_test.go
@@ -93,7 +93,7 @@ func TestParseUrl(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mod := mbtest.NewTestModule(t, map[string]interface{}{
+		mod := mbtest.NewTestModule(t, map[string]any{
 			"username": test.Username,
 			"password": test.Password,
 		})

--- a/metricbeat/module/postgresql/statement/statement_integration_test.go
+++ b/metricbeat/module/postgresql/statement/statement_integration_test.go
@@ -98,8 +98,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "postgresql",
 		"metricsets": []string{"statement"},
 		"hosts":      []string{postgresql.GetDSN(host)},

--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -50,8 +50,8 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 	}{
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeCounter,
 				Metric: []*p.OpenMetric{
 					{
@@ -80,8 +80,8 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeGauge,
 				Metric: []*p.OpenMetric{
 					{
@@ -104,8 +104,8 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeSummary,
 				Metric: []*p.OpenMetric{
 					{
@@ -114,7 +114,7 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 							SampleSum:   proto.Float64(10),
 							Quantile: []*p.Quantile{
 								{
-									Quantile: proto.Float64(0.99),
+									Quantile: new(0.99),
 									Value:    proto.Float64(10),
 								},
 							},
@@ -146,8 +146,8 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeHistogram,
 				Metric: []*p.OpenMetric{
 					{
@@ -156,7 +156,7 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 							SampleSum:   proto.Float64(10),
 							Bucket: []*p.Bucket{
 								{
-									UpperBound:      proto.Float64(0.99),
+									UpperBound:      new(0.99),
 									CumulativeCount: proto.Float64(10),
 								},
 							},
@@ -186,8 +186,8 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &p.MetricFamily{
-				Name: proto.String("http_request_duration_microseconds"),
-				Help: proto.String("foo"),
+				Name: new("http_request_duration_microseconds"),
+				Help: new("foo"),
 				Type: model.MetricTypeUnknown,
 				Metric: []*p.OpenMetric{
 					{
@@ -226,8 +226,8 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 func TestSkipMetricFamily(t *testing.T) {
 	testFamilies := []*p.MetricFamily{
 		{
-			Name: proto.String("http_request_duration_microseconds_a_a_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_a_a_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeCounter,
 			Metric: []*p.OpenMetric{
 				{
@@ -244,8 +244,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_a_b_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_a_b_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeCounter,
 			Metric: []*p.OpenMetric{
 				{
@@ -262,8 +262,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_b_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_b_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeGauge,
 			Metric: []*p.OpenMetric{
 				{
@@ -274,8 +274,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_c_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_c_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeSummary,
 			Metric: []*p.OpenMetric{
 				{
@@ -284,7 +284,7 @@ func TestSkipMetricFamily(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Quantile: []*p.Quantile{
 							{
-								Quantile: proto.Float64(0.99),
+								Quantile: new(0.99),
 								Value:    proto.Float64(10),
 							},
 						},
@@ -293,8 +293,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_d_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_d_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeHistogram,
 			Metric: []*p.OpenMetric{
 				{
@@ -303,7 +303,7 @@ func TestSkipMetricFamily(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(10),
 							},
 						},
@@ -312,8 +312,8 @@ func TestSkipMetricFamily(t *testing.T) {
 			},
 		},
 		{
-			Name: proto.String("http_request_duration_microseconds_e_in"),
-			Help: proto.String("foo"),
+			Name: new("http_request_duration_microseconds_e_in"),
+			Help: new("foo"),
 			Type: model.MetricTypeUnknown,
 			Metric: []*p.OpenMetric{
 				{
@@ -400,7 +400,7 @@ func TestFetchEventForCountingMetrics(t *testing.T) {
 
 	host := strings.TrimPrefix(server.URL, "http://")
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "prometheus",
 		"metricsets":    []string{"collector"},
 		"hosts":         []string{server.URL},

--- a/metricbeat/module/prometheus/query/data.go
+++ b/metricbeat/module/prometheus/query/data.go
@@ -44,7 +44,7 @@ type ArrayResponse struct {
 	Data   arrayData `json:"data"`
 }
 type arrayData struct {
-	Results []interface{} `json:"result"`
+	Results []any `json:"result"`
 }
 
 // InstantVectorResponse is for "vector" type from Prometheus Query API Request
@@ -67,7 +67,7 @@ type instantVectorData struct {
 }
 type instantVectorResult struct {
 	Metric map[string]string `json:"metric"`
-	Vector []interface{}     `json:"value"`
+	Vector []any             `json:"value"`
 }
 
 // RangeVectorResponse is for "vector" type from Prometheus Query API Request
@@ -90,7 +90,7 @@ type rangeVectorData struct {
 }
 type rangeVectorResult struct {
 	Metric  map[string]string `json:"metric"`
-	Vectors [][]interface{}   `json:"values"`
+	Vectors [][]any           `json:"values"`
 }
 
 func parseResponse(body []byte, pathConfig QueryConfig) ([]mb.Event, error) {
@@ -241,7 +241,7 @@ func getEventFromScalarOrString(body []byte, resultType string, queryName string
 	return mb.Event{}, fmt.Errorf("could not parse results")
 }
 
-func getTimestampFromVector(vector []interface{}) (float64, error) {
+func getTimestampFromVector(vector []any) (float64, error) {
 	// Example input: [ <unix_time>, "<sample_value>" ]
 	if len(vector) != 2 {
 		return 0, fmt.Errorf("could not parse results")
@@ -253,7 +253,7 @@ func getTimestampFromVector(vector []interface{}) (float64, error) {
 	return timestamp, nil
 }
 
-func getValueFromVector(vector []interface{}) (float64, error) {
+func getValueFromVector(vector []any) (float64, error) {
 	// Example input: [ <unix_time>, "<sample_value>" ]
 	if len(vector) != 2 {
 		return 0, errors.New("could not parse results")

--- a/metricbeat/module/prometheus/query/query_integration_test.go
+++ b/metricbeat/module/prometheus/query/query_integration_test.go
@@ -34,7 +34,7 @@ import (
 func TestData(t *testing.T) {
 	service := compose.EnsureUp(t, "prometheus")
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{service.Host()},
@@ -50,7 +50,7 @@ func TestData(t *testing.T) {
 	}
 	ms := mbtest.NewReportingMetricSetV2Error(t, config)
 	var err error
-	for retries := 0; retries < 3; retries++ {
+	for range 3 {
 		err = mbtest.WriteEventsReporterV2Error(ms, t, "")
 		if err == nil {
 			return
@@ -63,7 +63,7 @@ func TestData(t *testing.T) {
 func TestQueryFetch(t *testing.T) {
 	service := compose.EnsureUp(t, "prometheus")
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{service.Host()},
@@ -81,7 +81,7 @@ func TestQueryFetch(t *testing.T) {
 
 	var events []mb.Event
 	var errors []error
-	for retries := 0; retries < 3; retries++ {
+	for range 3 {
 		events, errors = mbtest.ReportingFetchV2Error(f)
 		if len(events) > 0 {
 			break

--- a/metricbeat/module/prometheus/query/query_test.go
+++ b/metricbeat/module/prometheus/query/query_test.go
@@ -51,7 +51,7 @@ func TestQueryFetchEventContentInstantVector(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{server.URL},
@@ -100,7 +100,7 @@ func TestQueryFetchEventContentRangeVector(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{server.URL},
@@ -146,7 +146,7 @@ func TestQueryFetchEventContentScalar(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{server.URL},
@@ -189,7 +189,7 @@ func TestQueryFetchEventContentString(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{server.URL},
@@ -228,7 +228,7 @@ func TestHTTPErrorCodeHandling(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{server.URL},
@@ -278,7 +278,7 @@ func TestQueryFetchPartialError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{server.URL},
@@ -330,7 +330,7 @@ func TestQueryFetchAllQueriesFailed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"query"},
 		"hosts":      []string{server.URL},

--- a/metricbeat/module/rabbitmq/connection/connection_test.go
+++ b/metricbeat/module/rabbitmq/connection/connection_test.go
@@ -67,8 +67,8 @@ func TestFetchEventContents(t *testing.T) {
 	assert.EqualValues(t, 60938, peer["port"])
 }
 
-func getConfig(url string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(url string) map[string]any {
+	return map[string]any{
 		"module":     "rabbitmq",
 		"metricsets": []string{"connection"},
 		"hosts":      []string{url},

--- a/metricbeat/module/rabbitmq/connection/data.go
+++ b/metricbeat/module/rabbitmq/connection/data.go
@@ -60,7 +60,7 @@ var (
 )
 
 func eventsMapping(content []byte, r mb.ReporterV2) error {
-	var connections []map[string]interface{}
+	var connections []map[string]any
 	err := json.Unmarshal(content, &connections)
 	if err != nil {
 		return fmt.Errorf("error in unmarshal: %w", err)
@@ -73,7 +73,7 @@ func eventsMapping(content []byte, r mb.ReporterV2) error {
 	return nil
 }
 
-func eventMapping(connection map[string]interface{}) mb.Event {
+func eventMapping(connection map[string]any) mb.Event {
 	fields, _ := schema.Apply(connection, s.FailOnRequired)
 
 	rootFields := mapstr.M{}

--- a/metricbeat/module/rabbitmq/exchange/data.go
+++ b/metricbeat/module/rabbitmq/exchange/data.go
@@ -55,7 +55,7 @@ var (
 )
 
 func eventsMapping(content []byte, r mb.ReporterV2) error {
-	var exchanges []map[string]interface{}
+	var exchanges []map[string]any
 	err := json.Unmarshal(content, &exchanges)
 	if err != nil {
 		return fmt.Errorf("error in unmarshal: %w", err)
@@ -68,7 +68,7 @@ func eventsMapping(content []byte, r mb.ReporterV2) error {
 	return nil
 }
 
-func eventMapping(exchange map[string]interface{}) mb.Event {
+func eventMapping(exchange map[string]any) mb.Event {
 	fields, _ := schema.Apply(exchange)
 
 	rootFields := mapstr.M{}

--- a/metricbeat/module/rabbitmq/exchange/exchange_test.go
+++ b/metricbeat/module/rabbitmq/exchange/exchange_test.go
@@ -76,8 +76,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(url string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(url string) map[string]any {
+	return map[string]any{
 		"module":     "rabbitmq",
 		"metricsets": []string{"exchange"},
 		"hosts":      []string{url},

--- a/metricbeat/module/rabbitmq/metricset_test.go
+++ b/metricbeat/module/rabbitmq/metricset_test.go
@@ -59,7 +59,7 @@ func TestManagementPathPrefix(t *testing.T) {
 	})
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":      "rabbitmq",
 		"metricsets":  []string{"test"},
 		"hosts":       []string{server.URL},

--- a/metricbeat/module/rabbitmq/mtest/integration.go
+++ b/metricbeat/module/rabbitmq/mtest/integration.go
@@ -23,8 +23,8 @@ import (
 
 // GetIntegrationConfig generates a base configuration with common values for
 // integration tests
-func GetIntegrationConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func GetIntegrationConfig(host string) map[string]any {
+	return map[string]any{
 		"module":   "rabbitmq",
 		"hosts":    []string{host},
 		"username": getTestRabbitMQUsername(),

--- a/metricbeat/module/rabbitmq/mtest/server.go
+++ b/metricbeat/module/rabbitmq/mtest/server.go
@@ -18,9 +18,9 @@
 package mtest
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -58,12 +58,12 @@ func Server(t *testing.T, c ServerConfig) *httptest.Server {
 	}
 
 	for k := range responses {
-		r, err := ioutil.ReadFile(filepath.Join(absPath, responses[k].file))
+		r, err := os.ReadFile(filepath.Join(absPath, responses[k].file))
 		responses[k].body = r
 		assert.NoError(t, err)
 	}
 
-	notFound, err := ioutil.ReadFile(filepath.Join(absPath, "notfound_response.json"))
+	notFound, err := os.ReadFile(filepath.Join(absPath, "notfound_response.json"))
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/rabbitmq/node/data.go
+++ b/metricbeat/module/rabbitmq/node/data.go
@@ -147,7 +147,7 @@ var (
 )
 
 func eventsMapping(r mb.ReporterV2, content []byte) error {
-	var nodes []map[string]interface{}
+	var nodes []map[string]any
 	err := json.Unmarshal(content, &nodes)
 	if err != nil {
 		return fmt.Errorf("error in Unmarshal: %w", err)
@@ -160,7 +160,7 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 	return nil
 }
 
-func eventMapping(node map[string]interface{}) mb.Event {
+func eventMapping(node map[string]any) mb.Event {
 	event, _ := schema.Apply(node)
 	return mb.Event{
 		MetricSetFields: event,

--- a/metricbeat/module/rabbitmq/node/node_integration_test.go
+++ b/metricbeat/module/rabbitmq/node/node_integration_test.go
@@ -54,7 +54,7 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())
 }
 
-func getConfig(host string) map[string]interface{} {
+func getConfig(host string) map[string]any {
 	config := mtest.GetIntegrationConfig(host)
 	config["metricsets"] = []string{"node"}
 	return config

--- a/metricbeat/module/rabbitmq/node/node_test.go
+++ b/metricbeat/module/rabbitmq/node/node_test.go
@@ -39,7 +39,7 @@ func testFetch(t *testing.T, collect string) {
 	server := mtest.Server(t, mtest.DefaultServerConfig)
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":       "rabbitmq",
 		"metricsets":   []string{"node"},
 		"hosts":        []string{server.URL},

--- a/metricbeat/module/rabbitmq/queue/data.go
+++ b/metricbeat/module/rabbitmq/queue/data.go
@@ -84,7 +84,7 @@ var (
 )
 
 func eventsMapping(content []byte, r mb.ReporterV2) error {
-	var queues []map[string]interface{}
+	var queues []map[string]any
 	err := json.Unmarshal(content, &queues)
 	if err != nil {
 		return fmt.Errorf("error in mapping: %w", err)
@@ -98,7 +98,7 @@ func eventsMapping(content []byte, r mb.ReporterV2) error {
 	return nil
 }
 
-func eventMapping(queue map[string]interface{}) mb.Event {
+func eventMapping(queue map[string]any) mb.Event {
 	fields, _ := schema.Apply(queue)
 
 	moduleFields := mapstr.M{}

--- a/metricbeat/module/rabbitmq/queue/queue_test.go
+++ b/metricbeat/module/rabbitmq/queue/queue_test.go
@@ -100,8 +100,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(url string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(url string) map[string]any {
+	return map[string]any{
 		"module":     "rabbitmq",
 		"metricsets": []string{"queue"},
 		"hosts":      []string{url},

--- a/metricbeat/module/rabbitmq/shovel/data.go
+++ b/metricbeat/module/rabbitmq/shovel/data.go
@@ -38,7 +38,7 @@ var (
 )
 
 func eventsMapping(content []byte, r mb.ReporterV2) error {
-	var shovels []map[string]interface{}
+	var shovels []map[string]any
 	err := json.Unmarshal(content, &shovels)
 	if err != nil {
 		return fmt.Errorf("error in mapping: %w", err)
@@ -52,7 +52,7 @@ func eventsMapping(content []byte, r mb.ReporterV2) error {
 	return nil
 }
 
-func eventMapping(shovel map[string]interface{}) mb.Event {
+func eventMapping(shovel map[string]any) mb.Event {
 	fields, _ := schema.Apply(shovel)
 
 	moduleFields := mapstr.M{}

--- a/metricbeat/module/rabbitmq/shovel/shovel_test.go
+++ b/metricbeat/module/rabbitmq/shovel/shovel_test.go
@@ -63,8 +63,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(url string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(url string) map[string]any {
+	return map[string]any{
 		"module":     "rabbitmq",
 		"metricsets": []string{"shovel"},
 		"hosts":      []string{url},

--- a/metricbeat/module/redis/info/data.go
+++ b/metricbeat/module/redis/info/data.go
@@ -275,7 +275,7 @@ func buildCommandstatsSchema(key string, schema s.Schema) {
 // Map data to MapStr
 func eventMapping(r mb.ReporterV2, info map[string]string) {
 	// Full mapping from info
-	source := map[string]interface{}{}
+	source := map[string]any{}
 	commandstatsSchema := s.Schema{}
 	for key, val := range info {
 		source[key] = val

--- a/metricbeat/module/redis/info/info_integration_test.go
+++ b/metricbeat/module/redis/info/info_integration_test.go
@@ -60,8 +60,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "redis",
 		"metricsets": []string{"info"},
 		"hosts":      []string{host},

--- a/metricbeat/module/redis/info/info_test.go
+++ b/metricbeat/module/redis/info/info_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestNewMetricSet(t *testing.T) {
 	t.Run("regular url", func(t *testing.T) {
-		c, err := conf.NewConfigFrom(map[string]interface{}{
+		c, err := conf.NewConfigFrom(map[string]any{
 			"module":     "redis",
 			"metricsets": []string{"info"},
 			"hosts": []string{
@@ -44,7 +44,7 @@ func TestNewMetricSet(t *testing.T) {
 	})
 
 	t.Run("pass in host", func(t *testing.T) {
-		c, err := conf.NewConfigFrom(map[string]interface{}{
+		c, err := conf.NewConfigFrom(map[string]any{
 			"module":     "redis",
 			"metricsets": []string{"info"},
 			"hosts": []string{
@@ -62,7 +62,7 @@ func TestNewMetricSet(t *testing.T) {
 	})
 
 	t.Run("password in config", func(t *testing.T) {
-		c, err := conf.NewConfigFrom(map[string]interface{}{
+		c, err := conf.NewConfigFrom(map[string]any{
 			"module":     "redis",
 			"metricsets": []string{"info"},
 			"hosts": []string{

--- a/metricbeat/module/redis/key/data.go
+++ b/metricbeat/module/redis/key/data.go
@@ -24,7 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-func eventMapping(keyspace uint, info map[string]interface{}) mb.Event {
+func eventMapping(keyspace uint, info map[string]any) mb.Event {
 	info["id"] = fmt.Sprintf("%d:%s", keyspace, info["name"])
 	return mb.Event{
 		MetricSetFields: info,

--- a/metricbeat/module/redis/key/key_integration_test.go
+++ b/metricbeat/module/redis/key/key_integration_test.go
@@ -70,7 +70,7 @@ func TestFetchMultipleKeyspaces(t *testing.T) {
 	}
 
 	config := getConfig(service.Host())
-	config["key.patterns"] = []map[string]interface{}{
+	config["key.patterns"] = []map[string]any{
 		{
 			"pattern":  "foo",
 			"keyspace": 0,
@@ -123,12 +123,12 @@ func addEntry(t *testing.T, host string, key string, keyspace uint) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "redis",
 		"metricsets": []string{"key"},
 		"hosts":      []string{host + "/1"},
-		"key.patterns": []map[string]interface{}{
+		"key.patterns": []map[string]any{
 			{
 				"pattern": "foo",
 			},

--- a/metricbeat/module/redis/keyspace/data.go
+++ b/metricbeat/module/redis/keyspace/data.go
@@ -72,7 +72,7 @@ func parseKeyspaceStats(keyspaceMap map[string]string) map[string]mapstr.M {
 		dbInfo := redis.ParseRedisLine(v, ",")
 
 		if len(dbInfo) == 3 || len(dbInfo) == 4 {
-			db := map[string]interface{}{}
+			db := map[string]any{}
 			for _, dbEntry := range dbInfo {
 				stats := redis.ParseRedisLine(dbEntry, "=")
 

--- a/metricbeat/module/redis/keyspace/data_test.go
+++ b/metricbeat/module/redis/keyspace/data_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // getInt64 attempts to normalize various numeric types (and numeric strings) to int64 for assertions.
-func getInt64(t *testing.T, v interface{}) int64 {
+func getInt64(t *testing.T, v any) int64 {
 	switch n := v.(type) {
 	case int:
 		return int64(n)

--- a/metricbeat/module/redis/keyspace/keyspace_integration_test.go
+++ b/metricbeat/module/redis/keyspace/keyspace_integration_test.go
@@ -99,7 +99,7 @@ func TestSubExpiryField(t *testing.T) {
 	// Make sure at least 1 db keyspace exists
 	assert.True(t, len(events) > 0)
 
-	var keyspace map[string]interface{}
+	var keyspace map[string]any
 	for _, event := range events {
 		if id, ok := event.MetricSetFields["id"].(string); ok && id == "db0" {
 			keyspace = event.MetricSetFields
@@ -127,8 +127,8 @@ func getRedisVersion(t *testing.T, host string) (int, int) {
 		t.Fatal("INFO", err)
 	}
 	var version string
-	lines := strings.Split(info, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(info, "\n")
+	for line := range lines {
 		if strings.HasPrefix(line, "redis_version:") {
 			version = strings.TrimSpace(strings.SplitN(line, ":", 2)[1])
 			break
@@ -193,8 +193,8 @@ func addEntry(t *testing.T, host string) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "redis",
 		"metricsets": []string{"keyspace"},
 		"hosts":      []string{host},

--- a/metricbeat/module/redis/metricset_integration_test.go
+++ b/metricbeat/module/redis/metricset_integration_test.go
@@ -129,7 +129,7 @@ func newDummyMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *dummyMetricSet) Fetch(r mb.ReporterV2) {
 }
 
-func getMetricSet(t *testing.T, registry *mb.Register, config map[string]interface{}) *MetricSet {
+func getMetricSet(t *testing.T, registry *mb.Register, config map[string]any) *MetricSet {
 	t.Helper()
 
 	c, err := conf.NewConfigFrom(config)
@@ -145,8 +145,8 @@ func getMetricSet(t *testing.T, registry *mb.Register, config map[string]interfa
 	return ms.MetricSet
 }
 
-func getConfig(host string, password string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string, password string) map[string]any {
+	return map[string]any{
 		"module":     "redis",
 		"metricsets": "test",
 		"hosts":      []string{host},

--- a/metricbeat/module/redis/redis.go
+++ b/metricbeat/module/redis/redis.go
@@ -109,7 +109,7 @@ func FetchSlowLogLength(c rd.Conn, logger *logp.Logger) (int64, error) {
 }
 
 // FetchKeyInfo collects info about a key
-func FetchKeyInfo(c rd.Conn, key string, logger *logp.Logger) (map[string]interface{}, error) {
+func FetchKeyInfo(c rd.Conn, key string, logger *logp.Logger) (map[string]any, error) {
 	keyType, err := rd.String(c.Do("TYPE", key))
 	if err != nil {
 		return nil, err
@@ -124,10 +124,10 @@ func FetchKeyInfo(c rd.Conn, key string, logger *logp.Logger) (map[string]interf
 		return nil, err
 	}
 
-	info := map[string]interface{}{
+	info := map[string]any{
 		"name": key,
 		"type": keyType,
-		"expire": map[string]interface{}{
+		"expire": map[string]any{
 			"ttl": keyTTL,
 		},
 	}

--- a/metricbeat/module/redis/redis_integration_test.go
+++ b/metricbeat/module/redis/redis_integration_test.go
@@ -111,20 +111,20 @@ func TestFetchKeyInfo(t *testing.T) {
 		Title    string
 		Key      string
 		Command  string
-		Value    []interface{}
+		Value    []any
 		Expire   uint
-		Expected map[string]interface{}
+		Expected map[string]any
 	}{
 		{
 			Title:   "plain string",
 			Key:     "string-key",
 			Command: "SET",
-			Value:   []interface{}{"foo"},
-			Expected: map[string]interface{}{
+			Value:   []any{"foo"},
+			Expected: map[string]any{
 				"name":   "string-key",
 				"type":   "string",
 				"length": int64(3),
-				"expire": map[string]interface{}{
+				"expire": map[string]any{
 					"ttl": int64(-1),
 				},
 			},
@@ -133,13 +133,13 @@ func TestFetchKeyInfo(t *testing.T) {
 			Title:   "plain string with TTL",
 			Key:     "string-key",
 			Command: "SET",
-			Value:   []interface{}{"foo"},
+			Value:   []any{"foo"},
 			Expire:  60,
-			Expected: map[string]interface{}{
+			Expected: map[string]any{
 				"name":   "string-key",
 				"type":   "string",
 				"length": int64(3),
-				"expire": map[string]interface{}{
+				"expire": map[string]any{
 					"ttl": int64(60),
 				},
 			},
@@ -148,12 +148,12 @@ func TestFetchKeyInfo(t *testing.T) {
 			Title:   "list",
 			Key:     "list-key",
 			Command: "LPUSH",
-			Value:   []interface{}{"foo", "bar"},
-			Expected: map[string]interface{}{
+			Value:   []any{"foo", "bar"},
+			Expected: map[string]any{
 				"name":   "list-key",
 				"type":   "list",
 				"length": int64(2),
-				"expire": map[string]interface{}{
+				"expire": map[string]any{
 					"ttl": int64(-1),
 				},
 			},
@@ -162,12 +162,12 @@ func TestFetchKeyInfo(t *testing.T) {
 			Title:   "set",
 			Key:     "set-key",
 			Command: "SADD",
-			Value:   []interface{}{"foo", "bar"},
-			Expected: map[string]interface{}{
+			Value:   []any{"foo", "bar"},
+			Expected: map[string]any{
 				"name":   "set-key",
 				"type":   "set",
 				"length": int64(2),
-				"expire": map[string]interface{}{
+				"expire": map[string]any{
 					"ttl": int64(-1),
 				},
 			},
@@ -176,12 +176,12 @@ func TestFetchKeyInfo(t *testing.T) {
 			Title:   "sorted set",
 			Key:     "sorted-set-key",
 			Command: "ZADD",
-			Value:   []interface{}{1, "foo", 2, "bar"},
-			Expected: map[string]interface{}{
+			Value:   []any{1, "foo", 2, "bar"},
+			Expected: map[string]any{
 				"name":   "sorted-set-key",
 				"type":   "zset",
 				"length": int64(2),
-				"expire": map[string]interface{}{
+				"expire": map[string]any{
 					"ttl": int64(-1),
 				},
 			},
@@ -190,12 +190,12 @@ func TestFetchKeyInfo(t *testing.T) {
 			Title:   "hash",
 			Key:     "hash-key",
 			Command: "HSET",
-			Value:   []interface{}{"foo", "bar"},
-			Expected: map[string]interface{}{
+			Value:   []any{"foo", "bar"},
+			Expected: map[string]any{
 				"name":   "hash-key",
 				"type":   "hash",
 				"length": int64(1),
-				"expire": map[string]interface{}{
+				"expire": map[string]any{
 					"ttl": int64(-1),
 				},
 			},
@@ -204,7 +204,7 @@ func TestFetchKeyInfo(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Title, func(t *testing.T) {
-			args := append([]interface{}{c.Key}, c.Value...)
+			args := append([]any{c.Key}, c.Value...)
 			conn.Do(c.Command, args...)
 			defer conn.Do("DEL", c.Key)
 			if c.Expire > 0 {

--- a/metricbeat/module/system/ntp/config_test.go
+++ b/metricbeat/module/system/ntp/config_test.go
@@ -51,7 +51,7 @@ func TestUnpackConfigReplacesServers(t *testing.T) {
 		Version: 4,
 	}
 
-	userCfg := ucfg.MustNewConfigFrom(map[string]interface{}{
+	userCfg := ucfg.MustNewConfigFrom(map[string]any{
 		"ntp.servers": []string{"custom.ntp.org"},
 	})
 

--- a/metricbeat/module/system/ntp/ntp_test.go
+++ b/metricbeat/module/system/ntp/ntp_test.go
@@ -40,8 +40,8 @@ func (n *ntpSuccess) validate(_ *ntp.Response) error {
 	return nil
 }
 
-func getTestConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getTestConfig() map[string]any {
+	return map[string]any{
 		"module":      "system",
 		"metricsets":  []string{"ntp"},
 		"ntp.servers": []string{"0.time.tom.com", "1.time.tom.com"},

--- a/metricbeat/module/vsphere/client/performance.go
+++ b/metricbeat/module/vsphere/client/performance.go
@@ -52,9 +52,9 @@ func (p *PerformanceDataFetcher) GetPerfMetrics(ctx context.Context,
 	objectName string,
 	objectReference types.ManagedObjectReference,
 	metrics map[string]*types.PerfCounterInfo,
-	metricSet map[string]struct{}) (metricMap map[string]interface{}, err error) {
+	metricSet map[string]struct{}) (metricMap map[string]any, err error) {
 
-	metricMap = make(map[string]interface{})
+	metricMap = make(map[string]any)
 
 	availableMetric, err := p.perfManager.AvailableMetric(ctx, objectReference, period)
 	if err != nil {

--- a/metricbeat/module/vsphere/client/performance_test.go
+++ b/metricbeat/module/vsphere/client/performance_test.go
@@ -64,7 +64,7 @@ func TestGetPerfMetrics(t *testing.T) {
 	tests := []struct {
 		name            string
 		mockPerfManager func(manager *MockPerfManager)
-		assertResults   func(t2 *testing.T, metricsMap map[string]interface{}, err error)
+		assertResults   func(t2 *testing.T, metricsMap map[string]any, err error)
 	}{
 		{
 			name: "success (percentage metric)",
@@ -101,9 +101,9 @@ func TestGetPerfMetrics(t *testing.T) {
 					},
 				}, nil)
 			},
-			assertResults: func(t2 *testing.T, metricMap map[string]interface{}, err error) {
+			assertResults: func(t2 *testing.T, metricMap map[string]any, err error) {
 				require.NoError(t, err)
-				assert.InDeltaMapValues(t, map[string]interface{}{
+				assert.InDeltaMapValues(t, map[string]any{
 					"metric1": 53.2,
 				}, metricMap, 0)
 			},
@@ -143,9 +143,9 @@ func TestGetPerfMetrics(t *testing.T) {
 					},
 				}, nil)
 			},
-			assertResults: func(t2 *testing.T, metricMap map[string]interface{}, err error) {
+			assertResults: func(t2 *testing.T, metricMap map[string]any, err error) {
 				require.NoError(t, err)
-				assert.InDeltaMapValues(t, map[string]interface{}{
+				assert.InDeltaMapValues(t, map[string]any{
 					"metric1": 1024,
 				}, metricMap, 0)
 			},
@@ -163,9 +163,9 @@ func TestGetPerfMetrics(t *testing.T) {
 					},
 				}).Return(nil, nil)
 			},
-			assertResults: func(t2 *testing.T, metricMap map[string]interface{}, err error) {
+			assertResults: func(t2 *testing.T, metricMap map[string]any, err error) {
 				require.NoError(t, err)
-				assert.InDeltaMapValues(t, map[string]interface{}{}, metricMap, 0)
+				assert.InDeltaMapValues(t, map[string]any{}, metricMap, 0)
 			},
 		},
 		{
@@ -191,7 +191,7 @@ func TestGetPerfMetrics(t *testing.T) {
 					},
 				}).Return(nil, errors.New("query error"))
 			},
-			assertResults: func(t *testing.T, metricMap map[string]interface{}, err error) {
+			assertResults: func(t *testing.T, metricMap map[string]any, err error) {
 				assert.Error(t, err, "query error")
 			},
 		},
@@ -219,7 +219,7 @@ func TestGetPerfMetrics(t *testing.T) {
 				}).Return(mSamples, nil)
 				manager.EXPECT().ToMetricSeries(gomock.Any(), mSamples).Return(nil, errors.New("ToMetricSeries error"))
 			},
-			assertResults: func(t2 *testing.T, metricMap map[string]interface{}, err error) {
+			assertResults: func(t2 *testing.T, metricMap map[string]any, err error) {
 				assert.Error(t, err, "ToMetricSeries error")
 			},
 		},

--- a/metricbeat/module/vsphere/cluster/cluster_test.go
+++ b/metricbeat/module/vsphere/cluster/cluster_test.go
@@ -87,10 +87,10 @@ func TestClusterMetricSetData(t *testing.T) {
 	assert.NoError(t, err, "failed to write events with reporter")
 }
 
-func getConfig(ts *simulator.Server) map[string]interface{} {
+func getConfig(ts *simulator.Server) map[string]any {
 	urlSimulator := ts.URL.Scheme + "://" + ts.URL.Host + ts.URL.Path
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "vsphere",
 		"metricsets": []string{"cluster"},
 		"hosts":      []string{urlSimulator},

--- a/metricbeat/module/vsphere/cluster/data_test.go
+++ b/metricbeat/module/vsphere/cluster/data_test.go
@@ -42,8 +42,8 @@ func TestEventMapping(t *testing.T) {
 		},
 		Configuration: types.ClusterConfigInfo{
 			DasConfig: types.ClusterDasConfigInfo{
-				Enabled:                 types.NewBool(false),
-				AdmissionControlEnabled: types.NewBool(true),
+				Enabled:                 new(false),
+				AdmissionControlEnabled: new(true),
 			},
 		},
 	}

--- a/metricbeat/module/vsphere/datastore/data.go
+++ b/metricbeat/module/vsphere/datastore/data.go
@@ -64,7 +64,7 @@ func (m *DataStoreMetricSet) mapEvent(ds mo.Datastore, data *metricData) mapstr.
 	return event
 }
 
-func mapPerfMetricToEvent(event mapstr.M, perfMetricMap map[string]interface{}) {
+func mapPerfMetricToEvent(event mapstr.M, perfMetricMap map[string]any) {
 	const bytesMultiplier int64 = 1024
 
 	if val, exist := perfMetricMap["datastore.read.average"]; exist {

--- a/metricbeat/module/vsphere/datastore/data_test.go
+++ b/metricbeat/module/vsphere/datastore/data_test.go
@@ -50,7 +50,7 @@ func TestEventMapping(t *testing.T) {
 	}
 
 	var metricDataTest = metricData{
-		perfMetrics: map[string]interface{}{
+		perfMetrics: map[string]any{
 			"datastore.read.average":      int64(100),
 			"datastore.write.average":     int64(200),
 			"disk.capacity.latest":        int64(10000),

--- a/metricbeat/module/vsphere/datastore/datastore.go
+++ b/metricbeat/module/vsphere/datastore/datastore.go
@@ -69,7 +69,7 @@ type triggeredAlarm struct {
 }
 
 type metricData struct {
-	perfMetrics     map[string]interface{}
+	perfMetrics     map[string]any
 	assetNames      assetNames
 	triggeredAlarms []triggeredAlarm
 }

--- a/metricbeat/module/vsphere/datastore/datastore_test.go
+++ b/metricbeat/module/vsphere/datastore/datastore_test.go
@@ -95,8 +95,8 @@ func TestDataStoreMetricSetData(t *testing.T) {
 	assert.NoError(t, err, "failed to write events with reporter")
 }
 
-func getConfig(ts *simulator.Server) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(ts *simulator.Server) map[string]any {
+	return map[string]any{
 		"module":     "vsphere",
 		"metricsets": []string{"datastore"},
 		"hosts":      []string{ts.URL.String()},

--- a/metricbeat/module/vsphere/datastorecluster/datastorecluster_test.go
+++ b/metricbeat/module/vsphere/datastorecluster/datastorecluster_test.go
@@ -76,8 +76,8 @@ func TestDatastoreCluster(t *testing.T) {
 	assert.NoError(t, err, "failed to write events with reporter")
 }
 
-func getConfig(ts *simulator.Server) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(ts *simulator.Server) map[string]any {
+	return map[string]any{
 		"module":     "vsphere",
 		"metricsets": []string{"datastorecluster"},
 		"hosts":      []string{ts.URL.String()},

--- a/metricbeat/module/vsphere/host/data.go
+++ b/metricbeat/module/vsphere/host/data.go
@@ -70,7 +70,7 @@ func (m *HostMetricSet) mapEvent(hs mo.HostSystem, data *metricData) mapstr.M {
 	return event
 }
 
-func mapPerfMetricToEvent(event mapstr.M, perfMetricMap map[string]interface{}) {
+func mapPerfMetricToEvent(event mapstr.M, perfMetricMap map[string]any) {
 	const bytesMultiplier int64 = 1024
 	if val, exist := perfMetricMap["disk.capacity.usage.average"]; exist {
 		event.Put("disk.capacity.usage.bytes", val.(int64)*bytesMultiplier)

--- a/metricbeat/module/vsphere/host/data_test.go
+++ b/metricbeat/module/vsphere/host/data_test.go
@@ -54,7 +54,7 @@ func TestEventMapping(t *testing.T) {
 	}
 
 	var metricDataTest = metricData{
-		perfMetrics: map[string]interface{}{
+		perfMetrics: map[string]any{
 			"disk.capacity.usage.average": int64(100),
 			"disk.deviceLatency.average":  int64(5),
 			"disk.maxTotalLatency.latest": int64(3),

--- a/metricbeat/module/vsphere/host/host.go
+++ b/metricbeat/module/vsphere/host/host.go
@@ -69,7 +69,7 @@ type triggeredAlarm struct {
 }
 
 type metricData struct {
-	perfMetrics     map[string]interface{}
+	perfMetrics     map[string]any
 	assetNames      assetNames
 	triggeredAlarms []triggeredAlarm
 }

--- a/metricbeat/module/vsphere/host/host_test.go
+++ b/metricbeat/module/vsphere/host/host_test.go
@@ -182,10 +182,10 @@ func TestHostMetricSetData(t *testing.T) {
 	assert.NoError(t, err, "failed to write events with reporter")
 }
 
-func getConfig(ts *simulator.Server) map[string]interface{} {
+func getConfig(ts *simulator.Server) map[string]any {
 	urlSimulator := ts.URL.Scheme + "://" + ts.URL.Host + ts.URL.Path
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "vsphere",
 		"metricsets": []string{"host"},
 		"hosts":      []string{urlSimulator},

--- a/metricbeat/module/vsphere/network/network_test.go
+++ b/metricbeat/module/vsphere/network/network_test.go
@@ -82,10 +82,10 @@ func TestNetworkMetricSetData(t *testing.T) {
 	assert.NoError(t, err, "failed to write events with reporter")
 }
 
-func getConfig(ts *simulator.Server) map[string]interface{} {
+func getConfig(ts *simulator.Server) map[string]any {
 	urlSimulator := ts.URL.Scheme + "://" + ts.URL.Host + ts.URL.Path
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "vsphere",
 		"metricsets": []string{"network"},
 		"hosts":      []string{urlSimulator},

--- a/metricbeat/module/vsphere/resourcepool/resourcepool_test.go
+++ b/metricbeat/module/vsphere/resourcepool/resourcepool_test.go
@@ -92,10 +92,10 @@ func TestResourcePoolMetricSetData(t *testing.T) {
 	assert.NoError(t, err, "failed to write events with reporter")
 }
 
-func getConfig(ts *simulator.Server) map[string]interface{} {
+func getConfig(ts *simulator.Server) map[string]any {
 	urlSimulator := ts.URL.Scheme + "://" + ts.URL.Host + ts.URL.Path
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "vsphere",
 		"metricsets": []string{"resourcepool"},
 		"hosts":      []string{urlSimulator},

--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
@@ -84,7 +84,7 @@ type VMData struct {
 	DatastoreNames  []string
 	CustomFields    mapstr.M
 	Snapshots       []VMSnapshotData
-	PerformanceData map[string]interface{}
+	PerformanceData map[string]any
 	triggeredAlarms []triggeredAlarm
 }
 

--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine_test.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine_test.go
@@ -101,10 +101,10 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(ts *simulator.Server) map[string]interface{} {
+func getConfig(ts *simulator.Server) map[string]any {
 	urlSimulator := ts.URL.Scheme + "://" + ts.URL.Host + ts.URL.Path
 
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "vsphere",
 		"metricsets": []string{"virtualmachine"},
 		"hosts":      []string{urlSimulator},

--- a/metricbeat/module/windows/wmi/utils.go
+++ b/metricbeat/module/windows/wmi/utils.go
@@ -101,18 +101,18 @@ func internalConvertDateTime(v string) (time.Time, error) {
 }
 
 // Type conversion that applies to both arrays and scalars
-type WmiConversionFunction func(interface{}) (interface{}, error)
+type WmiConversionFunction func(any) (any, error)
 
 // General-purpose function that invokes the internal WMI conversion on
 // both strings and arrays to avoid code duplication.
-func GenericWmiConversionFunction[T any](v interface{}, convert internalWmiConversionFunction[T]) (interface{}, error) {
+func GenericWmiConversionFunction[T any](v any, convert internalWmiConversionFunction[T]) (any, error) {
 	if v == nil {
 		return nil, nil
 	}
 	switch value := v.(type) {
 	case string:
 		return convert(value)
-	case []interface{}:
+	case []any:
 		results := make([]T, 0, len(value))
 		for i, raw := range value {
 			str, ok := raw.(string)
@@ -131,26 +131,26 @@ func GenericWmiConversionFunction[T any](v interface{}, convert internalWmiConve
 	}
 }
 
-func ConvertUint64(v interface{}) (interface{}, error) {
+func ConvertUint64(v any) (any, error) {
 	return GenericWmiConversionFunction[uint64](v, internalConvertUint64)
 }
 
-func ConvertSint64(v interface{}) (interface{}, error) {
+func ConvertSint64(v any) (any, error) {
 	return GenericWmiConversionFunction[int64](v, internalConvertSint64)
 }
 
-func ConvertDatetime(v interface{}) (interface{}, error) {
+func ConvertDatetime(v any) (any, error) {
 	return GenericWmiConversionFunction[time.Time](v, internalConvertDateTime)
 }
 
-func ConvertIdentity(v interface{}) (interface{}, error) {
+func ConvertIdentity(v any) (any, error) {
 	return v, nil
 }
 
 // Function that returns a WmiConversionFunction that reports an error
 // independently of the input value.
 func getInvalidConversion(err error) WmiConversionFunction {
-	return func(v interface{}) (interface{}, error) {
+	return func(v any) (any, error) {
 		return nil, err
 	}
 }

--- a/metricbeat/module/windows/wmi/utils_test.go
+++ b/metricbeat/module/windows/wmi/utils_test.go
@@ -68,8 +68,8 @@ func dummyUint64Converter(s string) (uint64, error) {
 func TestGenericWmiConversionFunction(t *testing.T) {
 	type testCase struct {
 		name        string
-		input       interface{}
-		want        interface{}
+		input       any
+		want        any
 		expectError bool
 	}
 
@@ -81,12 +81,12 @@ func TestGenericWmiConversionFunction(t *testing.T) {
 		},
 		{
 			name:  "slice of strings as []interface{}",
-			input: []interface{}{"1", "2", "3"},
+			input: []any{"1", "2", "3"},
 			want:  []uint64{1, 2, 3},
 		},
 		{
 			name:        "slice contains non-string",
-			input:       []interface{}{"1", 2, "3"},
+			input:       []any{"1", 2, "3"},
 			expectError: true,
 		},
 		{
@@ -115,8 +115,8 @@ func Test_ConversionFunctions(t *testing.T) {
 	tests := []struct {
 		name        string
 		conversion  WmiConversionFunction
-		input       interface{}
-		expected    interface{}
+		input       any
+		expected    any
 		expectErr   bool
 		description string
 	}{
@@ -132,7 +132,7 @@ func Test_ConversionFunctions(t *testing.T) {
 		{
 			name:        "ConvertUint64 - valid array input",
 			conversion:  ConvertUint64,
-			input:       []interface{}{"12345", "345"},
+			input:       []any{"12345", "345"},
 			expected:    []uint64{12345, 345},
 			expectErr:   false,
 			description: "Should convert string to uint64",
@@ -157,7 +157,7 @@ func Test_ConversionFunctions(t *testing.T) {
 		{
 			name:        "ConvertSint64 - valid array input",
 			conversion:  ConvertSint64,
-			input:       []interface{}{"-12345", "345"},
+			input:       []any{"-12345", "345"},
 			expected:    []int64{-12345, 345},
 			expectErr:   false,
 			description: "Should convert string to uint64",

--- a/metricbeat/module/windows/wmi/wmi.go
+++ b/metricbeat/module/windows/wmi/wmi.go
@@ -88,7 +88,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // This function handles the skip conditions
-func (m *MetricSet) shouldSkipNilOrEmptyValue(propertyValue interface{}) bool {
+func (m *MetricSet) shouldSkipNilOrEmptyValue(propertyValue any) bool {
 	if propertyValue == nil {
 		if !m.config.IncludeNullProperties {
 			return true // Skip if it's nil and IncludeNullProperties is false

--- a/metricbeat/module/windows/wmi/wmi_test.go
+++ b/metricbeat/module/windows/wmi/wmi_test.go
@@ -28,7 +28,7 @@ import (
 func TestShouldSkipNilOrEmptyValue(t *testing.T) {
 	tests := []struct {
 		key                string
-		propertyValue      interface{}
+		propertyValue      any
 		includeNull        bool
 		includeEmptyString bool
 		expectedShouldSkip bool

--- a/metricbeat/module/zookeeper/connection/connection_integration_test.go
+++ b/metricbeat/module/zookeeper/connection/connection_integration_test.go
@@ -35,8 +35,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "zookeeper",
 		"metricsets": []string{"connection"},
 		"hosts":      []string{host},

--- a/metricbeat/module/zookeeper/mntr/data.go
+++ b/metricbeat/module/zookeeper/mntr/data.go
@@ -64,7 +64,7 @@ var (
 )
 
 func eventMapping(serverId string, response io.Reader, r mb.ReporterV2, logger *logp.Logger) {
-	fullEvent := map[string]interface{}{}
+	fullEvent := map[string]any{}
 	scanner := bufio.NewScanner(response)
 
 	// Iterate through all events to gather data

--- a/metricbeat/module/zookeeper/mntr/mntr_integration_test.go
+++ b/metricbeat/module/zookeeper/mntr/mntr_integration_test.go
@@ -67,8 +67,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "zookeeper",
 		"metricsets": []string{"mntr"},
 		"hosts":      []string{host},

--- a/metricbeat/module/zookeeper/server/server_integration_test.go
+++ b/metricbeat/module/zookeeper/server/server_integration_test.go
@@ -63,8 +63,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "zookeeper",
 		"metricsets": []string{"server"},
 		"hosts":      []string{host},

--- a/metricbeat/module/zookeeper/zookeeper.go
+++ b/metricbeat/module/zookeeper/zookeeper.go
@@ -26,7 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+
 	"net"
 	"strings"
 	"time"
@@ -55,7 +55,7 @@ func RunCommand(command, address string, timeout time.Duration) (io.Reader, erro
 		return nil, fmt.Errorf("writing command '%s' failed: %w", command, err)
 	}
 
-	result, err := ioutil.ReadAll(conn)
+	result, err := io.ReadAll(conn)
 	if err != nil {
 		return nil, fmt.Errorf("read failed: %w", err)
 	}

--- a/x-pack/filebeat/input/cometd/input.go
+++ b/x-pack/filebeat/input/cometd/input.go
@@ -37,9 +37,7 @@ const (
 func (in *cometdInput) Run() {
 	var err error
 	in.workerOnce.Do(func() {
-		in.workerWg.Add(1)
-		go func() {
-			defer in.workerWg.Done()
+		in.workerWg.Go(func() {
 			defer in.workerCancel()
 			in.log.Info("Input worker has started.")
 			defer in.log.Info("Input worker has stopped.")
@@ -74,7 +72,7 @@ func (in *cometdInput) Run() {
 					}
 				}
 			}
-		}()
+		})
 	})
 }
 

--- a/x-pack/filebeat/input/cometd/input_test.go
+++ b/x-pack/filebeat/input/cometd/input_test.go
@@ -89,7 +89,7 @@ func TestSingleInput(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",
@@ -148,7 +148,7 @@ func TestInputStop_Wait(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",
@@ -178,16 +178,14 @@ func TestInputStop_Wait(t *testing.T) {
 	var waitForEventCollection sync.WaitGroup
 	var waitForConnections sync.WaitGroup
 	waitForEventCollection.Add(1)
-	waitForConnections.Add(1)
-	go func() {
+	waitForConnections.Go(func() {
 		require.Equal(t, 1, bay.GetConnectedCount()) // current open channels count should be 1
 		event := <-eventsCh
 		assertEventMatches(t, expected, event) // wait for single event
 		waitForEventCollection.Done()
 		time.Sleep(100 * time.Millisecond)           // let input.Stop() be executed.
 		require.Equal(t, 0, bay.GetConnectedCount()) // current open channels count should be 0
-		waitForConnections.Done()
-	}()
+	})
 
 	waitForEventCollection.Wait()
 	input.Wait()
@@ -269,7 +267,7 @@ func TestMultiInput(t *testing.T) {
 	expected1.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected1.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",
@@ -425,7 +423,7 @@ func TestMultiEventForEOFRetryHandlerInput(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",
@@ -497,7 +495,7 @@ func TestMultiEventForEOFRetryHandlerInput(t *testing.T) {
 	close(eventsCh)
 
 	go func() {
-		for j := 0; j < expectedEventCount; j++ {
+		for range expectedEventCount {
 			event := <-eventsCh
 			assertEventMatches(t, expected, event)
 		}
@@ -543,7 +541,7 @@ func TestNegativeCases(t *testing.T) {
 	expected.Msg.Data.Payload = []byte(`{"CountryIso": "IN"}`)
 	expected.Msg.Channel = "channel_name"
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"channel_name":              "channel_name",
 		"auth.oauth2.client.id":     "client.id",
 		"auth.oauth2.client.secret": "client.secret",

--- a/x-pack/filebeat/input/salesforce/batch_test.go
+++ b/x-pack/filebeat/input/salesforce/batch_test.go
@@ -191,9 +191,9 @@ func TestNextObjectBatchWindow(t *testing.T) {
 					EventMonitoringMethod: &eventMonitoringMethod{
 						Object: EventMonitoringConfig{
 							Batch: &batchConfig{
-								Enabled:          pointer(true),
+								Enabled:          new(true),
 								InitialInterval:  15 * time.Minute,
-								MaxWindowsPerRun: pointer(1),
+								MaxWindowsPerRun: new(1),
 								Window:           5 * time.Minute,
 							},
 						},

--- a/x-pack/filebeat/input/salesforce/config_auth_test.go
+++ b/x-pack/filebeat/input/salesforce/config_auth_test.go
@@ -17,13 +17,13 @@ func TestOAuth2Config(t *testing.T) {
 		config  UserPasswordFlow
 	}{
 		"auth disabled I":      {config: UserPasswordFlow{}, wantErr: nil},
-		"auth disabled II":     {config: UserPasswordFlow{Enabled: pointer(false)}, wantErr: nil},
-		"tokenURL missing":     {config: UserPasswordFlow{Enabled: pointer(true), TokenURL: ""}, wantErr: errors.New("token_url must be provided")},
-		"clientID missing":     {config: UserPasswordFlow{Enabled: pointer(true), TokenURL: "https://salesforce.com", ClientID: ""}, wantErr: errors.New("client.id must be provided")},
-		"clientSecret missing": {config: UserPasswordFlow{Enabled: pointer(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: ""}, wantErr: errors.New("client.secret must be provided")},
-		"username missing":     {config: UserPasswordFlow{Enabled: pointer(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: "abc", Username: ""}, wantErr: errors.New("username must be provided")},
-		"password missing":     {config: UserPasswordFlow{Enabled: pointer(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: "abc", Username: "user", Password: ""}, wantErr: errors.New("password must be provided")},
-		"all present":          {config: UserPasswordFlow{Enabled: pointer(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: "abc", Username: "user", Password: "pass"}, wantErr: nil},
+		"auth disabled II":     {config: UserPasswordFlow{Enabled: new(false)}, wantErr: nil},
+		"tokenURL missing":     {config: UserPasswordFlow{Enabled: new(true), TokenURL: ""}, wantErr: errors.New("token_url must be provided")},
+		"clientID missing":     {config: UserPasswordFlow{Enabled: new(true), TokenURL: "https://salesforce.com", ClientID: ""}, wantErr: errors.New("client.id must be provided")},
+		"clientSecret missing": {config: UserPasswordFlow{Enabled: new(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: ""}, wantErr: errors.New("client.secret must be provided")},
+		"username missing":     {config: UserPasswordFlow{Enabled: new(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: "abc", Username: ""}, wantErr: errors.New("username must be provided")},
+		"password missing":     {config: UserPasswordFlow{Enabled: new(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: "abc", Username: "user", Password: ""}, wantErr: errors.New("password must be provided")},
+		"all present":          {config: UserPasswordFlow{Enabled: new(true), TokenURL: "https://salesforce.com", ClientID: "xyz", ClientSecret: "abc", Username: "user", Password: "pass"}, wantErr: nil},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -39,13 +39,13 @@ func TestJWTConfig(t *testing.T) {
 		config  JWTBearerFlow
 	}{
 		"auth disabled I":            {config: JWTBearerFlow{}, wantErr: nil},
-		"auth disabled II":           {config: JWTBearerFlow{Enabled: pointer(false)}, wantErr: nil},
-		"url missing":                {config: JWTBearerFlow{Enabled: pointer(true), URL: ""}, wantErr: errors.New("url must be provided")},
-		"clientID missing":           {config: JWTBearerFlow{Enabled: pointer(true), URL: "https://salesforce.com", ClientID: ""}, wantErr: errors.New("client.id must be provided")},
-		"clientUsername missing":     {config: JWTBearerFlow{Enabled: pointer(true), URL: "https://salesforce.com", ClientID: "xyz", ClientUsername: ""}, wantErr: errors.New("client.username must be provided")},
-		"clientKeyPath missing":      {config: JWTBearerFlow{Enabled: pointer(true), URL: "https://salesforce.com", ClientID: "xyz", ClientUsername: "abc", ClientKeyPath: ""}, wantErr: errors.New("client.key_path must be provided")},
-		"all present":                {config: JWTBearerFlow{Enabled: pointer(true), URL: "https://salesforce.com", ClientID: "xyz", ClientUsername: "abc", ClientKeyPath: "def"}, wantErr: nil},
-		"all present with token_url": {config: JWTBearerFlow{Enabled: pointer(true), URL: "https://login.salesforce.com", TokenURL: "https://mydomain.my.salesforce.com/services/oauth2/token", ClientID: "xyz", ClientUsername: "abc", ClientKeyPath: "def"}, wantErr: nil},
+		"auth disabled II":           {config: JWTBearerFlow{Enabled: new(false)}, wantErr: nil},
+		"url missing":                {config: JWTBearerFlow{Enabled: new(true), URL: ""}, wantErr: errors.New("url must be provided")},
+		"clientID missing":           {config: JWTBearerFlow{Enabled: new(true), URL: "https://salesforce.com", ClientID: ""}, wantErr: errors.New("client.id must be provided")},
+		"clientUsername missing":     {config: JWTBearerFlow{Enabled: new(true), URL: "https://salesforce.com", ClientID: "xyz", ClientUsername: ""}, wantErr: errors.New("client.username must be provided")},
+		"clientKeyPath missing":      {config: JWTBearerFlow{Enabled: new(true), URL: "https://salesforce.com", ClientID: "xyz", ClientUsername: "abc", ClientKeyPath: ""}, wantErr: errors.New("client.key_path must be provided")},
+		"all present":                {config: JWTBearerFlow{Enabled: new(true), URL: "https://salesforce.com", ClientID: "xyz", ClientUsername: "abc", ClientKeyPath: "def"}, wantErr: nil},
+		"all present with token_url": {config: JWTBearerFlow{Enabled: new(true), URL: "https://login.salesforce.com", TokenURL: "https://mydomain.my.salesforce.com/services/oauth2/token", ClientID: "xyz", ClientUsername: "abc", ClientKeyPath: "def"}, wantErr: nil},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/x-pack/filebeat/input/salesforce/config_test.go
+++ b/x-pack/filebeat/input/salesforce/config_test.go
@@ -33,7 +33,7 @@ func TestValidate(t *testing.T) {
 			inputCfg: config{
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 					},
 				},
@@ -47,7 +47,7 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -57,8 +57,8 @@ func TestValidate(t *testing.T) {
 			inputCfg: config{
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
-						JWTBearerFlow:    &JWTBearerFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
+						JWTBearerFlow:    &JWTBearerFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -69,7 +69,7 @@ func TestValidate(t *testing.T) {
 				URL: "",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -81,7 +81,7 @@ func TestValidate(t *testing.T) {
 				URL:                   "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -91,14 +91,14 @@ func TestValidate(t *testing.T) {
 			inputCfg: config{
 				EventMonitoringMethod: &eventMonitoringMethod{
 					EventLogFile: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Duration(0),
 					},
 				},
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -108,14 +108,14 @@ func TestValidate(t *testing.T) {
 			inputCfg: config{
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Duration(0),
 					},
 				},
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -126,7 +126,7 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Cursor:   &cursorConfig{Field: "EventDate"},
 					},
@@ -134,7 +134,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -145,7 +145,7 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Query: &QueryConfig{
 							Default: &valueTpl{},
@@ -157,7 +157,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -168,7 +168,7 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					EventLogFile: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Query: &QueryConfig{
 							Default: &valueTpl{},
@@ -179,7 +179,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -190,7 +190,7 @@ func TestValidate(t *testing.T) {
 				Version: 45,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Query: &QueryConfig{
 							Default: &valueTpl{},
@@ -202,7 +202,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -213,12 +213,12 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Batch: &batchConfig{
-							Enabled:          pointer(true),
+							Enabled:          new(true),
 							InitialInterval:  0,
-							MaxWindowsPerRun: pointer(1),
+							MaxWindowsPerRun: new(1),
 							Window:           5 * time.Minute,
 						},
 					},
@@ -226,7 +226,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -237,12 +237,12 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Batch: &batchConfig{
-							Enabled:          pointer(true),
+							Enabled:          new(true),
 							InitialInterval:  time.Hour,
-							MaxWindowsPerRun: pointer(1),
+							MaxWindowsPerRun: new(1),
 							Window:           0,
 						},
 					},
@@ -250,7 +250,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -261,12 +261,12 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Batch: &batchConfig{
-							Enabled:          pointer(true),
+							Enabled:          new(true),
 							InitialInterval:  time.Hour,
-							MaxWindowsPerRun: pointer(0),
+							MaxWindowsPerRun: new(0),
 							Window:           5 * time.Minute,
 						},
 					},
@@ -274,7 +274,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -285,12 +285,12 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Batch: &batchConfig{
-							Enabled:          pointer(true),
+							Enabled:          new(true),
 							InitialInterval:  time.Hour,
-							MaxWindowsPerRun: pointer(2),
+							MaxWindowsPerRun: new(2),
 							Window:           5 * time.Minute,
 						},
 						Query: &QueryConfig{
@@ -303,7 +303,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -314,7 +314,7 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Query: &QueryConfig{
 							Default: getValueTpl(defaultLoginObjectQuery),
@@ -326,7 +326,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},
@@ -337,12 +337,12 @@ func TestValidate(t *testing.T) {
 				Version: 56,
 				EventMonitoringMethod: &eventMonitoringMethod{
 					Object: EventMonitoringConfig{
-						Enabled:  pointer(true),
+						Enabled:  new(true),
 						Interval: time.Hour,
 						Batch: &batchConfig{
-							Enabled:          pointer(true),
+							Enabled:          new(true),
 							InitialInterval:  time.Hour,
-							MaxWindowsPerRun: pointer(2),
+							MaxWindowsPerRun: new(2),
 							Window:           5 * time.Minute,
 						},
 						Query: &QueryConfig{
@@ -355,7 +355,7 @@ func TestValidate(t *testing.T) {
 				URL: "https://some-dummy-subdomain.salesforce.com/services/oauth2/token",
 				Auth: &authConfig{
 					OAuth2: &OAuth2{
-						UserPasswordFlow: &UserPasswordFlow{Enabled: pointer(true)},
+						UserPasswordFlow: &UserPasswordFlow{Enabled: new(true)},
 					},
 				},
 			},

--- a/x-pack/filebeat/input/salesforce/doc.go
+++ b/x-pack/filebeat/input/salesforce/doc.go
@@ -204,5 +204,5 @@
 //   - input_manager.go - v2 InputManager and cursor wiring.
 //   - soql.go          - SOQL querier implementing go-sfdc's QueryFormatter.
 //   - value_tpl.go     - template engine shared by "default" / "value" queries.
-//   - helper.go        - small utilities (timeNow indirection, generic pointer helper).
+//   - helper.go        - small utilities (timeNow indirection).
 package salesforce

--- a/x-pack/filebeat/input/salesforce/helper.go
+++ b/x-pack/filebeat/input/salesforce/helper.go
@@ -20,16 +20,3 @@ func mockTimeNow(t time.Time) {
 func resetTimeNow() {
 	timeNow = time.Now
 }
-
-// pointer returns a pointer to the given value.
-//
-// For example: Assigning &true to value of type *bool is not possible but
-// pointer(true) is assignable to the same value of type *bool as address operator
-// can be applied to pointer(true) as the returned value is an addressable value.
-//
-// See: https://go.dev/ref/spec#Address_operators
-//
-//go:fix inline
-func pointer[T any](d T) *T {
-	return new(d)
-}

--- a/x-pack/filebeat/input/salesforce/helper.go
+++ b/x-pack/filebeat/input/salesforce/helper.go
@@ -28,6 +28,8 @@ func resetTimeNow() {
 // can be applied to pointer(true) as the returned value is an addressable value.
 //
 // See: https://go.dev/ref/spec#Address_operators
+//
+//go:fix inline
 func pointer[T any](d T) *T {
-	return &d
+	return new(d)
 }

--- a/x-pack/filebeat/input/salesforce/input.go
+++ b/x-pack/filebeat/input/salesforce/input.go
@@ -977,10 +977,10 @@ func newRetryLog(log *logp.Logger) *retryLog {
 	return &retryLog{log: log.Named("retryablehttp").WithOptions(zap.AddCallerSkip(1))}
 }
 
-func (l *retryLog) Error(msg string, kv ...interface{}) { l.log.Errorw(msg, kv...) }
-func (l *retryLog) Info(msg string, kv ...interface{})  { l.log.Infow(msg, kv...) }
-func (l *retryLog) Debug(msg string, kv ...interface{}) { l.log.Debugw(msg, kv...) }
-func (l *retryLog) Warn(msg string, kv ...interface{})  { l.log.Warnw(msg, kv...) }
+func (l *retryLog) Error(msg string, kv ...any) { l.log.Errorw(msg, kv...) }
+func (l *retryLog) Info(msg string, kv ...any)  { l.log.Infow(msg, kv...) }
+func (l *retryLog) Debug(msg string, kv ...any) { l.log.Debugw(msg, kv...) }
+func (l *retryLog) Warn(msg string, kv ...any)  { l.log.Warnw(msg, kv...) }
 
 // retryErrorHandler returns a retryablehttp.ErrorHandler that will log retry resignation
 // but return the last retry attempt's response and a nil error to allow the retryablehttp.Client

--- a/x-pack/filebeat/input/salesforce/input_manager_test.go
+++ b/x-pack/filebeat/input/salesforce/input_manager_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/elastic/go-concert/unison"
 )
 
-func makeTestStore(data map[string]interface{}) *statestore.Store {
+func makeTestStore(data map[string]any) *statestore.Store {
 	memstore := &storetest.MapStore{Table: data}
 	reg := statestore.NewRegistry(&storetest.MemoryStore{
 		Stores: map[string]*storetest.MapStore{

--- a/x-pack/filebeat/input/salesforce/input_test.go
+++ b/x-pack/filebeat/input/salesforce/input_test.go
@@ -2716,8 +2716,8 @@ func TestSalesforceInputRunWithMethod(t *testing.T) {
 	defaultResource := resourceConfig{
 		Retry: retryConfig{
 			MaxAttempts: new(5),
-			WaitMin:     pointer(time.Minute),
-			WaitMax:     pointer(time.Minute),
+			WaitMin:     new(time.Minute),
+			WaitMax:     new(time.Minute),
 		},
 		Transport: httpcommon.DefaultHTTPTransportSettings(),
 	}
@@ -3039,7 +3039,7 @@ func TestJWTBearerFlowTokenURL(t *testing.T) {
 				Cursor:   &cursorConfig{Field: "Id"},
 			}},
 			Resource: &resourceConfig{
-				Retry:     retryConfig{MaxAttempts: new(1), WaitMin: pointer(time.Second), WaitMax: pointer(time.Second)},
+				Retry:     retryConfig{MaxAttempts: new(1), WaitMin: new(time.Second), WaitMax: new(time.Second)},
 				Transport: httpcommon.DefaultHTTPTransportSettings(),
 			},
 		}

--- a/x-pack/filebeat/input/salesforce/input_test.go
+++ b/x-pack/filebeat/input/salesforce/input_test.go
@@ -157,8 +157,8 @@ func TestFormQueryWithCursor(t *testing.T) {
 }
 
 var (
-	defaultUserPasswordFlowMap = map[string]interface{}{
-		"user_password_flow": map[string]interface{}{
+	defaultUserPasswordFlowMap = map[string]any{
+		"user_password_flow": map[string]any{
 			"enabled":       true,
 			"client.id":     "clientid",
 			"client.secret": "clientsecret",
@@ -167,8 +167,8 @@ var (
 			"password":      "password",
 		},
 	}
-	wrongUserPasswordFlowMap = map[string]interface{}{
-		"user_password_flow": map[string]interface{}{
+	wrongUserPasswordFlowMap = map[string]any{
+		"user_password_flow": map[string]any{
 			"enabled":       true,
 			"client.id":     "clientid-wrong",
 			"client.secret": "clientsecret-wrong",
@@ -178,48 +178,48 @@ var (
 		},
 	}
 
-	defaultObjectMonitoringMethodConfigMap = map[string]interface{}{
+	defaultObjectMonitoringMethodConfigMap = map[string]any{
 		"interval": "5s",
 		"enabled":  true,
-		"query": map[string]interface{}{
+		"query": map[string]any{
 			"default": defaultLoginObjectQuery,
 			"value":   valueLoginObjectQuery,
 		},
-		"cursor": map[string]interface{}{
+		"cursor": map[string]any{
 			"field": "EventDate",
 		},
 	}
-	defaultEventLogFileMonitoringMethodMap = map[string]interface{}{
+	defaultEventLogFileMonitoringMethodMap = map[string]any{
 		"interval": "5s",
 		"enabled":  true,
-		"query": map[string]interface{}{
+		"query": map[string]any{
 			"default": defaultLoginEventLogFileQuery,
 			"value":   valueLoginEventLogFileQuery,
 		},
-		"cursor": map[string]interface{}{
+		"cursor": map[string]any{
 			"field": "CreatedDate",
 		},
 	}
 
-	invalidObjectMonitoringMethodMap = map[string]interface{}{
+	invalidObjectMonitoringMethodMap = map[string]any{
 		"interval": "5m",
 		"enabled":  true,
-		"query": map[string]interface{}{
+		"query": map[string]any{
 			"default": invalidDefaultLoginEventObjectQuery,
 			"value":   valueLoginEventLogFileQuery,
 		},
-		"cursor": map[string]interface{}{
+		"cursor": map[string]any{
 			"field": "CreatedDate",
 		},
 	}
-	invalidEventLogFileMonitoringMethodMap = map[string]interface{}{
+	invalidEventLogFileMonitoringMethodMap = map[string]any{
 		"interval": "5m",
 		"enabled":  true,
-		"query": map[string]interface{}{
+		"query": map[string]any{
 			"default": invalidDefaultLoginEventLogFileQuery,
 			"value":   invalidValueLoginEventLogFileQuery,
 		},
-		"cursor": map[string]interface{}{
+		"cursor": map[string]any{
 			"field": "CreatedDate",
 		},
 	}
@@ -229,8 +229,8 @@ func TestInput(t *testing.T) {
 	logptest.NewTestingLogger(t, "")
 
 	tests := []struct {
-		setupServer      func(testing.TB, http.HandlerFunc, map[string]interface{})
-		baseConfig       map[string]interface{}
+		setupServer      func(testing.TB, http.HandlerFunc, map[string]any)
+		baseConfig       map[string]any
 		handler          http.HandlerFunc
 		persistentCursor *state
 		name             string
@@ -243,10 +243,10 @@ func TestInput(t *testing.T) {
 		{
 			name:        "Positive/event_monitoring_method_object_with_default_query_only",
 			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"version":     56,
 				"auth.oauth2": defaultUserPasswordFlowMap,
-				"event_monitoring_method": map[string]interface{}{
+				"event_monitoring_method": map[string]any{
 					"object": defaultObjectMonitoringMethodConfigMap,
 				},
 			},
@@ -256,10 +256,10 @@ func TestInput(t *testing.T) {
 		{
 			name:        "Negative/event_monitoring_method_object_with_error_in_data_collection",
 			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"version":     56,
 				"auth.oauth2": defaultUserPasswordFlowMap,
-				"event_monitoring_method": map[string]interface{}{
+				"event_monitoring_method": map[string]any{
 					"object": invalidObjectMonitoringMethodMap,
 				},
 			},
@@ -269,10 +269,10 @@ func TestInput(t *testing.T) {
 		{
 			name:        "Positive/event_monitoring_method_object_with_interval_5s",
 			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"version":     56,
 				"auth.oauth2": defaultUserPasswordFlowMap,
-				"event_monitoring_method": map[string]interface{}{
+				"event_monitoring_method": map[string]any{
 					"object": defaultObjectMonitoringMethodConfigMap,
 				},
 			},
@@ -283,10 +283,10 @@ func TestInput(t *testing.T) {
 		{
 			name:        "Positive/event_monitoring_method_object_with_Pagination",
 			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"version":     56,
 				"auth.oauth2": defaultUserPasswordFlowMap,
-				"event_monitoring_method": map[string]interface{}{
+				"event_monitoring_method": map[string]any{
 					"object": defaultObjectMonitoringMethodConfigMap,
 				},
 			},
@@ -298,10 +298,10 @@ func TestInput(t *testing.T) {
 		{
 			name:        "Positive/event_monitoring_method_elf_with_default_query_only",
 			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"version":     56,
 				"auth.oauth2": defaultUserPasswordFlowMap,
-				"event_monitoring_method": map[string]interface{}{
+				"event_monitoring_method": map[string]any{
 					"event_log_file": defaultEventLogFileMonitoringMethodMap,
 				},
 			},
@@ -311,10 +311,10 @@ func TestInput(t *testing.T) {
 		{
 			name:        "Negative/event_monitoring_method_elf_with_error_in_auth",
 			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"version":     56,
 				"auth.oauth2": wrongUserPasswordFlowMap,
-				"event_monitoring_method": map[string]interface{}{
+				"event_monitoring_method": map[string]any{
 					"event_log_file": defaultEventLogFileMonitoringMethodMap,
 				},
 			},
@@ -325,10 +325,10 @@ func TestInput(t *testing.T) {
 		{
 			name:        "Negative/event_monitoring_method_elf_with_error_in_data_collection",
 			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
+			baseConfig: map[string]any{
 				"version":     56,
 				"auth.oauth2": defaultUserPasswordFlowMap,
-				"event_monitoring_method": map[string]interface{}{
+				"event_monitoring_method": map[string]any{
 					"event_log_file": invalidEventLogFileMonitoringMethodMap,
 				},
 			},
@@ -446,8 +446,8 @@ func TestRunObjectWithBatching(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	authConfig := map[string]interface{}{
-		"user_password_flow": map[string]interface{}{
+	authConfig := map[string]any{
+		"user_password_flow": map[string]any{
 			"enabled":       true,
 			"client.id":     "clientid",
 			"client.secret": "clientsecret",
@@ -457,25 +457,25 @@ func TestRunObjectWithBatching(t *testing.T) {
 		},
 	}
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":         server.URL,
 		"version":     56,
 		"auth.oauth2": authConfig,
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "15m",
 					"max_windows_per_run": 2,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -514,10 +514,10 @@ func TestRunObjectWithBatching(t *testing.T) {
 	assert.Equal(t, []string{firstBatchQuery, secondBatchQuery}, queries, "expected batched query windows to be executed in order")
 	assert.Len(t, client.published, 2, "expected one event from each batch window")
 
-	var cursorState map[string]interface{}
+	var cursorState map[string]any
 	require.NoError(t, typeconv.Convert(&cursorState, s.cursor), "expected cursor state to be convertible")
 
-	objectCursor, ok := cursorState["object"].(map[string]interface{})
+	objectCursor, ok := cursorState["object"].(map[string]any)
 	require.True(t, ok, "expected object cursor state to be present")
 	assert.Equal(t, "2024-01-01T11:55:00.000Z", objectCursor["progress_time"], "expected batch progress to advance to the end of the last processed window")
 }
@@ -559,11 +559,11 @@ func TestRunObjectWithBatchingIncludesEventAtBatchEndBoundary(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -572,21 +572,21 @@ func TestRunObjectWithBatchingIncludesEventAtBatchEndBoundary(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "15m",
 					"max_windows_per_run": 2,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -626,10 +626,10 @@ func TestRunObjectWithBatchingIncludesEventAtBatchEndBoundary(t *testing.T) {
 	require.True(t, ok, "expected published event message to be a string")
 	assert.Contains(t, firstMessage, `"EventDate":"2024-01-01T11:50:00.000+0000"`, "expected the inclusive batch end-boundary event to be published")
 
-	var cursorState map[string]interface{}
+	var cursorState map[string]any
 	require.NoError(t, typeconv.Convert(&cursorState, s.cursor), "expected cursor state to be convertible")
 
-	objectCursor, ok := cursorState["object"].(map[string]interface{})
+	objectCursor, ok := cursorState["object"].(map[string]any)
 	require.True(t, ok, "expected object cursor state to be present")
 	assert.Equal(t, "2024-01-01T11:55:00.000Z", objectCursor["progress_time"], "expected batch progress to advance after processing a boundary event")
 }
@@ -649,7 +649,7 @@ func TestRunObjectRequiresObjectQueryCursorConfig(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.EventMonitoringMethod = &eventMonitoringMethod{
 		Object: EventMonitoringConfig{
-			Enabled:  pointer(true),
+			Enabled:  new(true),
 			Interval: time.Second,
 		},
 	}
@@ -696,11 +696,11 @@ func TestRunObjectWithBatchingSeedsFirstWindowFromLegacyFirstEventTime(t *testin
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -709,21 +709,21 @@ func TestRunObjectWithBatchingSeedsFirstWindowFromLegacyFirstEventTime(t *testin
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "15m",
 					"max_windows_per_run": 1,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -942,11 +942,11 @@ func TestRunObjectResumeWithLastEventIDKeepsSameTimestampRows(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -955,15 +955,15 @@ func TestRunObjectResumeWithLastEventIDKeepsSameTimestampRows(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultSetupAuditTrailQuery,
 					"value":   "SELECT Id,CreatedDate,Action FROM SetupAuditTrail WHERE CreatedDate > [[ .cursor.object.last_event_time ]][[ if .cursor.object.last_event_id ]] OR (CreatedDate = [[ .cursor.object.last_event_time ]] AND Id > '[[ .cursor.object.last_event_id ]]')[[ end ]] ORDER BY CreatedDate ASC, Id ASC",
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
@@ -1063,11 +1063,11 @@ func TestRunObjectSetupAuditTrailResumeWithoutLastEventIDUsesLegacyBoundary(t *t
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1076,15 +1076,15 @@ func TestRunObjectSetupAuditTrailResumeWithoutLastEventIDUsesLegacyBoundary(t *t
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": "SELECT Id,CreatedDate,Action FROM SetupAuditTrail ORDER BY CreatedDate ASC, Id ASC",
 					"value":   "SELECT Id,CreatedDate,Action FROM SetupAuditTrail WHERE CreatedDate > [[ .cursor.object.last_event_time ]][[ if .cursor.object.last_event_id ]] OR (CreatedDate = [[ .cursor.object.last_event_time ]] AND Id > '[[ .cursor.object.last_event_id ]]')[[ end ]] ORDER BY CreatedDate ASC, Id ASC",
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
@@ -1169,12 +1169,12 @@ func TestRunObjectUnbatchedRestoresCursorOnMidStreamFailure(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1183,15 +1183,15 @@ func TestRunObjectUnbatchedRestoresCursorOnMidStreamFailure(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -1267,11 +1267,11 @@ func TestRunObjectClearsStaleLastEventIDWhenQueryDropsIDWithoutRows(t *testing.T
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1280,15 +1280,15 @@ func TestRunObjectClearsStaleLastEventIDWhenQueryDropsIDWithoutRows(t *testing.T
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": customQuery,
 					"value":   customQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
@@ -1378,11 +1378,11 @@ func TestRunObjectReopensSessionOnInvalidSessionID(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1391,15 +1391,15 @@ func TestRunObjectReopensSessionOnInvalidSessionID(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": objectQuery,
 					"value":   objectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -1484,11 +1484,11 @@ func TestRunEventLogFileReopensSessionOnUnauthorizedDownload(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1497,15 +1497,15 @@ func TestRunEventLogFileReopensSessionOnUnauthorizedDownload(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"event_log_file": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"event_log_file": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginEventLogFileQuery,
 					"value":   valueLoginEventLogFileQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
@@ -1600,11 +1600,11 @@ func TestRunEventLogFileResumesWithinSameCreatedDateBucket(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1613,15 +1613,15 @@ func TestRunEventLogFileResumesWithinSameCreatedDateBucket(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"event_log_file": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"event_log_file": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultQuery,
 					"value":   resumeQueryTmpl,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
@@ -1695,11 +1695,11 @@ func TestRunObjectWithBatchingResumesFromProgressTime(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1708,21 +1708,21 @@ func TestRunObjectWithBatchingResumesFromProgressTime(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "15m",
 					"max_windows_per_run": 1,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -1761,10 +1761,10 @@ func TestRunObjectWithBatchingResumesFromProgressTime(t *testing.T) {
 
 	assert.Len(t, client.published, 1, "expected resumed batching to publish one event")
 
-	var cursorState map[string]interface{}
+	var cursorState map[string]any
 	require.NoError(t, typeconv.Convert(&cursorState, s.cursor), "expected cursor state to be convertible")
 
-	objectCursor, ok := cursorState["object"].(map[string]interface{})
+	objectCursor, ok := cursorState["object"].(map[string]any)
 	require.True(t, ok, "expected object cursor state to be present")
 	assert.Equal(t, "2024-01-01T12:00:00.000Z", objectCursor["progress_time"], "expected batch progress to advance from the persisted watermark")
 }
@@ -1800,11 +1800,11 @@ func TestRunObjectWithBatchingResumeUsesProgressTimeAsExclusiveBoundary(t *testi
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1813,21 +1813,21 @@ func TestRunObjectWithBatchingResumeUsesProgressTimeAsExclusiveBoundary(t *testi
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "15m",
 					"max_windows_per_run": 1,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -1875,21 +1875,21 @@ func TestRunObjectWithBatchingResumeUsesProgressTimeAsExclusiveBoundary(t *testi
 	require.True(t, ok, "expected published event message to be a string")
 	assert.Contains(t, firstMessage, `"EventDate":"2024-01-01T12:00:00.000+0000"`, "expected the resumed batch to publish the in-window boundary event")
 
-	var cursorState map[string]interface{}
+	var cursorState map[string]any
 	require.NoError(t, typeconv.Convert(&cursorState, s.cursor), "expected cursor state to be convertible")
 
-	objectCursor, ok := cursorState["object"].(map[string]interface{})
+	objectCursor, ok := cursorState["object"].(map[string]any)
 	require.True(t, ok, "expected object cursor state to be present")
 	assert.Equal(t, "2024-01-01T12:00:00.000Z", objectCursor["progress_time"], "expected resumed batch progress to advance to the end of the resumed window")
 }
 
 func TestRunObjectWithInvalidBatchProgressTime(t *testing.T) {
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     "https://salesforce.example",
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1898,21 +1898,21 @@ func TestRunObjectWithInvalidBatchProgressTime(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "15m",
 					"max_windows_per_run": 1,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -1966,11 +1966,11 @@ func TestRunObjectWithBatchingPagination(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -1979,21 +1979,21 @@ func TestRunObjectWithBatchingPagination(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "10m",
 					"max_windows_per_run": 1,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -2028,10 +2028,10 @@ func TestRunObjectWithBatchingPagination(t *testing.T) {
 
 	assert.Len(t, client.published, 2, "expected all paginated records within the window to be published")
 
-	var cursorState map[string]interface{}
+	var cursorState map[string]any
 	require.NoError(t, typeconv.Convert(&cursorState, s.cursor), "expected cursor state to be convertible")
 
-	objectCursor, ok := cursorState["object"].(map[string]interface{})
+	objectCursor, ok := cursorState["object"].(map[string]any)
 	require.True(t, ok, "expected object cursor state to be present")
 	assert.Equal(t, "2024-01-01T11:55:00.000Z", objectCursor["progress_time"], "expected paginated batch windows to advance progress once the full window is processed")
 }
@@ -2078,12 +2078,12 @@ func TestRunObjectWithBatchingPaginationFailureRetriesSameWindow(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -2092,21 +2092,21 @@ func TestRunObjectWithBatchingPaginationFailureRetriesSameWindow(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "10m",
 					"max_windows_per_run": 1,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -2154,10 +2154,10 @@ func TestRunObjectWithBatchingPaginationFailureRetriesSameWindow(t *testing.T) {
 	assert.Equal(t, 2, nextPageCount, "expected the next page to be retried after the initial failure")
 	assert.Len(t, retryPublisher.published, 2, "expected the retried batch to publish both pages")
 
-	var cursorState map[string]interface{}
+	var cursorState map[string]any
 	require.NoError(t, typeconv.Convert(&cursorState, s.cursor), "expected cursor state to be convertible")
 
-	objectCursor, ok := cursorState["object"].(map[string]interface{})
+	objectCursor, ok := cursorState["object"].(map[string]any)
 	require.True(t, ok, "expected object cursor state to be present")
 	assert.Equal(t, "2024-01-01T11:55:00.000Z", objectCursor["progress_time"], "expected retry to advance progress only after the full paginated window succeeds")
 }
@@ -2212,12 +2212,12 @@ func TestRunObjectWithBatchingResumesFromLastSuccessfulWindowAfterLaterWindowFai
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -2226,21 +2226,21 @@ func TestRunObjectWithBatchingResumesFromLastSuccessfulWindowAfterLaterWindowFai
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "15m",
 					"max_windows_per_run": 2,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -2316,11 +2316,11 @@ func TestRunObjectWithBatchingAdvancesProgressOnEmptyWindow(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -2329,21 +2329,21 @@ func TestRunObjectWithBatchingAdvancesProgressOnEmptyWindow(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"batch": map[string]interface{}{
+				"batch": map[string]any{
 					"enabled":             true,
 					"initial_interval":    "5m",
 					"max_windows_per_run": 1,
 					"window":              "5m",
 				},
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueBatchedLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -2377,10 +2377,10 @@ func TestRunObjectWithBatchingAdvancesProgressOnEmptyWindow(t *testing.T) {
 	require.NoError(t, err, "expected empty batched window to succeed")
 	assert.Empty(t, client.published, "expected empty batched windows to publish no events")
 
-	var cursorState map[string]interface{}
+	var cursorState map[string]any
 	require.NoError(t, typeconv.Convert(&cursorState, s.cursor), "expected cursor state to be convertible")
 
-	objectCursor, ok := cursorState["object"].(map[string]interface{})
+	objectCursor, ok := cursorState["object"].(map[string]any)
 	require.True(t, ok, "expected object cursor state to be present")
 	assert.Equal(t, "2024-01-01T12:00:00.000Z", objectCursor["progress_time"], "expected empty batched windows to still advance progress")
 }
@@ -2417,12 +2417,12 @@ func defaultHandler(flow string, withoutQuery bool, msg1, msg2 string) http.Hand
 	}
 }
 
-func newTestServer(newServer func(http.Handler) *httptest.Server) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
-	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+func newTestServer(newServer func(http.Handler) *httptest.Server) func(testing.TB, http.HandlerFunc, map[string]any) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]any) {
 		server := newServer(h)
 		config["url"] = server.URL
-		authOAuth2, _ := config["auth.oauth2"].(map[string]interface{})
-		userPasswordFlow, _ := authOAuth2["user_password_flow"].(map[string]interface{})
+		authOAuth2, _ := config["auth.oauth2"].(map[string]any)
+		userPasswordFlow, _ := authOAuth2["user_password_flow"].(map[string]any)
 		userPasswordFlow["token_url"] = server.URL
 		t.Cleanup(server.Close)
 	}
@@ -2433,17 +2433,17 @@ var _ inputcursor.Publisher = (*publisher)(nil)
 type publisher struct {
 	done      func()
 	published []beat.Event
-	cursors   []map[string]interface{}
+	cursors   []map[string]any
 	mu        sync.Mutex
 }
 
-func (p *publisher) Publish(e beat.Event, cursor interface{}) error {
+func (p *publisher) Publish(e beat.Event, cursor any) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	p.published = append(p.published, e)
 	if cursor != nil {
-		var cv map[string]interface{}
+		var cv map[string]any
 		err := typeconv.Convert(&cv, cursor)
 		if err != nil {
 			return err
@@ -2458,7 +2458,7 @@ func (p *publisher) Publish(e beat.Event, cursor interface{}) error {
 
 type failingPublisher struct{ err error }
 
-func (p failingPublisher) Publish(beat.Event, interface{}) error {
+func (p failingPublisher) Publish(beat.Event, any) error {
 	return p.err
 }
 
@@ -2561,11 +2561,11 @@ func TestPublishCSVRecordsReportsRowNumberOnParseError(t *testing.T) {
 
 func TestRunEventLogFileReturnsProcessingErrors(t *testing.T) {
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     "http://placeholder.invalid",
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -2574,15 +2574,15 @@ func TestRunEventLogFileReturnsProcessingErrors(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"event_log_file": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"event_log_file": map[string]any{
 				"interval": "5s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginEventLogFileQuery,
 					"value":   valueLoginEventLogFileQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
@@ -2625,7 +2625,7 @@ func TestRunEventLogFileRequiresQueryCursorConfig(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.EventMonitoringMethod = &eventMonitoringMethod{
 		EventLogFile: EventMonitoringConfig{
-			Enabled:  pointer(true),
+			Enabled:  new(true),
 			Interval: time.Hour,
 		},
 	}
@@ -2646,7 +2646,7 @@ func TestSalesforceInputRunWithMethod(t *testing.T) {
 		defaultUserPassAuthConfig = authConfig{
 			OAuth2: &OAuth2{
 				UserPasswordFlow: &UserPasswordFlow{
-					Enabled:      pointer(true),
+					Enabled:      new(true),
 					TokenURL:     "https://instance_id.develop.my.salesforce.com/services/oauth2/token",
 					ClientID:     "clientid",
 					ClientSecret: "clientsecret",
@@ -2657,7 +2657,7 @@ func TestSalesforceInputRunWithMethod(t *testing.T) {
 		}
 		objectEventMonitotingConfig = eventMonitoringMethod{
 			Object: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Second * 5,
 				Query: &QueryConfig{
 					Default: getValueTpl(defaultLoginObjectQuery),
@@ -2668,7 +2668,7 @@ func TestSalesforceInputRunWithMethod(t *testing.T) {
 		}
 		objectEventMonitoringWithWrongQuery = eventMonitoringMethod{
 			Object: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Second * 5,
 				Query: &QueryConfig{
 					Default: getValueTpl(invalidDefaultLoginEventObjectQuery),
@@ -2680,7 +2680,7 @@ func TestSalesforceInputRunWithMethod(t *testing.T) {
 
 		elfEventMonitotingConfig = eventMonitoringMethod{
 			EventLogFile: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Second * 5,
 				Query: &QueryConfig{
 					Default: getValueTpl(defaultLoginEventLogFileQuery),
@@ -2691,7 +2691,7 @@ func TestSalesforceInputRunWithMethod(t *testing.T) {
 		}
 		elfEventMonitotingWithWrongQuery = eventMonitoringMethod{
 			EventLogFile: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Second * 5,
 				Query: &QueryConfig{
 					Default: getValueTpl(invalidDefaultLoginEventLogFileQuery),
@@ -2715,7 +2715,7 @@ func TestSalesforceInputRunWithMethod(t *testing.T) {
 
 	defaultResource := resourceConfig{
 		Retry: retryConfig{
-			MaxAttempts: pointer(5),
+			MaxAttempts: new(5),
 			WaitMin:     pointer(time.Minute),
 			WaitMax:     pointer(time.Minute),
 		},
@@ -2951,11 +2951,11 @@ func TestUserPasswordFlowTokenURLAcceptsFullTokenEndpoint(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	cfg := defaultConfig()
-	err := conf.MustNewConfigFrom(map[string]interface{}{
+	err := conf.MustNewConfigFrom(map[string]any{
 		"url":     server.URL,
 		"version": 56,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -2964,15 +2964,15 @@ func TestUserPasswordFlowTokenURLAcceptsFullTokenEndpoint(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": "1s",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": "SELECT Id FROM Account",
 					"value":   "SELECT Id FROM Account WHERE Id > [[ .cursor.object.first_event_time ]]",
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "Id",
 				},
 			},
@@ -3025,7 +3025,7 @@ func TestJWTBearerFlowTokenURL(t *testing.T) {
 			Version: 56,
 			URL:     url,
 			Auth: &authConfig{OAuth2: &OAuth2{JWTBearerFlow: &JWTBearerFlow{
-				Enabled:        pointer(true),
+				Enabled:        new(true),
 				URL:            url,
 				TokenURL:       tokenURL,
 				ClientID:       "test-client",
@@ -3033,13 +3033,13 @@ func TestJWTBearerFlowTokenURL(t *testing.T) {
 				ClientKeyPath:  keyPath,
 			}}},
 			EventMonitoringMethod: &eventMonitoringMethod{Object: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Second,
 				Query:    &QueryConfig{Default: getValueTpl("SELECT Id FROM Account")},
 				Cursor:   &cursorConfig{Field: "Id"},
 			}},
 			Resource: &resourceConfig{
-				Retry:     retryConfig{MaxAttempts: pointer(1), WaitMin: pointer(time.Second), WaitMax: pointer(time.Second)},
+				Retry:     retryConfig{MaxAttempts: new(1), WaitMin: pointer(time.Second), WaitMax: pointer(time.Second)},
 				Transport: httpcommon.DefaultHTTPTransportSettings(),
 			},
 		}
@@ -3163,17 +3163,17 @@ func TestRunWithMixedMonitoringMethodsStartsEventLogFileBeforeObject(t *testing.
 	}))
 	t.Cleanup(server.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":         server.URL,
 		"version":     56,
 		"auth.oauth2": defaultUserPasswordFlowMap,
-		"event_monitoring_method": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
 			"event_log_file": defaultEventLogFileMonitoringMethodMap,
 			"object":         defaultObjectMonitoringMethodConfigMap,
 		},
 	}
-	authOAuth2, _ := baseConfig["auth.oauth2"].(map[string]interface{})
-	userPasswordFlow, _ := authOAuth2["user_password_flow"].(map[string]interface{})
+	authOAuth2, _ := baseConfig["auth.oauth2"].(map[string]any)
+	userPasswordFlow, _ := authOAuth2["user_password_flow"].(map[string]any)
 	userPasswordFlow["token_url"] = server.URL
 
 	cfg := defaultConfig()
@@ -3278,12 +3278,12 @@ func TestRunWithMixedMonitoringMethodsRunsBothTickersAfterStartup(t *testing.T) 
 	}))
 	t.Cleanup(server.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -3292,26 +3292,26 @@ func TestRunWithMixedMonitoringMethodsRunsBothTickersAfterStartup(t *testing.T) 
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"event_log_file": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"event_log_file": map[string]any{
 				"interval": "50ms",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginEventLogFileQuery,
 					"value":   valueLoginEventLogFileQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
-			"object": map[string]interface{}{
+			"object": map[string]any{
 				"interval": "80ms",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -3456,12 +3456,12 @@ func TestRunEventLogFileSkipsQueuedTickerAfterFailure(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -3470,15 +3470,15 @@ func TestRunEventLogFileSkipsQueuedTickerAfterFailure(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"event_log_file": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"event_log_file": map[string]any{
 				"interval": "50ms",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginEventLogFileQuery,
 					"value":   valueLoginEventLogFileQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
@@ -3597,12 +3597,12 @@ func TestRunWithMixedMonitoringMethodsContinuesObjectAfterEventLogFileTickerFail
 	}))
 	t.Cleanup(server.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -3611,26 +3611,26 @@ func TestRunWithMixedMonitoringMethodsContinuesObjectAfterEventLogFileTickerFail
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"event_log_file": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"event_log_file": map[string]any{
 				"interval": "40ms",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginEventLogFileQuery,
 					"value":   valueLoginEventLogFileQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
-			"object": map[string]interface{}{
+			"object": map[string]any{
 				"interval": "80ms",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -3785,12 +3785,12 @@ func TestRunWithMixedMonitoringMethodsContinuesEventLogFileAfterObjectTickerFail
 	}))
 	t.Cleanup(server.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -3799,26 +3799,26 @@ func TestRunWithMixedMonitoringMethodsContinuesEventLogFileAfterObjectTickerFail
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"event_log_file": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"event_log_file": map[string]any{
 				"interval": "80ms",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginEventLogFileQuery,
 					"value":   valueLoginEventLogFileQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "CreatedDate",
 				},
 			},
-			"object": map[string]interface{}{
+			"object": map[string]any{
 				"interval": "40ms",
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -4090,12 +4090,12 @@ func TestRunObjectCooldownSuppressesNextTickerTick(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -4104,15 +4104,15 @@ func TestRunObjectCooldownSuppressesNextTickerTick(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": interval.String(),
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},
@@ -4199,12 +4199,12 @@ func TestRunObjectInitialFailureSetsCooldown(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	baseConfig := map[string]interface{}{
+	baseConfig := map[string]any{
 		"url":                         server.URL,
 		"version":                     56,
 		"resource.retry.max_attempts": 1,
-		"auth.oauth2": map[string]interface{}{
-			"user_password_flow": map[string]interface{}{
+		"auth.oauth2": map[string]any{
+			"user_password_flow": map[string]any{
 				"enabled":       true,
 				"client.id":     "clientid",
 				"client.secret": "clientsecret",
@@ -4213,15 +4213,15 @@ func TestRunObjectInitialFailureSetsCooldown(t *testing.T) {
 				"password":      "password",
 			},
 		},
-		"event_monitoring_method": map[string]interface{}{
-			"object": map[string]interface{}{
+		"event_monitoring_method": map[string]any{
+			"object": map[string]any{
 				"interval": interval.String(),
 				"enabled":  true,
-				"query": map[string]interface{}{
+				"query": map[string]any{
 					"default": defaultLoginObjectQuery,
 					"value":   valueLoginObjectQuery,
 				},
-				"cursor": map[string]interface{}{
+				"cursor": map[string]any{
 					"field": "EventDate",
 				},
 			},

--- a/x-pack/filebeat/input/salesforce/live_activity_helpers_test.go
+++ b/x-pack/filebeat/input/salesforce/live_activity_helpers_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build salesforce_live
-// +build salesforce_live
 
 // Local-only Salesforce live-test helpers (build tag salesforce_live).
 //
@@ -338,12 +337,12 @@ func liveFilebeatOutputNDJSONSize(eventsOutDir string) (int64, error) {
 }
 
 // liveReadFilebeatOutputNDJSONRows reads all NDJSON event rows from date-rotated file output files.
-func liveReadFilebeatOutputNDJSONRows(eventsOutDir string) ([]map[string]interface{}, error) {
+func liveReadFilebeatOutputNDJSONRows(eventsOutDir string) ([]map[string]any, error) {
 	paths, err := liveGlobFilebeatNDJSONOutputFiles(eventsOutDir)
 	if err != nil {
 		return nil, err
 	}
-	var rows []map[string]interface{}
+	var rows []map[string]any
 	for _, p := range paths {
 		part, err := liveReadNDJSONFile(p)
 		if err != nil {
@@ -390,14 +389,14 @@ func liveRunFilebeatBounded(ctx context.Context, filebeatBinary, pathHome, confi
 	return out.Bytes(), err
 }
 
-func liveReadNDJSONFile(path string) ([]map[string]interface{}, error) {
+func liveReadNDJSONFile(path string) ([]map[string]any, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	var rows []map[string]interface{}
+	var rows []map[string]any
 	s := bufio.NewScanner(f)
 	// Override the default 64 KiB max token; large "message" fields exceed it.
 	s.Buffer(make([]byte, 0, 64*1024), liveFilebeatNDJSONMaxLineBytes)
@@ -406,7 +405,7 @@ func liveReadNDJSONFile(path string) ([]map[string]interface{}, error) {
 		if len(line) == 0 {
 			continue
 		}
-		var m map[string]interface{}
+		var m map[string]any
 		if err := json.Unmarshal(line, &m); err != nil {
 			return nil, fmt.Errorf("ndjson decode: %w", err)
 		}
@@ -418,11 +417,11 @@ func liveReadNDJSONFile(path string) ([]map[string]interface{}, error) {
 	return rows, nil
 }
 
-func liveEventDatasetFromMap(m map[string]interface{}) string {
+func liveEventDatasetFromMap(m map[string]any) string {
 	if v, ok := m["event.dataset"].(string); ok && v != "" {
 		return v
 	}
-	ev, ok := m["event"].(map[string]interface{})
+	ev, ok := m["event"].(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -433,11 +432,11 @@ func liveEventDatasetFromMap(m map[string]interface{}) string {
 }
 
 // liveEventProviderFromMap returns event.provider when the Beat event is ECS-shaped (nested event map).
-func liveEventProviderFromMap(m map[string]interface{}) string {
+func liveEventProviderFromMap(m map[string]any) string {
 	if v, ok := m["event.provider"].(string); ok && v != "" {
 		return v
 	}
-	ev, ok := m["event"].(map[string]interface{})
+	ev, ok := m["event"].(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -449,7 +448,7 @@ func liveEventProviderFromMap(m map[string]interface{}) string {
 
 // liveCountSalesforceModuleDatasetProvider counts rows from a fully wired Filebeat module run (e.g. output.file)
 // where nested event.dataset and event.provider match. provider "" means do not filter on provider.
-func liveCountSalesforceModuleDatasetProvider(rows []map[string]interface{}, dataset, provider string) int {
+func liveCountSalesforceModuleDatasetProvider(rows []map[string]any, dataset, provider string) int {
 	n := 0
 	for _, row := range rows {
 		if liveEventDatasetFromMap(row) != dataset {
@@ -463,7 +462,7 @@ func liveCountSalesforceModuleDatasetProvider(rows []map[string]interface{}, dat
 	return n
 }
 
-func liveCountDataset(rows []map[string]interface{}, dataset string) int {
+func liveCountDataset(rows []map[string]any, dataset string) int {
 	n := 0
 	for _, row := range rows {
 		if liveEventDatasetFromMap(row) == dataset {
@@ -474,7 +473,7 @@ func liveCountDataset(rows []map[string]interface{}, dataset string) int {
 }
 
 // liveMessageFromNDJSONRow returns the Beat "message" field (Salesforce JSON or ELF CSV line).
-func liveMessageFromNDJSONRow(m map[string]interface{}) string {
+func liveMessageFromNDJSONRow(m map[string]any) string {
 	if m == nil {
 		return ""
 	}
@@ -485,7 +484,7 @@ func liveMessageFromNDJSONRow(m map[string]interface{}) string {
 }
 
 // liveCountRowsWithMessageContaining counts NDJSON rows whose message contains sub.
-func liveCountRowsWithMessageContaining(rows []map[string]interface{}, sub string) int {
+func liveCountRowsWithMessageContaining(rows []map[string]any, sub string) int {
 	n := 0
 	for _, row := range rows {
 		if strings.Contains(liveMessageFromNDJSONRow(row), sub) {
@@ -497,7 +496,7 @@ func liveCountRowsWithMessageContaining(rows []map[string]interface{}, sub strin
 
 // liveCountLikelyLoginObjectMessages counts object API rows for LoginEvent (raw JSON in message).
 // Used for file-output smokes: Elasticsearch ingest pipelines (which set event.dataset) are not run.
-func liveCountLikelyLoginObjectMessages(rows []map[string]interface{}) int {
+func liveCountLikelyLoginObjectMessages(rows []map[string]any) int {
 	n := 0
 	for _, row := range rows {
 		msg := liveMessageFromNDJSONRow(row)
@@ -509,7 +508,7 @@ func liveCountLikelyLoginObjectMessages(rows []map[string]interface{}) int {
 }
 
 // liveCountLikelyApexELFMessages counts EventLogFile CSV rows for Apex event types shipped by the module.
-func liveCountLikelyApexELFMessages(rows []map[string]interface{}) int {
+func liveCountLikelyApexELFMessages(rows []map[string]any) int {
 	n := 0
 	for _, row := range rows {
 		// Prefer structured ECS fields when they exist.
@@ -536,7 +535,7 @@ func liveCountLikelyApexELFMessages(rows []map[string]interface{}) int {
 	return n
 }
 
-func liveCollectUniqueDatasets(rows []map[string]interface{}) []string {
+func liveCollectUniqueDatasets(rows []map[string]any) []string {
 	seen := make(map[string]struct{})
 	var out []string
 	for _, row := range rows {
@@ -583,14 +582,14 @@ func parseLiveSalesforceCredsContent(raw []byte) (liveSalesforceCreds, error) {
 		instanceFromLegacyLine string
 	)
 
-	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(string(raw)), "\n") {
 		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		if strings.HasPrefix(line, legacyPrefixInstanceURL) {
-			instanceFromLegacyLine = strings.TrimSpace(strings.TrimPrefix(line, legacyPrefixInstanceURL))
+		if after, ok := strings.CutPrefix(line, legacyPrefixInstanceURL); ok {
+			instanceFromLegacyLine = strings.TrimSpace(after)
 			continue
 		}
 

--- a/x-pack/filebeat/input/salesforce/live_filebeat_module_local_test.go
+++ b/x-pack/filebeat/input/salesforce/live_filebeat_module_local_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build salesforce_live
-// +build salesforce_live
 
 // End-to-end Filebeat module smoke for Salesforce (requires a built x-pack filebeat binary).
 //
@@ -119,7 +118,7 @@ func TestLiveFilebeatSalesforceModuleSmoke(t *testing.T) {
 		}{out, err}
 	}()
 
-	var rows []map[string]interface{}
+	var rows []map[string]any
 	var nLogin, nApex int
 	loginObserved := false
 	lastProgressLog := time.Now()

--- a/x-pack/filebeat/input/salesforce/live_filebeat_module_local_test.go
+++ b/x-pack/filebeat/input/salesforce/live_filebeat_module_local_test.go
@@ -53,7 +53,7 @@ func TestLiveFilebeatSalesforceModuleSmoke(t *testing.T) {
 
 	apexProbeCfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 		EventLogFile: EventMonitoringConfig{
-			Enabled:  pointer(true),
+			Enabled:  new(true),
 			Interval: time.Hour,
 			Query: &QueryConfig{
 				Default: getValueTpl(`SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE CreatedDate > [[ (formatTime (now.Add (parseDuration "-720h")) "2006-01-02T15:04:05.000Z0700") ]] AND (EventType = 'ApexCallout' OR EventType = 'ApexExecution' OR EventType = 'ApexRestApi' OR EventType = 'ApexSoap' OR EventType = 'ApexTrigger' OR EventType = 'ExternalCustomApexCallout') ORDER BY CreatedDate ASC NULLS FIRST LIMIT 1`),
@@ -74,13 +74,13 @@ func TestLiveFilebeatSalesforceModuleSmoke(t *testing.T) {
 	session := generateLoginActivity(t, creds)
 	waitCfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 		Object: EventMonitoringConfig{
-			Enabled:  pointer(true),
+			Enabled:  new(true),
 			Interval: 5 * time.Minute,
 			Batch: &batchConfig{
-				Enabled:          pointer(true),
+				Enabled:          new(true),
 				InitialInterval:  24 * time.Hour,
 				Window:           12 * time.Hour,
-				MaxWindowsPerRun: pointer(2),
+				MaxWindowsPerRun: new(2),
 			},
 			Query: &QueryConfig{
 				Default: getValueTpl("SELECT FIELDS(STANDARD) FROM LoginEvent ORDER BY EventDate DESC"),

--- a/x-pack/filebeat/input/salesforce/live_validation_local_test.go
+++ b/x-pack/filebeat/input/salesforce/live_validation_local_test.go
@@ -127,7 +127,7 @@ func liveConfigWithMethod(creds liveSalesforceCreds, method eventMonitoringMetho
 	cfg.Auth = &authConfig{
 		OAuth2: &OAuth2{
 			UserPasswordFlow: &UserPasswordFlow{
-				Enabled:      pointer(true),
+				Enabled:      new(true),
 				ClientID:     creds.ClientID,
 				ClientSecret: creds.ClientSecret,
 				TokenURL:     strings.TrimSuffix(creds.TokenURL, "/services/oauth2/token"),
@@ -216,13 +216,13 @@ func TestLiveSalesforceValidation(t *testing.T) {
 
 		cfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 			Object: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: 5 * time.Minute,
 				Batch: &batchConfig{
-					Enabled:          pointer(true),
+					Enabled:          new(true),
 					InitialInterval:  24 * time.Hour,
 					Window:           12 * time.Hour,
-					MaxWindowsPerRun: pointer(2),
+					MaxWindowsPerRun: new(2),
 				},
 				Query: &QueryConfig{
 					Default: getValueTpl("SELECT FIELDS(STANDARD) FROM LoginEvent ORDER BY EventDate DESC"),
@@ -266,13 +266,13 @@ func TestLiveSalesforceValidation(t *testing.T) {
 
 		cfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 			Object: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: 5 * time.Minute,
 				Batch: &batchConfig{
-					Enabled:          pointer(true),
+					Enabled:          new(true),
 					InitialInterval:  24 * time.Hour,
 					Window:           12 * time.Hour,
-					MaxWindowsPerRun: pointer(2),
+					MaxWindowsPerRun: new(2),
 				},
 				Query: &QueryConfig{
 					Default: getValueTpl("SELECT FIELDS(STANDARD) FROM LogoutEvent ORDER BY EventDate DESC"),
@@ -325,7 +325,7 @@ func TestLiveSalesforceValidation(t *testing.T) {
 	t.Run("setup audit trail object", func(t *testing.T) {
 		cfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 			Object: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: 5 * time.Minute,
 				Query: &QueryConfig{
 					Default: getValueTpl(`SELECT FIELDS(STANDARD) FROM SetupAuditTrail WHERE CreatedDate > [[ (formatTime (now.Add (parseDuration "-720h")) "2006-01-02T15:04:05.000Z0700") ]] ORDER BY CreatedDate ASC NULLS FIRST, Id ASC`),
@@ -366,7 +366,7 @@ func TestLiveSalesforceValidation(t *testing.T) {
 	t.Run("login event log file", func(t *testing.T) {
 		cfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 			EventLogFile: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Hour,
 				Query: &QueryConfig{
 					Default: getValueTpl(`SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE CreatedDate > [[ (formatTime (now.Add (parseDuration "-720h")) "2006-01-02T15:04:05.000Z0700") ]] AND EventType = 'Login' ORDER BY CreatedDate ASC NULLS FIRST, Id ASC LIMIT 1`),
@@ -411,7 +411,7 @@ func TestLiveSalesforceValidation(t *testing.T) {
 	t.Run("logout event log file", func(t *testing.T) {
 		cfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 			EventLogFile: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Hour,
 				Query: &QueryConfig{
 					Default: getValueTpl(`SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE CreatedDate > [[ (formatTime (now.Add (parseDuration "-720h")) "2006-01-02T15:04:05.000Z0700") ]] AND EventType = 'Logout' ORDER BY CreatedDate ASC NULLS FIRST, Id ASC LIMIT 1`),
@@ -455,7 +455,7 @@ func TestLiveSalesforceValidation(t *testing.T) {
 	t.Run("apex event log file", func(t *testing.T) {
 		cfg := liveConfigWithMethod(creds, eventMonitoringMethod{
 			EventLogFile: EventMonitoringConfig{
-				Enabled:  pointer(true),
+				Enabled:  new(true),
 				Interval: time.Hour,
 				Query: &QueryConfig{
 					Default: getValueTpl(`SELECT Id,CreatedDate,LogDate,LogFile FROM EventLogFile WHERE CreatedDate > [[ (formatTime (now.Add (parseDuration "-720h")) "2006-01-02T15:04:05.000Z0700") ]] AND (EventType = 'ApexCallout' OR EventType = 'ApexExecution' OR EventType = 'ApexRestApi' OR EventType = 'ApexSoap' OR EventType = 'ApexTrigger' OR EventType = 'ExternalCustomApexCallout') ORDER BY CreatedDate ASC NULLS FIRST, Id ASC LIMIT 1`),

--- a/x-pack/filebeat/input/salesforce/live_validation_local_test.go
+++ b/x-pack/filebeat/input/salesforce/live_validation_local_test.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build salesforce_live
-// +build salesforce_live
 
 // Local-only live Salesforce validation.
 //
@@ -146,7 +145,7 @@ func eventFieldValues(t *testing.T, events []string, field string) []string {
 
 	values := make([]string, 0, len(events))
 	for _, raw := range events {
-		var decoded map[string]interface{}
+		var decoded map[string]any
 		require.NoError(t, json.Unmarshal([]byte(raw), &decoded), "expected live event message to be valid JSON")
 		value, ok := decoded[field].(string)
 		if ok && value != "" {

--- a/x-pack/metricbeat/module/airflow/statsd/data_test.go
+++ b/x-pack/metricbeat/module/airflow/statsd/data_test.go
@@ -32,8 +32,8 @@ const (
 	STATSD_PORT = 8126
 )
 
-func getConfig() map[string]interface{} {
-	return map[string]interface{}{
+func getConfig() map[string]any {
+	return map[string]any{
 		"module":     "airflow",
 		"metricsets": []string{"statsd"},
 		"host":       STATSD_HOST,
@@ -62,7 +62,7 @@ func TestData(t *testing.T) {
 	ms := mbtest.NewPushMetricSetV2(t, getConfig())
 	var events []mb.Event
 	var reporter mb.PushReporterV2
-	done := make(chan interface{})
+	done := make(chan any)
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {

--- a/x-pack/metricbeat/module/aws/billing/billing.go
+++ b/x-pack/metricbeat/module/aws/billing/billing.go
@@ -298,9 +298,10 @@ func (m *MetricSet) getCostGroupBy(svcCostExplorer *costexplorer.Client, groupBy
 				event := m.addCostMetrics(group.Metrics, groupByOutput.GroupDefinitions[0], startDate, endDate)
 
 				// generate unique event ID for each event
-				eventID := startDate + endDate + *groupByOutput.GroupDefinitions[0].Key + string(groupByOutput.GroupDefinitions[0].Type)
+				var eventID strings.Builder
+				eventID.WriteString(startDate + endDate + *groupByOutput.GroupDefinitions[0].Key + string(groupByOutput.GroupDefinitions[0].Type))
 				for _, key := range group.Keys {
-					eventID += key
+					eventID.WriteString(key)
 					// key value like db.t2.micro or Amazon Simple Queue Service belongs to dimension
 					if !strings.Contains(key, "$") {
 						_, _ = event.MetricSetFields.Put("group_by."+groupBy.dimension, key)
@@ -325,7 +326,7 @@ func (m *MetricSet) getCostGroupBy(svcCostExplorer *costexplorer.Client, groupBy
 					event.Timestamp = t
 				}
 
-				event.ID = generateEventID(eventID)
+				event.ID = generateEventID(eventID.String())
 				events = append(events, event)
 			}
 		}

--- a/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
+++ b/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
@@ -71,8 +71,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func addCostExplorerToConfig(config map[string]interface{}) map[string]interface{} {
-	costExplorerConfig := map[string]interface{}{}
+func addCostExplorerToConfig(config map[string]any) map[string]any {
+	costExplorerConfig := map[string]any{}
 	costExplorerConfig["group_by_dimension_keys"] = []string{"AZ", "INSTANCE_TYPE", "LINKED_ACCOUNT"}
 	config["cost_explorer_config"] = costExplorerConfig
 	return config

--- a/x-pack/metricbeat/module/awsfargate/task_stats/task_stats_integration_test.go
+++ b/x-pack/metricbeat/module/awsfargate/task_stats/task_stats_integration_test.go
@@ -8,7 +8,7 @@ package task_stats
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -21,7 +21,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	config := map[string]interface{}{
+	config := map[string]any{
 		"period":     "10s",
 		"module":     "awsfargate",
 		"metricsets": []string{"task_stats"},
@@ -63,7 +63,7 @@ func TestData(t *testing.T) {
 		t.Skip("skip data generation tests")
 	}
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"period":     "10s",
 		"module":     "awsfargate",
 		"metricsets": []string{"task_stats"},
@@ -100,12 +100,12 @@ func TestData(t *testing.T) {
 // buildResponse is a test helper that loads the content of `filename` and returns
 // it as the body of a `http.Response`.
 func buildResponse(filename string) (*http.Response, error) {
-	fileContent, err := ioutil.ReadFile(filename)
+	fileContent, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
 	return &http.Response{
-		Body: ioutil.NopCloser(bytes.NewReader(fileContent)),
+		Body: io.NopCloser(bytes.NewReader(fileContent)),
 	}, nil
 }

--- a/x-pack/metricbeat/module/azure/app_insights/app_insights_integration_test.go
+++ b/x-pack/metricbeat/module/azure/app_insights/app_insights_integration_test.go
@@ -16,7 +16,7 @@ import (
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 )
 
-var metrics = []map[string]interface{}{{
+var metrics = []map[string]any{{
 	"id": "requests/count",
 }}
 

--- a/x-pack/metricbeat/module/azure/app_insights/client.go
+++ b/x-pack/metricbeat/module/azure/app_insights/client.go
@@ -41,7 +41,6 @@ func (client *Client) GetMetricValues() (ListMetricsResultsItem, error) {
 	var bodyMetrics []MetricsBatchRequestItem
 	var result ListMetricsResultsItem
 	for _, metrics := range client.Config.Metrics {
-		metrics := metrics
 		// Clone so each batch entry owns its slices; sharing the same backing
 		// array across requests would couple unrelated metric configs together.
 		aggregations := slices.Clone(metrics.Aggregation)

--- a/x-pack/metricbeat/module/azure/app_insights/data.go
+++ b/x-pack/metricbeat/module/azure/app_insights/data.go
@@ -8,7 +8,9 @@ package app_insights
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -40,7 +42,7 @@ var segmentNames = []string{
 
 type MetricValue struct {
 	SegmentName map[string]string
-	Value       map[string]interface{}
+	Value       map[string]any
 	Segments    []MetricValue
 	Interval    string
 	Start       *time.Time
@@ -59,7 +61,7 @@ func mapMetricValues(metricValues ListMetricsResultsItem) []MetricValue {
 		metricValue := MetricValue{
 			Start:       info.Start,
 			End:         info.End,
-			Value:       map[string]interface{}{},
+			Value:       map[string]any{},
 			SegmentName: map[string]string{},
 			Interval:    formatInterval(info.Start, info.End),
 		}
@@ -106,7 +108,7 @@ func formatInterval(start, end *time.Time) string {
 }
 
 func mapSegment(segment MetricsSegmentInfo, parentSeg map[string]string) MetricValue {
-	metricValue := MetricValue{Value: map[string]interface{}{}, SegmentName: map[string]string{}}
+	metricValue := MetricValue{Value: map[string]any{}, SegmentName: map[string]string{}}
 	if segment.AdditionalProperties != nil {
 		metrics := getAdditionalPropMetric(segment.AdditionalProperties)
 		for key, metric := range metrics {
@@ -122,9 +124,7 @@ func mapSegment(segment MetricsSegmentInfo, parentSeg map[string]string) MetricV
 		}
 	}
 	if len(parentSeg) > 0 {
-		for key, val := range parentSeg {
-			metricValue.SegmentName[key] = val
-		}
+		maps.Copy(metricValue.SegmentName, parentSeg)
 	}
 	if segment.Segments != nil {
 		for _, segment := range *segment.Segments {
@@ -137,12 +137,7 @@ func mapSegment(segment MetricsSegmentInfo, parentSeg map[string]string) MetricV
 }
 
 func isSegment(metric string) bool {
-	for _, seg := range segmentNames {
-		if metric == seg {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(segmentNames, metric)
 }
 
 type metricTimeKey struct {
@@ -344,9 +339,7 @@ func createGroupEvent(metricValue []MetricValue, metricTime metricTimeKey, appli
 	segments := make(map[string]string)
 
 	for _, v := range metricValue {
-		for sn, sv := range v.SegmentName {
-			segments[sn] = sv
-		}
+		maps.Copy(segments, v.SegmentName)
 	}
 
 	if len(segments) > 0 {
@@ -364,11 +357,11 @@ func createGroupEvent(metricValue []MetricValue, metricTime metricTimeKey, appli
 	return event
 }
 
-func getAdditionalPropMetric(addProp map[string]interface{}) map[string]interface{} {
-	metricNames := make(map[string]interface{})
+func getAdditionalPropMetric(addProp map[string]any) map[string]any {
+	metricNames := make(map[string]any)
 	for key, val := range addProp {
 		switch v := val.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			for subKey, subVal := range v {
 				if subVal != nil {
 					metricNames[cleanMetricNames(fmt.Sprintf("%s.%s", key, subKey))] = subVal

--- a/x-pack/metricbeat/module/azure/app_insights/data_test.go
+++ b/x-pack/metricbeat/module/azure/app_insights/data_test.go
@@ -18,12 +18,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-// timePtr is a small helper to take the address of a time.Time literal in test
-// fixtures, mirroring the previous &date.Time{Time: ...} pattern.
-//
-//go:fix inline
-func timePtr(t time.Time) *time.Time { return new(t) }
-
 func newMetricsTest(ts ...*time.Time) []MetricValue {
 	type values struct {
 		SegmentName map[string]string

--- a/x-pack/metricbeat/module/azure/app_insights/data_test.go
+++ b/x-pack/metricbeat/module/azure/app_insights/data_test.go
@@ -20,12 +20,14 @@ import (
 
 // timePtr is a small helper to take the address of a time.Time literal in test
 // fixtures, mirroring the previous &date.Time{Time: ...} pattern.
-func timePtr(t time.Time) *time.Time { return &t }
+//
+//go:fix inline
+func timePtr(t time.Time) *time.Time { return new(t) }
 
 func newMetricsTest(ts ...*time.Time) []MetricValue {
 	type values struct {
 		SegmentName map[string]string
-		Value       map[string]interface{}
+		Value       map[string]any
 		T           *time.Time
 	}
 
@@ -38,17 +40,17 @@ func newMetricsTest(ts ...*time.Time) []MetricValue {
 	vals := [numOfMetricValue]values{
 		{
 			SegmentName: map[string]string{"request_url_host": ""},
-			Value:       map[string]interface{}{"users_count.unique": 44},
+			Value:       map[string]any{"users_count.unique": 44},
 			T:           ts[0],
 		},
 		{
 			SegmentName: map[string]string{"request_url_host": ""},
-			Value:       map[string]interface{}{"sessions_count.unique": 44},
+			Value:       map[string]any{"sessions_count.unique": 44},
 			T:           ts[1],
 		},
 		{
 			SegmentName: map[string]string{"request_url_host": "localhost"},
-			Value:       map[string]interface{}{"sessions_count.unique": 44},
+			Value:       map[string]any{"sessions_count.unique": 44},
 			T:           ts[2],
 		},
 	}
@@ -58,11 +60,11 @@ func newMetricsTest(ts ...*time.Time) []MetricValue {
 		mv = append(mv,
 			MetricValue{
 				SegmentName: map[string]string{},
-				Value:       map[string]interface{}{},
+				Value:       map[string]any{},
 				Segments: []MetricValue{
 					{
 						SegmentName: map[string]string{},
-						Value:       map[string]interface{}{},
+						Value:       map[string]any{},
 						Segments: []MetricValue{
 							{
 								SegmentName: vals[i].SegmentName,
@@ -82,9 +84,9 @@ func newMetricsTest(ts ...*time.Time) []MetricValue {
 
 func TestGroupMetrics(t *testing.T) {
 	t.Run("two dimensions groups with same timestamps", func(t *testing.T) {
-		timestamp1 := timePtr(time.Now())
-		timestamp2 := timePtr(time.Now())
-		timestamp3 := timePtr(time.Now())
+		timestamp1 := new(time.Now())
+		timestamp2 := new(time.Now())
+		timestamp3 := new(time.Now())
 
 		metrics := newMetricsTest(timestamp1, timestamp2, timestamp3)
 
@@ -93,7 +95,7 @@ func TestGroupMetrics(t *testing.T) {
 				SegmentName: map[string]string{
 					"request_url_host": "",
 				},
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"users_count.unique": 44,
 				},
 				Start: timestamp1,
@@ -103,7 +105,7 @@ func TestGroupMetrics(t *testing.T) {
 				SegmentName: map[string]string{
 					"request_url_host": "",
 				},
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"sessions_count.unique": 44,
 				},
 				Start: timestamp2,
@@ -116,7 +118,7 @@ func TestGroupMetrics(t *testing.T) {
 				SegmentName: map[string]string{
 					"request_url_host": "localhost",
 				},
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"sessions_count.unique": 44,
 				},
 				Start: timestamp3,
@@ -143,9 +145,9 @@ func TestGroupMetrics(t *testing.T) {
 	})
 
 	t.Run("two dimensions groups with different timestamps", func(t *testing.T) {
-		timestamp1 := timePtr(time.Now())
-		timestamp2 := timePtr(time.Now().Add(time.Minute))
-		timestamp3 := timePtr(time.Now().Add(2 * time.Minute))
+		timestamp1 := new(time.Now())
+		timestamp2 := new(time.Now().Add(time.Minute))
+		timestamp3 := new(time.Now().Add(2 * time.Minute))
 
 		metrics := newMetricsTest(timestamp1, timestamp2, timestamp3)
 
@@ -154,7 +156,7 @@ func TestGroupMetrics(t *testing.T) {
 				SegmentName: map[string]string{
 					"request_url_host": "",
 				},
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"users_count.unique": 44,
 				},
 				Start: timestamp1,
@@ -167,7 +169,7 @@ func TestGroupMetrics(t *testing.T) {
 				SegmentName: map[string]string{
 					"request_url_host": "",
 				},
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"sessions_count.unique": 44,
 				},
 				Start: timestamp2,
@@ -180,7 +182,7 @@ func TestGroupMetrics(t *testing.T) {
 				SegmentName: map[string]string{
 					"request_url_host": "localhost",
 				},
-				Value: map[string]interface{}{
+				Value: map[string]any{
 					"sessions_count.unique": 44,
 				},
 				Start: timestamp3,
@@ -218,9 +220,9 @@ func TestEventMapping(t *testing.T) {
 	startDate := time.Now()
 	id := "123"
 	var info = MetricsResultInfo{
-		AdditionalProperties: map[string]interface{}{
-			"requests/count":  map[string]interface{}{"sum": 12},
-			"requests/failed": map[string]interface{}{"sum": 10},
+		AdditionalProperties: map[string]any{
+			"requests/count":  map[string]any{"sum": 12},
+			"requests/failed": map[string]any{"sum": 10},
 		},
 		Start: &startDate,
 		End:   &startDate,
@@ -278,9 +280,9 @@ func TestEventMappingGrouping(t *testing.T) {
 							End:   &end,
 							Segments: &[]MetricsSegmentInfo{
 								{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"request/urlHost": "",
-										"users/count":     map[string]interface{}{"unique": 1.0},
+										"users/count":     map[string]any{"unique": 1.0},
 									},
 								},
 							},
@@ -301,8 +303,8 @@ func TestEventMappingGrouping(t *testing.T) {
 							End:   &end,
 							Segments: &[]MetricsSegmentInfo{
 								{
-									AdditionalProperties: map[string]interface{}{
-										"sessions/count":  map[string]interface{}{"unique": 1.0},
+									AdditionalProperties: map[string]any{
+										"sessions/count":  map[string]any{"unique": 1.0},
 										"request/urlHost": "",
 									},
 								},
@@ -324,14 +326,14 @@ func TestEventMappingGrouping(t *testing.T) {
 							End:   &end,
 							Segments: &[]MetricsSegmentInfo{
 								{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"browserTiming/urlHost": "localhost",
 									},
 									Segments: &[]MetricsSegmentInfo{
 										{
-											AdditionalProperties: map[string]interface{}{
+											AdditionalProperties: map[string]any{
 												"browserTiming/urlPath":          "/test",
-												"browserTimings/networkDuration": map[string]interface{}{"avg": 1.5},
+												"browserTimings/networkDuration": map[string]any{"avg": 1.5},
 											},
 										},
 									},
@@ -354,13 +356,13 @@ func TestEventMappingGrouping(t *testing.T) {
 							End:   &end,
 							Segments: &[]MetricsSegmentInfo{
 								{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"browserTiming/urlHost": "localhost",
 									},
 									Segments: &[]MetricsSegmentInfo{
 										{
-											AdditionalProperties: map[string]interface{}{
-												"browserTimings/sendDuration": map[string]interface{}{"avg": 1.25},
+											AdditionalProperties: map[string]any{
+												"browserTimings/sendDuration": map[string]any{"avg": 1.25},
 												"browserTiming/urlPath":       "/test",
 											},
 										},
@@ -384,13 +386,13 @@ func TestEventMappingGrouping(t *testing.T) {
 							End:   &end,
 							Segments: &[]MetricsSegmentInfo{
 								{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"browserTiming/urlHost": "localhost",
 									},
 									Segments: &[]MetricsSegmentInfo{
 										{
-											AdditionalProperties: map[string]interface{}{
-												"browserTimings/receiveDuration": map[string]interface{}{"avg": 0.0},
+											AdditionalProperties: map[string]any{
+												"browserTimings/receiveDuration": map[string]any{"avg": 0.0},
 												"browserTiming/urlPath":          "/test",
 											},
 										},
@@ -414,13 +416,13 @@ func TestEventMappingGrouping(t *testing.T) {
 							End:   &end,
 							Segments: &[]MetricsSegmentInfo{
 								{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"browserTiming/urlHost": "localhost",
 									},
 									Segments: &[]MetricsSegmentInfo{
 										{
-											AdditionalProperties: map[string]interface{}{
-												"browserTimings/processingDuration": map[string]interface{}{"avg": 18.25},
+											AdditionalProperties: map[string]any{
+												"browserTimings/processingDuration": map[string]any{"avg": 18.25},
 												"browserTiming/urlPath":             "/test",
 											},
 										},
@@ -444,13 +446,13 @@ func TestEventMappingGrouping(t *testing.T) {
 							End:   &end,
 							Segments: &[]MetricsSegmentInfo{
 								{
-									AdditionalProperties: map[string]interface{}{
+									AdditionalProperties: map[string]any{
 										"browserTiming/urlHost": "localhost",
 									},
 									Segments: &[]MetricsSegmentInfo{
 										{
-											AdditionalProperties: map[string]interface{}{
-												"browserTimings/totalDuration": map[string]interface{}{"avg": 22},
+											AdditionalProperties: map[string]any{
+												"browserTimings/totalDuration": map[string]any{"avg": 22},
 												"browserTiming/urlPath":        "/test",
 											},
 										},

--- a/x-pack/metricbeat/module/azure/app_insights/service_test.go
+++ b/x-pack/metricbeat/module/azure/app_insights/service_test.go
@@ -88,7 +88,7 @@ func TestMetricsClient_GetMultiple(t *testing.T) {
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err, "reading request body should not fail")
-		var sent []map[string]interface{}
+		var sent []map[string]any
 		require.NoError(t, json.Unmarshal(body, &sent), "request body must be a JSON array")
 		require.Len(t, sent, 1, "test sends one metric in the batch")
 		require.Contains(t, sent[0], "parameters", "each batch entry must carry parameters")

--- a/x-pack/metricbeat/module/azure/app_insights/types.go
+++ b/x-pack/metricbeat/module/azure/app_insights/types.go
@@ -8,6 +8,7 @@ package app_insights
 
 import (
 	"encoding/json"
+	"maps"
 	"time"
 )
 
@@ -88,7 +89,7 @@ type MetricsResultInfo struct {
 	End                  *time.Time
 	Interval             *string
 	Segments             *[]MetricsSegmentInfo
-	AdditionalProperties map[string]interface{}
+	AdditionalProperties map[string]any
 }
 
 // UnmarshalJSON splits the known fields from the catch-all properties.
@@ -124,9 +125,9 @@ func (m *MetricsResultInfo) UnmarshalJSON(data []byte) error {
 	if len(raw) == 0 {
 		return nil
 	}
-	m.AdditionalProperties = make(map[string]interface{}, len(raw))
+	m.AdditionalProperties = make(map[string]any, len(raw))
 	for k, v := range raw {
-		var val interface{}
+		var val any
 		if err := json.Unmarshal(v, &val); err != nil {
 			return err
 		}
@@ -139,10 +140,8 @@ func (m *MetricsResultInfo) UnmarshalJSON(data []byte) error {
 // single JSON object. Provided mainly for symmetry and tests; the API itself
 // only requires unmarshaling.
 func (m MetricsResultInfo) MarshalJSON() ([]byte, error) {
-	out := map[string]interface{}{}
-	for k, v := range m.AdditionalProperties {
-		out[k] = v
-	}
+	out := map[string]any{}
+	maps.Copy(out, m.AdditionalProperties)
 	if m.Start != nil {
 		out["start"] = m.Start
 	}
@@ -166,7 +165,7 @@ type MetricsSegmentInfo struct {
 	Start                *time.Time
 	End                  *time.Time
 	Segments             *[]MetricsSegmentInfo
-	AdditionalProperties map[string]interface{}
+	AdditionalProperties map[string]any
 }
 
 // UnmarshalJSON splits the known fields from the catch-all properties.
@@ -196,9 +195,9 @@ func (m *MetricsSegmentInfo) UnmarshalJSON(data []byte) error {
 	if len(raw) == 0 {
 		return nil
 	}
-	m.AdditionalProperties = make(map[string]interface{}, len(raw))
+	m.AdditionalProperties = make(map[string]any, len(raw))
 	for k, v := range raw {
-		var val interface{}
+		var val any
 		if err := json.Unmarshal(v, &val); err != nil {
 			return err
 		}
@@ -210,10 +209,8 @@ func (m *MetricsSegmentInfo) UnmarshalJSON(data []byte) error {
 // MarshalJSON merges the known fields and AdditionalProperties back into a
 // single JSON object.
 func (m MetricsSegmentInfo) MarshalJSON() ([]byte, error) {
-	out := map[string]interface{}{}
-	for k, v := range m.AdditionalProperties {
-		out[k] = v
-	}
+	out := map[string]any{}
+	maps.Copy(out, m.AdditionalProperties)
 	if m.Start != nil {
 		out["start"] = m.Start
 	}

--- a/x-pack/metricbeat/module/cloudfoundry/container/container_test.go
+++ b/x-pack/metricbeat/module/cloudfoundry/container/container_test.go
@@ -41,7 +41,7 @@ func newTestMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func TestMetricSet(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("cloudfoundry"))
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "cloudfoundrytest",
 		"client_id":     "dummy",
 		"client_secret": "dummy",
@@ -80,7 +80,7 @@ func TestMetricSet(t *testing.T) {
 func TestMetricValuesAreNumbers(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("cloudfoundry"))
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "cloudfoundrytest",
 		"client_id":     "dummy",
 		"client_secret": "dummy",

--- a/x-pack/metricbeat/module/cloudfoundry/counter/counter_test.go
+++ b/x-pack/metricbeat/module/cloudfoundry/counter/counter_test.go
@@ -39,7 +39,7 @@ func newTestMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func TestMetricSet(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("cloudfoundry"))
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "cloudfoundrytest",
 		"client_id":     "dummy",
 		"client_secret": "dummy",

--- a/x-pack/metricbeat/module/cloudfoundry/mtest/config.go
+++ b/x-pack/metricbeat/module/cloudfoundry/mtest/config.go
@@ -13,7 +13,7 @@ import (
 	cftest "github.com/elastic/beats/v7/x-pack/libbeat/common/cloudfoundry/test"
 )
 
-func GetConfig(t *testing.T, metricset string) map[string]interface{} {
+func GetConfig(t *testing.T, metricset string) map[string]any {
 	t.Helper()
 
 	config := cftest.GetConfigFromEnv(t)

--- a/x-pack/metricbeat/module/cloudfoundry/value/value_test.go
+++ b/x-pack/metricbeat/module/cloudfoundry/value/value_test.go
@@ -41,7 +41,7 @@ func newTestMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func TestMetricSet(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("cloudfoundry"))
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "cloudfoundrytest",
 		"client_id":     "dummy",
 		"client_secret": "dummy",
@@ -76,7 +76,7 @@ func TestMetricSet(t *testing.T) {
 func TestValuesAreNumbers(t *testing.T) {
 	logp.TestingSetup(logp.WithSelectors("cloudfoundry"))
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "cloudfoundrytest",
 		"client_id":     "dummy",
 		"client_secret": "dummy",

--- a/x-pack/metricbeat/module/cockroachdb/status/status_integration_test.go
+++ b/x-pack/metricbeat/module/cockroachdb/status/status_integration_test.go
@@ -40,8 +40,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "cockroachdb",
 		"metricsets": []string{"status"},
 		"hosts":      []string{host},

--- a/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
@@ -27,8 +27,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "coredns",
 		"metricsets": []string{"stats"},
 		"hosts":      []string{host},

--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -79,12 +80,7 @@ func (c config) Validate() error {
 }
 
 func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, a)
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -343,8 +339,8 @@ func createTags(tagsItem bigquery.Value) []tag {
 	var tagsArray []tag
 
 	if tags, ok := tagsItem.(string); ok {
-		pairs := strings.Split(tags, ",")
-		for _, pair := range pairs {
+		pairs := strings.SplitSeq(tags, ",")
+		for pair := range pairs {
 			kv := strings.Split(pair, ":")
 			if len(kv) == 2 {
 				tagsArray = append(tagsArray, tag{Key: kv[0], Value: kv[1]})

--- a/x-pack/metricbeat/module/gcp/vertexai_logs/data.go
+++ b/x-pack/metricbeat/module/gcp/vertexai_logs/data.go
@@ -84,7 +84,7 @@ func processJSONField(jsonStr, fieldName string, fields mapstr.M, logger *logp.L
 		return nil
 	}
 
-	var parsedJSON interface{}
+	var parsedJSON any
 	if err := json.Unmarshal([]byte(jsonStr), &parsedJSON); err != nil {
 		// If JSON parsing fails, store the raw string in a structured way
 		fields[fieldName] = mapstr.M{"raw": jsonStr}

--- a/x-pack/metricbeat/module/gcp/vertexai_logs/vertexai_logs_test.go
+++ b/x-pack/metricbeat/module/gcp/vertexai_logs/vertexai_logs_test.go
@@ -79,9 +79,9 @@ func TestCreateEvent(t *testing.T) {
 		"model":             "gemini-2.5-pro",
 		"model_version":     "1.0",
 		"api_method":        "generateContent",
-		"full_request":      map[string]interface{}{"inputs": []interface{}{"test"}},
-		"full_response":     map[string]interface{}{"outputs": []interface{}{"result"}},
-		"metadata":          map[string]interface{}{"user_id": "user123"},
+		"full_request":      map[string]any{"inputs": []any{"test"}},
+		"full_response":     map[string]any{"outputs": []any{"result"}},
+		"metadata":          map[string]any{"user_id": "user123"},
 	}
 	assert.Equal(expectedFields, event.MetricSetFields)
 	// Check RootFields

--- a/x-pack/metricbeat/module/ibmmq/qmgr/qmgr_integration_test.go
+++ b/x-pack/metricbeat/module/ibmmq/qmgr/qmgr_integration_test.go
@@ -40,8 +40,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "ibmmq",
 		"metricsets": []string{"qmgr"},
 		"hosts":      []string{host},

--- a/x-pack/metricbeat/module/iis/application_pool/application_pool_test.go
+++ b/x-pack/metricbeat/module/iis/application_pool/application_pool_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMetricsetNoErrors(t *testing.T) {
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "iis",
 		"metricsets": []string{"application_pool"},
 	}

--- a/x-pack/metricbeat/module/iis/application_pool/reader.go
+++ b/x-pack/metricbeat/module/iis/application_pool/reader.go
@@ -9,6 +9,7 @@ package application_pool
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -303,10 +304,8 @@ func getProcessIds(counterValues map[string][]pdh.CounterValue) []WorkerProcess 
 func hasWorkerProcess(instance string, workers []WorkerProcess, pids []int) bool {
 	for _, worker := range workers {
 		if worker.instanceName == instance {
-			for _, pid := range pids {
-				if pid == worker.processId {
-					return true
-				}
+			if slices.Contains(pids, worker.processId) {
+				return true
 			}
 		}
 	}

--- a/x-pack/metricbeat/module/iis/test/integration.go
+++ b/x-pack/metricbeat/module/iis/test/integration.go
@@ -3,7 +3,6 @@
 // you may not use this file except in compliance with the Elastic License.
 
 //go:build windows
-// +build windows
 
 package test
 
@@ -21,8 +20,8 @@ type Service struct {
 	State   string
 }
 
-func GetConfig(metricset string) map[string]interface{} {
-	return map[string]interface{}{
+func GetConfig(metricset string) map[string]any {
+	return map[string]any{
 		"module":     "iis",
 		"metricsets": []string{metricset},
 	}

--- a/x-pack/metricbeat/module/meraki/reporter.go
+++ b/x-pack/metricbeat/module/meraki/reporter.go
@@ -43,7 +43,7 @@ func ReportMetricsForOrganization(reporter mb.ReporterV2, organizationID string,
 	}
 }
 
-func isEmpty(value interface{}) bool {
+func isEmpty(value any) bool {
 	// we make use of the fact that all the dashboard API responses utilize
 	// pointers for non-string types to filter out empty values from metric events.
 
@@ -53,7 +53,7 @@ func isEmpty(value interface{}) bool {
 
 	t := reflect.TypeOf(value)
 
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		return reflect.ValueOf(value).IsNil()
 	}
 

--- a/x-pack/metricbeat/module/meraki/reporter_test.go
+++ b/x-pack/metricbeat/module/meraki/reporter_test.go
@@ -16,7 +16,7 @@ import (
 func TestIsEmpty(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected bool
 	}{
 		{

--- a/x-pack/metricbeat/module/mssql/performance/performance_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/performance/performance_integration_test.go
@@ -19,7 +19,7 @@ import (
 
 type keyAssertion struct {
 	key       string
-	assertion func(v interface{}, key string)
+	assertion func(v any, key string)
 }
 
 func TestFetch(t *testing.T) {
@@ -35,8 +35,8 @@ func TestFetch(t *testing.T) {
 	}
 	assert.NotEmpty(t, events)
 
-	float64Assertion := func(f func(float64) bool) func(v interface{}, key string) {
-		return func(v interface{}, key string) {
+	float64Assertion := func(f func(float64) bool) func(v any, key string) {
+		return func(v any, key string) {
 			value, ok := v.(float64)
 			if !ok {
 				t.Fatalf("%v is not a float64, but %T", key, v)
@@ -46,8 +46,8 @@ func TestFetch(t *testing.T) {
 		}
 	}
 
-	int64Assertion := func(f func(int64) bool) func(v interface{}, key string) {
-		return func(v interface{}, key string) {
+	int64Assertion := func(f func(int64) bool) func(v any, key string) {
+		return func(v any, key string) {
 			value, ok := v.(int64)
 			if !ok {
 				t.Fatalf("%v is not a int64, but %T", key, v)

--- a/x-pack/metricbeat/module/mssql/testing/mssql.go
+++ b/x-pack/metricbeat/module/mssql/testing/mssql.go
@@ -10,8 +10,8 @@ import "os"
 
 // GetConfig returns the required configuration options for testing a MSSQL
 // metricset.
-func GetConfig(host string, metricSets ...string) map[string]interface{} {
-	return map[string]interface{}{
+func GetConfig(host string, metricSets ...string) map[string]any {
+	return map[string]any{
 		"module":     "mssql",
 		"metricsets": metricSets,
 		"hosts":      []string{host},

--- a/x-pack/metricbeat/module/oracle/connection.go
+++ b/x-pack/metricbeat/module/oracle/connection.go
@@ -19,9 +19,9 @@ import (
 // ConnectionDetails contains all possible data that can be used to create a connection with
 // an Oracle db
 type ConnectionDetails struct {
-	Username string        `config:"username"`
-	Password string        `config:"password"`
-	Patterns []interface{} `config:"patterns"`
+	Username string `config:"username"`
+	Password string `config:"password"`
+	Patterns []any  `config:"patterns"`
 }
 
 // HostParser parses host and extracts connection information and returns it to HostData

--- a/x-pack/metricbeat/module/oracle/performance/metricset_test.go
+++ b/x-pack/metricbeat/module/oracle/performance/metricset_test.go
@@ -56,8 +56,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "oracle",
 		"metricsets": []string{"performance"},
 		"hosts":      []string{oracle.GetOracleConnectionDetails(host)},

--- a/x-pack/metricbeat/module/oracle/sql.go
+++ b/x-pack/metricbeat/module/oracle/sql.go
@@ -40,7 +40,7 @@ func SetSqlValue(logger *logp.Logger, output mapstr.M, targetFieldName string, v
 
 type SqlValue interface {
 	isValid() bool
-	Value() interface{}
+	Value() any
 }
 
 type Float64Value struct {
@@ -51,7 +51,7 @@ func (i *Float64Value) isValid() bool {
 	return i.Valid
 }
 
-func (i *Float64Value) Value() interface{} {
+func (i *Float64Value) Value() any {
 	return i.Float64
 }
 
@@ -63,7 +63,7 @@ func (i *Int64Value) isValid() bool {
 	return i.Valid
 }
 
-func (i *Int64Value) Value() interface{} {
+func (i *Int64Value) Value() any {
 	return i.Int64
 }
 
@@ -75,6 +75,6 @@ func (s *StringValue) isValid() bool {
 	return s.Valid
 }
 
-func (s *StringValue) Value() interface{} {
+func (s *StringValue) Value() any {
 	return s.String
 }

--- a/x-pack/metricbeat/module/oracle/sysmetric/collector.go
+++ b/x-pack/metricbeat/module/oracle/sysmetric/collector.go
@@ -25,5 +25,5 @@ type collectedData struct {
 // which refers to the origin of the data for organization purposes.
 type sysmetricCollector struct {
 	db       *sql.DB
-	patterns []interface{}
+	patterns []any
 }

--- a/x-pack/metricbeat/module/oracle/sysmetric/metricset_test.go
+++ b/x-pack/metricbeat/module/oracle/sysmetric/metricset_test.go
@@ -48,8 +48,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "oracle",
 		"metricsets": []string{"sysmetric"},
 		"hosts":      []string{oracle.GetOracleConnectionDetails(host)},

--- a/x-pack/metricbeat/module/oracle/sysmetric/sysmetric_metric.go
+++ b/x-pack/metricbeat/module/oracle/sysmetric/sysmetric_metric.go
@@ -33,7 +33,7 @@ type sysmetricMetric struct {
  */
 func (e *sysmetricCollector) calculateQuery() string {
 	if len(e.patterns) == 0 {
-		e.patterns = make([]interface{}, 1)
+		e.patterns = make([]any, 1)
 		e.patterns[0] = "%"
 	}
 

--- a/x-pack/metricbeat/module/oracle/sysmetric/sysmetric_metric_test.go
+++ b/x-pack/metricbeat/module/oracle/sysmetric/sysmetric_metric_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestSysmetricCollectorCalculateQuery(t *testing.T) {
 	type fields struct {
-		patterns []interface{}
+		patterns []any
 	}
 	strpatterns := []string{"foo%", "%bar", "%foobar%"}
-	patterns := make([]interface{}, len(strpatterns))
+	patterns := make([]any, len(strpatterns))
 	for i, v := range strpatterns {
 		patterns[i] = v
 	}

--- a/x-pack/metricbeat/module/oracle/tablespace/metricset_test.go
+++ b/x-pack/metricbeat/module/oracle/tablespace/metricset_test.go
@@ -26,8 +26,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "oracle",
 		"metricsets": []string{"tablespace"},
 		"hosts":      []string{oracle.GetOracleConnectionDetails(host)},

--- a/x-pack/metricbeat/module/panw/client.go
+++ b/x-pack/metricbeat/module/panw/client.go
@@ -17,7 +17,7 @@ const Vsys = ""
 
 // PanwClient interface with an Op function
 type PanwClient interface {
-	Op(req interface{}, vsys string, extras, ans interface{}) ([]byte, error)
+	Op(req any, vsys string, extras, ans any) ([]byte, error)
 }
 
 type PanwFirewallClient struct {
@@ -29,7 +29,7 @@ type PanwTestClient struct {
 
 // Op is a mock function for testing that returns sample XML output based on the initial req parameter
 // XML output is stored in the testdata directory, one file per query string
-func (c *PanwTestClient) Op(req interface{}, vsys string, extras, ans interface{}) ([]byte, error) {
+func (c *PanwTestClient) Op(req any, vsys string, extras, ans any) ([]byte, error) {
 	return nil, nil
 }
 

--- a/x-pack/metricbeat/module/panw/interfaces/tunnels.go
+++ b/x-pack/metricbeat/module/panw/interfaces/tunnels.go
@@ -75,22 +75,17 @@ func getIPSecTunnelEvents(m *MetricSet) ([]mb.Event, error) {
 	jobs := make(chan int)
 	results := make(chan stateResult, len(response.Result.Entries))
 
-	workers := maxConcurrentTunnelStateQueries
-	if workers > len(response.Result.Entries) {
-		workers = len(response.Result.Entries)
-	}
+	workers := min(maxConcurrentTunnelStateQueries, len(response.Result.Entries))
 
 	var wg sync.WaitGroup
-	for w := 0; w < workers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range workers {
+		wg.Go(func() {
 			for i := range jobs {
 				entry := response.Result.Entries[i]
 				state, err := getTunnelState(m, entry.ID)
 				results <- stateResult{index: i, id: entry.ID, state: state, err: err}
 			}
-		}()
+		})
 	}
 
 	for i, entry := range response.Result.Entries {

--- a/x-pack/metricbeat/module/panw/sysinfo_test.go
+++ b/x-pack/metricbeat/module/panw/sysinfo_test.go
@@ -19,7 +19,7 @@ type MockClient struct {
 	err      error
 }
 
-func (m *MockClient) Op(req interface{}, vsys string, extras, ans interface{}) ([]byte, error) {
+func (m *MockClient) Op(req any, vsys string, extras, ans any) ([]byte, error) {
 	return m.response, m.err
 }
 

--- a/x-pack/metricbeat/module/prometheus/collector/collector_integration_test.go
+++ b/x-pack/metricbeat/module/prometheus/collector/collector_integration_test.go
@@ -17,7 +17,7 @@ import (
 func TestData(t *testing.T) {
 	service := compose.EnsureUp(t, "prometheus")
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "prometheus",
 		"metricsets":    []string{"collector"},
 		"hosts":         []string{service.Host()},
@@ -26,7 +26,7 @@ func TestData(t *testing.T) {
 	}
 	ms := mbtest.NewReportingMetricSetV2Error(t, config)
 	var err error
-	for retries := 0; retries < 3; retries++ {
+	for range 3 {
 		err = mbtest.WriteEventsReporterV2Error(ms, t, "")
 		if err == nil {
 			return

--- a/x-pack/metricbeat/module/prometheus/collector/collector_test.go
+++ b/x-pack/metricbeat/module/prometheus/collector/collector_test.go
@@ -43,7 +43,7 @@ func TestFetchEventForCountingMetrics(t *testing.T) {
 
 	host := strings.TrimPrefix(server.URL, "http://")
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        "prometheus",
 		"metricsets":    []string{"collector"},
 		"hosts":         []string{server.URL},

--- a/x-pack/metricbeat/module/prometheus/collector/histogram_test.go
+++ b/x-pack/metricbeat/module/prometheus/collector/histogram_test.go
@@ -38,7 +38,7 @@ func TestPromHistogramToES(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(10),
 							},
 						},
@@ -58,7 +58,7 @@ func TestPromHistogramToES(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(10),
 							},
 						},
@@ -71,10 +71,10 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(12),
-						SampleSum:   proto.Float64(10.123),
+						SampleSum:   new(10.123),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(12),
 							},
 						},
@@ -94,7 +94,7 @@ func TestPromHistogramToES(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(10),
 							},
 						},
@@ -107,15 +107,15 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(13),
-						SampleSum:   proto.Float64(15.23),
+						SampleSum:   new(15.23),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(12),
 							},
 							// New bucket on the go
 							{
-								UpperBound:      proto.Float64(9.99),
+								UpperBound:      new(9.99),
 								CumulativeCount: proto.Float64(13),
 							},
 						},
@@ -128,14 +128,14 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(15),
-						SampleSum:   proto.Float64(16.33),
+						SampleSum:   new(16.33),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(13),
 							},
 							{
-								UpperBound:      proto.Float64(9.99),
+								UpperBound:      new(9.99),
 								CumulativeCount: proto.Float64(15),
 							},
 						},
@@ -148,14 +148,14 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(16),
-						SampleSum:   proto.Float64(16.33),
+						SampleSum:   new(16.33),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(13),
 							},
 							{
-								UpperBound:      proto.Float64(9.99),
+								UpperBound:      new(9.99),
 								CumulativeCount: proto.Float64(16),
 							},
 						},
@@ -175,7 +175,7 @@ func TestPromHistogramToES(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(10),
 							},
 						},
@@ -188,15 +188,15 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(13),
-						SampleSum:   proto.Float64(15.23),
+						SampleSum:   new(15.23),
 						Bucket: []*p.Bucket{
 							// New bucket on the go
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(1),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(13),
 							},
 						},
@@ -209,14 +209,14 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(15),
-						SampleSum:   proto.Float64(16.33),
+						SampleSum:   new(16.33),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(2),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(15),
 							},
 						},
@@ -229,14 +229,14 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(16),
-						SampleSum:   proto.Float64(16.33),
+						SampleSum:   new(16.33),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(3),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(16),
 							},
 						},
@@ -256,11 +256,11 @@ func TestPromHistogramToES(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(0),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(10),
 							},
 						},
@@ -273,19 +273,19 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(13),
-						SampleSum:   proto.Float64(15.23),
+						SampleSum:   new(15.23),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(1),
 							},
 							// New bucket
 							{
-								UpperBound:      proto.Float64(0.49),
+								UpperBound:      new(0.49),
 								CumulativeCount: proto.Float64(2),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(13),
 							},
 						},
@@ -298,18 +298,18 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(16),
-						SampleSum:   proto.Float64(16.33),
+						SampleSum:   new(16.33),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(2),
 							},
 							{
-								UpperBound:      proto.Float64(0.49),
+								UpperBound:      new(0.49),
 								CumulativeCount: proto.Float64(4),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(16),
 							},
 						},
@@ -322,18 +322,18 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(18),
-						SampleSum:   proto.Float64(16.33),
+						SampleSum:   new(16.33),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(3),
 							},
 							{
-								UpperBound:      proto.Float64(0.49),
+								UpperBound:      new(0.49),
 								CumulativeCount: proto.Float64(5),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(18),
 							},
 						},
@@ -353,11 +353,11 @@ func TestPromHistogramToES(t *testing.T) {
 						SampleSum:   proto.Float64(10),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(10),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(8),
 							},
 						},
@@ -370,14 +370,14 @@ func TestPromHistogramToES(t *testing.T) {
 				{
 					histogram: p.Histogram{
 						SampleCount: proto.Float64(12),
-						SampleSum:   proto.Float64(10.45),
+						SampleSum:   new(10.45),
 						Bucket: []*p.Bucket{
 							{
-								UpperBound:      proto.Float64(0.09),
+								UpperBound:      new(0.09),
 								CumulativeCount: proto.Float64(12),
 							},
 							{
-								UpperBound:      proto.Float64(0.99),
+								UpperBound:      new(0.99),
 								CumulativeCount: proto.Float64(8),
 							},
 						},

--- a/x-pack/metricbeat/module/redisenterprise/node/node_integration_test.go
+++ b/x-pack/metricbeat/module/redisenterprise/node/node_integration_test.go
@@ -39,8 +39,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":                "redisenterprise",
 		"metricsets":            []string{"node"},
 		"hosts":                 []string{host},

--- a/x-pack/metricbeat/module/redisenterprise/proxy/proxy_integration_test.go
+++ b/x-pack/metricbeat/module/redisenterprise/proxy/proxy_integration_test.go
@@ -39,8 +39,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":                "redisenterprise",
 		"metricsets":            []string{"proxy"},
 		"hosts":                 []string{host},

--- a/x-pack/metricbeat/module/sql/module_test.go
+++ b/x-pack/metricbeat/module/sql/module_test.go
@@ -132,7 +132,7 @@ func TestGetCursorRegistryConcurrent(t *testing.T) {
 	}
 
 	type result struct {
-		reg interface{}
+		reg any
 		err error
 	}
 
@@ -140,7 +140,7 @@ func TestGetCursorRegistryConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	resultsCh := make(chan result, n)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(mod mb.Module) {
 			defer wg.Done()
@@ -161,7 +161,7 @@ func TestGetCursorRegistryConcurrent(t *testing.T) {
 	wg.Wait()
 	close(resultsCh)
 
-	var first interface{}
+	var first any
 	for r := range resultsCh {
 		require.NoError(t, r.err)
 		require.NotNil(t, r.reg)

--- a/x-pack/metricbeat/module/sql/query/cursor/config.go
+++ b/x-pack/metricbeat/module/sql/query/cursor/config.go
@@ -7,6 +7,7 @@ package cursor
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -109,12 +110,7 @@ func (c *Config) Validate() error {
 
 // isValidCursorType checks if the given type is a supported cursor type
 func isValidCursorType(t string) bool {
-	for _, valid := range supportedCursorTypes {
-		if t == valid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(supportedCursorTypes, t)
 }
 
 // isValidDirection checks if the given direction is valid

--- a/x-pack/metricbeat/module/sql/query/cursor/cursor.go
+++ b/x-pack/metricbeat/module/sql/query/cursor/cursor.go
@@ -169,7 +169,7 @@ func (m *Manager) initDefault() error {
 
 // CursorValueForQuery returns the cursor value converted to a driver-compatible argument.
 // The returned value is ready to be passed to db.QueryContext().
-func (m *Manager) CursorValueForQuery() interface{} {
+func (m *Manager) CursorValueForQuery() any {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -231,7 +231,7 @@ func (m *Manager) UpdateFromResults(rows []mapstr.M) error {
 
 	for idx, row := range rows {
 		// Find the cursor column (case-insensitive)
-		var rawVal interface{}
+		var rawVal any
 		var found bool
 
 		for key, val := range row {
@@ -366,7 +366,7 @@ func inferTypeFromRows(rows []mapstr.M, columnLower string) (string, error) {
 	inferredType := ""
 	for _, row := range rows {
 		var (
-			rawVal interface{}
+			rawVal any
 			found  bool
 		)
 

--- a/x-pack/metricbeat/module/sql/query/cursor/types.go
+++ b/x-pack/metricbeat/module/sql/query/cursor/types.go
@@ -85,7 +85,7 @@ func InferTypeFromDefaultValue(raw string) (string, error) {
 }
 
 // InferTypeFromDatabaseValue infers a cursor type from a database row value.
-func InferTypeFromDatabaseValue(dbVal interface{}) (string, error) {
+func InferTypeFromDatabaseValue(dbVal any) (string, error) {
 	if dbVal == nil {
 		return "", errors.New("column value is NULL")
 	}
@@ -178,7 +178,7 @@ func isDateOnlyString(s string) bool {
 
 // FromDatabaseValue creates a Value from a database result.
 // This handles the various types that SQL drivers may return.
-func FromDatabaseValue(dbVal interface{}, valueType string) (*Value, error) {
+func FromDatabaseValue(dbVal any, valueType string) (*Value, error) {
 	if dbVal == nil {
 		return nil, errors.New("column value is NULL")
 	}
@@ -201,7 +201,7 @@ func FromDatabaseValue(dbVal interface{}, valueType string) (*Value, error) {
 
 // ToDriverArg converts the Value to a type suitable for database/sql Query.
 // The returned value can be passed directly to db.QueryContext().
-func (v *Value) ToDriverArg() interface{} {
+func (v *Value) ToDriverArg() any {
 	switch v.Type {
 	case CursorTypeInteger:
 		i, _ := strconv.ParseInt(v.Raw, 10, 64)
@@ -288,7 +288,7 @@ func compareFloat64(a, b float64) int {
 
 // --- Integer parsing ---
 
-func parseIntegerFromDB(dbVal interface{}) (*Value, error) {
+func parseIntegerFromDB(dbVal any) (*Value, error) {
 	var intVal int64
 
 	switch v := dbVal.(type) {
@@ -351,7 +351,7 @@ func parseIntegerFromDB(dbVal interface{}) (*Value, error) {
 
 // --- Float parsing ---
 
-func parseFloatFromDB(dbVal interface{}) (*Value, error) {
+func parseFloatFromDB(dbVal any) (*Value, error) {
 	var floatVal float64
 
 	switch v := dbVal.(type) {
@@ -396,7 +396,7 @@ func parseFloatFromDB(dbVal interface{}) (*Value, error) {
 
 // --- Decimal parsing ---
 
-func parseDecimalFromDB(dbVal interface{}) (*Value, error) {
+func parseDecimalFromDB(dbVal any) (*Value, error) {
 	var d decimal.Decimal
 
 	switch v := dbVal.(type) {
@@ -460,7 +460,7 @@ func parseTimestampString(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("cannot parse timestamp: %s", s)
 }
 
-func parseTimestampFromDB(dbVal interface{}) (*Value, error) {
+func parseTimestampFromDB(dbVal any) (*Value, error) {
 	var t time.Time
 
 	switch v := dbVal.(type) {
@@ -509,7 +509,7 @@ func parseDateString(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("cannot parse date: %s", s)
 }
 
-func parseDateFromDB(dbVal interface{}) (*Value, error) {
+func parseDateFromDB(dbVal any) (*Value, error) {
 	var d time.Time
 
 	switch v := dbVal.(type) {

--- a/x-pack/metricbeat/module/sql/query/cursor/types_test.go
+++ b/x-pack/metricbeat/module/sql/query/cursor/types_test.go
@@ -147,7 +147,7 @@ func TestParseValue(t *testing.T) {
 func TestFromDatabaseValue_Integer(t *testing.T) {
 	tests := []struct {
 		name    string
-		dbVal   interface{}
+		dbVal   any
 		wantRaw string
 		wantErr bool
 	}{
@@ -262,7 +262,7 @@ func TestFromDatabaseValue_Timestamp(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		dbVal      interface{}
+		dbVal      any
 		wantRaw    string
 		wantTsNano int64
 		wantErr    bool
@@ -338,7 +338,7 @@ func TestFromDatabaseValue_Date(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		dbVal   interface{}
+		dbVal   any
 		wantRaw string
 		wantErr bool
 	}{
@@ -408,7 +408,7 @@ func TestValueToDriverArg(t *testing.T) {
 		name      string
 		value     *Value
 		wantType  string
-		wantValue interface{}
+		wantValue any
 	}{
 		{
 			name: "integer",
@@ -690,7 +690,7 @@ func TestParseValue_Float(t *testing.T) {
 func TestFromDatabaseValue_Float(t *testing.T) {
 	tests := []struct {
 		name    string
-		dbVal   interface{}
+		dbVal   any
 		wantRaw string
 		wantErr bool
 	}{
@@ -797,7 +797,7 @@ func TestParseValue_Decimal(t *testing.T) {
 func TestFromDatabaseValue_Decimal(t *testing.T) {
 	tests := []struct {
 		name    string
-		dbVal   interface{}
+		dbVal   any
 		wantRaw string
 		wantErr bool
 	}{
@@ -1119,7 +1119,7 @@ func TestInferTypeFromDefaultValue(t *testing.T) {
 func TestInferTypeFromDatabaseValue(t *testing.T) {
 	tests := []struct {
 		name     string
-		dbVal    interface{}
+		dbVal    any
 		wantType string
 		wantErr  bool
 	}{

--- a/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/cursor_integration_test.go
@@ -9,6 +9,7 @@ package query
 import (
 	"database/sql"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -43,7 +44,7 @@ const testTableName = "cursor_test_events"
 // The per-instance *paths.Path is passed straight to the module so cursor state
 // resolves under the per-test temp directory, without relying on any global
 // paths singleton.
-func newMetricSetWithPaths(t *testing.T, config map[string]interface{}, p *paths.Path) mb.MetricSet {
+func newMetricSetWithPaths(t *testing.T, config map[string]any, p *paths.Path) mb.MetricSet {
 	t.Helper()
 
 	c, err := conf.NewConfigFrom(config)
@@ -176,7 +177,7 @@ func insertTestData(t *testing.T, db *sql.DB, driver string, n int) {
 		t.Fatalf("unsupported driver for insertTestData: %s", driver)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i))
 		require.NoError(t, err)
 	}
@@ -209,7 +210,7 @@ func setupPostgresTestTable(t *testing.T, db *sql.DB) {
 	// Insert test data with values for all cursor types
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (event_data, created_at, score, price) VALUES ($1, $2, $3, $4)`, testTableName)
 	now := time.Now().UTC()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		score := float64(i+1) * 1.5   // 1.5, 3.0, 4.5, 6.0, 7.5
 		price := float64(i+1) * 10.25 // 10.25, 20.50, 30.75, 41.00, 51.25
 		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), now.Add(time.Duration(i)*time.Second), score, price)
@@ -243,7 +244,7 @@ func setupMySQLTestTable(t *testing.T, db *sql.DB) {
 	// Insert test data with values for all cursor types
 	insertSQL := fmt.Sprintf(`INSERT INTO %s (event_data, created_at, price) VALUES (?, ?, ?)`, testTableName)
 	now := time.Now().UTC()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		price := float64(i+1) * 10.25 // 10.25, 20.50, 30.75, 41.00, 51.25
 		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), now.Add(time.Duration(i)*time.Second), price)
 		require.NoError(t, err)
@@ -266,7 +267,7 @@ func testIntegerCursor(t *testing.T, driver, dsn string) {
 
 	query := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id > :cursor ORDER BY id ASC LIMIT 3", testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -324,7 +325,7 @@ func testTimestampCursor(t *testing.T, driver, dsn string) {
 
 	query := fmt.Sprintf("SELECT id, event_data, created_at FROM %s WHERE created_at > :cursor ORDER BY created_at ASC LIMIT 3", testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -369,7 +370,7 @@ func testFloatCursor(t *testing.T, driver, dsn string) {
 	// With cursor default 0.0 and LIMIT 3, first fetch gets 1.5, 3.0, 4.5
 	query := fmt.Sprintf("SELECT id, event_data, score FROM %s WHERE score > :cursor ORDER BY score ASC LIMIT 3", testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -423,7 +424,7 @@ func testDecimalCursor(t *testing.T, driver, dsn string) {
 	// With cursor default 0.00 and LIMIT 3, first fetch gets 10.25, 20.50, 30.75
 	query := fmt.Sprintf("SELECT id, event_data, price FROM %s WHERE price > :cursor ORDER BY price ASC LIMIT 3", testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -477,7 +478,7 @@ func testDescendingIntegerCursor(t *testing.T, driver, dsn string) {
 	// Default 999999, first fetch gets ids 5, 4, 3 (ORDER BY id DESC LIMIT 3)
 	query := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id < :cursor ORDER BY id DESC LIMIT 3", testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -536,7 +537,7 @@ func testCompoundWhereCursor(t *testing.T, driver, dsn string) {
 		"SELECT id, event_data FROM %s WHERE id > :cursor AND event_data LIKE 'event-%%' ORDER BY id ASC LIMIT 3",
 		testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -603,7 +604,7 @@ func TestCursorStatePersistence(t *testing.T) {
 
 	query := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id > :cursor ORDER BY id ASC", testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -687,7 +688,7 @@ func TestCursorNullValues(t *testing.T) {
 	defaultTimestamp := now.Add(-time.Hour).Format(time.RFC3339)
 	query := fmt.Sprintf("SELECT id, event_data, updated_at FROM %s WHERE updated_at > :cursor OR updated_at IS NULL ORDER BY id ASC", tableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -857,7 +858,7 @@ func setupOracleTestTable(t *testing.T, db *sql.DB) {
 	// This gives enough data to test multi-batch pagination (e.g., 3+3+3+1+0).
 	insertSQL := `INSERT INTO cursor_test_events (event_data, created_at, event_date) VALUES (:1, :2, :3)`
 	now := time.Now().UTC()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ts := now.Add(time.Duration(i) * time.Second)
 		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), ts, ts)
 		require.NoError(t, err, "Failed to insert Oracle test data row %d", i)
@@ -884,7 +885,7 @@ func testOracleIntegerCursor(t *testing.T, dsn string) {
 	// :cursor is translated to :cursor_val for Oracle by cursor.TranslateQuery
 	query := "SELECT id, event_data FROM cursor_test_events WHERE id > :cursor ORDER BY id ASC FETCH FIRST 3 ROWS ONLY"
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -955,7 +956,7 @@ func testOracleIntegerCursorRestart(t *testing.T, dsn string) {
 	// No FETCH FIRST — get all rows in one go
 	query := "SELECT id, event_data FROM cursor_test_events WHERE id > :cursor ORDER BY id ASC"
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1008,7 +1009,7 @@ func testOracleTimestampCursorMultiBatch(t *testing.T, dsn string) {
 
 	query := "SELECT id, event_data, created_at FROM cursor_test_events WHERE created_at > :cursor ORDER BY created_at ASC FETCH FIRST 3 ROWS ONLY"
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1085,7 +1086,7 @@ func testOracleTimestampTimezoneHandling(t *testing.T, dsn string) {
 
 	query := "SELECT id, event_data, created_at FROM cursor_test_events WHERE created_at > :cursor ORDER BY created_at ASC FETCH FIRST 5 ROWS ONLY"
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1140,7 +1141,7 @@ func testOracleTimestampPrecision(t *testing.T, dsn string) {
 	// FETCH FIRST 1 ROW ONLY to test single-row pagination
 	query := "SELECT id, event_data, created_at FROM cursor_test_events WHERE created_at > :cursor ORDER BY created_at ASC FETCH FIRST 1 ROWS ONLY"
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1157,7 +1158,7 @@ func testOracleTimestampPrecision(t *testing.T, dsn string) {
 	// Fetch rows one at a time — precision loss would cause rows to be
 	// skipped (cursor jumps too far) or re-fetched (cursor doesn't advance).
 	var totalFetched int
-	for i := 0; i < 12; i++ { // 10 rows + 2 safety iterations
+	for i := range 12 { // 10 rows + 2 safety iterations
 		ms := newMetricSetWithPaths(t, cfg, testPaths)
 		events, errs := fetchEvents(t, ms)
 		require.Empty(t, errs, "Fetch %d should not have errors", i+1)
@@ -1205,7 +1206,7 @@ func testOracleDateCursor(t *testing.T, dsn string) {
 	// Insert 6 rows across 6 distinct dates (today-5 .. today), all at midnight
 	// so TO_DATE comparison works cleanly.
 	today := time.Now().UTC().Truncate(24 * time.Hour)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		d := today.AddDate(0, 0, i-5) // today-5, today-4, ..., today
 		_, err := db.ExecContext(t.Context(),
 			fmt.Sprintf("INSERT INTO %s (event_data, event_date) VALUES (:1, :2)", tableName),
@@ -1222,7 +1223,7 @@ func testOracleDateCursor(t *testing.T, dsn string) {
 		tableName,
 	)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1302,7 +1303,7 @@ func testOracleNullHandling(t *testing.T, db *sql.DB, dsn string) {
 		"SELECT id, event_data, updated_at FROM %s WHERE updated_at > :cursor OR updated_at IS NULL ORDER BY id ASC",
 		tableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1338,7 +1339,7 @@ func testOracleEmptyResultSet(t *testing.T, dsn string) {
 
 	query := "SELECT id, event_data, created_at FROM cursor_test_events WHERE created_at > :cursor ORDER BY created_at ASC FETCH FIRST 3 ROWS ONLY"
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1383,7 +1384,7 @@ func testOracleQueryChangeResetsCursor(t *testing.T, dsn string) {
 	// First query — fetch 5 rows
 	query1 := "SELECT id, event_data FROM cursor_test_events WHERE id > :cursor ORDER BY id ASC FETCH FIRST 5 ROWS ONLY"
 
-	cfg1 := map[string]interface{}{
+	cfg1 := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1409,7 +1410,7 @@ func testOracleQueryChangeResetsCursor(t *testing.T, dsn string) {
 	// state key hash, so the cursor resets to default.
 	query2 := "SELECT id, event_data FROM cursor_test_events WHERE id > :cursor ORDER BY id ASC FETCH FIRST 3 ROWS ONLY"
 
-	cfg2 := map[string]interface{}{
+	cfg2 := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1467,7 +1468,7 @@ func testOracleDriverTypeConversions(t *testing.T, db *sql.DB) {
 		))
 	}
 
-	var id, createdAt, eventDate interface{}
+	var id, createdAt, eventDate any
 	err = rows.Scan(&id, &createdAt, &eventDate)
 	require.NoError(t, err)
 
@@ -1599,7 +1600,7 @@ func testOracleTimestampCursorTimezoneMismatch(t *testing.T, host, port string) 
 	// With params.Timezone=UTC, godror sends the raw UTC value and Oracle stores
 	// it as-is in the plain TIMESTAMP column (no timezone conversion on storage).
 	now := time.Now().UTC()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ts := now.Add(time.Duration(i) * time.Second)
 		_, err := db.ExecContext(t.Context(),
 			fmt.Sprintf("INSERT INTO %s (event_data, created_at) VALUES (:1, :2)", tableName),
@@ -1642,7 +1643,7 @@ func testOracleTimestampCursorTimezoneMismatch(t *testing.T, host, port string) 
 		"SELECT id, event_data, created_at FROM %s WHERE created_at > :cursor ORDER BY created_at ASC FETCH FIRST 3 ROWS ONLY",
 		tableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{mismatchDSN},
@@ -1779,7 +1780,7 @@ func setupMSSQLTestTable(t *testing.T, db *sql.DB) {
 	// Insert test data
 	insertSQL := `INSERT INTO cursor_test_events (event_data, created_at, event_date) VALUES (@p1, @p2, @p3)`
 	now := time.Now().UTC()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		ts := now.Add(time.Duration(i) * time.Second)
 		_, err := db.ExecContext(t.Context(), insertSQL, fmt.Sprintf("event-%d", i), ts, ts)
 		require.NoError(t, err, "Failed to insert MSSQL test data")
@@ -1802,7 +1803,7 @@ func testMSSQLIntegerCursor(t *testing.T, dsn string) {
 
 	query := "SELECT TOP 3 id, event_data FROM cursor_test_events WHERE id > @p1 ORDER BY id ASC"
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1854,7 +1855,7 @@ func testMSSQLTimestampCursor(t *testing.T, dsn string) {
 	testPaths := createTestPaths(t)
 	defaultTimestamp := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1895,7 +1896,7 @@ func testMSSQLDateCursor(t *testing.T, dsn string) {
 	testPaths := createTestPaths(t)
 	defaultDate := time.Now().Add(-24 * time.Hour).UTC().Format("2006-01-02")
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -1950,7 +1951,7 @@ func waitForMSSQLConnection(t *testing.T, host string) {
 
 	dsn := GetMSSQLConnectionDSN(host)
 
-	for i := 0; i < maxRetries; i++ {
+	for i := range maxRetries {
 		db, err := sql.Open("sqlserver", dsn)
 		if err == nil {
 			err = db.PingContext(t.Context())
@@ -1963,10 +1964,7 @@ func waitForMSSQLConnection(t *testing.T, host string) {
 			}
 		}
 
-		delay := time.Duration(1<<uint(i)) * baseDelay
-		if delay > 30*time.Second {
-			delay = 30 * time.Second
-		}
+		delay := min(time.Duration(1<<uint(i))*baseDelay, 30*time.Second)
 
 		t.Logf("MSSQL not ready yet (attempt %d/%d), waiting %v: %v", i+1, maxRetries, delay, err)
 		time.Sleep(delay)
@@ -2003,7 +2001,7 @@ func TestCursorQueryChangeResetsState(t *testing.T) {
 	query1 := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id > :cursor ORDER BY id ASC LIMIT 2", testTableName)
 	query2 := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id > :cursor ORDER BY id ASC LIMIT 3", testTableName)
 
-	cfgBase := map[string]interface{}{
+	cfgBase := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -2016,16 +2014,12 @@ func TestCursorQueryChangeResetsState(t *testing.T) {
 		"cursor.default":      "0",
 	}
 
-	cfg1 := map[string]interface{}{}
-	for k, v := range cfgBase {
-		cfg1[k] = v
-	}
+	cfg1 := map[string]any{}
+	maps.Copy(cfg1, cfgBase)
 	cfg1["sql_query"] = query1
 
-	cfg2 := map[string]interface{}{}
-	for k, v := range cfgBase {
-		cfg2[k] = v
-	}
+	cfg2 := map[string]any{}
+	maps.Copy(cfg2, cfgBase)
 	cfg2["sql_query"] = query2
 
 	// First run with query1 advances cursor to id=2.
@@ -2079,7 +2073,7 @@ func TestCursorStateIsolation(t *testing.T) {
 	query1 := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id > :cursor ORDER BY id ASC LIMIT 2", testTableName)
 	query2 := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id > :cursor ORDER BY id ASC LIMIT 3", testTableName)
 
-	cfg1 := map[string]interface{}{
+	cfg1 := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -2093,7 +2087,7 @@ func TestCursorStateIsolation(t *testing.T) {
 		"cursor.default":      "0",
 	}
 
-	cfg2 := map[string]interface{}{
+	cfg2 := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -2169,7 +2163,7 @@ func TestCursorRegistrySharing(t *testing.T) {
 	testPaths := createTestPaths(t)
 
 	// Configuration for first MetricSet - query with LIMIT 2
-	cfg1 := map[string]interface{}{
+	cfg1 := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -2185,7 +2179,7 @@ func TestCursorRegistrySharing(t *testing.T) {
 	}
 
 	// Configuration for second MetricSet - different query with LIMIT 3
-	cfg2 := map[string]interface{}{
+	cfg2 := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -2300,7 +2294,7 @@ func TestCursorQueryTimeout(t *testing.T) {
 		testTableName,
 	)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},
@@ -2372,7 +2366,7 @@ func TestCursorNormalQueryCompletesWithinTimeout(t *testing.T) {
 
 	query := fmt.Sprintf("SELECT id, event_data FROM %s WHERE id > :cursor ORDER BY id ASC LIMIT 3", testTableName)
 
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{dsn},

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -88,7 +88,7 @@ type rawData struct {
 // It allows unit tests to exercise fetch paths without real DB connections.
 type dbClient interface {
 	FetchTableMode(ctx context.Context, query string) ([]mapstr.M, error)
-	FetchTableModeWithParams(ctx context.Context, query string, args ...interface{}) ([]mapstr.M, error)
+	FetchTableModeWithParams(ctx context.Context, query string, args ...any) ([]mapstr.M, error)
 	FetchVariableMode(ctx context.Context, query string) (mapstr.M, error)
 	Close() error
 }

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -280,8 +280,8 @@ func testData(t *testing.T, cfg testFetchConfig, postfix string) {
 	m.WriteEvents(t, postfix)
 }
 
-func getConfig(cfg testFetchConfig) map[string]interface{} {
-	values := map[string]interface{}{
+func getConfig(cfg testFetchConfig) map[string]any {
+	values := map[string]any{
 		"module":           "sql",
 		"metricsets":       []string{"query"},
 		"hosts":            []string{cfg.Host},
@@ -386,7 +386,7 @@ func waitForOracleConnection(t *testing.T, host, port string) {
 	maxRetries := 30
 	baseDelay := 2 * time.Second
 
-	for i := 0; i < maxRetries; i++ {
+	for i := range maxRetries {
 		// First check if the port is open
 		conn, err := (&net.Dialer{Timeout: 10 * time.Second}).DialContext(t.Context(), "tcp", net.JoinHostPort(host, port))
 		if err == nil {
@@ -397,11 +397,9 @@ func waitForOracleConnection(t *testing.T, host, port string) {
 		}
 
 		// (1<<uint(i)) == 2^i, which doubles the delay at each iteration, then multiply by baseDelay
-		delay := time.Duration(1<<uint(i)) * baseDelay
-		// But don't let the delay get too long; max out at 30 seconds
-		if delay > 30*time.Second {
-			delay = 30 * time.Second
-		}
+		delay := min(
+			// But don't let the delay get too long; max out at 30 seconds
+			time.Duration(1<<uint(i))*baseDelay, 30*time.Second)
 
 		t.Logf("Oracle not ready yet (attempt %d/%d), waiting %v: %v", i+1, maxRetries, delay, err)
 		time.Sleep(delay)

--- a/x-pack/metricbeat/module/sql/query/query_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_test.go
@@ -9,6 +9,7 @@ package query
 import (
 	"context"
 	"errors"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -40,12 +41,12 @@ type fakeDBClient struct {
 	tableQueries     []string
 	variableQueries  []string
 	withParamQueries []string
-	withParamArgs    [][]interface{}
+	withParamArgs    [][]any
 	closed           bool
 
 	fetchTableFn          func(ctx context.Context, query string) ([]mapstr.M, error)
 	fetchVariableFn       func(ctx context.Context, query string) (mapstr.M, error)
-	fetchTableWithParamFn func(ctx context.Context, query string, args ...interface{}) ([]mapstr.M, error)
+	fetchTableWithParamFn func(ctx context.Context, query string, args ...any) ([]mapstr.M, error)
 }
 
 func (f *fakeDBClient) FetchTableMode(ctx context.Context, query string) ([]mapstr.M, error) {
@@ -56,7 +57,7 @@ func (f *fakeDBClient) FetchTableMode(ctx context.Context, query string) ([]maps
 	return f.tableRows, f.tableErr
 }
 
-func (f *fakeDBClient) FetchTableModeWithParams(ctx context.Context, query string, args ...interface{}) ([]mapstr.M, error) {
+func (f *fakeDBClient) FetchTableModeWithParams(ctx context.Context, query string, args ...any) ([]mapstr.M, error) {
 	f.withParamQueries = append(f.withParamQueries, query)
 	f.withParamArgs = append(f.withParamArgs, args)
 	if f.fetchTableWithParamFn != nil {
@@ -91,8 +92,8 @@ func (r *stopReporter) Error(_ error) bool {
 	return false
 }
 
-func testMetricSetConfig(queryText string) map[string]interface{} {
-	return map[string]interface{}{
+func testMetricSetConfig(queryText string) map[string]any {
+	return map[string]any{
 		"module":              "sql",
 		"metricsets":          []string{"query"},
 		"hosts":               []string{"postgres://user:pass@localhost:5432/mydb?sslmode=disable"},
@@ -102,7 +103,7 @@ func testMetricSetConfig(queryText string) map[string]interface{} {
 	}
 }
 
-func newTestMetricSet(t *testing.T, cfg map[string]interface{}) *MetricSet {
+func newTestMetricSet(t *testing.T, cfg map[string]any) *MetricSet {
 	t.Helper()
 
 	c, err := conf.NewConfigFrom(cfg)
@@ -163,7 +164,7 @@ func withFakeDBClientFactory(t *testing.T, db dbClient) {
 	})
 }
 
-func instantiateMetricSetWithConfig(t *testing.T, cfg map[string]interface{}) error {
+func instantiateMetricSetWithConfig(t *testing.T, cfg map[string]any) error {
 	t.Helper()
 
 	c, err := conf.NewConfigFrom(cfg)
@@ -291,7 +292,7 @@ func TestFetch_CursorPath_AppliesTimeoutContext(t *testing.T) {
 
 	deadlineSeen := false
 	fakeDB := &fakeDBClient{
-		fetchTableWithParamFn: func(ctx context.Context, _ string, _ ...interface{}) ([]mapstr.M, error) {
+		fetchTableWithParamFn: func(ctx context.Context, _ string, _ ...any) ([]mapstr.M, error) {
 			_, ok := ctx.Deadline()
 			deadlineSeen = ok
 			return []mapstr.M{}, nil
@@ -685,29 +686,29 @@ func TestNew_ConfigValidationErrors(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		overrides map[string]interface{}
+		overrides map[string]any
 		wantErr   string
 	}{
 		{
 			name: "invalid response format",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_response_format": "bad",
 			},
 			wantErr: "invalid sql_response_format value: bad",
 		},
 		{
 			name: "no query inputs",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_query":   "",
-				"sql_queries": []map[string]interface{}{},
+				"sql_queries": []map[string]any{},
 			},
 			wantErr: "no query input provided, must provide either sql_query or sql_queries",
 		},
 		{
 			name: "both query and queries",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_query": "SELECT 1",
-				"sql_queries": []map[string]interface{}{
+				"sql_queries": []map[string]any{
 					{"query": "SELECT 2", "response_format": "table"},
 				},
 			},
@@ -715,9 +716,9 @@ func TestNew_ConfigValidationErrors(t *testing.T) {
 		},
 		{
 			name: "cursor with multiple queries",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_query": "",
-				"sql_queries": []map[string]interface{}{
+				"sql_queries": []map[string]any{
 					{"query": "SELECT id FROM t", "response_format": "table"},
 				},
 				"cursor.enabled": true,
@@ -729,7 +730,7 @@ func TestNew_ConfigValidationErrors(t *testing.T) {
 		},
 		{
 			name: "cursor with fetch from all databases",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_query":                "SELECT id FROM t WHERE id > :cursor",
 				"sql_response_format":      "table",
 				"fetch_from_all_databases": true,
@@ -742,7 +743,7 @@ func TestNew_ConfigValidationErrors(t *testing.T) {
 		},
 		{
 			name: "cursor requires table format",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_query":           "SELECT id FROM t WHERE id > :cursor",
 				"sql_response_format": "variables",
 				"cursor.enabled":      true,
@@ -754,9 +755,9 @@ func TestNew_ConfigValidationErrors(t *testing.T) {
 		},
 		{
 			name: "invalid response format in sql_queries",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_query": "",
-				"sql_queries": []map[string]interface{}{
+				"sql_queries": []map[string]any{
 					{"query": "SELECT 1", "response_format": "invalid"},
 				},
 			},
@@ -764,7 +765,7 @@ func TestNew_ConfigValidationErrors(t *testing.T) {
 		},
 		{
 			name: "cursor query missing placeholder",
-			overrides: map[string]interface{}{
+			overrides: map[string]any{
 				"sql_query":           "SELECT id FROM t",
 				"sql_response_format": "table",
 				"cursor.enabled":      true,
@@ -778,13 +779,9 @@ func TestNew_ConfigValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := make(map[string]interface{}, len(base)+len(tt.overrides))
-			for k, v := range base {
-				cfg[k] = v
-			}
-			for k, v := range tt.overrides {
-				cfg[k] = v
-			}
+			cfg := make(map[string]any, len(base)+len(tt.overrides))
+			maps.Copy(cfg, base)
+			maps.Copy(cfg, tt.overrides)
 
 			err := instantiateMetricSetWithConfig(t, cfg)
 			require.Error(t, err)

--- a/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
+++ b/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
@@ -35,8 +35,8 @@ func TestFetch(t *testing.T) {
 	assert.NotEmpty(t, events)
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "stan",
 		"metricsets": []string{"channels"},
 		"hosts":      []string{host},

--- a/x-pack/metricbeat/module/stan/channels/channels_test.go
+++ b/x-pack/metricbeat/module/stan/channels/channels_test.go
@@ -5,9 +5,9 @@
 package channels
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,7 +17,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/channels.json")
+	content, err := os.ReadFile("./_meta/test/channels.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(content, reporter)
@@ -55,7 +55,7 @@ func TestFetchEventContent(t *testing.T) {
 	server := initServer()
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "stan",
 		"metricsets": []string{"channels"},
 		"hosts":      []string{server.URL},
@@ -74,7 +74,7 @@ func TestFetchEventContent(t *testing.T) {
 func initServer() *httptest.Server {
 	absPath, _ := filepath.Abs("./_meta/test/")
 
-	response, _ := ioutil.ReadFile(absPath + "/channels.json")
+	response, _ := os.ReadFile(absPath + "/channels.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/x-pack/metricbeat/module/stan/channels/data.go
+++ b/x-pack/metricbeat/module/stan/channels/data.go
@@ -62,7 +62,7 @@ type Channels struct {
 }
 
 // eventMapping maps a channel to a Metricbeat event
-func eventMapping(content map[string]interface{}) (mb.Event, error) {
+func eventMapping(content map[string]any) (mb.Event, error) {
 	fields, err := channelSchema.Apply(content)
 	if err != nil {
 		return mb.Event{}, fmt.Errorf("error applying channels schema: %w", err)
@@ -96,7 +96,7 @@ func eventsMapping(content []byte, r mb.ReporterV2) error {
 				maxSubSeq = sub.LastSent
 			}
 		}
-		chWrapper := map[string]interface{}{
+		chWrapper := map[string]any{
 			"cluster_id": channelsIn.ClusterID,
 			"server_id":  channelsIn.ServerID,
 			"name":       ch.Name,

--- a/x-pack/metricbeat/module/stan/stats/data.go
+++ b/x-pack/metricbeat/module/stan/stats/data.go
@@ -34,7 +34,7 @@ var (
 )
 
 func eventMapping(content []byte, r mb.ReporterV2) error {
-	var streaming = make(map[string]interface{})
+	var streaming = make(map[string]any)
 	if err := json.Unmarshal(content, &streaming); err != nil {
 		return fmt.Errorf("error in streaming server mapping: %w", err)
 	}

--- a/x-pack/metricbeat/module/stan/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/stan/stats/stats_integration_test.go
@@ -36,8 +36,8 @@ func TestFetch(t *testing.T) {
 	t.Logf("%s/%s event: %+v", m.Module().Name(), m.Name(), events[0])
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "stan",
 		"metricsets": []string{"stats"},
 		"hosts":      []string{host},

--- a/x-pack/metricbeat/module/stan/stats/stats_test.go
+++ b/x-pack/metricbeat/module/stan/stats/stats_test.go
@@ -5,9 +5,9 @@
 package stats
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,7 +17,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/serversz.json")
+	content, err := os.ReadFile("./_meta/test/serversz.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(content, reporter)
@@ -31,7 +31,7 @@ func TestFetchEventContent(t *testing.T) {
 	server := initServer()
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "stan",
 		"metricsets": []string{"stats"},
 		"hosts":      []string{server.URL},
@@ -49,7 +49,7 @@ func TestFetchEventContent(t *testing.T) {
 func initServer() *httptest.Server {
 	absPath, _ := filepath.Abs("./_meta/test/")
 
-	response, _ := ioutil.ReadFile(absPath + "/serversz.json")
+	response, _ := os.ReadFile(absPath + "/serversz.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/x-pack/metricbeat/module/stan/subscriptions/data.go
+++ b/x-pack/metricbeat/module/stan/subscriptions/data.go
@@ -35,7 +35,7 @@ var (
 
 // eventMapping maps a subscription to a Metricbeat event using subscriptionsSchema
 // to parse through each subscription under a presumed channel
-func eventMapping(content map[string]interface{}) (mb.Event, error) {
+func eventMapping(content map[string]any) (mb.Event, error) {
 	fields, err := subscriptionsSchema.Apply(content)
 	if err != nil {
 		return mb.Event{}, fmt.Errorf("error applying subscription schema: %w", err)
@@ -70,7 +70,7 @@ type Channel struct {
 	Bytes   int64  `json:"bytes"`
 	LastSeq int64  `json:"last_seq"`
 	// Subscriptions []Subscription `json:"subscriptions,omitempty"`
-	Subscriptions []map[string]interface{} `json:"subscriptions,omitempty"`
+	Subscriptions []map[string]any `json:"subscriptions,omitempty"`
 }
 
 // Channels stores channels related information

--- a/x-pack/metricbeat/module/stan/subscriptions/subscriptions_integration_test.go
+++ b/x-pack/metricbeat/module/stan/subscriptions/subscriptions_integration_test.go
@@ -35,8 +35,8 @@ func TestFetch(t *testing.T) {
 	assert.NotEmpty(t, events)
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     "stan",
 		"metricsets": []string{"subscriptions"},
 		"hosts":      []string{host},

--- a/x-pack/metricbeat/module/stan/subscriptions/subscriptions_test.go
+++ b/x-pack/metricbeat/module/stan/subscriptions/subscriptions_test.go
@@ -5,9 +5,9 @@
 package subscriptions
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,7 +17,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/subscriptions.json")
+	content, err := os.ReadFile("./_meta/test/subscriptions.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(content, reporter)
@@ -34,7 +34,7 @@ func TestFetchEventContent(t *testing.T) {
 	server := initServer()
 	defer server.Close()
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "stan",
 		"metricsets": []string{"subscriptions"},
 		"hosts":      []string{server.URL},
@@ -53,7 +53,7 @@ func TestFetchEventContent(t *testing.T) {
 func initServer() *httptest.Server {
 	absPath, _ := filepath.Abs("./_meta/test/")
 
-	response, _ := ioutil.ReadFile(absPath + "/subscriptions.json")
+	response, _ := os.ReadFile(absPath + "/subscriptions.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/x-pack/metricbeat/module/statsd/server/data.go
+++ b/x-pack/metricbeat/module/statsd/server/data.go
@@ -119,7 +119,7 @@ func parse(b []byte, log *logp.Logger) ([]statsdMetric, error) {
 	return metrics, nil
 }
 
-func eventMapping(metricName string, metricValue interface{}, mappings map[string]StatsdMapping, log *logp.Logger) mapstr.M {
+func eventMapping(metricName string, metricValue any, mappings map[string]StatsdMapping, log *logp.Logger) mapstr.M {
 	m := mapstr.M{}
 	if len(mappings) == 0 {
 		m[common.DeDot(metricName)] = metricValue

--- a/x-pack/metricbeat/module/statsd/server/data_test.go
+++ b/x-pack/metricbeat/module/statsd/server/data_test.go
@@ -281,8 +281,8 @@ func TestEventMapping(t *testing.T) {
 	var mappings []StatsdMapping
 	_ = yaml.Unmarshal([]byte(mappingsYml), &mappings)
 
-	countValue := map[string]interface{}{"count": 4}
-	timerValue := map[string]interface{}{
+	countValue := map[string]any{"count": 4}
+	timerValue := map[string]any{
 		"stddev":    0,
 		"p99_9":     100,
 		"mean_rate": 0.2689038235718098,
@@ -299,11 +299,11 @@ func TestEventMapping(t *testing.T) {
 		"15m_rate":  0.2,
 	}
 
-	gaugeValue := map[string]interface{}{"value": 2}
+	gaugeValue := map[string]any{"value": 2}
 
 	for _, test := range []struct {
 		metricName  string
-		metricValue interface{}
+		metricValue any
 		expected    mapstr.M
 	}{
 		{
@@ -1145,7 +1145,7 @@ func process(packets []string, ms *MetricSet) error {
 }
 
 func TestTagsGrouping(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric1:1.0|g|#k1:v1,k2:v2",
 		"metric2:2|c|#k1:v1,k2:v2",
@@ -1203,7 +1203,7 @@ func TestTagsGrouping(t *testing.T) {
 }
 
 func TestTagsCleanup(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd", "ttl": "1s"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd", "ttl": "1s"}).(*MetricSet)
 	testData := []string{
 		"metric1:1|g|#k1:v1,k2:v2",
 
@@ -1231,11 +1231,11 @@ func TestTagsCleanup(t *testing.T) {
 	events := ms.getEvents()
 	assert.Len(t, events, 1)
 
-	assert.Equal(t, events[0].MetricSetFields, mapstr.M{"metric1": map[string]interface{}{"value": float64(3)}})
+	assert.Equal(t, events[0].MetricSetFields, mapstr.M{"metric1": map[string]any{"value": float64(3)}})
 }
 
 func TestSetReset(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd", "ttl": "1s"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd", "ttl": "1s"}).(*MetricSet)
 	testData := []string{
 		"metric1:hello|s|#k1:v1,k2:v2",
 		"metric1:again|s|#k1:v1,k2:v2",
@@ -1246,14 +1246,14 @@ func TestSetReset(t *testing.T) {
 	events := ms.getEvents()
 	require.Len(t, events, 1)
 
-	assert.Equal(t, 2, events[0].MetricSetFields["metric1"].(map[string]interface{})["count"])
+	assert.Equal(t, 2, events[0].MetricSetFields["metric1"].(map[string]any)["count"])
 
 	events = ms.getEvents()
-	assert.Equal(t, 0, events[0].MetricSetFields["metric1"].(map[string]interface{})["count"])
+	assert.Equal(t, 0, events[0].MetricSetFields["metric1"].(map[string]any)["count"])
 }
 
 func TestData(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric01:1.0|g|#k1:v1,k2:v2",
 		"metric02:2|c|#k1:v1,k2:v2",
@@ -1278,7 +1278,7 @@ func TestData(t *testing.T) {
 }
 
 func TestGaugeDeltas(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric01:1.0|g|#k1:v1,k2:v2",
 		"metric01:-2.0|g|#k1:v1,k2:v2",
@@ -1290,7 +1290,7 @@ func TestGaugeDeltas(t *testing.T) {
 	assert.Len(t, events, 1)
 
 	assert.Equal(t, events[0].MetricSetFields, mapstr.M{
-		"metric01": map[string]interface{}{"value": -1.0},
+		"metric01": map[string]any{"value": -1.0},
 	})
 
 	// same value reported again
@@ -1298,12 +1298,12 @@ func TestGaugeDeltas(t *testing.T) {
 	assert.Len(t, events, 1)
 
 	assert.Equal(t, events[0].MetricSetFields, mapstr.M{
-		"metric01": map[string]interface{}{"value": -1.0},
+		"metric01": map[string]any{"value": -1.0},
 	})
 }
 
 func TestCounter(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric01:1|c|#k1:v1,k2:v2",
 		"metric01:2|c|#k1:v1,k2:v2",
@@ -1315,7 +1315,7 @@ func TestCounter(t *testing.T) {
 	assert.Len(t, events, 1)
 
 	assert.Equal(t, events[0].MetricSetFields, mapstr.M{
-		"metric01": map[string]interface{}{"count": int64(3)},
+		"metric01": map[string]any{"count": int64(3)},
 	})
 
 	// reset
@@ -1323,12 +1323,12 @@ func TestCounter(t *testing.T) {
 	assert.Len(t, events, 1)
 
 	assert.Equal(t, events[0].MetricSetFields, mapstr.M{
-		"metric01": map[string]interface{}{"count": int64(0)},
+		"metric01": map[string]any{"count": int64(0)},
 	})
 }
 
 func TestCounterSampled(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric01:1|c|@0.1",
 		"metric01:2|c|@0.2",
@@ -1340,12 +1340,12 @@ func TestCounterSampled(t *testing.T) {
 	assert.Len(t, events, 1)
 
 	assert.Equal(t, events[0].MetricSetFields, mapstr.M{
-		"metric01": map[string]interface{}{"count": int64(20)},
+		"metric01": map[string]any{"count": int64(20)},
 	})
 }
 
 func TestCounterSampledZero(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric01:1|c|@0.0",
 	}
@@ -1357,7 +1357,7 @@ func TestCounterSampledZero(t *testing.T) {
 }
 
 func TestTimerSampled(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric01:2|ms|@0.01",
 		"metric01:1|ms|@0.1",
@@ -1375,7 +1375,7 @@ func TestTimerSampled(t *testing.T) {
 	events := ms.getEvents()
 	assert.Len(t, events, 1)
 
-	actualMetric01 := events[0].MetricSetFields["metric01"].(map[string]interface{})
+	actualMetric01 := events[0].MetricSetFields["metric01"].(map[string]any)
 
 	// returns the extrapolated count
 	assert.Equal(t, int64(116), actualMetric01["count"])
@@ -1388,7 +1388,7 @@ func TestTimerSampled(t *testing.T) {
 }
 
 func TestChangeType(t *testing.T) {
-	ms := mbtest.NewMetricSet(t, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(t, map[string]any{"module": "statsd"}).(*MetricSet)
 	testData := []string{
 		"metric01:1|ms",
 		"metric01:2|c",
@@ -1400,7 +1400,7 @@ func TestChangeType(t *testing.T) {
 	assert.Len(t, events, 1)
 
 	assert.Equal(t, mapstr.M{
-		"metric01": map[string]interface{}{"count": int64(2)},
+		"metric01": map[string]any{"count": int64(2)},
 	}, events[0].MetricSetFields)
 }
 
@@ -1430,7 +1430,7 @@ func BenchmarkIngest(b *testing.B) {
 			},
 		}
 	}
-	ms := mbtest.NewMetricSet(b, map[string]interface{}{"module": "statsd"}).(*MetricSet)
+	ms := mbtest.NewMetricSet(b, map[string]any{"module": "statsd"}).(*MetricSet)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/x-pack/metricbeat/module/statsd/server/registry.go
+++ b/x-pack/metricbeat/module/statsd/server/registry.go
@@ -18,7 +18,7 @@ type metric struct {
 	name     string
 	tags     map[string]string
 	lastSeen time.Time
-	metric   interface{}
+	metric   any
 }
 
 type registry struct {
@@ -183,8 +183,8 @@ type metricsGroup struct {
 	metrics mapstr.M
 }
 
-func (r *registry) getMetric(metric interface{}) map[string]interface{} {
-	values := map[string]interface{}{}
+func (r *registry) getMetric(metric any) map[string]any {
+	values := map[string]any{}
 	switch m := metric.(type) {
 	case metrics.Counter:
 		values["count"] = m.Count()
@@ -280,7 +280,7 @@ func (r *registry) Delete(name string, tags map[string]string) {
 	}
 }
 
-func (r *registry) getOrNew(name string, tags map[string]string, new func() interface{}) interface{} {
+func (r *registry) getOrNew(name string, tags map[string]string, new func() any) any {
 	tagsKey := r.metricHash(tags)
 	tc, ok := r.metrics[tagsKey]
 	if !ok {
@@ -320,7 +320,7 @@ func (r *registry) clearTypeChanged(name string, tags map[string]string) {
 }
 
 func (r *registry) GetOrNewCounter(name string, tags map[string]string) metrics.Counter {
-	maybeCounter := r.getOrNew(name, tags, func() interface{} { return metrics.NewCounter() })
+	maybeCounter := r.getOrNew(name, tags, func() any { return metrics.NewCounter() })
 	counter, ok := maybeCounter.(metrics.Counter)
 	if ok {
 		return counter
@@ -331,7 +331,7 @@ func (r *registry) GetOrNewCounter(name string, tags map[string]string) metrics.
 }
 
 func (r *registry) GetOrNewTimer(name string, tags map[string]string) *samplingTimer {
-	timer, ok := r.getOrNew(name, tags, func() interface{} { return newSamplingTimer() }).(*samplingTimer)
+	timer, ok := r.getOrNew(name, tags, func() any { return newSamplingTimer() }).(*samplingTimer)
 	if ok {
 		return timer
 	}
@@ -341,7 +341,7 @@ func (r *registry) GetOrNewTimer(name string, tags map[string]string) *samplingT
 }
 
 func (r *registry) GetOrNewGauge64(name string, tags map[string]string) *deltaGaugeMetric {
-	gauge, ok := r.getOrNew(name, tags, func() interface{} { return &deltaGaugeMetric{} }).(*deltaGaugeMetric)
+	gauge, ok := r.getOrNew(name, tags, func() any { return &deltaGaugeMetric{} }).(*deltaGaugeMetric)
 	if ok {
 		return gauge
 	}
@@ -351,7 +351,7 @@ func (r *registry) GetOrNewGauge64(name string, tags map[string]string) *deltaGa
 }
 
 func (r *registry) GetOrNewHistogram(name string, tags map[string]string) metrics.Histogram {
-	histogram, ok := r.getOrNew(name, tags, func() interface{} { return metrics.NewHistogram(metrics.NewExpDecaySample(1028, 0.015)) }).(metrics.Histogram)
+	histogram, ok := r.getOrNew(name, tags, func() any { return metrics.NewHistogram(metrics.NewExpDecaySample(1028, 0.015)) }).(metrics.Histogram)
 	if ok {
 		return histogram
 	}
@@ -361,7 +361,7 @@ func (r *registry) GetOrNewHistogram(name string, tags map[string]string) metric
 }
 
 func (r *registry) GetOrNewSet(name string, tags map[string]string) *setMetric {
-	setmetric, ok := r.getOrNew(name, tags, func() interface{} { return newSetMetric() }).(*setMetric)
+	setmetric, ok := r.getOrNew(name, tags, func() any { return newSetMetric() }).(*setMetric)
 	if ok {
 		return setmetric
 	}


### PR DESCRIPTION
## Proposed commit message

```
metricbeat,x-pack/metricbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 254 file(s)
owned by @elastic/obs-infraobs-integrations in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

A second commit removes the helpers the rewrites orphaned; see the review notes below.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


REDUNDANT_CONVERSION = re.compile(r"new\(\(([\w.]+)\)\(")


def drop_redundant_parens(root: Path, files: list[str]) -> int:
    """Rewrite the `new((T)(x))` the newexpr fixer emits as `new(T(x))`.

    Dropping one paren on each side keeps the call balanced, and the pattern is narrow
    enough that a textual rewrite cannot match anything else.
    """
    touched = 0
    for name in files:
        path = root / name
        before = path.read_text()
        after = REDUNDANT_CONVERSION.sub(r"new(\1(", before)
        if after != before:
            path.write_text(after)
            touched += 1
    return touched


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]
        cleaned = drop_redundant_parens(root, files)
        if cleaned:
            log(f"  dropped redundant conversion parens in {cleaned} file(s)")

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Separate commits, so the hand-written part is obvious:

1. `metricbeat,x-pack/metricbeat: fix modernize lint findings` is pure tool output, nothing in it was written by hand.
2. `metricbeat,x-pack/metricbeat,x-pack/filebeat: drop orphaned helpers` is the part the tools could not produce:

   > `go fix` inlined the `//go:fix inline` pointer helpers at every call site,
   > leaving the helpers themselves unused, so they are deleted here.
   > 
   > It left `pointer` in x-pack/filebeat/input/salesforce behind because most of
   > its call sites sit under the `salesforce_live` build tag, which the fixers do
   > not run with; those are rewritten to `new(expr)` by hand.

- `metricbeat/module/aerospike/aerospike_test.go`
- `x-pack/filebeat/input/salesforce/doc.go`
- `x-pack/filebeat/input/salesforce/helper.go`
- `x-pack/filebeat/input/salesforce/input_test.go`
- `x-pack/filebeat/input/salesforce/live_filebeat_module_local_test.go`
- `x-pack/filebeat/input/salesforce/live_validation_local_test.go`
- `x-pack/metricbeat/module/azure/app_insights/data_test.go`

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
