### PR TITLE
heartbeat,x-pack/metricbeat: fix modernize lint findings

### DIFF
--- a/heartbeat/beater/heartbeat_test.go
+++ b/heartbeat/beater/heartbeat_test.go
@@ -34,7 +34,7 @@ import (
 func TestMakeESClient(t *testing.T) {
 	t.Run("should not modify the timeout setting from original config", func(t *testing.T) {
 		origTimeout := 90
-		origCfg, _ := conf.NewConfigFrom(map[interface{}]interface{}{
+		origCfg, _ := conf.NewConfigFrom(map[any]any{
 			"hosts":    []string{"http://localhost:9200"},
 			"username": "anyuser",
 			"password": "anypwd",

--- a/heartbeat/esutil/esutil.go
+++ b/heartbeat/esutil/esutil.go
@@ -26,7 +26,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 )
 
-func ToJsonRdr(i interface{}) (io.Reader, error) {
+func ToJsonRdr(i any) (io.Reader, error) {
 	b, err := json.Marshal(i)
 	if err != nil {
 		return nil, err

--- a/heartbeat/eventext/eventext.go
+++ b/heartbeat/eventext/eventext.go
@@ -41,7 +41,7 @@ func CancelEvent(event *beat.Event) {
 	}
 }
 
-func SetMeta(event *beat.Event, k string, v interface{}) {
+func SetMeta(event *beat.Event, k string, v any) {
 	if event.Meta == nil {
 		event.Meta = mapstr.M{}
 	}

--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -74,7 +74,7 @@ func HelloWorldHandler(status int) http.HandlerFunc {
 // character 'x'
 func SizedResponseHandler(bytes int) http.HandlerFunc {
 	var body strings.Builder
-	for i := 0; i < bytes; i++ {
+	for range bytes {
 		body.WriteString("x")
 	}
 
@@ -172,8 +172,8 @@ func BaseChecks(ip string, status string, typ string) validator.Validator {
 
 	return lookslike.Compose(
 		hbtestllext.MaybeHasEventType,
-		lookslike.MustCompile(map[string]interface{}{
-			"monitor": map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
+			"monitor": map[string]any{
 				"ip":          ipCheck,
 				"status":      status,
 				"duration.us": hbtestllext.IsInt64,
@@ -191,7 +191,7 @@ func BaseChecks(ip string, status string, typ string) validator.Validator {
 func SummaryStateChecks(up uint16, down uint16) validator.Validator {
 	return lookslike.Compose(
 		summarizertesthelper.SummaryValidator(up, down),
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"state": hbtestllext.IsMonitorState,
 		}),
 	)
@@ -199,8 +199,8 @@ func SummaryStateChecks(up uint16, down uint16) validator.Validator {
 
 // ResolveChecks returns a lookslike matcher for the 'resolve' fields.
 func ResolveChecks(ip string) validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
-		"resolve": map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
+		"resolve": map[string]any{
 			"ip":     ip,
 			"rtt.us": hbtestllext.IsInt64,
 		},
@@ -225,19 +225,19 @@ func SimpleURLChecks(t *testing.T, scheme string, host string, port uint16) vali
 func URLChecks(t *testing.T, u *url.URL) validator.Validator {
 	t.Helper()
 	require.NotNil(t, u)
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"url": wraputil.URLFields(u),
 	})
 }
 
 func ECSErrCodeChecks(ecode ecserr.ECode, messageContains string) validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"error": hbtestllext.IsECSErrMatchingCode(ecode, messageContains),
 	})
 }
 
 func ECSErrChecks(eErr *ecserr.ECSErr) validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"error": hbtestllext.IsECSErr(eErr),
 	})
 }
@@ -246,8 +246,8 @@ func ECSErrChecks(eErr *ecserr.ECSErr) validator.Validator {
 // consist of a message (or a lookslike isdef that can match the message) and a type under the error key.
 // The message is checked only as a substring since exact string matches can be fragile due to platform differences.
 func ErrorChecks(msgSubstr string, errType string) validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
-		"error": map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
+		"error": map[string]any{
 			"message": isdef.IsStringContaining(msgSubstr),
 			"type":    errType,
 		},
@@ -265,7 +265,7 @@ func ExpiredCertChecks(cert *x509.Certificate) validator.Validator {
 // RespondingTCPChecks creates a skima.Validator that represents the "tcp" field present
 // in all heartbeat events that use a Tcp connection as part of their DialChain
 func RespondingTCPChecks() validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{"tcp.rtt.connect.us": hbtestllext.IsInt64})
+	return lookslike.MustCompile(map[string]any{"tcp.rtt.connect.us": hbtestllext.IsInt64})
 }
 
 // CertToTempFile takes a certificate and returns an *os.File with a PEM encoded

--- a/heartbeat/hbtestllext/isdefs.go
+++ b/heartbeat/hbtestllext/isdefs.go
@@ -32,7 +32,7 @@ import (
 )
 
 // IsTime checks that the value is a time.Time instance.
-var IsTime = isdef.Is("time", func(path llpath.Path, v interface{}) *llresult.Results {
+var IsTime = isdef.Is("time", func(path llpath.Path, v any) *llresult.Results {
 	_, ok := v.(time.Time)
 	if !ok {
 		return llresult.SimpleResult(path, false, "expected a time.Time")
@@ -40,7 +40,7 @@ var IsTime = isdef.Is("time", func(path llpath.Path, v interface{}) *llresult.Re
 	return llresult.ValidResult(path)
 })
 
-var IsInt64 = isdef.Is("positiveInt64", func(path llpath.Path, v interface{}) *llresult.Results {
+var IsInt64 = isdef.Is("positiveInt64", func(path llpath.Path, v any) *llresult.Results {
 	_, ok := v.(int64)
 	if !ok {
 		return llresult.SimpleResult(path, false, "expected an int64")
@@ -48,7 +48,7 @@ var IsInt64 = isdef.Is("positiveInt64", func(path llpath.Path, v interface{}) *l
 	return llresult.ValidResult(path)
 })
 
-var IsUint16 = isdef.Is("positiveUInt16", func(path llpath.Path, v interface{}) *llresult.Results {
+var IsUint16 = isdef.Is("positiveUInt16", func(path llpath.Path, v any) *llresult.Results {
 	_, ok := v.(uint16)
 	if !ok {
 		return llresult.SimpleResult(path, false, "expected a uint16")
@@ -56,7 +56,7 @@ var IsUint16 = isdef.Is("positiveUInt16", func(path llpath.Path, v interface{}) 
 	return llresult.ValidResult(path)
 })
 
-var IsMonitorState = isdef.Is("isState", func(path llpath.Path, v interface{}) *llresult.Results {
+var IsMonitorState = isdef.Is("isState", func(path llpath.Path, v any) *llresult.Results {
 	_, ok := v.(monitorstate.State)
 	if !ok {
 		return llresult.SimpleResult(path, false, "expected a monitorstate.State")
@@ -67,7 +67,7 @@ var IsMonitorState = isdef.Is("isState", func(path llpath.Path, v interface{}) *
 var IsMonitorStateInLocation = func(locName string) isdef.IsDef {
 	locPattern := fmt.Sprintf("^%s-[a-z0-9]+-0$", locName)
 	stateIdMatch := regexp.MustCompile(locPattern)
-	return isdef.Is("isState", func(path llpath.Path, v interface{}) *llresult.Results {
+	return isdef.Is("isState", func(path llpath.Path, v any) *llresult.Results {
 		s, ok := v.(monitorstate.State)
 		if !ok {
 			return llresult.SimpleResult(path, false, "expected a monitorstate.State")
@@ -81,7 +81,7 @@ var IsMonitorStateInLocation = func(locName string) isdef.IsDef {
 }
 
 var IsECSErr = func(expectedErr *ecserr.ECSErr) isdef.IsDef {
-	return isdef.Is("matches ECS ERR", func(path llpath.Path, v interface{}) *llresult.Results {
+	return isdef.Is("matches ECS ERR", func(path llpath.Path, v any) *llresult.Results {
 		// This conditional is a bit awkward, apparently there's a bug in lookslike where a pointer
 		// value is de-referenced, so a given *ecserr.ECSErr turns into an ecserr.ECSErr
 		var givenErr *ecserr.ECSErr
@@ -108,7 +108,7 @@ var IsECSErr = func(expectedErr *ecserr.ECSErr) isdef.IsDef {
 }
 
 var IsECSErrMatchingCode = func(ecode ecserr.ECode, messageContains string) isdef.IsDef {
-	return isdef.Is("matches ECS ERR", func(path llpath.Path, v interface{}) *llresult.Results {
+	return isdef.Is("matches ECS ERR", func(path llpath.Path, v any) *llresult.Results {
 		// This conditional is a bit awkward, apparently there's a bug in lookslike where a pointer
 		// value is de-referenced, so a given *ecserr.ECSErr turns into an ecserr.ECSErr
 		var givenErr *ecserr.ECSErr

--- a/heartbeat/hbtestllext/validators.go
+++ b/heartbeat/hbtestllext/validators.go
@@ -23,22 +23,22 @@ import (
 )
 
 // MonitorTimespanValidator is tests for the `next_run` and `next_run_in.us` keys.
-var MonitorTimespanValidator = lookslike.MustCompile(map[string]interface{}{
-	"monitor": map[string]interface{}{
-		"timespan": map[string]interface{}{
+var MonitorTimespanValidator = lookslike.MustCompile(map[string]any{
+	"monitor": map[string]any{
+		"timespan": map[string]any{
 			"gte": IsTime,
 			"lt":  IsTime,
 		},
 	},
 })
 
-var MaybeHasEventType = lookslike.MustCompile(map[string]interface{}{
-	"event": map[string]interface{}{
+var MaybeHasEventType = lookslike.MustCompile(map[string]any{
+	"event": map[string]any{
 		"type": isdef.Optional(isdef.IsNonEmptyString),
 	},
 	"synthetics.type": isdef.Optional(isdef.IsNonEmptyString),
 })
 
-var MaybeHasDuration = lookslike.MustCompile(map[string]interface{}{
+var MaybeHasDuration = lookslike.MustCompile(map[string]any{
 	"monitor.duration.us": IsInt64,
 })

--- a/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta_test.go
+++ b/heartbeat/monitors/active/dialchain/tlsmeta/tlsmeta_test.go
@@ -115,7 +115,7 @@ func TestCertFields(t *testing.T) {
 	certNotAfter, err := time.Parse(time.RFC3339, "2020-07-16T03:15:39Z")
 	require.NoError(t, err)
 
-	elasticCertFields := lookslike.Strict(lookslike.MustCompile(map[string]interface{}{
+	elasticCertFields := lookslike.Strict(lookslike.MustCompile(map[string]any{
 		"server": mapstr.M{
 			"hash": mapstr.M{
 				"sha1":   "b7b4b89ef0d0caf39d223736f0fdbb03c7b426f1",
@@ -144,7 +144,7 @@ func TestCertFields(t *testing.T) {
 	letsEncryptCert := letsEncryptCerts(t)[0]
 
 	letsEncryptCertFields := func(notBefore time.Time, notAfter time.Time) validator.Validator {
-		return lookslike.Strict(lookslike.MustCompile(map[string]interface{}{
+		return lookslike.Strict(lookslike.MustCompile(map[string]any{
 			"server": mapstr.M{
 				"hash": mapstr.M{
 					"sha1":   "98d7ca35e3608b0ee7accc9ec665babdbdc6e39c",

--- a/heartbeat/monitors/active/http/check.go
+++ b/heartbeat/monitors/active/http/check.go
@@ -139,7 +139,7 @@ func checkHeaders(headers map[string]string) respValidator {
 	}
 }
 
-func parseBody(b interface{}) (positiveMatch, negativeMatch []match.Matcher, err error) {
+func parseBody(b any) (positiveMatch, negativeMatch []match.Matcher, err error) {
 	// run through this code block if there is only string
 	if pat, ok := b.(string); ok {
 		return append(positiveMatch, match.MustCompile(pat)), negativeMatch, nil
@@ -147,7 +147,7 @@ func parseBody(b interface{}) (positiveMatch, negativeMatch []match.Matcher, err
 
 	// run through this code block if there is no positive or negative keyword in response body
 	// in this case, there's only plain body
-	if p, ok := b.([]interface{}); ok {
+	if p, ok := b.([]any); ok {
 		for _, pp := range p {
 			if pat, ok := pp.(string); ok {
 				positiveMatch = append(positiveMatch, match.MustCompile(pat))
@@ -158,12 +158,12 @@ func parseBody(b interface{}) (positiveMatch, negativeMatch []match.Matcher, err
 
 	// run through this part if there exists positive/negative keyword in response body
 	// in this case, there will be 3 possibilities: positive + negative / positive / negative
-	if m, ok := b.(map[string]interface{}); ok {
+	if m, ok := b.(map[string]any); ok {
 		for checkType, v := range m {
 			if checkType != cfgPositive && checkType != cfgNegative {
 				return positiveMatch, negativeMatch, errBodyNoValidCheckType
 			}
-			if params, ok := v.([]interface{}); ok {
+			if params, ok := v.([]any); ok {
 				for _, param := range params {
 					if pat, ok := param.(string); ok {
 						if checkType == cfgPositive {

--- a/heartbeat/monitors/active/http/check_test.go
+++ b/heartbeat/monitors/active/http/check_test.go
@@ -19,7 +19,8 @@ package http
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
+
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -180,7 +181,7 @@ func TestCheckBody(t *testing.T) {
 			for _, n := range test.negative {
 				negativePatterns = append(negativePatterns, match.MustCompile(n))
 			}
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
 			check := checkBody(positivePatterns, negativePatterns)(res, string(body))
 

--- a/heartbeat/monitors/active/http/checkjson.go
+++ b/heartbeat/monitors/active/http/checkjson.go
@@ -34,7 +34,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-type jsonChecker func(interface{}) bool
+type jsonChecker func(any) bool
 type compiledJsonCheck struct {
 	description string
 	check       jsonChecker
@@ -52,7 +52,7 @@ func checkJson(checks []*jsonResponseCheck, logger *logp.Logger) (bodyValidator,
 				return nil, fmt.Errorf("could not compile gval expression '%s': %w", check.Expression, err)
 			}
 
-			checkFn := func(d interface{}) bool {
+			checkFn := func(d any) bool {
 				matches, err := eval.EvalBool(context.Background(), d)
 				if err != nil {
 					// Conditions cannot match array root JSON responses
@@ -75,8 +75,8 @@ func checkJson(checks []*jsonResponseCheck, logger *logp.Logger) (bodyValidator,
 				return nil, fmt.Errorf("could not load JSON condition '%s': %w", check.Description, err)
 			}
 
-			checkFn := func(d interface{}) bool {
-				ms, ok := d.(map[string]interface{})
+			checkFn := func(d any) bool {
+				ms, ok := d.(map[string]any)
 				if ok {
 					return cond.Check(mapstr.M(ms))
 				} else {
@@ -116,10 +116,7 @@ func createJsonCheck(expressionChecks []compiledJsonCheck, conditionChecks []com
 		}
 
 		if len(validationFailures) > 0 {
-			bodyTrunc := len(body)
-			if bodyTrunc > 2048 {
-				bodyTrunc = 2048
-			}
+			bodyTrunc := min(len(body), 2048)
 			return fmt.Errorf(
 				"JSON body did not match %d expressions or conditions '%s'. Received JSON (first 2048 chars): %s",
 				len(validationFailures),
@@ -132,7 +129,7 @@ func createJsonCheck(expressionChecks []compiledJsonCheck, conditionChecks []com
 	}
 }
 
-func decodeJson(body string, forCondition bool) (result interface{}, err error) {
+func decodeJson(body string, forCondition bool) (result any, err error) {
 	decoder := json.NewDecoder(strings.NewReader(body))
 	// Condition checks need to convert the parsed numeric
 	// values in a way appropriate for the condition evaluator. GVal only works if
@@ -147,7 +144,7 @@ func decodeJson(body string, forCondition bool) (result interface{}, err error) 
 	}
 
 	if forCondition {
-		if resMap, ok := result.(map[string]interface{}); ok {
+		if resMap, ok := result.(map[string]any); ok {
 			jsontransform.TransformNumbers(resMap)
 			return resMap, nil
 		} else {
@@ -158,7 +155,7 @@ func decodeJson(body string, forCondition bool) (result interface{}, err error) 
 	return result, nil
 }
 
-func runCompiledJSONChecks(decodedBody interface{}, compiledChecks []compiledJsonCheck) []string {
+func runCompiledJSONChecks(decodedBody any, compiledChecks []compiledJsonCheck) []string {
 	var errorDescs []string
 	for _, compiledCheck := range compiledChecks {
 		ok := compiledCheck.check(decodedBody)

--- a/heartbeat/monitors/active/http/checkjson_test.go
+++ b/heartbeat/monitors/active/http/checkjson_test.go
@@ -19,7 +19,7 @@ package http
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -124,7 +124,7 @@ func TestCheckJsonExpression(t *testing.T) {
 			)
 
 			require.NoError(t, err)
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
 			checkRes := checker(res, string(body))
 
@@ -141,12 +141,12 @@ func TestCheckJsonExpression(t *testing.T) {
 }
 
 func TestCheckJsonCondition(t *testing.T) {
-	fooBazEqualsBar := conf.MustNewConfigFrom(map[string]interface{}{"equals": map[string]interface{}{"foo": map[string]interface{}{"baz": "bar"}}})
+	fooBazEqualsBar := conf.MustNewConfigFrom(map[string]any{"equals": map[string]any{"foo": map[string]any{"baz": "bar"}}})
 	fooBazEqualsBarConf := &conditions.Config{}
 	err := fooBazEqualsBar.Unpack(fooBazEqualsBarConf)
 	require.NoError(t, err)
 
-	fooBazEqualsBarInt := conf.MustNewConfigFrom(map[string]interface{}{"equals": map[string]interface{}{"foo": 1}})
+	fooBazEqualsBarInt := conf.MustNewConfigFrom(map[string]any{"equals": map[string]any{"foo": 1}})
 	fooBazEqualsBarIntConf := &conditions.Config{}
 	err = fooBazEqualsBarInt.Unpack(fooBazEqualsBarIntConf)
 	require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestCheckJsonCondition(t *testing.T) {
 
 			checker, err := checkJson([]*jsonResponseCheck{{Description: test.condDesc, Condition: test.condConf}}, logptest.NewTestingLogger(t, ""))
 			require.NoError(t, err)
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
 			checkRes := checker(res, string(body))
 

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -70,7 +70,7 @@ type responseParameters struct {
 	// expected HTTP response configuration
 	Status      []uint16             `config:"status"`
 	RecvHeaders map[string]string    `config:"headers"`
-	RecvBody    interface{}          `config:"body"`
+	RecvBody    any                  `config:"body"`
 	RecvJSON    []*jsonResponseCheck `config:"json"`
 }
 

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -66,8 +67,8 @@ func sendSimpleTLSRequest(t *testing.T, testURL string, useUrls bool) *beat.Even
 
 // sendTLSRequest tests the given request. certPath is optional, if given
 // an empty string no cert will be set.
-func sendTLSRequest(t *testing.T, testURL string, useUrls bool, extraConfig map[string]interface{}) *beat.Event {
-	configSrc := map[string]interface{}{
+func sendTLSRequest(t *testing.T, testURL string, useUrls bool, extraConfig map[string]any) *beat.Event {
+	configSrc := map[string]any{
 		"timeout": "1s",
 	}
 
@@ -77,9 +78,7 @@ func sendTLSRequest(t *testing.T, testURL string, useUrls bool, extraConfig map[
 		configSrc["hosts"] = testURL
 	}
 
-	for k, v := range extraConfig {
-		configSrc[k] = v
-	}
+	maps.Copy(configSrc, extraConfig)
 
 	config, err := conf.NewConfigFrom(configSrc)
 	require.NoError(t, err)
@@ -111,7 +110,7 @@ func checkServer(t *testing.T, handlerFunc http.HandlerFunc, useUrls bool) (*htt
 // tests.
 func urlChecks(urlStr string) validator.Validator {
 	u, _ := url.Parse(urlStr)
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"url": wraputil.URLFields(u),
 	})
 }
@@ -125,8 +124,8 @@ func respondingHTTPChecks(url, mimeType string, statusCode int) validator.Valida
 }
 
 func respondingHTTPStatusAndTimingChecks(statusCode int) validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
-		"http": map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
+		"http": map[string]any{
 			"response.status_code":   statusCode,
 			"rtt.content.us":         hbtestllext.IsInt64,
 			"rtt.response_header.us": hbtestllext.IsInt64,
@@ -141,8 +140,8 @@ func minimalRespondingHTTPChecks(url, mimeType string, statusCode int) validator
 	return lookslike.Compose(
 		urlChecks(url),
 		httpBodyChecks(),
-		lookslike.MustCompile(map[string]interface{}{
-			"http": map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
+			"http": map[string]any{
 				"response.mime_type":   mimeType,
 				"response.status_code": statusCode,
 				"rtt.total.us":         hbtestllext.IsInt64,
@@ -152,22 +151,22 @@ func minimalRespondingHTTPChecks(url, mimeType string, statusCode int) validator
 }
 
 func httpBodyChecks() validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"http.response.body.bytes": isdef.IsIntGt(-1),
 		"http.response.body.hash":  isdef.IsString,
 	})
 }
 
 func respondingHTTPBodyChecks(body string) validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"http.response.body.content": body,
 		"http.response.body.bytes":   len(body),
 	})
 }
 
 func respondingHTTPHeaderChecks() validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
-		"http.response.headers": map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
+		"http.response.headers": map[string]any{
 			"Date":           isdef.Optional(isdef.IsString),
 			"Content-Length": isdef.Optional(isdef.IsString),
 			"Content-Type":   isdef.Optional(isdef.IsString),
@@ -249,7 +248,6 @@ var downStatuses = []int{
 func TestUpStatuses(t *testing.T) {
 	for _, useURLs := range []bool{true, false} {
 		for _, status := range upStatuses {
-			status := status
 
 			field := "hosts"
 			if useURLs {
@@ -291,7 +289,6 @@ func TestHeadersDisabled(t *testing.T) {
 
 func TestDownStatuses(t *testing.T) {
 	for _, status := range downStatuses {
-		status := status
 		t.Run(fmt.Sprintf("test down status %d", status), func(t *testing.T) {
 			server, event := checkServer(t, hbtest.HelloWorldHandler(status), false)
 
@@ -315,7 +312,7 @@ func TestLargeResponse(t *testing.T) {
 	server := httptest.NewServer(hbtest.SizedResponseHandler(1024 * 1024))
 	defer server.Close()
 
-	configSrc := map[string]interface{}{
+	configSrc := map[string]any{
 		"hosts":               server.URL,
 		"timeout":             "1s",
 		"check.response.body": "x",
@@ -431,7 +428,7 @@ func TestJsonBody(t *testing.T) {
 				jsonCheck["condition"] = tc.condition
 			}
 
-			configSrc := map[string]interface{}{
+			configSrc := map[string]any{
 				"hosts":                 server.URL,
 				"timeout":               "1s",
 				"response.include_body": "never",
@@ -484,7 +481,7 @@ func TestJsonBody(t *testing.T) {
 func runHTTPSServerCheck(
 	t *testing.T,
 	server *httptest.Server,
-	reqExtraConfig map[string]interface{}) {
+	reqExtraConfig map[string]any) {
 
 	// Parse the cert so we can test against it.
 	cert, err := x509.ParseCertificate(server.TLS.Certificates[0].Certificate[0])
@@ -495,15 +492,13 @@ func runHTTPSServerCheck(
 	require.NoError(t, certFile.Close())
 	defer os.Remove(certFile.Name())
 
-	mergedExtraConfig := map[string]interface{}{"ssl.certificate_authorities": certFile.Name()}
-	for k, v := range reqExtraConfig {
-		mergedExtraConfig[k] = v
-	}
+	mergedExtraConfig := map[string]any{"ssl.certificate_authorities": certFile.Name()}
+	maps.Copy(mergedExtraConfig, reqExtraConfig)
 
 	// Sometimes the test server can take a while to start. Since we're only using this to test up statuses,
 	// we give it a few attempts to see if the server can come up before we run the real assertions.
 	var event *beat.Event
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		event = sendTLSRequest(t, server.URL, false, mergedExtraConfig)
 		if v, err := event.GetValue("monitor.status"); err == nil && reflect.DeepEqual(v, "up") {
 			break
@@ -513,7 +508,7 @@ func runHTTPSServerCheck(
 
 	// When connecting through a proxy, the following fields are missing.
 	if _, isProxy := reqExtraConfig["proxy_url"]; isProxy {
-		missing := map[string]interface{}{
+		missing := map[string]any{
 			"http.rtt.response_header.us": int64(0),
 			"http.rtt.content.us":         int64(0),
 			"monitor.ip":                  "127.0.0.1",
@@ -557,7 +552,7 @@ func TestExpiredHTTPSServer(t *testing.T) {
 	defer closeSrv()
 	u := &url.URL{Scheme: "https", Host: net.JoinHostPort(host, port)}
 
-	extraConfig := map[string]interface{}{"ssl.certificate_authorities": "../fixtures/expired.cert"}
+	extraConfig := map[string]any{"ssl.certificate_authorities": "../fixtures/expired.cert"}
 	event := sendTLSRequest(t, u.String(), true, extraConfig)
 
 	testslike.Test(
@@ -604,7 +599,7 @@ func TestHTTPSx509Auth(t *testing.T) {
 	runHTTPSServerCheck(
 		t,
 		server,
-		map[string]interface{}{
+		map[string]any{
 			"ssl.certificate": clientCertPath,
 			"ssl.key":         clientKeyPath,
 		},
@@ -667,7 +662,7 @@ func TestRedirect(t *testing.T) {
 	defer server.Close()
 
 	testURL := server.URL + "/redirect_one"
-	configSrc := map[string]interface{}{
+	configSrc := map[string]any{
 		"urls":                testURL,
 		"timeout":             "1s",
 		"check.response.body": expectedBody,
@@ -696,7 +691,7 @@ func TestRedirect(t *testing.T) {
 			minimalRespondingHTTPChecks(testURL, "text/plain; charset=utf-8", 200),
 			respondingHTTPHeaderChecks(),
 			hbtest.SummaryStateChecks(1, 0),
-			lookslike.MustCompile(map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
 				// For redirects that are followed we shouldn't record this header because there's no sensible
 				// value
 				"http.response.headers.Location": isdef.KeyMissing,
@@ -738,7 +733,7 @@ func TestRedirectWithTLS(t *testing.T) {
 	defer os.Remove(certFile.Name())
 
 	testURL := server.URL + "/redirect_one"
-	configSrc := map[string]interface{}{
+	configSrc := map[string]any{
 		"urls":                        testURL,
 		"timeout":                     "5s",
 		"check.response.body":         expectedBody,
@@ -770,7 +765,7 @@ func TestRedirectWithTLS(t *testing.T) {
 			// Core regression assertion: TLS certificate metadata must be
 			// present even though redirects were followed over HTTPS.
 			hbtest.TLSCertChecks(cert),
-			lookslike.MustCompile(map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
 				"tls.established":      true,
 				"tls.version":          isdef.IsString,
 				"tls.version_protocol": isdef.IsString,
@@ -793,7 +788,7 @@ func TestNoHeaders(t *testing.T) {
 	server := httptest.NewServer(hbtest.HelloWorldHandler(200))
 	defer server.Close()
 
-	configSrc := map[string]interface{}{
+	configSrc := map[string]any{
 		"urls":                     server.URL,
 		"response.include_headers": false,
 	}
@@ -819,7 +814,7 @@ func TestNoHeaders(t *testing.T) {
 			hbtest.RespondingTCPChecks(),
 			respondingHTTPStatusAndTimingChecks(200),
 			minimalRespondingHTTPChecks(server.URL, "text/plain; charset=utf-8", 200),
-			lookslike.MustCompile(map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
 				"http.response.headers": isdef.KeyMissing,
 			}),
 		)),
@@ -830,7 +825,7 @@ func TestNoHeaders(t *testing.T) {
 func TestProxy(t *testing.T) {
 	server := httptest.NewTLSServer(hbtest.HelloWorldHandler(http.StatusOK))
 	proxy := httptest.NewServer(http.HandlerFunc(httpConnectTunnel))
-	runHTTPSServerCheck(t, server, map[string]interface{}{
+	runHTTPSServerCheck(t, server, map[string]any{
 		"proxy_url": proxy.URL,
 	})
 }
@@ -838,7 +833,7 @@ func TestProxy(t *testing.T) {
 func TestTLSProxy(t *testing.T) {
 	server := httptest.NewTLSServer(hbtest.HelloWorldHandler(http.StatusOK))
 	proxy := httptest.NewTLSServer(http.HandlerFunc(httpConnectTunnel))
-	runHTTPSServerCheck(t, server, map[string]interface{}{
+	runHTTPSServerCheck(t, server, map[string]any{
 		"proxy_url": proxy.URL,
 	})
 }
@@ -913,9 +908,9 @@ func TestDecodesGzip(t *testing.T) {
 	}))
 	defer server.Close()
 
-	evt := sendTLSRequest(t, server.URL, false, map[string]interface{}{
+	evt := sendTLSRequest(t, server.URL, false, map[string]any{
 		"response.include_body": "always",
-		"check.request.headers": map[string]interface{}{"Accept-Encoding": "gzip"},
+		"check.request.headers": map[string]any{"Accept-Encoding": "gzip"},
 	})
 
 	content, err := evt.Fields.GetValue("http.response.body.content")
@@ -934,9 +929,9 @@ func TestNoGzipDecodeWithoutHeader(t *testing.T) {
 	server := httptest.NewServer(hbtest.CustomResponseHandler(gzBuffer.Bytes(), 200, map[string]string{}))
 	defer server.Close()
 
-	evt := sendTLSRequest(t, server.URL, false, map[string]interface{}{
+	evt := sendTLSRequest(t, server.URL, false, map[string]any{
 		"response.include_body": "always",
-		"check.request.headers": map[string]interface{}{"Accept-Encoding": "gzip"},
+		"check.request.headers": map[string]any{"Accept-Encoding": "gzip"},
 	})
 
 	content, err := evt.Fields.GetValue("http.response.body.content")
@@ -958,7 +953,7 @@ func TestGzipDecodeWithoutRequestHeader(t *testing.T) {
 	}))
 	defer server.Close()
 
-	evt := sendTLSRequest(t, server.URL, false, map[string]interface{}{
+	evt := sendTLSRequest(t, server.URL, false, map[string]any{
 		// no header here from Heartbeat asking the server for `gzip`
 		"response.include_body": "always",
 	})
@@ -979,7 +974,7 @@ func TestUserAgentInject(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	cfg, err := conf.NewConfigFrom(map[string]interface{}{
+	cfg, err := conf.NewConfigFrom(map[string]any{
 		"urls": ts.URL,
 	})
 	require.NoError(t, err)

--- a/heartbeat/monitors/active/http/respbody.go
+++ b/heartbeat/monitors/active/http/respbody.go
@@ -75,13 +75,7 @@ func processBody(resp *http.Response, config responseConfig, validator multiVali
 
 		// Do not store more bytes than the config specifies. We may
 		// have read extra bytes for the validators
-		sampleNumBytes := len(respBody)
-		if bodyLenBytes < sampleNumBytes {
-			sampleNumBytes = bodyLenBytes
-		}
-		if config.IncludeBodyMaxBytes < sampleNumBytes {
-			sampleNumBytes = config.IncludeBodyMaxBytes
-		}
+		sampleNumBytes := min(config.IncludeBodyMaxBytes, min(bodyLenBytes, len(respBody)))
 
 		bodyFields["content"] = respBody[0:sampleNumBytes]
 	}

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -21,7 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -131,7 +131,7 @@ func Test_handleRespBody(t *testing.T) {
 				t.Errorf("invalid mime type - got: '%v' - want: '%v'", mimeType, tt.args.mimeType)
 			}
 
-			bodyMatch := map[string]interface{}{
+			bodyMatch := map[string]any{
 				"hash":  "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
 				"bytes": 5,
 			}
@@ -233,7 +233,7 @@ func Test_readPrefixAndHash(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rc := ioutil.NopCloser(strings.NewReader(tt.body))
+			rc := io.NopCloser(strings.NewReader(tt.body))
 			gotRespSize, gotPrefix, gotHashStr, err := readPrefixAndHash(rc, tt.len)
 
 			if tt.err {
@@ -256,5 +256,5 @@ func Test_readPrefixAndHash(t *testing.T) {
 }
 
 func simpleHTTPResponse() *http.Response {
-	return &http.Response{Body: ioutil.NopCloser(strings.NewReader("hello"))}
+	return &http.Response{Body: io.NopCloser(strings.NewReader("hello"))}
 }

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -23,7 +23,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
+
 	"net"
 	"net/http"
 	"net/url"
@@ -314,7 +315,7 @@ func execPing(
 func attachRequestBody(ctx *context.Context, req *http.Request, body []byte) *http.Request {
 	req = req.WithContext(*ctx)
 	if len(body) > 0 {
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
 		req.ContentLength = int64(len(body))
 	}
 

--- a/heartbeat/monitors/active/http/task_test.go
+++ b/heartbeat/monitors/active/http/task_test.go
@@ -146,7 +146,7 @@ func TestNonZeroRedirect(t *testing.T) {
 
 	var via []*http.Request
 	// Test requests within the limit
-	for i := 0; i < limit; i++ {
+	for range limit {
 		req := makeTestHTTPRequest(t)
 		assert.Nil(t, checker(req, via))
 		via = append(via, req)

--- a/heartbeat/monitors/active/icmp/icmp_test.go
+++ b/heartbeat/monitors/active/icmp/icmp_test.go
@@ -55,7 +55,7 @@ func TestICMPFields(t *testing.T) {
 			hbtest.SummaryStateChecks(1, 0),
 			hbtest.URLChecks(t, hostURL),
 			hbtest.ResolveChecks(ip),
-			lookslike.MustCompile(map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
 				"icmp.requests": 1,
 				"icmp.rtt":      look.RTT(testMockLoop.pingRtt),
 			}),

--- a/heartbeat/monitors/active/tcp/socks5_test.go
+++ b/heartbeat/monitors/active/tcp/socks5_test.go
@@ -80,11 +80,11 @@ func TestSocks5Job(t *testing.T) {
 					hbtest.SimpleURLChecks(t, "tcp", host, port),
 					hbtest.SummaryStateChecks(1, 0),
 					hbtest.ResolveChecks(ip),
-					lookslike.MustCompile(map[string]interface{}{
-						"tcp": map[string]interface{}{
+					lookslike.MustCompile(map[string]any{
+						"tcp": map[string]any{
 							"rtt.validate.us": hbtestllext.IsInt64,
 						},
-						"socks5": map[string]interface{}{
+						"socks5": map[string]any{
 							"rtt.connect.us": hbtestllext.IsInt64,
 						},
 					}),
@@ -120,13 +120,11 @@ func startSocks5Server(t *testing.T) (host string, port uint16, ip string, close
 	}
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		if err := server.Serve(listener); err != nil {
 			debugf("Error in SOCKS5 Test Server %v", err)
 		}
-		wg.Done()
-	}()
+	})
 
 	return host, uint16(portUint64), ip, func() error {
 		err := listener.Close()

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -182,8 +182,8 @@ func TestCheckUp(t *testing.T) {
 			hbtest.SimpleURLChecks(t, "tcp", host, port),
 			hbtest.SummaryStateChecks(1, 0),
 			hbtest.ResolveChecks(ip),
-			lookslike.MustCompile(map[string]interface{}{
-				"tcp": map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
+				"tcp": map[string]any{
 					"rtt.validate.us": hbtestllext.IsInt64,
 				},
 			}),
@@ -214,11 +214,11 @@ func TestCheckDown(t *testing.T) {
 			hbtest.SimpleURLChecks(t, "tcp", host, port),
 			hbtest.SummaryStateChecks(0, 1),
 			hbtest.ResolveChecks(ip),
-			lookslike.MustCompile(map[string]interface{}{
-				"tcp": map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
+				"tcp": map[string]any{
 					"rtt.validate.us": hbtestllext.IsInt64,
 				},
-				"error": map[string]interface{}{
+				"error": map[string]any{
 					"type":    "validate",
 					"message": "received string mismatch",
 				},

--- a/heartbeat/monitors/active/tcp/tls_test.go
+++ b/heartbeat/monitors/active/tcp/tls_test.go
@@ -107,8 +107,8 @@ func TestTLSInvalidCert(t *testing.T) {
 			hbtest.SummaryStateChecks(0, 1),
 			hbtest.SimpleURLChecks(t, "ssl", mismatchedHostname, port),
 			hbtest.ResolveChecks(ip),
-			lookslike.MustCompile(map[string]interface{}{
-				"error": map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
+				"error": map[string]any{
 					"message": x509.HostnameError{Certificate: cert, Host: mismatchedHostname}.Error(),
 					"type":    "io",
 				},

--- a/heartbeat/monitors/factory_test.go
+++ b/heartbeat/monitors/factory_test.go
@@ -177,8 +177,8 @@ func TestPreProcessors(t *testing.T) {
 			} else {
 				t.Run("observer location data should be set", func(t *testing.T) {
 					geoM, _ := util.GeoConfigToMap(tt.location.Geo)
-					lookslike.MustCompile(map[string]interface{}{
-						"observer": map[string]interface{}{
+					lookslike.MustCompile(map[string]any{
+						"observer": map[string]any{
 							"name": tt.location.ID,
 							"geo":  geoM,
 						},
@@ -212,14 +212,14 @@ func TestPreProcessors(t *testing.T) {
 }
 
 func TestDisabledMonitor(t *testing.T) {
-	testConfigs := []map[string]interface{}{
+	testConfigs := []map[string]any{
 		{
 			"type":     "test",
 			"enabled":  "false",
 			"schedule": "@every 10s",
 		},
 		{
-			"streams": []map[string]interface{}{
+			"streams": []map[string]any{
 				{
 					"type":     "test",
 					"enabled":  "false",
@@ -264,7 +264,7 @@ func TestRunFrom(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		confMap := map[string]interface{}{
+		confMap := map[string]any{
 			"type":     "test",
 			"urls":     []string{"http://example.net"},
 			"schedule": "@every 1ms",
@@ -273,7 +273,7 @@ func TestRunFrom(t *testing.T) {
 		if tt.loc != nil {
 			geo, err := util.GeoConfigToMap(tt.loc.Geo)
 			require.NoError(t, err)
-			confMap["run_from"] = map[string]interface{}{
+			confMap["run_from"] = map[string]any{
 				"id":  tt.loc.ID,
 				"geo": geo,
 			}

--- a/heartbeat/monitors/jobs/job_test.go
+++ b/heartbeat/monitors/jobs/job_test.go
@@ -64,7 +64,7 @@ func TestWrapAll(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         args
-		resultFields []map[string]interface{}
+		resultFields []map[string]any
 	}{
 		{
 			"simple",
@@ -72,7 +72,7 @@ func TestWrapAll(t *testing.T) {
 				[]Job{basicJob},
 				[]JobWrapper{addFoo},
 			},
-			[]map[string]interface{}{{"basic": "job", "foo": "bar"}},
+			[]map[string]any{{"basic": "job", "foo": "bar"}},
 		},
 		{
 			"multijob",
@@ -80,7 +80,7 @@ func TestWrapAll(t *testing.T) {
 				[]Job{basicJob, basicJob},
 				[]JobWrapper{addFoo},
 			},
-			[]map[string]interface{}{
+			[]map[string]any{
 				{"basic": "job", "foo": "bar"},
 				{"basic": "job", "foo": "bar"},
 			},
@@ -91,7 +91,7 @@ func TestWrapAll(t *testing.T) {
 				[]Job{contJob},
 				[]JobWrapper{addFoo},
 			},
-			[]map[string]interface{}{
+			[]map[string]any{
 				{"cont": "job", "foo": "bar"},
 				{"basic": "job", "foo": "bar"},
 			},
@@ -102,7 +102,7 @@ func TestWrapAll(t *testing.T) {
 				[]Job{contJob},
 				[]JobWrapper{addFoo, addBaz},
 			},
-			[]map[string]interface{}{
+			[]map[string]any{
 				{"cont": "job", "foo": "bar", "baz": "bot"},
 				{"basic": "job", "foo": "bar", "baz": "bot"},
 			},

--- a/heartbeat/monitors/logger/logger_test.go
+++ b/heartbeat/monitors/logger/logger_test.go
@@ -18,6 +18,7 @@
 package logger
 
 import (
+	"maps"
 	"testing"
 	"time"
 
@@ -108,9 +109,7 @@ func TestLogRun(t *testing.T) {
 		}
 		networkInfo := generateFakeNetworkInfo()
 		// Add network info to the event
-		for key, value := range networkInfo {
-			fields[key] = value
-		}
+		maps.Copy(fields, networkInfo)
 
 		event := beat.Event{Fields: fields}
 		eventext.SetMeta(&event, META_STEP_COUNT, steps)

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -191,8 +191,8 @@ func baseMockEventMonitorValidator(id string, name string, status string) valida
 	} else {
 		idMatcher = isdef.IsEqual(id)
 	}
-	return lookslike.MustCompile(map[string]interface{}{
-		"monitor": map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
+		"monitor": map[string]any{
 			"id":          idMatcher,
 			"name":        name,
 			"type":        "test",
@@ -213,7 +213,7 @@ func mockEventMonitorValidator(id string, name string) validator.Validator {
 	))
 }
 
-func mockEventCustomFields() map[string]interface{} {
+func mockEventCustomFields() map[string]any {
 	return mapstr.M{"foo": "bar"}
 }
 
@@ -270,7 +270,7 @@ func mockPluginsReg() (p *plugin.PluginsReg, built *atomic.Int64, closed *atomic
 }
 
 func mockPluginConf(t *testing.T, id string, name string, schedule string, url string) *config.C {
-	confMap := map[string]interface{}{
+	confMap := map[string]any{
 		"type":     "test",
 		"urls":     []string{url},
 		"schedule": schedule,
@@ -291,7 +291,7 @@ func mockPluginConf(t *testing.T, id string, name string, schedule string, url s
 // mockBadPluginConf returns a conf with an invalid plugin config.
 // This should fail after the generic plugin checks fail since the HTTP plugin requires 'urls' to be set.
 func mockBadPluginConf(t *testing.T, id string) *config.C {
-	confMap := map[string]interface{}{
+	confMap := map[string]any{
 		"type":        "test",
 		"notanoption": []string{"foo"},
 	}
@@ -307,7 +307,7 @@ func mockBadPluginConf(t *testing.T, id string) *config.C {
 }
 
 func mockInvalidPluginConf(t *testing.T) *config.C {
-	confMap := map[string]interface{}{
+	confMap := map[string]any{
 		"hoeutnheou": "oueanthoue",
 	}
 
@@ -318,7 +318,7 @@ func mockInvalidPluginConf(t *testing.T) *config.C {
 }
 
 func mockInvalidPluginConfWithStdFields(t *testing.T, id string, name string, schedule string) *config.C {
-	confMap := map[string]interface{}{
+	confMap := map[string]any{
 		"type":     "test",
 		"id":       id,
 		"name":     name,

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -210,7 +210,7 @@ func newMonitorUnsafe(
 }
 
 func (m *Monitor) configHash() (uint64, error) {
-	unpacked := map[string]interface{}{}
+	unpacked := map[string]any{}
 	err := m.config.Unpack(unpacked)
 	if err != nil {
 		return 0, err

--- a/heartbeat/monitors/monitor_test.go
+++ b/heartbeat/monitors/monitor_test.go
@@ -146,7 +146,7 @@ func (sr *MockStatusReporter) UpdateStatus(status status.Status, msg string) {
 }
 
 func TestStatusReporter(t *testing.T) {
-	confMap := map[string]interface{}{
+	confMap := map[string]any{
 		"type":     "fail",
 		"urls":     []string{"http://example.net"},
 		"schedule": "@every 1ms",

--- a/heartbeat/monitors/stdfields/unnest.go
+++ b/heartbeat/monitors/stdfields/unnest.go
@@ -43,7 +43,7 @@ type BaseStream struct {
 // UnnestStream detects configs that come from fleet and transforms the config into something compatible
 // with heartbeat, by mixing some fields (id, data_stream) with those from the first stream. It assumes
 // that there is exactly one stream associated with the input.
-func UnnestStream(config *conf.C, processors ...interface{}) (res *conf.C, err error) {
+func UnnestStream(config *conf.C, processors ...any) (res *conf.C, err error) {
 	optS := &OptionalStream{}
 	err = config.Unpack(optS)
 	if err != nil {

--- a/heartbeat/monitors/task_test.go
+++ b/heartbeat/monitors/task_test.go
@@ -53,7 +53,7 @@ func Test_runPublishJob(t *testing.T) {
 			"simple",
 			simpleJob,
 			[]validator.Validator{
-				lookslike.MustCompile(map[string]interface{}{"foo": "bar"}),
+				lookslike.MustCompile(map[string]any{"foo": "bar"}),
 			},
 		},
 		{
@@ -63,8 +63,8 @@ func Test_runPublishJob(t *testing.T) {
 				return []jobs.Job{simpleJob}, nil
 			},
 			[]validator.Validator{
-				lookslike.MustCompile(map[string]interface{}{"foo": "bar"}),
-				lookslike.MustCompile(map[string]interface{}{"foo": "bar"}),
+				lookslike.MustCompile(map[string]any{"foo": "bar"}),
+				lookslike.MustCompile(map[string]any{"foo": "bar"}),
 			},
 		},
 		{
@@ -77,9 +77,9 @@ func Test_runPublishJob(t *testing.T) {
 				}, nil
 			},
 			[]validator.Validator{
-				lookslike.MustCompile(map[string]interface{}{"foo": "bar"}),
-				lookslike.MustCompile(map[string]interface{}{"baz": "bot"}),
-				lookslike.MustCompile(map[string]interface{}{"blah": "blargh"}),
+				lookslike.MustCompile(map[string]any{"foo": "bar"}),
+				lookslike.MustCompile(map[string]any{"baz": "bot"}),
+				lookslike.MustCompile(map[string]any{"blah": "blargh"}),
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func Test_runPublishJob(t *testing.T) {
 				return []jobs.Job{simpleJob}, nil
 			},
 			[]validator.Validator{
-				lookslike.MustCompile(map[string]interface{}{"foo": "bar"}),
+				lookslike.MustCompile(map[string]any{"foo": "bar"}),
 			},
 		},
 	}

--- a/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
@@ -49,7 +49,7 @@ func TestStatesESLoader(t *testing.T) {
 	// Create three monitors in ES, load their states, and make sure we track them correctly
 	// We create a few to make sure the query isolates the monitors correctly
 	// and alternate between testing monitors that start up or down
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		testStatus := StatusUp
 		if i%2 == 1 {
 			testStatus = StatusDown
@@ -64,7 +64,7 @@ func TestStatesESLoader(t *testing.T) {
 		// Write the state a few times, enough to guarantee a stable state
 		count := FlappingThreshold * 2
 		var lastId string
-		for i := 0; i < count; i++ {
+		for i := range count {
 			ms = etc.tracker.RecordStatus(monID, testStatus, true)
 			if i == 0 {
 				lastId = ms.ID
@@ -82,7 +82,7 @@ func TestStatesESLoader(t *testing.T) {
 		}
 
 		origMsId := ms.ID
-		for i := 0; i < count; i++ {
+		for i := range count {
 			ms = etc.tracker.RecordStatus(monID, testStatus, true)
 			require.NotEqual(t, origMsId, ms.ID)
 			if i == 0 {

--- a/heartbeat/monitors/wrappers/monitorstate/monitorstate_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/monitorstate_test.go
@@ -60,7 +60,7 @@ func TestDuration(t *testing.T) {
 
 // recordFlappingSeries is a helper that should always put the monitor into a flapping state.
 func recordFlappingSeries(TestSf stdfields.StdMonitorFields, ms *State) {
-	for i := 0; i < FlappingThreshold; i++ {
+	for i := range FlappingThreshold {
 		if i%2 == 0 {
 			ms.recordCheck(TestSf, StatusUp, true)
 		} else {
@@ -71,7 +71,7 @@ func recordFlappingSeries(TestSf stdfields.StdMonitorFields, ms *State) {
 
 // recordStableSeries is a test helper for repeatedly recording one status
 func recordStableSeries(TestSf stdfields.StdMonitorFields, ms *State, count int, s StateStatus) {
-	for i := 0; i < count; i++ {
+	for range count {
 		ms.recordCheck(TestSf, s, true)
 	}
 }

--- a/heartbeat/monitors/wrappers/monitorstate/tracker_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker_test.go
@@ -34,7 +34,7 @@ func TestTrackerRecord(t *testing.T) {
 	require.Equal(t, StatusUp, ms.Status)
 	requireMSStatusCount(t, ms, StatusUp, 1)
 
-	for i := 0; i < FlappingThreshold; i++ {
+	for range FlappingThreshold {
 		_ = mst.RecordStatus(TestSf, StatusDown, true)
 		ms = mst.RecordStatus(TestSf, StatusUp, true)
 	}
@@ -42,7 +42,7 @@ func TestTrackerRecord(t *testing.T) {
 	requireMSCounts(t, ms, FlappingThreshold+1, FlappingThreshold)
 
 	// Restore stable state
-	for i := 0; i < FlappingThreshold; i++ {
+	for range FlappingThreshold {
 		_ = mst.RecordStatus(TestSf, StatusDown, true)
 	}
 
@@ -57,7 +57,7 @@ func TestTrackerRecordFlappingDisabled(t *testing.T) {
 	require.Equal(t, StatusUp, ms.Status)
 	requireMSStatusCount(t, ms, StatusUp, 1)
 
-	for i := 0; i < FlappingThreshold; i++ {
+	for range FlappingThreshold {
 		_ = mst.RecordStatus(TestSf, StatusDown, true)
 		ms = mst.RecordStatus(TestSf, StatusUp, true)
 	}

--- a/heartbeat/monitors/wrappers/summarizer/plugerr.go
+++ b/heartbeat/monitors/wrappers/summarizer/plugerr.go
@@ -33,7 +33,7 @@ import (
 // for browser monitors, preferentially using the journey/end event's
 // error field for errors.
 type BrowserErrPlugin struct {
-	summaryErrVal  interface{}
+	summaryErrVal  any
 	summaryErr     error
 	stepCount      int
 	journeyEndRcvd bool
@@ -134,7 +134,7 @@ func (esp *LightweightErrPlugin) BeforeEachEvent(event *beat.Event) {
 }
 
 // errToFieldVal reflects on the error and returns either an *ecserr.ECSErr if possible, and a look.Reason otherwise
-func errToFieldVal(eventErr error) (errVal interface{}) {
+func errToFieldVal(eventErr error) (errVal any) {
 	var asECS *ecserr.ECSErr
 	if errors.As(eventErr, &asECS) {
 		// Override the message of the error in the event it was wrapped
@@ -146,6 +146,6 @@ func errToFieldVal(eventErr error) (errVal interface{}) {
 	return errVal
 }
 
-func mergeErrVal(event *beat.Event, errVal interface{}) {
+func mergeErrVal(event *beat.Event, errVal any) {
 	eventext.MergeEventFields(event, mapstr.M{"error": errVal})
 }

--- a/heartbeat/monitors/wrappers/summarizer/summarizer_test.go
+++ b/heartbeat/monitors/wrappers/summarizer/summarizer_test.go
@@ -19,6 +19,7 @@ package summarizer
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -126,7 +127,6 @@ func TestSummarizer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dummyErr := fmt.Errorf("dummyerr")
@@ -153,9 +153,9 @@ func TestSummarizer(t *testing.T) {
 			tracker := monitorstate.NewTracker(monitorstate.NilStateLoader, false, logptest.NewTestingLogger(t, ""))
 			sf := stdfields.StdMonitorFields{ID: "testmon", Name: "testmon", Type: "http", MaxAttempts: uint16(tt.maxAttempts)}
 
-			rcvdStatuses := ""
-			rcvdStates := ""
-			rcvdAttempts := ""
+			var rcvdStatuses strings.Builder
+			var rcvdStates strings.Builder
+			var rcvdAttempts strings.Builder
 			rcvdEvents := []*beat.Event{}
 			rcvdSummaries := []*jobsummary.JobSummary{}
 			i := 0
@@ -170,12 +170,12 @@ func TestSummarizer(t *testing.T) {
 					rcvdEvents = append(rcvdEvents, event)
 					eventStatus, _ := event.GetValue("monitor.status")
 					eventStatusStr := eventStatus.(string)
-					rcvdStatuses += eventStatusStr[:1]
+					rcvdStatuses.WriteString(eventStatusStr[:1])
 					state, _ := event.GetValue("state")
 					if state != nil {
-						rcvdStates += string(state.(*monitorstate.State).Status)[:1]
+						rcvdStates.WriteString(string(state.(*monitorstate.State).Status)[:1])
 					} else {
-						rcvdStates += "_"
+						rcvdStates.WriteString("_")
 					}
 					summaryIface, _ := event.GetValue("summary")
 					summary := summaryIface.(*jobsummary.JobSummary)
@@ -197,7 +197,7 @@ func TestSummarizer(t *testing.T) {
 
 					if summary == nil {
 						// note missing summaries
-						rcvdAttempts += "!"
+						rcvdAttempts.WriteString("!")
 					} else if lastSummary != nil {
 						if summary.Attempt > 1 {
 							require.Equal(t, lastSummary.RetryGroup, summary.RetryGroup)
@@ -206,7 +206,7 @@ func TestSummarizer(t *testing.T) {
 						}
 					}
 
-					rcvdAttempts += fmt.Sprintf("%d", summary.Attempt)
+					rcvdAttempts.WriteString(fmt.Sprintf("%d", summary.Attempt))
 					lastSummary = summary
 				}
 				i += len(events)
@@ -214,9 +214,9 @@ func TestSummarizer(t *testing.T) {
 					break
 				}
 			}
-			require.Equal(t, tt.statusSequence, rcvdStatuses)
-			require.Equal(t, tt.expectedStates, rcvdStates)
-			require.Equal(t, tt.expectedAttempts, rcvdAttempts)
+			require.Equal(t, tt.statusSequence, rcvdStatuses.String())
+			require.Equal(t, tt.expectedStates, rcvdStates.String())
+			require.Equal(t, tt.expectedAttempts, rcvdAttempts.String())
 			require.Len(t, rcvdEvents, len(tt.statusSequence))
 			require.Len(t, rcvdSummaries, tt.expectedSummaries)
 		})
@@ -248,7 +248,6 @@ func TestSummarizerPluginOrder(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -362,7 +361,7 @@ func TestRetryLightweightMonitorDuration(t *testing.T) {
 
 	retryElapsed := time.Since(retryStart)
 	require.False(t, retryStart.IsZero())
-	var rcvdDuration interface{}
+	var rcvdDuration any
 	for _, event := range events {
 		summaryIface, _ := event.GetValue("summary")
 		summary := summaryIface.(*jobsummary.JobSummary)

--- a/heartbeat/monitors/wrappers/summarizer/summarizertesthelper/testhelper.go
+++ b/heartbeat/monitors/wrappers/summarizer/summarizertesthelper/testhelper.go
@@ -34,14 +34,14 @@ import (
 // This duplicates hbtest.SummaryChecks to avoid an import cycle.
 // It could be refactored out, but it just isn't worth it.
 func SummaryValidator(up uint16, down uint16) validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"summary":             summaryIsdef(up, down),
 		"monitor.duration.us": hbtestllext.IsInt64,
 	})
 }
 
 func summaryIsdef(up uint16, down uint16) isdef.IsDef {
-	return isdef.Is("summary", func(path llpath.Path, v interface{}) *llresult.Results {
+	return isdef.Is("summary", func(path llpath.Path, v any) *llresult.Results {
 		js, ok := v.(jobsummary.JobSummary)
 		if !ok {
 			return llresult.SimpleResult(path, false, "expected a *jobsummary.JobSummary, got %v", v)

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -112,8 +112,8 @@ func TestSimpleJob(t *testing.T) {
 		[]validator.Validator{
 			lookslike.Compose(
 				urlValidator(t, "tcp://foo.com:80"),
-				lookslike.MustCompile(map[string]interface{}{
-					"monitor": map[string]interface{}{
+				lookslike.MustCompile(map[string]any{
+					"monitor": map[string]any{
 						"duration.us": hbtestllext.IsInt64,
 						"id":          testMonFields.ID,
 						"name":        testMonFields.Name,
@@ -164,8 +164,8 @@ func TestAdditionalStdFields(t *testing.T) {
 				f.Service.Name = "mysvc"
 				return f
 			},
-			lookslike.MustCompile(map[string]interface{}{
-				"service": map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
+				"service": map[string]any{
 					"name": "mysvc",
 				},
 			}),
@@ -177,8 +177,8 @@ func TestAdditionalStdFields(t *testing.T) {
 				f.Origin = "ui"
 				return f
 			},
-			lookslike.MustCompile(map[string]interface{}{
-				"monitor": map[string]interface{}{"origin": "ui"},
+			lookslike.MustCompile(map[string]any{
+				"monitor": map[string]any{"origin": "ui"},
 			}),
 		},
 	}
@@ -193,8 +193,8 @@ func TestAdditionalStdFields(t *testing.T) {
 					lookslike.Compose(
 						tt.validator,
 						urlValidator(t, "tcp://foo.com:80"),
-						lookslike.MustCompile(map[string]interface{}{
-							"monitor": map[string]interface{}{
+						lookslike.MustCompile(map[string]any{
+							"monitor": map[string]any{
 								"duration.us": hbtestllext.IsInt64,
 								"id":          testMonFields.ID,
 								"name":        testMonFields.Name,
@@ -224,9 +224,9 @@ func TestErrorJob(t *testing.T) {
 	errorJobValidator := lookslike.Compose(
 		stateValidator(),
 		hbtestllext.MaybeHasEventType,
-		lookslike.MustCompile(map[string]interface{}{"error": map[string]interface{}{"message": "myerror", "type": "io"}}),
-		lookslike.MustCompile(map[string]interface{}{
-			"monitor": map[string]interface{}{
+		lookslike.MustCompile(map[string]any{"error": map[string]any{"message": "myerror", "type": "io"}}),
+		lookslike.MustCompile(map[string]any{
+			"monitor": map[string]any{
 				"duration.us": hbtestllext.IsInt64,
 				"id":          testMonFields.ID,
 				"name":        testMonFields.Name,
@@ -258,8 +258,8 @@ func TestMultiJobNoConts(t *testing.T) {
 	validatorMaker := func(u string) validator.Validator {
 		return lookslike.Compose(
 			urlValidator(t, u),
-			lookslike.MustCompile(map[string]interface{}{
-				"monitor": map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
+				"monitor": map[string]any{
 					"duration.us": hbtestllext.IsInt64,
 					"id":          uniqScope.IsUniqueTo("id"),
 					"name":        testMonFields.Name,
@@ -307,10 +307,10 @@ func TestMultiJobConts(t *testing.T) {
 	contJobValidator := func(u string, msg string) validator.Validator {
 		return lookslike.Compose(
 			urlValidator(t, u),
-			lookslike.MustCompile(map[string]interface{}{"cont": msg}),
+			lookslike.MustCompile(map[string]any{"cont": msg}),
 			hbtestllext.MaybeHasEventType,
-			lookslike.MustCompile(map[string]interface{}{
-				"monitor": map[string]interface{}{
+			lookslike.MustCompile(map[string]any{
+				"monitor": map[string]any{
 					"duration.us": isdef.Optional(hbtestllext.IsInt64),
 					"id":          uniqScope.IsUniqueTo(u),
 					"name":        testMonFields.Name,
@@ -372,9 +372,9 @@ func TestMultiJobContsCancelledEvents(t *testing.T) {
 		return lookslike.Compose(
 			urlValidator(t, u),
 			hbtestllext.MaybeHasEventType,
-			lookslike.MustCompile(map[string]interface{}{"cont": msg}),
-			lookslike.MustCompile(map[string]interface{}{
-				"monitor": map[string]interface{}{
+			lookslike.MustCompile(map[string]any{"cont": msg}),
+			lookslike.MustCompile(map[string]any{
+				"monitor": map[string]any{
 					"id":          uniqScope.IsUniqueTo(u),
 					"name":        testMonFields.Name,
 					"type":        testMonFields.Type,
@@ -387,7 +387,7 @@ func TestMultiJobContsCancelledEvents(t *testing.T) {
 		)
 	}
 
-	metaCancelledValidator := lookslike.MustCompile(map[string]interface{}{eventext.EventCancelledMetaKey: true})
+	metaCancelledValidator := lookslike.MustCompile(map[string]any{eventext.EventCancelledMetaKey: true})
 	testCommonWrap(t, testDef{
 		"multi-job-continuations",
 		testMonFields,
@@ -432,11 +432,11 @@ func makeURLJob(t *testing.T, u string) jobs.Job {
 func urlValidator(t *testing.T, u string) validator.Validator {
 	parsed, err := url.Parse(u)
 	require.NoError(t, err)
-	return lookslike.MustCompile(map[string]interface{}{"url": map[string]interface{}(wraputil.URLFields(parsed))})
+	return lookslike.MustCompile(map[string]any{"url": map[string]any(wraputil.URLFields(parsed))})
 }
 
 func stateValidator() validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{
+	return lookslike.MustCompile(map[string]any{
 		"state": hbtestllext.IsMonitorState,
 	})
 }
@@ -523,9 +523,9 @@ func TestInlineBrowserJob(t *testing.T) {
 				lookslike.Compose(
 					hbtestllext.MaybeHasEventType,
 					urlValidator(t, "http://foo.com"),
-					lookslike.MustCompile(map[string]interface{}{
+					lookslike.MustCompile(map[string]any{
 						"state": isdef.Optional(hbtestllext.IsMonitorState),
-						"monitor": map[string]interface{}{
+						"monitor": map[string]any{
 							"type":        "browser",
 							"id":          inlineMonitorValues.id,
 							"name":        inlineMonitorValues.name,
@@ -607,9 +607,9 @@ func TestProjectBrowserJob(t *testing.T) {
 
 	expectedMonFields := lookslike.Compose(
 		hbtestllext.MaybeHasDuration,
-		lookslike.MustCompile(map[string]interface{}{
+		lookslike.MustCompile(map[string]any{
 			"state": isdef.Optional(hbtestllext.IsMonitorState),
-			"monitor": map[string]interface{}{
+			"monitor": map[string]any{
 				"type":        "browser",
 				"id":          projectMonitorValues.id,
 				"name":        projectMonitorValues.name,
@@ -651,9 +651,9 @@ func TestProjectBrowserJob(t *testing.T) {
 					expectedMonFields,
 					hbtestllext.MaybeHasEventType,
 					summarizertesthelper.SummaryValidator(1, 0),
-					lookslike.MustCompile(map[string]interface{}{
-						"monitor": map[string]interface{}{"status": "up"},
-						"event": map[string]interface{}{
+					lookslike.MustCompile(map[string]any{
+						"monitor": map[string]any{"status": "up"},
+						"event": map[string]any{
 							"type": "heartbeat/summary",
 						},
 					}),
@@ -673,13 +673,13 @@ func TestProjectBrowserJob(t *testing.T) {
 					expectedMonFields,
 					hbtestllext.MaybeHasEventType,
 					summarizertesthelper.SummaryValidator(0, 1),
-					lookslike.MustCompile(map[string]interface{}{
-						"monitor": map[string]interface{}{"status": "down"},
-						"error": map[string]interface{}{
+					lookslike.MustCompile(map[string]any{
+						"monitor": map[string]any{"status": "down"},
+						"error": map[string]any{
 							"type":    isdef.IsString,
 							"message": "testerr",
 						},
-						"event": map[string]interface{}{
+						"event": map[string]any{
 							"type": "heartbeat/summary",
 						},
 					}),

--- a/heartbeat/monitors/wrappers/wraputil/util_test.go
+++ b/heartbeat/monitors/wrappers/wraputil/util_test.go
@@ -85,7 +85,7 @@ func TestURLFields(t *testing.T) {
 			require.NoError(t, err)
 
 			got := URLFields(parsed)
-			testslike.Test(t, lookslike.MustCompile(map[string]interface{}(tt.want)), got)
+			testslike.Test(t, lookslike.MustCompile(map[string]any(tt.want)), got)
 		})
 	}
 }

--- a/heartbeat/reload/list.go
+++ b/heartbeat/reload/list.go
@@ -20,6 +20,7 @@ package reload
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/elastic/beats/v7/heartbeat/monitors"
@@ -281,7 +282,7 @@ func (r *HBRunnerList) HashConfig(c *config.C) (uint64, error) {
 }
 
 func DefaultHashConfig(c *config.C) (uint64, error) {
-	var config map[string]interface{}
+	var config map[string]any
 	if err := c.Unpack(&config); err != nil {
 		return 0, err
 	}
@@ -291,9 +292,7 @@ func DefaultHashConfig(c *config.C) (uint64, error) {
 
 func (r *HBRunnerList) copyRunnerList() map[uint64]cfgfile.Runner {
 	list := make(map[uint64]cfgfile.Runner, len(r.runners))
-	for k, v := range r.runners {
-		list[k] = v
-	}
+	maps.Copy(list, r.runners)
 	return list
 }
 

--- a/heartbeat/scheduler/scheduler_test.go
+++ b/heartbeat/scheduler/scheduler_test.go
@@ -293,7 +293,7 @@ func BenchmarkScheduler(b *testing.B) {
 	mainWins := []maintwin.ParsedMaintWin{mainWin}
 
 	executed := make(chan struct{})
-	for i := 0; i < 1024; i++ {
+	for range 1024 {
 		_, err := s.Add(sched, mainWins, "testPostStop", func(_ context.Context) []TaskFunc {
 			executed <- struct{}{}
 			return nil

--- a/heartbeat/scheduler/timerqueue/heap.go
+++ b/heartbeat/scheduler/timerqueue/heap.go
@@ -33,12 +33,12 @@ func (th timerHeap) Swap(i, j int) {
 }
 
 // Push adds a new timerTask to the heap
-func (th *timerHeap) Push(tt interface{}) {
+func (th *timerHeap) Push(tt any) {
 	*th = append(*th, tt.(*timerTask))
 }
 
 // Pop returns the timerTask scheduled soonest.
-func (th *timerHeap) Pop() interface{} {
+func (th *timerHeap) Pop() any {
 	old := *th
 	n := len(old)
 	tt := old[n-1]

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -35,7 +35,7 @@ func TestRunsInOrder(t *testing.T) {
 
 // TestStress tries to figure out if we have any deadlocks that show up under concurrency
 func TestStress(t *testing.T) {
-	for i := 0; i < 120000; i++ {
+	for range 120000 {
 		failed := make(chan bool)
 		succeeded := make(chan bool)
 
@@ -110,8 +110,7 @@ Reader:
 }
 
 func TestQueueRunsTasksAddedAfterStart(t *testing.T) {
-	ctx, ctxCancel := context.WithCancel(context.Background())
-	defer ctxCancel()
+	ctx := t.Context()
 	tq := NewTimerQueue(ctx)
 
 	tq.Start()

--- a/heartbeat/scripts/mage/config.go
+++ b/heartbeat/scripts/mage/config.go
@@ -26,7 +26,7 @@ import (
 func ConfigFileParams() devtools.ConfigFileParams {
 	p := devtools.DefaultConfigFileParams()
 	p.Templates = append(p.Templates, devtools.OSSBeatDir("_meta/config/*.tmpl"))
-	p.ExtraVars = map[string]interface{}{
+	p.ExtraVars = map[string]any{
 		"UseObserverProcessor": true,
 		"ExcludeDashboards":    true,
 	}

--- a/heartbeat/tracer/tracer_test.go
+++ b/heartbeat/tracer/tracer_test.go
@@ -61,7 +61,6 @@ func TestSockTracer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/libbeat/processors/add_cloud_metadata/http_fetcher.go
+++ b/libbeat/processors/add_cloud_metadata/http_fetcher.go
@@ -22,7 +22,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
+
 	"net/http"
 
 	cfg "github.com/elastic/elastic-agent-libs/config"
@@ -42,7 +43,7 @@ type httpMetadataFetcher struct {
 // to the result according the HTTP response.
 type responseHandler func(all []byte, res *result) error
 
-type schemaConv func(m map[string]interface{}) mapstr.M
+type schemaConv func(m map[string]any) mapstr.M
 
 // newMetadataFetcher return metadataFetcher with one pass JSON responseHandler.
 func newMetadataFetcher(
@@ -111,7 +112,7 @@ func (f *httpMetadataFetcher) fetchRaw(
 		return
 	}
 
-	all, err := ioutil.ReadAll(rsp.Body)
+	all, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		result.err = fmt.Errorf("failed requesting %v metadata: %w", f.provider, err)
 		return

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
@@ -35,7 +35,7 @@ var alibabaCloudMetadataFetcher = provider{
 		ecsMetadataRegionURI := "/latest/meta-data/region-id"
 		ecsMetadataZoneURI := "/latest/meta-data/zone-id"
 
-		ecsSchema := func(m map[string]interface{}) mapstr.M {
+		ecsSchema := func(m map[string]any) mapstr.M {
 			m["service"] = mapstr.M{
 				"name": "ECS",
 			}

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
@@ -56,7 +56,7 @@ func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
 	server := initECSTestServer()
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"providers": []string{"alibaba"},
 		"host":      server.Listener.Addr().String(),
 	})

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -69,7 +69,7 @@ var ec2MetadataFetcher = provider{
 	DefaultEnabled: true,
 
 	Create: func(_ string, config *conf.C) (metadataFetcher, error) {
-		ec2Schema := func(m map[string]interface{}) mapstr.M {
+		ec2Schema := func(m map[string]any) mapstr.M {
 			meta := mapstr.M{
 				"cloud": mapstr.M{
 					"service": mapstr.M{
@@ -188,7 +188,7 @@ func getTagsFromIMDS(ctx context.Context, client IMDSClient, logger *logp.Logger
 		return tags, false
 	}
 
-	for _, tag := range strings.Split(string(b), "\n") {
+	for tag := range strings.SplitSeq(string(b), "\n") {
 		tagPath := fmt.Sprintf("%s/%s", tagsCategory, tag)
 		b, err := getMetadataHelper(ctx, client, tagPath, logger)
 		if err != nil {

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -410,7 +410,7 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 			}
 			defer func() { NewEC2Client = func(cfg awssdk.Config) EC2Client { return ec2.NewFromConfig(cfg) } }()
 
-			config, err := conf.NewConfigFrom(map[string]interface{}{
+			config, err := conf.NewConfigFrom(map[string]any{
 				"overwrite": tc.processorOverwrite,
 				"providers": []string{"aws"},
 			})

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
@@ -69,7 +69,7 @@ var azureVMMetadataFetcher = provider{
 	Create: func(_ string, config *conf.C) (metadataFetcher, error) {
 		azMetadataURI := "/metadata/instance/compute?api-version=2021-02-01"
 		azHeaders := map[string]string{"Metadata": "true"}
-		azHttpSchema := func(m map[string]interface{}) mapstr.M {
+		azHttpSchema := func(m map[string]any) mapstr.M {
 			m["serviceName"] = "Virtual Machines"
 			cloud, _ := s.Schema{
 				"account": s.Object{
@@ -93,7 +93,7 @@ var azureVMMetadataFetcher = provider{
 			return mapstr.M{"cloud": cloud}
 		}
 
-		azGenSchema := func(m map[string]interface{}) mapstr.M {
+		azGenSchema := func(m map[string]any) mapstr.M {
 			orchestrator := mapstr.M{
 				"orchestrator": mapstr.M{},
 			}

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -48,9 +47,9 @@ var cluster1Name = "testcluster1Name"
 var cluster1ID = "testcluster1ID"
 
 var cluster1 = armcontainerservice.ManagedCluster{
-	ID:         to.Ptr(cluster1ID),
-	Name:       to.Ptr(cluster1Name),
-	Properties: &armcontainerservice.ManagedClusterProperties{NodeResourceGroup: to.Ptr("MC_myname_group_myname_eastus")},
+	ID:         new(cluster1ID),
+	Name:       new(cluster1Name),
+	Properties: &armcontainerservice.ManagedClusterProperties{NodeResourceGroup: new("MC_myname_group_myname_eastus")},
 }
 
 const azInstanceIdentityDocument = `{
@@ -171,7 +170,7 @@ func TestRetrieveAzureMetadata(t *testing.T) {
 	server := initAzureTestServer()
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 	if err != nil {

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
@@ -31,7 +31,7 @@ var doMetadataFetcher = provider{
 	DefaultEnabled: true,
 
 	Create: func(provider string, config *conf.C) (metadataFetcher, error) {
-		doSchema := func(m map[string]interface{}) mapstr.M {
+		doSchema := func(m map[string]any) mapstr.M {
 			m["serviceName"] = "Droplets"
 			out, _ := s.Schema{
 				"instance": s.Object{

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
@@ -96,7 +96,7 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 	server := initDigitalOceanTestServer()
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 	if err != nil {

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce.go
@@ -50,7 +50,7 @@ var gceMetadataFetcher = provider{
 	Create: func(provider string, config *conf.C) (metadataFetcher, error) {
 		gceMetadataURI := "/computeMetadata/v1/?recursive=true&alt=json"
 		gceHeaders := map[string]string{"Metadata-Flavor": "Google"}
-		gceSchema := func(m map[string]interface{}) mapstr.M {
+		gceSchema := func(m map[string]any) mapstr.M {
 			cloud := mapstr.M{
 				"service": mapstr.M{
 					"name": "GCE",
@@ -70,7 +70,7 @@ var gceMetadataFetcher = provider{
 				_, _ = cloud.Put(key, path.Base(p))
 			}
 
-			if instance, ok := m["instance"].(map[string]interface{}); ok {
+			if instance, ok := m["instance"].(map[string]any); ok {
 				s.Schema{
 					"instance": s.Object{
 						"id":   c.StrFromNum("id"),
@@ -132,7 +132,7 @@ var gceMetadataFetcher = provider{
 				_ = meta.Delete("orchestrator")
 			}
 
-			if project, ok := m["project"].(map[string]interface{}); ok {
+			if project, ok := m["project"].(map[string]any); ok {
 				s.Schema{
 					"project": s.Object{
 						"id": c.Str("projectId"),

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -314,7 +314,7 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 	server := initGCETestServer(gceMetadataV1)
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 	if err != nil {
@@ -363,7 +363,7 @@ func TestRetrieveGCEMetadataInK8s(t *testing.T) {
 	server := initGCETestServer(gceK8sMetadataV1)
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 	if err != nil {
@@ -418,7 +418,7 @@ func TestRetrieveGCEMetadataInK8sNotOverriden(t *testing.T) {
 	server := initGCETestServer(gceK8sMetadataV1)
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 	if err != nil {
@@ -484,7 +484,7 @@ func TestRetrieveGCEMetadataInK8sPartial(t *testing.T) {
 	server := initGCETestServer(gceK8sPartialMetadataV1)
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 	if err != nil {

--- a/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud.go
@@ -35,7 +35,7 @@ var hetznerMetadataFetcher = provider{
 	Name:           "hetzner-cloud",
 	DefaultEnabled: true,
 	Create: func(_ string, c *conf.C) (metadataFetcher, error) {
-		hetznerSchema := func(m map[string]interface{}) mapstr.M {
+		hetznerSchema := func(m map[string]any) mapstr.M {
 			m["service"] = mapstr.M{
 				"name": "Cloud",
 			}

--- a/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud_test.go
@@ -60,7 +60,7 @@ func TestRetrieveHetznerMetadata(t *testing.T) {
 	server := httptest.NewServer(hetznerMetadataHandler())
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
@@ -46,7 +46,7 @@ var openstackNovaSSLMetadataFetcher = provider{
 
 func buildOpenstackNovaCreate(scheme string) func(provider string, c *conf.C) (metadataFetcher, error) {
 	return func(provider string, c *conf.C) (metadataFetcher, error) {
-		osSchema := func(m map[string]interface{}) mapstr.M {
+		osSchema := func(m map[string]any) mapstr.M {
 			m["service"] = mapstr.M{
 				"name": "Nova",
 			}

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
@@ -60,7 +60,7 @@ func TestRetrieveOpenstackNovaMetadata(t *testing.T) {
 	server := httptest.NewServer(openstackNovaMetadataHandler())
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host": server.Listener.Addr().String(),
 	})
 
@@ -77,7 +77,7 @@ func TestRetrieveOpenstackNovaMetadataWithHTTPS(t *testing.T) {
 	server := httptest.NewTLSServer(openstackNovaMetadataHandler())
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"host":                  server.Listener.Addr().String(),
 		"ssl.verification_mode": "none",
 	})

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
@@ -35,7 +35,7 @@ var qcloudMetadataFetcher = provider{
 		qcloudMetadataRegionURI := "/meta-data/placement/region"
 		qcloudMetadataZoneURI := "/meta-data/placement/zone"
 
-		qcloudSchema := func(m map[string]interface{}) mapstr.M {
+		qcloudSchema := func(m map[string]any) mapstr.M {
 			m["service"] = mapstr.M{
 				"name": "CVM",
 			}

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
@@ -56,7 +56,7 @@ func TestRetrieveQCloudMetadata(t *testing.T) {
 	server := initQCloudTestServer()
 	defer server.Close()
 
-	config, err := conf.NewConfigFrom(map[string]interface{}{
+	config, err := conf.NewConfigFrom(map[string]any{
 		"providers": []string{"tencent"},
 		"host":      server.Listener.Addr().String(),
 	})

--- a/libbeat/processors/add_cloud_metadata/providers.go
+++ b/libbeat/processors/add_cloud_metadata/providers.go
@@ -90,7 +90,7 @@ func providersFilter(configList providerList, allProviders map[string]provider) 
 		// this environment variable as a workaround in case the
 		// configured/default providers misbehave.
 		configList = nil
-		for _, name := range strings.Split(v, ",") {
+		for name := range strings.SplitSeq(v, ",") {
 			configList = append(configList, strings.TrimSpace(name))
 		}
 		if len(configList) == 0 {

--- a/libbeat/processors/add_cloud_metadata/providers_test.go
+++ b/libbeat/processors/add_cloud_metadata/providers_test.go
@@ -44,38 +44,38 @@ func TestProvidersFilter(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		config   map[string]interface{}
+		config   map[string]any
 		env      string
 		fail     bool
 		expected []string
 	}{
 		"all with local access only if not configured": {
-			config:   map[string]interface{}{},
+			config:   map[string]any{},
 			expected: allLocal,
 		},
 		"BEATS_ADD_CLOUD_METADATA_PROVIDERS overrides default": {
-			config:   map[string]interface{}{},
+			config:   map[string]any{},
 			env:      "alibaba, digitalocean",
 			expected: []string{"alibaba", "digitalocean"},
 		},
 		"none if BEATS_ADD_CLOUD_METADATA_PROVIDERS is explicitly set to an empty list": {
-			config:   map[string]interface{}{},
+			config:   map[string]any{},
 			env:      " ",
 			expected: nil,
 		},
 		"fail to load if unknown name is used": {
-			config: map[string]interface{}{
+			config: map[string]any{
 				"providers": []string{"unknown"},
 			},
 			fail: true,
 		},
 		"only selected": {
-			config: map[string]interface{}{
+			config: map[string]any{
 				"providers": []string{"aws", "gcp", "digitalocean"},
 			},
 		},
 		"BEATS_ADD_CLOUD_METADATA_PROVIDERS overrides selected": {
-			config: map[string]interface{}{
+			config: map[string]any{
 				"providers": []string{"aws", "gcp", "digitalocean"},
 			},
 			env:      "alibaba, digitalocean",
@@ -128,21 +128,21 @@ func Test_priorityResult(t *testing.T) {
 	tLogger := logptest.NewTestingLogger(t, "add_cloud_metadata testing")
 	awsRsp := result{
 		provider: "aws",
-		metadata: map[string]interface{}{
+		metadata: map[string]any{
 			"id": "a-1",
 		},
 	}
 
 	openStackRsp := result{
 		provider: "openstack",
-		metadata: map[string]interface{}{
+		metadata: map[string]any{
 			"id": "o-1",
 		},
 	}
 
 	digitaloceanRsp := result{
 		provider: "digitalocean",
-		metadata: map[string]interface{}{
+		metadata: map[string]any{
 			"id": "d-1",
 		},
 	}

--- a/metricbeat/module/kubernetes/container/container_test.go
+++ b/metricbeat/module/kubernetes/container/container_test.go
@@ -20,7 +20,8 @@
 package container
 
 import (
-	"io/ioutil"
+	"io"
+
 	"os"
 	"testing"
 
@@ -70,7 +71,7 @@ func (s *ContainerTestSuite) ReadTestFile(testFile string) []byte {
 	f, err := os.Open(testFile)
 	s.NoError(err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	s.NoError(err, "cannot read test file "+testFile)
 
 	return body
@@ -87,7 +88,7 @@ func (s *ContainerTestSuite) TestEventMapping() {
 
 	s.basicTests(events, err)
 
-	cpuMemoryTestCases := map[string]interface{}{
+	cpuMemoryTestCases := map[string]any{
 		"cpu.usage.core.ns":   43959424,
 		"cpu.usage.nanocores": 11263994,
 
@@ -109,7 +110,7 @@ func (s *ContainerTestSuite) TestEventMapping() {
 	s.RunMetricsTests(events[0], cpuMemoryTestCases)
 
 	containerEcsFields := ecsfields(events[0], s.Logger)
-	testEcs := map[string]interface{}{
+	testEcs := map[string]any{
 		"cpu.usage":    0.005631997,
 		"memory.usage": 0.01,
 		"name":         "nginx",
@@ -117,7 +118,7 @@ func (s *ContainerTestSuite) TestEventMapping() {
 	s.RunMetricsTests(containerEcsFields, testEcs)
 }
 
-func (s *ContainerTestSuite) testValue(event mapstr.M, field string, expected interface{}) {
+func (s *ContainerTestSuite) testValue(event mapstr.M, field string, expected any) {
 	data, err := event.GetValue(field)
 	s.NoError(err, "Could not read field "+field)
 	s.EqualValues(expected, data, "Wrong value for field "+field)
@@ -140,7 +141,7 @@ func (s *ContainerTestSuite) basicTests(events []mapstr.M, err error) {
 
 	s.Len(events, 1, "got wrong number of events")
 
-	basicTestCases := map[string]interface{}{
+	basicTestCases := map[string]any{
 		"logs.available.bytes": int64(98727014400),
 		"logs.capacity.bytes":  int64(101258067968),
 		"logs.used.bytes":      28672,
@@ -159,7 +160,7 @@ func (s *ContainerTestSuite) basicTests(events []mapstr.M, err error) {
 	s.RunMetricsTests(events[0], basicTestCases)
 }
 
-func (s *ContainerTestSuite) RunMetricsTests(event mapstr.M, testCases map[string]interface{}) {
+func (s *ContainerTestSuite) RunMetricsTests(event mapstr.M, testCases map[string]any) {
 	for k, v := range testCases {
 		s.testValue(event, k, v)
 	}

--- a/metricbeat/module/kubernetes/node/node_test.go
+++ b/metricbeat/module/kubernetes/node/node_test.go
@@ -20,7 +20,8 @@
 package node
 
 import (
-	"io/ioutil"
+	"io"
+
 	"os"
 	"testing"
 
@@ -46,7 +47,7 @@ func (s *NodeTestSuite) ReadTestFile(testFile string) []byte {
 	f, err := os.Open(testFile)
 	s.NoError(err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	s.NoError(err, "cannot read test file "+testFile)
 
 	return body
@@ -59,7 +60,7 @@ func (s *NodeTestSuite) TestEventMapping() {
 	s.basicTests(event, err)
 }
 
-func (s *NodeTestSuite) testValue(event mapstr.M, field string, expected interface{}) {
+func (s *NodeTestSuite) testValue(event mapstr.M, field string, expected any) {
 	data, err := event.GetValue(field)
 	s.NoError(err, "Could not read field "+field)
 	s.EqualValues(expected, data, "Wrong value for field "+field)
@@ -68,7 +69,7 @@ func (s *NodeTestSuite) testValue(event mapstr.M, field string, expected interfa
 func (s *NodeTestSuite) basicTests(event mapstr.M, err error) {
 	s.NoError(err, "error mapping "+testFile)
 
-	basicTestCases := map[string]interface{}{
+	basicTestCases := map[string]any{
 		"cpu.usage.core.ns":   int64(4189523881380),
 		"cpu.usage.nanocores": 18691146,
 
@@ -101,7 +102,7 @@ func (s *NodeTestSuite) basicTests(event mapstr.M, err error) {
 	s.RunMetricsTests(event, basicTestCases)
 }
 
-func (s *NodeTestSuite) RunMetricsTests(event mapstr.M, testCases map[string]interface{}) {
+func (s *NodeTestSuite) RunMetricsTests(event mapstr.M, testCases map[string]any) {
 	for k, v := range testCases {
 		s.testValue(event, k, v)
 	}

--- a/metricbeat/module/kubernetes/pod/pod_test.go
+++ b/metricbeat/module/kubernetes/pod/pod_test.go
@@ -95,7 +95,7 @@ func (s *PodTestSuite) TestEventMapping() {
 
 	s.basicTests(events, err)
 
-	cpuMemoryTestCases := map[string]interface{}{
+	cpuMemoryTestCases := map[string]any{
 		// calculated pct fields:
 		"cpu.usage.nanocores": 11263994,
 		"cpu.usage.node.pct":  0.005631997,
@@ -123,7 +123,7 @@ func (s *PodTestSuite) TestEventMappingWithZeroNodeMetrics() {
 
 	s.basicTests(events, err)
 
-	cpuMemoryTestCases := map[string]interface{}{
+	cpuMemoryTestCases := map[string]any{
 		"cpu.usage.nanocores": 11263994,
 		"cpu.usage.limit.pct": 0.022527988,
 
@@ -145,7 +145,7 @@ func (s *PodTestSuite) TestEventMappingWithNoNodeMetrics() {
 
 	s.basicTests(events, err)
 
-	cpuMemoryTestCases := map[string]interface{}{
+	cpuMemoryTestCases := map[string]any{
 		"cpu.usage.nanocores": 11263994,
 		"cpu.usage.limit.pct": 0.022527988,
 
@@ -168,7 +168,7 @@ func (s *PodTestSuite) TestEventMappingWithMultipleContainers_NodeAndOneContaine
 
 	s.basicTests(events, err)
 
-	cpuMemoryTestCases := map[string]interface{}{
+	cpuMemoryTestCases := map[string]any{
 		// Following comments explain what is the difference with the test `TestEventMapping`
 		"cpu.usage.nanocores": 22527988,    // 2x usage since 2 container
 		"cpu.usage.node.pct":  0.011263994, // 2x usage since 2 container
@@ -200,7 +200,7 @@ func (s *PodTestSuite) TestEventMappingWithMultipleContainers_AllMemLimits() {
 
 	s.basicTests(events, err)
 
-	cpuMemoryTestCases := map[string]interface{}{
+	cpuMemoryTestCases := map[string]any{
 		// Following comments explain what is the difference with the test `TestEventMapping
 		"cpu.usage.nanocores": 22527988,    // 2x usage since 2 container
 		"cpu.usage.node.pct":  0.011263994, // 2x usage since 2 container
@@ -215,7 +215,7 @@ func (s *PodTestSuite) TestEventMappingWithMultipleContainers_AllMemLimits() {
 	s.RunMetricsTests(events[0], cpuMemoryTestCases)
 }
 
-func (s *PodTestSuite) testValue(event mapstr.M, field string, expected interface{}) {
+func (s *PodTestSuite) testValue(event mapstr.M, field string, expected any) {
 	data, err := event.GetValue(field)
 	s.NoError(err, "Could not read field "+field)
 	s.EqualValues(expected, data, "Wrong value for field "+field)
@@ -238,7 +238,7 @@ func (s *PodTestSuite) basicTests(events []mapstr.M, err error) {
 
 	s.Len(events, 1, "got wrong number of events")
 
-	basicTestCases := map[string]interface{}{
+	basicTestCases := map[string]any{
 		"name": "nginx-deployment-2303442956-pcqfc",
 		"uid":  "beabc196-2456-11e7-a3ad-42010a840235",
 
@@ -251,7 +251,7 @@ func (s *PodTestSuite) basicTests(events []mapstr.M, err error) {
 	s.RunMetricsTests(events[0], basicTestCases)
 }
 
-func (s *PodTestSuite) RunMetricsTests(events mapstr.M, testCases map[string]interface{}) {
+func (s *PodTestSuite) RunMetricsTests(events mapstr.M, testCases map[string]any) {
 	for k, v := range testCases {
 		s.testValue(events, k, v)
 	}

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -174,13 +174,13 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 			if !ok {
 				m.Logger().Debugf("Error while casting containerID, got %T", containerID)
 			}
-			split := strings.Index(cID, "://")
-			if split != -1 {
-				kubernetes.ShouldPut(containerFields, "runtime", cID[:split], m.Logger())
+			before, after, ok := strings.Cut(cID, "://")
+			if ok {
+				kubernetes.ShouldPut(containerFields, "runtime", before, m.Logger())
 
 				// Add splitted container.id ECS field and update kubernetes.container.id with splitted value
-				kubernetes.ShouldPut(containerFields, "id", cID[split+3:], m.Logger())
-				kubernetes.ShouldPut(event, "id", cID[split+3:], m.Logger())
+				kubernetes.ShouldPut(containerFields, "id", after, m.Logger())
+				kubernetes.ShouldPut(event, "id", after, m.Logger())
 
 			}
 		}

--- a/metricbeat/module/kubernetes/state_job/state_job_integration_test.go
+++ b/metricbeat/module/kubernetes/state_job/state_job_integration_test.go
@@ -35,7 +35,7 @@ func TestFetchMetricset(t *testing.T) {
 	var errs []error
 	config := test.GetKubeStateMetricsConfig(t, "state_job")
 	metricSet := mbtest.NewFetcher(t, config)
-	for retries := 0; retries < 5; retries++ {
+	for range 5 {
 		events, errs = metricSet.FetchEvents()
 		if len(errs) == 0 && len(events) > 0 {
 			break

--- a/metricbeat/module/kubernetes/system/system_test.go
+++ b/metricbeat/module/kubernetes/system/system_test.go
@@ -20,7 +20,8 @@
 package system
 
 import (
-	"io/ioutil"
+	"io"
+
 	"os"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestEventMapping(t *testing.T) {
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
 	events, err := eventMapping(body, logger)
@@ -46,7 +47,7 @@ func TestEventMapping(t *testing.T) {
 
 	assert.Len(t, events, 1, "got wrong number of events")
 
-	testCases := map[string]interface{}{
+	testCases := map[string]any{
 		"container": "kubelet",
 
 		"memory.usage.bytes":      36683776,
@@ -64,7 +65,7 @@ func TestEventMapping(t *testing.T) {
 	}
 }
 
-func testValue(t *testing.T, event mapstr.M, field string, value interface{}) {
+func testValue(t *testing.T, event mapstr.M, field string, value any) {
 	data, err := event.GetValue(field)
 	assert.NoError(t, err, "Could not read field "+field)
 	assert.EqualValues(t, data, value, "Wrong value for field "+field)

--- a/metricbeat/module/kubernetes/test/integration.go
+++ b/metricbeat/module/kubernetes/test/integration.go
@@ -22,15 +22,15 @@ import (
 )
 
 // GetAPIServerConfig function returns configuration for talking to Kubernetes API server.
-func GetAPIServerConfig(t *testing.T, metricSetName string) map[string]interface{} {
+func GetAPIServerConfig(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
-	return map[string]interface{}{
+	return map[string]any{
 		"module":            "kubernetes",
 		"metricsets":        []string{metricSetName},
 		"host":              "${NODE_NAME}",
 		"hosts":             []string{"https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"},
 		"bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
-		"ssl": map[string]interface{}{
+		"ssl": map[string]any{
 			"certificate_authorities": []string{
 				"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			},
@@ -39,9 +39,9 @@ func GetAPIServerConfig(t *testing.T, metricSetName string) map[string]interface
 }
 
 // GetKubeStateMetricsConfig function returns configuration for talking to kube-state-metrics.
-func GetKubeStateMetricsConfig(t *testing.T, metricSetName string) map[string]interface{} {
+func GetKubeStateMetricsConfig(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "kubernetes",
 		"metricsets": []string{metricSetName},
 		"host":       "${NODE_NAME}",
@@ -50,24 +50,24 @@ func GetKubeStateMetricsConfig(t *testing.T, metricSetName string) map[string]in
 }
 
 // GetKubeletConfig function returns configuration for talking to Kubelet API.
-func GetKubeletConfig(t *testing.T, metricSetName string) map[string]interface{} {
+func GetKubeletConfig(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
-	return map[string]interface{}{
+	return map[string]any{
 		"module":            "kubernetes",
 		"metricsets":        []string{metricSetName},
 		"host":              "${NODE_NAME}",
 		"hosts":             []string{"https://localhost:10250"},
 		"bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
-		"ssl": map[string]interface{}{
+		"ssl": map[string]any{
 			"verification_mode": "none",
 		},
 	}
 }
 
 // GetKubeProxyConfig function returns configuration for talking to kube-proxy.
-func GetKubeProxyConfig(t *testing.T, metricSetName string) map[string]interface{} {
+func GetKubeProxyConfig(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
-	return map[string]interface{}{
+	return map[string]any{
 		"module":     "kubernetes",
 		"metricsets": []string{metricSetName},
 		"host":       "${NODE_NAME}",
@@ -76,9 +76,9 @@ func GetKubeProxyConfig(t *testing.T, metricSetName string) map[string]interface
 }
 
 // GetSchedulerConfig function returns configuration for talking to kube-scheduler.
-func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface{} {
+func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
-	return map[string]interface{}{
+	return map[string]any{
 		"module":                "kubernetes",
 		"metricsets":            []string{metricSetName},
 		"host":                  "${NODE_NAME}",
@@ -89,9 +89,9 @@ func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface
 }
 
 // GetControllerManagerConfig function returns configuration for talking to kube-controller-manager.
-func GetControllerManagerConfig(t *testing.T, metricSetName string) map[string]interface{} {
+func GetControllerManagerConfig(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
-	return map[string]interface{}{
+	return map[string]any{
 		"module":                "kubernetes",
 		"metricsets":            []string{metricSetName},
 		"host":                  "${NODE_NAME}",

--- a/metricbeat/module/kubernetes/types.go
+++ b/metricbeat/module/kubernetes/types.go
@@ -71,9 +71,9 @@ type Summary struct {
 				UsageBytes      uint64 `json:"usageBytes"`
 				WorkingSetBytes uint64 `json:"workingSetBytes"`
 			} `json:"memory"`
-			Name               string      `json:"name"`
-			StartTime          string      `json:"startTime"`
-			UserDefinedMetrics interface{} `json:"userDefinedMetrics"`
+			Name               string `json:"name"`
+			StartTime          string `json:"startTime"`
+			UserDefinedMetrics any    `json:"userDefinedMetrics"`
 		} `json:"systemContainers"`
 	} `json:"node"`
 	Pods []struct {
@@ -107,8 +107,8 @@ type Summary struct {
 				InodesUsed     uint64 `json:"inodesUsed"`
 				UsedBytes      uint64 `json:"usedBytes"`
 			} `json:"rootfs"`
-			StartTime          string      `json:"startTime"`
-			UserDefinedMetrics interface{} `json:"userDefinedMetrics"`
+			StartTime          string `json:"startTime"`
+			UserDefinedMetrics any    `json:"userDefinedMetrics"`
 		} `json:"containers"`
 		Network struct {
 			RxBytes  uint64 `json:"rxBytes"`

--- a/metricbeat/module/kubernetes/volume/volume_test.go
+++ b/metricbeat/module/kubernetes/volume/volume_test.go
@@ -20,7 +20,8 @@
 package volume
 
 import (
-	"io/ioutil"
+	"io"
+
 	"os"
 	"testing"
 
@@ -39,7 +40,7 @@ func TestEventMapping(t *testing.T) {
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
 	events, err := eventMapping(body, logger)
@@ -47,7 +48,7 @@ func TestEventMapping(t *testing.T) {
 
 	assert.Len(t, events, 2, "got wrong number of events")
 
-	testCases := []map[string]interface{}{
+	testCases := []map[string]any{
 		// Test for ephemeral volume
 		{
 			"name":               "default-token-sg8x5",
@@ -74,7 +75,7 @@ func TestEventMapping(t *testing.T) {
 	}
 }
 
-func testValue(t *testing.T, event mapstr.M, field string, value interface{}) {
+func testValue(t *testing.T, event mapstr.M, field string, value any) {
 	data, err := event.GetValue(field)
 	assert.NoError(t, err, "Could not read field "+field)
 	assert.EqualValues(t, data, value, "Wrong value for field "+field)

--- a/metricbeat/module/prometheus/remote_write/remote_write_test.go
+++ b/metricbeat/module/prometheus/remote_write/remote_write_test.go
@@ -277,7 +277,7 @@ func TestMetricsCount(t *testing.T) {
 // createTestWriteRequest creates a prompb.WriteRequest with the given number of samples
 func createTestWriteRequest(numSamples int) *prompb.WriteRequest {
 	samples := make([]prompb.Sample, numSamples)
-	for i := 0; i < numSamples; i++ {
+	for i := range numSamples {
 		samples[i] = prompb.Sample{
 			Value:     float64(i),
 			Timestamp: int64(i * 1000),
@@ -309,7 +309,7 @@ func encodeWriteRequest(req *prompb.WriteRequest) ([]byte, error) {
 // newTestMetricSet creates a MetricSet for testing using the mbtest infrastructure
 // to ensure proper initialization (including logger)
 func newTestMetricSet(t *testing.T, maxCompressedBodyBytes, maxDecodedBodyBytes int64) *MetricSet {
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":     "prometheus",
 		"metricsets": []string{"remote_write"},
 	}

--- a/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/cloudwatch_worker_test.go
@@ -67,7 +67,7 @@ func TestAckTracker(t *testing.T) {
 
 	t.Run("increments should not get blocked even if wait is not called", func(t *testing.T) {
 		tracker := newACKTracker()
-		done := make(chan interface{})
+		done := make(chan any)
 
 		go func() {
 			tracker.increaseAck(1)

--- a/x-pack/filebeat/input/awss3/contract_test.go
+++ b/x-pack/filebeat/input/awss3/contract_test.go
@@ -138,7 +138,7 @@ func TestContract_EventFieldPaths(t *testing.T) {
 
 	// aws.s3.metadata (stored as map[string]interface{}, which is the underlying type of mapstr.M)
 	v, _ = event.Fields.GetValue("aws.s3.metadata")
-	assert.Equal(t, map[string]interface{}{"x-amz-server-side-encryption": "AES256"}, v)
+	assert.Equal(t, map[string]any{"x-amz-server-side-encryption": "AES256"}, v)
 
 	// @metadata._id
 	expectedID := objectID(obj.S3.Object.LastModified, s3ObjectHash(obj), 42)
@@ -454,19 +454,19 @@ func TestContract_ExpandEventListFromField_EmptyArray(t *testing.T) {
 func TestContract_ConfigValidation_MutualExclusion(t *testing.T) {
 	cases := []struct {
 		name string
-		cfg  map[string]interface{}
+		cfg  map[string]any
 	}{
 		{
 			name: "queue_url_and_bucket_arn",
-			cfg:  map[string]interface{}{"queue_url": "https://sqs.us-east-1.amazonaws.com/1234/queue", "bucket_arn": "arn:aws:s3:::b"},
+			cfg:  map[string]any{"queue_url": "https://sqs.us-east-1.amazonaws.com/1234/queue", "bucket_arn": "arn:aws:s3:::b"},
 		},
 		{
 			name: "bucket_arn_and_non_aws_bucket_name",
-			cfg:  map[string]interface{}{"bucket_arn": "arn:aws:s3:::b", "non_aws_bucket_name": "nb", "region": "us-east-1"},
+			cfg:  map[string]any{"bucket_arn": "arn:aws:s3:::b", "non_aws_bucket_name": "nb", "region": "us-east-1"},
 		},
 		{
 			name: "none_set",
-			cfg:  map[string]interface{}{},
+			cfg:  map[string]any{},
 		},
 	}
 
@@ -587,7 +587,7 @@ func runExpandTest(t *testing.T, input, field string) []string {
 	return events
 }
 
-func makeConfig(overrides map[string]interface{}) config {
+func makeConfig(overrides map[string]any) config {
 	c := defaultConfig()
 	if v, ok := overrides["queue_url"]; ok {
 		c.QueueURL = v.(string) //nolint:errcheck // Statically known to be a string.

--- a/x-pack/filebeat/input/awss3/decoding_test.go
+++ b/x-pack/filebeat/input/awss3/decoding_test.go
@@ -273,6 +273,3 @@ func sameError(a, b error) bool {
 		return a.Error() == b.Error()
 	}
 }
-
-//go:fix inline
-func ptr[T any](v T) *T { return new(v) }

--- a/x-pack/filebeat/input/awss3/decoding_test.go
+++ b/x-pack/filebeat/input/awss3/decoding_test.go
@@ -102,7 +102,7 @@ func TestDecoding(t *testing.T) {
 					Codec: &decoder.CodecConfig{
 						CSV: &decoder.CSVCodecConfig{
 							Enabled: true,
-							Comma:   ptr[decoder.Rune](' '),
+							Comma:   new(decoder.Rune(' ')),
 						},
 					},
 				},
@@ -118,7 +118,7 @@ func TestDecoding(t *testing.T) {
 					Codec: &decoder.CodecConfig{
 						CSV: &decoder.CSVCodecConfig{
 							Enabled: true,
-							Comma:   ptr[decoder.Rune](' '),
+							Comma:   new(decoder.Rune(' ')),
 						},
 					},
 				},
@@ -184,7 +184,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   ptr[decoder.Rune](' '),
+					Comma:   new(decoder.Rune(' ')),
 					Comment: '#',
 				},
 			}},
@@ -215,7 +215,7 @@ codec:
 			Codec: &decoder.CodecConfig{
 				CSV: &decoder.CSVCodecConfig{
 					Enabled: true,
-					Comma:   ptr[decoder.Rune]('\x00'),
+					Comma:   new(decoder.Rune('\x00')),
 				},
 			}},
 	},
@@ -274,4 +274,5 @@ func sameError(a, b error) bool {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -71,8 +71,3 @@ func (im *s3InputManager) Create(cfg *conf.C) (v2.Input, error) {
 
 	return nil, fmt.Errorf("configuration has no SQS queue URL and no S3 bucket ARN")
 }
-
-// boolPtr returns a pointer to b.
-//
-//go:fix inline
-func boolPtr(b bool) *bool { return new(b) }

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -73,4 +73,6 @@ func (im *s3InputManager) Create(cfg *conf.C) (v2.Input, error) {
 }
 
 // boolPtr returns a pointer to b.
-func boolPtr(b bool) *bool { return &b }
+//
+//go:fix inline
+func boolPtr(b bool) *bool { return new(b) }

--- a/x-pack/filebeat/input/awss3/input_benchmark_test.go
+++ b/x-pack/filebeat/input/awss3/input_benchmark_test.go
@@ -112,7 +112,7 @@ func newS3PagerConstant(listPrefix string) *s3PagerConstant {
 		currentIndex: 0,
 	}
 
-	for i := 0; i < totalListingObjectsForInputS3; i++ {
+	for i := range totalListingObjectsForInputS3 {
 		ret.objects = append(ret.objects, s3Types.Object{
 			Key:          aws.String(fmt.Sprintf("%s-%d.json.gz", listPrefix, i)),
 			ETag:         aws.String(fmt.Sprintf("etag-%s-%d", listPrefix, i)),
@@ -336,7 +336,7 @@ func benchmarkInputS3(t *testing.T, numberOfWorkers int) testing.BenchmarkResult
 
 		errChan := make(chan error)
 		wg := new(sync.WaitGroup)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			wg.Add(1)
 			go func(i int, wg *sync.WaitGroup) {
 				defer wg.Done()

--- a/x-pack/filebeat/input/awss3/input_integration_test.go
+++ b/x-pack/filebeat/input/awss3/input_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,7 +65,7 @@ func getTerraformOutputs(t *testing.T, isLocalStack bool) terraformOutputData {
 		outputFile = terraformOutputYML
 	}
 
-	ymlData, err := ioutil.ReadFile(path.Join(path.Dir(filename), outputFile))
+	ymlData, err := os.ReadFile(path.Join(path.Dir(filename), outputFile))
 	if os.IsNotExist(err) {
 		t.Skipf("Run 'terraform apply' in %v to setup S3 and SQS for the test.", filepath.Dir(outputFile))
 	}
@@ -191,7 +190,7 @@ func makeLocalstackConfig(awsRegion string) (aws.Config, error) {
 	awsLocalstackEndpoint := "http://localhost:4566" // Default Localstack endpoint
 
 	// Add a custom endpointResolver to the awsConfig so that all the requests are routed to this endpoint
-	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...any) (aws.Endpoint, error) {
 		return aws.Endpoint{
 			PartitionID:   "aws",
 			URL:           awsLocalstackEndpoint,
@@ -544,7 +543,7 @@ func uploadS3TestFiles(t *testing.T, region, bucket string, s3Client *s3.Client,
 	_, basefile, _, _ := runtime.Caller(0)
 	basedir := path.Dir(basefile)
 	for _, filename := range filenames {
-		data, err := ioutil.ReadFile(path.Join(basedir, filename))
+		data, err := os.ReadFile(path.Join(basedir, filename))
 		if err != nil {
 			t.Fatalf("Failed to open file %q, %v", filename, err)
 		}

--- a/x-pack/filebeat/input/awss3/interfaces.go
+++ b/x-pack/filebeat/input/awss3/interfaces.go
@@ -133,13 +133,6 @@ func (a *awsSQSAPI) ReceiveMessage(ctx context.Context, maxMessages int) ([]type
 	return receiveMessageOutput.Messages, nil
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (a *awsSQSAPI) DeleteMessage(ctx context.Context, msg *types.Message) error {
 	ctx, cancel := context.WithTimeout(ctx, a.apiTimeout)
 	defer cancel()

--- a/x-pack/filebeat/input/awss3/s3.go
+++ b/x-pack/filebeat/input/awss3/s3.go
@@ -48,7 +48,7 @@ func createPipelineClient(pipeline beat.Pipeline, acks *awsACKHandler) (beat.Cli
 		Processing: beat.ProcessingConfig{
 			// This input only produces events with basic types so normalization
 			// is not required.
-			EventNormalization: boolPtr(false),
+			EventNormalization: new(false),
 		},
 	})
 }

--- a/x-pack/filebeat/input/awss3/s3_objects.go
+++ b/x-pack/filebeat/input/awss3/s3_objects.go
@@ -508,7 +508,7 @@ func s3Metadata(resp *s3.GetObjectOutput, keys ...string) mapstr.M {
 	allMeta := map[string]any{}
 
 	// Get headers using AWS SDK struct tags.
-	fields := reflect.TypeOf(resp).Elem()
+	fields := reflect.TypeFor[s3.GetObjectOutput]()
 	values := reflect.ValueOf(resp).Elem()
 	for i := 0; i < fields.NumField(); i++ {
 		f := fields.Field(i)

--- a/x-pack/filebeat/input/awss3/s3_objects_test.go
+++ b/x-pack/filebeat/input/awss3/s3_objects_test.go
@@ -513,10 +513,7 @@ func newMockS3Pager(ctrl *gomock.Controller, pageSize int, s3Objects []types.Obj
 	})
 	mockS3Pager.EXPECT().NextPage(gomock.Any()).AnyTimes().DoAndReturn(func(_ context.Context, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
 		startIdx := currentPage * pageSize
-		endIdx := currentPage + 1*pageSize
-		if endIdx > len(s3Objects) {
-			endIdx = len(s3Objects)
-		}
+		endIdx := min(currentPage+1*pageSize, len(s3Objects))
 		return &s3.ListObjectsV2Output{
 			Contents: s3Objects[startIdx:endIdx],
 		}, nil

--- a/x-pack/filebeat/input/awss3/script_session.go
+++ b/x-pack/filebeat/input/awss3/script_session.go
@@ -49,9 +49,9 @@ func newSession(p *goja.Program, conf scriptConfig, test bool, logger *logp.Logg
 
 	// Register mapstr.M as being a simple map[string]interface{} for
 	// treatment within the JS VM.
-	s.vm.RegisterSimpleMapType(reflect.TypeOf(mapstr.M(nil)),
-		func(i interface{}) map[string]interface{} {
-			return map[string]interface{}(i.(mapstr.M))
+	s.vm.RegisterSimpleMapType(reflect.TypeFor[mapstr.M](),
+		func(i any) map[string]any {
+			return map[string]any(i.(mapstr.M))
 		},
 	)
 
@@ -99,7 +99,7 @@ func (s *session) setParseFunction() error {
 }
 
 // registerScriptParams calls the register() function and passes the params.
-func (s *session) registerScriptParams(params map[string]interface{}) error {
+func (s *session) registerScriptParams(params map[string]any) error {
 	registerFunc := s.vm.Get(registerFunction)
 	if registerFunc == nil {
 		return errors.New("params were provided but no register function was found")

--- a/x-pack/filebeat/input/awss3/script_session_test.go
+++ b/x-pack/filebeat/input/awss3/script_session_test.go
@@ -30,7 +30,7 @@ func TestSessionScriptParams(t *testing.T) {
 
 	t.Run("register required for params", func(t *testing.T) {
 		_, err := newScriptFromConfig(log, &scriptConfig{
-			Source: header + footer, Params: map[string]interface{}{
+			Source: header + footer, Params: map[string]any{
 				"p1": 42,
 			},
 		}, path)
@@ -51,7 +51,7 @@ func TestSessionScriptParams(t *testing.T) {
 		`
 		_, err := newScriptFromConfig(log, &scriptConfig{
 			Source: script,
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"p1": 42,
 			},
 		}, path)
@@ -101,7 +101,7 @@ func TestSessionTestFunction(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		_, err := newScriptFromConfig(log, &scriptConfig{
 			Source: script,
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"fail": false,
 			},
 		}, path)
@@ -111,7 +111,7 @@ func TestSessionTestFunction(t *testing.T) {
 	t.Run("test failure", func(t *testing.T) {
 		_, err := newScriptFromConfig(log, &scriptConfig{
 			Source: script,
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"fail": true,
 			},
 		}, path)
@@ -173,7 +173,7 @@ func TestSessionParallel(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			for ctx.Err() == nil {

--- a/x-pack/filebeat/input/awss3/sqs_input.go
+++ b/x-pack/filebeat/input/awss3/sqs_input.go
@@ -239,7 +239,7 @@ func (in *sqsReaderInput) newSQSWorker() (*sqsWorker, error) {
 		Processing: beat.ProcessingConfig{
 			// This input only produces events with basic types so normalization
 			// is not required.
-			EventNormalization: boolPtr(false),
+			EventNormalization: new(false),
 		},
 	})
 	if err != nil {

--- a/x-pack/filebeat/input/awss3/sqs_s3_event.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event.go
@@ -181,11 +181,9 @@ func (p *sqsS3EventProcessor) ProcessSQS(ctx context.Context, msg *types.Message
 
 	// Start SQS keepalive worker.
 	var keepaliveWg sync.WaitGroup
-	keepaliveWg.Add(1)
-	go func() {
-		defer keepaliveWg.Done()
+	keepaliveWg.Go(func() {
 		p.keepalive(keepaliveCtx, log, msg)
-	}()
+	})
 
 	receiveCount := getSQSReceiveCount(msg.Attributes)
 	if receiveCount == 1 {

--- a/x-pack/filebeat/input/awss3/sqs_s3_event_test.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event_test.go
@@ -197,7 +197,6 @@ func TestSqsProcessor_keepalive(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		// Test will call ChangeMessageVisibility once and then keepalive will
 		// exit because the SQS receipt handle is not usable.

--- a/x-pack/filebeat/input/awss3/state_test.go
+++ b/x-pack/filebeat/input/awss3/state_test.go
@@ -143,7 +143,6 @@ func TestStateIsEqual(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			isSame := test.states[0].IsEqual(&test.states[1])
 			assert.Equal(t, test.isSame, isSame)

--- a/x-pack/filebeat/input/awss3/v2_input_integration_test.go
+++ b/x-pack/filebeat/input/awss3/v2_input_integration_test.go
@@ -80,14 +80,14 @@ func TestV2InputRunSQSOnLocalstack(t *testing.T) {
 		"testdata/log.txt",
 	)
 
-	sqsCfg := conf.MustNewConfigFrom(map[string]interface{}{
+	sqsCfg := conf.MustNewConfigFrom(map[string]any{
 		"queue_url":          queueURL,
 		"region":             region,
 		"endpoint":           "http://localhost:4566",
 		"number_of_workers":  1,
 		"visibility_timeout": "30s",
 		"path_style":         true,
-		"file_selectors": []map[string]interface{}{
+		"file_selectors": []map[string]any{
 			{
 				"regex":                        `events-array\.json$`,
 				"expand_event_list_from_field": "Events",
@@ -96,8 +96,8 @@ func TestV2InputRunSQSOnLocalstack(t *testing.T) {
 			{"regex": `\.(?:nd)?json(\.gz)?$`},
 			{
 				"regex": `multiline\.txt$`,
-				"parsers": []map[string]interface{}{
-					{"multiline": map[string]interface{}{
+				"parsers": []map[string]any{
+					{"multiline": map[string]any{
 						"pattern": "^<Event",
 						"negate":  true,
 						"match":   "after",
@@ -158,14 +158,14 @@ func TestV2InputRunS3PollingOnLocalstack(t *testing.T) {
 		"testdata/log.txt",
 	)
 
-	pollingCfg := conf.MustNewConfigFrom(map[string]interface{}{
+	pollingCfg := conf.MustNewConfigFrom(map[string]any{
 		"non_aws_bucket_name":  bucketName,
 		"region":               region,
 		"endpoint":             "http://localhost:4566",
 		"number_of_workers":    1,
 		"bucket_list_interval": "2s",
 		"path_style":           true,
-		"file_selectors": []map[string]interface{}{
+		"file_selectors": []map[string]any{
 			{
 				"regex":                        `events-array\.json$`,
 				"expand_event_list_from_field": "Events",
@@ -174,8 +174,8 @@ func TestV2InputRunS3PollingOnLocalstack(t *testing.T) {
 			{"regex": `\.(?:nd)?json(\.gz)?$`},
 			{
 				"regex": `multiline\.txt$`,
-				"parsers": []map[string]interface{}{
-					{"multiline": map[string]interface{}{
+				"parsers": []map[string]any{
+					{"multiline": map[string]any{
 						"pattern": "^<Event",
 						"negate":  true,
 						"match":   "after",
@@ -380,18 +380,18 @@ func newV2ContextWithRegistry(t *testing.T) (v2.Context, func()) {
 
 func enableV2(t *testing.T) {
 	t.Helper()
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
-		"features": map[string]interface{}{
-			"aws_s3_v2": map[string]interface{}{
+	cfg := conf.MustNewConfigFrom(map[string]any{
+		"features": map[string]any{
+			"aws_s3_v2": map[string]any{
 				"enabled": true,
 			},
 		},
 	})
 	require.NoError(t, features.UpdateFromConfig(cfg), "failed to enable V2 flag")
 	t.Cleanup(func() {
-		cfg := conf.MustNewConfigFrom(map[string]interface{}{
-			"features": map[string]interface{}{
-				"aws_s3_v2": map[string]interface{}{
+		cfg := conf.MustNewConfigFrom(map[string]any{
+			"features": map[string]any{
+				"aws_s3_v2": map[string]any{
 					"enabled": false,
 				},
 			},

--- a/x-pack/filebeat/input/awss3/v2_input_test.go
+++ b/x-pack/filebeat/input/awss3/v2_input_test.go
@@ -90,16 +90,16 @@ func TestInputV2_resolveSQSRegion(t *testing.T) {
 }
 
 func TestFeatureFlag_routes_to_V2(t *testing.T) {
-	cfg := conf.MustNewConfigFrom(map[string]interface{}{
-		"features": map[string]interface{}{
-			"aws_s3_v2": map[string]interface{}{"enabled": true},
+	cfg := conf.MustNewConfigFrom(map[string]any{
+		"features": map[string]any{
+			"aws_s3_v2": map[string]any{"enabled": true},
 		},
 	})
 	require.NoError(t, features.UpdateFromConfig(cfg))
 	t.Cleanup(func() {
-		off := conf.MustNewConfigFrom(map[string]interface{}{
-			"features": map[string]interface{}{
-				"aws_s3_v2": map[string]interface{}{"enabled": false},
+		off := conf.MustNewConfigFrom(map[string]any{
+			"features": map[string]any{
+				"aws_s3_v2": map[string]any{"enabled": false},
 			},
 		})
 		_ = features.UpdateFromConfig(off)
@@ -107,7 +107,7 @@ func TestFeatureFlag_routes_to_V2(t *testing.T) {
 
 	assert.True(t, features.AwsS3V2(), "V2 flag should be enabled")
 
-	inputCfg := conf.MustNewConfigFrom(map[string]interface{}{
+	inputCfg := conf.MustNewConfigFrom(map[string]any{
 		"queue_url": "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
 	})
 	in, err := Plugin(logptest.NewTestingLogger(t, inputName), openTestStatestore(), nil).Manager.Create(inputCfg)

--- a/x-pack/filebeat/input/awss3/v2_processor.go
+++ b/x-pack/filebeat/input/awss3/v2_processor.go
@@ -175,7 +175,7 @@ type downloadedObject struct {
 	body        io.ReadCloser
 	contentType string
 	requestURL  string
-	metadata    map[string]interface{}
+	metadata    map[string]any
 }
 
 func (op *objectProcessorV2) download(ctx context.Context, obj s3EventV2, rc *readerConfig) (*downloadedObject, error) {
@@ -378,7 +378,7 @@ type eventBuilderV2 struct {
 	obj        s3EventV2
 	hash       string
 	requestURL string
-	metadata   map[string]interface{}
+	metadata   map[string]any
 }
 
 func (b *eventBuilderV2) newEvent(message string, offset int64) beat.Event {

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -526,7 +526,7 @@ func storageContainerValidate(name string) error {
 	if !unicode.IsLower(runes[length-1]) && !unicode.IsNumber(runes[length-1]) {
 		return fmt.Errorf("storage_account_container (%s) must end with a lowercase letter or number", name)
 	}
-	for i := 0; i < length; i++ {
+	for i := range length {
 		if !unicode.IsLower(runes[i]) && !unicode.IsNumber(runes[i]) && runes[i] != '-' {
 			return fmt.Errorf("rune (%d) of storage_account_container (%s) is not a lowercase letter, number or dash", i, name)
 		}

--- a/x-pack/filebeat/input/azureeventhub/connection_string.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string.go
@@ -81,9 +81,9 @@ func parseConnectionString(connStr string) (ConnectionStringProperties, error) {
 
 	csp := ConnectionStringProperties{}
 
-	splits := strings.Split(connStr, ";")
+	splits := strings.SplitSeq(connStr, ";")
 
-	for _, split := range splits {
+	for split := range splits {
 		if split == "" {
 			continue
 		}

--- a/x-pack/filebeat/input/azureeventhub/connection_string_test.go
+++ b/x-pack/filebeat/input/azureeventhub/connection_string_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
 
 var (
@@ -83,7 +81,7 @@ func TestNewConnectionStringProperties(t *testing.T) {
 			FullyQualifiedNamespace: namespace + ".servicebus.windows.net",
 			SharedAccessKeyName:     nil,
 			SharedAccessKey:         nil,
-			SharedAccessSignature:   to.Ptr("SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"),
+			SharedAccessSignature:   new("SharedAccessSignature sr=" + namespace + ".servicebus.windows.net&sig=<base64-sig>&se=<expiry>&skn=<keyname>"),
 		}, props)
 	})
 

--- a/x-pack/filebeat/input/azureeventhub/decoder.go
+++ b/x-pack/filebeat/input/azureeventhub/decoder.go
@@ -55,7 +55,7 @@ type messageDecoder struct {
 // [^1]: the Diagnostic Settings is the Azure component used
 // to export logs and metrics from an Azure service.
 func (u *messageDecoder) Decode(bMessage []byte) []string {
-	var mapObject map[string][]interface{}
+	var mapObject map[string][]any
 	var records []string
 
 	// Clean up the message for known issues [1] where Azure services produce malformed JSON documents.
@@ -92,7 +92,7 @@ func (u *messageDecoder) Decode(bMessage []byte) []string {
 	} else {
 		u.log.Debugf("deserializing multiple messages to a `records` object returning error: %s", err)
 		// in some cases the message is an array
-		var arrayObject []interface{}
+		var arrayObject []any
 		err = json.Unmarshal(bMessage, &arrayObject)
 		if err != nil {
 			// return entire message

--- a/x-pack/filebeat/input/azureeventhub/sanitizers.go
+++ b/x-pack/filebeat/input/azureeventhub/sanitizers.go
@@ -28,8 +28,8 @@ const (
 // Sanitizers can use the spec field to provide additional
 // configuration.
 type SanitizerSpec struct {
-	Type string                 `config:"type"`
-	Spec map[string]interface{} `config:"spec"`
+	Type string         `config:"type"`
+	Spec map[string]any `config:"spec"`
 }
 
 // Sanitizer defines the interface for sanitizing JSON data.
@@ -162,7 +162,7 @@ func (s *singleQuotesSanitizer) Init() error {
 type replaceAllSanitizer struct {
 	re          *regexp.Regexp
 	replacement string
-	spec        map[string]interface{}
+	spec        map[string]any
 }
 
 func (s *replaceAllSanitizer) Sanitize(jsonByte []byte) []byte {
@@ -201,7 +201,7 @@ func (s *replaceAllSanitizer) Init() error {
 // getStringFromSpec returns a string from the spec map.
 //
 // It returns an error if the spec entry key is missing or the value is not a string.
-func getStringFromSpec(spec map[string]interface{}, entryKey string) (string, error) {
+func getStringFromSpec(spec map[string]any, entryKey string) (string, error) {
 	value, ok := spec[entryKey]
 	if !ok {
 		return "", fmt.Errorf("missing sanitizer spec entry: %s", entryKey)

--- a/x-pack/filebeat/input/azureeventhub/sanitizers_test.go
+++ b/x-pack/filebeat/input/azureeventhub/sanitizers_test.go
@@ -28,7 +28,7 @@ func TestSanitizersSanitize(t *testing.T) {
 
 	raSanitizer, err := newSanitizer(SanitizerSpec{
 		Type: SanitizerReplaceAll,
-		Spec: map[string]interface{}{
+		Spec: map[string]any{
 			"pattern":     `\[\s*([^\[\]{},\s]+(?:\s+[^\[\]{},\s]+)*)\s*\]`,
 			"replacement": "{}",
 		},

--- a/x-pack/filebeat/input/azureeventhub/tracer.go
+++ b/x-pack/filebeat/input/azureeventhub/tracer.go
@@ -41,12 +41,12 @@ type logsOnlyTracer struct {
 // ----------------------------------------------------------------------------
 
 // StartSpan returns the input context and a no-op Spanner
-func (nt *logsOnlyTracer) StartSpan(ctx context.Context, operationName string, opts ...interface{}) (context.Context, tab.Spanner) {
+func (nt *logsOnlyTracer) StartSpan(ctx context.Context, operationName string, opts ...any) (context.Context, tab.Spanner) {
 	return ctx, &logsOnlySpanner{nt.logger}
 }
 
 // StartSpanWithRemoteParent returns the input context and a no-op Spanner
-func (nt *logsOnlyTracer) StartSpanWithRemoteParent(ctx context.Context, operationName string, carrier tab.Carrier, opts ...interface{}) (context.Context, tab.Spanner) {
+func (nt *logsOnlyTracer) StartSpanWithRemoteParent(ctx context.Context, operationName string, carrier tab.Carrier, opts ...any) (context.Context, tab.Spanner) {
 	return ctx, &logsOnlySpanner{nt.logger}
 }
 
@@ -87,7 +87,7 @@ func (ns *logsOnlySpanner) Inject(carrier tab.Carrier) error {
 }
 
 // InternalSpan returns nil
-func (ns *logsOnlySpanner) InternalSpan() interface{} {
+func (ns *logsOnlySpanner) InternalSpan() any {
 	return nil
 }
 

--- a/x-pack/filebeat/input/azureeventhub/v1_input.go
+++ b/x-pack/filebeat/input/azureeventhub/v1_input.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	eventhub "github.com/Azure/azure-event-hubs-go/v3"
@@ -289,13 +288,13 @@ func (in *eventHubInputV1) processEvents(event *eventhub.Event) {
 
 func createPipelineClient(pipeline beat.Pipeline) (beat.Client, error) {
 	return pipeline.ConnectWith(beat.ClientConfig{
-		EventListener: acker.LastEventPrivateReporter(func(acked int, data interface{}) {
+		EventListener: acker.LastEventPrivateReporter(func(acked int, data any) {
 			// fmt.Println(acked, data)
 		}),
 		Processing: beat.ProcessingConfig{
 			// This input only produces events with basic types so normalization
 			// is not required.
-			EventNormalization: to.Ptr(false),
+			EventNormalization: new(false),
 		},
 	})
 }

--- a/x-pack/heartbeat/cmd/root.go
+++ b/x-pack/heartbeat/cmd/root.go
@@ -70,16 +70,16 @@ type streamRef struct{ input, stream int }
 // extractBrowserParams removes "params" from every browser stream in rawInputs
 // and pre-parses them with PathSep("") so dotted keys are kept literal.
 // Note: it mutates rawInputs.
-func extractBrowserParams(rawInputs []map[string]interface{}) (map[streamRef]*conf.C, error) {
+func extractBrowserParams(rawInputs []map[string]any) (map[streamRef]*conf.C, error) {
 	extracted := map[streamRef]*conf.C{}
 	for i, input := range rawInputs {
-		streams, _ := input["streams"].([]interface{})
+		streams, _ := input["streams"].([]any)
 		for j, s := range streams {
-			stream, ok := s.(map[string]interface{})
+			stream, ok := s.(map[string]any)
 			if kind, _ := stream["type"].(string); !ok || kind != "browser" {
 				continue
 			}
-			if params, ok := stream["params"].(map[string]interface{}); ok {
+			if params, ok := stream["params"].(map[string]any); ok {
 				parsed, err := ucfg.NewFrom(params, ucfg.PathSep(""))
 				if err != nil {
 					return nil, fmt.Errorf("error parsing browser params for stream %d: %w", j, err)
@@ -108,8 +108,8 @@ func restoreBrowserParams(configList []*reload.ConfigWithMeta, params map[stream
 }
 
 // TransformRawIn removes unwanted fields to keep consistent hashing on reload()
-func TransformRawIn(rawIn *proto.UnitExpectedConfig) []map[string]interface{} {
-	rawInput := []map[string]interface{}{rawIn.GetSource().AsMap()}
+func TransformRawIn(rawIn *proto.UnitExpectedConfig) []map[string]any {
+	rawInput := []map[string]any{rawIn.GetSource().AsMap()}
 
 	for _, p := range rawInput {
 		delete(p, "policy")
@@ -131,12 +131,12 @@ func init() {
 	}
 }
 
-func agentInfoRule(agentInfo *client.AgentInfo) []interface{} {
+func agentInfoRule(agentInfo *client.AgentInfo) []any {
 	// upstream API can sometimes return a nil agent info
 	if agentInfo == nil {
-		return []interface{}{}
+		return []any{}
 	}
-	var processors []interface{}
+	var processors []any
 
 	processors = append(processors, generateAddFieldsProcessor(
 		mapstr.M{"id": agentInfo.ID, "snapshot": agentInfo.Snapshot, "version": agentInfo.Version},

--- a/x-pack/heartbeat/cmd/root_test.go
+++ b/x-pack/heartbeat/cmd/root_test.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,7 +86,7 @@ func readRawIn(filename string, rawIn *proto.UnitExpectedConfig) error {
 	return err
 }
 
-func readOut(filename string) (cfg []map[string]interface{}, err error) {
+func readOut(filename string) (cfg []map[string]any, err error) {
 	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -103,19 +104,19 @@ func readOut(filename string) (cfg []map[string]interface{}, err error) {
 func TestHeartbeatCfg_BrowserParamsDottedKeys(t *testing.T) {
 	tests := []struct {
 		name         string
-		streamFields map[string]interface{}
-		assert       func(t *testing.T, monitor map[string]interface{})
+		streamFields map[string]any
+		assert       func(t *testing.T, monitor map[string]any)
 	}{
 		{
 			name: "dotted param keys are preserved literally",
-			streamFields: map[string]interface{}{
-				"params": map[string]interface{}{
+			streamFields: map[string]any{
+				"params": map[string]any{
 					"subdomain":             "value1",
 					"subdomain.example.com": "value2",
 				},
 			},
-			assert: func(t *testing.T, monitor map[string]interface{}) {
-				params, ok := monitor["params"].(map[string]interface{})
+			assert: func(t *testing.T, monitor map[string]any) {
+				params, ok := monitor["params"].(map[string]any)
 				require.True(t, ok, "expected browser params map in monitor config")
 				assert.Equal(t, "value1", params["subdomain"], "expected non-dotted param key to be preserved")
 				assert.Equal(t, "value2", params["subdomain.example.com"], "expected dotted param key to be preserved literally")
@@ -123,23 +124,23 @@ func TestHeartbeatCfg_BrowserParamsDottedKeys(t *testing.T) {
 		},
 		{
 			name: "dotted keys outside params still expand",
-			streamFields: map[string]interface{}{
+			streamFields: map[string]any{
 				// A dotted key that is NOT a param must still expand to nested structure.
 				"a.b.c": "nested",
-				"params": map[string]interface{}{
+				"params": map[string]any{
 					"subdomain.example.com": "literal",
 				},
 			},
-			assert: func(t *testing.T, monitor map[string]interface{}) {
+			assert: func(t *testing.T, monitor map[string]any) {
 				// The non-param dotted key expands into nested maps.
-				a, ok := monitor["a"].(map[string]interface{})
+				a, ok := monitor["a"].(map[string]any)
 				require.True(t, ok, "expected dotted key 'a.b.c' to expand into nested maps")
-				b, ok := a["b"].(map[string]interface{})
+				b, ok := a["b"].(map[string]any)
 				require.True(t, ok, "expected 'a.b' to be a nested map")
 				assert.Equal(t, "nested", b["c"], "expected 'a.b.c' to expand")
 
 				// The param dotted key stays literal.
-				params, ok := monitor["params"].(map[string]interface{})
+				params, ok := monitor["params"].(map[string]any)
 				require.True(t, ok, "expected browser params map in monitor config")
 				assert.Equal(t, "literal", params["subdomain.example.com"], "expected param dotted key to stay literal")
 				assert.NotContains(t, params, "subdomain", "param dotted key must not expand")
@@ -158,7 +159,7 @@ func TestHeartbeatCfg_BrowserParamsDottedKeys(t *testing.T) {
 // runBrowserCfg loads the browser test fixture, merges the given fields into its
 // first (browser) stream, runs it through heartbeatCfg, and returns the
 // resulting monitor configs as maps.
-func runBrowserCfg(t *testing.T, streamFields map[string]interface{}) []map[string]interface{} {
+func runBrowserCfg(t *testing.T, streamFields map[string]any) []map[string]any {
 	t.Helper()
 
 	var rawIn proto.UnitExpectedConfig
@@ -166,15 +167,13 @@ func runBrowserCfg(t *testing.T, streamFields map[string]interface{}) []map[stri
 	require.NoError(t, err, "failed to read browser test fixture")
 
 	sourceMap := rawIn.GetSource().AsMap()
-	streams, ok := sourceMap["streams"].([]interface{})
+	streams, ok := sourceMap["streams"].([]any)
 	require.True(t, ok, "expected streams to be a slice")
 	require.NotEmpty(t, streams, "expected at least one stream")
 
-	browserStream, ok := streams[0].(map[string]interface{})
+	browserStream, ok := streams[0].(map[string]any)
 	require.True(t, ok, "expected browser stream to be an object")
-	for k, v := range streamFields {
-		browserStream[k] = v
-	}
+	maps.Copy(browserStream, streamFields)
 
 	rawIn.Source, err = structpb.NewStruct(sourceMap)
 	require.NoError(t, err, "failed to rebuild proto source")
@@ -189,15 +188,15 @@ func runBrowserCfg(t *testing.T, streamFields map[string]interface{}) []map[stri
 	return got
 }
 
-func cfgToArrMap(cfg []*reload.ConfigWithMeta) ([]map[string]interface{}, error) {
-	res := make([]map[string]interface{}, 0, len(cfg))
+func cfgToArrMap(cfg []*reload.ConfigWithMeta) ([]map[string]any, error) {
+	res := make([]map[string]any, 0, len(cfg))
 	for _, c := range cfg {
 		var m mapstr.M
 		err := c.Config.Unpack(&m)
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, map[string]interface{}(m))
+		res = append(res, map[string]any(m))
 	}
 	return res, nil
 }

--- a/x-pack/heartbeat/monitors/browser/source/local_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/local_test.go
@@ -44,7 +44,7 @@ func TestLocalSourceValidate(t *testing.T) {
 	}
 }
 
-func dummyLocal(conf map[string]interface{}) (*LocalSource, error) {
+func dummyLocal(conf map[string]any) (*LocalSource, error) {
 	zus := &LocalSource{}
 	y, _ := yaml.Marshal(conf)
 	c, err := config.NewConfigWithYAML(y, string(y))

--- a/x-pack/heartbeat/monitors/browser/source/project_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/project_test.go
@@ -113,7 +113,7 @@ func fetchAndValidate(t *testing.T, psrc *ProjectSource) {
 	require.True(t, os.IsNotExist(err), "TargetDirectory %s should have been deleted", psrc.TargetDirectory)
 }
 
-func dummyPSource(conf map[string]interface{}) (*ProjectSource, error) {
+func dummyPSource(conf map[string]any) (*ProjectSource, error) {
 	psrc := &ProjectSource{}
 	y, _ := yaml.Marshal(conf)
 	c, err := config.NewConfigWithYAML(y, string(y))

--- a/x-pack/heartbeat/monitors/browser/source/zipurl_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/zipurl_test.go
@@ -105,7 +105,7 @@ func TestSimpleCases(t *testing.T) {
 	}
 }
 
-func dummyZus(conf map[string]interface{}) (*ZipURLSource, error) {
+func dummyZus(conf map[string]any) (*ZipURLSource, error) {
 	zus := &ZipURLSource{}
 	y, _ := yaml.Marshal(conf)
 	c, err := config.NewConfigWithYAML(y, string(y))

--- a/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer_test.go
@@ -18,7 +18,7 @@ func TestExecMultiplexer(t *testing.T) {
 	// Generate three fake journeys with three fake steps
 	testEvents := make([]*SynthEvent, 0, 3)
 	time := float64(0)
-	for jIdx := 0; jIdx < 3; jIdx++ {
+	for jIdx := range 3 {
 		time++ // fake time to make events seem spaced out
 		journey := &Journey{
 			Name: fmt.Sprintf("J%d", jIdx),
@@ -30,7 +30,7 @@ func TestExecMultiplexer(t *testing.T) {
 			TimestampEpochMicros: time,
 		})
 
-		for sIdx := 0; sIdx < 3; sIdx++ {
+		for sIdx := range 3 {
 			step := &Step{
 				Name:   fmt.Sprintf("S%d", sIdx),
 				Index:  sIdx,

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -47,7 +47,7 @@ type SynthexecTimeout string
 var SynthexecTimeoutKey = SynthexecTimeout("synthexec_timeout")
 
 // ProjectJob will run a single journey by name from the given project.
-func ProjectJob(ctx context.Context, projectPath string, params func() map[string]interface{}, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {
+func ProjectJob(ctx context.Context, projectPath string, params func() map[string]any, filterJourneys FilterJourneyConfig, fields stdfields.StdMonitorFields, extraArgs ...string) (jobs.Job, error) {
 	// Run the command in the given projectPath, use '.' as the first arg since the command runs
 	// in the correct dir
 	cmdFactory, err := projectCommandFactory(projectPath, extraArgs...)
@@ -79,7 +79,7 @@ func projectCommandFactory(projectPath string, args ...string) (func() *SynthCmd
 }
 
 // InlineJourneyJob returns a job that runs the given source as a single journey.
-func InlineJourneyJob(ctx context.Context, script string, params func() map[string]interface{}, fields stdfields.StdMonitorFields, extraArgs ...string) jobs.Job {
+func InlineJourneyJob(ctx context.Context, script string, params func() map[string]any, fields stdfields.StdMonitorFields, extraArgs ...string) jobs.Job {
 	newCmd := func() *SynthCmd {
 		return &SynthCmd{exec.Command("elastic-synthetics", append(extraArgs, "--inline")...)} //nolint:gosec,noctx // we are safely building a command here, users can add args at their own risk
 	}
@@ -90,7 +90,7 @@ func InlineJourneyJob(ctx context.Context, script string, params func() map[stri
 // startCmdJob adapts commands into a heartbeat job. This is a little awkward given that the command's output is
 // available via a sequence of events in the multiplexer, while heartbeat jobs are tail recursive continuations.
 // Here, we adapt one to the other, where each recursive job pulls another item off the chan until none are left.
-func startCmdJob(ctx context.Context, newCmd func() *SynthCmd, stdinStr *string, params func() map[string]interface{}, filterJourneys FilterJourneyConfig, sFields stdfields.StdMonitorFields) jobs.Job {
+func startCmdJob(ctx context.Context, newCmd func() *SynthCmd, stdinStr *string, params func() map[string]any, filterJourneys FilterJourneyConfig, sFields stdfields.StdMonitorFields) jobs.Job {
 	return func(event *beat.Event) ([]jobs.Job, error) {
 		senr := newStreamEnricher(sFields)
 		// Prefer the published monitor.check_group (set by the summarizer's
@@ -174,7 +174,7 @@ func runCmd(
 	ctx context.Context,
 	cmd *SynthCmd,
 	stdinStr *string,
-	params func() map[string]interface{},
+	params func() map[string]any,
 	filterJourneys FilterJourneyConfig,
 	sFields stdfields.StdMonitorFields,
 	traceID string,
@@ -235,34 +235,29 @@ func runCmd(
 	if err != nil {
 		return nil, fmt.Errorf("could not open stdout pipe: %w", err)
 	}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err := scanToSynthEvents(stdoutPipe, stdoutToSynthEvent, mpx.writeSynthEvent)
 		if err != nil {
 			//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
 			logp.L().Warn("could not scan stdout events from synthetics: %s", err)
 		}
 
-		wg.Done()
-	}()
+	})
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
 		return nil, fmt.Errorf("could not open stderr pipe: %w", err)
 	}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err := scanToSynthEvents(stderrPipe, stderrToSynthEvent, mpx.writeSynthEvent)
 		if err != nil {
 			//nolint:forbidigo // pre-existing global logger use; logger threading is out of scope here
 			logp.L().Warn("could not scan stderr events from synthetics: %s", err)
 		}
-		wg.Done()
-	}()
+	})
 
 	// Send the test results into the output
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		defer jsonReader.Close()
 
 		// We don't use scanToSynthEvents here because all lines here will be JSON
@@ -283,8 +278,7 @@ func runCmd(
 			mpx.writeSynthEvent(&se)
 		}
 
-		wg.Done()
-	}()
+	})
 
 	// This use of channels for results is awkward, but required for the thread locking below
 	cmdStarted := make(chan error)

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
@@ -138,7 +138,7 @@ func TestJsonToSynthEvent(t *testing.T) {
 					Index:  0,
 					Status: "succeeded",
 				},
-				Payload: map[string]interface{}{
+				Payload: map[string]any{
 					"source":      "async ({page, params}) => {await page.goto('http://www.elastic.co')}",
 					"duration_ms": float64(3472),
 					"url":         "https://www.elastic.co/",

--- a/x-pack/heartbeat/scenarios/basics_test.go
+++ b/x-pack/heartbeat/scenarios/basics_test.go
@@ -36,8 +36,8 @@ func TestSimpleScenariosBasicFields(t *testing.T) {
 		require.GreaterOrEqual(t, len(mtr.Events()), 1)
 		var checkHist []*CheckHistItem
 		for _, e := range mtr.Events() {
-			testslike.Test(t, lookslike.MustCompile(map[string]interface{}{
-				"monitor": map[string]interface{}{
+			testslike.Test(t, lookslike.MustCompile(map[string]any{
+				"monitor": map[string]any{
 					"id":          mtr.StdFields.ID,
 					"name":        mtr.StdFields.Name,
 					"type":        mtr.StdFields.Type,
@@ -86,8 +86,8 @@ func TestLightweightUrls(t *testing.T) {
 	t.Parallel()
 	scenarioDB.RunTag(t, "lightweight", func(t *testing.T, mtr *framework.MonitorTestRun, err error) {
 		for _, e := range mtr.Events() {
-			testslike.Test(t, lookslike.MustCompile(map[string]interface{}{
-				"url": map[string]interface{}{
+			testslike.Test(t, lookslike.MustCompile(map[string]any{
+				"url": map[string]any{
 					"full":   isdef.IsNonEmptyString,
 					"domain": isdef.IsNonEmptyString,
 					"scheme": mtr.StdFields.Type,
@@ -133,11 +133,11 @@ func TestRunFromOverride(t *testing.T) {
 			if isLast {
 				stateIsDef = hbtestllext.IsMonitorStateInLocation(TestLocationDefault.ID)
 			}
-			validator := lookslike.MustCompile(map[string]interface{}{
+			validator := lookslike.MustCompile(map[string]any{
 				"state": stateIsDef,
-				"observer": map[string]interface{}{
+				"observer": map[string]any{
 					"name": TestLocationDefault.ID,
-					"geo": map[string]interface{}{
+					"geo": map[string]any{
 						"name": TestLocationDefault.Geo.Name,
 					},
 				},

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -330,7 +330,7 @@ func InitEvent(regionName string, accountName string, accountID string, timestam
 
 // CheckTagFiltersExist compare tags filter with a set of tags to see if tags
 // filter is a subset of tags
-func CheckTagFiltersExist(tagsFilter []Tag, tags interface{}) bool {
+func CheckTagFiltersExist(tagsFilter []Tag, tags any) bool {
 	var tagKeys []string
 	var tagValues []string
 

--- a/x-pack/metricbeat/module/aws/aws_test.go
+++ b/x-pack/metricbeat/module/aws/aws_test.go
@@ -85,7 +85,7 @@ func TestCheckTagFiltersExist(t *testing.T) {
 	cases := []struct {
 		title          string
 		tagFilters     []Tag
-		tags           interface{}
+		tags           any
 		expectedExists bool
 	}{
 		{

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -476,20 +476,20 @@ func createMetricDataQueries(listMetricsTotal []metricsWithStatistics, dataGranu
 func constructLabel(metric aws.MetricWithID, statistic string) string {
 	// label = accountID + accountLabel + metricName + namespace + statistic + periodLabel + dimKeys + dimValues
 	label := strings.Join([]string{metric.AccountID, aws.LabelConst.AccountLabel, *metric.Metric.MetricName, *metric.Metric.Namespace, statistic, aws.LabelConst.PeriodLabel}, aws.LabelConst.LabelSeparator)
-	dimNames := ""
-	dimValues := ""
+	var dimNames strings.Builder
+	var dimValues strings.Builder
 	for i, dim := range metric.Metric.Dimensions {
-		dimNames += *dim.Name
-		dimValues += *dim.Value
+		dimNames.WriteString(*dim.Name)
+		dimValues.WriteString(*dim.Value)
 		if i != len(metric.Metric.Dimensions)-1 {
-			dimNames += dimensionSeparator
-			dimValues += dimensionSeparator
+			dimNames.WriteString(dimensionSeparator)
+			dimValues.WriteString(dimensionSeparator)
 		}
 	}
 
-	if dimNames != "" && dimValues != "" {
-		label += aws.LabelConst.LabelSeparator + dimNames
-		label += aws.LabelConst.LabelSeparator + dimValues
+	if dimNames.String() != "" && dimValues.String() != "" {
+		label += aws.LabelConst.LabelSeparator + dimNames.String()
+		label += aws.LabelConst.LabelSeparator + dimValues.String()
 	}
 	return label
 }
@@ -536,7 +536,7 @@ func insertRootFields(event mb.Event, metricValue float64, labels []string) mb.E
 
 	dimNames := strings.Split(labels[aws.LabelConst.IdentifierNameIdx], ",")
 	dimValues := strings.Split(labels[aws.LabelConst.IdentifierValueIdx], ",")
-	for i := 0; i < len(dimNames); i++ {
+	for i := range dimNames {
 		_, _ = event.RootFields.Put("aws.dimensions."+dimNames[i], dimValues[i])
 	}
 	return event
@@ -650,8 +650,8 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 				// split the identifier and check for each sub-identifier.
 				// For example, identifier might be [storageType, s3BucketName].
 				// And tags are only store under s3BucketName in resourceTagMap.
-				subIdentifiers := strings.Split(identifierValue, dimensionSeparator)
-				for _, subIdentifier := range subIdentifiers {
+				subIdentifiers := strings.SplitSeq(identifierValue, dimensionSeparator)
+				for subIdentifier := range subIdentifiers {
 
 					if len(infoAPImap) > 0 { // If infoAPImap includes data
 						if valAPIName, ok := infoAPImap[subIdentifier]; ok {

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
@@ -37,9 +37,9 @@ func TestData(t *testing.T) {
 	metricSet.WriteEvents(t, "/")
 }
 
-func addCloudwatchMetricsToConfig(config map[string]interface{}) map[string]interface{} {
-	cloudwatchMetricsConfig := []map[string]interface{}{}
-	cloudwatchMetric := map[string]interface{}{}
+func addCloudwatchMetricsToConfig(config map[string]any) map[string]any {
+	cloudwatchMetricsConfig := []map[string]any{}
+	cloudwatchMetric := map[string]any{}
 	cloudwatchMetric["namespace"] = "AWS/RDS"
 	cloudwatchMetricsConfig = append(cloudwatchMetricsConfig, cloudwatchMetric)
 	config["metrics"] = cloudwatchMetricsConfig

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1505,8 +1505,8 @@ func TestInsertTags(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			subIdentifiers := strings.Split(c.identifier, dimensionSeparator)
-			for _, subIdentifier := range subIdentifiers {
+			subIdentifiers := strings.SplitSeq(c.identifier, dimensionSeparator)
+			for subIdentifier := range subIdentifiers {
 				insertTags(events, c.identifier, subIdentifier, resourceTagMap)
 			}
 			value, err := events[c.identifier].RootFields.GetValue(c.expectedTagKey)

--- a/x-pack/metricbeat/module/aws/mtest/integration.go
+++ b/x-pack/metricbeat/module/aws/mtest/integration.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetConfigForTest function gets aws credentials for integration tests.
-func GetConfigForTest(t *testing.T, metricSetName string, period string) map[string]interface{} {
+func GetConfigForTest(t *testing.T, metricSetName string, period string) map[string]any {
 	t.Helper()
 
 	accessKeyID, okAccessKeyID := os.LookupEnv("AWS_ACCESS_KEY_ID")
@@ -22,13 +22,13 @@ func GetConfigForTest(t *testing.T, metricSetName string, period string) map[str
 		defaultRegion = "us-west-1"
 	}
 
-	config := map[string]interface{}{}
+	config := map[string]any{}
 	if !okAccessKeyID || accessKeyID == "" {
 		t.Fatal("$AWS_ACCESS_KEY_ID not set or set to empty")
 	} else if !okSecretAccessKey || secretAccessKey == "" {
 		t.Fatal("$AWS_SECRET_ACCESS_KEY not set or set to empty")
 	} else {
-		config = map[string]interface{}{
+		config = map[string]any{
 			"module":            "aws",
 			"period":            period,
 			"metricsets":        []string{metricSetName},
@@ -46,7 +46,7 @@ func GetConfigForTest(t *testing.T, metricSetName string, period string) map[str
 	return config
 }
 
-func compareType(metricValue interface{}, expectedType string, metricName string) (err error) {
+func compareType(metricValue any, expectedType string, metricName string) (err error) {
 	switch metricValue.(type) {
 	case float64:
 		if expectedType != "float" {

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -198,10 +198,7 @@ func (m *MockCloudwatchClientMultiplePages) ListMetrics(ctx context.Context, inp
 		startIndex = index
 	}
 
-	endIndex := startIndex + pageSize
-	if endIndex > len(allMetrics) {
-		endIndex = len(allMetrics)
-	}
+	endIndex := min(startIndex+pageSize, len(allMetrics))
 
 	nextToken := ""
 	if endIndex < len(allMetrics) {

--- a/x-pack/metricbeat/module/azure/azure.go
+++ b/x-pack/metricbeat/module/azure/azure.go
@@ -324,12 +324,7 @@ func hasConfigOptions(config []string) bool {
 	if config == nil {
 		return false
 	}
-	for _, group := range config {
-		if group == "" {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(config, "")
 }
 
 // calculateTimespan returns the start and end times for the metric values given

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -317,9 +317,9 @@ func (client *BaseClient) GetVMForMetadata(resource *Resource, referencePoint Ke
 	vm.Name = *expandedResource.Name
 
 	if expandedResource.Properties != nil {
-		if properties, ok := expandedResource.Properties.(map[string]interface{}); ok {
+		if properties, ok := expandedResource.Properties.(map[string]any); ok {
 			if hardware, ok := properties["hardwareProfile"]; ok {
-				if vmSz, ok := hardware.(map[string]interface{}); ok {
+				if vmSz, ok := hardware.(map[string]any); ok {
 					if vmSz, ok := vmSz["vmSize"]; ok {
 						vm.Size, _ = vmSz.(string)
 					}

--- a/x-pack/metricbeat/module/azure/client_batch.go
+++ b/x-pack/metricbeat/module/azure/client_batch.go
@@ -173,10 +173,7 @@ func (client *BatchClient) GetMetricsInBatch(groupedMetrics map[ResDefGroupingCr
 			filter = strings.Join(filterList, " AND ")
 		}
 		for i := 0; i < len(metricsDefinitions); i += BatchApiResourcesLimit {
-			end := i + BatchApiResourcesLimit
-			if end > len(metricsDefinitions) {
-				end = len(metricsDefinitions)
-			}
+			end := min(i+BatchApiResourcesLimit, len(metricsDefinitions))
 
 			// Slice the metrics to form the batch request
 			batchMetrics := metricsDefinitions[i:end]
@@ -184,10 +181,7 @@ func (client *BatchClient) GetMetricsInBatch(groupedMetrics map[ResDefGroupingCr
 			// Slice the Metric Names by batches of 20 due to batch api limitation
 			names := strings.Split(criteria.Names, ",")
 			for j := 0; j < len(names); j += metricNameLimit {
-				endMetric := j + metricNameLimit
-				if endMetric > len(names) {
-					endMetric = len(names)
-				}
+				endMetric := min(j+metricNameLimit, len(names))
 
 				// Make the batch API call (adjust parameters as needed)
 				response, err := client.AzureMonitorService.QueryResources(

--- a/x-pack/metricbeat/module/azure/client_batch_test.go
+++ b/x-pack/metricbeat/module/azure/client_batch_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/stretchr/testify/assert"
@@ -144,39 +143,39 @@ func TestGetMetricsInBatch(t *testing.T) {
 		m := &MockService{}
 		metrics := []azmetrics.Metric{
 			{
-				ID: to.Ptr("test"),
+				ID: new("test"),
 				Name: &azmetrics.LocalizableString{
-					Value:          to.Ptr("ActiveConnections"),
-					LocalizedValue: to.Ptr("Active Connections"),
+					Value:          new("ActiveConnections"),
+					LocalizedValue: new("Active Connections"),
 				},
 				TimeSeries: []azmetrics.TimeSeriesElement{
 					{
 						Data: []azmetrics.MetricValue{
 							{
-								Average:   to.Ptr(1.0),
-								Maximum:   to.Ptr(2.0),
-								Minimum:   to.Ptr(3.0),
-								TimeStamp: to.Ptr(time.Now()),
+								Average:   new(1.0),
+								Maximum:   new(2.0),
+								Minimum:   new(3.0),
+								TimeStamp: new(time.Now()),
 							},
 						},
 					},
 				},
-				Type:               to.Ptr("Microsoft.Insights/metrics"),
+				Type:               new("Microsoft.Insights/metrics"),
 				Unit:               &count,
-				DisplayDescription: to.Ptr("Total Active Connections for Microsoft.EventHub."),
-				ErrorCode:          to.Ptr("Success"),
+				DisplayDescription: new("Total Active Connections for Microsoft.EventHub."),
+				ErrorCode:          new("Success"),
 			},
 		}
 
 		m.On("QueryResources", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			[]azmetrics.MetricData{{
-				EndTime:        to.Ptr("2025-01-28T15:00:00Z"),
-				StartTime:      to.Ptr("2025-01-28T14:00:00Z"),
+				EndTime:        new("2025-01-28T15:00:00Z"),
+				StartTime:      new("2025-01-28T14:00:00Z"),
 				Values:         metrics,
-				Interval:       to.Ptr("PT1H"),
-				Namespace:      to.Ptr("Microsoft.EventHub/Namespaces"),
-				ResourceID:     to.Ptr("resourceId1"),
-				ResourceRegion: to.Ptr("West Europe")}},
+				Interval:       new("PT1H"),
+				Namespace:      new("Microsoft.EventHub/Namespaces"),
+				ResourceID:     new("resourceId1"),
+				ResourceRegion: new("West Europe")}},
 			nil,
 		)
 

--- a/x-pack/metricbeat/module/azure/client_test.go
+++ b/x-pack/metricbeat/module/azure/client_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/stretchr/testify/assert"
@@ -148,23 +147,23 @@ func TestGetMetricValues(t *testing.T) {
 			mock.Anything,
 		).Return(
 			[]armmonitor.Metric{{
-				ID: to.Ptr("test"),
+				ID: new("test"),
 				Name: &armmonitor.LocalizableString{
-					Value:          to.Ptr("ActiveConnections"),
-					LocalizedValue: to.Ptr("ActiveConnections"),
+					Value:          new("ActiveConnections"),
+					LocalizedValue: new("ActiveConnections"),
 				},
 				Timeseries: []*armmonitor.TimeSeriesElement{{
 					Data: []*armmonitor.MetricValue{{
-						Average:   to.Ptr(1.0),
-						Maximum:   to.Ptr(2.0),
-						Minimum:   to.Ptr(3.0),
-						TimeStamp: to.Ptr(time.Now()),
+						Average:   new(1.0),
+						Maximum:   new(2.0),
+						Minimum:   new(3.0),
+						TimeStamp: new(time.Now()),
 					}},
 				}},
-				Type:               to.Ptr("Microsoft.Insights/metrics"),
+				Type:               new("Microsoft.Insights/metrics"),
 				Unit:               &countUnit,
-				DisplayDescription: to.Ptr("Total Active Connections for Microsoft.EventHub."),
-				ErrorCode:          to.Ptr("Success"),
+				DisplayDescription: new("Total Active Connections for Microsoft.EventHub."),
+				ErrorCode:          new("Success"),
 			}},
 			"PT1M",
 			nil,
@@ -218,9 +217,9 @@ func TestGetMetricValues(t *testing.T) {
 			aggregation string
 			data        []*armmonitor.MetricValue
 		}{
-			{aggregation: "Maximum", data: []*armmonitor.MetricValue{{Maximum: to.Ptr(3.0), TimeStamp: to.Ptr(timestamp)}}},
-			{aggregation: "Minimum", data: []*armmonitor.MetricValue{{Minimum: to.Ptr(1.0), TimeStamp: to.Ptr(timestamp)}}},
-			{aggregation: "Average", data: []*armmonitor.MetricValue{{Average: to.Ptr(2.0), TimeStamp: to.Ptr(timestamp)}}},
+			{aggregation: "Maximum", data: []*armmonitor.MetricValue{{Maximum: new(3.0), TimeStamp: new(timestamp)}}},
+			{aggregation: "Minimum", data: []*armmonitor.MetricValue{{Minimum: new(1.0), TimeStamp: new(timestamp)}}},
+			{aggregation: "Average", data: []*armmonitor.MetricValue{{Average: new(2.0), TimeStamp: new(timestamp)}}},
 		}
 
 		for _, v := range x {
@@ -235,18 +234,18 @@ func TestGetMetricValues(t *testing.T) {
 				mock.Anything,
 			).Return(
 				[]armmonitor.Metric{{
-					ID: to.Ptr("test"),
+					ID: new("test"),
 					Name: &armmonitor.LocalizableString{
-						Value:          to.Ptr("ActiveConnections"),
-						LocalizedValue: to.Ptr("ActiveConnections"),
+						Value:          new("ActiveConnections"),
+						LocalizedValue: new("ActiveConnections"),
 					},
 					Timeseries: []*armmonitor.TimeSeriesElement{{
 						Data: v.data,
 					}},
-					Type:               to.Ptr("Microsoft.Insights/metrics"),
+					Type:               new("Microsoft.Insights/metrics"),
 					Unit:               &countUnit,
-					DisplayDescription: to.Ptr("Total Active Connections for Microsoft.EventHub."),
-					ErrorCode:          to.Ptr("Success"),
+					DisplayDescription: new("Total Active Connections for Microsoft.EventHub."),
+					ErrorCode:          new("Success"),
 				}},
 				"PT1M",
 				nil,

--- a/x-pack/metricbeat/module/azure/client_utils.go
+++ b/x-pack/metricbeat/module/azure/client_utils.go
@@ -222,11 +222,11 @@ func getVM(vmName string, vms []VmResource) (VmResource, bool) {
 
 // Helper function to generate a string key for the dimensions
 func getDimensionKey(dimensions []Dimension) string {
-	var dimensionKey string
+	var dimensionKey strings.Builder
 	for _, dimension := range dimensions {
-		dimensionKey += dimension.Name + ","
+		dimensionKey.WriteString(dimension.Name + ",")
 	}
-	return dimensionKey
+	return dimensionKey.String()
 }
 
 // Function to get the resource IDs from the batch of metrics

--- a/x-pack/metricbeat/module/azure/data.go
+++ b/x-pack/metricbeat/module/azure/data.go
@@ -31,7 +31,7 @@ const (
 // resource type, etc.).
 type KeyValuePoint struct {
 	Key           string
-	Value         interface{}
+	Value         any
 	Namespace     string
 	ResourceId    string
 	ResourceSubId string
@@ -322,16 +322,16 @@ func managePropertyName(metric string) string {
 func ReplaceUpperCase(src string) string {
 	replaceUpperCaseRegexp := regexp.MustCompile(replaceUpperCaseRegex)
 	return replaceUpperCaseRegexp.ReplaceAllStringFunc(src, func(str string) string {
-		var newStr string
+		var newStr strings.Builder
 		for _, r := range str {
 			// split into fields based on class of unicode character
 			if unicode.IsUpper(r) {
-				newStr += "_" + strings.ToLower(string(r))
+				newStr.WriteString("_" + strings.ToLower(string(r)))
 			} else {
-				newStr += string(r)
+				newStr.WriteString(string(r))
 			}
 		}
-		return newStr
+		return newStr.String()
 	})
 }
 

--- a/x-pack/metricbeat/module/azure/data_test.go
+++ b/x-pack/metricbeat/module/azure/data_test.go
@@ -87,7 +87,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 		}
 
@@ -149,7 +149,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			}, {
 				Key:           fmt.Sprintf("%s.%s", metricName, "max"),
 				Value:         &maxValue,
@@ -158,7 +158,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			}, {
 				Key:           fmt.Sprintf("%s.%s", metricName, "avg"),
 				Value:         &avgValue,
@@ -167,7 +167,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "total"),
@@ -177,7 +177,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "count"),
@@ -187,7 +187,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 		}
 
@@ -222,7 +222,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "max"),
@@ -232,7 +232,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "avg"),
@@ -242,7 +242,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "total"),
@@ -252,7 +252,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 			{
 				Key:           fmt.Sprintf("%s.%s", metricName, "count"),
@@ -262,7 +262,7 @@ func TestMapToKeyValuePoints(t *testing.T) {
 				Timestamp:     timestamp,
 				ResourceId:    resourceId,
 				ResourceSubId: resourceSubId,
-				Dimensions:    map[string]interface{}{},
+				Dimensions:    map[string]any{},
 			},
 		}
 

--- a/x-pack/metricbeat/module/azure/monitor/client_helper.go
+++ b/x-pack/metricbeat/module/azure/monitor/client_helper.go
@@ -113,12 +113,12 @@ func filterMetricNames(resourceId string, metricConfig azure.MetricConfig, metri
 func filterConfiguredMetrics(selectedRange []string, allRange []*armmonitor.MetricDefinition) ([]string, []string) {
 	var inRange []string
 	var notInRange []string
-	var allMetrics string
+	var allMetrics strings.Builder
 	for _, definition := range allRange {
-		allMetrics += *definition.Name.Value + " "
+		allMetrics.WriteString(*definition.Name.Value + " ")
 	}
 	for _, name := range selectedRange {
-		if strings.Contains(allMetrics, name) {
+		if strings.Contains(allMetrics.String(), name) {
 			inRange = append(inRange, name)
 		} else {
 			notInRange = append(notInRange, name)

--- a/x-pack/metricbeat/module/azure/monitor/monitor_integration_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/monitor_integration_test.go
@@ -30,9 +30,9 @@ func TestFetchMetricset(t *testing.T) {
 
 func TestData(t *testing.T) {
 	config := test.GetConfig(t, "monitor")
-	config["resources"] = []map[string]interface{}{{
+	config["resources"] = []map[string]any{{
 		"resource_query": "resourceType eq 'Microsoft.DocumentDb/databaseAccounts'",
-		"metrics": []map[string]interface{}{{"namespace": "Microsoft.DocumentDb/databaseAccounts",
+		"metrics": []map[string]any{{"namespace": "Microsoft.DocumentDb/databaseAccounts",
 			"name": []string{"DataUsage", "DocumentCount", "DocumentQuota"}}}}}
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEvents(t, "/")
@@ -40,10 +40,10 @@ func TestData(t *testing.T) {
 
 func TestDataMultipleDimensions(t *testing.T) {
 	config := test.GetConfig(t, "monitor")
-	config["resources"] = []map[string]interface{}{{
+	config["resources"] = []map[string]any{{
 		"resource_query": "resourceType eq 'Microsoft.KeyVault/vaults'",
-		"metrics": []map[string]interface{}{{"namespace": "Microsoft.KeyVault/vaults",
-			"name": []string{"Availability"}, "dimensions": []map[string]interface{}{{"name": "ActivityName", "value": "*"}}}}}}
+		"metrics": []map[string]any{{"namespace": "Microsoft.KeyVault/vaults",
+			"name": []string{"Availability"}, "dimensions": []map[string]any{{"name": "ActivityName", "value": "*"}}}}}}
 	metricSet := mbtest.NewFetcher(t, config)
 	metricSet.WriteEventsCond(t, "/", func(m mapstr.M) bool {
 		if m["azure"].(mapstr.M)["dimensions"].(mapstr.M)["activity_name"] == "secretget" {

--- a/x-pack/metricbeat/module/azure/monitor/monitor_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/monitor_test.go
@@ -43,7 +43,7 @@ var (
 		"resources": []mapstr.M{
 			{
 				"resource_id": "test",
-				"metrics": []map[string]interface{}{
+				"metrics": []map[string]any{
 					{
 						"namespace": "namespace_name",
 						"name":      []string{"metric_name"},

--- a/x-pack/metricbeat/module/azure/storage/storage_test.go
+++ b/x-pack/metricbeat/module/azure/storage/storage_test.go
@@ -43,7 +43,7 @@ var (
 		"resources": []mapstr.M{
 			{
 				"resource_id": "test",
-				"metrics": []map[string]interface{}{
+				"metrics": []map[string]any{
 					{
 						"name": []string{"*"},
 					}},

--- a/x-pack/metricbeat/module/azure/test/integration.go
+++ b/x-pack/metricbeat/module/azure/test/integration.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetConfig function gets azure credentials for integration tests.
-func GetConfig(t *testing.T, metricSetName string) map[string]interface{} {
+func GetConfig(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
 
 	clientId, ok := os.LookupEnv("AZURE_CLIENT_ID")
@@ -31,7 +31,7 @@ func GetConfig(t *testing.T, metricSetName string) map[string]interface{} {
 	if !ok {
 		t.Fatal("Could not find var AZURE_SUBSCRIPTION_ID")
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"module":                "azure",
 		"period":                "300s",
 		"refresh_list_interval": "600s",
@@ -44,7 +44,7 @@ func GetConfig(t *testing.T, metricSetName string) map[string]interface{} {
 }
 
 // GetConfigForInsights function gets azure credentials for integration tests.
-func GetConfigForInsights(t *testing.T, metricSetName string) map[string]interface{} {
+func GetConfigForInsights(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
 	applicationId, ok := os.LookupEnv("AZURE_APPLICATION_ID")
 	if !ok {
@@ -54,7 +54,7 @@ func GetConfigForInsights(t *testing.T, metricSetName string) map[string]interfa
 	if !ok {
 		t.Fatal("Could not find var AZURE_API_KEY")
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"module":         "azure",
 		"period":         "300s",
 		"metricsets":     []string{metricSetName},

--- a/x-pack/metricbeat/module/gcp/metadata_cache.go
+++ b/x-pack/metricbeat/module/gcp/metadata_cache.go
@@ -6,6 +6,7 @@ package gcp
 
 import (
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -60,9 +61,7 @@ func (c *Cache[T]) EnsureFresh(refreshFunc func() (map[string]T, error)) error {
 	}
 
 	c.data = make(map[string]T, len(newData))
-	for k, v := range newData {
-		c.data[k] = v
-	}
+	maps.Copy(c.data, newData)
 	c.lastRefreshed = time.Now()
 
 	return nil

--- a/x-pack/metricbeat/module/gcp/metadata_cache_test.go
+++ b/x-pack/metricbeat/module/gcp/metadata_cache_test.go
@@ -221,10 +221,3 @@ func TestCacheRegistry_TypedCaches(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, dataprocCluster, retrievedCluster)
 }
-
-// Helper function for string pointers
-//
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}

--- a/x-pack/metricbeat/module/gcp/metadata_cache_test.go
+++ b/x-pack/metricbeat/module/gcp/metadata_cache_test.go
@@ -197,7 +197,7 @@ func TestCacheRegistry_TypedCaches(t *testing.T) {
 	logger := logp.NewLogger("test")
 	registry := NewCacheRegistry(logger, 5*time.Minute)
 
-	computeInstance := &computepb.Instance{Name: stringPtr("test-instance")}
+	computeInstance := &computepb.Instance{Name: new("test-instance")}
 	registry.Compute.data["instance1"] = computeInstance
 	retrieved, found := registry.Compute.Get("instance1")
 	assert.True(t, found)
@@ -223,6 +223,8 @@ func TestCacheRegistry_TypedCaches(t *testing.T) {
 }
 
 // Helper function for string pointers
+//
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }

--- a/x-pack/metricbeat/module/gcp/metrics/cloudsql/metadata.go
+++ b/x-pack/metricbeat/module/gcp/metrics/cloudsql/metadata.go
@@ -70,8 +70,8 @@ type cloudsqlMetadata struct {
 
 	User     map[string]string
 	Metadata map[string]string
-	Metrics  interface{}
-	System   interface{}
+	Metrics  any
+	System   any
 }
 
 type metadataCollector struct {

--- a/x-pack/metricbeat/module/gcp/metrics/compute/metadata.go
+++ b/x-pack/metricbeat/module/gcp/metrics/compute/metadata.go
@@ -71,8 +71,8 @@ type computeMetadata struct {
 
 	User     map[string]string
 	Metadata map[string]string
-	Metrics  interface{}
-	System   interface{}
+	Metrics  any
+	System   any
 }
 
 type metadataCollector struct {

--- a/x-pack/metricbeat/module/gcp/metrics/dataproc/metadata.go
+++ b/x-pack/metricbeat/module/gcp/metrics/dataproc/metadata.go
@@ -73,8 +73,8 @@ type dataprocMetadata struct {
 
 	User     map[string]string
 	Metadata map[string]string
-	Metrics  interface{}
-	System   interface{}
+	Metrics  any
+	System   any
 }
 
 type metadataCollector struct {

--- a/x-pack/metricbeat/module/gcp/metrics/integration.go
+++ b/x-pack/metricbeat/module/gcp/metrics/integration.go
@@ -11,19 +11,19 @@ import (
 
 // GetConfigForTest function gets aws credentials for integration tests.
 // GCP_REGION, GCP_PROJECT_ID and GCP_CREDENTIALS_FILE_PATH are required.
-func GetConfigForTest(t *testing.T, metricSetName string) map[string]interface{} {
+func GetConfigForTest(t *testing.T, metricSetName string) map[string]any {
 	t.Helper()
 	region, okRegion := os.LookupEnv("GCP_REGION")
 	projectID, okProjectID := os.LookupEnv("GCP_PROJECT_ID")
 	credentialsFilePath, okCredentialsFilePath := os.LookupEnv("GCP_CREDENTIALS_FILE_PATH")
 
-	config := map[string]interface{}{}
+	config := map[string]any{}
 	if !okProjectID || projectID == "" {
 		t.Fatal("$GCP_PROJECT_ID not set or set to empty")
 	} else if !okCredentialsFilePath || credentialsFilePath == "" {
 		t.Fatal("$GCP_CREDENTIALS_FILE_PATH not set or set to empty")
 	} else {
-		config = map[string]interface{}{
+		config = map[string]any{
 			"module":                "gcp",
 			"period":                "1m",
 			"metricsets":            []string{metricSetName},

--- a/x-pack/metricbeat/module/gcp/metrics/redis/metadata.go
+++ b/x-pack/metricbeat/module/gcp/metrics/redis/metadata.go
@@ -71,8 +71,8 @@ type redisMetadata struct {
 
 	User     map[string]string
 	Metadata map[string]string
-	Metrics  interface{}
-	System   interface{}
+	Metrics  any
+	System   any
 }
 
 type metadataCollector struct {

--- a/x-pack/metricbeat/module/gcp/metrics/response_parser.go
+++ b/x-pack/metricbeat/module/gcp/metrics/response_parser.go
@@ -34,7 +34,7 @@ type incomingFieldMapper struct {
 // @timestamp, and metadata.
 type KeyValuePoint struct {
 	Key       string
-	Value     interface{}
+	Value     any
 	Labels    mapstr.M
 	ECS       mapstr.M
 	Timestamp time.Time
@@ -272,7 +272,7 @@ func remap(l *logp.Logger, s string) string {
 	return s
 }
 
-func getValueFromPoint(p *monitoringpb.Point) (out interface{}) {
+func getValueFromPoint(p *monitoringpb.Point) (out any) {
 	switch v := p.Value.Value.(type) {
 	case *monitoringpb.TypedValue_DoubleValue:
 		out = v.DoubleValue

--- a/x-pack/metricbeat/module/gcp/timeseries_metadata_collector.go
+++ b/x-pack/metricbeat/module/gcp/timeseries_metadata_collector.go
@@ -89,7 +89,7 @@ func (s *StackdriverTimeSeriesMetadataCollector) Metadata(ctx context.Context, i
 	}
 
 	if s.timeSeries.Metric != nil {
-		metrics := make(map[string]interface{})
+		metrics := make(map[string]any)
 		// common.Mapstr seems to not work as expected when deleting keys so I have to iterate over all results to add
 		// the ones I want
 		for k, v := range s.timeSeries.Metric.Labels {
@@ -107,7 +107,7 @@ func (s *StackdriverTimeSeriesMetadataCollector) Metadata(ctx context.Context, i
 	}
 
 	if s.timeSeries.Resource != nil {
-		resources := make(map[string]interface{})
+		resources := make(map[string]any)
 		// common.Mapstr seems to not work as expected when deleting keys so I have to iterate over all results to add
 		// the ones I want
 		for k, v := range s.timeSeries.Resource.Labels {


### PR DESCRIPTION
## Proposed commit message

```
heartbeat,x-pack/metricbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 137 file(s)
owned by @elastic/obs-ds-hosted-services in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

A second commit removes the helpers the rewrites orphaned; see the review notes below.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


REDUNDANT_CONVERSION = re.compile(r"new\(\(([\w.]+)\)\(")


def drop_redundant_parens(root: Path, files: list[str]) -> int:
    """Rewrite the `new((T)(x))` the newexpr fixer emits as `new(T(x))`.

    Dropping one paren on each side keeps the call balanced, and the pattern is narrow
    enough that a textual rewrite cannot match anything else.
    """
    touched = 0
    for name in files:
        path = root / name
        before = path.read_text()
        after = REDUNDANT_CONVERSION.sub(r"new(\1(", before)
        if after != before:
            path.write_text(after)
            touched += 1
    return touched


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]
        cleaned = drop_redundant_parens(root, files)
        if cleaned:
            log(f"  dropped redundant conversion parens in {cleaned} file(s)")

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Separate commits, so the hand-written part is obvious:

1. `heartbeat,x-pack/metricbeat: fix modernize lint findings` is pure tool output, nothing in it was written by hand.
2. `x-pack/filebeat,x-pack/metricbeat: finish the modernize cleanup` is the part the tools could not produce:

   > `go fix` inlined the `//go:fix inline` pointer helpers at every call site,
   > leaving the helpers themselves unused, so they are deleted here.
   > 
   > The rewrite also emitted `new((decoder.Rune)(' '))` in the awss3 decoding tests;
   > the parentheses around the conversion target are redundant and are dropped.

- `x-pack/filebeat/input/awss3/decoding_test.go`
- `x-pack/filebeat/input/awss3/input.go`
- `x-pack/metricbeat/module/gcp/metadata_cache_test.go`

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
